### PR TITLE
Standardise block-opening-brace-* options

### DIFF
--- a/src/rules/block-opening-brace-newline-after/README.md
+++ b/src/rules/block-opening-brace-newline-after/README.md
@@ -11,7 +11,7 @@ Require a newline after the opening brace of blocks.
 
 ## Options
 
-`string`: `"always"|"always-multi-line"`
+`string`: `"always"|"always-multi-line"|"never-multi-line`
 
 ### `"always"`
 
@@ -62,3 +62,26 @@ a { color: pink; }
 a {
 color: pink; }
 ```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace after the opening brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a {color: pink;
+}
+```
+

--- a/src/rules/block-opening-brace-newline-after/README.md
+++ b/src/rules/block-opening-brace-newline-after/README.md
@@ -1,6 +1,6 @@
 # block-opening-brace-newline-after
 
-Require a newline or disallow whitespace after the opening brace of blocks.
+Require a newline after the opening brace of blocks.
 
 ```css
     a {
@@ -9,17 +9,9 @@ Require a newline or disallow whitespace after the opening brace of blocks.
  * The newline after this brace */
 ```
 
-End-of-line comments are allowed one space after the opening brace.
-
-```css
-a { /* something to say */
-  color: pink;
-}
-```
-
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"always-multi-line"`
 
 ### `"always"`
 
@@ -32,26 +24,35 @@ a{ color: pink; }
 ```
 
 ```css
-a {color: pink;}
+a{ color: pink;
+}
 ```
 
 The following patterns are *not* considered warnings:
-
-```css
-a{
-color: pink; }
-```
 
 ```css
 a {
 color: pink; }
 ```
 
-### `"never"`
+```css
+a
+{
+color: pink; }
+```
 
-There *must never* be whitespace after the opening brace.
+### `"always-multi-line"`
+
+There *must always* be a newline after the opening brace in multi-line blocks.
 
 The following patterns are considered warnings:
