### PR TITLE
Test block-closing-brace-*-after nested; closes #71

### DIFF
--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -8,10 +8,16 @@ testRule("always", tr => {
   tr.ok("a { color: pink; }\nb { color: red; }")
   tr.ok("a { color: pink;}\n\t\tb { color: red;}")
 
+  // Ignores nested closing braces
+  tr.ok("@media print { a { color: pink; }\nb { color: red; }}")
+  tr.ok("@media print { a { color: pink; }}\n@media screen { b { color: red; }}")
+
   tr.notOk("a { color: pink; }b { color: red; }", messages.expectedAfter())
   tr.notOk("a { color: pink; } b { color: red; }", messages.expectedAfter())
   tr.notOk("a { color: pink; }  b { color: red; }", messages.expectedAfter())
   tr.notOk("a { color: pink; }\tb { color: red; }", messages.expectedAfter())
+  tr.notOk("@media print { a { color: pink; } b { color: red; }}", messages.expectedAfter())
+  tr.notOk("@media print { a { color: pink; }} @media screen { b { color: red; }}", messages.expectedAfter())
 })
 
 testRule("never", tr => {
@@ -19,16 +25,26 @@ testRule("never", tr => {
   tr.ok("a { color: pink; }b { color: red; }")
   tr.ok("a { color: pink;}b { color: red;}")
 
+  // Ignores nested closing braces
+  tr.ok("@media print { a { color: pink; }b { color: red; } }")
+  tr.ok("@media print { a { color: pink; } }@media screen { b { color: red; } }")
+
   tr.notOk("a { color: pink; }\nb { color: red; }", messages.rejectedAfter())
   tr.notOk("a { color: pink; } b { color: red; }", messages.rejectedAfter())
   tr.notOk("a { color: pink; }  b { color: red; }", messages.rejectedAfter())
   tr.notOk("a { color: pink; }\tb { color: red; }", messages.rejectedAfter())
+  tr.notOk("@media print { a { color: pink; }\nb { color: red; }}", messages.rejectedAfter())
+  tr.notOk("@media print { a { color: pink; }}\n @media screen { b { color: red; }}", messages.rejectedAfter())
 })
 
 testRule("always-single-line", tr => {
   tr.ok("a { color: pink; }")
   tr.ok("a { color: pink; }\nb { color: red; }")
   tr.ok("a { color: pink;}\n\t\tb { color: red;}")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a { color: pink; }\nb { color: red; }}")
+  tr.ok("@media print { a { color: pink; }}\n@media screen { b { color: red; }}")
 
   // Ignore multi-line
   tr.ok("a { color: pink;\ntop: 0; }b { color: red; }")
@@ -38,12 +54,18 @@ testRule("always-single-line", tr => {
   tr.notOk("a { color: pink; } b { color: red; }", messages.expectedAfterSingleLine())
   tr.notOk("a { color: pink; }  b { color: red; }", messages.expectedAfterSingleLine())
   tr.notOk("a { color: pink; }\tb { color: red; }", messages.expectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; } b { color: red; }}", messages.expectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; }} @media screen { b { color: red; }}", messages.expectedAfterSingleLine())
 })
 
 testRule("never-single-line", tr => {
   tr.ok("a { color: pink; }")
   tr.ok("a { color: pink; }b { color: red; }")
   tr.ok("a { color: pink;}b { color: red;}")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a { color: pink; }b { color: red; }}")
+  tr.ok("@media print { a { color: pink; }}@media screen { b { color: red; }}")
 
   // Ignore multi-line
   tr.ok("a { color: pink;\ntop: 0; }\nb { color: red; }")
@@ -53,12 +75,18 @@ testRule("never-single-line", tr => {
   tr.notOk("a { color: pink; } b { color: red; }", messages.rejectedAfterSingleLine())
   tr.notOk("a { color: pink; }  b { color: red; }", messages.rejectedAfterSingleLine())
   tr.notOk("a { color: pink; }\tb { color: red; }", messages.rejectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; }\nb { color: red; }}", messages.rejectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; }}\n @media screen { b { color: red; }}", messages.rejectedAfterSingleLine())
 })
 
 testRule("always-multi-line", tr => {
   tr.ok("a { color: pink;\ntop: 0; }")
   tr.ok("a { color: pink;\ntop: 0; }\nb { color: red; }")
   tr.ok("a { color: pink;\ntop: 0;}\n\t\tb { color: red;}")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a {\ncolor: pink; }\nb { color: red; }}")
+  tr.ok("@media print { a {\ncolor: pink; }}\n@media screen { b { color: red; }}")
 
   // Ignore single-line
   tr.ok("a { color: pink; }\nb { color: red; }")
@@ -68,12 +96,18 @@ testRule("always-multi-line", tr => {
   tr.notOk("a { color: pink;\ntop: 0; } b { color: red; }", messages.expectedAfterMultiLine())
   tr.notOk("a { color: pink;\ntop: 0; }  b { color: red; }", messages.expectedAfterMultiLine())
   tr.notOk("a { color: pink;\ntop: 0; }\tb { color: red; }", messages.expectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; } b { color: red; }}", messages.expectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; }} @media screen { b {\ncolor: red; }}", messages.expectedAfterMultiLine())
 })
 
 testRule("never-multi-line", tr => {
   tr.ok("a { color: pink;\ntop: 0; }")
   tr.ok("a { color: pink;\ntop: 0; }b { color: red; }")
   tr.ok("a { color: pink;\ntop: 0;}b { color: red;}")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a {\ncolor: pink; }b { color: red; }}")
+  tr.ok("@media print { a {\ncolor: pink; }}@media screen { b { color: red; }}")
 
   // Ignore single-line
   tr.ok("a { color: pink; }\nb { color: red; }")
@@ -83,4 +117,6 @@ testRule("never-multi-line", tr => {
   tr.notOk("a { color: pink;\ntop: 0; } b { color: red; }", messages.rejectedAfterMultiLine())
   tr.notOk("a { color: pink;\ntop: 0; }  b { color: red; }", messages.rejectedAfterMultiLine())
   tr.notOk("a { color: pink;\ntop: 0; }\tb { color: red; }", messages.rejectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; }\nb { color: red; }}", messages.rejectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; }}\n@media screen { b {\ncolor: red; }}", messages.rejectedAfterMultiLine())
 })

