### PR TITLE
Standardise warnings

### DIFF
--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -6,7 +6,7 @@ import {
 export const ruleName = "color-no-invalid-hex"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: c => `Invalid hex color "${c}"`,
+  rejected: c => `Unexpected invalid hex color "${c}"`,
 })
 
 export default function () {

--- a/src/rules/declaration-colon-space-after/index.js
+++ b/src/rules/declaration-colon-space-after/index.js
@@ -7,7 +7,7 @@ export const ruleName = "declaration-colon-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ":"`,
-  rejectedAfter: () => `Unexpected space after comma ":"`,
+  rejectedAfter: () => `Unexpected space after ":"`,
 })
 
 /**

--- a/src/rules/declaration-colon-space-before/index.js
+++ b/src/rules/declaration-colon-space-before/index.js
@@ -8,7 +8,7 @@ export const ruleName = "declaration-colon-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ":"`,
-  rejectedBefore: () => `Unexpected space before comma ":"`,
+  rejectedBefore: () => `Unexpected space before ":"`,
 })
 
 /**

--- a/src/rules/declaration-comma-space-after/index.js
+++ b/src/rules/declaration-comma-space-after/index.js
@@ -7,8 +7,8 @@ import {
 export const ruleName = "declaration-comma-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => `Expected single space after comma within a declaration value`,
-  rejectedAfter: () => `Unexpected space after comma within a declaration value`,
+  expectedAfter: () => `Expected single space after ","`,
+  rejectedAfter: () => `Unexpected space after ","`,
 })
 
 /**

--- a/src/rules/declaration-comma-space-before/index.js
+++ b/src/rules/declaration-comma-space-before/index.js
@@ -7,8 +7,8 @@ import { declarationCommaSpaceChecker } from "../declaration-comma-space-after"
 export const ruleName = "declaration-comma-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => `Expected single space before comma within a declaration value`,
-  rejectedBefore: () => `Unexpected space before comma within a declaration value`,
+  expectedBefore: () => `Expected single space before ","`,
+  rejectedBefore: () => `Unexpected space before ","`,
 })
 
 /**

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -8,9 +8,9 @@ import {
 export const ruleName = "function-calc-no-unspaced-operator"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: o => `Expected single space before "${o}" operator within calc function`,
-  expectedAfter: o => `Expected single space after "${o}" operator within calc function`,
-  expectedOperatorBeforeSign: o => `Expected an operator before sign "${o}" within calc function`,
+  expectedBefore: o => `Expected single space before "${o}" operator`,
+  expectedAfter: o => `Expected single space after "${o}" operator`,
+  expectedOperatorBeforeSign: o => `Expected an operator before sign "${o}"`,
 })
 
 export default function () {

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -7,8 +7,8 @@ import {
 export const ruleName = "function-comma-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => `Expected single space after comma within a function`,
-  rejectedAfter: () => `Unexpected space after comma within a function`,
+  expectedAfter: () => `Expected single space after ","`,
+  rejectedAfter: () => `Unexpected space after ","`,
 })
 
 /**

--- a/src/rules/function-comma-space-before/index.js
+++ b/src/rules/function-comma-space-before/index.js
@@ -7,8 +7,8 @@ import { functionCommaSpaceChecker } from "../function-comma-space-after"
 export const ruleName = "function-comma-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => `Expected single space before comma within a function`,
-  rejectedBefore: () => `Unexpected space before comma within a function`,
+  expectedBefore: () => `Expected single space before ","`,
+  rejectedBefore: () => `Unexpected space before ","`,
 })
 
 /**

--- a/src/rules/function-parentheses-inside-space/index.js
+++ b/src/rules/function-parentheses-inside-space/index.js
@@ -7,10 +7,10 @@ import {
 export const ruleName = "function-parentheses-inside-space"
 
 export const messages = ruleMessages(ruleName, {
-  expectedOpening: "Expected single space before \"(\" of a function",
-  rejectedOpening: "Unexpected space before \"(\" of a function",
-  expectedClosing: "Expected single space before \")\" of a function",
-  rejectedClosing: "Unexpected space before \")\" of a function",
+  expectedOpening: "Expected single space before \"(\"",
+  rejectedOpening: "Unexpected space before \"(\"",
+  expectedClosing: "Expected single space before \")\"",
+  rejectedClosing: "Unexpected space before \")\"",
 })
 
 /**

--- a/src/rules/function-space-after/index.js
+++ b/src/rules/function-space-after/index.js
@@ -7,8 +7,8 @@ import {
 export const ruleName = "function-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expected: "Expected single space after function's \")\"",
-  rejected: "Unexpected space after function's \")\"",
+  expected: "Expected single space after \")\"",
+  rejected: "Unexpected space after \")\"",
 })
 
 /**

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -7,8 +7,8 @@ import {
 export const ruleName = "media-feature-colon-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => `Expected single space after ":" in media feature`,
-  rejectedAfter: () => `Unexpected space after ":" in media feature`,
+  expectedAfter: () => `Expected single space after ":"`,
+  rejectedAfter: () => `Unexpected space after ":"`,
 })
 
 /**

--- a/src/rules/media-feature-colon-space-before/index.js
+++ b/src/rules/media-feature-colon-space-before/index.js
@@ -7,8 +7,8 @@ import { mediaFeatureColonSpaceChecker } from "../media-feature-colon-space-afte
 export const ruleName = "media-feature-colon-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => `Expected single space before ":" in media feature`,
-  rejectedBefore: () => `Unexpected space before ":" in media feature`,
+  expectedBefore: () => `Expected single space before ":"`,
+  rejectedBefore: () => `Unexpected space before ":"`,
 })
 
 /**

--- a/src/rules/media-feature-range-operator-space-after/index.js
+++ b/src/rules/media-feature-range-operator-space-after/index.js
@@ -6,8 +6,8 @@ import {
 export const ruleName = "media-feature-range-operator-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => `Expected single space after range operator in media feature`,
-  rejectedAfter: () => `Unexpected space after range operator in media feature`,
+  expectedAfter: () => `Expected single space after range operator`,
+  rejectedAfter: () => `Unexpected space after range operator`,
 })
 
 const rangeOperatorRegex = /[^><](>=?|<=?|=)/g

--- a/src/rules/media-feature-range-operator-space-before/index.js
+++ b/src/rules/media-feature-range-operator-space-before/index.js
@@ -7,8 +7,8 @@ import { findMediaOperator } from "../media-feature-range-operator-space-after"
 export const ruleName = "media-feature-range-operator-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => `Expected single space before range operator in media feature`,
-  rejectedBefore: () => `Unexpected space before range operator in media feature`,
+  expectedBefore: () => `Expected single space before range operator`,
+  rejectedBefore: () => `Unexpected space before range operator`,
 })
 
 /**

--- a/src/rules/media-query-parentheses-inside-space/index.js
+++ b/src/rules/media-query-parentheses-inside-space/index.js
@@ -6,10 +6,10 @@ import {
 export const ruleName = "media-query-parentheses-inside-space"
 
 export const messages = ruleMessages(ruleName, {
-  expectedOpening: "Expected single space before \"(\" of a function",
-  rejectedOpening: "Unexpected space before \"(\" of a function",
-  expectedClosing: "Expected single space before \")\" of a function",
-  rejectedClosing: "Unexpected space before \")\" of a function",
+  expectedOpening: "Expected single space before \"(\"",
+  rejectedOpening: "Unexpected space before \"(\"",
+  expectedClosing: "Expected single space before \")\"",
+  rejectedClosing: "Unexpected space before \")\"",
 })
 
 /**

--- a/src/rules/number-leading-zero/index.js
+++ b/src/rules/number-leading-zero/index.js
@@ -4,8 +4,8 @@ import {
 
 export const ruleName = "number-leading-zero"
 export const messages = ruleMessages(ruleName, {
-  expected: `Expected a leading zero for fractional value less than 1`,
-  rejected: `Unexpected leading zero for fractional value less than 1`,
+  expected: `Expected a leading zero`,
+  rejected: `Unexpected leading zero`,
 })
 
 /**

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -10,7 +10,7 @@ import {
 
 export const ruleName = "number-zero-length-no-unit"
 export const messages = ruleMessages(ruleName, {
-  rejected: "Unexpected unit on zero length value",
+  rejected: "Unexpected unit on zero length number",
 })
 
 // Only length units can be left off

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -3,7 +3,7 @@ import { ruleMessages } from "../../utils"
 export const ruleName = "root-no-standard-properties"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: p => `Unexpected standard property "${p}" in rule set applied to ":root"`,
+  rejected: p => `Unexpected standard property "${p}" applied to ":root"`,
 })
 
 export default function () {

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -6,8 +6,8 @@ import {
 export const ruleName = "selector-combinator-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: c => `Expected single space after combinator "${c}"`,
-  rejectedAfter: c => `Unexpected space after combinator "${c}"`,
+  expectedAfter: c => `Expected single space after "${c}" combinator `,
+  rejectedAfter: c => `Unexpected space after "${c}" combinator`,
 })
 
 const combinators = [ ">", "+", "~" ]

--- a/src/rules/selector-combinator-space-before/index.js
+++ b/src/rules/selector-combinator-space-before/index.js
@@ -7,8 +7,8 @@ import { selectorCombinatorSpaceChecker } from "../selector-combinator-space-aft
 export const ruleName = "selector-combinator-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: c => `Expected single space before combinator "${c}"`,
-  rejectedBefore: c => `Unexpected space before combinator "${c}"`,
+  expectedBefore: c => `Expected single space before "${c}" combinator`,
+  rejectedBefore: c => `Unexpected space before "${c}" combinator`,
 })
 
 /**


### PR DESCRIPTION
Corrects a few typos,  standardises the structure of the warning messages and removes redundant text from the warning messages when it can be determined by the rule name e.g.

```console
Expected single space before "${o}" operator within calc function (function-calc-no-unspaced-operator)
```

Becomes

```console
Expected single space before "${o}" operator (function-calc-no-unspaced-operator)
```