+
+```css
+a{color: pink;
+}
+```
+
+The following patterns are *not* considered warnings:
 
 ```css
 a { color: pink; }
@@ -59,11 +60,5 @@ a { color: pink; }
 
 ```css
 a {
-color: pink;}
-```
-
-The following patterns are *not* considered warnings:
-
-```css
-a{color: pink; }
+color: pink; }
 ```

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -64,3 +64,26 @@ testRule("always-multi-line", tr => {
   tr.ok("a {  color: pink;  background: orange; }")
   tr.ok("a { /* 1 */ color: pink; }")
 })
+
+testRule("never-multi-line", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a {color: pink;\nbackground: orange; }")
+  tr.ok("a{color: pink;\nbackground: orange; }")
+  tr.ok("@media print {a {color: pink;\nbackground: orange; } }")
+  tr.ok("@media print{a{color: pink;\nbackground: orange; } }")
+
+  // Ignore single-line
+  tr.ok("a { color: pink; }")
+  tr.ok("a {  color: pink; }")
+  tr.ok("a {\tcolor: pink; }")
+  tr.ok("@media print { a { color: pink; } }")
+  tr.ok("@media print {\ta {\tcolor: pink; } }")
+
+  tr.notOk("a { color: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
+  tr.notOk("a {\ncolor: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
+  tr.notOk("a {  color: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
+  tr.notOk("a {\tcolor: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
+  tr.notOk("@media print {\na {color: pink;\nbackground: orange; } }", messages.rejectedAfterMultiLine())
+  tr.notOk("@media print {a {\ncolor: pink;\nbackground: orange; } }", messages.rejectedAfterMultiLine())
+})

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -38,22 +38,6 @@ testRule("always", tr => {
   )
 })
 
-testRule("never", tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a {color: pink; }")
-  tr.ok("a{color: pink; }")
-  tr.ok("@media print {a {color: pink; } }")
-  tr.ok("@media print{a{color: pink; } }")
-
-  tr.notOk("a { color: pink; }", messages.rejectedAfter())
-  tr.notOk("a {\ncolor: pink; }", messages.rejectedAfter())
-  tr.notOk("a {  color: pink; }", messages.rejectedAfter())
-  tr.notOk("a {\tcolor: pink; }", messages.rejectedAfter())
-  tr.notOk("@media print {\na {color: pink; } }", messages.rejectedAfter())
-  tr.notOk("@media print {a {\ncolor: pink; } }", messages.rejectedAfter())
-})
-
 testRule("always-multi-line", tr => {
   warningFreeBasics(tr)
 
@@ -79,27 +63,4 @@ testRule("always-multi-line", tr => {
   tr.ok("a {\tcolor: pink; }")
   tr.ok("a {  color: pink;  background: orange; }")
   tr.ok("a { /* 1 */ color: pink; }")
-})
-
-testRule("never-multi-line", tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a {color: pink;\nbackground: orange; }")
-  tr.ok("a{color: pink;\nbackground: orange; }")
-  tr.ok("@media print {a {color: pink;\nbackground: orange; } }")
-  tr.ok("@media print{a{color: pink;\nbackground: orange; } }")
-
-  // Ignore single-line
-  tr.ok("a { color: pink; }")
-  tr.ok("a {  color: pink; }")
-  tr.ok("a {\tcolor: pink; }")
-  tr.ok("@media print { a { color: pink; } }")
-  tr.ok("@media print {\ta {\tcolor: pink; } }")
-
-  tr.notOk("a { color: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
-  tr.notOk("a {\ncolor: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
-  tr.notOk("a {  color: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
-  tr.notOk("a {\tcolor: pink;\nbackground: orange; }", messages.rejectedAfterMultiLine())
-  tr.notOk("@media print {\na {color: pink;\nbackground: orange; } }", messages.rejectedAfterMultiLine())
-  tr.notOk("@media print {a {\ncolor: pink;\nbackground: orange; } }", messages.rejectedAfterMultiLine())
 })

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -10,13 +10,12 @@ export const ruleName = "block-opening-brace-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after "{"`,
-  rejectedAfter: () => `Unexpected whitespace after "{"`,
   expectedAfterMultiLine: () => `Expected newline after "{" of a multi-line block`,
   rejectedAfterMultiLine: () => `Unexpected whitespace after "{" of a multi-line block`,
 })
 
 /**
- * @param {"always"|"never"|"always-multi-line"|"never-multi-line"} expectation
+ * @param {"always"|"always-multi-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)

--- a/src/rules/block-opening-brace-newline-before/README.md
+++ b/src/rules/block-opening-brace-newline-before/README.md
@@ -1,6 +1,6 @@
 # block-opening-brace-newline-before
 
-Require a newline or disallow whitespace before the opening brace of blocks.
+Require a newline before the opening brace of blocks.
 
 ```css
     a
@@ -11,7 +11,7 @@ Require a newline or disallow whitespace before the opening brace of blocks.
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"always-single-line"|"always-multi-line"`
 
 ### `"always"`
 
@@ -24,7 +24,8 @@ a{ color: pink; }
 ```
 
 ```css
-a {color: pink;}
+a{ color: pink;
+}
 ```
 
 The following patterns are *not* considered warnings:
@@ -34,23 +35,52 @@ a
 { color: pink; }
 ```
 
-### `"never"`
+```css
+a
+{
+color: pink; }
+```
 
-There *must never* be whitespace before the opening brace.
+### `"always-single-line"`
+
+There *must always* be a newline before the opening brace in single-line blocks.
 
 The following patterns are considered warnings:
 
 ```css
-a { color: pink; }
+a{ color: pink; }
 ```
+
+The following patterns are *not* considered warnings:
 
 ```css
 a
-{color: pink;}
+{ color: pink; }
+```
+
+```css
+a{
+color: pink; }
+```
+
+### `"always-multi-line"`
+
+There *must always* be a newline before the opening brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a{
+color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
 a{ color: pink; }
+```
+
+```css
+a {
+color: pink; }
 ```

--- a/src/rules/block-opening-brace-newline-before/README.md
+++ b/src/rules/block-opening-brace-newline-before/README.md
@@ -1,6 +1,6 @@
 # block-opening-brace-newline-before
 
-Require a newline before the opening brace of blocks.
+Require a newline or disallow whitespace before the opening brace of blocks.
 
 ```css
     a
@@ -11,7 +11,7 @@ Require a newline before the opening brace of blocks.
 
 ## Options
 
-`string`: `"always"|"always-single-line"|"always-multi-line"`
+`string`: `"always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -63,6 +63,27 @@ a{
 color: pink; }
 ```
 
+### `"never-single-line"`
+
+There *must never* be whitespace before the opening brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a{ color: pink; }
+```
+
+```css
+a {
+color: pink; }
+```
+
 ### `"always-multi-line"`
 
 There *must always* be a newline before the opening brace in multi-line blocks.
@@ -83,4 +104,26 @@ a{ color: pink; }
 ```css
 a {
 color: pink; }
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace before the opening brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a {
+color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a{
+color: pink;}
 ```

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -30,22 +30,6 @@ testRule("always", tr => {
   tr.notOk("a\n/* foo */{ a{ color: pink; } }", messages.expectedBefore())
 })
 
