### PR TITLE
Check required options; simplify option validation with nothing possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Head
+
+- Added: invalid options cause the rule to abort instead of performing meaningless checks.
+- Added: special warning for missing required options from `validateOptions()`.
+
 # 0.6.2
 
 - Fixed: npm package no longer includes test files (reducing package size by 500KB).

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -25,6 +25,7 @@ export default function (expectation, options) {
         except: [ "blockless-group", "first-nested", "all-nested" ],
         ignore: ["all-nested"],
       },
+      optional: true,
     })
     if (!validOptions) { return }
 

--- a/src/rules/at-rule-no-vendor-prefix/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: p => `Unexpected vendor-prefixed at-rule "@${p}"`,
 })
 
-export default function (o) {
+export default function (actual) {
   return function (root, result) {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachAtRule(function (atRule) {

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: `Unexpected empty block`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     // Check both kinds of statements: rules and at-rules

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: c => `Unexpected invalid hex color "${c}"`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/custom-property-no-outside-root/index.js
+++ b/src/rules/custom-property-no-outside-root/index.js
@@ -10,12 +10,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: `Unexpected custom property outside root`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/declaration-no-important/index.js
+++ b/src/rules/declaration-no-important/index.js
@@ -10,12 +10,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: `Unexpected !important`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -15,14 +15,11 @@ export const messages = ruleMessages(ruleName, {
   expectedOperatorBeforeSign: o => `Expected an operator before sign "${o}"`,
 })
 
-export default function (o) {
+export default function (actual) {
   const checker = whitespaceChecker("space", "always", messages)
 
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -49,6 +49,7 @@ export default function (space, options) {
         except: [ "block", "value" ],
         hierarchicalSelectors: [isBoolean],
       },
+      optional: true,
     })
     if (!validOptions) { return }
 

--- a/src/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected vendor-prefixed media feature name",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachAtRule(atRule => {

--- a/src/rules/no-eol-whitespace/index.js
+++ b/src/rules/no-eol-whitespace/index.js
@@ -13,12 +13,9 @@ export const messages = ruleMessages(ruleName, {
 
 const whitespacesToReject = [ " ", "\t" ]
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     let lineCount = 0

--- a/src/rules/no-missing-eof-newline/index.js
+++ b/src/rules/no-missing-eof-newline/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected missing newline at end of file",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     if (root.source.input.css.slice(-1) !== "\n") {

--- a/src/rules/no-multiple-empty-lines/index.js
+++ b/src/rules/no-multiple-empty-lines/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: line => `Unexpected empty line at line ${line}`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     let lineCount = 0

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -10,12 +10,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected trailing zero(s)",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -24,12 +24,9 @@ const lengthUnits = new Set([
   "vmin", "vmax",
 ])
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: p => `Unexpected vendor-prefixed property "${p}"`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -10,12 +10,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: p => `Unexpected standard property "${p}" applied to ":root"`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/rule-nested-empty-line-before/index.js
+++ b/src/rules/rule-nested-empty-line-before/index.js
@@ -33,6 +33,7 @@ export default function (expectation, options) {
           "after-comment",
         ],
       },
+      optional: true,
     })
     if (!validOptions) { return }
 

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -10,12 +10,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: p => `Unexpected duplicate property "${p}"`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     // In order to accommodate nested blocks (postcss-nested),

--- a/src/rules/rule-no-shorthand-property-overrides/index.js
+++ b/src/rules/rule-no-shorthand-property-overrides/index.js
@@ -14,12 +14,9 @@ export const messages = ruleMessages(ruleName, {
   ),
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/rule-no-single-line/index.js
+++ b/src/rules/rule-no-single-line/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: `Unexpected single-line rule`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/rule-non-nested-empty-line-before/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/index.js
@@ -29,6 +29,7 @@ export default function (expectation, options) {
       possible: {
         ignore: ["after-comment"],
       },
+      optional: true,
     })
     if (!validOptions) { return }
 

--- a/src/rules/selector-no-attribute/index.js
+++ b/src/rules/selector-no-attribute/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected attribute selector",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-combinator/index.js
+++ b/src/rules/selector-no-combinator/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected combinator",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected id selector",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected type selector",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-universal/index.js
+++ b/src/rules/selector-no-universal/index.js
@@ -11,12 +11,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected universal selector",
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-no-vendor-prefix/index.js
+++ b/src/rules/selector-no-vendor-prefix/index.js
@@ -12,12 +12,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: p => `Unexpected vendor-prefixed selector "${p}"`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/selector-root-no-composition/index.js
+++ b/src/rules/selector-root-no-composition/index.js
@@ -10,12 +10,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: `Unexpected composition of the ":root" selector`,
 })
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachRule(rule => {

--- a/src/rules/value-no-vendor-prefix/index.js
+++ b/src/rules/value-no-vendor-prefix/index.js
@@ -14,12 +14,9 @@ export const messages = ruleMessages(ruleName, {
 
 const valuePrefixes = [ "-webkit-", "-moz-", "-ms-", "-o-" ]
 
-export default function (o) {
+export default function (actual) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: o,
-      possible: [],
-    })
+    const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
     root.eachDecl(decl => {

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -54,6 +54,14 @@ test("validateOptions for primary options", t => {
   t.ok(result.warn.calledWith("Invalid option value \"1\" for rule \"bar\""))
   result.warn.reset()
 
+  validateOptions(result, "foo", {
+    possible: [ true, false ],
+    actual: undefined,
+  })
+  t.ok(result.warn.calledOnce, "undefined `actual` with `possible` values and no `optional` option")
+  t.ok(result.warn.calledWith("Expected option value for rule \"foo\""))
+  result.warn.reset()
+
   t.end()
 })
 
@@ -96,6 +104,14 @@ test("validateOptions for secondary options objects", t => {
   t.ok(result.warn.calledWith("Invalid option name \"barr\" for rule \"bar\""))
   result.warn.reset()
 
+  validateOptions(result, "foo", {
+    possible: [ true, false ],
+    actual: undefined,
+    optional: true,
+  })
+  t.notOk(result.warn.calledOnce, "undefined `actual` with `possible` values and an `optional` option")
+  result.warn.reset()
+
   t.end()
 })
 
@@ -124,30 +140,33 @@ test("validateOptions for secondary options objects with subarrays", t => {
   t.end()
 })
 
-test("validateOptions for `*-no-*` rule with no options", t => {
+test("validateOptions for `*-no-*` rule with no valid options", t => {
   const result = mockResult()
 
   validateOptions(result, "no-dancing", {
-    possible: [],
     actual: undefined,
   })
-  t.notOk(result.warn.called)
+  t.notOk(result.warn.called, "with empty array as `possible`")
   result.warn.reset()
 
   validateOptions(result, "no-dancing", {
-    possible: [],
+    actual: undefined,
+  })
+  t.notOk(result.warn.called, "with `possible` left undefined")
+  result.warn.reset()
+
+  validateOptions(result, "no-dancing", {
     actual: "foo",
   })
   t.ok(result.warn.calledOnce)
-  t.ok(result.warn.calledWith("Invalid option value \"foo\" for rule \"no-dancing\""))
+  t.ok(result.warn.calledWith("Unexpected option value \"foo\" for rule \"no-dancing\""))
   result.warn.reset()
 
   validateOptions(result, "no-dancing", {
-    possible: [],
     actual: false,
   })
   t.ok(result.warn.calledOnce)
-  t.ok(result.warn.calledWith("Invalid option value \"false\" for rule \"no-dancing\""))
+  t.ok(result.warn.calledWith("Unexpected option value \"false\" for rule \"no-dancing\""))
   result.warn.reset()
 
   t.end()


### PR DESCRIPTION
I did two things related to option validation:

- Simplified the syntax for the common case (in `-no-` rules) when there are no possibilities.
- Added an option to `validateOptions()` to specify that the options are `optional`. If that option is not set to `true` (which we should do for secondary options), and there are in fact possible options, then `undefined` or `null` will cause a warning.