### PR TITLE
Create and test string-quotes; closes #96

### DIFF
--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -1,0 +1,32 @@
+import { ruleTester } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule("single", tr => {
+  tr.ok("")
+  tr.ok("a { color: pink; }")
+  tr.ok("a::before { content: 'foo'; }")
+  tr.ok("a::before { content: 'foo\"horse\"\'cow\''; }")
+  tr.ok("a { background: url('foo'); }")
+  tr.ok("a[id='foo'] {}")
+
+  tr.notOk("a::before { content: \"foo\"; }", messages.expected("single", 1))
+  tr.notOk("a::before\n{\n  content: \"foo\";\n}", messages.expected("single", 3))
+  tr.notOk("a[id=\"foo\"] {}", messages.expected("single", 1))
+  tr.notOk("a { background: url(\"foo\"); }", messages.expected("single", 1))
+})
+
+testRule("double", tr => {
+  tr.ok("")
+  tr.ok("a { color: pink; }")
+  tr.ok("a::before { content: \"foo\"; }")
+  tr.ok(`a::before { content: "foo\"horse\"'cow'"; }`)
+  tr.ok("a { background: url(\"foo\"); }")
+  tr.ok("a[id=\"foo\"] {}")
+
+  tr.notOk("a::before { content: 'foo'; }", messages.expected("double", 1))
+  tr.notOk("a::before\n{\n  content: 'foo';\n}", messages.expected("double", 3))
+  tr.notOk("a[id='foo'] {}", messages.expected("double", 1))
+  tr.notOk("a { background: url('foo'); }", messages.expected("double", 1))
+})

--- a/src/rules/string-quotes/index.js
+++ b/src/rules/string-quotes/index.js
@@ -1,0 +1,29 @@
+import {
+  ruleMessages,
+  valueIndexOf,
+  lineCount
+} from "../../utils"
+
+export const ruleName = "string-quotes"
+
+export const messages = ruleMessages(ruleName, {
+  expected: (q, l) => `Expected ${q} quotes around string on line ${l}`,
+})
+
+/**
+ * @param {"single"|"double"} expectation
+ */
+export default function (expectation) {
+
+  const erroneousQuote = (expectation === "single") ? "\"" : "'"
+
+  return function (root, result) {
+    const cssString = root.source.input.css
+    valueIndexOf({ value: cssString, char: erroneousQuote }, index => {
+      result.warn(
+        messages.expected(expectation, lineCount(cssString.slice(0, index))),
+        { node: root }
+      )
+    })
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,6 +4,7 @@ import isWhitespace from "./isWhitespace"
 import ruleMessages from "./ruleMessages"
 import whitespaceChecker from "./whitespaceChecker"
 import valueIndexOf from "./valueIndexOf"
+import lineCount from "./lineCount"
 
 export default {
   charNeighbor,
@@ -12,4 +13,5 @@ export default {
   ruleMessages,
   whitespaceChecker,
   valueIndexOf,
+  lineCount,
 }

--- a/src/utils/lineCount.js
+++ b/src/utils/lineCount.js
@@ -1,0 +1,9 @@
+/**
+ * Count the lines in a string.
+ *
+ * @param {string} source
+ * @returns {number} Line count
+ */
+export default function (source) {
+  return source.split(/(?:\r\n|\n|\r)/g).length
+}

--- a/src/utils/ruleMessages.js
+++ b/src/utils/ruleMessages.js
@@ -11,7 +11,7 @@ export default function (ruleName, messages) {
     const value = messages[k]
     r[k] = (typeof value === "string")
       ? `${value} (${ruleName})`
-      : x => `${value(x)} (${ruleName})`
+      : (...args) => `${value(...args)} (${ruleName})`
     return r
   }, {})
 }

--- a/src/utils/valueIndexOf.js
+++ b/src/utils/valueIndexOf.js
@@ -37,6 +37,11 @@ export default function (options, callback) {
       if (value[i - 1] === "\\") { continue }
       openingQuote = currentChar
       isInsideString = true
+
+      // For string-quotes rule
+      if (charMatchesCharToFind(currentChar)) {
+        matchFound(i)
+      }
       continue
     }
     if (isInsideString && currentChar === openingQuote) {
@@ -67,9 +72,13 @@ export default function (options, callback) {
     if (!isInsideString && charMatchesCharToFind(currentChar)) {
       if (insideFunction && !isInsideFunction) { continue }
       if (outsideFunction && isInsideFunction) { continue }
-      count++
-      callback(i, count)
+      matchFound(i)
       if (options.onlyOne) { return }
     }
+  }
+
+  function matchFound(i) {
+    count++
+    callback(i, count)
   }
 }


### PR DESCRIPTION
For this I also made a utility function that gets the line count. It's probably more reliable than the method I used in `eol-no-whitespace`, so I should switch that out.