### PR TITLE
Accurately check nested blocks for duplicate properties

### DIFF
--- a/src/rules/rule-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/rule-no-duplicate-properties/__tests__/index.js
@@ -11,12 +11,18 @@ testRule(null, tr => {
 
   tr.ok("a { color: pink; }")
   tr.ok("a { color: pink; background: orange; }")
+  tr.ok("a { color: pink; { &:hover { color: orange; } } }", "spec nested")
   tr.ok("a { color: pink; @media { color: orange; } }", "nested")
   tr.ok("a { color: pink; @media { color: orange; &::before { color: black; } } }", "double nested")
 
   tr.notOk("a { color: pink; color: orange }", messages.rejected("color"))
   tr.notOk("a { color: pink; background: orange; color: orange }", messages.rejected("color"))
   tr.notOk("a { color: pink; background: orange; background: pink; }", messages.rejected("background"))
+  tr.notOk(
+    "a { color: pink; { &:hover { color: orange; color: black; } } }",
+    messages.rejected("color"),
+    "spec nested"
+  )
   tr.notOk(
     "a { color: pink; @media { color: orange; color: black; } }",
     messages.rejected("color"),

--- a/src/rules/rule-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/rule-no-duplicate-properties/__tests__/index.js
@@ -11,8 +11,25 @@ testRule(null, tr => {
 
   tr.ok("a { color: pink; }")
   tr.ok("a { color: pink; background: orange; }")
+  tr.ok("a { color: pink; @media { color: orange; } }", "nested")
+  tr.ok("a { color: pink; @media { color: orange; &::before { color: black; } } }", "double nested")
 
   tr.notOk("a { color: pink; color: orange }", messages.rejected("color"))
   tr.notOk("a { color: pink; background: orange; color: orange }", messages.rejected("color"))
   tr.notOk("a { color: pink; background: orange; background: pink; }", messages.rejected("background"))
+  tr.notOk(
+    "a { color: pink; @media { color: orange; color: black; } }",
+    messages.rejected("color"),
+    "nested"
+  )
+  tr.notOk(
+    "a { color: pink; @media { color: orange; &::before { color: black; color: white; } } }",
+    messages.rejected("color"),
+    "double nested"
+  )
+  tr.notOk(
+    "a { color: pink; @media { color: orange; .foo { color: black; color: white; } } }",
+    messages.rejected("color"),
+    "double nested again"
+  )
 })

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -23,8 +23,8 @@ export default function () {
     })
 
     function checkRulesInNode(node) {
-      var decls = []
-      node.each(function (child) {
+      let decls = []
+      node.each(child => {
         if (child.nodes && child.nodes.length) {
           checkRulesInNode(child)
         }

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -11,20 +11,35 @@ export const messages = ruleMessages(ruleName, {
 
 export default function () {
   return (root, result) => {
-    root.eachRule(rule => {
+    // In order to accommodate nested blocks (postcss-nested),
+    // we need to run a shallow loop (instead of eachDecl() or eachRule(),
+    // which loop recursively) and allow each nested block to accumulate
+    // its own list of properties -- so that a property in a nested rule
+    // does not conflict with the same property in the parent rule
+    root.each(node => {
+      if (node.type === "rule" || node.type === "at-rule") {
+        checkRulesInNode(node)
+      }
+    })
+
+    function checkRulesInNode(node) {
       var decls = []
-      rule.eachDecl(function (decl) {
-        const prop = decl.prop
+      node.each(function (child) {
+        if (child.nodes && child.nodes.length) {
+          checkRulesInNode(child)
+        }
+        if (child.type !== "decl") { return }
+        const prop = child.prop
         if (decls.indexOf(prop) !== -1) {
           report({
             message: messages.rejected(prop),
-            node: decl,
+            node: child,
             result,
             ruleName,
           })
         }
         decls.push(prop)
       })
-    })
+    }
   }
 }


### PR DESCRIPTION
@benfrain this should address the problem you mentioned [here](https://github.com/stylelint/stylelint/issues/133#issuecomment-120550968), I think.

Relates to #266: If we want to start trying to accommodate non-standard syntaxes, here we go. 