### PR TITLE
Tighten-up eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,13 +12,6 @@ env:
 
 # 0: off, 1: warning, 2: error
 rules:
-  # semicolons are useless
-  semi: [2, "never"]
-
-  quotes: [2, "double"]
-
-  # 2 spaces indentation
-  indent: [2, 2]
 
   # trailing coma are cool for diff
   comma-dangle: [2, "always-multiline"]
@@ -26,5 +19,35 @@ rules:
   # enforce comma at eol (never before)
   comma-style: [2, "last"]
 
+  # 2 spaces indentation
+  indent: [2, 2]
+
+  # quotes are always double
+  quotes: [2, "double"]
+
+  # single empty lines only
+  no-multiple-empty-lines: [2, {"max": 1}]
+
   # allow functions declarations at bottom of scope
   no-use-before-define: [2, "nofunc"]
+
+  # semicolons are useless
+  semi: [2, "never"]
+
+  # consistent whitespace before function paren
+  space-before-function-paren: [2, {"anonymous": "always", "named": "never"}]
+
+  # consistent whitespace after keywords
+  space-after-keywords: [2, "always"]
+
+  # consistent whitespace in parens
+  space-in-parens: [2, "never"]
+
+  # consistent whitespace in brackets (disabled as buggy)
+  # space-in-brackets: [2, "always"]
+
+  # consistent whitespace in single line comments
+  spaced-line-comment: [2, "always"]
+
+  # consistent whitespace before blocks
+  space-before-blocks: [2, "always"]

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,8 @@ rules:
   # consistent whitespace before function paren
   space-before-function-paren: [2, {"anonymous": "always", "named": "never"}]
 
-  # consistent whitespace in brackets (disabled as buggy)
+  # consistent whitespace in brackets
+  # disabled as possibly buggy: https://github.com/babel/babel-eslint/issues/87
   # space-in-brackets: [2, "always"]
 
   # consistent whitespace in parens

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,20 +34,20 @@ rules:
   # semicolons are useless
   semi: [2, "never"]
 
-  # consistent whitespace before function paren
-  space-before-function-paren: [2, {"anonymous": "always", "named": "never"}]
-
   # consistent whitespace after keywords
   space-after-keywords: [2, "always"]
 
-  # consistent whitespace in parens
-  space-in-parens: [2, "never"]
+  # consistent whitespace before blocks
+  space-before-blocks: [2, "always"]
+
+  # consistent whitespace before function paren
+  space-before-function-paren: [2, {"anonymous": "always", "named": "never"}]
 
   # consistent whitespace in brackets (disabled as buggy)
   # space-in-brackets: [2, "always"]
 
+  # consistent whitespace in parens
+  space-in-parens: [2, "never"]
+
   # consistent whitespace in single line comments
   spaced-line-comment: [2, "always"]
-
-  # consistent whitespace before blocks
-  space-before-blocks: [2, "always"]


### PR DESCRIPTION
Getting things ready in case other people want to help out...

I've enabled a couple of rules for consistent whitespace in the code e.g. after the `function` keyword and within parentheses etc

The current code in master is nice and consistent, so no changes were needed there. :)

Ok with you guys?

Ref #15 