### PR TITLE
Allow tests to run when root node is an at-rule

### DIFF
--- a/src/rules/rule-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/rule-no-duplicate-properties/__tests__/index.js
@@ -29,6 +29,11 @@ testRule(undefined, tr => {
     "nested"
   )
   tr.notOk(
+    "@media { color: orange; .foo { color: black; color: white; } }",
+    messages.rejected("color"),
+    "nested"
+  )
+  tr.notOk(
     "a { color: pink; @media { color: orange; &::before { color: black; color: white; } } }",
     messages.rejected("color"),
     "double nested"

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -20,7 +20,7 @@ export default function (o) {
     // its own list of properties -- so that a property in a nested rule
     // does not conflict with the same property in the parent rule
     root.each(node => {
-      if (node.type === "rule" || node.type === "at-rule") {
+      if (node.type === "rule" || node.type === "atrule") {
         checkRulesInNode(node)
       }
     })

--- a/src/rules/rule-properties-order/__tests__/index.js
+++ b/src/rules/rule-properties-order/__tests__/index.js
@@ -44,6 +44,8 @@ testRule("alphabetical", tr => {
     messages.expected("color", "top"))
   tr.notOk("a { width: 0; @media print { top: 0; color: red; } }",
     messages.expected("color", "top"))
+  tr.notOk("@media print { top: 0; color: red; }",
+    messages.expected("color", "top"))
 })
 
 testRule([

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -24,7 +24,7 @@ export default function (expectation) {
 
     // Shallow loop
     root.each(node => {
-      if (node.type === "rule" || node.type === "at-rule") {
+      if (node.type === "rule" || node.type === "atrule") {
         checkInNode(node)
       }
     })


### PR DESCRIPTION
A typo in the value of `node.type` was preventing `rule-properties-order` and `rule-no-duplicate-properties` from running when the root node was an at-rule.

Closes #336 