### PR TITLE
PoC for validating options; addresses #30

### DIFF
--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -22,6 +22,18 @@ export const messages = ruleMessages(ruleName, {
  */
 export default function (expectation, options) {
   return (root, result) => {
+    validateOptions({ result, ruleName,
+      actual: expectation,
+      possible: [ "always", "never" ],
+    })
+    validateOptions({ result, ruleName,
+      actual: options,
+      possible: {
+        except: [ "blockless-group", "first-nested", "all-nested" ],
+        ignore: ["all-nested"],
+      },
+    })
+
     root.eachAtRule(atRule => {
 
       // Ignore the first node
@@ -74,18 +86,6 @@ export default function (expectation, options) {
           && atRule === atRule.parent.first
         )
       }
-    })
-
-    validateOptions({ result, ruleName,
-      actual: expectation,
-      possible: [ "always", "never" ],
-    })
-    validateOptions({ result, ruleName,
-      actual: options,
-      possible: {
-        except: [ "blockless-group", "first-nested", "all-nested" ],
-        ignore: ["all-nested"],
-      },
     })
   }
 }

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -3,7 +3,8 @@ import {
   optionsHaveException,
   optionsHaveIgnored,
   report,
-  ruleMessages
+  ruleMessages,
+  validateOptions
 } from "../../utils"
 
 export const ruleName = "at-rule-empty-line-before"
@@ -73,6 +74,18 @@ export default function (expectation, options) {
           && atRule === atRule.parent.first
         )
       }
+    })
+
+    validateOptions({ result, ruleName,
+      actual: expectation,
+      possible: [ "always", "never" ],
+    })
+    validateOptions({ result, ruleName,
+      actual: options,
+      possible: {
+        except: [ "blockless-group", "first-nested", "all-nested" ],
+        ignore: ["all-nested"],
+      },
     })
   }
 }

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -161,3 +161,42 @@ test("validateOptions for secondary options objects with subarrays", t => {
 
   t.end()
 })
+
+test("validateOptions for `*-no-*` rule with no options", t => {
+  const result = mockResult()
+
+  validateOptions({
+    result,
+    ruleName: "no-dancing",
+    possible: [],
+    actual: undefined,
+  })
+  t.notOk(result.warn.called)
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "no-dancing",
+    possible: [],
+    actual: "foo",
+  })
+  t.ok(result.warn.calledOnce)
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid option value \"foo\" for rule \"no-dancing\"",
+  }))
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "no-dancing",
+    possible: [],
+    actual: false,
+  })
+  t.ok(result.warn.calledOnce)
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid option value \"false\" for rule \"no-dancing\"",
+  }))
+  result.warn.reset()
+
+  t.end()
+})

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -25,9 +25,7 @@ test("validateOptions for primary options", t => {
     actual: "d",
   })
   t.ok(result.warn.calledOnce, "failing string equivalence")
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid option value \"d\" for rule \"foo\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid option value \"d\" for rule \"foo\""))
   result.warn.reset()
 
   validateOptions({
@@ -46,9 +44,7 @@ test("validateOptions for primary options", t => {
     actual: "a",
   })
   t.ok(result.warn.calledOnce, "failing boolean equivalence")
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid option value \"a\" for rule \"foo\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid option value \"a\" for rule \"foo\""))
   result.warn.reset()
 
   validateOptions({
@@ -67,9 +63,7 @@ test("validateOptions for primary options", t => {
     actual: 1,
   })
   t.ok(result.warn.calledOnce, "failing evaluation")
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid option value \"1\" for rule \"bar\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid option value \"1\" for rule \"bar\""))
   result.warn.reset()
 
   t.end()
@@ -108,12 +102,8 @@ test("validateOptions for secondary options objects", t => {
     actual: { foo: "neveer", bar: false },
   })
   t.ok(result.warn.calledTwice)
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid value \"neveer\" for option \"foo\" of rule \"bar\"",
-  }))
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid value \"false\" for option \"bar\" of rule \"bar\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid value \"neveer\" for option \"foo\" of rule \"bar\""))
+  t.ok(result.warn.calledWith("Invalid value \"false\" for option \"bar\" of rule \"bar\""))
   result.warn.reset()
 
   validateOptions({
@@ -123,9 +113,7 @@ test("validateOptions for secondary options objects", t => {
     actual: { foo: "never", barr: 1 },
   })
   t.ok(result.warn.calledOnce)
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid option name \"barr\" for rule \"bar\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid option name \"barr\" for rule \"bar\""))
   result.warn.reset()
 
   t.end()
