### PR TITLE
Remove jsesc devDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Head
+* Removed: `jsesc` devDependency.
 * Added: `ruleTester` to `stylelint.utils` for use by authors of custom rules.
 
 # 0.3.2

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-eslint": "^3.1.17",
     "babel-tape-runner": "^1.1.0",
     "eslint": "^0.24.0",
-    "jsesc": "^0.5.0",
     "sinon": "^1.15.3",
     "tape": "^4.0.0"
   },

--- a/src/testUtils/ruleTester.js
+++ b/src/testUtils/ruleTester.js
@@ -1,5 +1,4 @@
 import postcss from "postcss"
-import jsesc from "jsesc"
 import test from "tape"
 import disableRanges from "../disableRanges"
 
@@ -51,7 +50,7 @@ export default function (rule, ruleName) {
          * @param {string} cssString
          */
         ok(cssString, description) {
-          t.test(`pass: ${jsesc(cssString)}`, st => {
+          t.test(`pass: ${JSON.stringify(cssString)}`, st => {
             postcssProcess(cssString, result => {
               st.equal(result.warnings().length, 0, `${description} should pass`)
               st.end()
@@ -69,7 +68,7 @@ export default function (rule, ruleName) {
          * @param {string} [description]
          */
         notOk(cssString, warningMessage, description) {
-          t.test(`fail: ${jsesc(cssString)}`, st => {
+          t.test(`fail: ${JSON.stringify(cssString)}`, st => {
             postcssProcess(cssString, result => {
               const warnings = result.warnings()
               st.equal(warnings.length, 1, `${description} should warn`)


### PR DESCRIPTION
Anybody object to this?

I did it so that it would be a little easier for custom plugin authors to use `ruleTester` --- they just need to have postcss and tape installed as devDependencies ... not `jsesc`, too. Besides, I think `JSON.stringify()` does what we need.