### PR TITLE
Standardise structure of test files

### DIFF
--- a/src/rules/declaration-no-important/__tests__/index.js
+++ b/src/rules/declaration-no-important/__tests__/index.js
@@ -1,9 +1,9 @@
 import { ruleTester } from "../../../testUtils"
-import declarationNoImportant, { ruleName, messages } from ".."
+import rule, { ruleName, messages } from ".."
 
-const testDeclarationNoImportant = ruleTester(declarationNoImportant, ruleName)
+const testRule = ruleTester(rule, ruleName)
 
-testDeclarationNoImportant(null, tr => {
+testRule(null, tr => {
   tr.ok("a {}", "no values")
   tr.ok("a { color: pink; }", "without !important")
 

--- a/src/rules/number-leading-zero/__tests__/index.js
+++ b/src/rules/number-leading-zero/__tests__/index.js
@@ -1,9 +1,9 @@
 import { ruleTester } from "../../../testUtils"
-import numberLeadingZero, { ruleName, messages } from ".."
+import rule, { ruleName, messages } from ".."
 
-const testNumberLeadingZero = ruleTester(numberLeadingZero, ruleName)
+const testRule = ruleTester(rule, ruleName)
 
-testNumberLeadingZero("always", tr => {
+testRule("always", tr => {
   tr.ok("a {}", "no values")
   tr.ok("a { margin: 0; }", "plain zero")
   tr.ok("a { line-height: 2; }", "plain integer")
@@ -63,7 +63,7 @@ testNumberLeadingZero("always", tr => {
   )
 })
 
-testNumberLeadingZero("never", tr => {
+testRule("never", tr => {
   tr.ok("a {}", "no values")
   tr.ok("a { margin: 0; }", "plain zero")
   tr.ok("a { line-height: 2; }", "plain integer")

--- a/src/rules/rule-no-single-line/__tests__/index.js
+++ b/src/rules/rule-no-single-line/__tests__/index.js
@@ -1,9 +1,9 @@
 import { ruleTester } from "../../../testUtils"
-import ruleSetNoSingleLine, { ruleName, messages } from ".."
+import rule, { ruleName, messages } from ".."
 
-const testRuleSetNoSingleLine = ruleTester(ruleSetNoSingleLine, ruleName)
+const testRule = ruleTester(rule, ruleName)
 
-testRuleSetNoSingleLine(true, tr => {
+testRule(true, tr => {
   tr.ok(
     "a {\ncolor: pink; }",
     "multi-line rule with newline at start"
@@ -29,7 +29,7 @@ testRuleSetNoSingleLine(true, tr => {
   )
 })
 
-testRuleSetNoSingleLine(false, tr => {
+testRule(false, tr => {
   tr.ok("a {\ncolor: pink;\n}", "multi-line rule")
   tr.ok("a { color: pink; }", "single-line rule")
 })

--- a/src/rules/rule-trailing-semicolon/__tests__/index.js
+++ b/src/rules/rule-trailing-semicolon/__tests__/index.js
@@ -1,9 +1,9 @@
 import { ruleTester } from "../../../testUtils"
-import ruleTrailingSemicolon, { ruleName, messages } from ".."
+import rule, { ruleName, messages } from ".."
 
-const testRuleTrailingSemicolon = ruleTester(ruleTrailingSemicolon, ruleName)
+const testRule = ruleTester(rule, ruleName)
 
-testRuleTrailingSemicolon("always", tr => {
+testRule("always", tr => {
   tr.ok("a {}")
   tr.ok("a { }")
   tr.ok(
@@ -27,7 +27,7 @@ testRuleTrailingSemicolon("always", tr => {
   )
 })
 
-testRuleTrailingSemicolon("never", tr => {
+testRule("never", tr => {
   tr.ok("a {}")
   tr.ok("a { }")
   tr.ok(


### PR DESCRIPTION
I accidentally missed doing this when I merged and renamed the `declaration-block` and `rule-set` rules.