### PR TITLE
Add color-hex-length. Closes #283

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 * Added: `color-hex-case` rule.
+* Added: `color-hex-length` rule.
 
 # 0.1.2
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -12,7 +12,7 @@
 * [`block-opening-brace-space-after`](../src/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks.
 * [`block-opening-brace-space-before`](../src/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks.
 * [`color-hex-case`](../src/rules/color-hex-case/README.md): Specify lowercase or uppercase for hex colors.
-* [`color-hex-length`](../src/rules/color-hex-length/README.md): Specify lowercase or uppercase for hex colors.
+* [`color-hex-length`](../src/rules/color-hex-length/README.md): Specify short or long notation for hex colors.
 * [`color-no-invalid-hex`](../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
 * [`comment-empty-line-before`](../src/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
 * [`comment-space-inside`](../src/rules/comment-space-inside/README.md): Require a single space or disallow whitespace on the inside of comment markers.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -12,6 +12,7 @@
 * [`block-opening-brace-space-after`](../src/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks.
 * [`block-opening-brace-space-before`](../src/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks.
 * [`color-hex-case`](../src/rules/color-hex-case/README.md): Specify lowercase or uppercase for hex colors.
+* [`color-hex-length`](../src/rules/color-hex-length/README.md): Specify lowercase or uppercase for hex colors.
 * [`color-no-invalid-hex`](../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
 * [`comment-empty-line-before`](../src/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
 * [`comment-space-inside`](../src/rules/comment-space-inside/README.md): Require a single space or disallow whitespace on the inside of comment markers.

--- a/src/rules/color-hex-length/README.md
+++ b/src/rules/color-hex-length/README.md
@@ -1,0 +1,59 @@
+# color-hex-length
+
+Specify short or long notation for hex colors.
+
+```css
+    a { color: #fff }
+/**              ↑
+ * These hex colors */
+```
+
+## Options
+
+`string`: `"short"|"long"`
+
+### `"short"`
+
+The following patterns are considered warnings:
+
+```css
+a { color: #ffffff; }
+```
+
+```css
+a { color: #fffffaa; }
+```
+
+The following patterns are *not* considered warnings:
+
+
+```css
+a { color: #fff; }
+```
+
+```css
+a { color: #fffa; }
+```
+
+### `"long"`
+
+The following patterns are considered warnings:
+
+```css
+a { color: #fff; }
+```
+
+```css
+a { color: #fffa; }
+```
+
+The following patterns are *not* considered warnings:
+
+
+```css
+a { color: #ffffff; }
+```
+
+```css
+a { color: #fffffaa; }
+```

--- a/src/rules/color-hex-length/__tests__/index.js
+++ b/src/rules/color-hex-length/__tests__/index.js
@@ -24,10 +24,10 @@ testRule("short", tr => {
   tr.ok("a::before { content: \"#ABABAB\"; }")
   tr.ok("a { color: white /* #FFFFFF */; }")
 
-  tr.notOk("a { color: #FFFFFF; }", messages.expected("short", "#FFFFFF", "#FFF"))
-  tr.notOk("a { color: #FfaAFF; }", messages.expected("short", "#FfaAFF", "#FaF"))
-  tr.notOk("a { color: #00aa00aa; }", messages.expected("short", "#00aa00aa", "#0a0a"))
-  tr.notOk("a { something: #fff, #aba, #00ffAAaa; }", messages.expected("short", "#00ffAAaa", "#0fAa"))
+  tr.notOk("a { color: #FFFFFF; }", messages.expected("#FFFFFF", "#FFF"))
+  tr.notOk("a { color: #FfaAFF; }", messages.expected("#FfaAFF", "#FaF"))
+  tr.notOk("a { color: #00aa00aa; }", messages.expected("#00aa00aa", "#0a0a"))
+  tr.notOk("a { something: #fff, #aba, #00ffAAaa; }", messages.expected("#00ffAAaa", "#0fAa"))
 })
 
 testRule("long", tr => {
@@ -48,8 +48,8 @@ testRule("long", tr => {
   tr.ok("a::before { content: \"#ABA\"; }")
   tr.ok("a { color: white /* #FFF */; }")
 
-  tr.notOk("a { color: #FFF; }", messages.expected("long", "#FFF", "#FFFFFF"))
-  tr.notOk("a { color: #Ffa; }", messages.expected("long", "#Ffa", "#FFffaa"))
-  tr.notOk("a { color: #0a0a; }", messages.expected("long", "#0a0a", "#00aa00aa"))
-  tr.notOk("a { something: #ffffff, #aabbaa, #0fAa; }", messages.expected("long", "#0fAa", "#00ffAAaa"))
+  tr.notOk("a { color: #FFF; }", messages.expected("#FFF", "#FFFFFF"))
+  tr.notOk("a { color: #Ffa; }", messages.expected("#Ffa", "#FFffaa"))
+  tr.notOk("a { color: #0a0a; }", messages.expected("#0a0a", "#00aa00aa"))
+  tr.notOk("a { something: #ffffff, #aabbaa, #0fAa; }", messages.expected("#0fAa", "#00ffAAaa"))
 })

--- a/src/rules/color-hex-length/__tests__/index.js
+++ b/src/rules/color-hex-length/__tests__/index.js
@@ -24,10 +24,10 @@ testRule("short", tr => {
   tr.ok("a::before { content: \"#ABABAB\"; }")
   tr.ok("a { color: white /* #FFFFFF */; }")
 
-  tr.notOk("a { color: #FFFFFF; }", messages.expected("short", "#FFFFFF"))
-  tr.notOk("a { color: #FfaAFF; }", messages.expected("short", "#FfaAFF"))
-  tr.notOk("a { color: #00aa00aa; }", messages.expected("short", "#00aa00aa"))
-  tr.notOk("a { something: #fff, #aba, #00ffAAaa; }", messages.expected("short", "#00ffAAaa"))
+  tr.notOk("a { color: #FFFFFF; }", messages.expected("short", "#FFFFFF", "#FFF"))
+  tr.notOk("a { color: #FfaAFF; }", messages.expected("short", "#FfaAFF", "#FaF"))
+  tr.notOk("a { color: #00aa00aa; }", messages.expected("short", "#00aa00aa", "#0a0a"))
+  tr.notOk("a { something: #fff, #aba, #00ffAAaa; }", messages.expected("short", "#00ffAAaa", "#0fAa"))
 })
 
 testRule("long", tr => {
@@ -48,8 +48,8 @@ testRule("long", tr => {
   tr.ok("a::before { content: \"#ABA\"; }")
   tr.ok("a { color: white /* #FFF */; }")
 
-  tr.notOk("a { color: #FFF; }", messages.expected("long", "#FFF"))
-  tr.notOk("a { color: #Ffa; }", messages.expected("long", "#Ffa"))
-  tr.notOk("a { color: #0a0a; }", messages.expected("long", "#0a0a"))
-  tr.notOk("a { something: #ffffff, #aabbaa, #0fAa; }", messages.expected("long", "#0fAa"))
+  tr.notOk("a { color: #FFF; }", messages.expected("long", "#FFF", "#FFFFFF"))
+  tr.notOk("a { color: #Ffa; }", messages.expected("long", "#Ffa", "#FFffaa"))
+  tr.notOk("a { color: #0a0a; }", messages.expected("long", "#0a0a", "#00aa00aa"))
+  tr.notOk("a { something: #ffffff, #aabbaa, #0fAa; }", messages.expected("long", "#0fAa", "#00ffAAaa"))
 })

--- a/src/rules/color-hex-length/__tests__/index.js
+++ b/src/rules/color-hex-length/__tests__/index.js
@@ -1,0 +1,55 @@
+import {
+  ruleTester,
+  warningFreeBasics
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule("short", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: #000; }")
+  tr.ok("a { color: #FFF; }")
+  tr.ok("a { color: #fFf; }", "mixed case")
+  tr.ok("a { color: #fffa; }")
+  tr.ok("a { something: #000, #fff, #aba; }")
+
+  tr.ok("a { color: #ff; }", "invalid short")
+  tr.ok("a { color: #ffffffa; }", "invalid long")
+  tr.ok("a { color: #fffffffffff; }", "invalid extra long")
+
+  tr.ok("a { padding: 000000; }")
+  tr.ok("a::before { content: \"#ABABAB\"; }")
+  tr.ok("a { color: white /* #FFFFFF */; }")
+
+  tr.notOk("a { color: #FFFFFF; }", messages.expected("short", "#FFFFFF"))
+  tr.notOk("a { color: #FfaAFF; }", messages.expected("short", "#FfaAFF"))
+  tr.notOk("a { color: #00aa00aa; }", messages.expected("short", "#00aa00aa"))
+  tr.notOk("a { something: #fff, #aba, #00ffAAaa; }", messages.expected("short", "#00ffAAaa"))
+})
+
+testRule("long", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: #000000; }")
+  tr.ok("a { color: #FFFFFF; }")
+  tr.ok("a { color: #fFfFfF; }", "mixed case")
+  tr.ok("a { color: #ffffffaa; }")
+  tr.ok("a { something: #000000, #ffffff, #ababab; }")
+
+  tr.ok("a { color: #ff; }", "invalid short")
+  tr.ok("a { color: #ffffffa; }", "invalid long")
+  tr.ok("a { color: #fffffffffff; }", "invalid extra long")
+
+  tr.ok("a { padding: 000; }")
+  tr.ok("a::before { content: \"#ABA\"; }")
+  tr.ok("a { color: white /* #FFF */; }")
+
+  tr.notOk("a { color: #FFF; }", messages.expected("long", "#FFF"))
+  tr.notOk("a { color: #Ffa; }", messages.expected("long", "#Ffa"))
+  tr.notOk("a { color: #0a0a; }", messages.expected("long", "#0a0a"))
+  tr.notOk("a { something: #ffffff, #aabbaa, #0fAa; }", messages.expected("long", "#0fAa"))
+})

--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -1,0 +1,48 @@
+import {
+  report,
+  ruleMessages,
+  styleSearch
+} from "../../utils"
+
+export const ruleName = "color-hex-length"
+
+export const messages = ruleMessages(ruleName, {
+  expected: (l, h) => `Expected ${l} hex color ${h}`,
+})
+
+/**
+ * @param {"short"|"long"} expectation
+ */
+export default function (expectation) {
+  return (root, result) => {
+    root.eachDecl(decl => {
+      const value = decl.value
+
+      styleSearch({ source: value, target: "#" }, match => {
+
+        const hexValue = /^#[0-9A-Za-z]+/.exec(value.substr(match.startIndex))[0]
+
+        if (expectation === "long" && hexValue.length !== 4 && hexValue.length !== 5) { return }
+
+        if (expectation === "short" && (hexValue.length < 6 || !canShrink(hexValue))) { return }
+
+        report({
+          message: messages.expected(expectation, hexValue),
+          node: decl,
+          result,
+          ruleName,
+        })
+      })
+    })
+
+    function canShrink(hex) {
+      hex = hex.toLowerCase()
+
+      return (
+        hex[1] === hex[2] &&
+        hex[3] === hex[4] &&
+        hex[5] === hex[6] &&
+        (hex.length === 7 || (hex.length === 9 && hex[7] === hex[8])))
+    }
+  }
+}

--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -7,7 +7,7 @@ import {
 export const ruleName = "color-hex-length"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (l, h) => `Expected ${l} hex color ${h}`,
+  expected: (l, h, v) => `Expected "${h}"" to be in the ${l} notation form of "${v}"`,
 })
 
 /**
@@ -26,23 +26,41 @@ export default function (expectation) {
 
         if (expectation === "short" && (hexValue.length < 6 || !canShrink(hexValue))) { return }
 
+        const variant = expectation === "long" ? longer : shorter
+
         report({
-          message: messages.expected(expectation, hexValue),
+          message: messages.expected(expectation, hexValue, variant(hexValue)),
           node: decl,
           result,
           ruleName,
         })
       })
     })
-
-    function canShrink(hex) {
-      hex = hex.toLowerCase()
-
-      return (
-        hex[1] === hex[2] &&
-        hex[3] === hex[4] &&
-        hex[5] === hex[6] &&
-        (hex.length === 7 || (hex.length === 9 && hex[7] === hex[8])))
-    }
   }
+}
+
+function canShrink(hex) {
+  hex = hex.toLowerCase()
+
+  return (
+    hex[1] === hex[2] &&
+    hex[3] === hex[4] &&
+    hex[5] === hex[6] &&
+    (hex.length === 7 || (hex.length === 9 && hex[7] === hex[8])))
+}
+
+function shorter(hex) {
+  let hexVariant = "#"
+  for (let i = 1; i < hex.length; i = i + 2) {
+    hexVariant += hex[i]
+  }
+  return hexVariant
+}
+
+function longer(hex) {
+  let hexVariant = "#"
+  for (let i = 1; i < hex.length; i++) {
+    hexVariant += hex[i] + hex[i]
+  }
+  return hexVariant
 }

--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -7,7 +7,7 @@ import {
 export const ruleName = "color-hex-length"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (l, h, v) => `Expected "${h}"" to be in the ${l} notation form of "${v}"`,
+  expected: (h, v) => `Expected "${h}" to be "${v}"`,
 })
 
 /**
@@ -29,7 +29,7 @@ export default function (expectation) {
         const variant = expectation === "long" ? longer : shorter
 
         report({
-          message: messages.expected(expectation, hexValue, variant(hexValue)),
+          message: messages.expected(hexValue, variant(hexValue)),
           node: decl,
           result,
           ruleName,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -10,6 +10,7 @@ import blockOpeningBraceNewlineBefore from "./block-opening-brace-newline-before
 import blockOpeningBraceSpaceAfter from "./block-opening-brace-space-after"
 import blockOpeningBraceSpaceBefore from "./block-opening-brace-space-before"
 import colorHexCase from "./color-hex-case"
+import colorHexLength from "./color-hex-length"
 import colorNoInvalidHex from "./color-no-invalid-hex"
 import commentEmptyLineBefore from "./comment-empty-line-before"
 import commentSpaceInside from "./comment-space-inside"
@@ -91,6 +92,7 @@ export default {
   "block-opening-brace-space-after": blockOpeningBraceSpaceAfter,
   "block-opening-brace-space-before": blockOpeningBraceSpaceBefore,
   "color-hex-case": colorHexCase,
+  "color-hex-length": colorHexLength,
   "color-no-invalid-hex": colorNoInvalidHex,
   "comment-empty-line-before": commentEmptyLineBefore,
   "comment-space-inside": commentSpaceInside,


### PR DESCRIPTION
I've tried to:

1. keep regexs to a minimum
2. avoid flagging invalid hex