@@ -154,9 +142,7 @@ test("validateOptions for secondary options objects with subarrays", t => {
     actual: { bar: [ "one", "three", "floor" ] },
   })
   t.ok(result.warn.calledOnce)
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid value \"floor\" for option \"bar\" of rule \"foo\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid value \"floor\" for option \"bar\" of rule \"foo\""))
   result.warn.reset()
 
   t.end()
@@ -181,9 +167,7 @@ test("validateOptions for `*-no-*` rule with no options", t => {
     actual: "foo",
   })
   t.ok(result.warn.calledOnce)
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid option value \"foo\" for rule \"no-dancing\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid option value \"foo\" for rule \"no-dancing\""))
   result.warn.reset()
 
   validateOptions({
@@ -193,9 +177,7 @@ test("validateOptions for `*-no-*` rule with no options", t => {
     actual: false,
   })
   t.ok(result.warn.calledOnce)
-  t.ok(result.warn.calledWithMatch({
-    message: "Invalid option value \"false\" for rule \"no-dancing\"",
-  }))
+  t.ok(result.warn.calledWith("Invalid option value \"false\" for rule \"no-dancing\""))
   result.warn.reset()
 
   t.end()

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -1,0 +1,163 @@
+import test from "tape"
+import sinon from "sinon"
+import validateOptions from "../validateOptions"
+
+function mockResult() {
+  return { warn: sinon.spy() }
+}
+
+test("validateOptions for primary options", t => {
+  const result = mockResult()
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: [ "a", "b", "c" ],
+    actual: "a",
+  })
+  t.notOk(result.warn.calledOnce, "passing string equivalence")
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: [ "a", "b", "c" ],
+    actual: "d",
+  })
+  t.ok(result.warn.calledOnce, "failing string equivalence")
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid option value \"d\" for rule \"foo\"",
+  }))
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: [ true, false ],
+    actual: false,
+  })
+  t.notOk(result.warn.calledOnce, "passing boolean equivalence")
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: [ true, false ],
+    actual: "a",
+  })
+  t.ok(result.warn.calledOnce, "failing boolean equivalence")
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid option value \"a\" for rule \"foo\"",
+  }))
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "bar",
+    possible: [ "a", x => x > 2, "c" ],
+    actual: 3,
+  })
+  t.notOk(result.warn.calledOnce, "passing evaluation")
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "bar",
+    possible: [ "a", x => x > 2, "c" ],
+    actual: 1,
+  })
+  t.ok(result.warn.calledOnce, "failing evaluation")
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid option value \"1\" for rule \"bar\"",
+  }))
+  result.warn.reset()
+
+  t.end()
+})
+
+test("validateOptions for secondary options objects", t => {
+  const result = mockResult()
+
+  const schema = {
+    foo: [ "always", "never" ],
+    bar: [ x => typeof x === "number", "tab" ],
+  }
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: schema,
+    actual: { foo: "always", bar: 2 },
+  })
+  t.notOk(result.warn.called)
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: schema,
+    actual: { foo: "never", bar: "tab" },
+  })
+  t.notOk(result.warn.called)
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "bar",
+    possible: schema,
+    actual: { foo: "neveer", bar: false },
+  })
+  t.ok(result.warn.calledTwice)
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid value \"neveer\" for option \"foo\" of rule \"bar\"",
+  }))
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid value \"false\" for option \"bar\" of rule \"bar\"",
+  }))
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "bar",
+    possible: schema,
+    actual: { foo: "never", barr: 1 },
+  })
+  t.ok(result.warn.calledOnce)
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid option name \"barr\" for rule \"bar\"",
+  }))
+  result.warn.reset()
+
+  t.end()
+})
+
+test("validateOptions for secondary options objects with subarrays", t => {
+  const result = mockResult()
+
+  const schema = {
+    bar: [ "one", "two", "three", "four" ],
+  }
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: schema,
+    actual: { bar: [ "one", "three" ] },
+  })
+  t.notOk(result.warn.called)
+  result.warn.reset()
+
+  validateOptions({
+    result,
+    ruleName: "foo",
+    possible: schema,
+    actual: { bar: [ "one", "three", "floor" ] },
+  })
+  t.ok(result.warn.calledOnce)
+  t.ok(result.warn.calledWithMatch({
+    message: "Invalid value \"floor\" for option \"bar\" of rule \"foo\"",
+  }))
+  result.warn.reset()
+
+  t.end()
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,6 +13,7 @@ import optionsHaveIgnored from "./optionsHaveIgnored"
 import report from "./report"
 import ruleMessages from "./ruleMessages"
 import styleSearch from "./styleSearch"
