### PR TITLE
Standardise options for block-closing-brace-* rules

### DIFF
--- a/src/rules/block-closing-brace-newline-after/README.md
+++ b/src/rules/block-closing-brace-newline-after/README.md
@@ -4,14 +4,14 @@ Require a newline or disallow whitespace after the closing brace of blocks.
 
 ```css
     a { color: pink; }
-    b { color: red; }↑
+    a { color: red; }↑
 /**                  ↑
  * The newline after this brace */
 ```
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -20,12 +20,12 @@ There *must always* be a newline after the closing brace.
 The following patterns are considered warnings:
 
 ```css
-a { color: pink; } b { color: red; }
+a { color: pink; }b { color: red; }
 ```
 
 ```css
 a { color: pink;
-} b { color: red;}
+} b { color: red; }
 ```
 
 The following patterns are *not* considered warnings:
@@ -35,16 +35,33 @@ a { color: pink; }
 b { color: red; }
 ```
 
-### `"never"`
+### `"always-single-line"`
 
-There *must never* be whitespace after the closing brace.
+There *must always* be a newline after the closing brace in single-line blocks.
 
 The following patterns are considered warnings:
+
+```css
+a { color: pink; } b { color: red; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink;
+} b { color: red; }
+```
 
 ```css
 a { color: pink; }
 b { color: red; }
 ```
+
+### `"never-single-line"`
+
+There *must never* be whitespace after the closing brace in single-line blocks.
+
+The following patterns are considered warnings:
 
 ```css
 a { color: pink; } b { color: red; }
@@ -54,4 +71,54 @@ The following patterns are *not* considered warnings:
 
 ```css
 a { color: pink; }b { color: red; }
+```
+
+```css
+a { color: pink;
+} b { color: red; }
+```
+
+### `"always-multi-line"`
+
+There *must always* be a newline after the closing brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink;
+}b { color: red; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }b { color: red; }
+```
+
+```css
+a { color: pink;
+}
+b { color: red; }
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace after the closing brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink;
+} b { color: red; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; } b { color: red; }
+```
+
+```css
+a { color: pink;
+}b { color: red; }
 ```

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -27,25 +27,6 @@ testRule("always", tr => {
   tr.notOk("@media print { a { color: pink; }} @media screen { b { color: red; }}", messages.expectedAfter())
 })
 
-testRule("never", tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a { color: pink; }")
-  tr.ok("a { color: pink; }b { color: red; }")
-  tr.ok("a { color: pink;}b { color: red;}")
-
-  // Ignores nested closing braces
-  tr.ok("@media print { a { color: pink; }b { color: red; } }")
-  tr.ok("@media print { a { color: pink; } }@media screen { b { color: red; } }")
-
-  tr.notOk("a { color: pink; }\nb { color: red; }", messages.rejectedAfter())
-  tr.notOk("a { color: pink; } b { color: red; }", messages.rejectedAfter())
-  tr.notOk("a { color: pink; }  b { color: red; }", messages.rejectedAfter())
-  tr.notOk("a { color: pink; }\tb { color: red; }", messages.rejectedAfter())
-  tr.notOk("@media print { a { color: pink; }\nb { color: red; }}", messages.rejectedAfter())
-  tr.notOk("@media print { a { color: pink; }}\n @media screen { b { color: red; }}", messages.rejectedAfter())
-})
-
 testRule("always-single-line", tr => {
   warningFreeBasics(tr)
 

--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -8,7 +8,6 @@ export const ruleName = "block-closing-brace-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after "}"`,
-  rejectedAfter: () => `Unexpected whitespace after "}"`,
   expectedAfterSingleLine: () => `Expected single space after "}" of a single-line block`,
   rejectedAfterSingleLine: () => `Unexpected whitespace after "}" of a single-line block`,
   expectedAfterMultiLine: () => `Expected single space after "}" of a multi-line block`,
