### PR TITLE
Add small section about shareable configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ If you prefer to enforce a third-party styleguide (rather than craft your own co
 
 * [SuitCSS shareable config](https://github.com/stylelint/stylelint-config-suitcss)
 
+You can also extend a shareable config file, starting with what's there and making your own modifications and additions.
+
 ## Requirements
 
 * node@0.12 or io.js@2

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Some rules require options. There are no default values, so each rule that requi
 }
 ```
 
+#### Shareable configs
+
+If you perfer to enforce a third-party styleguide (rather than craft your own config), you can use:
+
+* [SuitCSS shareable config](https://github.com/stylelint/stylelint-config-suitcss)
+
 ## Requirements
 
 * node@0.12 or io.js@2

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Some rules require options. There are no default values, so each rule that requi
 
 #### Shareable configs
 
-If you perfer to enforce a third-party styleguide (rather than craft your own config), you can use:
+If you prefer to enforce a third-party styleguide (rather than craft your own config), you can use:
 
 * [SuitCSS shareable config](https://github.com/stylelint/stylelint-config-suitcss)
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,24 @@ If you prefer to enforce a third-party styleguide (rather than craft your own co
 
 * [SuitCSS shareable config](https://github.com/stylelint/stylelint-config-suitcss)
 
-You can also extend a shareable config file, starting with what's there and making your own modifications and additions.
+You can also extend a shareable config file, starting with what's there and making your own modifications and additions:
+
+```js
+var assign = require("lodash.assign")
+var configSuitcss = require("stylelint-config-suitcss")
+
+// change indentation to tabs and disable the number-leading-zero rule
+var myConfig = {
+  "rules": {
+    "indentation": [2, "tab"],
+    "number-leading-zero": 0,
+  }
+}
+
+var config = {
+  rules: assign(configSuitcss.rules, myConfig.rules)
+}
+```
 
 ## Requirements
 


### PR DESCRIPTION
I was having to update (on each change to the rules) each of my config files spread across the projects I'm testing stylelint on, so I figured I'd create a shareable config to make things easier for myself:

https://github.com/stylelint/stylelint-config-suitcss

I think it's worth having this section in the main `README.md`, rather than the user guide, as it means first-time users can get going quickly with something that works out-of-the-box, rather than having to take the time to hand-craft their own configs before they see anything happening. What do you guys think?

Also, if you have any thoughts on the config itself (or the (minimal) code behind it) please flag that up in the repo :)