### PR TITLE
Bring custom-property rule message inline with conventions

### DIFF
--- a/src/rules/custom-property-pattern/__tests__/index.js
+++ b/src/rules/custom-property-pattern/__tests__/index.js
@@ -11,8 +11,8 @@ testRule(/foo-.+/, tr => {
 
   tr.ok(":root { --foo-bar: 0; }")
   tr.ok(":root { --boo-foo-bar: 0; }")
-  tr.notOk(":root { --boo-bar: 0; }", messages.rejected)
-  tr.notOk(":root { --foo-: 0; }", messages.rejected)
+  tr.notOk(":root { --boo-bar: 0; }", messages.expected)
+  tr.notOk(":root { --foo-: 0; }", messages.expected)
 })
 
 testRule(/^[A-Z][a-z]+-[a-z][a-zA-Z]+$/, tr => {
@@ -20,7 +20,7 @@ testRule(/^[A-Z][a-z]+-[a-z][a-zA-Z]+$/, tr => {
 
   tr.ok(":root { --Foo-bar: 0; }")
   tr.ok(":root { --Foo-barBaz: 0; }")
-  tr.notOk(":root { --boo-Foo-bar: 0; }", messages.rejected)
-  tr.notOk(":root { --foo-bar: 0; }", messages.rejected)
-  tr.notOk(":root { --Foo-Bar: 0; }", messages.rejected)
+  tr.notOk(":root { --boo-Foo-bar: 0; }", messages.expected)
+  tr.notOk(":root { --foo-bar: 0; }", messages.expected)
+  tr.notOk(":root { --Foo-Bar: 0; }", messages.expected)
 })

--- a/src/rules/custom-property-pattern/index.js
+++ b/src/rules/custom-property-pattern/index.js
@@ -8,7 +8,7 @@ import {
 export const ruleName = "custom-property-pattern"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: `Custom property name does not match specified pattern`,
+  expected: `Expected custom property name to match specified pattern`,
 })
 
 export default function (pattern) {
@@ -21,7 +21,7 @@ export default function (pattern) {
 
       if (!pattern.test(prop.slice(2))) {
         report({
-          message: messages.rejected,
+          message: messages.expected,
           node: decl,
           result,
           ruleName,


### PR DESCRIPTION
I missed this one when I standardised all the messages of the rules a while back.

Only the `*-no-*` and `*-black/whitelist` rules have single rejection messages. Everything else has "expected", especially when the user specifies something via an option.