### PR TITLE
Add disableRanges to real-life #223 and minimal integration tests #202

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,1 +1,3 @@
-// @todo minimal integration tests
+import "./integration"
+import "./disableRanges-test"
+import "./disableRanges-integration-test"

--- a/src/__tests__/integration.js
+++ b/src/__tests__/integration.js
@@ -1,0 +1,47 @@
+import test from "tape"
+import postcss from "postcss"
+import stylelint from "../"
+
+const config = {
+  rules: {
+    "block-opening-brace-newline-after": [ 2, "always" ],
+    "color-no-invalid-hex": 2,
+  },
+}
+
+const css = (
+`a {
+  color: #zzz;
+}
+
+b { background: pink; }
+
+/* stylelint-disable color-no-invalid-hex */
+.foo {
+  color: #yyy;
+}
+/* stylelint-enable */
+
+.bar {
+  color: #mmm;
+}
+`)
+
+postcss()
+  .use(stylelint(config))
+  .process(css)
+  .then(checkResult)
+  .catch(e => console.log(e.stack))
+
+function checkResult(result) {
+  const { messages } = result
+  test("expected warnings", t => {
+    t.equal(messages.length, 3)
+    t.ok(messages.every(m => m.type === "warning"))
+    t.ok(messages.every(m => m.plugin === "stylelint"))
+    t.equal(messages[0].text, "Expected newline after \"{\" (block-opening-brace-newline-after)")
+    t.equal(messages[1].text, "Unexpected invalid hex color \"#zzz\" (color-no-invalid-hex)")
+    t.equal(messages[2].text, "Unexpected invalid hex color \"#mmm\" (color-no-invalid-hex)")
+    t.end()
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,14 @@
 import postcss from "postcss"
 import ruleDefinitions from "./rules"
+import disableRanges from "./disableRanges"
 
 export default postcss.plugin("stylelint", settings => {
   return (css, result) => {
     if (!settings) { return }
     if (!settings.rules) { return }
+
+    // First check for disabled ranges
+    disableRanges(css, result)
 
     Object.keys(settings.rules).forEach(ruleName => {
       if (!ruleDefinitions[ruleName]) {


### PR DESCRIPTION
Guess I forgot to integrate disableRanges into the code that people actually use. Should be there now, fixing #223. 

To test that it indeed was I created the minimal integration tests discussed in #202. So if we're happy with what they look like we could close that one, as well.