### PR TITLE
Create and test property-no-vendor-prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dist"
   ],
   "dependencies": {
+    "autoprefixer-core": "^5.1.11",
     "lodash": "^3.9.1",
     "postcss": "^4.1.9"
   },

--- a/src/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/property-no-vendor-prefix/__tests__/index.js
@@ -1,0 +1,22 @@
+import { ruleTester } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(null, tr => {
+  tr.ok("a {}")
+  tr.ok(":root { --foo-bar: 1px; }")
+  tr.ok("a { color: pink; --webkit-transform: 1px; }")
+  tr.ok("a { transform: scale(1); }")
+  tr.ok("a { box-sizing: border-box; }")
+  tr.ok("a { -webkit-font-smoothing: antialiased; }", "non-standard prefixed property")
+
+  tr.notOk("a { -webkit-transform: scale(1); }", messages.rejected("-webkit-transform"))
+  tr.notOk("a { -webkit-transform: scale(1); transform: scale(1); }", messages.rejected("-webkit-transform"))
+  tr.notOk("a { transform: scale(1); -webkit-transform: scale(1); }", messages.rejected("-webkit-transform"))
+  tr.notOk("a { -moz-transition: all 3s; }", messages.rejected("-moz-transition"))
+  tr.notOk("a { -moz-columns: 2; }", messages.rejected("-moz-columns"))
+
+  tr.notOk("a { -o-columns: 2; }", messages.rejected("-o-columns"), "mistaken prefix")
+  tr.notOk("a { -ms-interpolation-mode: nearest-neighbor; }", messages.rejected("-ms-interpolation-mode"), "\"hack\" prefix")
+})

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -1,0 +1,26 @@
+import {
+  ruleMessages,
+  isAutoprefixable
+} from "../../utils"
+
+export const ruleName = "property-no-vendor-prefix"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: p => `Unexpected vendor-prefixed property "${p}"`,
+})
+
+export default function () {
+  return function (css, result) {
+    css.eachDecl(function (decl) {
+      const prop = decl.prop
+
+      // Make sure there's a vendor prefix,
+      // but this isn't a custom property
+      if (prop[0] !== "-" || prop[1] === "-") { return }
+
+      if (isAutoprefixable(prop)) {
+        result.warn(messages.rejected(prop), { node: decl })
+      }
+    })
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,6 +5,7 @@ import ruleMessages from "./ruleMessages"
 import whitespaceChecker from "./whitespaceChecker"
 import valueIndexOf from "./valueIndexOf"
 import lineCount from "./lineCount"
+import isAutoprefixable from "./isAutoprefixable"
 
 export default {
   charNeighbor,
@@ -14,4 +15,5 @@ export default {
   whitespaceChecker,
   valueIndexOf,
   lineCount,
+  isAutoprefixable,
 }

--- a/src/utils/isAutoprefixable.js
+++ b/src/utils/isAutoprefixable.js
@@ -1,0 +1,20 @@
+import autoprefixer from "autoprefixer-core"
+import Prefixes from "autoprefixer-core/lib/prefixes"
+import Browsers from "autoprefixer-core/lib/browsers"
+
+const prefixes = new Prefixes(
+  autoprefixer.data.prefixes,
+  new Browsers(autoprefixer.data.browsers, [])
+)
+
+/**
+ * Determine whether a vendor-prefixed CSS identifier
+ * would be added by Autoprefixer if the standard
+ * version of the identifier were used.
+ *
+ * @param {string} prefixedIdent
+ * @return {boolean}
+ */
+export default function (prefixedIdent) {
+  return autoprefixer.data.prefixes[prefixes.unprefixed(prefixedIdent)]
+}


### PR DESCRIPTION
Exemplifies method devised in #103. After this is merged, `isAutoprefixable()` can be used for other `no-vendor-prefix` rules.