### PR TITLE
Fix `selector-no-attribute` rule description title.

### DIFF
--- a/src/rules/selector-no-attribute/README.md
+++ b/src/rules/selector-no-attribute/README.md
@@ -1,4 +1,4 @@
-# selector-no-type
+# selector-no-attribute
 
 Disallow attribute selectors.
 


### PR DESCRIPTION
This is a small fix for the `selector-no-attribute` rule description title. Current was `selector-no-type`.