### PR TITLE
Create and test block-opening-brace-newline

### DIFF
--- a/src/rules/block-opening-brace-newline/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline/__tests__/index.js
@@ -1,0 +1,127 @@
+import { ruleTester } from "../../../testUtils"
+import blockOpeningBraceNewline, { ruleName, messages } from ".."
+
+const testBlockOpeningBraceNewline = ruleTester(blockOpeningBraceNewline, ruleName)
+
+testBlockOpeningBraceNewline({ before: "always" }, tr => {
+  tr.ok("a\n{ color: pink; }")
+  tr.ok("a\n{color: pink; }")
+  tr.ok("@media print\n{ a\n{ color: pink; } }")
+  tr.ok("@media print\n{a\n{color: pink; } }")
+
+  tr.notOk("a { color: pink; }", messages.expectedBefore())
+  tr.notOk("a{ color: pink; }", messages.expectedBefore())
+  tr.notOk("a  { color: pink; }", messages.expectedBefore())
+  tr.notOk("a\t{ color: pink; }", messages.expectedBefore())
+  tr.notOk("@media print { a\n{ color: pink; } }", messages.expectedBefore())
+  tr.notOk("@media print\n{ a { color: pink; } }", messages.expectedBefore())
+  tr.notOk("@media print{ a\n{ color: pink; } }", messages.expectedBefore())
+  tr.notOk("@media print\n{ a{ color: pink; } }", messages.expectedBefore())
+})
+
+testBlockOpeningBraceNewline({ after: "always" }, tr => {
+  tr.ok("a {\ncolor: pink; }")
+  tr.ok("a{\ncolor: pink; }")
+  tr.ok("a{\n\tcolor: pink; }")
+  tr.ok("a{\n  color: pink; }")
+  tr.ok("@media print {\na {\ncolor: pink; } }")
+  tr.ok("@media print{\na{\ncolor: pink; } }")
+  tr.ok("@media print{\n\ta{\n  color: pink; } }")
+
+  tr.notOk("a { color: pink; }", messages.expectedAfter())
+  tr.notOk("a {color: pink; }", messages.expectedAfter())
+  tr.notOk("a {  color: pink; }", messages.expectedAfter())
+  tr.notOk("a {\tcolor: pink; }", messages.expectedAfter())
+  tr.notOk("@media print { a {\ncolor: pink; } }", messages.expectedAfter())
+  tr.notOk("@media print {\na { color: pink; } }", messages.expectedAfter())
+})
+
+testBlockOpeningBraceNewline({ before: "never" }, tr => {
+  tr.ok("a{ color: pink; }")
+  tr.ok("a{color: pink; }")
+  tr.ok("@media print{ a{ color: pink; } }")
+  tr.ok("@media print{a{color: pink; } }")
+
+  tr.notOk("a { color: pink; }", messages.rejectedBefore())
+  tr.notOk("a\n{ color: pink; }", messages.rejectedBefore())
+  tr.notOk("a  { color: pink; }", messages.rejectedBefore())
+  tr.notOk("a\t{ color: pink; }", messages.rejectedBefore())
+  tr.notOk("@media print\n{ a{ color: pink; } }", messages.rejectedBefore())
+  tr.notOk("@media print{ a\n{ color: pink; } }", messages.rejectedBefore())
+})
+
+testBlockOpeningBraceNewline({ after: "never" }, tr => {
+  tr.ok("a {color: pink; }")
+  tr.ok("a{color: pink; }")
+  tr.ok("@media print {a {color: pink; } }")
+  tr.ok("@media print{a{color: pink; } }")
+
+  tr.notOk("a { color: pink; }", messages.rejectedAfter())
+  tr.notOk("a {\ncolor: pink; }", messages.rejectedAfter())
+  tr.notOk("a {  color: pink; }", messages.rejectedAfter())
+  tr.notOk("a {\tcolor: pink; }", messages.rejectedAfter())
+  tr.notOk("@media print {\na {color: pink; } }", messages.rejectedAfter())
+  tr.notOk("@media print {a {\ncolor: pink; } }", messages.rejectedAfter())
+})
+
+testBlockOpeningBraceNewline({ before: "always", after: "always" }, tr => {
+  tr.ok("a\n{\ncolor: pink; }")
+  tr.ok("a\n{\n\tcolor: pink; }")
+  tr.ok("@media print\n{\na\n{\ncolor: pink; } }")
+  tr.ok("@media print\n{\n  a\n{\n  color: pink; } }")
+
+  tr.notOk("a{\ncolor: pink; }", messages.expectedBefore())
+  tr.notOk("a {\ncolor: pink; }", messages.expectedBefore())
+  tr.notOk("a\n{color: pink; }", messages.expectedAfter())
+  tr.notOk("a\n{ color: pink; }", messages.expectedAfter())
+  tr.notOk("@media print\n{ a\n{\ncolor: pink; } }", messages.expectedAfter())
+  tr.notOk("@media print {\na\n{\ncolor: pink; } }", messages.expectedBefore())
+  tr.notOk("@media print\n{\na\n{ color: pink; } }", messages.expectedAfter())
+  tr.notOk("@media print\n{\na {\ncolor: pink; } }", messages.expectedBefore())
+})
+
+testBlockOpeningBraceNewline({ before: "always", after: "never" }, tr => {
+  tr.ok("a\n{color: pink; }")
+  tr.ok("@media print\n{a\n{color: pink; } }")
+
+  tr.notOk("a{color: pink; }", messages.expectedBefore())
+  tr.notOk("a {color: pink; }", messages.expectedBefore())
+  tr.notOk("a\n{\ncolor: pink; }", messages.rejectedAfter())
+  tr.notOk("a\n{ color: pink; }", messages.rejectedAfter())
+  tr.notOk("@media print\n{ a\n{color: pink; } }", messages.rejectedAfter())
+  tr.notOk("@media print {a\n{color: pink; } }", messages.expectedBefore())
+  tr.notOk("@media print\n{a\n{ color: pink; } }", messages.rejectedAfter())
+  tr.notOk("@media print\n{a {color: pink; } }", messages.expectedBefore())
+})
+
+testBlockOpeningBraceNewline({ before: "never", after: "always" }, tr => {
+  tr.ok("a{\ncolor: pink; }")
+  tr.ok("a{\n  color: pink; }")
+  tr.ok("a{\n\tcolor: pink; }")
+  tr.ok("@media print{\na{\ncolor: pink; } }")
+  tr.ok("@media print{\n  a{\n  color: pink; } }")
+  tr.ok("@media print{\n\ta{\n\tcolor: pink; } }")
+
+  tr.notOk("a\n{\ncolor: pink; }", messages.rejectedBefore())
+  tr.notOk("a {\ncolor: pink; }", messages.rejectedBefore())
+  tr.notOk("a{ color: pink; }", messages.expectedAfter())
+  tr.notOk("a{color: pink; }", messages.expectedAfter())
+  tr.notOk("@media print{ a{\ncolor: pink; } }", messages.expectedAfter())
+  tr.notOk("@media print\n{\na{\ncolor: pink; } }", messages.rejectedBefore())
+  tr.notOk("@media print{\na{ color: pink; } }", messages.expectedAfter())
+  tr.notOk("@media print{\na\n{\ncolor: pink; } }", messages.rejectedBefore())
+})
+
+testBlockOpeningBraceNewline({ before: "never", after: "never" }, tr => {
+  tr.ok("a{color: pink; }")
+  tr.ok("@media print{a{color: pink; } }")
+
+  tr.notOk("a\n{color: pink; }", messages.rejectedBefore())
+  tr.notOk("a {color: pink; }", messages.rejectedBefore())
+  tr.notOk("a{\ncolor: pink; }", messages.rejectedAfter())
+  tr.notOk("a{ color: pink; }", messages.rejectedAfter())
+  tr.notOk("@media print{\na{color: pink; } }", messages.rejectedAfter())
+  tr.notOk("@media print\n{a{color: pink; } }", messages.rejectedBefore())
+  tr.notOk("@media print{a{\ncolor: pink; } }", messages.rejectedAfter())
+  tr.notOk("@media print{a\n{color: pink; } }", messages.rejectedBefore())
+})

