### PR TITLE
More accurate messages for whitespace 'never' option

### DIFF
--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -8,11 +8,11 @@ export const ruleName = "block-closing-brace-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after "}"`,
-  rejectedAfter: () => `Unexpected space after "}"`,
+  rejectedAfter: () => `Unexpected whitespace after "}"`,
   expectedAfterSingleLine: () => `Expected single space after "}" of a single-line block`,
-  rejectedAfterSingleLine: () => `Unexpected space after "}" of a single-line block`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after "}" of a single-line block`,
   expectedAfterMultiLine: () => `Expected single space after "}" of a multi-line block`,
-  rejectedAfterMultiLine: () => `Unexpected space after "}" of a multi-line block`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "}" of a multi-line block`,
 })
 
 /**

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -10,9 +10,9 @@ export const ruleName = "block-closing-brace-newline-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before "}"`,
-  rejectedBefore: () => `Unexpected space before "}"`,
+  rejectedBefore: () => `Unexpected whitespace before "}"`,
   expectedBeforeMultiLine: () => `Expected newline before "}" of a multi-line block`,
-  rejectedBeforeMultiLine: () => `Unexpected space before "}" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "}" of a multi-line block`,
 })
 
 /**

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -8,7 +8,7 @@ export const ruleName = "block-closing-brace-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after "}"`,
-  rejectedAfter: () => `Unexpected space after "}"`,
+  rejectedAfter: () => `Unexpected whitespace after "}"`,
   expectedAfterMultiLine: () => `Expected single space after "}" of a multi-line block`,
 })
 

--- a/src/rules/block-closing-brace-space-before/index.js
+++ b/src/rules/block-closing-brace-space-before/index.js
@@ -10,11 +10,11 @@ export const ruleName = "block-closing-brace-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before "}"`,
-  rejectedBefore: () => `Unexpected space before "}"`,
+  rejectedBefore: () => `Unexpected whitespace before "}"`,
   expectedBeforeSingleLine: () => `Expected single space before "}" of a single-line block`,
-  rejectedBeforeSingleLine: () => `Unexpected space before "}" of a single-line block`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "}" of a single-line block`,
   expectedBeforeMultiLine: () => `Expected single space before "}" of a multi-line block`,
-  rejectedBeforeMultiLine: () => `Unexpected space before "}" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "}" of a multi-line block`,
 })
 
 /**

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -10,9 +10,9 @@ export const ruleName = "block-opening-brace-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after "{"`,
-  rejectedAfter: () => `Unexpected space after "{"`,
+  rejectedAfter: () => `Unexpected whitespace after "{"`,
   expectedAfterMultiLine: () => `Expected newline after "{" of a multi-line block`,
-  rejectedAfterMultiLine: () => `Unexpected space after "{" of a multi-line block`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "{" of a multi-line block`,
 })
 
 /**

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -12,9 +12,9 @@ export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before "{"`,
   rejectedBefore: () => `Unexpected newline before "{"`,
   expectedBeforeSingleLine: () => `Expected newline before "{" of a single-line block`,
-  rejectedBeforeSingleLine: () => `Unexpected space before "{" of a single-line block`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "{" of a single-line block`,
   expectedBeforeMultiLine: () => `Expected newline before "{" of a multi-line block`,
-  rejectedBeforeMultiLine: () => `Unexpected space before "{" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "{" of a multi-line block`,
 })
 
 /**

--- a/src/rules/block-opening-brace-space-after/index.js
+++ b/src/rules/block-opening-brace-space-after/index.js
@@ -10,11 +10,11 @@ export const ruleName = "block-opening-brace-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after "{"`,
-  rejectedAfter: () => `Unexpected space after "{"`,
+  rejectedAfter: () => `Unexpected whitespace after "{"`,
   expectedAfterSingleLine: () => `Expected single space after "{" of a single-line block`,
-  rejectedAfterSingleLine: () => `Unexpected space after "{" of a single-line block`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after "{" of a single-line block`,
   expectedAfterMultiLine: () => `Expected single space after "{" of a multi-line block`,
-  rejectedAfterMultiLine: () => `Unexpected space after "{" of a multi-line block`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "{" of a multi-line block`,
 })
 
 /**

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -8,11 +8,11 @@ export const ruleName = "block-opening-brace-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before "{"`,
-  rejectedBefore: () => `Unexpected space before "{"`,
+  rejectedBefore: () => `Unexpected whitespace before "{"`,
   expectedBeforeSingleLine: () => `Expected single space before "{" of a single-line block`,
-  rejectedBeforeSingleLine: () => `Unexpected space before "{" of a single-line block`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "{" of a single-line block`,
   expectedBeforeMultiLine: () => `Expected single space before "{" of a multi-line block`,
-  rejectedBeforeMultiLine: () => `Unexpected space before "{" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "{" of a multi-line block`,
 })
 
 /**

--- a/src/rules/comment-space-inside/index.js
+++ b/src/rules/comment-space-inside/index.js
@@ -7,9 +7,9 @@ export const ruleName = "comment-space-inside"
 
 export const messages = ruleMessages(ruleName, {
   expectedOpening: `Expected single space after "/*`,
-  rejectedOpening: `Unexpected space after "/*`,
+  rejectedOpening: `Unexpected whitespace after "/*`,
   expectedClosing: `Expected single space before "*/"`,
