### PR TITLE
Create and test property-no-vendor-prefix; closes #103

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dist"
   ],
   "dependencies": {
+    "autoprefixer-core": "^5.1.11",
     "postcss": "^4.1.9"
   },
   "devDependencies": {

--- a/src/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/property-no-vendor-prefix/__tests__/index.js
@@ -1,0 +1,20 @@
+import { ruleTester } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(null, tr => {
+  tr.ok("a {}")
+  tr.ok("a { transform: scale(1); }")
+  tr.ok("a { -webkit-font-smoothing: antialiased; }", "non-standard property")
+
+  tr.notOk("a { -webkit-transform: scale(1); }", messages.rejected("-webkit-transform"))
+  tr.notOk(
+    "a { -moz-columns: 2; columns: 2; }",
+    messages.rejected("-moz-columns")
+  )
+  tr.notOk(
+    "a { columns: 2; -o-columns: 2; }",
+    messages.rejected("-o-columns")
+  )
+})

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -1,0 +1,25 @@
+import {
+  ruleMessages,
+  vendorPrefixSets,
+  stripVendorPrefix
+} from "../../utils"
+
+export const ruleName = "property-no-vendor-prefix"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: p => `Unexpected vendor prefix "${p}"`,
+})
+
+export default function () {
+  return function (css, result) {
+    css.eachDecl(function (decl) {
+      const prop = decl.prop
+
+      if (prop[0] !== "-") { return }
+
+      if (vendorPrefixSets.properties.has(stripVendorPrefix(prop))) {
+        result.warn(messages.rejected(prop), { node: decl })
+      }
+    })
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,6 +4,8 @@ import isWhitespace from "./isWhitespace"
 import ruleMessages from "./ruleMessages"
 import whitespaceChecker from "./whitespaceChecker"
 import valueIndexOf from "./valueIndexOf"
+import vendorPrefixSets from "./vendorPrefixSets"
+import stripVendorPrefix from "./stripVendorPrefix"
 
 export default {
   charNeighbor,
@@ -12,4 +14,6 @@ export default {
   ruleMessages,
   whitespaceChecker,
   valueIndexOf,
+  vendorPrefixSets,
+  stripVendorPrefix,
 }

--- a/src/utils/stripVendorPrefix.js
+++ b/src/utils/stripVendorPrefix.js
@@ -1,0 +1,9 @@
+export default function (str) {
+  if (str[0] !== "-") {
+    return str
+  }
+
+  // Return the string after the second hyphen,
+  // which is where the prefix ends
+  return str.slice(str.slice(1).indexOf("-") + 2)
+}

--- a/src/utils/vendorPrefixSets.js
+++ b/src/utils/vendorPrefixSets.js
@@ -1,0 +1,23 @@
+var autoprefixer = require("autoprefixer-core")
+
+const properties = new Set()
+const selectors = new Set()
+const atRules = new Set()
+
+Object.keys(autoprefixer.data.prefixes).forEach(function (item) {
+  if (item[0] === ":") {
+    selectors.add(item)
+    return
+  }
+  if (item[0] === "@") {
+    atRules.add(item)
+    return
+  }
+  properties.add(item)
+})
+
+export default {
+  properties,
+  selectors,
+  atRules,
+}


### PR DESCRIPTION
The method I opted for here is to pull in autoprefixer as a dependency and get its list of data only once, then check properties (and, later, selectors and at-rules) against sets derived from that data. I figured this would be faster than parsing with autoprefixer repeatedly, and more reliable than just looking for non-prefixed versions. 