--- a/src/rules/block-opening-brace-newline/index.js
+++ b/src/rules/block-opening-brace-newline/index.js
@@ -1,0 +1,49 @@
+import {
+  standardWhitespaceOptions,
+  standardWhitespaceChecker,
+  standardWhitespaceMessages
+} from "../../utils"
+
+export const ruleName = "block-opening-brace-newline"
+
+export const messages = standardWhitespaceMessages(ruleName, {
+  expectedBefore: () => `Expected newline before opening "{"`,
+  rejectedBefore: () => `Unexpected space before opening "{"`,
+  expectedAfter: () => `Expected newline after opening "{"`,
+  rejectedAfter: () => `Unexpected space after opening "{"`,
+})
+
+/**
+ * @param {object} options
+ * @param {"always"|"never"} [options.before]
+ * @param {"always"|"never"} [options.after]
+ */
+export default function (options) {
+  const spaceOptions = standardWhitespaceOptions(options)
+  const spaceChecker = standardWhitespaceChecker("\n", spaceOptions, messages)
+
+  return function (css, result) {
+    // Check both kinds of "block": rules and at-rules
+    css.eachRule(checkBlock)
+    css.eachAtRule(checkBlock)
+
+    function checkBlock(block) {
+      const blockString = block.toString()
+      for (let i = 0, l = blockString.length; i < l; i++) {
+        if (blockString[i] !== "{") { continue }
+        // Only pay attention to the first brace encountered
+        checkBrace(i)
+        break
+      }
+
+      function checkBrace(index) {
+        spaceChecker.before(blockString, index, msg => {
+          result.warn(msg, { node: block })
+        })
+        spaceChecker.oneAfter(blockString, index, msg => {
+          result.warn(msg, { node: block })
+        })
+      }
+    }
+  }
+}

