### PR TITLE
Add after-comment ignore option to at-rule-empty-line-before. Closes …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Added: `after-comment` `ignore` option to the `at-rule-empty-line-before` rule.
+
 # 0.7.0
 
 * Added: invalid options cause the rule to abort instead of performing meaningless checks.

--- a/src/rules/at-rule-empty-line-before/README.md
+++ b/src/rules/at-rule-empty-line-before/README.md
@@ -161,6 +161,23 @@ b {
 }
 ```
 
+### `ignore: ["after-comment"]`
+
+Ignore rules that come after a comment.
+
+The following patterns are *not* considered warnings:
+
+```css
+/* comment */
+@media {}
+```
+
+```css
+/* comment */
+
+@media {}
+```
+
 ### `ignore: ["all-nested"]`
 
 Ignore at-rules that are nested.

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -42,6 +42,14 @@ testRule("always", { except: ["blockless-group"] }, tr => {
   tr.notOk("@import 'x.css';\n\n@import 'y.css'", messages.rejected)
 })
 
+testRule("always", { ignore: ["after-comment"] }, tr => {
+  tr.ok("/* foo */\n@media {}")
+  tr.ok("/* foo */\n\n@media{}")
+  tr.ok("/* foo */\r\n\r\n@media {}", "CRLF")
+
+  tr.notOk("a {} @media {}", messages.expected)
+})
+
 testRule("always", { except: ["all-nested"] }, tr => {
   sharedAlwaysTests(tr)
 
@@ -135,6 +143,15 @@ testRule("never", { except: ["first-nested"] }, tr => {
 
   tr.notOk("a {\n  color: pink;\n\n  @mixin foo;\n}", messages.rejected)
   tr.notOk("a {\n  @mixin foo;\n  color: pink;\n}", messages.expected)
+})
+
+testRule("never", { ignore: ["after-comment"] }, tr => {
+  tr.ok("/* foo */\n@media {}")
+  tr.ok("/* foo */\r\na@media {}", "CRLF")
+  tr.ok("/* foo */\n\n@media {}")
+
+  tr.notOk("b {}\n\n@media {}", messages.rejected)
+  tr.notOk("b {}\r\n\r\n@media {}", messages.rejected, "CRLF")
 })
 
 testRule("never", { ignore: ["all-nested"] }, tr => {

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -23,7 +23,7 @@ export default function (expectation, options) {
       actual: options,
       possible: {
         except: [ "blockless-group", "first-nested", "all-nested" ],
-        ignore: ["all-nested"],
+        ignore: [ "after-comment", "all-nested" ],
       },
       optional: true,
     })
@@ -36,6 +36,10 @@ export default function (expectation, options) {
 
       const isNested = atRule.parent !== root
       if (optionsHaveIgnored(options, "all-nested") && isNested) { return }
+
+      // Optionally ignore the expectation if a comment precedes this node
+      if (optionsHaveIgnored(options, "after-comment")
+        && atRule.prev() && atRule.prev().type === "comment") { return }
 
       const emptyLineBefore = atRule.before.indexOf("\n\n") !== -1
         || atRule.before.indexOf("\r\n\r\n") !== -1


### PR DESCRIPTION
… #350

Back on the train and I figured I'd quickly tick this one off.