-  rejectedClosing: `Unexpected space before "*/"`,
+  rejectedClosing: `Unexpected whitespace before "*/"`,
 })
 
 /**

--- a/src/rules/declaration-bang-space-after/index.js
+++ b/src/rules/declaration-bang-space-after/index.js
@@ -8,7 +8,7 @@ export const ruleName = "declaration-bang-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => "Expected single space after \"!\"",
-  rejectedAfter: () => "Unexpected space after \"!\"",
+  rejectedAfter: () => "Unexpected whitespace after \"!\"",
 })
 
 /**

--- a/src/rules/declaration-bang-space-before/index.js
+++ b/src/rules/declaration-bang-space-before/index.js
@@ -8,7 +8,7 @@ export const ruleName = "declaration-bang-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => "Expected single space before \"!\"",
-  rejectedBefore: () => "Unexpected space before \"!\"",
+  rejectedBefore: () => "Unexpected whitespace before \"!\"",
 })
 
 /**

--- a/src/rules/declaration-block-semicolon-newline-before/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/index.js
@@ -8,9 +8,9 @@ export const ruleName = "declaration-block-semicolon-newline-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before ";"`,
-  rejectedBefore: () => `Unexpected space before ";"`,
+  rejectedBefore: () => `Unexpected whitespace before ";"`,
   expectedBeforeMultiLine: () => `Expected newline before ";" within multi-line rule`,
-  rejectedBeforeMultiLine: () => `Unexpected space before ";" within multi-line rule`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before ";" within multi-line rule`,
 })
 
 /**

--- a/src/rules/declaration-block-semicolon-space-after/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/index.js
@@ -8,9 +8,9 @@ export const ruleName = "declaration-block-semicolon-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ";"`,
-  rejectedAfter: () => `Unexpected space after ";"`,
+  rejectedAfter: () => `Unexpected whitespace after ";"`,
   expectedAfterSingleLine: () => `Expected single space after ";" within single-line rule`,
-  rejectedAfterSingleLine: () => `Unexpected space after ";" within single-line rule`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after ";" within single-line rule`,
 })
 
 /**

--- a/src/rules/declaration-block-semicolon-space-before/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/index.js
@@ -8,9 +8,9 @@ export const ruleName = "declaration-block-semicolon-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ";"`,
-  rejectedBefore: () => `Unexpected space before ";"`,
+  rejectedBefore: () => `Unexpected whitespace before ";"`,
   expectedBeforeSingleLine: () => `Expected single space before ";" within single-line rule`,
-  rejectedBeforeSingleLine: () => `Unexpected space before ";" within single-line rule`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before ";" within single-line rule`,
 })
 
 /**

--- a/src/rules/declaration-colon-space-after/index.js
+++ b/src/rules/declaration-colon-space-after/index.js
@@ -8,7 +8,7 @@ export const ruleName = "declaration-colon-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ":"`,
-  rejectedAfter: () => `Unexpected space after ":"`,
+  rejectedAfter: () => `Unexpected whitespace after ":"`,
 })
 
 /**

--- a/src/rules/declaration-colon-space-before/index.js
+++ b/src/rules/declaration-colon-space-before/index.js
@@ -8,7 +8,7 @@ export const ruleName = "declaration-colon-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ":"`,
-  rejectedBefore: () => `Unexpected space before ":"`,
+  rejectedBefore: () => `Unexpected whitespace before ":"`,
 })
 
 /**

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -9,7 +9,7 @@ export const ruleName = "function-comma-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ","`,
-  rejectedAfter: () => `Unexpected space after ","`,
+  rejectedAfter: () => `Unexpected whitespace after ","`,
 })
 
 /**

--- a/src/rules/function-comma-space-before/index.js
+++ b/src/rules/function-comma-space-before/index.js
@@ -8,7 +8,7 @@ export const ruleName = "function-comma-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ","`,
-  rejectedBefore: () => `Unexpected space before ","`,
+  rejectedBefore: () => `Unexpected whitespace before ","`,
 })
 
 /**

--- a/src/rules/function-parentheses-space-inside/index.js
+++ b/src/rules/function-parentheses-space-inside/index.js
@@ -9,9 +9,9 @@ export const ruleName = "function-parentheses-space-inside"
 
 export const messages = ruleMessages(ruleName, {
   expectedOpening: `Expected single space after "("`,
-  rejectedOpening: `Unexpected space after "("`,
+  rejectedOpening: `Unexpected whitespace after "("`,
   expectedClosing: `Expected single space before ")"`,
-  rejectedClosing: `Unexpected space before ")"`,
+  rejectedClosing: `Unexpected whitespace before ")"`,
 })
 
 /**

--- a/src/rules/function-space-after/index.js
+++ b/src/rules/function-space-after/index.js
@@ -9,7 +9,7 @@ export const ruleName = "function-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expected: "Expected single space after \")\"",
-  rejected: "Unexpected space after \")\"",
+  rejected: "Unexpected whitespace after \")\"",
 })
 
 /**

--- a/src/rules/function-token-no-space/index.js
+++ b/src/rules/function-token-no-space/index.js
@@ -8,7 +8,7 @@ import {
 export const ruleName = "function-token-no-space"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: `Unexpected space between function name and "("`,
+  rejected: `Unexpected whitespace between function name and "("`,
 })
 
 export default function () {

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -9,7 +9,7 @@ export const ruleName = "media-feature-colon-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ":"`,
-  rejectedAfter: () => `Unexpected space after ":"`,
+  rejectedAfter: () => `Unexpected whitespace after ":"`,
 })
 
 /**

--- a/src/rules/media-feature-colon-space-before/index.js
+++ b/src/rules/media-feature-colon-space-before/index.js
@@ -9,7 +9,7 @@ export const ruleName = "media-feature-colon-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ":"`,
-  rejectedBefore: () => `Unexpected space before ":"`,
+  rejectedBefore: () => `Unexpected whitespace before ":"`,
 })
 
 /**

--- a/src/rules/media-feature-range-operator-space-after/index.js
+++ b/src/rules/media-feature-range-operator-space-after/index.js
@@ -8,7 +8,7 @@ export const ruleName = "media-feature-range-operator-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after range operator`,
-  rejectedAfter: () => `Unexpected space after range operator`,
+  rejectedAfter: () => `Unexpected whitespace after range operator`,
 })
 
 const rangeOperatorRegex = /[^><](>=?|<=?|=)/g

--- a/src/rules/media-feature-range-operator-space-before/index.js
+++ b/src/rules/media-feature-range-operator-space-before/index.js
@@ -10,7 +10,7 @@ export const ruleName = "media-feature-range-operator-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before range operator`,
-  rejectedBefore: () => `Unexpected space before range operator`,
+  rejectedBefore: () => `Unexpected whitespace before range operator`,
 })
 
 /**

--- a/src/rules/media-query-list-comma-newline-after/index.js
+++ b/src/rules/media-query-list-comma-newline-after/index.js
@@ -8,7 +8,7 @@ export const ruleName = "media-query-list-comma-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after ","`,
-  rejectedAfter: () => `Unexpected space after ","`,
+  rejectedAfter: () => `Unexpected whitespace after ","`,
 })
 
 /**

--- a/src/rules/media-query-list-comma-newline-before/index.js
+++ b/src/rules/media-query-list-comma-newline-before/index.js
@@ -9,7 +9,7 @@ export const ruleName = "media-query-list-comma-newline-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before ","`,
-  rejectedBefore: () => `Unexpected space before ","`,
+  rejectedBefore: () => `Unexpected whitespace before ","`,
 })
 
 /**

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -9,7 +9,7 @@ export const ruleName = "media-query-list-comma-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ","`,
-  rejectedAfter: () => `Unexpected space after ","`,
+  rejectedAfter: () => `Unexpected whitespace after ","`,
 })
 
 /**

--- a/src/rules/media-query-list-comma-space-before/index.js
+++ b/src/rules/media-query-list-comma-space-before/index.js
@@ -8,7 +8,7 @@ export const ruleName = "media-query-list-comma-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ","`,
-  rejectedBefore: () => `Unexpected space before ","`,
+  rejectedBefore: () => `Unexpected whitespace before ","`,
 })
 
 /**

--- a/src/rules/media-query-parentheses-space-inside/index.js
+++ b/src/rules/media-query-parentheses-space-inside/index.js
@@ -8,9 +8,9 @@ export const ruleName = "media-query-parentheses-space-inside"
 
 export const messages = ruleMessages(ruleName, {
   expectedOpening: `Expected single space after "("`,
-  rejectedOpening: `Unexpected space after "("`,
+  rejectedOpening: `Unexpected whitespace after "("`,
   expectedClosing: `Expected single space before ")"`,
-  rejectedClosing: `Unexpected space before ")"`,
+  rejectedClosing: `Unexpected whitespace before ")"`,
 })
 
 /**

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -8,7 +8,7 @@ export const ruleName = "selector-combinator-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: c => `Expected single space after "${c}" combinator `,
-  rejectedAfter: c => `Unexpected space after "${c}" combinator`,
+  rejectedAfter: c => `Unexpected whitespace after "${c}" combinator`,
 })
 
 const combinators = [ ">", "+", "~" ]

--- a/src/rules/selector-combinator-space-before/index.js
+++ b/src/rules/selector-combinator-space-before/index.js
@@ -9,7 +9,7 @@ export const ruleName = "selector-combinator-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: c => `Expected single space before "${c}" combinator`,
-  rejectedBefore: c => `Unexpected space before "${c}" combinator`,
+  rejectedBefore: c => `Unexpected whitespace before "${c}" combinator`,
 })
 
 /**

--- a/src/rules/selector-delimiter-newline-after/index.js
+++ b/src/rules/selector-delimiter-newline-after/index.js
@@ -10,7 +10,7 @@ export const ruleName = "selector-delimiter-newline-after"
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after ","`,
   expectedAfterMultiLine: () => `Expected newline after "," in multi-line selector`,
-  rejectedAfterMultiLine: () => `Unexpected space after "," in multi-line selector`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "," in multi-line selector`,
 })
 
 /**

--- a/src/rules/selector-delimiter-newline-before/index.js
+++ b/src/rules/selector-delimiter-newline-before/index.js
@@ -10,7 +10,7 @@ export const ruleName = "selector-delimiter-newline-before"
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before ","`,
   expectedBeforeMultiLine: () => `Expected newline before "," in multi-line selector`,
-  rejectedBeforeMultiLine: () => `Unexpected space before "," in multi-line selector`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "," in multi-line selector`,
 })
 
 /**

--- a/src/rules/selector-delimiter-space-after/index.js
+++ b/src/rules/selector-delimiter-space-after/index.js
@@ -9,9 +9,9 @@ export const ruleName = "selector-delimiter-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ","`,
-  rejectedAfter: () => `Unexpected space after ","`,
+  rejectedAfter: () => `Unexpected whitespace after ","`,
   expectedAfterSingleLine: () => `Expected single space after "," in a single-line selector`,
-  rejectedAfterSingleLine: () => `Unexpected space after "," in a single-line selector`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after "," in a single-line selector`,
 })
 
 /**

--- a/src/rules/selector-delimiter-space-before/index.js
+++ b/src/rules/selector-delimiter-space-before/index.js
@@ -9,9 +9,9 @@ export const ruleName = "selector-delimiter-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ","`,
-  rejectedBefore: () => `Unexpected space before ","`,
+  rejectedBefore: () => `Unexpected whitespace before ","`,
   expectedBeforeSingleLine: () => `Expected single space before "," in a single-line selector`,
-  rejectedBeforeSingleLine: () => `Unexpected space before "," in a single-line selector`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "," in a single-line selector`,
 })
 
 /**

--- a/src/rules/value-list-comma-newline-after/index.js
+++ b/src/rules/value-list-comma-newline-after/index.js
@@ -9,7 +9,7 @@ export const ruleName = "value-list-comma-newline-after"
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after ","`,
   expectedAfterMultiLine: () => `Expected newline after "," in multi-line value`,
-  rejectedAfterMultiLine: () => `Unexpected space after "," in multi-line value`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "," in multi-line value`,
 })
 
 /**

--- a/src/rules/value-list-comma-newline-before/index.js
+++ b/src/rules/value-list-comma-newline-before/index.js
@@ -9,7 +9,7 @@ export const ruleName = "value-list-comma-newline-before"
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before ","`,
   expectedBeforeMultiLine: () => `Expected newline before "," in multi-line value`,
-  rejectedBeforeMultiLine: () => `Unexpected space before "," in multi-line value`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "," in multi-line value`,
 })
 
 /**

--- a/src/rules/value-list-comma-space-after/index.js
+++ b/src/rules/value-list-comma-space-after/index.js
@@ -9,9 +9,9 @@ export const ruleName = "value-list-comma-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ","`,
-  rejectedAfter: () => `Unexpected space after ","`,
+  rejectedAfter: () => `Unexpected whitespace after ","`,
   expectedAfterSingleLine: () => `Expected single space after "," in a single-line value`,
-  rejectedAfterSingleLine: () => `Unexpected space after "," in a single-line value`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after "," in a single-line value`,
 })
 
 /**

--- a/src/rules/value-list-comma-space-before/index.js
+++ b/src/rules/value-list-comma-space-before/index.js
@@ -8,9 +8,9 @@ export const ruleName = "value-list-comma-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ","`,
-  rejectedBefore: () => `Unexpected space before ","`,
-  expectedBeforeSingleLine: () => `Unexpected space before "," in a single-line value`,
-  rejectedBeforeSingleLine: () => `Unexpected space before "," in a single-line value`,
+  rejectedBefore: () => `Unexpected whitespace before ","`,
+  expectedBeforeSingleLine: () => `Unexpected whitespace before "," in a single-line value`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "," in a single-line value`,
 })
 
 /**


### PR DESCRIPTION
The `"never-*"` option of the `*-space-*` and `*-newline-*` rules checks for *any* whitespace. This PR updates all the messages for all the `"never-*"` options across all the `*-space-*` and `*-newline-*` rules to reflect this.

Check out the test report to see what I mean. Hopefully much clearer. E.g.

```console
# DECLARATION-COLON-SPACE-BEFORE: "always"
# fail: a { color :pink; }
ok 1257 no space after should warn
ok 1258 no space after should report "Expected single space after ":" (declaration-colon-space-after)"
# fail: a { color :  pink; }
ok 1259 two spaces after should warn
ok 1260 two spaces after should report "Expected single space after ":" (declaration-colon-space-after)"
# fail: a { color :\tpink; }
ok 1261 tab after should warn
ok 1262 tab after should report "Expected single space after ":" (declaration-colon-space-after)"
# fail: a { color :\npink; }
ok 1263 newline after should warn
ok 1264 newline after should report "Expected single space after ":" (declaration-colon-space-after)"

# DECLARATION-COLON-SPACE-AFTER: "never"
# fail: a { color : pink; }
ok 1268 space after should warn
ok 1269 space after should report "Unexpected whitespace after ":" (declaration-colon-space-after)"
# fail: a { color:  pink; }
ok 1270 two spaces after should warn
ok 1271 two spaces after should report "Unexpected whitespace after ":" (declaration-colon-space-after)"
# fail: a { color :\tpink; }
ok 1272 tab after should warn
ok 1273 tab after should report "Unexpected whitespace after ":" (declaration-colon-space-after)"
# fail: a { color :\npink; }
ok 1274 newline after should warn
ok 1275 newline after should report "Unexpected whitespace after ":" (declaration-colon-space-after)"
```