### PR TITLE
Add selector-pseudo-element-colon-notation

### DIFF
--- a/src/rules/selector-pseudo-element-colon-notation/README.md
+++ b/src/rules/selector-pseudo-element-colon-notation/README.md
@@ -1,0 +1,113 @@
+# selector-pseudo-element-colon-notation
+
+Specify single or double colon notation for applicable pseudo-elements.
+
+```css
+    a::before { color:pink; }
+/**  ↑
+ * This notation */
+```
+
+The `::` notation was chosen for *pseudo-elements* to establish a discrimination between *pseudo-classes* (which subclass existing elements) and *pseudo-elements* (which are elements not represented in the document tree).
+
+However, for compatibility with existing style sheets, user agents also accept the previous one-colon notation for *pseudo-elements* introduced in CSS levels 1 and 2 (namely, `:first-line`, `:first-letter`, `:before` and `:after`).
+
+## Options
+
+`string`: `"single"|"double"`
+
+### `"single"`
+
+Applicable pseudo-elements *must always* use the single colon notation.
+
+The following patterns are considered warnings:
+
+```css
+a::before { color: pink; }
+```
+
+```css
+a::after { color: pink; }
+```
+
+```css
+a::first-letter { color: pink; }
+```
+
+```css
+a::first-line { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a:before { color: pink; }
+```
+
+```css
+a:after { color: pink; }
+```
+
+```css
+a:first-letter { color: pink; }
+```
+
+```css
+a:first-line { color: pink; }
+```
+
+```css
+input::placeholder { color: pink; }
+```
+
+```css
+li::marker { font-variant-numeric: tabular-nums; }
+```
+
+### `"double"`
+
+Applicable pseudo-elements *must always* use the double colon notation.
+
+The following patterns are considered warnings:
+
+```css
+a:before { color: pink; }
+```
+
+```css
+a:after { color: pink; }
+```
+
+```css
+a:first-letter { color: pink; }
+```
+
+```css
+a:first-line { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a::before { color: pink; }
+```
+
+```css
+a::after { color: pink; }
+```
+
+```css
+a::first-letter { color: pink; }
+```
+
+```css
+a::first-line { color: pink; }
+```
+
+```css
+input::placeholder { color: pink; }
+```
+
+```css
+li::marker { font-variant-numeric: tabular-nums; }
+```

--- a/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -1,0 +1,44 @@
+import { ruleTester } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule("single", tr => {
+  tr.ok("")
+  tr.ok("a { color: pink; }")
+  tr.ok("::selection { color: pink; }")
+  tr.ok("a::spelling-error { color: pink; }")
+  tr.ok("a::grammar-error { color: pink; }")
+  tr.ok("li::marker { font-variant-numeric: tabular-nums; }")
+  tr.ok("input::placeholder { color: pink; }")
+
+  tr.ok("a:before { color: pink; }")
+  tr.ok("a:after { color: pink; }")
+  tr.ok("a:first-letter { color: pink; }")
+  tr.ok("a:first-line { color: pink; }")
+
+  tr.notOk("a::before { color: pink; }", messages.expected("single"))
+  tr.notOk("a::after { color: pink; }", messages.expected("single"))
+  tr.notOk("a::first-line { color: pink; }", messages.expected("single"))
+  tr.notOk("a::first-letter { color: pink; }", messages.expected("single"))
+})
+
+testRule("double", tr => {
+  tr.ok("")
+  tr.ok("a { color: pink; }")
+  tr.ok("::selection { color: pink; }")
+  tr.ok("a::spelling-error { color: pink; }")
+  tr.ok("a::grammar-error { color: pink; }")
+  tr.ok("li::marker { font-variant-numeric: tabular-nums; }")
+  tr.ok("input::placeholder { color: pink; }")
+
+  tr.ok("a::before { color: pink; }")
+  tr.ok("a::after { color: pink; }")
+  tr.ok("a::first-letter { color: pink; }")
+  tr.ok("a::first-line { color: pink; }")
+
+  tr.notOk("a:before { color: pink; }", messages.expected("double"))
+  tr.notOk("a:after { color: pink; }", messages.expected("double"))
+  tr.notOk("a:first-line { color: pink; }", messages.expected("double"))
+  tr.notOk("a:first-letter { color: pink; }", messages.expected("double"))
+})

