### PR TITLE
Proof of concept single-multi

### DIFF
--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -29,13 +29,13 @@ export function blockOpeningBraceNewlineChecker(locationChecker) {
       for (let i = 0, l = blockString.length; i < l; i++) {
         if (blockString[i] !== "{") { continue }
         // Only pay attention to the first brace encountered
-        checkLocation(blockString, i, block)
+        checkLocation(blockString, i, block, blockString.slice(i))
         break
       }
     }
 
-    function checkLocation(str, index, node) {
-      locationChecker(str, index, m => result.warn(m, { node }))
+    function checkLocation(str, index, node, lineCheckStr) {
+      locationChecker(str, index, m => result.warn(m, { node }), lineCheckStr)
     }
   }
 }

--- a/src/rules/block-opening-brace-space-after/index.js
+++ b/src/rules/block-opening-brace-space-after/index.js
@@ -29,13 +29,13 @@ export function blockOpeningBraceSpaceChecker(locationChecker) {
       for (let i = 0, l = blockString.length; i < l; i++) {
         if (blockString[i] !== "{") { continue }
         // Only pay attention to the first brace encountered
-        checkLocation(blockString, i, block)
+        checkLocation(blockString, i, block, blockString.slice(i))
         break
       }
     }
 
-    function checkLocation(str, index, node) {
-      locationChecker(str, index, m => result.warn(m, { node }))
+    function checkLocation(str, index, node, lineCheckStr) {
+      locationChecker(str, index, m => result.warn(m, { node }), lineCheckStr)
     }
   }
 }

--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -26,3 +26,82 @@ testRule("never", tr => {
   tr.notOk("@media print { a{ color: pink; } }", messages.rejectedBefore())
   tr.notOk("@media print{ a { color: pink; } }", messages.rejectedBefore())
 })
