### PR TITLE
Simple pluggability; closes #295

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,55 @@ var config = {
 }
 ```
 
+### Plugin rules
+
+#### Using plugin rules
+
+To use a plugin rule, add a `"plugins"` property to your config.
+The key is the rule's name; the value is the rule function itself.
+Then, within the `"rules"` object, your can add settings for your plugin rule just like any standard rule.
+
+```js
+var myConfig = {
+  plugins: {
+    "special-rule": require("special-rule"),
+  },
+  rules: {
+    // ...
+    "special-rule": [ 2, "everything" ],
+    // ...
+  },
+}
+```
+
+#### Creating plugin rules
+
+```js
+// Abbreviated example:
+
+var stylelint = require("stylelint")
+
+var myPluginRule = function(expectationKeyword, optionsObject) {
+  return function(postcssRoot, postcssResult) {
+    // ... some logic ...
+    stylelint.utils.report({ .. })
+  }
+}
+```
+
+In order for your plugin rule to work with the standard configuration format, (e.g. `[2, "tab", { hierarchicalSelectors: true }]`), it should be a function that accepts 2 arguments: the expectation keyword (e.g. `"tab"`) and, optionally, an options object (e.g. `{ hierarchicalSelectors: true }`).
+
+It should return a function that is essentially a little PostCSS plugin: it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult.
+You'll have to [learn about the PostCSS API](https://github.com/postcss/postcss/blob/master/docs/api.md).
+
+A few of stylelint's internal utilities are exposed publicly in `stylelint.utils`, to help you write plugin rules.
+For details about the APIs of these functions, please look at comments in the source code and examples in the standard rules.
+
+- `report`: Report your linting warnings. *You'll want to use this: do not use `node.warn()` directly.* If you use `report`,
+your plugin will respect disabled ranges and other possible future features of stylelint, so it will fit in better with the standard rules.
+- `ruleMessages`: Tailor your messages to look like the messages of other stylelint rules. Currently, this means that the name of the rule is appended, in parentheses, to the end of the message.
+- `styleSearch`: Search within CSS strings, and for every match found invoke a callback, passing a match object with details about the match. `styleSearch` ignores CSS strings (e.g. `content: "foo";`) and by default ignores comments. It can also be restricted to substrings within or outside of CSS functional notation.
+
 ## Complementary tools
 
 The linter works well with:

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,3 +1,4 @@
 import "./integration"
 import "./disableRanges-test"
 import "./disableRanges-integration-test"
+import "./plugins-test"

--- a/src/__tests__/plugins-test.js
+++ b/src/__tests__/plugins-test.js
@@ -1,0 +1,80 @@
+import postcss from "postcss"
+import test from "tape"
+import stylelint from ".."
+
+function warnAboutFoo(expectation) {
+  return (root, result) => {
+    let foundFoo
+    root.eachRule(rule => {
+      if (rule.selector === ".foo") {
+        if (expectation === "always") {
+          result.warn("found .foo")
+          foundFoo = true
+        }
+      }
+    })
+    if (!foundFoo) {
+      result.warn("never found .foo")
+    }
+  }
+}
+
+const cssA = (
+`.foo {}`
+)
+
+const cssB = (
+`.bar {}`
+)
+
+const configA = {
+  plugins: {
+    warnAboutFoo,
+  },
+  rules: {
+    warnAboutFoo: [ 2, "always" ],
+    "block-no-empty": 2,
+  },
+}
+
+test("plugin runs", t => {
+  t.plan(4)
+
+  const processor = postcss().use(stylelint(configA))
+
+  processor.process(cssA)
+    .then(result => {
+      t.equal(result.warnings().length, 2)
+      t.equal(result.warnings()[0].text, "found .foo")
+    })
+
+  processor.process(cssB)
+    .then(result => {
+      t.equal(result.warnings().length, 2)
+      t.equal(result.warnings()[0].text, "never found .foo")
+    })
+})
+
+const configB = {
+  plugins: {
+    linterSet: {
+      warnAboutFoo,
+    },
+  },
+  rules: {
+    warnAboutFoo: [ 2, "always" ],
+    "block-no-empty": 2,
+  },
+}
+
+test("plugin within set runs", t => {
+  t.plan(2)
+
+  const processor = postcss().use(stylelint(configB))
+
+  processor.process(cssA)
+    .then(result => {
+      t.equal(result.warnings().length, 2)
+      t.equal(result.warnings()[0].text, "found .foo")
+    })
+})

--- a/src/__tests__/plugins-test.js
+++ b/src/__tests__/plugins-test.js
@@ -2,19 +2,34 @@ import postcss from "postcss"
 import test from "tape"
 import stylelint from ".."
 
+const warnAboutFooMessages = stylelint.utils.ruleMessages("warn-about-foo", {
+  found: "found .foo",
+  notFound: "never found .foo",
+})
+
 function warnAboutFoo(expectation) {
   return (root, result) => {
     let foundFoo
     root.eachRule(rule => {
       if (rule.selector === ".foo") {
         if (expectation === "always") {
-          result.warn("found .foo")
+          stylelint.utils.report({
+            result,
+            ruleName: "warn-about-foo",
+            message: warnAboutFooMessages.found,
+            node: rule,
+          })
           foundFoo = true
         }
       }
     })
     if (!foundFoo) {
-      result.warn("never found .foo")
+      stylelint.utils.report({
+        result,
+        line: 1,
+        ruleName: "warn-about-foo",
+        message: warnAboutFooMessages.notFound,
+      })
     }
   }
 }
@@ -38,21 +53,25 @@ const configA = {
 }
 
 test("plugin runs", t => {
-  t.plan(4)
+  t.plan(6)
 
   const processor = postcss().use(stylelint(configA))
 
   processor.process(cssA)
     .then(result => {
       t.equal(result.warnings().length, 2)
-      t.equal(result.warnings()[0].text, "found .foo")
+      t.equal(result.warnings()[0].text, "found .foo (warn-about-foo)")
+      t.ok(result.warnings()[0].node)
     })
+    .catch(e => console.log(e.stack))
 
   processor.process(cssB)
     .then(result => {
       t.equal(result.warnings().length, 2)
-      t.equal(result.warnings()[0].text, "never found .foo")
+      t.equal(result.warnings()[0].text, "never found .foo (warn-about-foo)")
+      t.notOk(result.warnings()[0].node)
     })
+    .catch(e => console.log(e.stack))
 })
 
 const configB = {
@@ -75,6 +94,6 @@ test("plugin within set runs", t => {
   processor.process(cssA)
     .then(result => {
       t.equal(result.warnings().length, 2)
-      t.equal(result.warnings()[0].text, "found .foo")
+      t.equal(result.warnings()[0].text, "found .foo (warn-about-foo)")
     })
 })

--- a/src/__tests__/plugins-test.js
+++ b/src/__tests__/plugins-test.js
@@ -44,10 +44,10 @@ const cssB = (
 
 const configA = {
   plugins: {
-    warnAboutFoo,
+    "warn-about-foo": warnAboutFoo,
   },
   rules: {
-    warnAboutFoo: [ 2, "always" ],
+    "warn-about-foo": [ 2, "always" ],
     "block-no-empty": 2,
   },
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,10 @@ export default postcss.plugin("stylelint", settings => {
     if (!settings) { return }
     if (!settings.rules) { return }
 
+    if (settings.plugins) {
+      addPluginsToDefinitions(settings.plugins, ruleDefinitions)
+    }
+
     // First check for disabled ranges
     disableRanges(root, result)
 
@@ -19,7 +23,6 @@ export default postcss.plugin("stylelint", settings => {
 
       // If severity is 0, run nothing
       const ruleSettings = settings.rules[ruleName]
-
       const ruleSeverity = (Array.isArray(ruleSettings))
         ? ruleSettings[0]
         : ruleSettings
@@ -30,3 +33,13 @@ export default postcss.plugin("stylelint", settings => {
     })
   }
 })
+
+function addPluginsToDefinitions(plugins, definitions) {
+  Object.keys(plugins).forEach(name => {
+    if (typeof plugins[name] !== "function") {
+      addPluginsToDefinitions(plugins[name], definitions)
+      return
+    }
+    definitions[name] = plugins[name]
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,45 +1,7 @@
-import postcss from "postcss"
-import ruleDefinitions from "./rules"
-import disableRanges from "./disableRanges"
+module.exports = require("./plugin")
 
-export default postcss.plugin("stylelint", settings => {
-  return (root, result) => {
-    if (!settings) { return }
-    if (!settings.rules) { return }
-
-    if (settings.plugins) {
-      addPluginsToDefinitions(settings.plugins, ruleDefinitions)
-    }
-
-    // First check for disabled ranges
-    disableRanges(root, result)
-
-    Object.keys(settings.rules).forEach(ruleName => {
-      if (!ruleDefinitions[ruleName]) {
-        throw new Error(
-          `Undefined rule ${ruleName}`
-        )
-      }
-
-      // If severity is 0, run nothing
-      const ruleSettings = settings.rules[ruleName]
-      const ruleSeverity = (Array.isArray(ruleSettings))
-        ? ruleSettings[0]
-        : ruleSettings
-      if (ruleSeverity === 0) { return }
-
-      // Otherwise, run the rule with the primary and secondary options
-      ruleDefinitions[ruleName](ruleSettings[1], ruleSettings[2])(root, result)
-    })
-  }
-})
-
-function addPluginsToDefinitions(plugins, definitions) {
-  Object.keys(plugins).forEach(name => {
-    if (typeof plugins[name] !== "function") {
-      addPluginsToDefinitions(plugins[name], definitions)
-      return
-    }
-    definitions[name] = plugins[name]
-  })
+module.exports.utils = {
+  report: require("./utils/report"),
+  ruleMessages: require("./utils/ruleMessages"),
+  styleSearch: require("./utils/styleSearch"),
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,0 +1,45 @@
+import postcss from "postcss"
+import ruleDefinitions from "./rules"
+import disableRanges from "./disableRanges"
+
+export default postcss.plugin("stylelint", settings => {
+  return (root, result) => {
+    if (!settings) { return }
+    if (!settings.rules) { return }
+
+    if (settings.plugins) {
+      addPluginsToDefinitions(settings.plugins, ruleDefinitions)
+    }
+
+    // First check for disabled ranges
+    disableRanges(root, result)
+
+    Object.keys(settings.rules).forEach(ruleName => {
+      if (!ruleDefinitions[ruleName]) {
+        throw new Error(
+          `Undefined rule ${ruleName}`
+        )
+      }
+
+      // If severity is 0, run nothing
+      const ruleSettings = settings.rules[ruleName]
+      const ruleSeverity = (Array.isArray(ruleSettings))
+        ? ruleSettings[0]
+        : ruleSettings
+      if (ruleSeverity === 0) { return }
+
+      // Otherwise, run the rule with the primary and secondary options
+      ruleDefinitions[ruleName](ruleSettings[1], ruleSettings[2])(root, result)
+    })
+  }
+})
+
+function addPluginsToDefinitions(plugins, definitions) {
+  Object.keys(plugins).forEach(name => {
+    if (typeof plugins[name] !== "function") {
+      addPluginsToDefinitions(plugins[name], definitions)
+      return
+    }
+    definitions[name] = plugins[name]
+  })
+}

--- a/src/utils/report.js
+++ b/src/utils/report.js
@@ -6,12 +6,14 @@
  * it is ignored. Otherwise, it is attached to the result as a
  * postcss warning.
  *
+ * You *must* pass *either* a node or a line number.
+ *
  * @param {object} violation - Violation details object
  * @param {string} violation.ruleName - The name of the rule
  * @param {Result} violation.result - postcss Result object
  * @param {string} violation.message - Message to inform user of the violation
- * @param {number} violation.line - Line number of the violation
- * @param {Node} violation.node - postcss Node object
+ * @param {Node} [violation.node] - postcss Node object
+ * @param {number} [violation.line] - Line number of the violation
  */
 export default function ({ ruleName, result, message, line, node }) {
 


### PR DESCRIPTION
As discussed in #295 ...

You should be able to do the following in a config:

```js
module.exports = {
  plugins: {
    foo: function(expectation) { .. },
    bar: function(expectation, options) { .. },
    baz: {
      bazFoo: function(expectation) { .. },
      bazBar: function(expectation, options) { .. }
    }
  },
  rules: [ .. ]
}
```

And `rules` would contain configuration for all rules, including the plugin rules `foo` and `bar` and also those within the set `baz`.