### PR TITLE
Adapt declaration-no-important to new config structure

### DIFF
--- a/src/rules/declaration-no-important/README.md
+++ b/src/rules/declaration-no-important/README.md
@@ -2,13 +2,6 @@
 
 Disallow the use of `!important` within declarations.
 
-## Options
-
-* `true`: there *must not* be `!important` within declarations.
-* `false`: there *can* be `!important` within declarations.
-
-### `true`
-
 The following patterns are considered warnings:
 
 ```css
@@ -17,21 +10,22 @@ body {
 }
 ```
 
-The following patterns are *not* considered warnings:
-
 ```css
 body {
-  background: pink;
+  background: pink ! important;
 }
 ```
 
-### `false`
+```css
+body {
+  background: pink!important;
+}
+```
 
 The following patterns are *not* considered warnings:
 
 ```css
 body {
   background: pink;
-  color: red !important;
 }
 ```

--- a/src/rules/declaration-no-important/__tests__/index.js
+++ b/src/rules/declaration-no-important/__tests__/index.js
@@ -3,17 +3,25 @@ import declarationNoImportant, { ruleName, messages } from ".."
 
 const testDeclarationNoImportant = ruleTester(declarationNoImportant, ruleName)
 
-testDeclarationNoImportant(true, tr => {
-  tr.ok("a { color: pink; }", "declaration without !important")
+testDeclarationNoImportant(null, tr => {
+  tr.ok("a {}", "no values")
+  tr.ok("a { color: pink; }", "without !important")
 
   tr.notOk(
     "a { color: pink !important; }",
-    "declaration with !important",
-    messages.unexpected
+    "with !important",
+    messages.rejected
   )
-})
 
-testDeclarationNoImportant(false, tr => {
-  tr.ok("a { color: pink; }", "declaration without !important")
-  tr.ok("a { color: pink !important; }", "declaration with !important")
+  tr.notOk(
+    "a { color: pink ! important; }",
+    "with ! important",
+    messages.rejected
+  )
+
+  tr.notOk(
+    "a { color: pink!important; }",
+    "with value!important",
+    messages.rejected
+  )
 })

--- a/src/rules/declaration-no-important/index.js
+++ b/src/rules/declaration-no-important/index.js
@@ -1,17 +1,11 @@
 export const ruleName = "declaration-no-important"
 
 export const messages = {
-  unexpected: `Unexpected !important (${ruleName})`,
+  rejected: `!important disallowed (${ruleName})`,
 }
 
-/**
- * @param {boolean} options - If true, no !important;
- *   if false, do nothing
- */
-export default function declarationNoImportant(options) {
+export default function declarationNoImportant() {
   return (css, result) => {
-
-    if (!options) { return }
 
     css.eachDecl(function (decl) {
       if (!decl.important) {
@@ -19,7 +13,7 @@ export default function declarationNoImportant(options) {
       }
 
       result.warn(
-        messages.unexpected,
+        messages.rejected,
         { node: decl }
       )
     })


### PR DESCRIPTION
Updates `declaration-no-important` for the new config e.g.

```js
declaration-no-important: 2
```

Am I right to pass `null` into `testDeclarationNoImportant()` in the tests?

Adds a couple of extra tests too and updated the readme accordingly.