@@ -16,7 +15,7 @@ export const messages = ruleMessages(ruleName, {
 })
 
 /**
- * @param {"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"} expectation
+ * @param {"always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)

--- a/src/rules/block-closing-brace-newline-before/README.md
+++ b/src/rules/block-closing-brace-newline-before/README.md
@@ -11,7 +11,7 @@ Require a newline or disallow whitespace before the closing brace of blocks.
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -20,38 +20,62 @@ There *must always* be a newline before the closing brace.
 The following patterns are considered warnings:
 
 ```css
-a { color: pink; } b { color: red;}
-```
-
-```css
-a { color: pink; }
-b { color: red; }
+a { color: pink;}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
 a { color: pink;
-} b { color: red; }
+}
 ```
 
-### `"never"`
+```css
+a {
+color: pink;
+}
+```
 
-There *must never* be whitespace before the closing brace.
+### `"always-multi-line"`
+
+There *must always* be a newline before the closing brace in multi-line blocks.
 
 The following patterns are considered warnings:
 
 ```css
-a { color: pink;
-} b { color: red; }
-```
-
-```css
-a { color: pink; } b { color: red; }
+a {
+color: pink;}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a { color: pink;}b { color: red; }
+a { color: pink; }
+```
+
+```css
+a { color: pink;
+}
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace before the closing brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a {
+color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a {
+color: pink;}
 ```

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -27,20 +27,6 @@ testRule("always", tr => {
   tr.notOk("a { color: pink;\n} b { color: red; }", messages.expectedBefore())
 })
 
-testRule("never", tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a { color: pink;}")
-  tr.ok("a { color: pink;} b { color: red;}")
-  tr.ok("a { color: pink;}b { color: red;}")
-
-  tr.notOk("a { color: pink; }", messages.rejectedBefore())
-  tr.notOk("a { color: pink;\n}", messages.rejectedBefore())
-  tr.notOk("a { color: pink;  }", messages.rejectedBefore())
-  tr.notOk("a { color: pink;\t}", messages.rejectedBefore())
-  tr.notOk("a { color: pink;} b { color: red;\n}", messages.rejectedBefore())
-})
-
 testRule("always-multi-line", tr => {
   warningFreeBasics(tr)
 

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -10,13 +10,12 @@ export const ruleName = "block-closing-brace-newline-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before "}"`,
-  rejectedBefore: () => `Unexpected whitespace before "}"`,
   expectedBeforeMultiLine: () => `Expected newline before "}" of a multi-line block`,
   rejectedBeforeMultiLine: () => `Unexpected whitespace before "}" of a multi-line block`,
 })
 
 /**
- * @param {"always"|"never"|"always-multi-line"|"never-multi-line"} expectation
+ * @param {"always"|"always-multi-line"|"never-multi-line"} expectation
  */
 export default function (expectation) {
   return function (css, result) {

--- a/src/rules/block-closing-brace-space-after/README.md
+++ b/src/rules/block-closing-brace-space-after/README.md
@@ -10,7 +10,7 @@ Require a single space or disallow whitespace after the closing brace of blocks.
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -20,6 +20,11 @@ The following patterns are considered warnings:
 
 ```css
 a { color: pink; }b { color: red; }
+```
+
+```css
+a { color: pink; }
+b { color: red; }
 ```
 
 The following patterns are *not* considered warnings:
@@ -38,8 +43,104 @@ The following patterns are considered warnings:
 a { color: pink; } b { color: red; }
 ```
 
+```css
+a { color: pink; }
+b { color: red; }
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
 a { color: pink; }b { color: red; }
+```
+
+```css
+a { color: pink;
+}b { color: red; }
+```
+
+### `"always-single-line"`
+
+There *must always* be a single space after the closing brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink; }b { color: red; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; } b { color: red; }
+```
+
+```css
+a { color: pink;
+}b { color: red; }
+```
+
+### `"never-single-line"`
+
+There *must never* be whitespace after the closing brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink; } b { color: red; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }b { color: red; }
+```
+
+```css
+a { color: pink;
+} b { color: red; }
+```
+
+### `"always-multi-line"`
+
+There *must always* be a single space after the closing brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink;
+}b { color: red; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }b { color: red; }
+```
+
+```css
+a { color: pink;
+} b { color: red; }
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace after the closing brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink;
+} b { color: red; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; } b { color: red; }
+```
+
+```css
+a { color: pink;
+}b { color: red; }
 ```

--- a/src/rules/block-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-after/__tests__/index.js
@@ -46,6 +46,52 @@ testRule("never", tr => {
   tr.notOk("@media print { a { color: pink; }} @media screen { b { color: red; }}", messages.rejectedAfter())
 })
 
+testRule("always-single-line", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; background: orange; }")
+  tr.ok("a { color: pink; background: orange; } b { color: red; }")
+  tr.ok("a { color: pink; background: orange;} b { color: red;}")
+
+  // Ignore multi line
+  tr.ok("a { color:\npink;}")
+  tr.ok("a { color:\npink;}b { color: red; }")
+  tr.ok("a { color:\npink;}b { color:\nred;}")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a {\ncolor: pink; } b { color: red;}}")
+  tr.ok("@media print { a {\ncolor: pink; }} @media screen { b { color: red;}}")
+
+  tr.notOk("a { color: pink; background: orange;}b { color: red; }", messages.expectedAfterSingleLine())
+  tr.notOk("a { color: pink; background: orange;}  b { color: red; }", messages.expectedAfterSingleLine())
+  tr.notOk("a { color: pink; background: orange;}\tb { color: red; }", messages.expectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; }b { color: red; }}", messages.expectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; }}@media screen { b { color: red; }}", messages.expectedAfterSingleLine())
+})
+
+testRule("never-single-line", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; background: orange; }")
+  tr.ok("a { color: pink; background: orange; }b { color: red; }")
+  tr.ok("a { color: pink; background: orange;}b { color: red;}")
+
+  // Ignore multi line
+  tr.ok("a { color:\npink;}")
+  tr.ok("a { color:\npink;} b { color: red; }")
+  tr.ok("a { color:\npink;} b { color:\nred;}")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a {\ncolor: pink;} b { color: red;} }")
+  tr.ok("@media print { a {\ncolor: pink;} } @media screen { b { color: red;} }")
+
+  tr.notOk("a { color: pink; background: orange;} b { color: red; }", messages.rejectedAfterSingleLine())
+  tr.notOk("a { color: pink; background: orange;}  b { color: red; }", messages.rejectedAfterSingleLine())
+  tr.notOk("a { color: pink; background: orange;}\tb { color: red; }", messages.rejectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; } b { color: red; }}", messages.rejectedAfterSingleLine())
+  tr.notOk("@media print { a { color: pink; }} @media screen { b { color: red; }}", messages.rejectedAfterSingleLine())
+})
+
 testRule("always-multi-line", tr => {
   warningFreeBasics(tr)
 
@@ -68,4 +114,28 @@ testRule("always-multi-line", tr => {
   tr.notOk("a { color: pink;\nbackground: orange;}\tb { color: red; }", messages.expectedAfterMultiLine())
   tr.notOk("@media print { a {\ncolor: pink; }b { color: red; }}", messages.expectedAfterMultiLine())
   tr.notOk("@media print { a {\ncolor: pink; }}@media screen { b {\ncolor: red; }}", messages.expectedAfterMultiLine())
+})
+
+testRule("never-multi-line", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink;\nbackground: orange; }")
+  tr.ok("a { color: pink;\nbackground: orange; }b { color: red; }")
+  tr.ok("a { color: pink;\nbackground: orange;}b { color: red;}")
+
+  // Ignore single line
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; } b { color: red; }")
+  tr.ok("a { color: pink;} b { color: red;}")
+
+  // Ignores nested closing braces
+  tr.ok("@media print { a {\ncolor: pink; }b { color: red; } }")
+  tr.ok("@media print { a {\ncolor: pink; }}@media screen { b { color: red; } }")
+
+  tr.notOk("a { color: pink;\nbackground: orange;} b { color: red; }", messages.rejectedAfterMultiLine())
+  tr.notOk("a { color: pink;\nbackground: orange;}  b { color: red; }", messages.rejectedAfterMultiLine())
+  tr.notOk("a { color: pink;\nbackground: orange;}\nb { color: red; }", messages.rejectedAfterMultiLine())
+  tr.notOk("a { color: pink;\nbackground: orange;}\tb { color: red; }", messages.rejectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; } b { color: red; }}", messages.rejectedAfterMultiLine())
+  tr.notOk("@media print { a {\ncolor: pink; }} @media screen { b {\ncolor: red; }}", messages.rejectedAfterMultiLine())
 })

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -9,11 +9,14 @@ export const ruleName = "block-closing-brace-space-after"
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after "}"`,
   rejectedAfter: () => `Unexpected whitespace after "}"`,
+  expectedAfterSingleLine: () => `Expected single space after "}" of a single-line block`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after "}" of a single-line block`,
   expectedAfterMultiLine: () => `Expected single space after "}" of a multi-line block`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "}" of a multi-line block`,
 })
 
 /**
- * @param {"always"|"never"|"always-multi-line"} expectation
+ * @param {"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"} expectation
  */
 export default function (expectation) {
   const checker = whitespaceChecker(" ", expectation, messages)

--- a/src/rules/block-closing-brace-space-before/README.md
+++ b/src/rules/block-closing-brace-space-before/README.md
@@ -10,7 +10,7 @@ Require a single space or disallow whitespace before the closing brace of blocks
 
 ## Options
 
-`string`: `"always"|"never"`
+`string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 
@@ -19,11 +19,12 @@ There *must always* be a single space before the closing brace.
 The following patterns are considered warnings:
 
 ```css
-a{ color: pink;}
+a { color: pink;}
 ```
 
 ```css
-a { color: pink;} b { color: red;}
+a
+{ color: pink;}
 ```
 
 The following patterns are *not* considered warnings:
