### PR TITLE
Clarify block/statement relationship. Cope with blockless statements

### DIFF
--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -7,12 +7,12 @@ import {
 export const ruleName = "block-closing-brace-newline-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => "Expected newline after \"}\"",
-  rejectedAfter: () => "Unexpected space after \"}\"",
-  expectedAfterSingleLine: () => "Expected single space after \"}\" of a single-line block",
-  rejectedAfterSingleLine: () => "Unexpected space after \"}\" of a single-line block",
-  expectedAfterMultiLine: () => "Expected single space after \"}\" of a multi-line block",
-  rejectedAfterMultiLine: () => "Unexpected space after \"}\" of a multi-line block",
+  expectedAfter: () => `Expected newline after "}"`,
+  rejectedAfter: () => `Unexpected space after "}"`,
+  expectedAfterSingleLine: () => `Expected single space after "}" of a single-line block`,
+  rejectedAfterSingleLine: () => `Unexpected space after "}" of a single-line block`,
+  expectedAfterMultiLine: () => `Expected single space after "}" of a multi-line block`,
+  rejectedAfterMultiLine: () => `Unexpected space after "}" of a multi-line block`,
 })
 
 /**
@@ -21,27 +21,28 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)
   return function (css, result) {
-    // Check both kinds of "block": rules and at-rules
-    css.eachRule(checkBlock)
-    css.eachAtRule(checkBlock)
 
-    function checkBlock(block) {
-      const nextNode = block.next()
+    // Check both kinds of statements: rules and at-rules
+    css.eachRule(check)
+    css.eachAtRule(check)
+
+    function check(statement) {
+      const nextNode = statement.next()
       if (!nextNode) { return }
 
-      const blockString = block.toString()
-      const blockStringNoSelector = blockString.slice(blockString.indexOf("{"))
+      const statementString = statement.toString()
+      const blockString = statementString.slice(statementString.indexOf("{"))
 
       // Only check one after, because there might be other
       // spaces handled by the indentation rule
       checker.afterOneOnly(nextNode.toString(), -1, msg => {
         report({
           message: msg,
-          node: block,
+          node: statement,
           result,
           ruleName,
         })
-      }, blockStringNoSelector)
+      }, blockString)
     }
   }
 }

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -6,6 +6,7 @@ const testRule = ruleTester(rule, ruleName)
 testRule("always", tr => {
   tr.ok("a {}")
   tr.ok("a { }")
+  tr.ok("@import url(x.css)")
   tr.ok("a { color: pink;\n}")
   tr.ok("a { color: pink;\n\t\t}")
   tr.ok("a { color: pink;\n} b { color: red;\n}")

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -7,9 +7,9 @@ import {
 export const ruleName = "block-closing-brace-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => "Expected single space after \"}\"",
-  rejectedAfter: () => "Unexpected space after \"}\"",
-  expectedAfterMultiLine: () => "Expected single space after \"}\" of a multi-line block",
+  expectedAfter: () => `Expected single space after "}"`,
+  rejectedAfter: () => `Unexpected space after "}"`,
+  expectedAfterMultiLine: () => `Expected single space after "}" of a multi-line block`,
 })
 
 /**
@@ -18,23 +18,24 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker(" ", expectation, messages)
   return function (css, result) {
-    // Check both kinds of "block": rules and at-rules
-    css.eachRule(checkBlock)
-    css.eachAtRule(checkBlock)
 
-    function checkBlock(block) {
-      const blockString = block.toString()
-      const blockStringNoSelector = blockString.slice(blockString.indexOf("{"))
-      const nextNode = block.next()
+    // Check both kinds of statements: rules and at-rules
+    css.eachRule(check)
+    css.eachAtRule(check)
+
+    function check(statement) {
+      const statementString = statement.toString()
+      const blockString = statementString.slice(statementString.indexOf("{"))
+      const nextNode = statement.next()
       if (!nextNode) { return }
       checker.after(nextNode.toString(), -1, msg => {
         report({
           message: msg,
-          node: block,
+          node: statement,
           result,
           ruleName,
         })
-      }, blockStringNoSelector)
+      }, blockString)
     }
   }
 }

--- a/src/rules/block-closing-brace-space-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const testRule = ruleTester(rule, ruleName)
 testRule("always", tr => {
   tr.ok("a {}")
   tr.ok("a { }")
+  tr.ok("@import url(x.css)")
   tr.ok("a { color: pink; }")
   tr.ok("a { color: pink; } b { color: red; }")
   tr.ok("a { color: pink; }b { color: red; }")

--- a/src/rules/block-closing-brace-space-before/index.js
+++ b/src/rules/block-closing-brace-space-before/index.js
@@ -1,4 +1,6 @@
 import {
+  hasBlock,
+  hasEmptyBlock,
   report,
   ruleMessages,
   whitespaceChecker
@@ -7,12 +9,12 @@ import {
 export const ruleName = "block-closing-brace-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => "Expected single space before \"}\"",
-  rejectedBefore: () => "Unexpected space before \"}\"",
-  expectedBeforeSingleLine: () => "Expected single space before \"}\" of a single-line block",
-  rejectedBeforeSingleLine: () => "Unexpected space before \"}\" of a single-line block",
-  expectedBeforeMultiLine: () => "Expected single space before \"}\" of a multi-line block",
-  rejectedBeforeMultiLine: () => "Unexpected space before \"}\" of a multi-line block",
+  expectedBefore: () => `Expected single space before "}"`,
+  rejectedBefore: () => `Unexpected space before "}"`,
+  expectedBeforeSingleLine: () => `Expected single space before "}" of a single-line block`,
+  rejectedBeforeSingleLine: () => `Unexpected space before "}" of a single-line block`,
+  expectedBeforeMultiLine: () => `Expected single space before "}" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected space before "}" of a multi-line block`,
 })
 
 /**
@@ -21,25 +23,26 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker(" ", expectation, messages)
   return function (css, result) {
-    // Check both kinds of "block": rules and at-rules
-    css.eachRule(checkBlock)
-    css.eachAtRule(checkBlock)
 
-    function checkBlock(block) {
+    // Check both kinds of statement: rules and at-rules
+    css.eachRule(check)
+    css.eachAtRule(check)
 
-      // return early if an empty block
-      if (block.nodes.length === 0) { return }
+    function check(statement) {
 
-      const blockString = block.toString()
-      const blockStringNoSelector = blockString.slice(blockString.indexOf("{"))
-      checker.before(blockString, blockString.length - 1, msg => {
+      // return early if blockless or has empty block
+      if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
+
+      const statementString = statement.toString()
+      const blockString = statementString.slice(statementString.indexOf("{"))
+      checker.before(statementString, statementString.length - 1, msg => {
         report({
           message: msg,
-          node: block,
+          node: statement,
           result,
           ruleName,
         })
-      }, blockStringNoSelector)
+      }, blockString)
     }
   }
 }

--- a/src/rules/block-no-empty/__tests__/index.js
+++ b/src/rules/block-no-empty/__tests__/index.js
@@ -6,6 +6,7 @@ const testRule = ruleTester(rule, ruleName)
 testRule(null, tr => {
   tr.ok("a { color: pink; }")
   tr.ok("@media print { a { color: pink; } }")
+  tr.ok("@import url(x.css)")
 
   tr.notOk("a {}", messages.rejected)
   tr.notOk("a { }", messages.rejected)

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -1,26 +1,28 @@
 import {
-  ruleMessages,
-  report
+  hasBlock,
+  hasEmptyBlock,
+  report,
+  ruleMessages
 } from "../../utils"
 
 export const ruleName = "block-no-empty"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: "Unexpected empty block",
+  rejected: `Unexpected empty block`,
 })
 
 export default function () {
   return function (css, result) {
 
-    // Check both kinds of "block": rules and at-rules
-    css.eachRule(checkBlock)
-    css.eachAtRule(checkBlock)
+    // Check both kinds of statements: rules and at-rules
+    css.eachRule(check)
+    css.eachAtRule(check)
 
-    function checkBlock(block) {
-      if (block.nodes.length === 0) {
+    function check(statement) {
+      if (hasBlock(statement) && hasEmptyBlock(statement)) {
         report({
           message: messages.rejected,
-          node: block,
+          node: statement,
           result,
           ruleName,
         })

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -6,6 +6,7 @@ const testRule = ruleTester(rule, ruleName)
 testRule("always", tr => {
   tr.ok("a {}")
   tr.ok("a { }")
+  tr.ok("@import url(x.css)")
   tr.ok("a {\ncolor: pink; }")
   tr.ok("a{\ncolor: pink; }")
   tr.ok("a{\n\tcolor: pink; }")

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -1,4 +1,6 @@
 import {
+  hasBlock,
+  hasEmptyBlock,
   report,
   ruleMessages,
   whitespaceChecker
@@ -7,10 +9,10 @@ import {
 export const ruleName = "block-opening-brace-newline-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => "Expected newline after \"{\"",
-  rejectedAfter: () => "Unexpected space after \"{\"",
-  expectedAfterMultiLine: () => "Expected newline after \"{\" of a multi-line block",
-  rejectedAfterMultiLine: () => "Unexpected space after \"{\" of a multi-line block",
+  expectedAfter: () => `Expected newline after "{"`,
+  rejectedAfter: () => `Unexpected space after "{"`,
+  expectedAfterMultiLine: () => `Expected newline after "{" of a multi-line block`,
+  rejectedAfterMultiLine: () => `Unexpected space after "{" of a multi-line block`,
 })
 
 /**
@@ -23,20 +25,21 @@ export default function (expectation) {
 
 export function blockOpeningBraceNewlineChecker(checkLocation) {
   return function (css, result) {
-    // Check both kinds of "block": rules and at-rules
-    css.eachRule(checkBlock)
-    css.eachAtRule(checkBlock)
 
-    function checkBlock(block) {
+    // Check both kinds of statement: rules and at-rules
+    css.eachRule(check)
+    css.eachAtRule(check)
 
-      // return early if an empty block
-      if (block.nodes.length === 0) { return }
+    function check(statement) {
 
-      const blockString = block.toString()
-      for (let i = 0, l = blockString.length; i < l; i++) {
-        if (blockString[i] !== "{") { continue }
+      // return early if blockless or has empty block
+      if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
+
+      const statementString = statement.toString()
+      for (let i = 0, l = statementString.length; i < l; i++) {
+        if (statementString[i] !== "{") { continue }
         // Only pay attention to the first brace encountered
-        checkBrace(blockString, i, block, blockString.slice(i))
+        checkBrace(statementString, i, statement, statementString.slice(i))
         break
       }
     }

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -4,6 +4,7 @@ import rule, { ruleName, messages } from ".."
 const testRule = ruleTester(rule, ruleName)
 
 testRule("always", tr => {
+  tr.ok("@import url(x.css)")
   tr.ok("a\n{ color: pink; }")
   tr.ok("a\n{color: pink; }")
   tr.ok("@media print\n{ a\n{ color: pink; } }")

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -7,12 +7,12 @@ import { blockOpeningBraceNewlineChecker } from "../block-opening-brace-newline-
 export const ruleName = "block-opening-brace-newline-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => "Expected newline before \"{\"",
-  rejectedBefore: () => "Unexpected newline before \"{\"",
-  expectedBeforeSingleLine: () => "Expected newline before \"{\" of a single-line block",
-  rejectedBeforeSingleLine: () => "Unexpected space before \"{\" of a single-line block",
-  expectedBeforeMultiLine: () => "Expected newline before \"{\" of a multi-line block",
-  rejectedBeforeMultiLine: () => "Unexpected space before \"{\" of a multi-line block",
+  expectedBefore: () => `Expected newline before "{"`,
+  rejectedBefore: () => `Unexpected newline before "{"`,
+  expectedBeforeSingleLine: () => `Expected newline before "{" of a single-line block`,
+  rejectedBeforeSingleLine: () => `Unexpected space before "{" of a single-line block`,
+  expectedBeforeMultiLine: () => `Expected newline before "{" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected space before "{" of a multi-line block`,
 })
 
 /**

--- a/src/rules/block-opening-brace-space-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-after/__tests__/index.js
@@ -6,6 +6,7 @@ const testRule = ruleTester(rule, ruleName)
 testRule("always", tr => {
   tr.ok("a {}")
   tr.ok("a { }")
+  tr.ok("@import url(x.css)")
   tr.ok("a { color: pink; }")
   tr.ok("@media print { a { color: pink; } }")
 

--- a/src/rules/block-opening-brace-space-after/index.js
+++ b/src/rules/block-opening-brace-space-after/index.js
@@ -1,4 +1,6 @@
 import {
+  hasBlock,
+  hasEmptyBlock,
   report,
   ruleMessages,
   whitespaceChecker
@@ -7,12 +9,12 @@ import {
 export const ruleName = "block-opening-brace-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => "Expected single space after \"{\"",
-  rejectedAfter: () => "Unexpected space after \"{\"",
-  expectedAfterSingleLine: () => "Expected single space after \"{\" of a single-line block",
-  rejectedAfterSingleLine: () => "Unexpected space after \"{\" of a single-line block",
-  expectedAfterMultiLine: () => "Expected single space after \"{\" of a multi-line block",
-  rejectedAfterMultiLine: () => "Unexpected space after \"{\" of a multi-line block",
+  expectedAfter: () => `Expected single space after "{"`,
+  rejectedAfter: () => `Unexpected space after "{"`,
+  expectedAfterSingleLine: () => `Expected single space after "{" of a single-line block`,
+  rejectedAfterSingleLine: () => `Unexpected space after "{" of a single-line block`,
+  expectedAfterMultiLine: () => `Expected single space after "{" of a multi-line block`,
+  rejectedAfterMultiLine: () => `Unexpected space after "{" of a multi-line block`,
 })
 
 /**
@@ -25,20 +27,21 @@ export default function (expectation) {
 
 export function blockOpeningBraceSpaceChecker(checkLocation) {
   return function (css, result) {
-    // Check both kinds of "block": rules and at-rules
+
+    // Check both kinds of statements: rules and at-rules
     css.eachRule(checkBlock)
     css.eachAtRule(checkBlock)
 
-    function checkBlock(block) {
+    function checkBlock(statement) {
 
-      // return early if an empty block
-      if (block.nodes.length === 0) { return }
+      // return early if blockless or has empty block
+      if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
 
-      const blockString = block.toString()
-      for (let i = 0, l = blockString.length; i < l; i++) {
-        if (blockString[i] !== "{") { continue }
+      const statementString = statement.toString()
+      for (let i = 0, l = statementString.length; i < l; i++) {
+        if (statementString[i] !== "{") { continue }
         // Only pay attention to the first brace encountered
-        checkBrace(blockString, i, block, blockString.slice(i))
+        checkBrace(statementString, i, statement, statementString.slice(i))
         break
       }
     }

--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -4,6 +4,8 @@ import rule, { ruleName, messages } from ".."
 const testRule = ruleTester(rule, ruleName)
 
 testRule("always", tr => {
+  tr.ok("a {}")
+  tr.ok("@import url(x.css)")
   tr.ok("a { color: pink; }")
   tr.ok("@media print { a { color: pink; } }")
 

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -7,12 +7,12 @@ import { blockOpeningBraceSpaceChecker } from "../block-opening-brace-space-afte
 export const ruleName = "block-opening-brace-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => "Expected single space before \"{\"",
-  rejectedBefore: () => "Unexpected space before \"{\"",
-  expectedBeforeSingleLine: () => "Expected single space before \"{\" of a single-line block",
-  rejectedBeforeSingleLine: () => "Unexpected space before \"{\" of a single-line block",
-  expectedBeforeMultiLine: () => "Expected single space before \"{\" of a multi-line block",
-  rejectedBeforeMultiLine: () => "Unexpected space before \"{\" of a multi-line block",
+  expectedBefore: () => `Expected single space before "{"`,
+  rejectedBefore: () => `Unexpected space before "{"`,
+  expectedBeforeSingleLine: () => `Expected single space before "{" of a single-line block`,
+  rejectedBeforeSingleLine: () => `Unexpected space before "{" of a single-line block`,
+  expectedBeforeMultiLine: () => `Expected single space before "{" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected space before "{" of a multi-line block`,
 })
 
 /**

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -42,15 +42,15 @@ export default function (expectation) {
   }
 
   return function (css, result) {
-    css.eachAtRule(checkBlock)
-    css.eachRule(checkBlock)
+    css.eachAtRule(check)
+    css.eachRule(check)
 
-    function checkBlock(block) {
-      if (block.type === "atrule") {
-        checkAtRuleParams(block)
+    function check(statement) {
+      if (statement.type === "atrule") {
+        checkAtRuleParams(statement)
       }
 
-      block.eachDecl(function (decl) {
+      statement.eachDecl(function (decl) {
         functionArguments(decl.value, "url", args => {
           if (strDefiesExpectation(args)) {
             report({

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -15,9 +15,6 @@ export default function (expectation) {
 
     css.eachRule(function (rule) {
 
-      // return early if an empty block
-      if (rule.nodes.length === 0) { return }
-
       let previousProp = {}
       let isFirstDecl = true
 

--- a/src/utils/__tests__/hasBlock-test.js
+++ b/src/utils/__tests__/hasBlock-test.js
@@ -1,0 +1,37 @@
+import hasBlock from "../hasBlock"
+import postcss from "postcss"
+import test from "tape"
+
+test("hasBlock", t => {
+  t.ok(postcssCheck("a {}"), "empty rule")
+  t.ok(postcssCheck("a { }"), "emtpy rule with space")
+  t.ok(postcssCheck("a {\n}"), "emtpy rule with newline")
+  t.ok(postcssCheck("@media print {}"), "empty @media")
+  t.ok(postcssCheck("@supports (animation-name: test) {}"), "empty @supports")
+  t.ok(postcssCheck("@document url(http://www.w3.org/) {}"), "empty @document")
+  t.ok(postcssCheck("@page :pseudo-class {}"), "empty page")
+  t.ok(postcssCheck("@font-face {}"), "empty font-face")
+  t.ok(postcssCheck("@keyframes identifier {}"), "empty keyframes")
+
+  t.ok(postcssCheck("a { color: pink; }"), "not empty rule")
+  t.ok(postcssCheck("@media print { a { color: pink; } }"), "not empty @media")
+  t.ok(postcssCheck("@supports (animation-name: test) { a { color: pink; } }"), "not empty @supports")
+  t.ok(postcssCheck("@document url(http://www.w3.org/) { a { color: pink; } }"), "not empty @document")
+  t.ok(postcssCheck("@page :pseudo-class { a { color: pink; } }"), "not empty @page")
+  t.ok(postcssCheck("@font-face { font-family: sans; }"), "not empty @font-face")
+  t.ok(postcssCheck("@keyframes identifier { 0% { top: 0; left:} }"), "not empty @keyframes")
+
+  t.notOk(postcssCheck("@import url(x.css)"), "@import url")
+  t.notOk(postcssCheck("@import 'x.css'"), "@import single quoted string")
+  t.notOk(postcssCheck("@import \"x.css\""), "@import double quoted string")
+  t.notOk(postcssCheck("@charset \"UTF-8\""), "@charset")
+  t.notOk(postcssCheck("@namespace url(http://www.w3.org/1999/xhtml)"), "@namespace")
+  t.notOk(postcssCheck("@namespace svg url(http://www.w3.org/2000/svg)"), "@namespace with prefix")
+
+  t.end()
+})
+
+function postcssCheck(cssString) {
+  const root = postcss.parse(cssString)
+  return hasBlock(root.first)
+}

--- a/src/utils/__tests__/hasEmptyBlock-test.js
+++ b/src/utils/__tests__/hasEmptyBlock-test.js
@@ -1,0 +1,36 @@
+import hasEmptyBlock from "../hasEmptyBlock"
+import postcss from "postcss"
+import test from "tape"
+
+test("hasEmptyBlock", t => {
+  t.ok(postcssCheck("a {}"), "empty rule")
+  t.ok(postcssCheck("a { }"), "emtpy rule with space")
+  t.ok(postcssCheck("a {\n}"), "emtpy rule with newline")
+  t.ok(postcssCheck("@media print {}"), "empty @media")
+  t.ok(postcssCheck("@supports (animation-name: test) {}"), "empty @supports")
+  t.ok(postcssCheck("@document url(http://www.w3.org/) {}"), "empty @document")
+  t.ok(postcssCheck("@page :pseudo-class {}"), "empty page")
+  t.ok(postcssCheck("@font-face {}"), "empty font-face")
+  t.ok(postcssCheck("@keyframes identifier {}"), "empty keyframes")
+
+  t.notOk(postcssCheck("a { color: pink; }"), "not empty rule")
+  t.notOk(postcssCheck("@media print { a { color: pink; } }"), "not empty @media")
+  t.notOk(postcssCheck("@supports (animation-name: test) { a { color: pink; } }"), "not empty @supports")
+  t.notOk(postcssCheck("@document url(http://www.w3.org/) { a { color: pink; } }"), "not empty @document")
+  t.notOk(postcssCheck("@page :pseudo-class { a { color: pink; } }"), "not empty @page")
+  t.notOk(postcssCheck("@font-face { font-family: sans; }"), "not empty @font-face")
+  t.notOk(postcssCheck("@keyframes identifier { 0% { top: 0; left:} }"), "not empty @keyframes")
+  t.notOk(postcssCheck("@import url(x.css)"), "@import url")
+  t.notOk(postcssCheck("@import 'x.css'"), "@import single quoted string")
+  t.notOk(postcssCheck("@import \"x.css\""), "@import double quoted string")
+  t.notOk(postcssCheck("@charset \"UTF-8\""), "@charset")
+  t.notOk(postcssCheck("@namespace url(http://www.w3.org/1999/xhtml)"), "@namespace")
+  t.notOk(postcssCheck("@namespace svg url(http://www.w3.org/2000/svg)"), "@namespace with prefix")
+
+  t.end()
+})
+
+function postcssCheck(cssString) {
+  const root = postcss.parse(cssString)
+  return hasEmptyBlock(root.first)
+}

--- a/src/utils/hasBlock.js
+++ b/src/utils/hasBlock.js
@@ -1,0 +1,11 @@
+/**
+ * Check if a statement has an block (empty or otherwise)
+ *
+ * @param {object} statement - A rule or at-rule postcss node
+ * @return {boolean} true is has a block (empty or otherwise)
+ */
+export default function (statment) {
+  return (
+    statment.nodes !== undefined
+  )
+}

