### PR TITLE
Refactor remaining rules to use report()

### DIFF
--- a/src/rules/custom-property-no-outside-root/index.js
+++ b/src/rules/custom-property-no-outside-root/index.js
@@ -1,11 +1,12 @@
 import {
+  report,
   ruleMessages
 } from "../../utils"
 
 export const ruleName = "custom-property-no-outside-root"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: "Unexpected custom property outside root",
+  rejected: `Unexpected custom property outside root`,
 })
 
 export default function () {
@@ -16,7 +17,12 @@ export default function () {
 
       rule.eachDecl(decl => {
         if (decl.prop.substr(0, 2) === "--") {
-          result.warn(messages.rejected, { node: decl })
+          report({
+            message: messages.rejected,
+            node: decl,
+            result,
+            ruleName,
+          })
         }
       })
     })

--- a/src/rules/custom-property-pattern/index.js
+++ b/src/rules/custom-property-pattern/index.js
@@ -1,11 +1,12 @@
 import {
+  report,
   ruleMessages
 } from "../../utils"
 
 export const ruleName = "custom-property-pattern"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: "Custom property name does not match specified pattern",
+  rejected: `Custom property name does not match specified pattern`,
 })
 
 /**
@@ -18,7 +19,12 @@ export default function (pattern) {
       if (prop.slice(0, 2) !== "--") { return }
 
       if (!pattern.test(prop.slice(2))) {
-        result.warn(messages.rejected, { node: decl })
+        report({
+          message: messages.rejected,
+          node: decl,
+          result,
+          ruleName,
+        })
       }
     })
   }

--- a/src/rules/media-query-list-comma-newline-before/index.js
+++ b/src/rules/media-query-list-comma-newline-before/index.js
@@ -1,7 +1,8 @@
 import {
+  isWhitespace,
+  report,
   ruleMessages,
-  styleSearch,
-  isWhitespace
+  styleSearch
 } from "../../utils"
 
 export const ruleName = "media-query-list-comma-newline-before"
@@ -24,10 +25,20 @@ export default function (expectation) {
         // Check for a newline anywhere before the comma, while allowing
         // arbitrary indentation between the newline and the comma
         if (expectation === "always" && !/[^\s]\n[ \t]*$/.test(paramsBeforeComma)) {
-          result.warn(messages.expectedBefore(), { node: atRule })
+          report({
+            message: messages.expectedBefore(),
+            node: atRule,
+            result,
+            ruleName,
+          })
         }
         if (expectation === "never" && isWhitespace(params[match.startIndex - 1])) {
-          result.warn(messages.rejectedBefore(), { node: atRule })
+          report({
+            message: messages.rejectedBefore(),
+            node: atRule,
+            result,
+            ruleName,
+          })
         }
       })
     })

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -1,7 +1,8 @@
 import {
+  report,
   ruleMessages,
-  whitespaceChecker,
-  styleSearch
+  styleSearch,
+  whitespaceChecker
 } from "../../utils"
 
 export const ruleName = "media-query-list-comma-space-after"
@@ -29,7 +30,14 @@ export function mediaQueryListCommaChecker(checkLocation) {
     })
 
     function checkComma(source, index, node) {
-      checkLocation(source, index, m => result.warn(m, { node }))
+      checkLocation(source, index, m =>
+        report({
+          message: m,
+          node,
+          result,
+          ruleName,
+        })
+      )
     }
   }
 }

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -1,9 +1,10 @@
 import {
-  findLastIndex,
   findIndex,
+  findLastIndex,
   range
 } from "lodash"
 import {
+  report,
   ruleMessages,
   styleSearch
 } from "../../utils"
@@ -91,7 +92,12 @@ export default function () {
           && !lengthUnits.has(valueWithZero.slice(-4))
         ) { return }
 
-        result.warn(messages.rejected, { node })
+        report({
+          message: messages.rejected,
+          node,
+          result,
+          ruleName,
+        })
       })
     }
   }


### PR DESCRIPTION
Oops, not sure what happened but it looks like I missed a few `warn()`'s last time. I think this is the last of them.