### PR TITLE
eol-comments after opening brace; fixes #210

### DIFF
--- a/src/rules/block-opening-brace-newline-after/README.md
+++ b/src/rules/block-opening-brace-newline-after/README.md
@@ -3,10 +3,18 @@
 Require or disallow a newline after the opening brace of blocks.
 
 ```css
-    a { 
+    a {
       ↑ color: pink; }
 /**   ↑  
  * The newline after this brace */
+```
+
+End-of-line comments are allowed one space after the opening brace.
+
+```css
+a { /* something to say */
+  color: pink;
+}
 ```
 
 ## Options

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -14,6 +14,8 @@ testRule("always", tr => {
   tr.ok("@media print {\na {\ncolor: pink; } }")
   tr.ok("@media print{\na{\ncolor: pink; } }")
   tr.ok("@media print{\n\ta{\n  color: pink; } }")
+  tr.ok("a { /* 1 */\n  color: pink;\n}", "end-of-line comment")
+  tr.ok("a {\n  /* 1 */\n  color: pink;\n}", "next-line comment")
 
   tr.notOk("a { color: pink; }", messages.expectedAfter())
   tr.notOk("a {color: pink; }", messages.expectedAfter())
@@ -21,6 +23,16 @@ testRule("always", tr => {
   tr.notOk("a {\tcolor: pink; }", messages.expectedAfter())
   tr.notOk("@media print { a {\ncolor: pink; } }", messages.expectedAfter())
   tr.notOk("@media print {\na { color: pink; } }", messages.expectedAfter())
+  tr.notOk(
+    "a {  /* 1 */\n  color: pink;\n}",
+    messages.expectedAfter(),
+    "end-of-line comment with two spaces before"
+  )
+  tr.notOk(
+    "a { /* 1 */ color: pink; }",
+    messages.expectedAfter(),
+    "next node is comment without newline after"
+  )
 })
 
 testRule("never", tr => {
@@ -63,6 +75,7 @@ testRule("always-multi-line", tr => {
   tr.ok("a { color: pink; }")
   tr.ok("a {\tcolor: pink; }")
   tr.ok("a {  color: pink;  background: orange; }")
+  tr.ok("a { /* 1 */ color: pink; }")
 })
 
 testRule("never-multi-line", tr => {

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -18,6 +18,7 @@ testRule("always", tr => {
   tr.notOk("@media print\n{ a { color: pink; } }", messages.expectedBefore())
   tr.notOk("@media print{ a\n{ color: pink; } }", messages.expectedBefore())
   tr.notOk("@media print\n{ a{ color: pink; } }", messages.expectedBefore())
+  tr.notOk("a\n/* foo */{ a{ color: pink; } }", messages.expectedBefore())
 })
 
 testRule("never", tr => {


### PR DESCRIPTION
I had to rewrite the `-before` rule, as well, because it could no longer simply re-use `-after`'s code.