### PR TITLE
Create and test block-closing-brace-space and refactor whitespaceChec…

### DIFF
--- a/src/rules/block-closing-brace-space/__tests__/index.js
+++ b/src/rules/block-closing-brace-space/__tests__/index.js
@@ -1,0 +1,90 @@
+import { ruleTester } from "../../../testUtils"
+import blockOpeningBraceSpace, { ruleName, messages } from ".."
+
+const testBlockOpeningBraceSpace = ruleTester(blockOpeningBraceSpace, ruleName)
+
+testBlockOpeningBraceSpace({ before: "always" }, tr => {
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; } b { color: red; }")
+  tr.ok("a { color: pink; }b { color: red; }")
+
+  tr.notOk("a { color: pink;}", messages.expectedBefore())
+  tr.notOk("a { color: pink;  }", messages.expectedBefore())
+  tr.notOk("a { color: pink;\n}", messages.expectedBefore())
+  tr.notOk("a { color: pink;\t}", messages.expectedBefore())
+  tr.notOk("a { color: pink; } b { color: red;}", messages.expectedBefore())
+})
+
+testBlockOpeningBraceSpace({ before: "never" }, tr => {
+  tr.ok("a { color: pink;}")
+  tr.ok("a { color: pink;} b { color: red;}")
+  tr.ok("a { color: pink;}b { color: red;}")
+
+  tr.notOk("a { color: pink; }", messages.rejectedBefore())
+  tr.notOk("a { color: pink;  }", messages.rejectedBefore())
+  tr.notOk("a { color: pink;\n}", messages.rejectedBefore())
+  tr.notOk("a { color: pink;\t}", messages.rejectedBefore())
+  tr.notOk("a { color: pink;} b { color: red; }", messages.rejectedBefore())
+})
+
+testBlockOpeningBraceSpace({ after: "always" }, tr => {
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; } b { color: red; }")
+  tr.ok("a { color: pink;} b { color: red;}")
+
+  tr.notOk("a { color: pink; }b { color: red; }", messages.expectedAfter())
+  tr.notOk("a { color: pink; }  b { color: red; }", messages.expectedAfter())
+  tr.notOk("a { color: pink; }\nb { color: red; }", messages.expectedAfter())
+  tr.notOk("a { color: pink; }\tb { color: red; }", messages.expectedAfter())
+})
+
+testBlockOpeningBraceSpace({ after: "never" }, tr => {
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; }b { color: red; }")
+  tr.ok("a { color: pink;}b { color: red;}")
+
+  tr.notOk("a { color: pink; } b { color: red; }", messages.rejectedAfter())
+  tr.notOk("a { color: pink; }  b { color: red; }", messages.rejectedAfter())
+  tr.notOk("a { color: pink; }\nb { color: red; }", messages.rejectedAfter())
+  tr.notOk("a { color: pink; }\tb { color: red; }", messages.rejectedAfter())
+})
+
+testBlockOpeningBraceSpace({ before: "always", after: "always" }, tr => {
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; } b { color: red; }")
+
+  tr.notOk("a { color: pink;} b { color: red; }", messages.expectedBefore())
+  tr.notOk("a { color: pink; } b { color: red;\n}", messages.expectedBefore())
+  tr.notOk("a { color: pink; }b { color: red; }", messages.expectedAfter())
+  tr.notOk("a { color: pink; }\nb { color: red; }", messages.expectedAfter())
+})
+
+testBlockOpeningBraceSpace({ before: "never", after: "always" }, tr => {
+  tr.ok("a { color: pink;}")
+  tr.ok("a { color: pink;} b { color: red;}")
+
+  tr.notOk("a { color: pink; } b { color: red;}", messages.rejectedBefore())
+  tr.notOk("a { color: pink;} b { color: red;\n}", messages.rejectedBefore())
+  tr.notOk("a { color: pink;}b { color: red;}", messages.expectedAfter())
+  tr.notOk("a { color: pink;}\nb { color: red;}", messages.expectedAfter())
+})
+
+testBlockOpeningBraceSpace({ before: "always", after: "never" }, tr => {
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; }b { color: red; }")
+
+  tr.notOk("a { color: pink;}b { color: red; }", messages.expectedBefore())
+  tr.notOk("a { color: pink; }b { color: red;\n}", messages.expectedBefore())
+  tr.notOk("a { color: pink; } b { color: red; }", messages.rejectedAfter())
+  tr.notOk("a { color: pink; }\nb { color: red; }", messages.rejectedAfter())
+})
+
+testBlockOpeningBraceSpace({ before: "never", after: "never" }, tr => {
+  tr.ok("a { color: pink;}")
+  tr.ok("a { color: pink;}b { color: red;}")
+
+  tr.notOk("a { color: pink; }b { color: red;}", messages.rejectedBefore())
+  tr.notOk("a { color: pink;}b { color: red;\n}", messages.rejectedBefore())
+  tr.notOk("a { color: pink;} b { color: red;}", messages.rejectedAfter())
+  tr.notOk("a { color: pink;}\nb { color: red;}", messages.rejectedAfter())
+})

