### PR TITLE
Add nesting tests to rule-trailing-semicolon

### DIFF
--- a/src/rules/rule-trailing-semicolon/__tests__/index.js
+++ b/src/rules/rule-trailing-semicolon/__tests__/index.js
@@ -18,6 +18,21 @@ testRule("always", tr => {
     "multi-line declaration block with trailing semicolon"
   )
 
+  tr.ok(
+    "a {{ &:hover { color: pink; }}}",
+    "nesting without first-level decl"
+  )
+
+  tr.ok(
+    "a { color: red; { &:hover { color: pink; }}}",
+    "nesting with first-level decl"
+  )
+
+  tr.ok(
+    "a { &:hover { color: pink; }}",
+    "nested"
+  )
+
   tr.notOk(
     "a { color: pink }",
     messages.expected,
@@ -27,6 +42,30 @@ testRule("always", tr => {
     "a { background: orange; color: pink }",
     messages.expected,
     "multi-line declaration block without trailing semicolon"
+  )
+
+  tr.notOk(
+    "a {{ &:hover { color: pink }}}",
+    messages.expected,
+    "nesting without first-level decl"
+  )
+
+  tr.notOk(
+    "a { color: red { &:hover { color: pink; }}}",
+    messages.expected,
+    "nesting with first-level decl"
+  )
+
+  tr.notOk(
+    "a { color: red; { &:hover { color: pink }}}",
+    messages.expected,
+    "nesting with first-level decl"
+  )
+
+  tr.notOk(
+    "a { &:hover { color: pink }}",
+    messages.expected,
+    "nested"
   )
 })
 

--- a/src/rules/rule-trailing-semicolon/__tests__/index.js
+++ b/src/rules/rule-trailing-semicolon/__tests__/index.js
@@ -51,12 +51,6 @@ testRule("always", tr => {
   )
 
   tr.notOk(
-    "a { color: red { &:hover { color: pink; }}}",
-    messages.expected,
-    "nesting with first-level decl"
-  )
-
-  tr.notOk(
     "a { color: red; { &:hover { color: pink }}}",
     messages.expected,
     "nesting with first-level decl"

--- a/src/rules/rule-trailing-semicolon/index.js
+++ b/src/rules/rule-trailing-semicolon/index.js
@@ -18,9 +18,10 @@ export default function (expectation) {
   return (root, result) => {
 
     root.eachRule(rule => {
-
       // Return early if an empty rule
       if (cssStatementHasEmptyBlock(rule)) { return }
+
+      if (!rule.last || rule.last.type !== "decl") { return }
 
       // Check semi colon
       if (expectation === "always" && rule.semicolon) { return }

--- a/src/rules/rule-trailing-semicolon/index.js
+++ b/src/rules/rule-trailing-semicolon/index.js
@@ -1,6 +1,7 @@
 import {
   report,
-  ruleMessages
+  ruleMessages,
+  cssStatementHasEmptyBlock
 } from "../../utils"
 
 export const ruleName = "rule-trailing-semicolon"
@@ -18,10 +19,10 @@ export default function (expectation) {
 
     root.eachRule(rule => {
 
-      // return early if an empty rule
-      if (rule.nodes.length === 0) { return }
+      // Return early if an empty rule
+      if (cssStatementHasEmptyBlock(rule)) { return }
 
-      // check semi colon
+      // Check semi colon
       if (expectation === "always" && rule.semicolon) { return }
       if (expectation === "never" && !rule.semicolon) { return }
 


### PR DESCRIPTION
We're revisiting the very first rule :)

`rule.semicolon` doesn't seem to play well with *nesting blocks*. I've added some breaking tests accordingly.

I've had a think about how to resolve this, but nothing obvious sprung to mind. 

Any ideas?