+
+testRule("always-single-line", tr => {
+  // Regular "always" tests
+  tr.ok("a { color: pink; }")
+  tr.ok("@media print { a { color: pink; } }")
+
+  tr.notOk("a{ color: pink; }", messages.expectedBeforeSingleLine())
+  tr.notOk("a  { color: pink; }", messages.expectedBeforeSingleLine())
+  tr.notOk("a\t{ color: pink; }", messages.expectedBeforeSingleLine())
+  tr.notOk("a\n{ color: pink; }", messages.expectedBeforeSingleLine())
+  tr.notOk("@media print\n{ a { color: pink; } }", messages.expectedBeforeSingleLine())
+  tr.notOk("@media print { a\n{ color: pink; } }", messages.expectedBeforeSingleLine())
+
+  // Ignoring multi-line blocks
+  tr.ok("a { color: pink; }")
+  tr.ok("@media print { a { color: pink; } }")
+  tr.ok("a{ color:\npink; }")
+  tr.ok("@media print { a{ color:\npink; } }")
+  tr.ok("@media print{ a { color:\npink; } }")
+  tr.ok("@media print{\na { color: pink; } }")
+})
+
+testRule("never-single-line", tr => {
+  // Regular "never" tests
+  tr.ok("a{ color: pink; }")
+  tr.ok("@media print{ a{ color: pink; } }")
+
+  tr.notOk("a { color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("a  { color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("a\t{ color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("a\n{ color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("@media print { a{ color: pink; } }", messages.rejectedBeforeSingleLine())
+  tr.notOk("@media print{ a { color: pink; } }", messages.rejectedBeforeSingleLine())
+
+  // Ignoring multi-line blocks
+  tr.ok("a { color:\npink; }")
+  tr.ok("@media print { a { color:\npink; } }")
+  tr.ok("@media print{ a{ color:\npink; } }")
+  tr.ok("@media print {\na{ color: pink; } }")
+  tr.ok("@media print{\na{ color: pink; } }")
+})
+
+testRule("always-multi-line", tr => {
+  tr.ok("a { color: pink;\nbackground: orange; }")
+  tr.ok("@media print {\na { color: pink;\nbackground: orange } }")
+
+  // Ignoring single-line blocks
+  tr.ok("a { color: pink; }")
+  tr.ok("@media print { a { color: pink; } }")
+  tr.ok("a{ color: pink; }")
+  tr.ok("a  { color: pink; }")
+  tr.ok("a\t{ color: pink; }")
+
+  tr.notOk("a{ color: pink;\nbackground: orange; }", messages.expectedBeforeMultiLine())
+  tr.notOk("a  { color: pink;\nbackground: orange; }", messages.expectedBeforeMultiLine())
+  tr.notOk("a\t{ color: pink;\nbackground: orange; }", messages.expectedBeforeMultiLine())
+  tr.notOk("a\n{ color: pink;\nbackground: orange; }", messages.expectedBeforeMultiLine())
+  tr.notOk("@media print\n{\na { color: pink;\nbackground: orange; } }", messages.expectedBeforeMultiLine())
+  tr.notOk("@media print { a\n{ color: pink;\nbackground: orange; } }", messages.expectedBeforeMultiLine())
+})
+
+testRule("never-multi-line", tr => {
+  tr.ok("a{ color: pink;\nbackground: orange; }")
+  tr.ok("@media print{\na{ color: pink;\nbackground: orange } }")
+
+  // Ignoring single-line blocks
+  tr.ok("a { color: pink; }")
+  tr.ok("@media print { a { color: pink; } }")
+  tr.ok("a{ color: pink; }")
+  tr.ok("a  { color: pink; }")
+  tr.ok("a\t{ color: pink; }")
+
+  tr.notOk("a { color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("a  { color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("a\t{ color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("a\n{ color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("@media print\n{\na{ color: pink;\nbackground: orange; } }", messages.rejectedBeforeMultiLine())
+  tr.notOk("@media print{ a\n{ color: pink;\nbackground: orange; } }", messages.rejectedBeforeMultiLine())
+})

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -9,6 +9,10 @@ export const ruleName = "block-opening-brace-space-before"
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => "Expected single space before \"{\"",
   rejectedBefore: () => "Unexpected space before \"{\"",
+  expectedBeforeSingleLine: () => "Expected single space before \"{\" of a single-line block",
+  rejectedBeforeSingleLine: () => "Unexpected space before \"{\" of a single-line block",
+  expectedBeforeMultiLine: () => "Expected single space before \"{\" of a multi-line block",
+  rejectedBeforeMultiLine: () => "Unexpected space before \"{\" of a multi-line block",
 })
 
 /**

--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -1,70 +1,141 @@
 import isWhitespace from "./isWhitespace"
+import isSingleLineString from "./isSingleLineString"
 
-export default function (whitespace, expectation, messages) {
+/**
+ * Create a whitespaceChecker, which exposes the following functions:
+ * - `before()`
+ * - `after()`
+ * - `afterOneOnly()`
+ *
+ * @param {" "|"\n"} targetWhitespace
+ * @param {"always"} expectation - One of the "always"/"never" strings
+ * @param {object} messages - An object of message functions;
+ *   calling `before()` or `after()` and the `expectation` that is passed
+ *   determines which message functions are required
+ * @param {function} [messages.exectedBefore]
+ * @param {function} [messages.rejectedBefore]
+ * @param {function} [messages.expectedAfter]
+ * @param {function} [messages.rejectedAfter]
+ * @param {function} [messages.expectedBeforeSingleLine]
+ * @param {function} [messages.rejectedBeforeSingleLine]
+ * @param {function} [messages.expectedBeforeMultiLine]
+ * @param {function} [messages.rejectedBeforeMultiLine]
+ * @return {object} The checker
+ */
+export default function (targetWhitespace, expectation, messages) {
 
-  function before(source, index, err, oneCharOnly=false) {
+  // Keep track of active arguments in order to avoid passing
+  // too much stuff around, making signatures confusing.
+  // This variable gets reset anytime `before()` or `after()` is called.
+  let activeArgs
+
+  /**
+   * Check for whitespace before a character.
+   *
+   * @param {string} source
+   * @param {number} index - The index of the character to check before
+   * @param {function} err - A callback that receives the warning message
+   *   if there is one. Typically this callback will register the message
+   *   as a warning on the PostCSS result that the rule is dealing with.
+   * @param {string} [lineCheckStr] - Single- and multi-line checkers
+   *   will use this string to check whether they should proceed. If none
+   *   is passed, they will use `source`.
+   * @param {string} [onlyOneChar=false] - Only check *one* character before.
+   *   By default, "always-*" checks will look for the `targetWhitespace` one
+   *   before and then ensure there is no whitespace two before; this option
+   *   bypasses that second check.
+   */
+  function before(source, index, err, lineCheckStr, onlyOneChar=false) {
+    activeArgs = { source, index, err, onlyOneChar }
     switch (expectation) {
       case "always":
-        expectBefore(source, index, err, oneCharOnly)
+        expectBefore()
         break
       case "never":
-        rejectBefore(source, index, err)
+        rejectBefore()
+        break
+      case "always-single-line":
+        if (!isSingleLineString(lineCheckStr || source)) { return }
+        expectBefore(messages.expectedBeforeSingleLine)
+        break
+      case "never-single-line":
+        if (!isSingleLineString(lineCheckStr || source)) { return }
+        rejectBefore(messages.rejectedBeforeSingleLine)
+        break
+      case "always-multi-line":
+        if (isSingleLineString(lineCheckStr || source)) { return }
+        expectBefore(messages.expectedBeforeMultiLine)
+        break
+      case "never-multi-line":
+        if (isSingleLineString(lineCheckStr || source)) { return }
+        rejectBefore(messages.rejectedBeforeMultiLine)
         break
       default:
         throw new Error(`Unknown expectation "${expectation}"`)
     }
   }
 
-  function after(source, index, err, oneCharOnly=false) {
+  /**
+   * Check for whitespace after a character.
+   *
+   * Parameters are the same as for `before()`, above, just substitute
+   * the word "after" for "before".
+   */
+  function after(source, index, err, lineCheckStr, onlyOneChar=false) {
+    activeArgs = { source, index, err, onlyOneChar }
     switch (expectation) {
       case "always":
-        expectAfter(source, index, err, oneCharOnly)
+        expectAfter()
         break
       case "never":
-        rejectAfter(source, index, err)
+        rejectAfter()
         break
       default:
         throw new Error(`Unknown expectation "${expectation}"`)
     }
   }
 
-  function afterOneOnly(source, index, err) {
-    after(source, index, err, true)
-  }
-
-  function expectBefore(source, index, err, oneCharOnly) {
+  function expectBefore(messageFunc=messages.expectedBefore) {
+    const { source, index } = activeArgs
     const oneCharBefore = source[index - 1]
     const twoCharsBefore = source[index - 2]
 
-    if ((isValue(oneCharBefore) && oneCharBefore !== whitespace)
-      || (!oneCharOnly && isValue(twoCharsBefore) && isWhitespace(twoCharsBefore))) {
-      err(messages.expectedBefore(source[index]))
+    if ((isValue(oneCharBefore) && oneCharBefore !== targetWhitespace)
+      || (!activeArgs.onlyOneChar && isValue(twoCharsBefore) && isWhitespace(twoCharsBefore))) {
+      activeArgs.err(messageFunc(source[index]))
     }
   }
 
-  function rejectBefore(source, index, err) {
+  function rejectBefore(messageFunc=messages.rejectedBefore) {
+    const { source, index } = activeArgs
     const oneCharBefore = source[index - 1]
 
     if (isValue(oneCharBefore) && isWhitespace(oneCharBefore)) {
-      err(messages.rejectedBefore(source[index]))
+      activeArgs.err(messageFunc(source[index]))
     }
   }
 
-  function expectAfter(source, index, err, oneCharOnly) {
+  function afterOneOnly(source, index, err, lineCheckStr) {
+    after(source, index, err, lineCheckStr, true)
+  }
+
+  function expectAfter(messageFunc=messages.expectedAfter) {
+    const { source, index } = activeArgs
     const oneCharAfter = source[index + 1]
     const twoCharsAfter = source[index + 2]
 
-    if ((isValue(oneCharAfter) && oneCharAfter !== whitespace)
-      || (!oneCharOnly && isValue(twoCharsAfter) && isWhitespace(twoCharsAfter))) {
-      err(messages.expectedAfter(source[index]))
+    if ((isValue(oneCharAfter) && oneCharAfter !== targetWhitespace)
+      || (!activeArgs.onlyOneChar && isValue(twoCharsAfter) && isWhitespace(twoCharsAfter))) {
+      activeArgs.err(messageFunc(source[index]))
     }
   }
 
-  function rejectAfter(source, index, err) {
+  function rejectAfter(messageFunc=messages.rejectedAfter) {
+    const { source, index } = activeArgs
     const oneCharAfter = source[index + 1]
 
     if (isValue(oneCharAfter) && isWhitespace(oneCharAfter)) {
-      err(messages.rejectedAfter(source[index]))
+      activeArgs.err(messageFunc(source[index]))
     }
   }
 


### PR DESCRIPTION
@MoOx is this what you were talking about with two successive PRs? I think I got it right ...

Needs to be merged after #75.

`block-opening-brace-space-before` now exemplifies the single-multi options. This involved some changes to `whitespaceChecker()`. I tried to comment it up to help you all read/understand what's going on. Please provide feedback if you think anything could be done in a clearer or more efficient way!

Note that this also exemplifies point one from https://github.com/stylelint/stylelint/issues/72 ---- selecting what part of the string to check for newlines when making the single-multi distinction.