### PR TITLE
Remove markdown exception from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,3 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.md]
-trim_trailing_whitespace = false


### PR DESCRIPTION
Anyone know why there's an exception for markdown files? Seems to cause more trouble than it's worth when it comes to diffs.