### PR TITLE
Create and test eol-no-whitespace

### DIFF
--- a/src/rules/eol-no-whitespace/__tests__/index.js
+++ b/src/rules/eol-no-whitespace/__tests__/index.js
@@ -1,0 +1,108 @@
+import { ruleTester } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(null, tr => {
+  tr.ok("", "empty string")
+
+  tr.ok("\n", "no nodes")
+  tr.notOk(" \n", messages.rejected(1), "no nodes with space before newline")
+
+  tr.ok("a {}", "no newline")
+
+  tr.ok("a::before { content: \"  \n\t\n\"; }", "breaking the rule within a string")
+
+  tr.ok("a,\nb {}", "selector delimiter")
+  tr.notOk("a, \nb {}", messages.rejected(1),
+    "selector delimiter with space before newline")
+
+  tr.ok("a\n{}", "before opening brace")
+  tr.notOk("a\t\n{}", messages.rejected(1),
+    "before opening brace with tab before newline")
+
+  tr.ok("a {\n  color: pink; }", "after opening brace with space after newline")
+  tr.notOk("a { \n  color: pink; }", messages.rejected(1),
+    "after opening brace with space before and after newline")
+
+  tr.ok("a { color: pink;\n}", "before closing brace")
+  tr.notOk("a { color: pink; \n}", messages.rejected(1),
+    "before closing brace with space before newline")
+
+  tr.ok("a { color: pink; }\nb { color: orange; }", "after closing brace")
+  tr.notOk("a { color: pink; }\t\nb { color: orange; }", messages.rejected(1),
+    "after closing brace with tab before newline")
+
+  tr.ok("a { color: pink; }\n\n\nb { color: orange; }",
+    "multiple newlines after closing brace")
+  tr.notOk("a { color: pink; } \n\n\nb { color: orange; }", messages.rejected(1))
+  tr.notOk("a { color: pink; }\n \n\nb { color: orange; }", messages.rejected(2))
+  tr.notOk("a { color: pink; }\n\n \nb { color: orange; }", messages.rejected(3))
+
+  tr.ok("a { color: pink;\n  top: 0; }",
+    "between declarations with two spaces after newline")
+  tr.notOk("a { color: pink; \n  top: 0; }", messages.rejected(1),
+    "between declarations with space before and two after newline")
+
+  tr.ok("a { color:\n\tpink; }", "between properties and values with tab after newline")
+  tr.notOk("a { color:\t\n\tpink; }", messages.rejected(1),
+    "between properties and values with tab before and after newline")
+
+  tr.ok("a { background-position: top left,\ntop right; }", "within values")
+  tr.notOk("a { background-position: top left, \ntop right; }", messages.rejected(1),
+    "within values with space before newline")
+
+  tr.ok("@media print,\nscreen {}", "within media query list")
+  tr.notOk("@media print, \nscreen {}", messages.rejected(1),
+    "within media query list with space before newline")
+
+  tr.ok("@media print {\n  a { color: pink; } }",
+    "after opening brace of media query with space after newline")
+  tr.notOk("@media print { \n  a { color: pink; } }", messages.rejected(1),
+    "after opening brace of media query with space before and after newline")
+
+  tr.ok("a\r{}", "carriage return opening brace")
+  tr.notOk("a\t\r{}", messages.rejected(1),
+    "tab before carriage return before opening brace")
+
+  // Realistic lots-of-lines input
+  tr.ok("a\n{\n\tcolor: pink;\n\ttop: 0;\n}")
+  tr.notOk("a \n{\n\tcolor: pink;\n\ttop: 0;\n}", messages.rejected(1))
+  tr.notOk("a\n{\t\n\tcolor: pink;\n\ttop: 0;\n}", messages.rejected(2))
+  tr.notOk("a\n{\n\tcolor: pink; \n\ttop: 0;\n}", messages.rejected(3))
+  tr.notOk("a\n{\n\tcolor: pink;\n\ttop: 0;  \n}", messages.rejected(4))
+
+  tr.ok("@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}")
+  tr.notOk(
+    "@media print { \n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
+    messages.rejected(1)
+  )
+  tr.notOk(
+    "@media print {\n  a { \n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
+    messages.rejected(2)
+  )
+  tr.notOk(
+    "@media print {\n  a {\n  color: pink; \n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
+    messages.rejected(3)
+  )
+  tr.notOk(
+    "@media print {\n  a {\n  color: pink;\n  } \n}\n\n@media screen {\n  b { color: orange; }\n}",
+    messages.rejected(4)
+  )
+  tr.notOk(
+    "@media print {\n  a {\n  color: pink;\n  }\n} \n\n@media screen {\n  b { color: orange; }\n}",
+    messages.rejected(5)
+  )
+  tr.notOk(
+    "@media print {\n  a {\n  color: pink;\n  }\n}\n \n@media screen {\n  b { color: orange; }\n}",
+    messages.rejected(6)
+  )
+  tr.notOk(
+    "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen { \n  b { color: orange; }\n}",
+    messages.rejected(7)
+  )
+  tr.notOk(
+    "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; } \n}",
+    messages.rejected(8)
+  )
+})

