### PR TITLE
Add list of features to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 > Modern CSS linter.
 
-Supports the latest CSS syntax and features, including custom properties, range context for media features, calc() and nesting.
+## Features
+
+* _Over 85 rules_ - from stylistic rules, such as checking the spacing around the colon in every declaration, to rules that catch subtle coding mistakes, such as invalid hex colors or [overriding shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Tricky_edge_cases).
+* _Support for the latest CSS syntax and features_ - including custom properties, range context for media features, calc() and nesting.
+* _Completely unopinionated_ - only enable the rules you want and configure them with the options to tailor the linter.
+* _Sharable configs_ - if you don't want to craft your own config you can use a shareable config, for example one that checks against the [SuitCSS code style](https://github.com/suitcss/suit/blob/master/doc/STYLE.md).
+* _Support for plugins_ - it's easy to create your own rules and add them to the linter.
+* _Options validator_ - so you can be confident that config is valid and linter is working correctly.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Features
 
-* _Over 85 rules_ - from stylistic rules, such as checking the spacing around the colon in every declaration, to rules that catch subtle coding mistakes, such as invalid hex colors or [overriding shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Tricky_edge_cases).
-* _Support for the latest CSS syntax and features_ - including custom properties, range context for media features, calc() and nesting.
-* _Completely unopinionated_ - only enable the rules you want and configure them with the options to tailor the linter.
+* _Nearly a hundred rules_ - from stylistic rules, such as checking the spacing around the colon in declarations, to rules that catch subtle coding mistakes, such as invalid hex colors or [overriding shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Tricky_edge_cases).
+* _Support for the latest CSS syntax_ - including custom properties, range context for media features, calc() and nesting.
+* _Completely unopinionated_ - only enable the rules you want and configure them with options to tailor the linter to your needs.
 * _Sharable configs_ - if you don't want to craft your own config you can use a shareable config, for example one that checks against the [SuitCSS code style](https://github.com/suitcss/suit/blob/master/doc/STYLE.md).
 * _Support for plugins_ - it's easy to create your own rules and add them to the linter.
 * _Options validator_ - so you can be confident that config is valid and linter is working correctly.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 * _Nearly a hundred rules_ - from stylistic rules, such as checking the spacing around the colon in declarations, to rules that catch subtle coding mistakes, such as invalid hex colors or [overriding shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Tricky_edge_cases).
 * _Support for the latest CSS syntax_ - including custom properties, range context for media features, calc() and nesting.
 * _Completely unopinionated_ - only enable the rules you want and configure them with options to tailor the linter to your needs.
-* _Sharable configs_ - if you don't want to craft your own config you can use a shareable config, for example one that checks against the [SuitCSS code style](https://github.com/suitcss/suit/blob/master/doc/STYLE.md).
+* _Shareable configs_ - if you don't want to craft your own config you can use a shareable config.
 * _Support for plugins_ - it's easy to create your own rules and add them to the linter.
-* _Options validator_ - so you can be confident that config is valid and linter is working correctly.
+* _Options validator_ - so you can be confident that config is valid.
 
 ## Installation
 


### PR DESCRIPTION
A top-level overview so potential new users can see what's available without having to pick through the rest of the docs.

I think the quantity of rules, latest css syntax support, being unopinionated, shareable configs, plugin and the options validator are the main features. Have a missed any, or would you replace any?

@davidtheclark I'd appreciate your language skills in fine-tuning this one :)