### PR TITLE
Check selector indentation with indentation;

### DIFF
--- a/src/rules/indentation/README.md
+++ b/src/rules/indentation/README.md
@@ -50,11 +50,31 @@ a {
 }
 ```
 
+```css
+@media print {
+  a,
+    b {
+    background-position: top left,
+      top right;
+  }
+}
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
 @media print {
   a {
+    background-position: top left,
+      top right;
+  }
+}
+```
+
+```css
+@media print {
+  a,
+  b {
     background-position: top left,
       top right;
   }

--- a/src/rules/indentation/__tests__/index.js
+++ b/src/rules/indentation/__tests__/index.js
@@ -1,2 +1,3 @@
 import "./rules"
 import "./at-rules"
+import "./selectors"

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -75,6 +75,13 @@ tr.notOk(
 messages.expected("0 spaces at line 3"))
 
 tr.notOk(
+`a,
+b {
+  color: pink;
+  }`,
+messages.expected("0 spaces at line 4"))
+
+tr.notOk(
 `a { color: pink;
   }`,
 messages.expected("0 spaces at line 2"))

--- a/src/rules/indentation/__tests__/selectors.js
+++ b/src/rules/indentation/__tests__/selectors.js
@@ -1,0 +1,68 @@
+/* eslint-disable indent, no-multiple-empty-lines */
+
+import {
+  ruleTester
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+// 2 spaces
+testRule(2, tr => {
+
+tr.ok(
+`a { color: pink; }
+`)
+
+tr.ok(
+`a,
+b { color: pink; }
+`)
+
+tr.ok(
+`a,
+b,
+c { color: pink; }
+`)
+
+tr.ok(
+`@media print {
+  a,
+  b { color: pink;}
+}
+`)
+
+tr.notOk(
+`a,
+  b { color: pink; }
+`, messages.expected("0 spaces at line 2"))
+
+tr.notOk(
+`a,
+b,
+ c { color: pink; }
+`, messages.expected("0 spaces at line 3"))
+
+tr.notOk(
+`@media print {
+  a,
+b { color: pink;}
+}
+`, messages.expected("2 spaces at line 3"))
+
+tr.notOk(
+`@media print {
+  a,
+   b { color: pink;}
+}
+`, messages.expected("2 spaces at line 3"))
+
+tr.notOk(
+`@media print {
+   a,
+  b { color: pink;}
+}
+`, messages.expected("2 spaces at line 2"))
+
+
+})

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -19,6 +19,7 @@ testRule("always", tr => {
   tr.ok("a {\n  &:hover,\n  &:focus {\n    color: pink; }\n}", "nested in rule set")
   tr.ok("@media (min-width: 10px) {\n  a,\n  b {}\n}", "nested in at-rule")
   tr.ok("@media (min-width: 10px) {\r\n  a,\r\n  b {}\r\n}", "nested in at-rule and CRLF")
+  tr.ok("\ta,\n\tb {}", "indented statement")
 
   tr.notOk("a,b {}", messages.expectedAfter())
   tr.notOk("a, b {}", messages.expectedAfter())
@@ -26,9 +27,6 @@ testRule("always", tr => {
   tr.notOk("a,\tb {}", messages.expectedAfter())
   tr.notOk("a,\nb,c {}", messages.expectedAfter())
   tr.notOk("a,\r\nb,c {}", messages.expectedAfter(), "CRLF")
-  tr.notOk("a,\nb,\n c {}", messages.expectedAfter())
-  tr.notOk("a,\n  b {}", messages.expectedAfter())
-  tr.notOk("a,\r\n  b {}", messages.expectedAfter(), "CRLF")
 })
 
 testRule("always-multi-line", tr => {
@@ -39,6 +37,7 @@ testRule("always-multi-line", tr => {
   tr.ok("a, b {}", "ignores single-line")
   tr.ok("a, b {\n}", "ignores single-line selector list, multi-line block")
   tr.ok("a, b {\r\n}", "ignores single-line selector list, multi-line block with CRLF")
+  tr.ok("\ta,\n\tb {\n}", "indented statement")
 
   tr.notOk("a,\nb, c {}", messages.expectedAfterMultiLine())
   tr.notOk("a,\nb, c {\n}", messages.expectedAfterMultiLine())

--- a/src/rules/selector-list-comma-newline-after/index.js
+++ b/src/rules/selector-list-comma-newline-after/index.js
@@ -20,15 +20,9 @@ export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
     root.eachRule(rule => {
-      // Allow for the special case of nested rule sets
-      // that should be indented
-      const checkLocation = (rule.parent === root)
-        ? checker.after
-        : checker.afterOneOnly
-
       const selector = rule.selector
       styleSearch({ source: selector, target: "," }, match => {
-        checkLocation({
+        checker.afterOneOnly({
           source: selector,
           index: match.startIndex,
           err: m =>

--- a/src/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -19,6 +19,7 @@ testRule("always", tr => {
   tr.ok("a\n    ,b {}", "indentation after the newline before the comma")
   tr.ok("a\r\n    ,b {}", "indentation after the CRLF before the comma")
   tr.ok("a\n\t\t,b {}", "indentation after the newline before the comma")
+  tr.ok("\ta\n\t, b {}", "indented statement")
 
   tr.notOk("a,b {}", messages.expectedBefore())
   tr.notOk("a ,b {}", messages.expectedBefore())
@@ -35,6 +36,7 @@ testRule("always-multi-line", tr => {
   tr.ok("a\r\n,b {}", "CRLF")
   tr.ok("a, b {}", "ignores single-line")
   tr.ok("a, b {\n}", "ignores single-line selector list, multi-line block")
+  tr.ok("\ta\n\t, b {\n}", "indented statement")
 
   tr.notOk("a\n,b, c {}", messages.expectedBeforeMultiLine())
   tr.notOk("a\r\n,b, c {}", messages.expectedBeforeMultiLine(), "CRLF")


### PR DESCRIPTION
ignore it in newline check;
fixes #285 

Because the `newline` rule was kind of checking indentation of the selector, and that was causing the problem, I formalized selector-indentation-checking within the `indentation` rule and allowed for arbitrary whitespace after the newline in the `selector-list-comma-newline-*` rules.