--- a/src/rules/block-closing-brace-space/index.js
+++ b/src/rules/block-closing-brace-space/index.js
@@ -1,0 +1,44 @@
+import {
+  standardWhitespaceOptions,
+  standardWhitespaceChecker,
+  standardWhitespaceMessages
+} from "../../utils"
+
+export const ruleName = "block-closing-brace-space"
+
+export const messages = standardWhitespaceMessages(ruleName, {
+  expectedBefore: () => `Expected single space before closing "}"`,
+  rejectedBefore: () => `Unexpected space before closing "}"`,
+  expectedAfter: () => `Expected single space after closing "}"`,
+  rejectedAfter: () => `Unexpected space after closing "}"`,
+})
+
+/**
+ * @param {object} options
+ * @param {"always"|"never"} [options.before]
+ * @param {"always"|"never"} [options.after]
+ */
+export default function (options) {
+  const spaceOptions = standardWhitespaceOptions(options)
+  const spaceChecker = standardWhitespaceChecker(" ", spaceOptions, messages)
+
+  return function (css, result) {
+    // Check both kinds of "block": rules and at-rules
+    css.eachRule(checkBlock)
+    css.eachAtRule(checkBlock)
+
+    function checkBlock(block) {
+      const blockString = block.toString()
+
+      spaceChecker.before(blockString, blockString.length - 1, msg => {
+        result.warn(msg, { node: block })
+      })
+
+      const nextNode = block.next()
+      if (!nextNode) { return }
+      spaceChecker.after(nextNode.toString(), -1, msg => {
+        result.warn(msg, { node: block })
+      })
+    }
+  }
+}

--- a/src/rules/declaration-colon-space/index.js
+++ b/src/rules/declaration-colon-space/index.js
@@ -28,16 +28,22 @@ export default function (options) {
 
     css.eachDecl(function (decl) {
 
-      const between = decl.between
-      const charIndex = between.indexOf(":")
+      const declString = decl.toString()
 
-      spaceChecker.before(between, charIndex, msg => {
-        result.warn(msg, { node: decl })
-      })
+      for (let i = 0, l = declString.length; i < l; i++) {
+        if (declString[i] !== ":") { continue }
+        checkColon(i)
+        break
+      }
 
-      spaceChecker.after(between, charIndex, msg => {
-        result.warn(msg, { node: decl })
-      })
+      function checkColon(index) {
+        spaceChecker.before(declString, index, msg => {
+          result.warn(msg, { node: decl })
+        })
+        spaceChecker.after(declString, index, msg => {
+          result.warn(msg, { node: decl })
+        })
+      }
     })
   }
 }

--- a/src/utils/standardWhitespaceChecker.js
+++ b/src/utils/standardWhitespaceChecker.js
@@ -6,10 +6,10 @@ import isWhitespace from "./isWhitespace"
  *
  * @param {string} expectedWhitespace - The whitespace to look for
  * @param {object} whitespaceOptions - A set of options created by
- *   `standardWhitespaceOptions()`; so it will have properties
+ *   `standardWhitespaceOptions()` so it will have properties
  *   `expectBefore`, `expectAfter`, `rejectBefore`, etc.
  * @param {object} whitespaceMessages - A set of messages passed through
- *   `standardWhitespaceMessages()`; so it will have functions
+ *   `standardWhitespaceMessages()` so it will have functions
  *   `expectedBefore()`, `expectedAfter()`, `rejectedBefore()`, etc.
  * @return {objects} The standardWhitespaceChecker with fun functions to use
  */