@@ -33,7 +34,8 @@ a { color: pink; }
 ```
 
 ```css
-a { color: pink; } b { color: red; }
+a {
+color: pink; }
 ```
 
 ### `"never"`
@@ -47,7 +49,8 @@ a { color: pink; }
 ```
 
 ```css
-a { color: pink; } b { color: red; }
+a
+{ color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
@@ -57,5 +60,92 @@ a{ color: pink;}
 ```
 
 ```css
-a { color: pink;} b { color: red;}
+a{
+color: pink;}
+```
+
+### `"always-single-line"`
+
+There *must always* be a single space before the closing brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink;}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a {
+color: pink;}
+```
+
+### `"never-single-line"`
+
+There *must never* be whitespace before the closing brace in single-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink;}
+```
+
+```css
+a {
+color: pink; }
+```
+
+### `"always-multi-line"`
+
+There *must always* be a single space before the closing brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a {
+color: pink;}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink;}
+```
+
+```css
+a {
+color: pink; }
+```
+
+### `"never-multi-line"`
+
+There *must never* be whitespace before the closing brace in multi-line blocks.
+
+The following patterns are considered warnings:
+
+```css
+a {
+color: pink; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a {
+color: pink;}
 ```


### PR DESCRIPTION
Same as #247 but for `closing-brace`