+import validateOptions from "./validateOptions"
 import whitespaceChecker from "./whitespaceChecker"
 
 export default {
@@ -31,5 +32,6 @@ export default {
   report,
   ruleMessages,
   styleSearch,
+  validateOptions,
   whitespaceChecker,
 }

--- a/src/utils/validateOptions.js
+++ b/src/utils/validateOptions.js
@@ -2,9 +2,7 @@ export default function ({ result, ruleName, possible, actual }) {
 
   if (Array.isArray(possible)) {
     if (isValid(possible, actual)) { return }
-    result.warn({
-      message: `Invalid option value "${actual}" for rule "${ruleName}"`,
-    })
+    result.warn(`Invalid option value "${actual}" for rule "${ruleName}"`)
     return
   }
 
@@ -12,9 +10,7 @@ export default function ({ result, ruleName, possible, actual }) {
 
   Object.keys(actual).forEach(optionName => {
     if (!possible[optionName]) {
-      result.warn({
-        message: `Invalid option name "${optionName}" for rule "${ruleName}"`,
-      })
+      result.warn(`Invalid option name "${optionName}" for rule "${ruleName}"`)
       return
     }
 
@@ -23,18 +19,14 @@ export default function ({ result, ruleName, possible, actual }) {
     if (Array.isArray(actualOptionValue)) {
       actualOptionValue.forEach(singleValue => {
         if (isValid(possible[optionName], singleValue)) { return }
-        result.warn({
-          message: `Invalid value "${singleValue}" for option "${optionName}" of rule "${ruleName}"`,
-        })
+        result.warn(`Invalid value "${singleValue}" for option "${optionName}" of rule "${ruleName}"`)
       })
       return
     }
 
     if (isValid(possible[optionName], actualOptionValue)) { return }
 
-    result.warn({
-      message: `Invalid value "${actualOptionValue}" for option "${optionName}" of rule "${ruleName}"`,
-    })
+    result.warn(`Invalid value "${actualOptionValue}" for option "${optionName}" of rule "${ruleName}"`)
   })
 }
 

--- a/src/utils/validateOptions.js
+++ b/src/utils/validateOptions.js
@@ -39,6 +39,10 @@ export default function ({ result, ruleName, possible, actual }) {
 }
 
 function isValid(possibilities, actuality) {
+  if (!possibilities.length) {
+    return actuality === undefined
+  }
+
   for (let i = 0, l = possibilities.length; i < l; i++) {
     const possibility = possibilities[i]
     if (typeof possibility === "function" && possibility(actuality)) { return true }

--- a/src/utils/validateOptions.js
+++ b/src/utils/validateOptions.js
@@ -1,0 +1,47 @@
+export default function ({ result, ruleName, possible, actual }) {
+
+  if (Array.isArray(possible)) {
+    if (isValid(possible, actual)) { return }
+    result.warn({
+      message: `Invalid option value "${actual}" for rule "${ruleName}"`,
+    })
+    return
+  }
+
+  if (!actual) { return }
+
+  Object.keys(actual).forEach(optionName => {
+    if (!possible[optionName]) {
+      result.warn({
+        message: `Invalid option name "${optionName}" for rule "${ruleName}"`,
+      })
+      return
+    }
+
+    const actualOptionValue = actual[optionName]
+
+    if (Array.isArray(actualOptionValue)) {
+      actualOptionValue.forEach(singleValue => {
+        if (isValid(possible[optionName], singleValue)) { return }
+        result.warn({
+          message: `Invalid value "${singleValue}" for option "${optionName}" of rule "${ruleName}"`,
+        })
+      })
+      return
+    }
+
+    if (isValid(possible[optionName], actualOptionValue)) { return }
+
+    result.warn({
+      message: `Invalid value "${actualOptionValue}" for option "${optionName}" of rule "${ruleName}"`,
+    })
+  })
+}
+
+function isValid(possibilities, actuality) {
+  for (let i = 0, l = possibilities.length; i < l; i++) {
+    const possibility = possibilities[i]
+    if (typeof possibility === "function" && possibility(actuality)) { return true }
+    if (actuality === possibility) { return true }
+  }
+}


### PR DESCRIPTION
I have here a proof-of-concept for the ideas I tried to describe in #30.

I wrote the validating function and its tests, and tried it out in one rule.

So you can see in `at-rule-empty-line-before/index.js` how it would look to put this kind of validation into a file.

And you can see in `src/utils/__tests__/validateOptions-test.js` some other possibilities for validation schemas.

I *think* (though I'm not 100% sure) that this would be flexible enough to accommodate the varieties of options we currently have and plan for.

I'm interested in your feedback. And if we decide that it will work for us, I guess we'll have to add it to every rule. (It could also be an exposed utility, so 3rd party rules could use it.)