--- a/src/utils/hasEmptyBlock.js
+++ b/src/utils/hasEmptyBlock.js
@@ -1,0 +1,12 @@
+/**
+ * Check if a statement has an empty block
+ *
+ * @param {object} statement - A rule or at-rule postcss node
+ * @return {boolean} true is has a block and is empty
+ */
+export default function (statment) {
+  return (
+    statment.nodes !== undefined // has block
+    && statment.nodes.length === 0 // and is empty
+  )
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,21 +1,25 @@
-import isSingleLineString from "./isSingleLineString"
-import isWhitespace from "./isWhitespace"
-import ruleMessages from "./ruleMessages"
-import whitespaceChecker from "./whitespaceChecker"
-import styleSearch from "./styleSearch"
-import lineCount from "./lineCount"
 import functionArguments from "./functionArguments"
 import isAutoprefixable from "./isAutoprefixable"
+import hasBlock from "./hasBlock"
+import hasEmptyBlock from "./hasEmptyBlock"
+import isSingleLineString from "./isSingleLineString"
+import isWhitespace from "./isWhitespace"
+import lineCount from "./lineCount"
 import report from "./report"
+import ruleMessages from "./ruleMessages"
+import styleSearch from "./styleSearch"
+import whitespaceChecker from "./whitespaceChecker"
 
 export default {
-  isSingleLineString,
-  isWhitespace,
-  ruleMessages,
-  whitespaceChecker,
-  styleSearch,
-  lineCount,
   functionArguments,
   isAutoprefixable,
+  hasBlock,
+  hasEmptyBlock,
+  isSingleLineString,
+  isWhitespace,
+  lineCount,
   report,
+  ruleMessages,
+  styleSearch,
+  whitespaceChecker,
 }


### PR DESCRIPTION
I've looked a little deeper into how the `block-*` rules deal with blockless statements.

We access blocks via postcss's `eachRule` and `eachAtRule`, which give us access to "statements" ([ref](http://apps.workflower.fi/vocabs/css/en#statement)) . As such, I've added two utils:

1. One to test if a statement has a block
2. The other to test if a statement has an empty block.

These two utils provide the necessary flexibility to support both the `block-*-*-brace-*` whitespace rules and the `block-no-empty` rule.

I've refactored a few of the rules (mostly just renaming variable) to reflect the use of statements. 

Ok with you guys?

Wasn't sure if it should be `isBlockless` or `hasBlock`.
