### PR TITLE
Tests for *-newline-before

### DIFF
--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -40,14 +40,19 @@ export default function (expectation) {
 
       // Only check one after, because there might be other
       // spaces handled by the indentation rule
-      checker.afterOneOnly(nextNode.toString(), -1, msg => {
-        report({
-          message: msg,
-          node: statement,
-          result,
-          ruleName,
-        })
-      }, blockString)
+      checker.afterOneOnly({
+        source: nextNode.toString(),
+        index: -1,
+        err: msg => {
+          report({
+            message: msg,
+            node: statement,
+            result,
+            ruleName,
+          })
+        },
+        lineCheckStr: blockString,
+      })
     }
   }
 }

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -14,6 +14,11 @@ testRule("always", tr => {
   tr.ok("a { color: pink;\n} b { color: red;\n}")
   tr.ok("a { color: pink;\n}b { color: red;\n}")
 
+  tr.ok("@media print {\n  a {\n     color: pink;\n  }\n}",
+    "indentation after the newline before the closing braces")
+  tr.ok("@media print {\n\ta {\n\t\tcolor: pink;\n\t\t{\n\t\t\t&:hover;\n\t\t\t}\n\t\t}\n}",
+    "3 level deep nesting with indentation after the newline before the closing braces")
+
   tr.notOk("a { color: pink;}", messages.expectedBefore())
   tr.notOk("a { color: pink; }", messages.expectedBefore())
   tr.notOk("a { color: pink; \n}", messages.expectedBefore())

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -33,14 +33,19 @@ export default function (expectation) {
 
       const nextNode = statement.next()
       if (!nextNode) { return }
-      checker.after(nextNode.toString(), -1, msg => {
-        report({
-          message: msg,
-          node: statement,
-          result,
-          ruleName,
-        })
-      }, blockString)
+      checker.after({
+        source: nextNode.toString(),
+        index: -1,
+        err: msg => {
+          report({
+            message: msg,
+            node: statement,
+            result,
+            ruleName,
+          })
+        },
+        lineCheckStr: blockString,
+      })
     }
   }
 }

--- a/src/rules/block-closing-brace-space-before/index.js
+++ b/src/rules/block-closing-brace-space-before/index.js
@@ -40,14 +40,19 @@ export default function (expectation) {
       if (openingBraceIndex === -1) { return }
       const blockString = statementString.slice(openingBraceIndex)
 
-      checker.before(blockString, blockString.length - 1, msg => {
-        report({
-          message: msg,
-          node: statement,
-          result,
-          ruleName,
-        })
-      }, blockString)
+      checker.before({
+        source: blockString,
+        index: blockString.length - 1,
+        err: msg => {
+          report({
+            message: msg,
+            node: statement,
+            result,
+            ruleName,
+          })
+        },
+        lineCheckStr: blockString,
+      })
     }
   }
 }

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -49,12 +49,19 @@ export default function (expectation) {
             ("@" + statement.name + statement.afterName + statement.params + statement.between).length
           )
 
