### PR TITLE
Update the selector-delimiter- rules to use standard whitespace options

### DIFF
--- a/src/rules/selector-delimiter-newline-after/README.md
+++ b/src/rules/selector-delimiter-newline-after/README.md
@@ -3,15 +3,15 @@
 Require or disallow a newline after the delimiters of selectors.
 
 ```css
-    a, 
+    a,
     b↑{ color: pink; }
-/**  ↑  
+/**  ↑
  * The newline after this delimiter */
 ```
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -31,7 +31,7 @@ a
 The following patterns are *not* considered warnings:
 
 ```css
-a, 
+a,
 b { color: pink; }
 ```
 
@@ -41,11 +41,22 @@ a
 b { color: pink; }
 ```
 
-### `"never"`
+### `"always-multi-line"`
 
-There *must never* be whitepace after the delimiter.
+There *must always* be a single newline after the delimiter in multi-line selectors.
 
 The following patterns are considered warnings:
+
+```css
+a
+, b { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a, b { color: pink; }
+```
 
 ```css
 a,
@@ -54,7 +65,23 @@ b { color: pink; }
 
 ```css
 a
-, 
+,
+b { color: pink; }
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace after the delimiter in multi-line selectors.
+
+The following patterns are considered warnings:
+
+```css
+a
+, b { color: pink; }
+```
+
+```css
+a,
 b { color: pink; }
 ```
 

--- a/src/rules/selector-delimiter-newline-after/__tests__/index.js
+++ b/src/rules/selector-delimiter-newline-after/__tests__/index.js
@@ -22,18 +22,20 @@ testRule("always", tr => {
   tr.notOk("a,\n  b {}", messages.expectedAfter())
 })
 
-testRule("never", tr => {
-  tr.ok("a {}")
-  tr.ok("a,b {}")
-  tr.ok("a,b,c {}")
-  tr.ok("a ,b {}")
-  tr.ok("a\n,b {}")
-  tr.ok("a,b[data-foo=\"tr, tr\"] {}")
+testRule("always-multi-line", tr => {
+  tr.ok("a,\nb {}")
+  tr.ok("a, b {}", "ignores single-line")
+  tr.ok("a, b {\n}", "ignores single-line selector, multi-line block")
 
-  tr.notOk("a, b {}", messages.rejectedAfter())
-  tr.notOk("a,  b {}", messages.rejectedAfter())
-  tr.notOk("a,\nb {}", messages.rejectedAfter())
-  tr.notOk("a,\tb {}", messages.rejectedAfter())
-  tr.notOk("a,b, c {}", messages.rejectedAfter())
-  tr.notOk("a,b,\n c {}", messages.rejectedAfter())
+  tr.notOk("a,\nb, c {}", messages.expectedAfterMultiLine())
+  tr.notOk("a,\nb, c {\n}", messages.expectedAfterMultiLine())
+})
+
+testRule("never-multi-line", tr => {
+  tr.ok("a\n,b {}")
+  tr.ok("a ,b {}", "ignores single-line")
+  tr.ok("a ,b {\n}", "ignores single-line selector, multi-line block")
+
+  tr.notOk("a,\nb ,c {}", messages.rejectedAfterMultiLine())
+  tr.notOk("a,\nb ,c {\n}", messages.rejectedAfterMultiLine())
 })

--- a/src/rules/selector-delimiter-newline-after/index.js
+++ b/src/rules/selector-delimiter-newline-after/index.js
@@ -8,11 +8,13 @@ import {
 export const ruleName = "selector-delimiter-newline-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => "Expected newline after selector delimiter",
-  rejectedAfter: () => "Unexpected space after selector delimiter",
+  expectedAfter: () => `Expected newline after ","`,
+  expectedAfterMultiLine: () => `Expected newline after "," in multi-line selector`,
+  rejectedAfterMultiLine: () => `Unexpected space after "," in multi-line selector`,
 })
+
 /**
- * @param {"always"|"never"} expectation
+ * @param {"always"|"always-multi-line"|"never-multi-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)

--- a/src/rules/selector-delimiter-newline-before/README.md
+++ b/src/rules/selector-delimiter-newline-before/README.md
@@ -5,13 +5,13 @@ Require or disallow a newline before the delimiters of selectors.
 ```css
     a
     , b { color: pink; }
-/** ↑  
+/** ↑
  * The newline before this delimiter */
 ```
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -24,7 +24,7 @@ a, b { color: pink; }
 ```
 
 ```css
-a, 
+a,
 b { color: pink; }
 ```
 
@@ -40,19 +40,49 @@ a
 ,b { color: pink; }
 ```
 
-### `"never"`
+### `"always-multi-line"`
 
-There *must never* be whitepace before the delimiter.
+There *must always* be a single newline before the delimiter in multi-line selectors.
 
 The following patterns are considered warnings:
 
 ```css
-a ,b { color: pink; }
+a,
+b { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a, b { color: pink; }
 ```
 
 ```css
 a
+,b { color: pink; }
+```
+
+```css
+a
+,
+b { color: pink; }
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace before the delimiter in multi-line selectors.
+
+The following patterns are considered warnings:
+
+```css
+a
 , b { color: pink; }
+```
+
+```css
+a
+,
+b { color: pink; }
 ```
 
 The following patterns are *not* considered warnings:

--- a/src/rules/selector-delimiter-newline-before/__tests__/index.js
+++ b/src/rules/selector-delimiter-newline-before/__tests__/index.js
@@ -19,17 +19,20 @@ testRule("always", tr => {
   tr.notOk("a\n,b\n ,c {}", messages.expectedBefore())
 })
 
-testRule("never", tr => {
-  tr.ok("a {}")
-  tr.ok("a,b {}")
-  tr.ok("a,b,c {}")
-  tr.ok("a, b {}")
-  tr.ok("a,\nb {}")
-  tr.ok("a,b[data-foo=\"tr ,tr\"] {}")
+testRule("always-multi-line", tr => {
+  tr.ok("a\n,b {}")
+  tr.ok("a, b {}", "ignores single-line")
+  tr.ok("a, b {\n}", "ignores single-line selector, multi-line block")
 
-  tr.notOk("a ,b {}", messages.rejectedBefore())
-  tr.notOk("a  ,b {}", messages.rejectedBefore())
-  tr.notOk("a\t,b {}", messages.rejectedBefore())
-  tr.notOk("a,b ,c {}", messages.rejectedBefore())
-  tr.notOk("a,b\n ,c {}", messages.rejectedBefore())
+  tr.notOk("a\n,b, c {}", messages.expectedBeforeMultiLine())
+  tr.notOk("a\n,b, c {\n}", messages.expectedBeforeMultiLine())
+})
+
+testRule("never-multi-line", tr => {
+  tr.ok("a,\nb {}")
+  tr.ok("a ,b {}", "ignores single-line")
+  tr.ok("a ,b {\n}", "ignores single-line selector, multi-line block")
+
+  tr.notOk("a,\nb , c {}", messages.rejectedBeforeMultiLine())
+  tr.notOk("a,\nb , c {\n}", messages.rejectedBeforeMultiLine())
 })

--- a/src/rules/selector-delimiter-newline-before/index.js
+++ b/src/rules/selector-delimiter-newline-before/index.js
@@ -8,11 +8,13 @@ import { selectorDelimiterSpaceChecker } from "../selector-delimiter-space-after
 export const ruleName = "selector-delimiter-newline-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => "Expected newline before selector delimiter",
-  rejectedBefore: () => "Unexpected space before selector delimiter",
+  expectedBefore: () => `Expected newline before ","`,
+  expectedBeforeMultiLine: () => `Expected newline before "," in multi-line selector`,
+  rejectedBeforeMultiLine: () => `Unexpected space before "," in multi-line selector`,
 })
+
 /**
- * @param {"always"|"never"} expectation
+ * @param {"always"|"always-multi-line"|"never-multi-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)

--- a/src/rules/selector-delimiter-space-after/README.md
+++ b/src/rules/selector-delimiter-space-after/README.md
@@ -4,13 +4,14 @@ Require or disallow a space after the delimiters of selectors.
 
 ```css
     a, b { color: pink; }
-/**  ↑  
+/**  ↑
  * The space after this delimiter */
 ```
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"never"|"always-single-line"|"never-single-line"`
+
 
 ### `"always"`
 
@@ -58,4 +59,38 @@ a,b { color: pink; }
 
 ```css
 a ,b { color: pink; }
+```
+
+### `"always-single-line"`
+
+There *must always* be a single space after the delimiter in single-line selectors.
+
+The following patterns are considered warnings:
+
+```css
+a,b { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a
+,b { color: pink; }
+```
+
+### `"never-single-line"`
+
+There *must never* be a single space after the delimiter in single-line selectors.
+
+The following patterns are considered warnings:
+
+```css
+a, b { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a
+, b { color: pink; }
 ```

--- a/src/rules/selector-delimiter-space-after/__tests__/index.js
+++ b/src/rules/selector-delimiter-space-after/__tests__/index.js
@@ -34,3 +34,19 @@ testRule("never", tr => {
   tr.notOk("a,b, c {}", messages.rejectedAfter())
   tr.notOk("a,b,  c {}", messages.rejectedAfter())
 })
+
+testRule("always-single-line", tr => {
+  tr.ok("a, b {}")
+  tr.ok("a, b {\n}", "single-line selector, multi-line block")
+
+  tr.notOk("a,b {}", messages.expectedAfterSingleLine())
+  tr.notOk("a,b {\n}", messages.expectedAfterSingleLine())
+})
+
+testRule("never-single-line", tr => {
+  tr.ok("a,b {}")
+  tr.ok("a,b {\n}", "single-line selector, multi-line block")
+
+  tr.notOk("a, b {}", messages.rejectedAfterSingleLine())
+  tr.notOk("a, b {\n}", messages.rejectedAfterSingleLine())
+})

--- a/src/rules/selector-delimiter-space-after/index.js
+++ b/src/rules/selector-delimiter-space-after/index.js
@@ -8,11 +8,14 @@ import {
 export const ruleName = "selector-delimiter-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: () => "Expected single space after selector delimiter",
-  rejectedAfter: () => "Unexpected space after selector delimiter",
+  expectedAfter: () => `Expected single space after ","`,
+  rejectedAfter: () => `Unexpected space after ","`,
+  expectedAfterSingleLine: () => `Expected single space after "," in a single-line selector`,
+  rejectedAfterSingleLine: () => `Unexpected space after "," in a single-line selector`,
 })
+
 /**
- * @param {"always"|"never"} expectation
+ * @param {"always"|"never"|"always-single-line"|"never-single-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker(" ", expectation, messages)

--- a/src/rules/selector-delimiter-space-before/README.md
+++ b/src/rules/selector-delimiter-space-before/README.md
@@ -4,13 +4,14 @@ Require or disallow a space before the delimiters of selectors.
 
 ```css
     a, b { color: pink; }
-/**  ↑  
+/**  ↑
  * The space before this delimiter */
 ```
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"never"|"always-single-line"|"never-single-line"`
+
 
 ### `"always"`
 
@@ -58,4 +59,38 @@ a,b { color: pink; }
 
 ```css
 a, b { color: pink; }
+```
+
+### `"always-single-line"`
+
+There *must always* be a single space before the delimiter in single-line selectors.
+
+The following patterns are considered warnings:
+
+```css
+a,b { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a,
+b { color: pink; }
+```
+
+### `"never-single-line"`
+
+There *must never* be a single space before the delimiter in single-line selectors.
+
+The following patterns are considered warnings:
+
+```css
+a ,b { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a ,
+b { color: pink; }
 ```

--- a/src/rules/selector-delimiter-space-before/__tests__/index.js
+++ b/src/rules/selector-delimiter-space-before/__tests__/index.js
@@ -34,3 +34,19 @@ testRule("never", tr => {
   tr.notOk("a,b ,c {}", messages.rejectedBefore())
   tr.notOk("a,b  ,c {}", messages.rejectedBefore())
 })
+
+testRule("always-single-line", tr => {
+  tr.ok("a ,b {}")
+  tr.ok("a ,b {\n}", "single-line selector, multi-line block")
+
+  tr.notOk("a,b {}", messages.expectedBeforeSingleLine())
+  tr.notOk("a,b {\n}", messages.expectedBeforeSingleLine())
+})
+
+testRule("never-single-line", tr => {
+  tr.ok("a,b {}")
+  tr.ok("a,b {\n}", "single-line selector, multi-line block")
+
+  tr.notOk("a ,b {}", messages.rejectedBeforeSingleLine())
+  tr.notOk("a ,b {\n}", messages.rejectedBeforeSingleLine())
+})

--- a/src/rules/selector-delimiter-space-before/index.js
+++ b/src/rules/selector-delimiter-space-before/index.js
@@ -8,9 +8,12 @@ import { selectorDelimiterSpaceChecker } from "../selector-delimiter-space-after
 export const ruleName = "selector-delimiter-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: () => "Expected single space before selector delimiter",
-  rejectedBefore: () => "Unexpected space before selector delimiter",
+  expectedBefore: () => `Expected single space before ","`,
+  rejectedBefore: () => `Unexpected space before ","`,
+  expectedBeforeSingleLine: () => `Expected single space before "," in a single-line selector`,
+  rejectedBeforeSingleLine: () => `Unexpected space before "," in a single-line selector`,
 })
+
 /**
  * @param {"always"|"never"} expectation
  */


### PR DESCRIPTION
Lets us use the new funky standardised whitespace options ( https://github.com/stylelint/stylelint/blob/master/docs/user-guide.md#whitespace-rules-work-together) with selector delimiters.

Ref #231 