### PR TITLE
rule-semicolon-newline-after allows eol comments; fixes #208

### DIFF
--- a/src/rules/rule-semicolon-newline-after/README.md
+++ b/src/rules/rule-semicolon-newline-after/README.md
@@ -3,12 +3,21 @@
 Require or disallow a newline after the semicolons of rules.
 
 ```css
-    a { 
-      color: pink; 
+    a {
+      color: pink;
       top: 0;    ↑
     }            ↑
 /**              ↑  
  * The newline after this semicolon */
+```
+
+End-of-line comments are allowed one space after the semicolon.
+
+```css
+a {
+  color: pink; /* something to say */
+  top: 0;
+}
 ```
 
 ## Options
@@ -28,8 +37,8 @@ a { color: pink; top: 0; }
 The following patterns are *not* considered warnings:
 
 ```css
-a { 
-  color: pink; 
+a {
+  color: pink;
   top: 0;
 }
 ```
@@ -46,9 +55,9 @@ a { color: pink;
 ```
 
 ```css
-a { 
-  color: pink; 
-  top: 0; 
+a {
+  color: pink;
+  top: 0;
 }
 ```
 
@@ -59,8 +68,8 @@ a { color: pink; }
 ```
 
 ```css
-a { 
-  color: pink; top: 0; 
+a {
+  color: pink; top: 0;
 }
 ```
 
@@ -71,8 +80,8 @@ There *must always* be a single newline after the semicolon in multi-line rules.
 The following patterns are considered warnings:
 
 ```css
-a { 
-  color: pink; top: 0; 
+a {
+  color: pink; top: 0;
 }
 ```
 
@@ -87,9 +96,9 @@ a { color: pink; top: 0; }
 ```
 
 ```css
-a { 
-  color: pink; 
-  top: 0; 
+a {
+  color: pink;
+  top: 0;
 }
 ```
 
@@ -100,9 +109,9 @@ There *must never* be whitespace after the semicolon in multi-line rules.
 The following patterns are considered warnings:
 
 ```css
-a { 
-  color: pink; 
-  top: 0; 
+a {
+  color: pink;
+  top: 0;
 }
 ```
 
@@ -117,8 +126,8 @@ a { color: pink; top: 0; }
 ```
 
 ```css
-a { 
+a {
   color: pink
-  ; top: 0; 
+  ; top: 0;
 }
 ```

--- a/src/rules/rule-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/rule-semicolon-newline-after/__tests__/index.js
@@ -13,11 +13,23 @@ testRule("always", tr => {
   tr.ok("a { color: pink;\ntop: 0; }", "space between trailing semicolon and closing brace")
   tr.ok("a { color: pink;\ntop: 0;}", "no space between trailing semicolon and closing brace")
   tr.ok("a { color: pink;\ntop: 0}")
+  tr.ok("a {\n  color: pink; /* 1 */\n  top: 0\n}", "end-of-line comment")
+  tr.ok("a {\n  color: pink;\n  /* 1 */\n  top: 0\n}", "next-line comment")
 
   tr.notOk("a { color: pink;top: 0; }", messages.expectedAfter())
   tr.notOk("a { color: pink; top: 0; }", messages.expectedAfter())
   tr.notOk("a { color: pink; top: 0; }", messages.expectedAfter())
   tr.notOk("a { color: pink;\ttop: 0; }", messages.expectedAfter())
+  tr.notOk(
+    "a {\n  color: pink;  /* 1 */\n  top: 0\n}",
+    messages.expectedAfter(),
+    "end-of-line comment with two spaces before"
+  )
+  tr.notOk(
+    "a {\n  color: pink; /* 1 */ top: 0\n}",
+    messages.expectedAfter(),
+    "next node is comment without newline after"
+  )
 })
 
 testRule("never", tr => {
@@ -45,6 +57,7 @@ testRule("always-multi-line", tr => {
 
   // Ignore single-line
   tr.ok("a { color: pink; top: 0; }")
+  tr.ok("a { color: pink; /* 1 */ top: 0; }")
 
   tr.notOk("a {\ncolor: pink;top: 0;\n}", messages.expectedAfterMultiLine())
   tr.notOk("a {\ncolor: pink; top: 0;\n}", messages.expectedAfterMultiLine())

--- a/src/rules/rule-semicolon-newline-after/index.js
+++ b/src/rules/rule-semicolon-newline-after/index.js
@@ -24,9 +24,15 @@ export default function (expectation) {
       const parentRule = decl.parent
       if (!parentRule.semicolon && parentRule.last === decl) { return }
 
-      const nextDecl = decl.next()
-      if (!nextDecl) { return }
-      check.afterOneOnly(nextDecl.toString(), -1, m => {
+      const nextNode = decl.next()
+      if (!nextNode) { return }
+
+      // Allow end-of-line comments one space after the semicolon
+      let nodeToCheck = (nextNode.type === "comment" && nextNode.before === " ")
+        ? nextNode.next()
+        : nextNode
+
+      check.afterOneOnly(nodeToCheck.toString(), -1, m => {
         return report({
           message: m,
           node: decl,


### PR DESCRIPTION
Apologies for the eol-whitespace deletion that bloats the diff a bit.