### PR TITLE
PoC of exiting early if options invalid

### DIFF
--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -16,17 +16,17 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation, options) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [ "always", "never" ],
-    })
-    validateOptions({ result, ruleName,
+    }, {
       actual: options,
       possible: {
         except: [ "blockless-group", "first-nested", "all-nested" ],
         ignore: ["all-nested"],
       },
     })
+    if (!validOptions) { return }
 
     root.eachAtRule(atRule => {
 

--- a/src/rules/at-rule-no-vendor-prefix/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return function (root, result) {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachAtRule(function (atRule) {
       const name = atRule.name

--- a/src/rules/at-rule-no-vendor-prefix/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return function (root, result) {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachAtRule(function (atRule) {

--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -20,7 +20,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -30,6 +30,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -26,6 +26,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -21,7 +21,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return function (root, result) {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -32,6 +32,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-closing-brace-space-before/index.js
+++ b/src/rules/block-closing-brace-space-before/index.js
@@ -22,7 +22,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -33,6 +33,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statement: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -20,7 +20,7 @@ export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
 
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -28,6 +28,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statement: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -23,7 +23,7 @@ export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
 
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -33,6 +33,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statement: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-opening-brace-space-after/index.js
+++ b/src/rules/block-opening-brace-space-after/index.js
@@ -22,7 +22,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -33,6 +33,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules
     root.eachRule(check)

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -24,7 +24,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -35,6 +35,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules
     root.eachRule(check)

--- a/src/rules/color-hex-case/index.js
+++ b/src/rules/color-hex-case/index.js
@@ -13,13 +13,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "lower",
         "upper",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const value = decl.value

--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -13,13 +13,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "short",
         "long",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const value = decl.value

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const value = decl.value

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -13,13 +13,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachComment(comment => {
 

--- a/src/rules/comment-space-inside/index.js
+++ b/src/rules/comment-space-inside/index.js
@@ -15,13 +15,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return function (root, result) {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachComment(function (comment) {
 

--- a/src/rules/custom-media-pattern/index.js
+++ b/src/rules/custom-media-pattern/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (pattern) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: pattern, possible: isRegExp })
+    const validOptions = validateOptions(result, ruleName, { actual: pattern, possible: isRegExp })
+    if (!validOptions) { return }
 
     root.eachAtRule(atRule => {
       if (atRule.name !== "custom-media") { return }

--- a/src/rules/custom-property-no-outside-root/index.js
+++ b/src/rules/custom-property-no-outside-root/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       // Ignore rules whose selector is just `:root`

--- a/src/rules/custom-property-no-outside-root/index.js
+++ b/src/rules/custom-property-no-outside-root/index.js
@@ -12,7 +12,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/custom-property-pattern/index.js
+++ b/src/rules/custom-property-pattern/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (pattern) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: pattern, possible: isRegExp })
+    const validOptions = validateOptions(result, ruleName, { actual: pattern, possible: isRegExp })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const prop = decl.prop

--- a/src/rules/declaration-bang-space-after/index.js
+++ b/src/rules/declaration-bang-space-after/index.js
@@ -15,13 +15,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     declarationBangSpaceChecker(checker.after, root, result)
   }

--- a/src/rules/declaration-bang-space-before/index.js
+++ b/src/rules/declaration-bang-space-before/index.js
@@ -15,13 +15,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     declarationBangSpaceChecker(checker.before, root, result)
   }

--- a/src/rules/declaration-block-semicolon-newline-after/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/index.js
@@ -17,7 +17,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const check = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -25,6 +25,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       // Ignore last declaration if there's no trailing semicolon

--- a/src/rules/declaration-block-semicolon-newline-before/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/index.js
@@ -17,7 +17,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const check = whitespaceChecker("newline", expectation, messages)
   return function (root, result) {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -25,6 +25,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(function (decl) {
       const parentRule = decl.parent

--- a/src/rules/declaration-block-semicolon-space-after/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const check = whitespaceChecker("space", expectation, messages)
   return function (root, result) {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -27,6 +27,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(function (decl) {
       // Ignore last declaration if there's no trailing semicolon

--- a/src/rules/declaration-block-semicolon-space-before/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const check = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -27,6 +27,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       // Ignore last declaration if there's no trailing semicolon

--- a/src/rules/declaration-colon-space-after/index.js
+++ b/src/rules/declaration-colon-space-after/index.js
@@ -15,13 +15,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     declarationColonSpaceChecker(checker.after, root, result)
   }

--- a/src/rules/declaration-colon-space-before/index.js
+++ b/src/rules/declaration-colon-space-before/index.js
@@ -15,13 +15,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     declarationColonSpaceChecker(checker.before, root, result)
   }

--- a/src/rules/declaration-no-important/index.js
+++ b/src/rules/declaration-no-important/index.js
@@ -12,7 +12,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/declaration-no-important/index.js
+++ b/src/rules/declaration-no-important/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       if (!decl.important) { return }

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -19,7 +19,8 @@ export default function (o) {
   const checker = whitespaceChecker("space", "always", messages)
 
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const value = decl.value

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -19,7 +19,10 @@ export default function (o) {
   const checker = whitespaceChecker("space", "always", messages)
 
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -16,13 +16,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     functionCommaSpaceChecker(checker.after, root, result)
   }

--- a/src/rules/function-comma-space-before/index.js
+++ b/src/rules/function-comma-space-before/index.js
@@ -15,13 +15,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     functionCommaSpaceChecker(checker.before, root, result)
   }

--- a/src/rules/function-parentheses-space-inside/index.js
+++ b/src/rules/function-parentheses-space-inside/index.js
@@ -17,13 +17,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const value = decl.value

--- a/src/rules/function-space-after/index.js
+++ b/src/rules/function-space-after/index.js
@@ -15,13 +15,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const value = decl.value

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -40,7 +40,7 @@ export default function (expectation) {
   }
 
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "single",
@@ -48,6 +48,7 @@ export default function (expectation) {
         "none",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachAtRule(check)
     root.eachRule(check)

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -40,17 +40,17 @@ export default function (space, options) {
   const warningWord = (isTab) ? "tab" : "space"
 
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: space,
       possible: [ isNumber, "tab" ],
-    })
-    validateOptions({ result, ruleName,
+    }, {
       actual: options,
       possible: {
         except: [ "block", "value" ],
         hierarchicalSelectors: [isBoolean],
       },
     })
+    if (!validOptions) { return }
 
     // Cycle through all nodes using eachInside.
     // This is done instead of using

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -16,13 +16,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     mediaFeatureColonSpaceChecker(checker.after, root, result)
   }

--- a/src/rules/media-feature-colon-space-before/index.js
+++ b/src/rules/media-feature-colon-space-before/index.js
@@ -16,13 +16,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     mediaFeatureColonSpaceChecker(checker.before, root, result)
   }

--- a/src/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachAtRule(atRule => {

--- a/src/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachAtRule(atRule => {
       const { params } = atRule

--- a/src/rules/media-feature-range-operator-space-after/index.js
+++ b/src/rules/media-feature-range-operator-space-after/index.js
@@ -17,13 +17,14 @@ const rangeOperatorRegex = /[^><](>=?|<=?|=)/g
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachAtRule(atRule => {
       findMediaOperator(atRule, checkAfterOperator)

--- a/src/rules/media-feature-range-operator-space-before/index.js
+++ b/src/rules/media-feature-range-operator-space-before/index.js
@@ -17,13 +17,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachAtRule(atRule => {
       findMediaOperator(atRule, checkBeforeOperator)

--- a/src/rules/media-query-list-comma-newline-after/index.js
+++ b/src/rules/media-query-list-comma-newline-after/index.js
@@ -17,7 +17,7 @@ export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
 
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -25,6 +25,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     // Only check for the newline after the comma, while allowing
     // arbitrary indentation after the newline

--- a/src/rules/media-query-list-comma-newline-before/index.js
+++ b/src/rules/media-query-list-comma-newline-before/index.js
@@ -16,7 +16,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -24,6 +24,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
     mediaQueryListCommaWhitespaceChecker(checker.beforeAllowingIndentation, root, result)
   }
 }

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -27,6 +27,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
     mediaQueryListCommaWhitespaceChecker(checker.after, root, result)
   }
 }

--- a/src/rules/media-query-list-comma-space-before/index.js
+++ b/src/rules/media-query-list-comma-space-before/index.js
@@ -17,7 +17,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -26,6 +26,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
 
     mediaQueryListCommaWhitespaceChecker(checker.before, root, result)
   }

--- a/src/rules/media-query-parentheses-space-inside/index.js
+++ b/src/rules/media-query-parentheses-space-inside/index.js
@@ -16,13 +16,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachAtRule(atRule => {
       if (atRule.name !== "media") { return }

--- a/src/rules/nesting-block-opening-brace-newline-before/index.js
+++ b/src/rules/nesting-block-opening-brace-newline-before/index.js
@@ -21,7 +21,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -31,6 +31,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     checkNestingBlockOpeningBraceBefore(checker, root, result)
   }

--- a/src/rules/nesting-block-opening-brace-space-before/index.js
+++ b/src/rules/nesting-block-opening-brace-space-before/index.js
@@ -19,7 +19,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -30,6 +30,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     checkNestingBlockOpeningBraceBefore(checker, root, result)
   }

--- a/src/rules/no-eol-whitespace/index.js
+++ b/src/rules/no-eol-whitespace/index.js
@@ -15,7 +15,10 @@ const whitespacesToReject = [ " ", "\t" ]
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     let lineCount = 0

--- a/src/rules/no-eol-whitespace/index.js
+++ b/src/rules/no-eol-whitespace/index.js
@@ -15,7 +15,8 @@ const whitespacesToReject = [ " ", "\t" ]
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     let lineCount = 0
     const rootString = root.source.input.css

--- a/src/rules/no-missing-eof-newline/index.js
+++ b/src/rules/no-missing-eof-newline/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     if (root.source.input.css.slice(-1) !== "\n") {
       report({

--- a/src/rules/no-missing-eof-newline/index.js
+++ b/src/rules/no-missing-eof-newline/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     if (root.source.input.css.slice(-1) !== "\n") {

--- a/src/rules/no-multiple-empty-lines/index.js
+++ b/src/rules/no-multiple-empty-lines/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     let lineCount = 0

--- a/src/rules/no-multiple-empty-lines/index.js
+++ b/src/rules/no-multiple-empty-lines/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     let lineCount = 0
     const rootString = root.source.input.css

--- a/src/rules/number-leading-zero/index.js
+++ b/src/rules/number-leading-zero/index.js
@@ -13,13 +13,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       check(decl.value, decl)

--- a/src/rules/number-max-precision/index.js
+++ b/src/rules/number-max-precision/index.js
@@ -14,10 +14,11 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (precision) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: precision,
       possible: [isNumber],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       // Don't bother with strings

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -12,7 +12,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       check(decl.value, decl)

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -26,7 +26,8 @@ const lengthUnits = new Set([
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ result, ruleName, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       check(decl.value, decl)

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -26,7 +26,10 @@ const lengthUnits = new Set([
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/property-blacklist/index.js
+++ b/src/rules/property-blacklist/index.js
@@ -14,10 +14,11 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (blacklist) {
   return (root, result) => {
-    validateOptions({ result, ruleName,
+    const validOptions = validateOptions(result, ruleName, {
       actual: blacklist,
       possible: [isString],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
 

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const prop = decl.prop

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/property-whitelist/index.js
+++ b/src/rules/property-whitelist/index.js
@@ -14,10 +14,11 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (whitelist) {
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: whitelist,
       possible: [isString],
     })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
 

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       if (rule.selector.indexOf(":root") === -1) { return }

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -12,7 +12,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/rule-nested-empty-line-before/index.js
+++ b/src/rules/rule-nested-empty-line-before/index.js
@@ -14,7 +14,7 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation, options) {
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -22,8 +22,7 @@ export default function (expectation, options) {
         "always-multi-line",
         "never-multi-line",
       ],
-    })
-    validateOptions({ ruleName, result,
+    }, {
       actual: options,
       possible: {
         ignore: [
@@ -35,6 +34,7 @@ export default function (expectation, options) {
         ],
       },
     })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
 

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     // In order to accommodate nested blocks (postcss-nested),
     // we need to run a shallow loop (instead of eachDecl() or eachRule(),

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -12,7 +12,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     // In order to accommodate nested blocks (postcss-nested),

--- a/src/rules/rule-no-shorthand-property-overrides/index.js
+++ b/src/rules/rule-no-shorthand-property-overrides/index.js
@@ -16,7 +16,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       const ruleDeclarations = new Set()

--- a/src/rules/rule-no-shorthand-property-overrides/index.js
+++ b/src/rules/rule-no-shorthand-property-overrides/index.js
@@ -16,7 +16,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/rule-no-single-line/index.js
+++ b/src/rules/rule-no-single-line/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
 

--- a/src/rules/rule-no-single-line/index.js
+++ b/src/rules/rule-no-single-line/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/rule-non-nested-empty-line-before/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/index.js
@@ -16,7 +16,7 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation, options) {
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -24,13 +24,13 @@ export default function (expectation, options) {
         "always-multi-line",
         "never-multi-line",
       ],
-    })
-    validateOptions({ ruleName, result,
+    }, {
       actual: options,
       possible: {
         ignore: ["after-comment"],
       },
     })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
 

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -14,13 +14,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "alphabetical",
         isString,
       ],
     })
+    if (!validOptions) { return }
 
     // Shallow loop
     root.each(node => {

--- a/src/rules/rule-trailing-semicolon/index.js
+++ b/src/rules/rule-trailing-semicolon/index.js
@@ -14,13 +14,14 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (expectation) {
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       // Return early if an empty rule

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -18,13 +18,14 @@ const combinators = [ ">", "+", "~" ]
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     selectorCombinatorSpaceChecker(checker.after, root, result)
   }

--- a/src/rules/selector-combinator-space-before/index.js
+++ b/src/rules/selector-combinator-space-before/index.js
@@ -16,13 +16,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
         "never",
       ],
     })
+    if (!validOptions) { return }
 
     selectorCombinatorSpaceChecker(checker.before, root, result)
   }

--- a/src/rules/selector-list-comma-newline-after/index.js
+++ b/src/rules/selector-list-comma-newline-after/index.js
@@ -17,7 +17,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -25,6 +25,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       const selector = rule.selector

--- a/src/rules/selector-list-comma-newline-before/index.js
+++ b/src/rules/selector-list-comma-newline-before/index.js
@@ -17,7 +17,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -25,6 +25,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     selectorListCommaWhitespaceChecker(checker.beforeAllowingIndentation, root, result)
   }

--- a/src/rules/selector-list-comma-space-after/index.js
+++ b/src/rules/selector-list-comma-space-after/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -27,6 +27,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
 
     selectorListCommaWhitespaceChecker(checker.after, root, result)
   }

--- a/src/rules/selector-list-comma-space-before/index.js
+++ b/src/rules/selector-list-comma-space-before/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -27,6 +27,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
 
     selectorListCommaWhitespaceChecker(checker.before, root, result)
   }

--- a/src/rules/selector-no-attribute/index.js
+++ b/src/rules/selector-no-attribute/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-attribute/index.js
+++ b/src/rules/selector-no-attribute/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       selectorParser(selectorAST => {

--- a/src/rules/selector-no-combinator/index.js
+++ b/src/rules/selector-no-combinator/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-combinator/index.js
+++ b/src/rules/selector-no-combinator/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       selectorParser(selectorAST => {

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       selectorParser(selectorAST => {

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       selectorParser(selectorAST => {

--- a/src/rules/selector-no-universal/index.js
+++ b/src/rules/selector-no-universal/index.js
@@ -13,7 +13,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-universal/index.js
+++ b/src/rules/selector-no-universal/index.js
@@ -13,7 +13,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       selectorParser(selectorAST => {

--- a/src/rules/selector-no-vendor-prefix/index.js
+++ b/src/rules/selector-no-vendor-prefix/index.js
@@ -14,7 +14,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-vendor-prefix/index.js
+++ b/src/rules/selector-no-vendor-prefix/index.js
@@ -14,7 +14,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       const selector = rule.selector

--- a/src/rules/selector-pseudo-element-colon-notation/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/index.js
@@ -14,13 +14,14 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
 
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "single",
         "double",
       ],
     })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       const selector = rule.selector

--- a/src/rules/selector-root-no-composition/index.js
+++ b/src/rules/selector-root-no-composition/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachRule(rule => {
       if (rule.selector.indexOf(":root") === -1) { return }

--- a/src/rules/selector-root-no-composition/index.js
+++ b/src/rules/selector-root-no-composition/index.js
@@ -12,7 +12,10 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/string-quotes/index.js
+++ b/src/rules/string-quotes/index.js
@@ -17,13 +17,14 @@ export default function (expectation) {
   const erroneousQuote = (expectation === "single") ? "\"" : "'"
 
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "single",
         "double",
       ],
     })
+    if (!validOptions) { return }
 
     const cssString = root.source.input.css
     styleSearch({ source: cssString, target: erroneousQuote }, match => {

--- a/src/rules/value-list-comma-newline-after/index.js
+++ b/src/rules/value-list-comma-newline-after/index.js
@@ -16,7 +16,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -24,6 +24,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     valueListCommaWhitespaceChecker(checker.afterOneOnly, root, result)
   }

--- a/src/rules/value-list-comma-newline-before/index.js
+++ b/src/rules/value-list-comma-newline-before/index.js
@@ -16,7 +16,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -24,6 +24,7 @@ export default function (expectation) {
         "never-multi-line",
       ],
     })
+    if (!validOptions) { return }
 
     valueListCommaWhitespaceChecker(checker.beforeAllowingIndentation, root, result)
   }

--- a/src/rules/value-list-comma-space-after/index.js
+++ b/src/rules/value-list-comma-space-after/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -27,6 +27,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
 
     valueListCommaWhitespaceChecker(checker.after, root, result)
   }

--- a/src/rules/value-list-comma-space-before/index.js
+++ b/src/rules/value-list-comma-space-before/index.js
@@ -17,7 +17,7 @@ export const messages = ruleMessages(ruleName, {
 export default function (expectation) {
   const checker = whitespaceChecker("space", expectation, messages)
   return (root, result) => {
-    validateOptions({ ruleName, result,
+    const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
         "always",
@@ -26,6 +26,7 @@ export default function (expectation) {
         "never-single-line",
       ],
     })
+    if (!validOptions) { return }
 
     valueListCommaWhitespaceChecker(checker.before, root, result)
   }

--- a/src/rules/value-no-vendor-prefix/index.js
+++ b/src/rules/value-no-vendor-prefix/index.js
@@ -16,7 +16,10 @@ const valuePrefixes = [ "-webkit-", "-moz-", "-ms-", "-o-" ]
 
 export default function (o) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual: o })
+    const validOptions = validateOptions(result, ruleName, {
+      actual: o,
+      possible: [],
+    })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/value-no-vendor-prefix/index.js
+++ b/src/rules/value-no-vendor-prefix/index.js
@@ -16,7 +16,8 @@ const valuePrefixes = [ "-webkit-", "-moz-", "-ms-", "-o-" ]
 
 export default function (o) {
   return (root, result) => {
-    validateOptions({ ruleName, result, actual: o })
+    const validOptions = validateOptions(result, ruleName, { actual: o })
+    if (!validOptions) { return }
 
     root.eachDecl(decl => {
       const { prop, value } = decl

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -9,18 +9,14 @@ function mockResult() {
 test("validateOptions for primary options", t => {
   const result = mockResult()
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: [ "a", "b", "c" ],
     actual: "a",
   })
   t.notOk(result.warn.calledOnce, "passing string equivalence")
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: [ "a", "b", "c" ],
     actual: "d",
   })
@@ -28,18 +24,14 @@ test("validateOptions for primary options", t => {
   t.ok(result.warn.calledWith("Invalid option value \"d\" for rule \"foo\""))
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: [ true, false ],
     actual: false,
   })
   t.notOk(result.warn.calledOnce, "passing boolean equivalence")
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: [ true, false ],
     actual: "a",
   })
@@ -47,18 +39,14 @@ test("validateOptions for primary options", t => {
   t.ok(result.warn.calledWith("Invalid option value \"a\" for rule \"foo\""))
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "bar",
+  validateOptions(result, "bar", {
     possible: [ "a", x => x > 2, "c" ],
     actual: 3,
   })
   t.notOk(result.warn.calledOnce, "passing evaluation")
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "bar",
+  validateOptions(result, "bar", {
     possible: [ "a", x => x > 2, "c" ],
     actual: 1,
   })
@@ -77,27 +65,21 @@ test("validateOptions for secondary options objects", t => {
     bar: [ x => typeof x === "number", "tab" ],
   }
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: schema,
     actual: { foo: "always", bar: 2 },
   })
   t.notOk(result.warn.called)
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: schema,
     actual: { foo: "never", bar: "tab" },
   })
   t.notOk(result.warn.called)
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "bar",
+  validateOptions(result, "bar", {
     possible: schema,
     actual: { foo: "neveer", bar: false },
   })
@@ -106,9 +88,7 @@ test("validateOptions for secondary options objects", t => {
   t.ok(result.warn.calledWith("Invalid value \"false\" for option \"bar\" of rule \"bar\""))
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "bar",
+  validateOptions(result, "bar", {
     possible: schema,
     actual: { foo: "never", barr: 1 },
   })
@@ -126,18 +106,14 @@ test("validateOptions for secondary options objects with subarrays", t => {
     bar: [ "one", "two", "three", "four" ],
   }
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: schema,
     actual: { bar: [ "one", "three" ] },
   })
   t.notOk(result.warn.called)
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "foo",
+  validateOptions(result, "foo", {
     possible: schema,
     actual: { bar: [ "one", "three", "floor" ] },
   })
@@ -151,18 +127,14 @@ test("validateOptions for secondary options objects with subarrays", t => {
 test("validateOptions for `*-no-*` rule with no options", t => {
   const result = mockResult()
 
-  validateOptions({
-    result,
-    ruleName: "no-dancing",
+  validateOptions(result, "no-dancing", {
     possible: [],
     actual: undefined,
   })
   t.notOk(result.warn.called)
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "no-dancing",
+  validateOptions(result, "no-dancing", {
     possible: [],
     actual: "foo",
   })
@@ -170,14 +142,42 @@ test("validateOptions for `*-no-*` rule with no options", t => {
   t.ok(result.warn.calledWith("Invalid option value \"foo\" for rule \"no-dancing\""))
   result.warn.reset()
 
-  validateOptions({
-    result,
-    ruleName: "no-dancing",
+  validateOptions(result, "no-dancing", {
     possible: [],
     actual: false,
   })
   t.ok(result.warn.calledOnce)
   t.ok(result.warn.calledWith("Invalid option value \"false\" for rule \"no-dancing\""))
+  result.warn.reset()
+
+  t.end()
+})
+
+test("validateOptions for multiple actual/possible pairs, checking return value", t => {
+  const result = mockResult()
+
+  const validOptions = validateOptions(result, "foo", {
+    possible: [ "one", "two" ],
+    actual: "one",
+  }, {
+    possible: [ "three", "four" ],
+    actual: "three",
+  })
+  t.equal(validOptions, true)
+  t.notOk(result.warn.called)
+  result.warn.reset()
+
+  const validOptions2 = validateOptions(result, "foo", {
+    possible: [ "one", "two" ],
+    actual: "onne",
+  }, {
+    possible: [ "three", "four" ],
+    actual: "threee",
+  })
+  t.equal(validOptions2, false)
+  t.ok(result.warn.calledTwice)
+  t.ok(result.warn.calledWith("Invalid option value \"onne\" for rule \"foo\""))
+  t.ok(result.warn.calledWith("Invalid option value \"threee\" for rule \"foo\""))
   result.warn.reset()
 
   t.end()

--- a/src/utils/validateOptions.js
+++ b/src/utils/validateOptions.js
@@ -1,52 +1,80 @@
-export default function ({ result, ruleName, actual, possible }) {
+/**
+ * Validate a rule's options.
+ *
+ * See existing rules for examples.
+ *
+ * @param {Result} result - postcss result
+ * @param {string} ruleName
+ * @param {...object} ...optionDescriptions - Each optionDescription should
+ *   have `possible` and `actual` properties. `actual` is just the actual
+ *   passed options. `possible` is a schema representation of what values are
+ *   valid for those options. `possible` should be an object if the
+ *   options are an object, with corresponding keys; if the options are not an
+ *   object, `possible` isn't, either. All `possible` value representations
+ *   should be **arrays of either values or functions**. Values are === checked
+ *   against `actual`. Functions are fed `actual` as an argument and their
+ *   return value is interpreted: truthy = valid, falsy = invalid.
+ * @return {boolean} Whether or not the options are valid (true = valid)
+ */
+export default function (result, ruleName, ...optionDescriptions) {
+  let noErrors = true
 
-  if (typeof actual === "undefined" && (!possible || possible.length)) { return }
+  optionDescriptions.forEach(validate)
 
-  // If `possible` is an array instead of an object ...
-  if (Array.isArray(possible)) {
-    const check = a => {
-      if (isValid(possible, a)) { return }
-      result.warn(`Invalid option value "${a}" for rule "${ruleName}"`)
-    }
-    if (Array.isArray(actual)) {
-      actual.forEach(check)
-    } else {
-      check(actual)
-    }
-    return
-  }
+  return noErrors
 
-  if (!actual) { return }
+  function validate({ possible, actual }) {
+    if (typeof actual === "undefined" && (!possible || possible.length)) { return }
 
-  // If possible is an object ...
-  Object.keys(actual).forEach(optionName => {
-    if (!possible[optionName]) {
-      result.warn(`Invalid option name "${optionName}" for rule "${ruleName}"`)
+    // If `possible` is an array instead of an object ...
+    if (Array.isArray(possible)) {
+      const check = a => {
+        if (isValid(possible, a)) { return }
+        noErrors = false
+        result.warn(`Invalid option value "${a}" for rule "${ruleName}"`)
+      }
+      if (Array.isArray(actual)) {
+        actual.forEach(check)
+      } else {
+        check(actual)
+      }
       return
     }
 
-    const actualOptionValue = actual[optionName]
-    const check = a => {
-      if (isValid(possible[optionName], a)) { return }
-      result.warn(`Invalid value "${a}" for option "${optionName}" of rule "${ruleName}"`)
-    }
+    if (!actual) { return }
 
-    if (Array.isArray(actualOptionValue)) {
-      actualOptionValue.forEach(check)
-    } else {
-      check(actualOptionValue)
-    }
-  })
+    // If possible is an object ...
+    Object.keys(actual).forEach(optionName => {
+      if (!possible[optionName]) {
+        noErrors = false
+        result.warn(`Invalid option name "${optionName}" for rule "${ruleName}"`)
+        return
+      }
+
+      const actualOptionValue = actual[optionName]
+      const check = a => {
+        if (isValid(possible[optionName], a)) { return }
+        noErrors = false
+        result.warn(`Invalid value "${a}" for option "${optionName}" of rule "${ruleName}"`)
+      }
+
+      if (Array.isArray(actualOptionValue)) {
+        actualOptionValue.forEach(check)
+      } else {
+        check(actualOptionValue)
+      }
+    })
+  }
 }
 
-function isValid(possibilities, actuality) {
-  if (!possibilities.length) {
-    return actuality === undefined
+function isValid(possible, actual) {
+  if (!possible.length) {
+    return actual === undefined
   }
 
-  for (let i = 0, l = possibilities.length; i < l; i++) {
-    const possibility = possibilities[i]
-    if (typeof possibility === "function" && possibility(actuality)) { return true }
-    if (actuality === possibility) { return true }
+  for (let i = 0, l = possible.length; i < l; i++) {
+    const possibility = possible[i]
+    if (typeof possibility === "function" && possibility(actual)) { return true }
+    if (actual === possibility) { return true }
   }
 }


### PR DESCRIPTION
INCOMPLETE DO NOT MERGE

As discussed in https://github.com/stylelint/stylelint/issues/338

I refactored `validateOptions()` so that multiple option actual/possible pairs could be checked in one function call, with the return value being a boolean representing whether the options are valid (true = valid). So rules can then exit early if their options are invalid.

@jeddy3: You could help by double-checking in whatever ways you want to see if this is going to address our needs; and then changing the `validateOptions()` call in every rule to use the new signature and then exit early based on the result. That would complete this PR. Thanks!

If you're unable to finish that before the weekend I'll probably be able to take care of it then.