### PR TITLE
Rename the selector-delimiter rules to selector-list-comma

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -58,10 +58,10 @@ import rulePropertiesOrder from "./rule-properties-order"
 import ruleTrailingSemicolon from "./rule-trailing-semicolon"
 import selectorCombinatorSpaceAfter from "./selector-combinator-space-after"
 import selectorCombinatorSpaceBefore from "./selector-combinator-space-before"
-import selectorDelimiterNewlineAfter from "./selector-list-comma-newline-after"
-import selectorDelimiterNewlineBefore from "./selector-list-comma-newline-before"
-import selectorDelimiterSpaceAfter from "./selector-list-comma-space-after"
-import selectorDelimiterSpaceBefore from "./selector-list-comma-space-before"
+import selectorListCommaNewlineAfter from "./selector-list-comma-newline-after"
+import selectorListCommaNewlineBefore from "./selector-list-comma-newline-before"
+import selectorListCommaSpaceAfter from "./selector-list-comma-space-after"
+import selectorListCommaSpaceBefore from "./selector-list-comma-space-before"
 import selectorNoAttribute from "./selector-no-attribute"
 import selectorNoCombinator from "./selector-no-combinator"
 import selectorNoId from "./selector-no-id"
@@ -138,10 +138,10 @@ export default {
   "rule-trailing-semicolon": ruleTrailingSemicolon,
   "selector-combinator-space-after": selectorCombinatorSpaceAfter,
   "selector-combinator-space-before": selectorCombinatorSpaceBefore,
-  "selector-list-comma-newline-after": selectorDelimiterNewlineAfter,
-  "selector-list-comma-newline-before": selectorDelimiterNewlineBefore,
-  "selector-list-comma-space-after": selectorDelimiterSpaceAfter,
-  "selector-list-comma-space-before": selectorDelimiterSpaceBefore,
+  "selector-list-comma-newline-after": selectorListCommaNewlineAfter,
+  "selector-list-comma-newline-before": selectorListCommaNewlineBefore,
+  "selector-list-comma-space-after": selectorListCommaSpaceAfter,
+  "selector-list-comma-space-before": selectorListCommaSpaceBefore,
   "selector-no-attribute": selectorNoAttribute,
   "selector-no-combinator": selectorNoCombinator,
   "selector-no-id": selectorNoId,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -58,10 +58,10 @@ import rulePropertiesOrder from "./rule-properties-order"
 import ruleTrailingSemicolon from "./rule-trailing-semicolon"
 import selectorCombinatorSpaceAfter from "./selector-combinator-space-after"
 import selectorCombinatorSpaceBefore from "./selector-combinator-space-before"
-import selectorDelimiterNewlineAfter from "./selector-delimiter-newline-after"
-import selectorDelimiterNewlineBefore from "./selector-delimiter-newline-before"
-import selectorDelimiterSpaceAfter from "./selector-delimiter-space-after"
-import selectorDelimiterSpaceBefore from "./selector-delimiter-space-before"
+import selectorDelimiterNewlineAfter from "./selector-list-comma-newline-after"
+import selectorDelimiterNewlineBefore from "./selector-list-comma-newline-before"
+import selectorDelimiterSpaceAfter from "./selector-list-comma-space-after"
+import selectorDelimiterSpaceBefore from "./selector-list-comma-space-before"
 import selectorNoAttribute from "./selector-no-attribute"
 import selectorNoCombinator from "./selector-no-combinator"
 import selectorNoId from "./selector-no-id"
@@ -138,10 +138,10 @@ export default {
   "rule-trailing-semicolon": ruleTrailingSemicolon,
   "selector-combinator-space-after": selectorCombinatorSpaceAfter,
   "selector-combinator-space-before": selectorCombinatorSpaceBefore,
-  "selector-delimiter-newline-after": selectorDelimiterNewlineAfter,
-  "selector-delimiter-newline-before": selectorDelimiterNewlineBefore,
-  "selector-delimiter-space-after": selectorDelimiterSpaceAfter,
-  "selector-delimiter-space-before": selectorDelimiterSpaceBefore,
+  "selector-list-comma-newline-after": selectorDelimiterNewlineAfter,
+  "selector-list-comma-newline-before": selectorDelimiterNewlineBefore,
+  "selector-list-comma-space-after": selectorDelimiterSpaceAfter,
+  "selector-list-comma-space-before": selectorDelimiterSpaceBefore,
   "selector-no-attribute": selectorNoAttribute,
   "selector-no-combinator": selectorNoCombinator,
   "selector-no-id": selectorNoId,

--- a/src/rules/selector-list-comma-newline-after/README.md
+++ b/src/rules/selector-list-comma-newline-after/README.md
@@ -1,12 +1,12 @@
-# selector-delimiter-newline-after
+# selector-list-comma-newline-after
 
-Require a newline or disallow whitespace after the delimiters of selectors.
+Require a newline or disallow whitespace after the commas of selector lists.
 
 ```css
     a,
     b↑{ color: pink; }
 /**  ↑
- * The newline after this delimiter */
+ * The newline after this comma */
 ```
 
 ## Options
@@ -15,7 +15,7 @@ Require a newline or disallow whitespace after the delimiters of selectors.
 
 ### `"always"`
 
-There *must always* be a newline after the delimiters.
+There *must always* be a newline after the commas.
 
 The following patterns are considered warnings:
 
@@ -43,7 +43,7 @@ b { color: pink; }
 
 ### `"always-multi-line"`
 
-There *must always* be a newline after the delimiters in multi-line selectors.
+There *must always* be a newline after the commas in multi-line selector lists.
 
 The following patterns are considered warnings:
 
@@ -71,7 +71,7 @@ b { color: pink; }
 
 ### `"never-multi-line"`
 
-There *must never* be whitespace after the delimiters in multi-line selectors.
+There *must never* be whitespace after the commas in multi-line selector lists.
 
 The following patterns are considered warnings:
 

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -31,7 +31,7 @@ testRule("always-multi-line", tr => {
 
   tr.ok("a,\nb {}")
   tr.ok("a, b {}", "ignores single-line")
-  tr.ok("a, b {\n}", "ignores single-line selector, multi-line block")
+  tr.ok("a, b {\n}", "ignores single-line selector list, multi-line block")
 
   tr.notOk("a,\nb, c {}", messages.expectedAfterMultiLine())
   tr.notOk("a,\nb, c {\n}", messages.expectedAfterMultiLine())
@@ -42,7 +42,7 @@ testRule("never-multi-line", tr => {
 
   tr.ok("a\n,b {}")
   tr.ok("a ,b {}", "ignores single-line")
-  tr.ok("a ,b {\n}", "ignores single-line selector, multi-line block")
+  tr.ok("a ,b {\n}", "ignores single-line selector list, multi-line block")
 
   tr.notOk("a,\nb ,c {}", messages.rejectedAfterMultiLine())
   tr.notOk("a,\nb ,c {\n}", messages.rejectedAfterMultiLine())

--- a/src/rules/selector-list-comma-newline-after/index.js
+++ b/src/rules/selector-list-comma-newline-after/index.js
@@ -5,12 +5,12 @@ import {
   whitespaceChecker
 } from "../../utils"
 
-export const ruleName = "selector-delimiter-newline-after"
+export const ruleName = "selector-list-comma-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after ","`,
-  expectedAfterMultiLine: () => `Expected newline after "," in a multi-line selector`,
-  rejectedAfterMultiLine: () => `Unexpected whitespace after "," in a multi-line selector`,
+  expectedAfterMultiLine: () => `Expected newline after "," in a multi-line list`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "," in a multi-line list`,
 })
 
 /**

--- a/src/rules/selector-list-comma-newline-before/README.md
+++ b/src/rules/selector-list-comma-newline-before/README.md
@@ -1,12 +1,12 @@
-# selector-delimiter-newline-before
+# selector-list-comma-newline-before
 
-Require a newline or disallow whitespace before the delimiters of selectors.
+Require a newline or disallow whitespace before the commas of selector lists.
 
 ```css
     a
     , b { color: pink; }
 /** ↑
- * The newline before this delimiter */
+ * The newline before this comma */
 ```
 
 ## Options
@@ -15,7 +15,7 @@ Require a newline or disallow whitespace before the delimiters of selectors.
 
 ### `"always"`
 
-There *must always* be a newline before the delimiters.
+There *must always* be a newline before the commas.
 
 The following patterns are considered warnings:
 
@@ -42,7 +42,7 @@ a
 
 ### `"always-multi-line"`
 
-There *must always* be a newline before the delimiters in multi-line selectors.
+There *must always* be a newline before the commas in multi-line selector lists.
 
 The following patterns are considered warnings:
 
@@ -70,7 +70,7 @@ b { color: pink; }
 
 ### `"never-multi-line"`
 
-There *must never* be whitespace before the delimiters in multi-line selectors.
+There *must never* be whitespace before the commas in multi-line selector lists.
 
 The following patterns are considered warnings:
 

--- a/src/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -29,7 +29,7 @@ testRule("always-multi-line", tr => {
 
   tr.ok("a\n,b {}")
   tr.ok("a, b {}", "ignores single-line")
-  tr.ok("a, b {\n}", "ignores single-line selector, multi-line block")
+  tr.ok("a, b {\n}", "ignores single-line selector list, multi-line block")
 
   tr.notOk("a\n,b, c {}", messages.expectedBeforeMultiLine())
   tr.notOk("a\n,b, c {\n}", messages.expectedBeforeMultiLine())
@@ -40,7 +40,7 @@ testRule("never-multi-line", tr => {
 
   tr.ok("a,\nb {}")
   tr.ok("a ,b {}", "ignores single-line")
-  tr.ok("a ,b {\n}", "ignores single-line selector, multi-line block")
+  tr.ok("a ,b {\n}", "ignores single-line selector list, multi-line block")
 
   tr.notOk("a,\nb , c {}", messages.rejectedBeforeMultiLine())
   tr.notOk("a,\nb , c {\n}", messages.rejectedBeforeMultiLine())

--- a/src/rules/selector-list-comma-newline-before/index.js
+++ b/src/rules/selector-list-comma-newline-before/index.js
@@ -3,14 +3,14 @@ import {
   whitespaceChecker
 } from "../../utils"
 
-import { selectorDelimiterSpaceChecker } from "../selector-delimiter-space-after"
+import { selectorDelimiterSpaceChecker } from "../selector-list-comma-space-after"
 
-export const ruleName = "selector-delimiter-newline-before"
+export const ruleName = "selector-list-comma-newline-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before ","`,
-  expectedBeforeMultiLine: () => `Expected newline before "," in a multi-line selector`,
-  rejectedBeforeMultiLine: () => `Unexpected whitespace before "," in a multi-line selector`,
+  expectedBeforeMultiLine: () => `Expected newline before "," in a multi-line list`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "," in a multi-line list`,
 })
 
 /**

--- a/src/rules/selector-list-comma-newline-before/index.js
+++ b/src/rules/selector-list-comma-newline-before/index.js
@@ -3,7 +3,7 @@ import {
   whitespaceChecker
 } from "../../utils"
 
-import { selectorDelimiterSpaceChecker } from "../selector-list-comma-space-after"
+import { selectorListCommaWhitespaceChecker } from "../selector-list-comma-space-after"
 
 export const ruleName = "selector-list-comma-newline-before"
 
@@ -18,5 +18,5 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation) {
   const checker = whitespaceChecker("\n", expectation, messages)
-  return selectorDelimiterSpaceChecker(checker.beforeAllowingIndentation)
+  return selectorListCommaWhitespaceChecker(checker.beforeAllowingIndentation)
 }

--- a/src/rules/selector-list-comma-space-after/README.md
+++ b/src/rules/selector-list-comma-space-after/README.md
@@ -1,11 +1,11 @@
-# selector-delimiter-space-before
+# selector-list-comma-space-after
 
-Require a single space or disallow whitespace before the delimiters of selectors.
+Require a single space or disallow whitespace after the commas of selector lists.
 
 ```css
     a, b { color: pink; }
 /**  ↑
- * The space before this delimiter */
+ * The space after this comma */
 ```
 
 ## Options
@@ -15,7 +15,7 @@ Require a single space or disallow whitespace before the delimiters of selectors
 
 ### `"always"`
 
-There *must always* be a single space before the delimiters.
+There *must always* be a single space after the commas.
 
 The following patterns are considered warnings:
 
@@ -24,13 +24,13 @@ a,b { color: pink; }
 ```
 
 ```css
-a, b { color: pink; }
+a ,b { color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a ,b { color: pink; }
+a, b { color: pink; }
 ```
 
 ```css
@@ -39,12 +39,12 @@ a , b { color: pink; }
 
 ### `"never"`
 
-There *must never* be whitespace before the delimiters.
+There *must never* be whitespace after the commas.
 
 The following patterns are considered warnings:
 
 ```css
-a ,b { color: pink; }
+a, b { color: pink; }
 ```
 
 ```css
@@ -58,12 +58,12 @@ a,b { color: pink; }
 ```
 
 ```css
-a, b { color: pink; }
+a ,b { color: pink; }
 ```
 
 ### `"always-single-line"`
 
-There *must always* be a single space before the delimiters in single-line selectors.
+There *must always* be a single space after the commas in single-line selector lists.
 
 The following patterns are considered warnings:
 
@@ -74,23 +74,23 @@ a,b { color: pink; }
 The following patterns are *not* considered warnings:
 
 ```css
-a,
-b { color: pink; }
+a
+,b { color: pink; }
 ```
 
 ### `"never-single-line"`
 
-There *must never* be a single space before the delimiters in single-line selectors.
+There *must never* be a single space after the commas in single-line selector lists.
 
 The following patterns are considered warnings:
 
 ```css
-a ,b { color: pink; }
+a, b { color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a ,
-b { color: pink; }
+a
+, b { color: pink; }
 ```

--- a/src/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-after/__tests__/index.js
@@ -46,7 +46,7 @@ testRule("always-single-line", tr => {
   warningFreeBasics(tr)
 
   tr.ok("a, b {}")
-  tr.ok("a, b {\n}", "single-line selector, multi-line block")
+  tr.ok("a, b {\n}", "single-line selector list, multi-line block")
 
   tr.notOk("a,b {}", messages.expectedAfterSingleLine())
   tr.notOk("a,b {\n}", messages.expectedAfterSingleLine())
@@ -56,7 +56,7 @@ testRule("never-single-line", tr => {
   warningFreeBasics(tr)
 
   tr.ok("a,b {}")
-  tr.ok("a,b {\n}", "single-line selector, multi-line block")
+  tr.ok("a,b {\n}", "single-line selector list, multi-line block")
 
   tr.notOk("a, b {}", messages.rejectedAfterSingleLine())
   tr.notOk("a, b {\n}", messages.rejectedAfterSingleLine())

--- a/src/rules/selector-list-comma-space-after/index.js
+++ b/src/rules/selector-list-comma-space-after/index.js
@@ -5,13 +5,13 @@ import {
   whitespaceChecker
 } from "../../utils"
 
-export const ruleName = "selector-delimiter-space-after"
+export const ruleName = "selector-list-comma-space-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ","`,
   rejectedAfter: () => `Unexpected whitespace after ","`,
-  expectedAfterSingleLine: () => `Expected single space after "," in a single-line selector`,
-  rejectedAfterSingleLine: () => `Unexpected whitespace after "," in a single-line selector`,
+  expectedAfterSingleLine: () => `Expected single space after "," in a single-line list`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after "," in a single-line list`,
 })
 
 /**

--- a/src/rules/selector-list-comma-space-after/index.js
+++ b/src/rules/selector-list-comma-space-after/index.js
@@ -19,10 +19,10 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation) {
   const checker = whitespaceChecker(" ", expectation, messages)
-  return selectorDelimiterSpaceChecker(checker.after)
+  return selectorListCommaWhitespaceChecker(checker.after)
 }
 
-export function selectorDelimiterSpaceChecker(checkLocation) {
+export function selectorListCommaWhitespaceChecker(checkLocation) {
   return function (css, result) {
     css.eachRule(function (rule) {
       const selector = rule.selector

--- a/src/rules/selector-list-comma-space-before/README.md
+++ b/src/rules/selector-list-comma-space-before/README.md
@@ -1,11 +1,11 @@
-# selector-delimiter-space-after
+# selector-list-comma-space-before
 
-Require a single space or disallow whitespace after the delimiters of selectors.
+Require a single space or disallow whitespace before the commas of selector lists.
 
 ```css
     a, b { color: pink; }
 /**  ↑
- * The space after this delimiter */
+ * The space before this comma */
 ```
 
 ## Options
@@ -15,7 +15,7 @@ Require a single space or disallow whitespace after the delimiters of selectors.
 
 ### `"always"`
 
-There *must always* be a single space after the delimiters.
+There *must always* be a single space before the commas.
 
 The following patterns are considered warnings:
 
@@ -24,13 +24,13 @@ a,b { color: pink; }
 ```
 
 ```css
-a ,b { color: pink; }
+a, b { color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a, b { color: pink; }
+a ,b { color: pink; }
 ```
 
 ```css
@@ -39,12 +39,12 @@ a , b { color: pink; }
 
 ### `"never"`
 
-There *must never* be whitespace after the delimiters.
+There *must never* be whitespace before the commas.
 
 The following patterns are considered warnings:
 
 ```css
-a, b { color: pink; }
+a ,b { color: pink; }
 ```
 
 ```css
@@ -58,12 +58,12 @@ a,b { color: pink; }
 ```
 
 ```css
-a ,b { color: pink; }
+a, b { color: pink; }
 ```
 
 ### `"always-single-line"`
 
-There *must always* be a single space after the delimiters in single-line selectors.
+There *must always* be a single space before the commas in single-line selector lists.
 
 The following patterns are considered warnings:
 
@@ -74,23 +74,23 @@ a,b { color: pink; }
 The following patterns are *not* considered warnings:
 
 ```css
-a
-,b { color: pink; }
+a,
+b { color: pink; }
 ```
 
 ### `"never-single-line"`
 
-There *must never* be a single space after the delimiters in single-line selectors.
+There *must never* be a single space before the commas in single-line selector lists.
 
 The following patterns are considered warnings:
 
 ```css
-a, b { color: pink; }
+a ,b { color: pink; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a
-, b { color: pink; }
+a ,
+b { color: pink; }
 ```

--- a/src/rules/selector-list-comma-space-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-before/__tests__/index.js
@@ -46,7 +46,7 @@ testRule("always-single-line", tr => {
   warningFreeBasics(tr)
 
   tr.ok("a ,b {}")
-  tr.ok("a ,b {\n}", "single-line selector, multi-line block")
+  tr.ok("a ,b {\n}", "single-line selector list, multi-line block")
 
   tr.notOk("a,b {}", messages.expectedBeforeSingleLine())
   tr.notOk("a,b {\n}", messages.expectedBeforeSingleLine())
@@ -56,7 +56,7 @@ testRule("never-single-line", tr => {
   warningFreeBasics(tr)
 
   tr.ok("a,b {}")
-  tr.ok("a,b {\n}", "single-line selector, multi-line block")
+  tr.ok("a,b {\n}", "single-line selector list, multi-line block")
 
   tr.notOk("a ,b {}", messages.rejectedBeforeSingleLine())
   tr.notOk("a ,b {\n}", messages.rejectedBeforeSingleLine())

--- a/src/rules/selector-list-comma-space-before/index.js
+++ b/src/rules/selector-list-comma-space-before/index.js
@@ -3,15 +3,15 @@ import {
   whitespaceChecker
 } from "../../utils"
 
-import { selectorDelimiterSpaceChecker } from "../selector-delimiter-space-after"
+import { selectorDelimiterSpaceChecker } from "../selector-list-comma-space-after"
 
-export const ruleName = "selector-delimiter-space-before"
+export const ruleName = "selector-list-comma-space-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ","`,
   rejectedBefore: () => `Unexpected whitespace before ","`,
-  expectedBeforeSingleLine: () => `Expected single space before "," in a single-line selector`,
-  rejectedBeforeSingleLine: () => `Unexpected whitespace before "," in a single-line selector`,
+  expectedBeforeSingleLine: () => `Expected single space before "," in a single-line list`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "," in a single-line list`,
 })
 
 /**

--- a/src/rules/selector-list-comma-space-before/index.js
+++ b/src/rules/selector-list-comma-space-before/index.js
@@ -3,7 +3,7 @@ import {
   whitespaceChecker
 } from "../../utils"
 
-import { selectorDelimiterSpaceChecker } from "../selector-list-comma-space-after"
+import { selectorListCommaWhitespaceChecker } from "../selector-list-comma-space-after"
 
 export const ruleName = "selector-list-comma-space-before"
 
@@ -19,5 +19,5 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation) {
   const checker = whitespaceChecker(" ", expectation, messages)
-  return selectorDelimiterSpaceChecker(checker.before)
+  return selectorListCommaWhitespaceChecker(checker.before)
 }


### PR DESCRIPTION
A group of selectors has changed to "a selector list separated by commas" in the CSS Selectors Level 4 Spec ([ref](http://dev.w3.org/csswg/selectors-4/#grouping)). 

Which is super convenient for us as it lets us rename the `selector-delimiter-*` rules match our other lists rules: `media-query-list-*`, `value-list-*` :)

You've gotta love that level of consistency :)