@@ -22,39 +22,47 @@ export default function (expectedWhitespace, whitespaceOptions, whitespaceMessag
      * @param {string} source
      * @param {number} index - The index of the character to look before
      *   in `source`
-     * @param {function} cb - A callback that accepts a message
+     * @param {function} err - A callback that accepts a message
      */
-    before(source, index, cb) {
+    before(source, index, err) {
       if (whitespaceOptions.ignoreBefore) { return }
+
+      const oneCharBefore = source[index - 1]
+      const twoCharsBefore = source[index - 2]
 
       if (whitespaceOptions.expectBefore) {
         // Check for the space 1 character before and no additional
         // whitespace 2 characters before
-        if (source[index - 1] === expectedWhitespace
-          && !isWhitespace(source[index - 2])) { return }
-        cb(whitespaceMessages.expectedBefore(source[index]))
+        if ((isValue(oneCharBefore) && oneCharBefore !== expectedWhitespace)
+          || (isValue(twoCharsBefore) && isWhitespace(twoCharsBefore))) {
+          err(whitespaceMessages.expectedBefore(source[index]))
+        }
       }
 
       if (whitespaceOptions.rejectBefore) {
         // Check that there's no whitespace at all before
-        if (!isWhitespace(source[index - 1])) { return }
-        cb(whitespaceMessages.rejectedBefore(source[index]))
+        if (isValue(oneCharBefore) && isWhitespace(oneCharBefore)) {
+          err(whitespaceMessages.rejectedBefore(source[index]))
+        }
       }
     },
 
-    oneBefore(source, index, cb) {
+    oneBefore(source, index, err) {
       if (whitespaceOptions.ignoreBefore) { return }
 
+      const oneCharBefore = source[index - 1]
+
       if (whitespaceOptions.expectBefore) {
-        // Check only the character before
-        if (source[index - 1] === expectedWhitespace) { return }
-        cb(whitespaceMessages.expectedBefore(source[index]))
+        if (isValue(oneCharBefore) && oneCharBefore !== expectedWhitespace) {
+          err(whitespaceMessages.expectedBefore(source[index]))
+        }
       }
 
       if (whitespaceOptions.rejectBefore) {
         // Check that there's no whitespace at all before
-        if (!isWhitespace(source[index - 1])) { return }
-        cb(whitespaceMessages.rejectedBefore(source[index]))
+        if (isValue(oneCharBefore) && isWhitespace(oneCharBefore)) {
+          err(whitespaceMessages.rejectedBefore(source[index]))
+        }
       }
     },
 
@@ -64,40 +72,52 @@ export default function (expectedWhitespace, whitespaceOptions, whitespaceMessag
      * @param {string} source
      * @param {number} index - The index of the character to look after
      *   in `source`
-     * @param {function} cb - A callback that accepts a message
+     * @param {function} err - A callback that accepts a message
      */
-    after(source, index, cb) {
+    after(source, index, err) {
       if (whitespaceOptions.ignoreAfter) { return }
+
+      const oneCharAfter = source[index + 1]
+      const twoCharsAfter = source[index + 2]
 
       if (whitespaceOptions.expectAfter) {
         // Check for the space 1 character after and no additional
         // whitespace 2 characters after
-        if (source[index + 1] === expectedWhitespace
-          && !isWhitespace(source[index + 2])) { return }
-        cb(whitespaceMessages.expectedAfter(source[index]))
+        if ((isValue(oneCharAfter) && oneCharAfter !== expectedWhitespace)
+          || (isValue(twoCharsAfter) && isWhitespace(twoCharsAfter))) {
+          err(whitespaceMessages.expectedAfter(source[index]))
+        }
       }
 
       if (whitespaceOptions.rejectAfter) {
         // Check that there's no whitespace at all ater
-        if (!isWhitespace(source[index + 1])) { return }
-        cb(whitespaceMessages.rejectedAfter(source[index]))
+        if (isValue(oneCharAfter) && isWhitespace(oneCharAfter)) {
+          err(whitespaceMessages.rejectedAfter(source[index]))
+        }
       }
     },
 
-    oneAfter(source, index, cb) {
+    oneAfter(source, index, err) {
       if (whitespaceOptions.ignoreAfter) { return }
 
+      const oneCharAfter = source[index + 1]
+
       if (whitespaceOptions.expectAfter) {
-        // Check only the character after
-        if (source[index + 1] === expectedWhitespace) { return }
-        cb(whitespaceMessages.expectedAfter(source[index]))
+        if (isValue(oneCharAfter) && oneCharAfter !== expectedWhitespace) {
+          err(whitespaceMessages.expectedAfter(source[index]))
+        }
       }
 
       if (whitespaceOptions.rejectAfter) {
         // Check that there's no whitespace at all ater
-        if (!isWhitespace(source[index + 1])) { return }
-        cb(whitespaceMessages.rejectedAfter(source[index]))
+        if (isValue(oneCharAfter) && isWhitespace(oneCharAfter)) {
+          err(whitespaceMessages.rejectedAfter(source[index]))
+        }
       }
     },
   }
+}
+
+function isValue(x) {
+  return x !== undefined && x !== null
 }


### PR DESCRIPTION
…ker; addresses #21 

The refactoring of standardWhitespaceChecker is to ensure that it doesn't complain if it runs against the edge of the string, e.g. if whitespace is expected after closing brace but this is the last closing brace in the document.

That refactor triggered a need to fix up `declaration-colon-space` a little, because it was using `decl.between` so didn't actually include the characters before the colon, so I think those weren't being checked after my refactor or something? Anyway, it passes the same tests now, and looks more like the others like it, I guess.