--- a/src/rules/eol-no-whitespace/index.js
+++ b/src/rules/eol-no-whitespace/index.js
@@ -1,0 +1,25 @@
+import {
+  ruleMessages,
+  valueIndexOf
+} from "../../utils"
+
+export const ruleName = "eol-no-whitespace"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: line => `Unexpected whitespace at end of line ${line}`,
+})
+
+const whitespacesToReject = [ " ", "\t" ]
+
+export default function declarationNoImportant() {
+  return function (css, result) {
+    let lineCount = 0
+    const rootString = css.source.input.css
+    valueIndexOf({ value: rootString, char: [ "\n", "\r" ] }, function (index) {
+      lineCount++
+      if (whitespacesToReject.indexOf(rootString[index - 1]) !== -1) {
+        result.warn(messages.rejected(lineCount), { node: css })
+      }
+    })
+  }
+}

--- a/src/utils/valueIndexOf.js
+++ b/src/utils/valueIndexOf.js
@@ -16,12 +16,20 @@ const quotes = [ "\"", "'" ]
  * @return {undefined}
  */
 export default function (options, callback) {
-  const { value, insideFunction, outsideFunction } = options
+  const { value, char, insideFunction, outsideFunction } = options
   let isInsideString = false
   let isInsideFunction = false
   let openingQuote
   let openingParenCount = 0
   let count = 0
+
+  const charToFindIsArray = Array.isArray(char)
+  function charMatchesCharToFind(charToCheck) {
+    if (charToFindIsArray) {
+      return char.indexOf(charToCheck) !== -1
+    }
+    return charToCheck === char
+  }
 
   for (let i = 0, l = value.length; i < l; i++) {
     const currentChar = value[i]
@@ -56,7 +64,7 @@ export default function (options, callback) {
     // If we have a match,
     // and it is inside or outside of a function, as requested in options,
     // send it to the callback
-    if (!isInsideString && currentChar === options.char) {
+    if (!isInsideString && charMatchesCharToFind(currentChar)) {
       if (insideFunction && !isInsideFunction) { continue }
       if (outsideFunction && isInsideFunction) { continue }
       count++


### PR DESCRIPTION
Well ... the "hacky" parts about this attempt is that I'm just running through the entire source as a string, looking for newlines (or carriage returns) and independently accumulating a line count for the warning, which gets attached to the root instead of a specific node.

Maybe there's a better way to do it? Maybe not?

If we wanted to attach the warnings to more localized nodes, we'd have to cycle through a variety of node types, instead of running through every character in the source string. We'd have to calculate line numbers relative to the parsed line number for each node. (I don't know whether that would ever turn out to be accurate where this current method, of just counting `\n` and `\r` would be inaccurate.)

@ai I wonder if in your work on PostCSS's parser you've developed some ideas about how this kind of line counting can be done most effectively? Also, if you know of a better way to register these warnings than attaching them to root?

Even if we change the implementation, at the very least this PR will give us some tests to start with.