### PR TITLE
Add rules.md generator. Closes #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ postcss()
 
 #### Configuring rules
 
-Rules are configured within the `rules` key of the config. Each rule can be turned off or on: 
+[Rules](docs/rules.md) are configured within the `rules` key of the config. Each rule can be turned off or on: 
 
 * 0 - turn the rule off
 * 2 - turn the rule on

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,54 @@
+# Rules
+
+* [`at-rule-no-vendor-prefix`](../src/rules/at-rule-no-vendor-prefix/README.md): Disallow vendor prefixes for @rules.
+* [`block-closing-brace-newline-after`](../src/rules/block-closing-brace-newline-after/README.md): Require or disallow a newline after the closing brace of blocks.
+* [`block-closing-brace-newline-before`](../src/rules/block-closing-brace-newline-before/README.md): Require or disallow a newline before the closing brace blocks.
+* [`block-closing-brace-space-after`](../src/rules/block-closing-brace-space-after/README.md): Require or disallow a space after the closing brace of blocks.
+* [`block-closing-brace-space-before`](../src/rules/block-closing-brace-space-before/README.md): Require or disallow a space before the closing brace of blocks.
+* [`block-no-empty`](../src/rules/block-no-empty/README.md): Disallow empty blocks.
+* [`block-opening-brace-newline-after`](../src/rules/block-opening-brace-newline-after/README.md): Require or disallow a newline after the opening brace of blocks.
+* [`block-opening-brace-newline-before`](../src/rules/block-opening-brace-newline-before/README.md): Require or disallow a newline before the opening brace of blocks.
+* [`block-opening-brace-space-after`](../src/rules/block-opening-brace-space-after/README.md): Require or disallow a space after the opening brace of blocks.
+* [`block-opening-brace-space-before`](../src/rules/block-opening-brace-space-before/README.md): Require or disallow a space before the opening brace of blocks.
+* [`color-no-invalid-hex`](../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
+* [`declaration-bang-space-after`](../src/rules/declaration-bang-space-after/README.md): Require or disallow a space after the bang of declarations.
+* [`declaration-bang-space-before`](../src/rules/declaration-bang-space-before/README.md): Require or disallow a space before the bang of declarations.
+* [`declaration-colon-space-after`](../src/rules/declaration-colon-space-after/README.md): Require or disallow a space after the colon of declarations.
+* [`declaration-colon-space-before`](../src/rules/declaration-colon-space-before/README.md): Require or disallow a space before the colon of declarations.
+* [`declaration-comma-space-after`](../src/rules/declaration-comma-space-after/README.md): Require or disallow a space after the commas of declarations.
+* [`declaration-comma-space-before`](../src/rules/declaration-comma-space-before/README.md): Require or disallow a space before the commas of declarations.
+* [`declaration-no-important`](../src/rules/declaration-no-important/README.md): Disallow `!important` within declarations.
+* [`function-calc-no-unspaced-operator`](../src/rules/function-calc-no-unspaced-operator/README.md): Disallow an unspaced operator within `calc` functions.
+* [`function-comma-space-after`](../src/rules/function-comma-space-after/README.md): Require or disallow a space after the commas of functions.
+* [`function-comma-space-before`](../src/rules/function-comma-space-before/README.md): Require or disallow a space before the commas of functions.
+* [`function-parentheses-inside-space`](../src/rules/function-parentheses-inside-space/README.md): Require or disallow a single space on the inside of the parentheses of functions.
+* [`function-space-after`](../src/rules/function-space-after/README.md): Require or disallow a space after functions.
+* [`function-token-no-space`](../src/rules/function-token-no-space/README.md): Disallow a space between function tokens and their parameters.
+* [`function-url-quotes`](../src/rules/function-url-quotes/README.md): Specify single, double or no quotes for urls.
+* [`indentation`](../src/rules/indentation/README.md): Specify indentation
+* [`media-feature-colon-space-after`](../src/rules/media-feature-colon-space-after/README.md): Require or disallow a space after colon in media features.
+* [`media-feature-colon-space-before`](../src/rules/media-feature-colon-space-before/README.md): Require or disallow a space before colon in media features.
+* [`media-feature-range-operator-space-after`](../src/rules/media-feature-range-operator-space-after/README.md): Require or disallow a space after range operator in media features.
+* [`media-feature-range-operator-space-before`](../src/rules/media-feature-range-operator-space-before/README.md): Require or disallow a space before range operator in media features.
+* [`media-query-parentheses-inside-space`](../src/rules/media-query-parentheses-inside-space/README.md): Require or disallow a single space on the inside of the parentheses within media queries.
+* [`no-eol-whitespace`](../src/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
+* [`no-missing-eof-newline`](../src/rules/no-missing-eof-newline/README.md): Disallow missing end-of-file newline.
+* [`number-leading-zero`](../src/rules/number-leading-zero/README.md): Require or disallow a leading zero for fractional numbers less than 1.
+* [`number-no-trailing-zeros`](../src/rules/number-no-trailing-zeros/README.md): Disallow trailing zeros within numbers.
+* [`property-no-vendor-prefix`](../src/rules/property-no-vendor-prefix/README.md): Disallow vendor prefixes for properties.
+* [`property-value-no-vendor-prefix`](../src/rules/property-value-no-vendor-prefix/README.md): Disallow vendor prefixes for property values.
+* [`root-no-standard-properties`](../src/rules/root-no-standard-properties/README.md): Disallow standard properties inside `:root` selectors.
+* [`rule-no-duplicate-properties`](../src/rules/rule-no-duplicate-properties/README.md): Disallow duplicate properties within rules.
+* [`rule-no-single-line`](../src/rules/rule-no-single-line/README.md): Disallow single-line rules.
+* [`rule-non-nested-empty-line-before`](../src/rules/rule-non-nested-empty-line-before/README.md): Require or disallow an empty line before non-nested rules.
+* [`rule-trailing-semicolon`](../src/rules/rule-trailing-semicolon/README.md): Require or disallow a trailing semicolon within rules.
+* [`selector-combinator-space-after`](../src/rules/selector-combinator-space-after/README.md): Require or disallow a space after the combinator of selectors.
+* [`selector-combinator-space-before`](../src/rules/selector-combinator-space-before/README.md): Require or disallow a space before the combinator of selectors.
+* [`selector-delimiter-newline-after`](../src/rules/selector-delimiter-newline-after/README.md): Require or disallow a newline after the delimiters of selectors.
+* [`selector-delimiter-newline-before`](../src/rules/selector-delimiter-newline-before/README.md): Require or disallow a newline before the delimiters of selectors.
+* [`selector-delimiter-space-after`](../src/rules/selector-delimiter-space-after/README.md): Require or disallow a space after the delimiters of selectors.
+* [`selector-delimiter-space-before`](../src/rules/selector-delimiter-space-before/README.md): Require or disallow a space before the delimiters of selectors.
+* [`selector-no-vendor-prefix`](../src/rules/selector-no-vendor-prefix/README.md): Disallow vendor prefixes for selectors.
+* [`selector-pseudo-element-colon-notation`](../src/rules/selector-pseudo-element-colon-notation/README.md): Specify single or double colon notation for applicable pseudo-elements.
+* [`selector-root-no-composition`](../src/rules/selector-root-no-composition/README.md): Disallow the composition of`:root` selectors.
+* [`string-quotes`](../src/rules/string-quotes/README.md): Specify single or double quotes around strings.

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "tape": "^4.0.0"
   },
   "scripts": {
-    "prepublish": "babel src --out-dir dist",
+    "docs-build": "babel-node scripts/rules",
     "lint": "eslint . --ignore-path .gitignore",
+    "prepublish": "babel src --out-dir dist",
     "tape": "babel-tape-runner \"src/**/__tests__/*.js\"",
     "test": "npm run lint && npm run tape"
   }

--- a/scripts/rules.js
+++ b/scripts/rules.js
@@ -3,15 +3,15 @@ import fs from "fs"
 const ruleDirectory = "src/rules"
 const rulesMdFile = "docs/rules.md"
 
-fs.writeFileSync(rulesMdFile, `# Rules\n\n`);
+fs.writeFileSync(rulesMdFile, `# Rules\n\n`)
 
 fs.readdirSync(ruleDirectory).forEach(filename => {
 
-  let readmeFile = `${ruleDirectory}/${filename}/README.md`;
+  let readmeFile = `${ruleDirectory}/${filename}/README.md`
 
   if (!fs.existsSync(readmeFile)) { return }
 
-  let lines = fs.readFileSync(readmeFile).toString('utf-8').split("\n");
+  let lines = fs.readFileSync(readmeFile).toString("utf-8").split("\n")
 
-  fs.appendFileSync(rulesMdFile, `* [\`${filename}\`](../${readmeFile}): ${lines[2]}\n`);
-});
+  fs.appendFileSync(rulesMdFile, `* [\`${filename}\`](../${readmeFile}): ${lines[2]}\n`)
+})

--- a/scripts/rules.js
+++ b/scripts/rules.js
@@ -1,0 +1,17 @@
+import fs from "fs"
+
+const ruleDirectory = "src/rules"
+const rulesMdFile = "docs/rules.md"
+
+fs.writeFileSync(rulesMdFile, `# Rules\n\n`);
+
+fs.readdirSync(ruleDirectory).forEach(filename => {
+
+  let readmeFile = `${ruleDirectory}/${filename}/README.md`;
+
+  if (!fs.existsSync(readmeFile)) { return }
+
+  let lines = fs.readFileSync(readmeFile).toString('utf-8').split("\n");
+
+  fs.appendFileSync(rulesMdFile, `* [\`${filename}\`](../${readmeFile}): ${lines[2]}\n`);
+});


### PR DESCRIPTION
Quick fix for `0.1.0` so that a list of all the rules is easily accessible.

`npm run docs-build`