### PR TITLE
Allow for indentation of delimited selectors; fixes #217

### DIFF
--- a/src/rules/selector-delimiter-newline-after/__tests__/index.js
+++ b/src/rules/selector-delimiter-newline-after/__tests__/index.js
@@ -10,6 +10,8 @@ testRule("always", tr => {
   tr.ok("a ,\nb {}")
   tr.ok("a\n,\nb {}")
   tr.ok("a,\nb[data-foo=\"tr,tr\"] {}")
+  tr.ok("a {\n  &:hover,\n  &:focus {\n    color: pink; }\n}", "nested in rule set")
+  tr.ok("@media (min-width: 10px) {\n  a,\n  b {}\n}", "nested in at-rule")
 
   tr.notOk("a,b {}", messages.expectedAfter())
   tr.notOk("a, b {}", messages.expectedAfter())
@@ -17,6 +19,7 @@ testRule("always", tr => {
   tr.notOk("a,\tb {}", messages.expectedAfter())
   tr.notOk("a,\nb,c {}", messages.expectedAfter())
   tr.notOk("a,\nb,\n c {}", messages.expectedAfter())
+  tr.notOk("a,\n  b {}", messages.expectedAfter())
 })
 
 testRule("never", tr => {

--- a/src/rules/selector-delimiter-newline-after/index.js
+++ b/src/rules/selector-delimiter-newline-after/index.js
@@ -1,9 +1,9 @@
 import {
   ruleMessages,
+  styleSearch,
+  report,
   whitespaceChecker
 } from "../../utils"
-
-import { selectorDelimiterSpaceChecker } from "../selector-delimiter-space-after"
 
 export const ruleName = "selector-delimiter-newline-after"
 
@@ -16,5 +16,25 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)
-  return selectorDelimiterSpaceChecker(checker.after)
+  return (root, result) => {
+    root.eachRule(rule => {
+      // Allow for the special case of nested rule sets
+      // that should be indented
+      const checkLocation = (rule.parent === root)
+        ? checker.after
+        : checker.afterOneOnly
+
+      const selector = rule.selector
+      styleSearch({ source: selector, target: "," }, match => {
+        checkLocation(selector, match.startIndex, m =>
+          report({
+            message: m,
+            node: rule,
+            result,
+            ruleName,
+          })
+        )
+      })
+    })
+  }
 }


### PR DESCRIPTION
I think the same problem would have applied to media queries, not just rules within rules. So I applied a test for both.