### PR TITLE
Change color-hex-case message to be consistent with color-hex-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Changed: The `color-hex-case` rule message to be consistent with the `color-hex-length` rule.
+
 # 0.2.0
 
 * Added: `color-hex-case` rule.

--- a/src/rules/color-hex-case/__tests__/index.js
+++ b/src/rules/color-hex-case/__tests__/index.js
@@ -19,10 +19,10 @@ testRule("lower", tr => {
   tr.ok("a::before { content: \"#ABABA\"; }")
   tr.ok("a { color: white /* #FFF */; }")
 
-  tr.notOk("a { color: #Ababa; }", messages.expected("lower", "#Ababa"))
-  tr.notOk("a { something: #000F, #fff, #ababab; }", messages.expected("lower", "#000F"))
-  tr.notOk("a { something: #000, #FFFFAZ, #ababab; }", messages.expected("lower", "#FFFFAZ"))
-  tr.notOk("a { something: #000, #fff, #12345AA; }", messages.expected("lower", "#12345AA"))
+  tr.notOk("a { color: #Ababa; }", messages.expected("#Ababa", "#ababa"))
+  tr.notOk("a { something: #000F, #fff, #ababab; }", messages.expected("#000F", "#000f"))
+  tr.notOk("a { something: #000, #FFFFAZ, #ababab; }", messages.expected("#FFFFAZ", "#ffffaz"))
+  tr.notOk("a { something: #000, #fff, #12345AA; }", messages.expected("#12345AA", "#12345aa"))
 })
 
 testRule("upper", tr => {
@@ -38,8 +38,8 @@ testRule("upper", tr => {
   tr.ok("a::before { content: \"#ababa\"; }")
   tr.ok("a { color: white /* #fff */; }")
 
-  tr.notOk("a { color: #aBABA; }", messages.expected("upper", "#aBABA"))
-  tr.notOk("a { something: #000f, #FFF, #ABABAB; }", messages.expected("upper", "#000f"))
-  tr.notOk("a { something: #000, #ffffaz, #ABABAB; }", messages.expected("upper", "#ffffaz"))
-  tr.notOk("a { something: #000, #FFF, #12345aa; }", messages.expected("upper", "#12345aa"))
+  tr.notOk("a { color: #aBABA; }", messages.expected("#aBABA", "#ABABA"))
+  tr.notOk("a { something: #000f, #FFF, #ABABAB; }", messages.expected("#000f", "#000F"))
+  tr.notOk("a { something: #000, #ffffaz, #ABABAB; }", messages.expected("#ffffaz", "#FFFFAZ"))
+  tr.notOk("a { something: #000, #FFF, #12345aa; }", messages.expected("#12345aa", "#12345AA"))
 })

--- a/src/rules/color-hex-case/index.js
+++ b/src/rules/color-hex-case/index.js
@@ -7,7 +7,7 @@ import {
 export const ruleName = "color-hex-case"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (c, h) => `Expected ${c}case hex color ${h}`,
+  expected: (h, v) => `Expected "${h}" to be "${v}"`,
 })
 
 /**
@@ -21,13 +21,17 @@ export default function (expectation) {
       styleSearch({ source: value, target: "#" }, match => {
 
         const hexValue = /^#[0-9A-Za-z]+/.exec(value.substr(match.startIndex))[0]
+        const hexValueLower = hexValue.toLowerCase()
+        const hexValueUpper = hexValue.toUpperCase()
 
-        if (expectation === "lower" && hexValue === hexValue.toLowerCase()) { return }
+        if (expectation === "lower" && hexValue === hexValueLower) { return }
 
-        if (expectation === "upper" && hexValue === hexValue.toUpperCase()) { return }
+        if (expectation === "upper" && hexValue === hexValueUpper) { return }
+
+        const variant = expectation === "lower" ? hexValueLower : hexValueUpper
 
         report({
-          message: messages.expected(expectation, hexValue),
+          message: messages.expected(hexValue, variant),
           node: decl,
           result,
           ruleName,


### PR DESCRIPTION
Changes the message from:

`Expected a lowercase hex color #FFF (color-hex-case)`

to

`Expected "#FFF" to be "#fff" (color-hex-case)`