--- a/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -16,6 +16,7 @@ testRule("single", tr => {
   tr.ok("a:after { color: pink; }")
   tr.ok("a:first-letter { color: pink; }")
   tr.ok("a:first-line { color: pink; }")
+  tr.ok("a:before, a[data-before='before'] { color: pink; }")
 
   tr.notOk("a::before { color: pink; }", messages.expected("single"))
   tr.notOk("a::after { color: pink; }", messages.expected("single"))
@@ -26,6 +27,7 @@ testRule("single", tr => {
 testRule("double", tr => {
   tr.ok("")
   tr.ok("a { color: pink; }")
+
   tr.ok("::selection { color: pink; }")
   tr.ok("a::spelling-error { color: pink; }")
   tr.ok("a::grammar-error { color: pink; }")
@@ -36,6 +38,7 @@ testRule("double", tr => {
   tr.ok("a::after { color: pink; }")
   tr.ok("a::first-letter { color: pink; }")
   tr.ok("a::first-line { color: pink; }")
+  tr.ok("a::before, a[data-before='before'] { color: pink; }")
 
   tr.notOk("a:before { color: pink; }", messages.expected("double"))
   tr.notOk("a:after { color: pink; }", messages.expected("double"))

--- a/src/rules/selector-pseudo-element-colon-notation/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/index.js
@@ -1,0 +1,38 @@
+import {
+  ruleMessages,
+  styleSearch
+} from "../../utils"
+
+export const ruleName = "selector-psuedo-element-colon-notation"
+
+export const messages = ruleMessages(ruleName, {
+  expected: (q) => `Expected ${q} colon pseudo-element notation`,
+})
+
+/**
+ * @param {"single"|"double"} expectation
+ */
+export default function (expectation) {
+
+  return function (css, result) {
+
+    css.eachRule(function (rule) {
+      const selector = rule.selector
+
+      // get out early if no pseudo elements or classes
+      if (selector.indexOf(":") === -1) { return }
+
+      // match only level 1 and 2 pseudo elements
+      styleSearch({ source: selector, target: [ "before", "after", "first-line", "first-letter" ] }, match => {
+
+        let prevChar = selector[match.startIndex - 2]
+
+        if (expectation === "single" && prevChar === ":") {
+          result.warn(messages.expected("single"), { node: rule })
+        } else if (expectation === "double" && prevChar !== ":") {
+          result.warn(messages.expected("double"), { node: rule })
+        }
+      })
+    })
+  }
+}

--- a/src/rules/selector-pseudo-element-colon-notation/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/index.js
@@ -25,13 +25,12 @@ export default function (expectation) {
       // match only level 1 and 2 pseudo elements
       styleSearch({ source: selector, target: [ ":before", ":after", ":first-line", ":first-letter" ] }, match => {
 
-        let prevChar = selector[match.startIndex - 1]
+        const prevCharIsColon = selector[match.startIndex - 1] === ":"
 
-        if (expectation === "single" && prevChar === ":") {
-          result.warn(messages.expected("single"), { node: rule })
-        } else if (expectation === "double" && prevChar !== ":") {
-          result.warn(messages.expected("double"), { node: rule })
-        }
+        if (expectation === "single" && !prevCharIsColon) { return }
+        if (expectation === "double" && prevCharIsColon) { return }
+
+        result.warn(messages.expected(expectation), { node: rule })
       })
     })
   }

--- a/src/rules/selector-pseudo-element-colon-notation/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/index.js
@@ -23,9 +23,9 @@ export default function (expectation) {
       if (selector.indexOf(":") === -1) { return }
 
       // match only level 1 and 2 pseudo elements
-      styleSearch({ source: selector, target: [ "before", "after", "first-line", "first-letter" ] }, match => {
+      styleSearch({ source: selector, target: [ ":before", ":after", ":first-line", ":first-letter" ] }, match => {
 
-        let prevChar = selector[match.startIndex - 2]
+        let prevChar = selector[match.startIndex - 1]
 
         if (expectation === "single" && prevChar === ":") {
           result.warn(messages.expected("single"), { node: rule })


### PR DESCRIPTION
I finally got around to doing this one :)

Is there a better way to do this conditional?

```js
if (expectation === "single" && prevChar === ":") {
  result.warn(messages.expected("single"), { node: rule })
} else if (expectation === "double" && prevChar !== ":") {
  result.warn(messages.expected("double"), { node: rule })
}
```

Closes #74 
