### PR TITLE
Add comment sensitivity to styleSearch and various comment-related te…

### DIFF
--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -5,6 +5,7 @@ const testRule = ruleTester(rule, ruleName)
 
 testRule(null, tr => {
   tr.ok("a {}")
+  tr.ok("a { padding: 0 /* calc(1px+2px) */ 0; }")
   tr.ok("a { color: color(red s(-10%)); }")
   tr.ok("a { color: color(red s( -10%)); }")
 

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -10,6 +10,11 @@ testRule({ space: 2 }, tr => {
 
 tr.ok("")
 tr.ok("a {color: pink;}")
+tr.ok(
+`/* anything
+    goes
+\t\t\twithin a comment */
+`)
 
 tr.ok(
 `a {

--- a/src/rules/no-eol-whitespace/README.md
+++ b/src/rules/no-eol-whitespace/README.md
@@ -3,8 +3,8 @@
 Disallow end-of-line whitespace.
 
 ```css
-    a { color: pink; }···   
-/**                    ↑ 
+    a { color: pink; }···
+/**                    ↑
  *       This whitespace */
 ```
 
@@ -18,8 +18,20 @@ a { color: pink; }·
 a { color: pink; }····
 ```
 
+Comment strings are also checked -- so the following is a warning:
+
+```css
+/* something····
+ * something else */
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
 a { color: pink; }
+```
+
+```css
+/* something
+ * something else */
 ```

--- a/src/rules/no-eol-whitespace/__tests__/index.js
+++ b/src/rules/no-eol-whitespace/__tests__/index.js
@@ -13,6 +13,12 @@ testRule(null, tr => {
 
   tr.ok("a::before { content: \"  \n\t\n\"; }", "breaking the rule within a string")
 
+  tr.notOk(
+    "/* foo  \nbar */ a { color: pink; }",
+    messages.rejected(1),
+    "eol-whitespace within a comment"
+  )
+
   tr.ok("a,\nb {}", "selector delimiter")
   tr.notOk("a, \nb {}", messages.rejected(1),
     "selector delimiter with space before newline")

--- a/src/rules/no-eol-whitespace/index.js
+++ b/src/rules/no-eol-whitespace/index.js
@@ -16,7 +16,7 @@ export default function () {
   return function (css, result) {
     let lineCount = 0
     const rootString = css.source.input.css
-    styleSearch({ source: rootString, target: [ "\n", "\r" ] }, match => {
+    styleSearch({ source: rootString, target: [ "\n", "\r" ], checkComments: true }, match => {
       lineCount++
       if (whitespacesToReject.indexOf(rootString[match.startIndex - 1]) !== -1) {
         report({

--- a/src/rules/no-multiple-empty-lines/README.md
+++ b/src/rules/no-multiple-empty-lines/README.md
@@ -11,6 +11,17 @@ a {}
 b {}
 ```
 
+Comment strings are also checked -- so the following is a warning:
+
+```css
+/**
+ * Call me Ishmael.
+ *
+ *
+ * Some years ago -- never mind how log precisely -- ...
+ */
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
@@ -26,4 +37,12 @@ b {}
 
 ```css
 a {} b {}
+```
+
+```css
+/**
+ * Call me Ishmael.
+ *
+ * Some years ago -- never mind how long precisely -- ...
+ */
 ```

--- a/src/rules/no-multiple-empty-lines/__tests__/index.js
+++ b/src/rules/no-multiple-empty-lines/__tests__/index.js
@@ -13,4 +13,5 @@ testRule(null, tr => {
 
   tr.notOk("a {}\n\n\nb{}", messages.rejected(3))
   tr.notOk("a {}\n\n/** horse */\n\n\nb{}", messages.rejected(5))
+  tr.notOk("/* horse\n\n\n */\na{}", messages.rejected(3))
 })

--- a/src/rules/no-multiple-empty-lines/index.js
+++ b/src/rules/no-multiple-empty-lines/index.js
@@ -14,7 +14,7 @@ export default function () {
   return function (css, result) {
     let lineCount = 0
     const rootString = css.source.input.css
-    styleSearch({ source: rootString, target: [ "\n", "\r" ] }, match => {
+    styleSearch({ source: rootString, target: [ "\n", "\r" ], checkComments: true }, match => {
       lineCount++
       if (isNewline(rootString[match.startIndex + 1])
         && isNewline(rootString[match.startIndex + 2])) {

--- a/src/rules/number-zero-length-no-unit/__tests__/index.js
+++ b/src/rules/number-zero-length-no-unit/__tests__/index.js
@@ -5,6 +5,7 @@ const testRule = ruleTester(rule, ruleName)
 
 testRule(null, tr => {
   tr.ok("a { top: 0; }", "unitless zero")
+  tr.ok("a { padding: 0 /* 0px */; }", "united zero in comment")
   tr.ok("a { top: 10px; }", "zero at end of non-zero value")
   tr.ok("a { top: 100.00px; }", "zero at end of non-zero value after decimal")
   tr.ok("a { top: 100.010px; }")

--- a/src/rules/string-quotes/README.md
+++ b/src/rules/string-quotes/README.md
@@ -8,6 +8,13 @@ Specify single or double quotes around strings.
  * These quotes and these quotes */
 ```
 
+Quotes within comments are ignored.
+
+```css
+/* "This is fine" */
+/* 'And this is also fine' */
+```
+
 ## Options
 
 `string`: `"single"|"double"`

--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -8,6 +8,7 @@ testRule("single", tr => {
   tr.ok("a { color: pink; }")
   tr.ok("a::before { content: 'foo'; }")
   tr.ok("a::before { content: 'foo\"horse\"\'cow\''; }")
+  tr.ok("a { /* \"horse\" */ }")
   tr.ok("a { background: url('foo'); }")
   tr.ok("a[id='foo'] {}")
 
@@ -22,6 +23,7 @@ testRule("double", tr => {
   tr.ok("a { color: pink; }")
   tr.ok("a::before { content: \"foo\"; }")
   tr.ok(`a::before { content: "foo\"horse\"'cow'"; }`)
+  tr.ok("a { /* 'horse' */ }")
   tr.ok("a { background: url(\"foo\"); }")
   tr.ok("a[id=\"foo\"] {}")
 

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -125,6 +125,18 @@ test("ignores matches within double-quote strings", t => {
   /* eslint-enable quotes */
 })
 
+test("ignores matches within comments", t => {
+  t.deepEqual(styleSearchResults({
+    source: "abc/*comment*/",
+    target: "m",
+  }), [])
+  t.deepEqual(styleSearchResults({
+    source: "abc/*command*/",
+    target: "a",
+  }), [0])
+  t.end()
+})
+
 test("handles escaped double-quotes in double-quote strings", t => {
   /* eslint-disable quotes */
   t.deepEqual(styleSearchResults({


### PR DESCRIPTION
…sts; fixes #206 

I think I updated documentation in all the places where I made some deliberate decision about whether comments are ignored or not.

(For most rules this was not a problem because the PostCSS API returns strings with comments already stripped for many properties, like `decl.value`.)  