### PR TITLE
Tweak color-hex-case option names

### DIFF
--- a/src/rules/color-hex-case/README.md
+++ b/src/rules/color-hex-case/README.md
@@ -10,9 +10,9 @@ Specify lowercase or uppercase for hex colors.
 
 ## Options
 
-`string`: `"lowecase"|"uppercase"`
+`string`: `"lower"|"upper"`
 
-### `"lowercase"`
+### `"lower"`
 
 The following patterns are considered warnings:
 
@@ -31,7 +31,7 @@ a { color: #000; }
 a { color: #fff; }
 ```
 
-### `"uppercase"`
+### `"upper"`
 
 The following patterns are considered warnings:
 

--- a/src/rules/color-hex-case/__tests__/index.js
+++ b/src/rules/color-hex-case/__tests__/index.js
@@ -6,7 +6,7 @@ import rule, { ruleName, messages } from ".."
 
 const testRule = ruleTester(rule, ruleName)
 
-testRule("lowercase", tr => {
+testRule("lower", tr => {
   warningFreeBasics(tr)
 
   tr.ok("a { color: pink; }")
@@ -19,13 +19,13 @@ testRule("lowercase", tr => {
   tr.ok("a::before { content: \"#ABABA\"; }")
   tr.ok("a { color: white /* #FFF */; }")
 
-  tr.notOk("a { color: #Ababa; }", messages.expected("lowercase", "#Ababa"))
-  tr.notOk("a { something: #000F, #fff, #ababab; }", messages.expected("lowercase", "#000F"))
-  tr.notOk("a { something: #000, #FFFFAZ, #ababab; }", messages.expected("lowercase", "#FFFFAZ"))
-  tr.notOk("a { something: #000, #fff, #12345AA; }", messages.expected("lowercase", "#12345AA"))
+  tr.notOk("a { color: #Ababa; }", messages.expected("lower", "#Ababa"))
+  tr.notOk("a { something: #000F, #fff, #ababab; }", messages.expected("lower", "#000F"))
+  tr.notOk("a { something: #000, #FFFFAZ, #ababab; }", messages.expected("lower", "#FFFFAZ"))
+  tr.notOk("a { something: #000, #fff, #12345AA; }", messages.expected("lower", "#12345AA"))
 })
 
-testRule("uppercase", tr => {
+testRule("upper", tr => {
   warningFreeBasics(tr)
 
   tr.ok("a { color: pink; }")
@@ -38,8 +38,8 @@ testRule("uppercase", tr => {
   tr.ok("a::before { content: \"#ababa\"; }")
   tr.ok("a { color: white /* #fff */; }")
 
-  tr.notOk("a { color: #aBABA; }", messages.expected("uppercase", "#aBABA"))
-  tr.notOk("a { something: #000f, #FFF, #ABABAB; }", messages.expected("uppercase", "#000f"))
-  tr.notOk("a { something: #000, #ffffaz, #ABABAB; }", messages.expected("uppercase", "#ffffaz"))
-  tr.notOk("a { something: #000, #FFF, #12345aa; }", messages.expected("uppercase", "#12345aa"))
+  tr.notOk("a { color: #aBABA; }", messages.expected("upper", "#aBABA"))
+  tr.notOk("a { something: #000f, #FFF, #ABABAB; }", messages.expected("upper", "#000f"))
+  tr.notOk("a { something: #000, #ffffaz, #ABABAB; }", messages.expected("upper", "#ffffaz"))
+  tr.notOk("a { something: #000, #FFF, #12345aa; }", messages.expected("upper", "#12345aa"))
 })

--- a/src/rules/color-hex-case/index.js
+++ b/src/rules/color-hex-case/index.js
@@ -7,11 +7,11 @@ import {
 export const ruleName = "color-hex-case"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (c, h) => `Expected ${c} hex color ${h}`,
+  expected: (c, h) => `Expected ${c}case hex color ${h}`,
 })
 
 /**
- * @param {"lowercase"|"uppercase"} expectation
+ * @param {"lower"|"upper"} expectation
  */
 export default function (expectation) {
   return (root, result) => {
@@ -22,9 +22,9 @@ export default function (expectation) {
 
         const hexValue = /^#[0-9A-Za-z]+/.exec(value.substr(match.startIndex))[0]
 
-        if (expectation === "lowercase" && hexValue === hexValue.toLowerCase()) { return }
+        if (expectation === "lower" && hexValue === hexValue.toLowerCase()) { return }
 
-        if (expectation === "uppercase" && hexValue === hexValue.toUpperCase()) { return }
+        if (expectation === "upper" && hexValue === hexValue.toUpperCase()) { return }
 
         report({
           message: messages.expected(expectation, hexValue),


### PR DESCRIPTION
A little tweak so configs read:

```js
"color-hex-case": [2, "upper"]
```

Rather than duplicating "case" e.g. :

```js
"color-hex-case": [2, "uppercase"]
```