### PR TITLE
Enable and configure eslint's space-in-brackets

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,8 +44,7 @@ rules:
   space-before-function-paren: [2, {"anonymous": "always", "named": "never"}]
 
   # consistent whitespace in brackets
-  # disabled as possibly buggy: https://github.com/babel/babel-eslint/issues/87
-  # space-in-brackets: [2, "always"]
+  space-in-brackets: [2, "always", {"singleValue": false, "propertyName": false}]
 
   # consistent whitespace in parens
   space-in-parens: [2, "never"]

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "devDependencies": {
     "babel": "^5.2.15",
-    "babel-eslint": "^3.0.1",
+    "babel-eslint": "^3.1.1",
     "babel-tape-runner": "^1.1.0",
-    "eslint": "^0.20.0",
+    "eslint": "^0.21.0",
     "tape": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
I think you'll need to do an `npm install`.

I've configured it to match the current code style. I've run it against master and @davidtheclark [PR 33](https://github.com/stylelint/stylelint/pull/33) with no warnings.

We might need to tweak the [exceptions](https://github.com/eslint/eslint/blob/master/docs/rules/space-in-brackets.md#exceptions) as we go on.

Ref: #15 