### PR TITLE
Make override message consistent

### DIFF
--- a/src/rules/rule-no-shorthand-property-overrides/index.js
+++ b/src/rules/rule-no-shorthand-property-overrides/index.js
@@ -9,8 +9,7 @@ export const ruleName = "rule-no-shorthand-property-overrides"
 
 export const messages = ruleMessages(ruleName, {
   rejected: (shorthand, original) => (
-    `Unexpected shorthand property override: ` +
-    `"${shorthand}" will override "${original}"`
+    `Unexpected shorthand "${shorthand}" after "${original}"`
   ),
 })
 


### PR DESCRIPTION
Small tweak to make the `rule-no-shorthand-property-overrides` message consistent with other messages:

* no longer repeats the gist of the rule name in the message.
* now uses the word "after", similar to how `rule-properties-order` uses "before" - another rule dealing with property orders.

Becomes:

`Unexpected shorthand "margin" after "margin-bottom" (rule-no-shorthand-property-overrides)`


