### PR TITLE
Exclude nesting blocks from opening-brace-space-before rule

### DIFF
--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -13,6 +13,9 @@ testRule("always", tr => {
   tr.ok("a { color: pink; }")
   tr.ok("@media print { a { color: pink; } }")
 
+  tr.ok("a {{ &:hover { color: pink; }}}")
+  tr.ok("a {\n{ &:hover { color: pink; }}}")
+
   tr.notOk("a{ color: pink; }", messages.expectedBefore())
   tr.notOk("a  { color: pink; }", messages.expectedBefore())
   tr.notOk("a\t{ color: pink; }", messages.expectedBefore())

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -2,9 +2,10 @@ import {
   cssStatementBlockString,
   cssStatementHasBlock,
   cssStatementHasEmptyBlock,
+  cssStatementIsNestingBlock,
+  cssStatementStringBeforeBlock,
   report,
   ruleMessages,
-  cssStatementStringBeforeBlock,
   whitespaceChecker
 } from "../../utils"
 
@@ -31,8 +32,8 @@ export default function (expectation) {
     root.eachAtRule(check)
 
     function check(statement) {
-      // Return early if blockless or has empty block
-      if (!cssStatementHasBlock(statement) || cssStatementHasEmptyBlock(statement)) { return }
+      // Return early if blockless, has empty block or is a nesting block
+      if (!cssStatementHasBlock(statement) || cssStatementHasEmptyBlock(statement) || cssStatementIsNestingBlock(statement)) { return }
 
       const source = cssStatementStringBeforeBlock(statement)
 

--- a/src/utils/__tests__/cssStatementIsNestingBlock-test.js
+++ b/src/utils/__tests__/cssStatementIsNestingBlock-test.js
@@ -23,10 +23,16 @@ function postcssCheck(cssString) {
   const root = postcss.parse(cssString)
   let isNestingBlock = false
   root.eachRule(rule => {
-    if (cssStatementIsNestingBlock(rule)) { isNestingBlock = true }
+    if (cssStatementIsNestingBlock(rule)) {
+      isNestingBlock = true
+      return false
+    }
   })
   root.eachAtRule(atRule => {
-    if (cssStatementIsNestingBlock(atRule)) { isNestingBlock = true }
+    if (cssStatementIsNestingBlock(atRule)) {
+      isNestingBlock = true
+      return false
+    }
   })
   return isNestingBlock
 }

--- a/src/utils/__tests__/cssStatementIsNestingBlock-test.js
+++ b/src/utils/__tests__/cssStatementIsNestingBlock-test.js
@@ -1,0 +1,32 @@
+import cssStatementIsNestingBlock from "../cssStatementIsNestingBlock"
+import postcss from "postcss"
+import test from "tape"
+
+test("cssStatementIsNestingBlock", t => {
+
+  t.ok(postcssCheck("a {{ &:hover { color: pink; }}}"), "nesting without first level")
+  t.ok(postcssCheck("a { color: red; { &:hover { color: pink; }}}"), "nesting with first level")
+
+  t.notOk(postcssCheck("a {}"), "empty rule")
+  t.notOk(postcssCheck("a { color: pink; }"), "not empty rule")
+  t.notOk(postcssCheck("@media print { a { color: pink; } }"), "not empty @media")
+  t.notOk(postcssCheck("@supports (animation-name: test) { a { color: pink; } }"), "not empty @supports")
+  t.notOk(postcssCheck("@document url(http://www.w3.org/) { a { color: pink; } }"), "not empty @document")
+  t.notOk(postcssCheck("@page :pseudo-class { a { color: pink; } }"), "not empty @page")
+  t.notOk(postcssCheck("@font-face { font-family: sans; }"), "not empty @font-face")
+  t.notOk(postcssCheck("@keyframes identifier { 0% { top: 0; left:} }"), "not empty @keyframes")
+
+  t.end()
+})
+
+function postcssCheck(cssString) {
+  const root = postcss.parse(cssString)
+  let isNestingBlock = false
+  root.eachRule(rule => {
+    if (cssStatementIsNestingBlock(rule)) { isNestingBlock = true }
+  })
+  root.eachAtRule(atRule => {
+    if (cssStatementIsNestingBlock(atRule)) { isNestingBlock = true }
+  })
+  return isNestingBlock
+}

--- a/src/utils/cssStatementIsNestingBlock.js
+++ b/src/utils/cssStatementIsNestingBlock.js
@@ -1,0 +1,11 @@
+/**
+ * Check if a statement is a nesting block
+ *
+ * @param {Rule|AtRule} statement - postcss rule or at-rule node
+ * @return {boolean} True if `statement` is a nesting block
+ */
+export default function (statement) {
+  return (
+    statement.type === "rule" && statement.selector === ""
+  )
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,10 @@
-import cssStatementBlockString from "./cssStatementBlockString"
 import cssFunctionArguments from "./cssFunctionArguments"
-import isAutoprefixable from "./isAutoprefixable"
+import cssStatementBlockString from "./cssStatementBlockString"
 import cssStatementHasBlock from "./cssStatementHasBlock"
 import cssStatementHasEmptyBlock from "./cssStatementHasEmptyBlock"
+import cssStatementIsNestingBlock from "./cssStatementIsNestingBlock"
+import cssStatementStringBeforeBlock from "./cssStatementStringBeforeBlock"
+import isAutoprefixable from "./isAutoprefixable"
 import isSingleLineString from "./isSingleLineString"
 import isWhitespace from "./isWhitespace"
 import lineCount from "./lineCount"
@@ -10,16 +12,17 @@ import optionsHaveException from "./optionsHaveException"
 import optionsHaveIgnored from "./optionsHaveIgnored"
 import report from "./report"
 import ruleMessages from "./ruleMessages"
-import cssStatementStringBeforeBlock from "./cssStatementStringBeforeBlock"
 import styleSearch from "./styleSearch"
 import whitespaceChecker from "./whitespaceChecker"
 
 export default {
-  cssStatementBlockString,
   cssFunctionArguments,
-  isAutoprefixable,
+  cssStatementBlockString,
   cssStatementHasBlock,
   cssStatementHasEmptyBlock,
+  cssStatementIsNestingBlock,
+  cssStatementStringBeforeBlock,
+  isAutoprefixable,
   isSingleLineString,
   isWhitespace,
   lineCount,
@@ -27,7 +30,6 @@ export default {
   optionsHaveIgnored,
   report,
   ruleMessages,
-  cssStatementStringBeforeBlock,
   styleSearch,
   whitespaceChecker,
 }


### PR DESCRIPTION
There appears to be a couple more issues with *nesting blocks*. This PR looks at the opening braces of them.

```
a {
  color: red;
  { /* <-- this brace */
    &:hover {
      color: pink;
    }
  }
}
```

I'm thinking we should treat the opening brace of a *nesting block* as a special case. Perhaps with it's own whitespace rules e.g. `nesting-block-opening-brace-space|newline-before`.

In the meantime, this PR excludes *nesting blocks* from the `block-opening-brace-space-before` rule as it currently flags up warnings against these nesting block braces.

What does everyone think?