--- a/src/utils/standardWhitespaceChecker.js
+++ b/src/utils/standardWhitespaceChecker.js
@@ -4,7 +4,7 @@ import isWhitespace from "./isWhitespace"
  * Create a standardWhitespaceChecker that exposes `before()` and `after()`
  * functions for checking whitespace around a given point in a string.
  *
- * @param {string} whitespace - The whitespace to look for
+ * @param {string} expectedWhitespace - The whitespace to look for
  * @param {object} whitespaceOptions - A set of options created by
  *   `standardWhitespaceOptions()`; so it will have properties
  *   `expectBefore`, `expectAfter`, `rejectBefore`, etc.
@@ -13,7 +13,7 @@ import isWhitespace from "./isWhitespace"
  *   `expectedBefore()`, `expectedAfter()`, `rejectedBefore()`, etc.
  * @return {objects} The standardWhitespaceChecker with fun functions to use
  */
-export default function (whitespace, whitespaceOptions, whitespaceMessages) {
+export default function (expectedWhitespace, whitespaceOptions, whitespaceMessages) {
   return {
 
     /**
@@ -30,8 +30,24 @@ export default function (whitespace, whitespaceOptions, whitespaceMessages) {
       if (whitespaceOptions.expectBefore) {
         // Check for the space 1 character before and no additional
         // whitespace 2 characters before
-        if (source[index - 1] === whitespace
+        if (source[index - 1] === expectedWhitespace
           && !isWhitespace(source[index - 2])) { return }
+        cb(whitespaceMessages.expectedBefore(source[index]))
+      }
+
+      if (whitespaceOptions.rejectBefore) {
+        // Check that there's no whitespace at all before
+        if (!isWhitespace(source[index - 1])) { return }
+        cb(whitespaceMessages.rejectedBefore(source[index]))
+      }
+    },
+
+    oneBefore(source, index, cb) {
+      if (whitespaceOptions.ignoreBefore) { return }
+
+      if (whitespaceOptions.expectBefore) {
+        // Check only the character before
+        if (source[index - 1] === expectedWhitespace) { return }
         cb(whitespaceMessages.expectedBefore(source[index]))
       }
 
@@ -56,8 +72,24 @@ export default function (whitespace, whitespaceOptions, whitespaceMessages) {
       if (whitespaceOptions.expectAfter) {
         // Check for the space 1 character after and no additional
         // whitespace 2 characters after
-        if (source[index + 1] === whitespace
+        if (source[index + 1] === expectedWhitespace
           && !isWhitespace(source[index + 2])) { return }
+        cb(whitespaceMessages.expectedAfter(source[index]))
+      }
+
+      if (whitespaceOptions.rejectAfter) {
+        // Check that there's no whitespace at all ater
+        if (!isWhitespace(source[index + 1])) { return }
+        cb(whitespaceMessages.rejectedAfter(source[index]))
+      }
+    },
+
+    oneAfter(source, index, cb) {
+      if (whitespaceOptions.ignoreAfter) { return }
+
+      if (whitespaceOptions.expectAfter) {
+        // Check only the character after
+        if (source[index + 1] === expectedWhitespace) { return }
         cb(whitespaceMessages.expectedAfter(source[index]))
       }
 


### PR DESCRIPTION
The new assumption here is that in situations where we can't know precisely what the user wants, we will limit the scope of our checking. This case is that after the opening brace, we can demand a newline, but then can't demand that there be no space, one space, a tab, etc. after that newline and before the first declaration. That's the domain of another rule. So I added the `oneBefore()` and `oneAfter()` functions to the `ruleChecker`, which only checks one before/after, instead of also checking 2.