### PR TITLE
Update deps, including swapping autoprefixer-core to autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
     "!**/testUtils"
   ],
   "dependencies": {
-    "autoprefixer-core": "^5.2.1",
+    "autoprefixer": "^6.0.0",
     "balanced-match": "^0.2.0",
     "execall": "^1.0.0",
-    "lodash": "^3.9.3",
+    "lodash": "^3.10.1",
     "postcss": "^5.0.4",
-    "postcss-selector-parser": "^1.0.1"
+    "postcss-selector-parser": "^1.1.4"
   },
   "devDependencies": {
-    "babel": "^5.6.3",
-    "babel-tape-runner": "^1.1.0",
-    "eslint": "^1.0.0",
+    "babel": "^5.8.23",
+    "babel-tape-runner": "^1.2.0",
+    "eslint": "^1.3.1",
     "eslint-config-stylelint": "^0.1.0",
-    "sinon": "^1.15.3",
+    "sinon": "^1.16.1",
     "stylelint-rule-tester": "^0.3.0",
-    "tape": "^4.0.1"
+    "tape": "^4.2.0"
   },
   "scripts": {
     "prepublish": "babel src --out-dir dist",

--- a/src/utils/isAutoprefixable.js
+++ b/src/utils/isAutoprefixable.js
@@ -1,6 +1,6 @@
-import autoprefixer from "autoprefixer-core"
-import Prefixes from "autoprefixer-core/lib/prefixes"
-import Browsers from "autoprefixer-core/lib/browsers"
+import autoprefixer from "autoprefixer"
+import Prefixes from "autoprefixer/lib/prefixes"
+import Browsers from "autoprefixer/lib/browsers"
 
 /**
  * Use Autoprefixer's secret powers to determine whether or


### PR DESCRIPTION
Looks like `autoprefixer-core` is deprecated in favour of `autoprefixer` in `6.0`

Everything else was hunky-dory.