### PR TITLE
Initial experiment with value-trailing-semicolon

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,14 @@
 "use strict";
 
-module.exports = function() {}
+var postcss = require("postcss");
+var rules = require("./lib/rules");
+
+module.exports = postcss.plugin("stylelint", function(opts) {
+  return function(css, result) {
+    for (var rule in opts) {
+      if (opts.hasOwnProperty(rule)) {
+        rules[rule](opts[rule])(css, result);
+      }
+    }
+  };
+});

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "value-trailing-semicolon": require("./value-trailing-semicolon")
+};

--- a/lib/rules/value-trailing-semicolon.js
+++ b/lib/rules/value-trailing-semicolon.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = function valueTrailingSemicolon() {
+  return function(css, result) {
+    css.eachRule(function(rule) {
+      if (rule.semicolon) {
+        return;
+      }
+      result.warn(
+        "Expected a trailing semicolon (value-trailing-semicolon)",
+        {node: rule}
+      );
+    });
+  };
+};

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "LICENSE",
     "index.js"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "postcss": "^4.1.9"
+  },
   "devDependencies": {
     "eslint": "^0.10.1",
     "jscs": "^1.8.1",
-    "tape": "^3.0.3"
+    "tape": "4.0.0"
   },
   "scripts": {
     "jscs": "jscs .",

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,3 @@
 "use strict";
 
-var test = require("tape")
-
-test("nothing is tested", function(t) {
-  t.ok(true, "nothing is tested indeed!")
-
-  t.end()
-})
+require("./rules/value-trailing-semicolon");

--- a/test/rules/value-trailing-semicolon.js
+++ b/test/rules/value-trailing-semicolon.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var valueTrailingSemicolon = require("../../lib/rules/value-trailing-semicolon");
+var testRule = require("../util/testRule");
+var test = require("tape");
+var testValueTrailingSemicolon = testRule(valueTrailingSemicolon);
+
+test("value-trailing-semicolon success", function(t) {
+  t.plan(2);
+  testValueTrailingSemicolon("body { background: pink; }", function(warnings) {
+    t.equal(warnings.length, 0, "lone declaration");
+  });
+  testValueTrailingSemicolon("body { color: orange; background: pink; }", function(warnings) {
+    t.equal(warnings.length, 0, "multiple declarations");
+  });
+});
+
+test("value-trailing-semicolon failure", function(t) {
+  t.plan(4);
+  testValueTrailingSemicolon("body { background: pink }", function(warnings) {
+    t.equal(warnings.length, 1, "lone declaration");
+    t.equal(warnings[0].text, "Expected a trailing semicolon (value-trailing-semicolon)",
+      "correct warning message");
+  });
+  testValueTrailingSemicolon("body { color: orange; background: pink }", function(warnings) {
+    t.equal(warnings.length, 1, "multiple declarations");
+    t.equal(warnings[0].text, "Expected a trailing semicolon (value-trailing-semicolon)",
+      "correct warning message");
+  });
+});

--- a/test/util/testRule.js
+++ b/test/util/testRule.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var postcss = require("postcss");
+
+module.exports = function testRule(rule) {
+  return function(cssString, options, callback) {
+    if (typeof options === "function") {
+      callback = options;
+      options = null;
+    }
+    postcss()
+      .use(rule(options))
+      .process(cssString)
+      .then(function(result) {
+        callback(result.warnings());
+      });
+  };
+  // againstFixture could be a method attached to this ...
+};


### PR DESCRIPTION
@MoOx @jeddy3 @necolas --- anybody else interested in this repo --- I thought we could get some juices flowing if I PR'ed a little code to consider. value-trailing-semicolon is a ridiculously simple rule, since postcss already takes care of it, essentially (thanks @ai).

I figured that the approach could be to keep it very simple. Rules could be much like postcss plugins: functions that accept options, which return functions that accept css AST and the result object. They run their checks and register warnings on the result. They are tested individually --- probably most of the time you'd want to check that given some input the length of the warnings array is what you'd expect and that the message is what you'd expect.

What do you think? Does this seem like a decent setup to start writing and testing rules with, at least? Any comments, suggestions, foreseeable problems, etc?

With the intent to attract as many contributors as possible, what would you think about using ESLint or JSCS or whatever to enforce some semi-standard JS style like [airbnb's](https://github.com/airbnb/javascript)?

If there's some agreement that the direction is worthwhile I might start writing rules according to this pattern. Or some other pattern that's agreed on :) (I had to look at some old legacy CSS today and I'm scared enough that I want to get this thing going!)