### PR TITLE
Consolidate list of npm published files into package.json. Closes #332.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-__tests__
-src/testUtils

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "main": "dist/index.js",
   "files": [
-    "CHANGELOG.md",
-    "LICENSE",
     "dist",
-    "src"
+    "src",
+    "!**/__tests__",
+    "!**/testUtils"
   ],
   "dependencies": {
     "autoprefixer-core": "^5.2.1",


### PR DESCRIPTION
So, the npm docs aren't totally clear:
https://docs.npmjs.com/files/package.json#files

> "You can also provide a ".npmignore" file in the root of your package, which will keep files from being included, *even if they would be picked up by the files array*."

But it doesn't seem to work that way.

> "If you name a folder in the array, then it will also include the files inside that folder. *(Unless they would be ignored by another rule.)*"

Anyway, it turns out the files array allows negation, which is handy as a whitelist + nested exclusions seems to produce the cleanest release. Plus choosing what files and included and excluded is consolidated within `package.json`.

> Certain files are always included, regardless of settings: package.json,README (and its variants), CHANGELOG (and its variants), LICENSE / LICENCE

It also seems that CHANGELOG and LICENCE are automatically included, so they've gone from the files array.