### PR TITLE
Add always-except-blockless-pair option

### DIFF
--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -16,6 +16,26 @@ testRule("always", tr => {
   tr.notOk("a {}\n\n/* comment */\n@media {}", messages.expected)
 })
 
+testRule("always-except-blockless-pair", tr => {
+  tr.ok("")
+  tr.ok("a {} b {}", "rule ignored")
+  tr.ok("@font-face {}", "first node ignored")
+  tr.ok("a {}\n\n@media {}")
+  tr.ok("@keyframes foo {}\n\n@media {}")
+
+  tr.ok("@keyframes foo {}\n\n@import 'x.css'", "empty line not blockless pair")
+  tr.ok("@import 'x.css';\n@import 'y.css'", "no empty line blockless pair")
+  tr.ok("@import 'x.css';", "single blockless rule")
+
+  tr.notOk("a {} @media {}", messages.expected)
+  tr.notOk("@keyframes foo {} @media {}", messages.expected)
+  tr.notOk("a {}\n@media {}", messages.expected)
+  tr.notOk("a {}\n\n/* comment */\n@media {}", messages.expected)
+
+  tr.notOk("@keyframes foo {}\n@import 'x.css'", messages.expected)
+  tr.notOk("@import 'x.css';\n\n@import 'y.css'", messages.expected)
+})
+
 testRule("never", tr => {
   tr.ok("")
   tr.ok("a {}\n\nb {}", "rule ignored")

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -16,7 +16,7 @@ testRule("always", tr => {
   tr.notOk("a {}\n\n/* comment */\n@media {}", messages.expected)
 })
 
-testRule("always-except-blockless-pair", tr => {
+testRule("always-except-blockless-group", tr => {
   tr.ok("")
   tr.ok("a {} b {}", "rule ignored")
   tr.ok("@font-face {}", "first node ignored")

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -1,4 +1,5 @@
 import {
+  hasBlock,
   report,
   ruleMessages
 } from "../../utils"
@@ -26,7 +27,23 @@ export default function (expectation) {
 
       if (expectation === "never" && !emptyLineBefore) { return }
 
-      const message = (expectation === "always") ? messages.expected : messages.rejected
+      if (expectation === "always-except-blockless-pair") {
+        const previousNode = atRule.prev()
+
+        if (previousNode.type === "atrule"
+          && !hasBlock(previousNode)
+          && !hasBlock(atRule)
+          && !emptyLineBefore) { return }
+
+        if (previousNode.type === "atrule"
+          && hasBlock(previousNode)
+          && emptyLineBefore) { return }
+
+        if (previousNode.type !== "atrule"
+          && emptyLineBefore) { return }
+      }
+
+      const message = (expectation === "never") ? messages.rejected : messages.expected
 
       report({
         message: message,

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -27,7 +27,7 @@ export default function (expectation) {
 
       if (expectation === "never" && !emptyLineBefore) { return }
 
-      if (expectation === "always-except-blockless-pair") {
+      if (expectation === "always-except-blockless-group") {
         const previousNode = atRule.prev()
 
         if (previousNode.type === "atrule"


### PR DESCRIPTION
Adds new option that enforces an empty line before at rules unless it is a blockless pair. E.g:

```css
@import url(x.css); /* a blockless pairs have no empty lines */
@import url(y.css);
@import url(z.css);

@media print { /* at rule with block has empty line */
}
```