### PR TITLE
Stylesearch match object

### DIFF
--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -14,8 +14,9 @@ export default function () {
     css.eachDecl(function (decl) {
       const value = decl.value
 
-      styleSearch({ source: value, target: "#" }, hashIndex => {
-        const hexValue = /^#[0-9A-Za-z]+/.exec(value.substr(hashIndex))[0]
+      styleSearch({ source: value, target: "#" }, match => {
+        console.log(match)
+        const hexValue = /^#[0-9A-Za-z]+/.exec(value.substr(match.startIndex))[0]
 
         if (!/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(hexValue)) {
           result.warn(messages.rejected(hexValue), { node: decl })

--- a/src/rules/declaration-comma-space-after/index.js
+++ b/src/rules/declaration-comma-space-after/index.js
@@ -24,8 +24,8 @@ export function declarationCommaSpaceChecker(checkLocation) {
     css.eachDecl(function (decl) {
       const value = decl.value
 
-      styleSearch({ source: value, target: ",", outsideFunctionalNotation: true }, index => {
-        checkComma(value, index, decl)
+      styleSearch({ source: value, target: ",", outsideFunctionalNotation: true }, match => {
+        checkComma(value, match.startIndex, decl)
       })
     })
 

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -28,7 +28,9 @@ export default function () {
         checkSymbol("/")
 
         function checkSymbol(symbol) {
-          styleSearch({ source: expression, target: symbol, outsideFunctionalNotation: true }, index => {
+          styleSearch({ source: expression, target: symbol, outsideFunctionalNotation: true }, match => {
+            const index = match.startIndex
+
             // Deal with signs
             if ((symbol === "+" || symbol === "-") && /\d/.test(expression[index + 1])) {
               const expressionBeforeSign = expression.substr(0, index)

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -24,8 +24,8 @@ export function functionCommaSpaceChecker(checkLocation) {
     css.eachDecl(function (decl) {
       const value = decl.value
 
-      styleSearch({ source: value, target: ",", withinFunctionalNotation: true }, index => {
-        checkComma(value, index, decl)
+      styleSearch({ source: value, target: ",", withinFunctionalNotation: true }, match => {
+        checkComma(value, match.startIndex, decl)
       })
     })
 

--- a/src/rules/function-parentheses-inside-space/index.js
+++ b/src/rules/function-parentheses-inside-space/index.js
@@ -21,11 +21,11 @@ export default function (expectation) {
     css.eachDecl(function (decl) {
       const value = decl.value
 
-      styleSearch({ source: value, target: "(" }, index => {
-        checkOpening(value, index, decl)
+      styleSearch({ source: value, target: "(" }, match => {
+        checkOpening(value, match.startIndex, decl)
       })
-      styleSearch({ source: value, target: ")" }, index => {
-        checkClosing(value, index, decl)
+      styleSearch({ source: value, target: ")" }, match => {
+        checkClosing(value, match.startIndex, decl)
       })
     })
 

--- a/src/rules/function-space-after/index.js
+++ b/src/rules/function-space-after/index.js
@@ -21,8 +21,8 @@ export default function (expectation) {
     css.eachDecl(function (decl) {
       const value = decl.value
 
-      styleSearch({ source: value, target: ")" }, index => {
-        checkClosingParen(value, index, decl)
+      styleSearch({ source: value, target: ")" }, match => {
+        checkClosingParen(value, match.startIndex, decl)
       })
     })
 

--- a/src/rules/function-token-no-space/index.js
+++ b/src/rules/function-token-no-space/index.js
@@ -15,8 +15,8 @@ export default function () {
     css.eachDecl(function (decl) {
       const value = decl.value
 
-      styleSearch({ source: value, target: "(" }, index => {
-        checkOpeningParen(value, index, decl)
+      styleSearch({ source: value, target: "(" }, match => {
+        checkOpeningParen(value, match.startIndex, decl)
       })
     })
 

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -103,11 +103,11 @@ export default function (options) {
         : declLevel + 1
       const postNewlineExpected = repeat(indentChar, valueLevel)
 
-      styleSearch({ source: value, target: "\n" }, (newlineIndex, newlineCount) => {
+      styleSearch({ source: value, target: "\n" }, (match, newlineCount) => {
         // Starting at the index after the newline, we want to
         // check that the whitespace characters before the first
         // non-whitespace character equal the expected indentation
-        const postNewlineActual = /^(\s*)\S/.exec(value.slice(newlineIndex + 1))[1]
+        const postNewlineActual = /^(\s*)\S/.exec(value.slice(match.startIndex + 1))[1]
 
         if (postNewlineActual !== postNewlineExpected) {
           result.warn(

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -23,8 +23,8 @@ export function mediaFeatureColonSpaceChecker(checkLocation) {
   return function (css, result) {
     css.eachAtRule(function (atRule) {
       const params = atRule.params
-      styleSearch({ source: params, target: ":" }, index => {
-        checkColon(params, index, atRule)
+      styleSearch({ source: params, target: ":" }, match => {
+        checkColon(params, match.startIndex, atRule)
       })
     })
 

--- a/src/rules/media-query-parentheses-inside-space/index.js
+++ b/src/rules/media-query-parentheses-inside-space/index.js
@@ -22,8 +22,8 @@ export default function (expectation) {
 
       const params = atRule.params
 
-      styleSearch({ source: params, target: "(" }, index => {
-        const nextCharIsSpace = params[index + 1] === " "
+      styleSearch({ source: params, target: "(" }, match => {
+        const nextCharIsSpace = params[match.startIndex + 1] === " "
         if (nextCharIsSpace && expectation === "never") {
           result.warn(messages.rejectedOpening, { node: atRule })
         }
@@ -32,8 +32,8 @@ export default function (expectation) {
         }
       })
 
-      styleSearch({ source: params, target: ")" }, index => {
-        const prevCharIsSpace = params[index - 1] === " "
+      styleSearch({ source: params, target: ")" }, match => {
+        const prevCharIsSpace = params[match.startIndex - 1] === " "
         if (prevCharIsSpace && expectation === "never") {
           result.warn(messages.rejectedClosing, { node: atRule })
         }

--- a/src/rules/no-eol-whitespace/index.js
+++ b/src/rules/no-eol-whitespace/index.js
@@ -15,9 +15,9 @@ export default function () {
   return function (css, result) {
     let lineCount = 0
     const rootString = css.source.input.css
-    styleSearch({ source: rootString, target: [ "\n", "\r" ] }, function (index) {
+    styleSearch({ source: rootString, target: [ "\n", "\r" ] }, match => {
       lineCount++
-      if (whitespacesToReject.indexOf(rootString[index - 1]) !== -1) {
+      if (whitespacesToReject.indexOf(rootString[match.startIndex - 1]) !== -1) {
         result.warn(messages.rejected(lineCount), { node: css })
       }
     })

--- a/src/rules/property-value-no-vendor-prefix/index.js
+++ b/src/rules/property-value-no-vendor-prefix/index.js
@@ -17,8 +17,8 @@ export default function () {
     css.eachDecl(function (decl) {
       const { prop, value } = decl
 
-      styleSearch({ source: value, target: valuePrefixes }, index => {
-        const fullIdentifier = /^(-[a-z-]+)\b/.exec(value.slice(index))[1]
+      styleSearch({ source: value, target: valuePrefixes }, match => {
+        const fullIdentifier = /^(-[a-z-]+)\b/.exec(value.slice(match.startIndex))[1]
         if (isAutoprefixable.propertyValue(prop, fullIdentifier)) {
           result.warn(messages.rejected(fullIdentifier), { node: decl })
         }

--- a/src/rules/selector-delimiter-space-after/index.js
+++ b/src/rules/selector-delimiter-space-after/index.js
@@ -22,8 +22,8 @@ export function selectorDelimiterSpaceChecker(checkLocation) {
   return function (css, result) {
     css.eachRule(function (rule) {
       const selector = rule.selector
-      styleSearch({ source: selector, target: "," }, function (index) {
-        checkDelimiter(selector, index, rule)
+      styleSearch({ source: selector, target: "," }, match => {
+        checkDelimiter(selector, match.startIndex, rule)
       })
     })
 

--- a/src/rules/selector-no-vendor-prefix/index.js
+++ b/src/rules/selector-no-vendor-prefix/index.js
@@ -16,8 +16,8 @@ export default function () {
       const selector = rule.selector
 
       // Check each pseudo-selector
-      styleSearch({ source: selector, target: ":" }, index => {
-        const pseudoSelector = /:{1,2}[a-z-]+\b/.exec(selector.slice(index))[0]
+      styleSearch({ source: selector, target: ":" }, match => {
+        const pseudoSelector = /:{1,2}[a-z-]+\b/.exec(selector.slice(match.startIndex))[0]
         if (isAutoprefixable.selector(pseudoSelector)) {
           result.warn(messages.rejected(pseudoSelector), { node: rule })
         }

--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -14,7 +14,7 @@ testRule("single", tr => {
   tr.notOk("a::before { content: \"foo\"; }", messages.expected("single", 1))
   tr.notOk("a::before\n{\n  content: \"foo\";\n}", messages.expected("single", 3))
   tr.notOk("a[id=\"foo\"] {}", messages.expected("single", 1))
-  tr.notOk("a { background: url(\"foo\"); }", messages.expected("single", 1))
+  tr.notOk("a\n{ background: url(\"foo\"); }", messages.expected("single", 2))
 })
 
 testRule("double", tr => {

--- a/src/rules/string-quotes/index.js
+++ b/src/rules/string-quotes/index.js
@@ -19,9 +19,9 @@ export default function (expectation) {
 
   return function (root, result) {
     const cssString = root.source.input.css
-    styleSearch({ source: cssString, target: erroneousQuote }, index => {
+    styleSearch({ source: cssString, target: erroneousQuote }, match => {
       result.warn(
-        messages.expected(expectation, lineCount(cssString.slice(0, index))),
+        messages.expected(expectation, lineCount(cssString.slice(0, match.startIndex))),
         { node: root }
       )
     })

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -214,6 +214,6 @@ test("array target", t => {
 
 function styleSearchResults(options) {
   const results = []
-  styleSearch(options, i => results.push(i))
+  styleSearch(options, match => results.push(match.startIndex))
   return results
 }

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -212,6 +212,28 @@ test("array target", t => {
   t.end()
 })
 
+test("match object", t => {
+  styleSearch({ source: "abc", target: "bc" }, match => {
+    t.equal(match.startIndex, 1)
+    t.equal(match.endIndex, 3)
+    t.equal(match.target, "bc")
+  })
+
+  const twoMatches = []
+  styleSearch({ source: "abc bca", target: [ "bc ", "ca" ] }, match => {
+    twoMatches.push(match)
+  })
+  const firstMatch = twoMatches[0]
+  const secondMatch = twoMatches[1]
+  t.equal(firstMatch.startIndex, 1)
+  t.equal(firstMatch.endIndex, 4)
+  t.equal(firstMatch.target, "bc ")
+  t.equal(secondMatch.startIndex, 5)
+  t.equal(secondMatch.endIndex, 7)
+  t.equal(secondMatch.target, "ca")
+  t.end()
+})
+
 function styleSearchResults(options) {
   const results = []
   styleSearch(options, match => results.push(match.startIndex))

--- a/src/utils/functionArguments.js
+++ b/src/utils/functionArguments.js
@@ -14,9 +14,9 @@ import styleSearch from "./styleSearch"
  *   as the argument
  */
 export default function (source, functionName, callback) {
-  styleSearch({ source, target: functionName }, index => {
-    if (source[index + functionName.length] !== "(") { return }
-    const parensMatch = balanacedMatch("(", ")", source.substr(index))
+  styleSearch({ source, target: functionName }, match => {
+    if (source[match.endIndex] !== "(") { return }
+    const parensMatch = balanacedMatch("(", ")", source.substr(match.startIndex))
     callback(parensMatch.body)
   })
 }

--- a/src/utils/styleSearch.js
+++ b/src/utils/styleSearch.js
@@ -37,9 +37,9 @@ export default function (options, callback) {
     if (!targetIsArray) {
       return checkChar.bind(null, target)
     }
-    return () => {
+    return (index) => {
       for (let ti = 0, tl = target.length; ti < tl; ti++) {
-        const checkResult = checkChar(target[ti])
+        const checkResult = checkChar(target[ti], index)
         if (checkResult) { return checkResult }
       }
       return false
@@ -86,7 +86,7 @@ export default function (options, callback) {
 
       // For string-quotes rule
       if (target === currentChar) {
-        matchFound(i)
+        matchFound(checkAgainstTarget(i))
       }
       continue
     }

--- a/src/utils/styleSearch.js
+++ b/src/utils/styleSearch.js
@@ -4,6 +4,11 @@
  * Ignores any matches within CSS strings. Optionally restricts
  * the search to characters within or outside of functional notation.
  *
+ * Returns a `match` object with the following properties:
+ * - startIndex
+ * - endIndex
+ * - target
+ *
  * @param {object} options
  * @param {string} options.source - The source to search through
  * @param {string|string[]} options.target - The target of the search. Can be
@@ -32,10 +37,12 @@ export default function (options, callback) {
     if (!targetIsArray) {
       return checkChar.bind(null, target)
     }
-    return function (index) {
-      return target.some(t => {
-        return checkChar(t, index)
-      })
+    return () => {
+      for (let ti = 0, tl = target.length; ti < tl; ti++) {
+        const checkResult = checkChar(target[ti])
+        if (checkResult) { return checkResult }
+      }
+      return false
     }
   }())
 
@@ -43,12 +50,20 @@ export default function (options, callback) {
     const targetStringLength = targetString.length
 
     // Target is a single character
-    if (targetStringLength === 1) {
-      return source[index] === targetString
+    if (targetStringLength === 1 && source[index] !== targetString) {
+      return false
     }
 
     // Target is multiple characters
-    return source.substr(index, targetStringLength) === targetString
+    if (source.substr(index, targetStringLength) !== targetString) {
+      return false
+    }
+
+    return {
+      startIndex: index,
+      endIndex: index + targetStringLength,
+      target: targetString,
+    }
   }
 
   let insideString = false
@@ -119,19 +134,21 @@ export default function (options, callback) {
       }
     }
 
-    if (checkAgainstTarget(i)) {
-      // If we have a match,
-      // and it is inside or outside of a function, as requested in options,
-      // send it to the callback
-      if (withinFunctionalNotation && !insideFunction) { continue }
-      if (outsideFunctionalNotation && insideFunction) { continue }
-      matchFound(i)
-      if (options.onlyOne) { return }
-    }
+    const match = checkAgainstTarget(i)
+
+    if (!match) { continue }
+
+    // If we have a match,
+    // and it is inside or outside of a function, as requested in options,
+    // send it to the callback
+    if (withinFunctionalNotation && !insideFunction) { continue }
+    if (outsideFunctionalNotation && insideFunction) { continue }
+    matchFound(match)
+    if (options.onlyOne) { return }
   }
 
-  function matchFound(i) {
+  function matchFound(match) {
     matchCount++
-    callback(i, matchCount)
+    callback(match, matchCount)
   }
 }


### PR DESCRIPTION
This refactor of styleSearch means that it now passes the callback an object instead of just the index. That way we can tack more information onto this object as needed. For example, if I passed in an array as the `target` argument I wanted to be able to know which string in the array a particular match pertains to.