-      checker.afterOneOnly(nodeToCheck.toString(), -1, m => report({
-        message: m,
-        node: nodeToCheck,
-        result,
-        ruleName,
-      }), lineCheckStr)
+      checker.afterOneOnly({
+        lineCheckStr,
+        source: nodeToCheck.toString(),
+        index: -1,
+        err: m => {
+          report({
+            message: m,
+            node: nodeToCheck,
+            result,
+            ruleName,
+          })
+        },
+      })
     }
   }
 }

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -14,6 +14,10 @@ testRule("always", tr => {
   tr.ok("a\n{color: pink; }")
   tr.ok("@media print\n{ a\n{ color: pink; } }")
   tr.ok("@media print\n{a\n{color: pink; } }")
+  tr.ok("@media print\n\t{a\n\t\t{color: pink; } }",
+    "indentation after the newline before the opening braces")
+  tr.ok("@media print\n\t{a\n\t\t{color: pink;\n\t\t{\n\t\t\t&:hover{\n\t\t\t\tcolor:black;} } } }",
+    "3 level deep indentation after the newline before the opening braces")
 
   tr.notOk("a { color: pink; }", messages.expectedBefore())
   tr.notOk("a{ color: pink; }", messages.expectedBefore())

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -16,7 +16,7 @@ testRule("always", tr => {
   tr.ok("@media print\n{a\n{color: pink; } }")
   tr.ok("@media print\n\t{a\n\t\t{color: pink; } }",
     "indentation after the newline before the opening braces")
-  tr.ok("@media print\n\t{a\n\t\t{color: pink;\n\t\t{\n\t\t\t&:hover{\n\t\t\t\tcolor:black;} } } }",
+  tr.ok("@media print\n\t{a\n\t\t{color: pink;\n\t\t&:hover\n\t\t\t{\n\t\t\t\tcolor:black;} } }",
     "3 level deep indentation after the newline before the opening braces")
 
   tr.notOk("a { color: pink; }", messages.expectedBefore())

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -42,12 +42,19 @@ export default function (expectation) {
       // the curly braces and everything between them
       const lineCheckStr = statement.toString().slice(strBeforeOpeningBrace.length)
 
-      checker.before(strBeforeOpeningBrace.toString(), strBeforeOpeningBrace.length, m => report({
-        message: m,
-        node: statement,
-        result,
-        ruleName,
-      }), lineCheckStr)
+      checker.before({
+        lineCheckStr,
+        source: strBeforeOpeningBrace.toString(),
+        index: strBeforeOpeningBrace.length,
+        err: m => {
+          report({
+            message: m,
+            node: statement,
+            result,
+            ruleName,
+          })
+        },
+      })
     }
   }
 }

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -42,7 +42,7 @@ export default function (expectation) {
       // the curly braces and everything between them
       const lineCheckStr = statement.toString().slice(strBeforeOpeningBrace.length)
 
-      checker.before({
+      checker.beforeAllowingIndentation({
         lineCheckStr,
         source: strBeforeOpeningBrace.toString(),
         index: strBeforeOpeningBrace.length,

--- a/src/rules/block-opening-brace-space-after/index.js
+++ b/src/rules/block-opening-brace-space-after/index.js
@@ -46,14 +46,20 @@ export function blockOpeningBraceSpaceChecker(checkLocation) {
       }
     }
 
-    function checkBrace(str, index, node, lineCheckStr) {
-      checkLocation(str, index, m =>
-        report({
-          message: m,
-          node: node,
-          result,
-          ruleName,
-        }), lineCheckStr)
+    function checkBrace(source, index, node, lineCheckStr) {
+      checkLocation({
+        source,
+        index,
+        lineCheckStr,
+        err: m => {
+          report({
+            message: m,
+            node: node,
+            result,
+            ruleName,
+          })
+        },
+      })
     }
   }
 }

--- a/src/rules/declaration-bang-space-after/index.js
+++ b/src/rules/declaration-bang-space-after/index.js
@@ -34,15 +34,15 @@ export function declarationBangSpaceChecker(locationChecker) {
       }
     })
 
-    function check(str, index, node) {
-      locationChecker(str, index, m =>
+    function check(source, index, node) {
+      locationChecker({ source, index, err: m =>
         report({
           message: m,
           node: node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/rules/declaration-block-semicolon-newline-after/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/index.js
@@ -34,14 +34,19 @@ export default function (expectation) {
 
       const parentRuleString = parentRule.toString()
 
-      check.afterOneOnly(nodeToCheck.toString(), -1, m => {
-        return report({
-          message: m,
-          node: decl,
-          result,
-          ruleName,
-        })
-      }, parentRuleString.slice(parentRuleString.indexOf("{")))
+      check.afterOneOnly({
+        source: nodeToCheck.toString(),
+        index: -1,
+        err: m => {
+          return report({
+            message: m,
+            node: decl,
+            result,
+            ruleName,
+          })
+        },
+        lineCheckStr: parentRuleString.slice(parentRuleString.indexOf("{")),
+      })
     })
   }
 }

--- a/src/rules/declaration-block-semicolon-newline-before/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/index.js
@@ -25,14 +25,19 @@ export default function (expectation) {
       const declString = decl.toString()
       const parentRuleString = parentRule.toString()
 
-      check.before(declString, declString.length, m => {
-        return report({
-          message: m,
-          node: decl,
-          result,
-          ruleName,
-        })
-      }, parentRuleString.slice(parentRuleString.indexOf("{")))
+      check.before({
+        source: declString,
+        index: declString.length,
+        err: m => {
+          return report({
+            message: m,
+            node: decl,
+            result,
+            ruleName,
+          })
+        },
+        lineCheckStr: parentRuleString.slice(parentRuleString.indexOf("{")),
+      })
     })
   }
 }

--- a/src/rules/declaration-block-semicolon-space-after/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/index.js
@@ -29,14 +29,19 @@ export default function (expectation) {
 
       const parentRuleString = parentRule.toString()
 
-      check.after(nextDecl.toString(), -1, m => {
-        return report({
-          message: m,
-          node: decl,
-          result,
-          ruleName,
-        })
-      }, parentRuleString.slice(parentRuleString.indexOf("{")))
+      check.after({
+        source: nextDecl.toString(),
+        index: -1,
+        err: m => {
+          return report({
+            message: m,
+            node: decl,
+            result,
+            ruleName,
+          })
+        },
+        lineCheckStr: parentRuleString.slice(parentRuleString.indexOf("{")),
+      })
     })
   }
 }

--- a/src/rules/declaration-block-semicolon-space-before/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/index.js
@@ -27,14 +27,19 @@ export default function (expectation) {
       const declString = decl.toString()
       const parentRuleString = parentRule.toString()
 
-      check.before(declString, declString.length, m => {
-        return report({
-          message: m,
-          node: decl,
-          result,
-          ruleName,
-        })
-      }, parentRuleString.slice(parentRuleString.indexOf("{")))
+      check.before({
+        source: declString,
+        index: declString.length,
+        err: m => {
+          return report({
+            message: m,
+            node: decl,
+            result,
+            ruleName,
+          })
+        },
+        lineCheckStr: parentRuleString.slice(parentRuleString.indexOf("{")),
+      })
     })
   }
 }