--- a/src/rules/block-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-after/__tests__/index.js
@@ -7,11 +7,19 @@ testRule("always", tr => {
   tr.ok("a { color: pink; }")
   tr.ok("a { color: pink; } b { color: red; }")
   tr.ok("a { color: pink;} b { color: red;}")
+  tr.ok("@media print { a { color: pink; } b { color: red; } }")
+  tr.ok("@media print { a { color: pink; } } @media screen { b { color: red; } }")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a { color: pink; } b { color: red; }}")
+  tr.ok("@media print { a { color: pink; }} @media screen { b { color: red; }}")
 
   tr.notOk("a { color: pink; }b { color: red; }", messages.expectedAfter())
   tr.notOk("a { color: pink; }  b { color: red; }", messages.expectedAfter())
   tr.notOk("a { color: pink; }\nb { color: red; }", messages.expectedAfter())
   tr.notOk("a { color: pink; }\tb { color: red; }", messages.expectedAfter())
+  tr.notOk("@media print { a { color: pink; }b { color: red; }}", messages.expectedAfter())
+  tr.notOk("@media print { a { color: pink; }}@media screen { b { color: red; }}", messages.expectedAfter())
 })
 
 testRule("never", tr => {
@@ -19,10 +27,16 @@ testRule("never", tr => {
   tr.ok("a { color: pink; }b { color: red; }")
   tr.ok("a { color: pink;}b { color: red;}")
 
+  // Ignores nested closing braces
+  tr.ok("@media print { a { color: pink; }b { color: red; } }")
+  tr.ok("@media print { a { color: pink; } }@media screen { b { color: red; } }")
+
   tr.notOk("a { color: pink; } b { color: red; }", messages.rejectedAfter())
   tr.notOk("a { color: pink; }  b { color: red; }", messages.rejectedAfter())
   tr.notOk("a { color: pink; }\nb { color: red; }", messages.rejectedAfter())
   tr.notOk("a { color: pink; }\tb { color: red; }", messages.rejectedAfter())
+  tr.notOk("@media print { a { color: pink; } b { color: red; }}", messages.rejectedAfter())
+  tr.notOk("@media print { a { color: pink; }} @media screen { b { color: red; }}", messages.rejectedAfter())
 })
 
 testRule("always-multi-line", tr => {
@@ -35,8 +49,14 @@ testRule("always-multi-line", tr => {
   tr.ok("a { color: pink; }b { color: red; }")
   tr.ok("a { color: pink;}b { color: red;}")
 
+  // Ignores nested closing braces
+  tr.ok("@media print { a {\ncolor: pink; } b { color: red; }}")
+  tr.ok("@media print { a {\ncolor: pink; }} @media screen { b { color: red; }}")
+
   tr.notOk("a { color: pink;\nbackground: orange;}b { color: red; }", messages.expectedAfterMultiLine())
   tr.notOk("a { color: pink;\nbackground: orange;}  b { color: red; }", messages.expectedAfterMultiLine())
   tr.notOk("a { color: pink;\nbackground: orange;}\nb { color: red; }", messages.expectedAfterMultiLine())
   tr.notOk("a { color: pink;\nbackground: orange;}\tb { color: red; }", messages.expectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; }b { color: red; }}", messages.expectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; }}@media screen { b {\ncolor: red; }}", messages.expectedAfterMultiLine())
 })


### PR DESCRIPTION
As mentioned in #71: I actually didn't need to change any of the code to make it work as we discussed. So I just added tests to ensure it continues to do that.