### PR TITLE
Improve selector warning location accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Fixed: `postcss-selector-parser` updated to improve location accuracy for `selector-no-*` rules.
+
 # 1.0.0
 
 * Removed: compatibility with PostCSS `4.x`.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "execall": "^1.0.0",
     "lodash": "^3.10.1",
     "postcss": "^5.0.4",
-    "postcss-selector-parser": "^1.1.4"
+    "postcss-selector-parser": "^1.2.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/rules/selector-no-attribute/__tests__/index.js
+++ b/src/rules/selector-no-attribute/__tests__/index.js
@@ -21,21 +21,21 @@ testRule(undefined, tr => {
   tr.notOk("a[rel=\"external\"] {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 2,
   })
   tr.notOk("a, .foo[type=\"text\"] {}", {
     message: messages.rejected,
     line: 1,
-    column: 4,
+    column: 8,
   })
   tr.notOk("a > [foo] {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 5,
   })
   tr.notOk("a[rel='external'] {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 2,
   })
 })

--- a/src/rules/selector-no-attribute/index.js
+++ b/src/rules/selector-no-attribute/index.js
@@ -22,7 +22,7 @@ export default function (actual) {
           report({
             message: messages.rejected,
             node: rule,
-            word: attribute.parent.toString().trim(),
+            index: attribute.sourceIndex,
             ruleName,
             result,
           })

--- a/src/rules/selector-no-combinator/__tests__/index.js
+++ b/src/rules/selector-no-combinator/__tests__/index.js
@@ -16,41 +16,41 @@ testRule(undefined, tr => {
   tr.notOk("a b {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 2,
   })
   tr.notOk("a + a {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 3,
   })
   tr.notOk("a > a {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 3,
   })
   tr.notOk("a ~ a {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 3,
   })
   tr.notOk("a b, .foo {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 2,
   })
   tr.notOk(".foo, a b {}", {
     message: messages.rejected,
     line: 1,
-    column: 7,
+    column: 8,
   })
   tr.notOk("\t.foo,\n\ta b {}", {
     message: messages.rejected,
     line: 2,
-    column: 2,
+    column: 3,
   })
   tr.notOk("a#foo ~ b {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 7,
   })
 })

--- a/src/rules/selector-no-combinator/index.js
+++ b/src/rules/selector-no-combinator/index.js
@@ -22,7 +22,7 @@ export default function (actual) {
           report({
             message: messages.rejected,
             node: rule,
-            word: combinator.parent.toString().trim(),
+            index: combinator.sourceIndex,
             ruleName,
             result,
           })

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -21,7 +21,7 @@ testRule(undefined, tr => {
   tr.notOk(".bar > #foo {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 8,
   })
   tr.notOk("#foo.bar {}", {
     message: messages.rejected,

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -22,7 +22,7 @@ export default function (actual) {
           report({
             message: messages.rejected,
             node: rule,
-            word: id.parent.toString().trim(),
+            index: id.sourceIndex,
             ruleName,
             result,
           })

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -22,7 +22,7 @@ testRule(undefined, tr => {
   tr.notOk(".bar > foo {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 8,
   })
   tr.notOk("foo.bar {}", {
     message: messages.rejected,

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -22,7 +22,7 @@ export default function (actual) {
           report({
             message: messages.rejected,
             node: rule,
-            word: tag.parent.toString().trim(),
+            index: tag.sourceIndex,
             ruleName,
             result,
           })

--- a/src/rules/selector-no-universal/__tests__/index.js
+++ b/src/rules/selector-no-universal/__tests__/index.js
@@ -22,7 +22,7 @@ testRule(undefined, tr => {
   tr.notOk(".bar * {}", {
     message: messages.rejected,
     line: 1,
-    column: 1,
+    column: 6,
   })
   tr.notOk("*.bar {}", {
     message: messages.rejected,

--- a/src/rules/selector-no-universal/index.js
+++ b/src/rules/selector-no-universal/index.js
@@ -22,7 +22,7 @@ export default function (actual) {
           report({
             message: messages.rejected,
             node: rule,
-            word: universal.parent.toString().trim(),
+            index: universal.sourceIndex,
             ruleName,
             result,
           })


### PR DESCRIPTION
I put some work into adding position data to postcss-selector-parser, so now we can have precise locations for *everything*.

I added note to changelog. If you feel good about this and merge it, let's have a patch release. Sound good?