--- a/src/rules/declaration-colon-space-after/index.js
+++ b/src/rules/declaration-colon-space-after/index.js
@@ -31,15 +31,15 @@ export function declarationColonSpaceChecker(locationChecker) {
       }
     })
 
-    function check(str, index, node) {
-      locationChecker(str, index, m =>
+    function check(source, index, node) {
+      locationChecker({ source, index, err: m =>
         report({
           message: m,
           node: node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -51,22 +51,22 @@ export default function () {
               return
             }
 
-            checker.after(expression, index, m =>
+            checker.after({ index, source: expression, err: m =>
               report({
                 message: m,
                 node: decl,
                 result,
                 ruleName,
-              })
-            )
-            checker.before(expression, index, m =>
+              }),
+            })
+            checker.before({ index, source: expression, err: m =>
               report({
                 message: m,
                 node: decl,
                 result,
                 ruleName,
-              })
-            )
+              }),
+            })
           })
         }
       })

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -31,14 +31,14 @@ export function functionCommaSpaceChecker(checkLocation) {
     })
 
     function checkComma(source, index, node) {
-      checkLocation(source, index, m =>
+      checkLocation({ source, index, err: m =>
         report({
           message: m,
           node: node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -30,14 +30,14 @@ export function mediaFeatureColonSpaceChecker(checkLocation) {
     })
 
     function checkColon(source, index, node) {
-      checkLocation(source, index, m =>
+      checkLocation({ source, index, err: m =>
         report({
           message: m,
           node: node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/rules/media-feature-range-operator-space-after/index.js
+++ b/src/rules/media-feature-range-operator-space-after/index.js
@@ -24,14 +24,18 @@ export default function (expectation) {
     })
 
     function checkAfterOperator(match, params, node) {
-      checker.after(params, match.index + match[1].length, m =>
-        report({
-          message: m,
-          node: node,
-          result,
-          ruleName,
-        })
-      )
+      checker.after({
+        source: params,
+        index: match.index + match[1].length,
+        err: m => {
+          report({
+            message: m,
+            node: node,
+            result,
+            ruleName,
+          })
+        },
+      })
     }
   }
 }

--- a/src/rules/media-feature-range-operator-space-before/index.js
+++ b/src/rules/media-feature-range-operator-space-before/index.js
@@ -26,13 +26,17 @@ export default function (expectation) {
     function checkBeforeOperator(match, params, node) {
       // The extra `+ 1` is because the match itself contains
       // the character before the operator
-      checker.before(params, match.index + 1, m => {
-        report({
-          message: m,
-          node: node,
-          result,
-          ruleName,
-        })
+      checker.before({
+        source: params,
+        index: match.index + 1,
+        err: m => {
+          report({
+            message: m,
+            node: node,
+            result,
+            ruleName,
+          })
+        },
       })
     }
   }

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -32,14 +32,14 @@ export function mediaQueryListCommaChecker(checkLocation) {
     })
 
     function checkComma(source, index, node) {
-      checkLocation(source, index, m =>
+      checkLocation({ source, index, err: m =>
         report({
           message: m,
           node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -31,15 +31,15 @@ export function selectorCombinatorSpaceChecker(locationChecker) {
       }
     })
 
-    function check(str, index, node) {
-      locationChecker(str, index, m =>
+    function check(source, index, node) {
+      locationChecker({ source, index, err: m =>
         report({
           message: m,
           node: node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/rules/selector-delimiter-newline-after/index.js
+++ b/src/rules/selector-delimiter-newline-after/index.js
@@ -28,14 +28,17 @@ export default function (expectation) {
 
       const selector = rule.selector
       styleSearch({ source: selector, target: "," }, match => {
-        checkLocation(selector, match.startIndex, m =>
-          report({
-            message: m,
-            node: rule,
-            result,
-            ruleName,
-          })
-        )
+        checkLocation({
+          source: selector,
+          index: match.startIndex,
+          err: m =>
+            report({
+              message: m,
+              node: rule,
+              result,
+              ruleName,
+            }),
+        })
       })
     })
   }

--- a/src/rules/selector-delimiter-newline-before/__tests__/index.js
+++ b/src/rules/selector-delimiter-newline-before/__tests__/index.js
@@ -14,6 +14,8 @@ testRule("always", tr => {
   tr.ok("a\n, b {}")
   tr.ok("a\n,\nb {}")
   tr.ok("a\n,b[data-foo=\"tr,tr\"] {}")
+  tr.ok("a\n    ,b {}", "indentation after the newline before the comma")
+  tr.ok("a\n\t\t,b {}", "indentation after the newline before the comma")
 
   tr.notOk("a,b {}", messages.expectedBefore())
   tr.notOk("a ,b {}", messages.expectedBefore())

--- a/src/rules/selector-delimiter-newline-before/__tests__/index.js
+++ b/src/rules/selector-delimiter-newline-before/__tests__/index.js
@@ -22,7 +22,6 @@ testRule("always", tr => {
   tr.notOk("a  ,b {}", messages.expectedBefore())
   tr.notOk("a\t,b {}", messages.expectedBefore())
   tr.notOk("a\n,b,c {}", messages.expectedBefore())
-  tr.notOk("a\n,b\n ,c {}", messages.expectedBefore())
 })
 
 testRule("always-multi-line", tr => {

--- a/src/rules/selector-delimiter-newline-before/index.js
+++ b/src/rules/selector-delimiter-newline-before/index.js
@@ -18,5 +18,5 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)
-  return selectorDelimiterSpaceChecker(checker.before)
+  return selectorDelimiterSpaceChecker(checker.beforeAllowingIndentation)
 }

--- a/src/rules/selector-delimiter-space-after/index.js
+++ b/src/rules/selector-delimiter-space-after/index.js
@@ -32,14 +32,14 @@ export function selectorDelimiterSpaceChecker(checkLocation) {
     })
 
     function checkDelimiter(source, index, node) {
-      checkLocation(source, index, m =>
+      checkLocation({ source, index, err: m =>
         report({
           message: m,
           node: node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/rules/value-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-before/__tests__/index.js
@@ -11,6 +11,8 @@ testRule("always", tr => {
 
   tr.ok("a { background-size: 0\n,0\n,0; }")
   tr.ok("a { background-size: 0\n,  0\n,\t0; }")
+  tr.ok("a { background-size: 0\n    ,0\n,0; }", "indentation after the newline before the comma")
+  tr.ok("a { background-size: 0\n\t\t,0\n,0; }", "indentation after the newline before the comma")
   tr.notOk("a { background-size: 0, 0; }", messages.expectedBefore())
   tr.notOk("a { background-size: 0 , 0; }", messages.expectedBefore())
   tr.notOk("a { background-size: 0  , 0; }", messages.expectedBefore())

--- a/src/rules/value-list-comma-newline-before/index.js
+++ b/src/rules/value-list-comma-newline-before/index.js
@@ -17,5 +17,5 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)
-  return valueListCommaSpaceChecker(checker.before)
+  return valueListCommaSpaceChecker(checker.beforeAllowingIndentation)
 }

--- a/src/rules/value-list-comma-space-after/index.js
+++ b/src/rules/value-list-comma-space-after/index.js
@@ -33,14 +33,14 @@ export function valueListCommaSpaceChecker(checkLocation) {
     })
 
     function checkComma(source, index, node) {
-      checkLocation(source, index, m =>
+      checkLocation({ source, index, err: m =>
         report({
           message: m,
           node: node,
           result,
           ruleName,
-        })
-      )
+        }),
+      })
     }
   }
 }

--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -1,3 +1,4 @@
+import { assign } from "lodash"
 import isWhitespace from "./isWhitespace"
 import isSingleLineString from "./isSingleLineString"
 
@@ -45,7 +46,7 @@ export default function (targetWhitespace, expectation, messages) {
    *   before and then ensure there is no whitespace two before; this option
    *   bypasses that second check.
    */
-  function before(source, index, err, lineCheckStr, onlyOneChar=false) {
+  function before({ source, index, err, lineCheckStr, onlyOneChar=false }) {
     activeArgs = { source, index, err, onlyOneChar }
     switch (expectation) {
       case "always":
@@ -81,7 +82,7 @@ export default function (targetWhitespace, expectation, messages) {
    * Parameters are the same as for `before()`, above, just substitute
    * the word "after" for "before".
    */
-  function after(source, index, err, lineCheckStr, onlyOneChar=false) {
+  function after({ source, index, err, lineCheckStr, onlyOneChar=false }) {
     activeArgs = { source, index, err, onlyOneChar }
     switch (expectation) {
       case "always":
@@ -131,8 +132,8 @@ export default function (targetWhitespace, expectation, messages) {
     }
   }
 
-  function afterOneOnly(source, index, err, lineCheckStr) {
-    after(source, index, err, lineCheckStr, true)
+  function afterOneOnly(obj) {
+    after(assign({}, obj, { onlyOneChar: true }))
   }
 
   function expectAfter(messageFunc=messages.expectedAfter) {


### PR DESCRIPTION
Ref: #231 

@davidtheclark I was hoping to get your advice on this as you're closest to the whitespace rules and the `whitespaceChecker`.

There's so much good stuff going on in the whitespace rules. I think this is a last minor hurdle we need to get over before we can release `0.1.0`. :)

So, both:

* `block-closing-brace-newline-before`
* `media-query-list-comma-newline-before`

Can deal with an arbitrary amount of indentation after the newline and before the comma/brace.

```css
@media print
  ,screen { }
↑
This indentation before the comma
```

```css
@media print {
  a {
    color:pink;
  }
}↑
 ↑
And this indentation before the closing brace
```

As they have special clauses to deal with it:

* https://github.com/stylelint/stylelint/blob/master/src/rules/block-closing-brace-newline-before/index.js#L47
* https://github.com/stylelint/stylelint/blob/master/src/rules/media-query-list-comma-newline-before/index.js#L27

Whereas:

* `value-list-comma-newline-before`
* `selector-delimiter-newline-before`
* `block-opening-brace-newline-before`

Don't handle the indention so well. 

```css
@media print 
{
  a
  , b /* this delimiter indentation */
  {  /* this opening brace indentation */
    background: 0
      ,0; /* this value-list indention */
  }
}
```

I've added tests to show this.

So, I had two questions:

1. Do we want to go to the trouble of supporting these styles (a. comma at the start of the line & b. opening brace on a newline), or should we wait until they are requested? i.e. strip all the`*-newline-before` rules except `block-closing-brace-newline-before`.* Remembering that the combination of the remaining three whitespace rules (`*-newline-after`, `*-space-before` and `*-space-after`) allows the user to enforce pretty much everything except the above two styles, including having multi-line and single-line lists in the same stylesheet!

2. If we do want to support these styles now, @davidtheclark any advice on whether it is possible to move the `*-newline-before` logic from `media-query-list-comma-newline-before` into `whitespaceChecker` so that it can be reused by the other comma rules? And also, how best to re-purpose (if possible) the logic from `block-closing-brace-newline-before` into `block-opening-brace-newline-before`?

What do you think guys? 
