### PR TITLE
Remove babel-eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,5 @@
 ---
 # babel support more syntax stuff than eslint for now
-parser: babel-eslint
 
 ecmaFeatures:
   modules: true

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "babel": "^5.6.3",
-    "babel-eslint": "^3.1.17",
     "babel-tape-runner": "^1.1.0",
     "eslint": "^0.24.0",
     "sinon": "^1.15.3",

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -15,7 +15,7 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation) {
 
-  const quoteMsg = (() => {
+  const quoteMsg = (function () {
     switch (expectation) {
       case "single":
         return "single quotes"
@@ -26,7 +26,7 @@ export default function (expectation) {
     }
   }())
 
-  const charDefiesExpectation = (() => {
+  const charDefiesExpectation = (function () {
     switch (expectation) {
       case "single":
         return c => c !== "'"

--- a/src/utils/styleSearch.js
+++ b/src/utils/styleSearch.js
@@ -40,7 +40,7 @@ export default function (options, callback) {
   // If the target is an array of strings, though, we have to
   // check whether some index of the source mathces *any* of
   // those target strings (stopping after the first match).
-  const checkAgainstTarget = (() => {
+  const checkAgainstTarget = (function () {
     if (!targetIsArray) {
       return checkChar.bind(null, target)
     }

--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -171,7 +171,7 @@ export default function (targetWhitespace, expectation, messages) {
 
   function expectBeforeAllowingIndentation(messageFunc=messages.expectedBefore) {
     const { source, index, err } = activeArgs
-    const expectedChar = (() => {
+    const expectedChar = (function () {
       if (targetWhitespace === "newline") { return "\n" }
       if (targetWhitespace === "space") { return " " }
     }())


### PR DESCRIPTION
Something seems to be going wrong with babel-eslint that is breaking the build. We don't need it, anyway, because ESLint understands the syntax we're using -- except, I guess, IIFE arrow functions. 