-testRule("never", tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a{ color: pink; }")
-  tr.ok("a{color: pink; }")
-  tr.ok("@media print{ a{ color: pink; } }")
-  tr.ok("@media print{a{color: pink; } }")
-
-  tr.notOk("a { color: pink; }", messages.rejectedBefore())
-  tr.notOk("a\n{ color: pink; }", messages.rejectedBefore())
-  tr.notOk("a  { color: pink; }", messages.rejectedBefore())
-  tr.notOk("a\t{ color: pink; }", messages.rejectedBefore())
-  tr.notOk("@media print\n{ a{ color: pink; } }", messages.rejectedBefore())
-  tr.notOk("@media print{ a\n{ color: pink; } }", messages.rejectedBefore())
-})
-
 testRule("always-single-line", tr => {
   warningFreeBasics(tr)
 
@@ -68,28 +52,6 @@ testRule("always-single-line", tr => {
   tr.notOk("@media print\n{ a{ color: pink; } }", messages.expectedBeforeSingleLine())
 })
 
-testRule("never-single-line", tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a{ color: pink; }")
-  tr.ok("a{color: pink; }")
-  tr.ok("@media print{ a{ color: pink; } }")
-  tr.ok("@media print{a{color: pink; } }")
-
-  // Ignoring multi-line blocks
-  tr.ok("a\n{ color: pink;\nbackground:orange; }")
-  tr.ok("@media print { a\n{ color: pink;\nbackground:orange; } }")
-  tr.ok("@media print{ a\n{ color: pink;\nbackground:orange; } }")
-  tr.ok("@media print{\na{ color: pink; } }")
-
-  tr.notOk("a\n{ color: pink; }", messages.rejectedBeforeSingleLine())
-  tr.notOk("a { color: pink; }", messages.rejectedBeforeSingleLine())
-  tr.notOk("a  { color: pink; }", messages.rejectedBeforeSingleLine())
-  tr.notOk("a\t{ color: pink; }", messages.rejectedBeforeSingleLine())
-  tr.notOk("@media print\n{ a\n{ color: pink; } }", messages.rejectedBeforeSingleLine())
-  tr.notOk("@media print { a\n{ color: pink; } }", messages.rejectedBeforeSingleLine())
-})
-
 testRule("always-multi-line", tr => {
   warningFreeBasics(tr)
 
@@ -109,25 +71,4 @@ testRule("always-multi-line", tr => {
   tr.notOk("a { color: pink;\nbackground: orange; }", messages.expectedBeforeMultiLine())
   tr.notOk("@media print\n{\na { color: pink;\nbackground: orange; } }", messages.expectedBeforeMultiLine())
   tr.notOk("@media print { a\n{ color: pink;\nbackground: orange; } }", messages.expectedBeforeMultiLine())
-})
-
-testRule("never-multi-line", tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a{ color: pink;\nbackground: orange; }")
-  tr.ok("@media print{\na{ color: pink;\nbackground: orange } }")
-
-  // Ignoring single-line blocks
-  tr.ok("a { color: pink; }")
-  tr.ok("@media print { a { color: pink; } }")
-  tr.ok("a{ color: pink; }")
-  tr.ok("a  { color: pink; }")
-  tr.ok("a\t{ color: pink; }")
-
-  tr.notOk("a { color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
-  tr.notOk("a  { color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
-  tr.notOk("a\t{ color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
-  tr.notOk("a\n{ color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
-  tr.notOk("@media print\n{\na{ color: pink;\nbackground: orange; } }", messages.rejectedBeforeMultiLine())
-  tr.notOk("@media print{ a\n{ color: pink;\nbackground: orange; } }", messages.rejectedBeforeMultiLine())
 })

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -52,6 +52,28 @@ testRule("always-single-line", tr => {
   tr.notOk("@media print\n{ a{ color: pink; } }", messages.expectedBeforeSingleLine())
 })
 
+testRule("never-single-line", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a{ color: pink; }")
+  tr.ok("a{color: pink; }")
+  tr.ok("@media print{ a{ color: pink; } }")
+  tr.ok("@media print{a{color: pink; } }")
+
+  // Ignoring multi-line blocks
+  tr.ok("a\n{ color: pink;\nbackground:orange; }")
+  tr.ok("@media print { a\n{ color: pink;\nbackground:orange; } }")
+  tr.ok("@media print{ a\n{ color: pink;\nbackground:orange; } }")
+  tr.ok("@media print{\na{ color: pink; } }")
+
+  tr.notOk("a\n{ color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("a { color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("a  { color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("a\t{ color: pink; }", messages.rejectedBeforeSingleLine())
+  tr.notOk("@media print\n{ a\n{ color: pink; } }", messages.rejectedBeforeSingleLine())
+  tr.notOk("@media print { a\n{ color: pink; } }", messages.rejectedBeforeSingleLine())
+})
+
 testRule("always-multi-line", tr => {
   warningFreeBasics(tr)
 
@@ -71,4 +93,25 @@ testRule("always-multi-line", tr => {
   tr.notOk("a { color: pink;\nbackground: orange; }", messages.expectedBeforeMultiLine())
   tr.notOk("@media print\n{\na { color: pink;\nbackground: orange; } }", messages.expectedBeforeMultiLine())
   tr.notOk("@media print { a\n{ color: pink;\nbackground: orange; } }", messages.expectedBeforeMultiLine())
+})
+
+testRule("never-multi-line", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a{ color: pink;\nbackground: orange; }")
+  tr.ok("@media print{\na{ color: pink;\nbackground: orange } }")
+
+  // Ignoring single-line blocks
+  tr.ok("a { color: pink; }")
+  tr.ok("@media print { a { color: pink; } }")
+  tr.ok("a{ color: pink; }")
+  tr.ok("a  { color: pink; }")
+  tr.ok("a\t{ color: pink; }")
+
+  tr.notOk("a { color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("a  { color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("a\t{ color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("a\n{ color: pink;\nbackground: orange; }", messages.rejectedBeforeMultiLine())
+  tr.notOk("@media print\n{\na{ color: pink;\nbackground: orange; } }", messages.rejectedBeforeMultiLine())
+  tr.notOk("@media print{ a\n{ color: pink;\nbackground: orange; } }", messages.rejectedBeforeMultiLine())
 })

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -11,11 +11,13 @@ export const ruleName = "block-opening-brace-newline-before"
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before "{"`,
   expectedBeforeSingleLine: () => `Expected newline before "{" of a single-line block`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "{" of a single-line block`,
   expectedBeforeMultiLine: () => `Expected newline before "{" of a multi-line block`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "{" of a multi-line block`,
 })
 
 /**
- * @param {"always"|"always-single-line"|"always-multi-line"} expectation
+ * @param {"always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -10,15 +10,12 @@ export const ruleName = "block-opening-brace-newline-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before "{"`,
-  rejectedBefore: () => `Unexpected newline before "{"`,
   expectedBeforeSingleLine: () => `Expected newline before "{" of a single-line block`,
-  rejectedBeforeSingleLine: () => `Unexpected whitespace before "{" of a single-line block`,
   expectedBeforeMultiLine: () => `Expected newline before "{" of a multi-line block`,
-  rejectedBeforeMultiLine: () => `Unexpected whitespace before "{" of a multi-line block`,
 })
 
 /**
- * @param {"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"} expectation
+ * @param {"always"|"always-single-line"|"always-multi-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)

--- a/src/rules/block-opening-brace-space-after/README.md
+++ b/src/rules/block-opening-brace-space-after/README.md
@@ -10,7 +10,7 @@ Require a single space or disallow whitespace after the opening brace of blocks.
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -19,11 +19,12 @@ There *must always* be a single space after the opening brace.
 The following patterns are considered warnings:
 
 ```css
-a{color: pink;}
+a {color: pink; }
 ```
 
 ```css
-a {color: pink;}
+a {
+color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
@@ -33,7 +34,8 @@ a { color: pink; }
 ```
 
 ```css
-a{ color: pink; }
+a { color: pink;
+}
 ```
 
 ### `"never"`
@@ -47,15 +49,103 @@ a { color: pink; }
 ```
 
 ```css
-a{ color: pink; }
+a {
+color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a {color: pink;}
+a {color: pink; }
 ```
 
 ```css
-a{color: pink;}
+a
+{color: pink; }
+```
+
+### `"always-single-line"`
+
+There *must always* be a single space after the opening brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a {color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a {color: pink;
+}
+```
+
+### `"never-single-line"`
+
+There *must never* be whitespace after the opening brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {color: pink; }
+```
+
+```css
+a { color: pink;
+}
+```
+
+### `"always-multi-line"`
+
+There *must always* be a single space after the opening brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a {color: pink;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {color: pink; }
+```
+
+```css
+a { color: pink;
+}
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace after the opening brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a {color: pink;
+}
 ```

--- a/src/rules/block-opening-brace-space-before/README.md
+++ b/src/rules/block-opening-brace-space-before/README.md
@@ -10,7 +10,7 @@ Require a single space or disallow whitespace before the opening brace of blocks
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -23,7 +23,8 @@ a{ color: pink; }
 ```
 
 ```css
-a{color: pink;}
+a
+{ color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
@@ -33,7 +34,8 @@ a { color: pink; }
 ```
 
 ```css
-a {color: pink;}
+a {
+color: pink; }
 ```
 
 ### `"never"`
@@ -47,7 +49,8 @@ a { color: pink; }
 ```
 
 ```css
-a {color: pink;}
+a
+{ color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
@@ -57,5 +60,92 @@ a{ color: pink; }
 ```
 
 ```css
-a{color: pink;}
+a{
+color: pink; }
+```
+
+### `"always-single-line"`
+
+There *must always* be a single space before the opening brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a{ color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a{
+color: pink; }
+```
+
+### `"never-single-line"`
+
+There *must never* be whitespace before the opening brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a{ color: pink; }
+```
+
+```css
+a {
+color: pink; }
+```
+
+### `"always-multi-line"`
+
+There *must always* be a single space before the opening brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a{
+color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a{ color: pink; }
+```
+
+```css
+a {
+color: pink; }
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace before the opening brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a {
+color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a{
+color: pink;}
 ```


### PR DESCRIPTION
Oh wow, it's taken me long enough but I *finally* understand why these rules need a different set of options to those in all the `*-comma-*` rules. All the `*-comma-*` rules look at the commas *in* single and multi-line lists, whereas these `*-brace-*` rules look at the braces *of* single or multi-line blocks. It's a subtle difference, which has only just clicked for me, but it means these rules do need their larger set of options as you can have a newline before and after a *single-line* block.

e.g. `block-opening-brace-space-before`:

## always

```css
a { color: pink; }
```

```css
a {
color: pink; 
}
```

## never

```css
a{ color: pink; }
```

```css
a{
color: pink; 
}
```

## always-single-line

```css
a { color: pink; }
```

```css
a{
color: pink; 
}
```

## never-single-line

```css
a{ color: pink; }
```

```css
a {
color: pink; 
}
```

## always-multi-line

```css
a{ color: pink; }
```

```css
a {
color: pink; 
}
```

## never-multi-line

```css
a { color: pink; }
```

```css
a{
color: pink; 
}
```

And that's why we all have the following options for this `*-space-before` rule:

`"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

@davidtheclark Thanks for seeing this difference, and implementing all these details, yonks ago! Sorry, it took me so long to wrap my head around it!

Also, thanks @m-allanson for making a start on updating the READMEs in your fork.

So, in this PR I've updated the README's and, as with the other whitespace rules, I've stripped out the duplicated plain `"never` options from the newline rules.

Ok with you guys?