### PR TITLE
Create and test color-no-invalid-hex; closes #121

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dist"
   ],
   "dependencies": {
+    "color": "^0.8.0",
     "lodash": "^3.9.1",
     "postcss": "^4.1.9"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "dist"
   ],
   "dependencies": {
-    "color": "^0.8.0",
     "lodash": "^3.9.1",
     "postcss": "^4.1.9"
   },

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -15,6 +15,6 @@ testRule(null, tr => {
 
   tr.notOk("a { color: #ababa; }", messages.rejected("#ababa"))
   tr.notOk("a { something: #00, #fff, #ababab; }", messages.rejected("#00"))
-  tr.notOk("a { something: #000, #fff1ap, #ababab; }", messages.rejected("#fff1ap"))
+  tr.notOk("a { something: #000, #fff1az, #ababab; }", messages.rejected("#fff1az"))
   tr.notOk("a { something: #000, #fff, #12345aa; }", messages.rejected("#12345aa"))
 })

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -1,0 +1,18 @@
+import { ruleTester } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(null, tr => {
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: #000; }")
+  tr.ok("a { something: #000, #fff, #ababab; }")
+
+  tr.ok("a { padding: 000; }")
+  tr.ok("a::before { content: \"#ababa\"; }")
+
+  tr.notOk("a { color: #ababa; }", messages.rejected("#ababa"))
+  tr.notOk("a { something: #00, #fff, #ababab; }", messages.rejected("#00"))
+  tr.notOk("a { something: #000, #fff1ap, #ababab; }", messages.rejected("#fff1ap"))
+  tr.notOk("a { something: #000, #fff, #12345aa; }", messages.rejected("#12345aa"))
+})

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -7,6 +7,8 @@ testRule(null, tr => {
   tr.ok("a { color: pink; }")
   tr.ok("a { color: #000; }")
   tr.ok("a { something: #000, #fff, #ababab; }")
+  tr.ok("a { color: #0000ffcc; }", "eight digits")
+  tr.ok("a { color: #00fc; }", "four digits")
 
   tr.ok("a { padding: 000; }")
   tr.ok("a::before { content: \"#ababa\"; }")

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -1,0 +1,31 @@
+import color from "color"
+import {
+  ruleMessages,
+  valueIndexOf
+} from "../../utils"
+
+export const ruleName = "color-no-invalid-hex"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: c => `Invalid hex color "${c}"`,
+})
+
+export default function () {
+  return function (css, result) {
+    css.eachDecl(function (decl) {
+      const value = decl.value
+
+      valueIndexOf({ value, char: "#" }, hashIndex => {
+        const hexValue = /^#[0-9A-Za-z]+/.exec(value.substr(hashIndex))[0]
+        try {
+          color(hexValue)
+        } catch (err) {
+          // Ensure that this is the error we are looking for
+          if (err.message.slice(0, 21) === "Unable to parse color") {
+            result.warn(messages.rejected(hexValue), { node: decl })
+          }
+        }
+      })
+    })
+  }
+}

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -1,4 +1,3 @@
-import color from "color"
 import {
   ruleMessages,
   valueIndexOf
@@ -17,13 +16,9 @@ export default function () {
 
       valueIndexOf({ value, char: "#" }, hashIndex => {
         const hexValue = /^#[0-9A-Za-z]+/.exec(value.substr(hashIndex))[0]
-        try {
-          color(hexValue)
-        } catch (err) {
-          // Ensure that this is the error we are looking for
-          if (err.message.slice(0, 21) === "Unable to parse color") {
-            result.warn(messages.rejected(hexValue), { node: decl })
-          }
+
+        if (!/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(hexValue)) {
+          result.warn(messages.rejected(hexValue), { node: decl })
         }
       })
     })


### PR DESCRIPTION
I pulled in the `color` module here. I'm sure it will be useful for the other color-related rules.