### PR TITLE
Start on raws-raw revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Fixed: Rules use `node.raw()` instead of `node.raws` to avoid expected errors.
+
 # 1.0.1
 
 * Fixed: `postcss-selector-parser` updated to improve location accuracy for `selector-no-*` rules.

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -41,8 +41,11 @@ export default function (expectation, options) {
       if (optionsHaveIgnored(options, "after-comment")
         && atRule.prev() && atRule.prev().type === "comment") { return }
 
-      const emptyLineBefore = atRule.raws.before.indexOf("\n\n") !== -1
-        || atRule.raws.before.indexOf("\r\n\r\n") !== -1
+      const before = atRule.raw("before")
+      const emptyLineBefore = before && (
+        before.indexOf("\n\n") !== -1
+        || before.indexOf("\r\n\r\n") !== -1
+      )
 
       let expectEmptyLineBefore = (expectation === "always") ? true : false
 

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -38,13 +38,16 @@ export default function (expectation) {
       if (!cssStatementHasBlock(statement) || cssStatementHasEmptyBlock(statement)) { return }
 
       const blockIsMultiLine = !isSingleLineString(cssStatementBlockString(statement))
+      const after = statement.raw("after")
+
+      if (typeof after === "undefined") { return }
 
       // We're really just checking whether a
       // newline *starts* the block's final space -- between
       // the last declaration and the closing brace. We can
       // ignore any other whitespace between them, because that
       // will be checked by the indentation rule.
-      if (statement.raws.after[0] !== "\n" && statement.raws.after.substr(0, 2) !== "\r\n") {
+      if (after[0] !== "\n" && after.substr(0, 2) !== "\r\n") {
         if (expectation === "always") {
           report({
             message: messages.expectedBefore(),
@@ -63,7 +66,7 @@ export default function (expectation) {
           })
         }
       }
-      if (statement.raws.after) {
+      if (after !== "") {
         if (expectation === "never") {
           report({
             message: messages.rejectedBefore(),

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -43,7 +43,7 @@ export default function (expectation) {
 
       // Allow an end-of-line comment one space after the brace
       const firstNode = statement.first
-      const nodeToCheck = (firstNode.type === "comment" && firstNode.raws.before === " ")
+      const nodeToCheck = (firstNode.type === "comment" && firstNode.raw("before") === " ")
         ? firstNode.next()
         : firstNode
       if (!nodeToCheck) { return }

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -27,13 +27,15 @@ export default function (expectation) {
       // Ignore the first node
       if (comment === root.first) { return }
 
+      const before = comment.raw("before")
+
       // Ignore inline comments
-      if (comment.raws.before.indexOf("\n") === -1) { return }
+      if (before.indexOf("\n") === -1) { return }
 
       const expectEmptyLineBefore = (expectation === "always") ? true : false
 
-      const emptyLineBefore = comment.raws.before.indexOf("\n\n") !== -1
-        || comment.raws.before.indexOf("\r\n\r\n") !== -1
+      const emptyLineBefore = before.indexOf("\n\n") !== -1
+        || before.indexOf("\r\n\r\n") !== -1
 
       // Return if the exceptation is met
       if (expectEmptyLineBefore === emptyLineBefore) { return }

--- a/src/rules/comment-space-inside/index.js
+++ b/src/rules/comment-space-inside/index.js
@@ -26,7 +26,8 @@ export default function (expectation) {
 
     root.walkComments(function (comment) {
 
-      const { left, right } = comment.raws
+      const left = comment.raw("left")
+      const right = comment.raw("right")
 
       if (left !== "" && expectation === "never") {
         report({

--- a/src/rules/custom-media-pattern/index.js
+++ b/src/rules/custom-media-pattern/index.js
@@ -1,5 +1,6 @@
 import { isRegExp } from "lodash"
 import {
+  mediaQueryParamIndexOffset,
   report,
   ruleMessages,
   validateOptions
@@ -25,7 +26,7 @@ export default function (pattern) {
         report({
           message: messages.expected,
           node: atRule,
-          index: 1 + atRule.name.length + atRule.raws.afterName.length,
+          index: mediaQueryParamIndexOffset(atRule),
           result,
           ruleName,
         })

--- a/src/rules/declaration-block-semicolon-newline-after/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/index.js
@@ -31,13 +31,13 @@ export default function (expectation) {
     root.walkDecls(decl => {
       // Ignore last declaration if there's no trailing semicolon
       const parentRule = decl.parent
-      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
+      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
 
       const nextNode = decl.next()
       if (!nextNode) { return }
 
       // Allow end-of-line comments one space after the semicolon
-      let nodeToCheck = (nextNode.type === "comment" && nextNode.raws.before === " ")
+      let nodeToCheck = (nextNode.type === "comment" && nextNode.raw("before") === " ")
         ? nextNode.next()
         : nextNode
       if (!nodeToCheck) { return }

--- a/src/rules/declaration-block-semicolon-newline-before/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/index.js
@@ -29,7 +29,7 @@ export default function (expectation) {
 
     root.walkDecls(function (decl) {
       const parentRule = decl.parent
-      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
+      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
 
       const declString = decl.toString()
 

--- a/src/rules/declaration-block-semicolon-space-after/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/index.js
@@ -33,7 +33,7 @@ export default function (expectation) {
     root.walkDecls(function (decl) {
       // Ignore last declaration if there's no trailing semicolon
       const parentRule = decl.parent
-      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
+      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
 
       const nextDecl = decl.next()
       if (!nextDecl) { return }

--- a/src/rules/declaration-block-semicolon-space-before/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/index.js
@@ -32,7 +32,7 @@ export default function (expectation) {
     root.walkDecls(decl => {
       // Ignore last declaration if there's no trailing semicolon
       const parentRule = decl.parent
-      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
+      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
 
       const declString = decl.toString()
 

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -1,5 +1,6 @@
 import {
   cssFunctionArguments,
+  mediaQueryParamIndexOffset,
   report,
   ruleMessages,
   validateOptions
@@ -79,7 +80,7 @@ export default function (expectation) {
           report({
             message: messages.expected(quoteMsg),
             node: atRule,
-            index: index + 1 + atRule.name.length + atRule.raws.afterName.length,
+            index: index + mediaQueryParamIndexOffset(atRule),
             result,
             ruleName,
           })
@@ -90,7 +91,7 @@ export default function (expectation) {
           report({
             message: messages.expected(quoteMsg, "url-prefix"),
             node: atRule,
-            index: index + 1 + atRule.name.length + atRule.raws.afterName.length,
+            index: index + mediaQueryParamIndexOffset(atRule),
             result,
             ruleName,
           })
@@ -101,7 +102,7 @@ export default function (expectation) {
           report({
             message: messages.expected(quoteMsg, "domain"),
             node: atRule,
-            index: index + 1 + atRule.name.length + atRule.raws.afterName.length,
+            index: index + mediaQueryParamIndexOffset(atRule),
             result,
             ruleName,
           })

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -77,7 +77,12 @@ export default function (space, options) {
 
       const expectedWhitespace = repeat(indentChar, nodeLevel)
 
-      let { before, after } = node.raws
+      let before = node.raw("before")
+      let after = node.raw("after")
+
+      console.log("NODE: " + JSON.stringify(node.toString()))
+      console.log("BEFORE: ", JSON.stringify(node.raws.before), JSON.stringify(node.raw("before")))
+      console.log("AFTER: ", JSON.stringify(node.raws.after), JSON.stringify(node.raw("after")))
 
       // Only inspect the spaces before the node
       // if this is the first node in root

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -80,10 +80,6 @@ export default function (space, options) {
       let before = node.raw("before")
       let after = node.raw("after")
 
-      console.log("NODE: " + JSON.stringify(node.toString()))
-      console.log("BEFORE: ", JSON.stringify(node.raws.before), JSON.stringify(node.raw("before")))
-      console.log("AFTER: ", JSON.stringify(node.raws.after), JSON.stringify(node.raw("after")))
-
       // Only inspect the spaces before the node
       // if this is the first node in root
       // or there is a newline in the `before` string.
@@ -112,8 +108,12 @@ export default function (space, options) {
       // Only blocks have the `after` string to check.
       // Only inspect `after` strings that start with a newline;
       // otherwise there's no indentation involved.
-      if (after && after.indexOf("\n") !== -1
-        && after.slice(after.lastIndexOf("\n") + 1) !== expectedWhitespace) {
+      if (
+        cssStatementHasBlock(node)
+        && after
+        && after.indexOf("\n") !== -1
+        && after.slice(after.lastIndexOf("\n") + 1) !== expectedWhitespace
+      ) {
         report({
           message: messages.expected(legibleExpectation(nodeLevel)),
           node,

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -1,4 +1,5 @@
 import {
+  mediaQueryParamIndexOffset,
   report,
   ruleMessages,
   styleSearch,
@@ -46,7 +47,7 @@ export function mediaFeatureColonSpaceChecker(checkLocation, root, result) {
       report({
         message: m,
         node,
-        index: index + 1 + node.name.length + node.raws.afterName.length,
+        index: index + mediaQueryParamIndexOffset(node),
         result,
         ruleName,
       }),

--- a/src/rules/media-feature-range-operator-space-after/index.js
+++ b/src/rules/media-feature-range-operator-space-after/index.js
@@ -1,4 +1,5 @@
 import {
+  mediaQueryParamIndexOffset,
   report,
   ruleMessages,
   validateOptions,
@@ -32,6 +33,7 @@ export default function (expectation) {
 
     function checkAfterOperator(match, params, node) {
       const endIndex = match.index + match[1].length
+
       checker.after({
         source: params,
         index: endIndex,
@@ -39,7 +41,7 @@ export default function (expectation) {
           report({
             message: m,
             node,
-            index: endIndex + node.name.length + node.raws.afterName.length + 2,
+            index: endIndex + mediaQueryParamIndexOffset(node) + 1,
             result,
             ruleName,
           })

--- a/src/rules/media-feature-range-operator-space-before/index.js
+++ b/src/rules/media-feature-range-operator-space-before/index.js
@@ -1,4 +1,5 @@
 import {
+  mediaQueryParamIndexOffset,
   report,
   ruleMessages,
   validateOptions,
@@ -40,7 +41,7 @@ export default function (expectation) {
           report({
             message: m,
             node,
-            index: match.index + node.name.length + node.raws.afterName.length + 1,
+            index: match.index + mediaQueryParamIndexOffset(node),
             result,
             ruleName,
           })

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -1,4 +1,5 @@
 import {
+  mediaQueryParamIndexOffset,
   report,
   ruleMessages,
   styleSearch,
@@ -45,7 +46,7 @@ export function mediaQueryListCommaWhitespaceChecker(checkLocation, root, result
       report({
         message: m,
         node,
-        index: index + 1 + node.name.length + node.raws.afterName.length,
+        index: index + mediaQueryParamIndexOffset(node),
         result,
         ruleName,
       }),

--- a/src/rules/media-query-parentheses-space-inside/index.js
+++ b/src/rules/media-query-parentheses-space-inside/index.js
@@ -1,4 +1,5 @@
 import {
+  mediaQueryParamIndexOffset,
   report,
   ruleMessages,
   styleSearch,
@@ -29,7 +30,7 @@ export default function (expectation) {
       if (atRule.name !== "media") { return }
 
       const params = atRule.params
-      const indexBoost = atRule.name.length + atRule.raws.afterName.length + 1
+      const indexBoost = mediaQueryParamIndexOffset(atRule)
 
       styleSearch({ source: params, target: "(" }, match => {
         const nextCharIsSpace = params[match.startIndex + 1] === " "

--- a/src/rules/rule-non-nested-empty-line-before/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/index.js
@@ -64,8 +64,9 @@ export function checkRuleEmptyLineBefore(rule, expectation, options, result, msg
     expectEmptyLineBefore = !expectEmptyLineBefore
   }
 
-  const emptyLineBefore = rule.raws.before.indexOf("\n\n") !== -1
-    || rule.raws.before.indexOf("\r\n\r\n") !== -1
+  const before = rule.raw("before")
+  const emptyLineBefore = before && before.indexOf("\n\n") !== -1
+    || before.indexOf("\r\n\r\n") !== -1
 
   // Return if the exceptation is met
   if (expectEmptyLineBefore === emptyLineBefore) { return }

--- a/src/rules/rule-trailing-semicolon/index.js
+++ b/src/rules/rule-trailing-semicolon/index.js
@@ -29,16 +29,21 @@ export default function (expectation) {
 
       if (!rule.last || rule.last.type !== "decl") { return }
 
+      let errorIndexOffset = rule.toString().length
+      if (rule.raw("after")) {
+        errorIndexOffset += rule.raw("after").length
+      }
+
       let errorIndex
       let message
       if (expectation === "always") {
-        if (rule.raws.semicolon) { return }
-        errorIndex = rule.toString().length - rule.raws.after.length - 1
+        if (rule.raw("semicolon")) { return }
+        errorIndex = errorIndexOffset - 1
         message = messages.expected
       }
       if (expectation === "never") {
-        if (!rule.raws.semicolon) { return }
-        errorIndex = rule.toString().length - rule.raws.after.length - 2
+        if (!rule.raw("semicolon")) { return }
+        errorIndex = errorIndexOffset - 2
         message = messages.rejected
       }
 

--- a/src/rules/rule-trailing-semicolon/index.js
+++ b/src/rules/rule-trailing-semicolon/index.js
@@ -30,19 +30,20 @@ export default function (expectation) {
       if (!rule.last || rule.last.type !== "decl") { return }
 
       let errorIndexOffset = rule.toString().length
-      if (rule.raw("after")) {
-        errorIndexOffset += rule.raw("after").length
+      let after = rule.raw("after")
+      if (after) {
+        errorIndexOffset -= after.length
       }
 
       let errorIndex
       let message
       if (expectation === "always") {
-        if (rule.raw("semicolon")) { return }
+        if (rule.raws.semicolon) { return }
         errorIndex = errorIndexOffset - 1
         message = messages.expected
       }
       if (expectation === "never") {
-        if (!rule.raw("semicolon")) { return }
+        if (!rule.raws.semicolon) { return }
         errorIndex = errorIndexOffset - 2
         message = messages.rejected
       }

--- a/src/utils/cssStatementStringBeforeBlock.js
+++ b/src/utils/cssStatementStringBeforeBlock.js
@@ -17,13 +17,13 @@ export default function (statement, { noBefore }={}) {
 
   let result = ""
   if (!noBefore) {
-    result += statement.raws.before
+    result += statement.raw("before")
   }
   if (statement.type === "rule") {
     result += statement.selector
   } else {
-    result += "@" + statement.name + statement.raws.afterName + statement.params
+    result += "@" + statement.name + statement.raw("afterName") + statement.params
   }
-  result += statement.raws.between
+  result += statement.raw("between")
   return result
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,6 +9,7 @@ import isAutoprefixable from "./isAutoprefixable"
 import isSingleLineString from "./isSingleLineString"
 import isWhitespace from "./isWhitespace"
 import lineCount from "./lineCount"
+import mediaQueryParamIndexOffset from "./mediaQueryParamIndexOffset"
 import optionsHaveException from "./optionsHaveException"
 import optionsHaveIgnored from "./optionsHaveIgnored"
 import rawNodeString from "./rawNodeString"
@@ -30,6 +31,7 @@ export default {
   isSingleLineString,
   isWhitespace,
   lineCount,
+  mediaQueryParamIndexOffset,
   optionsHaveException,
   optionsHaveIgnored,
   report,

--- a/src/utils/mediaQueryParamIndexOffset.js
+++ b/src/utils/mediaQueryParamIndexOffset.js
@@ -1,0 +1,7 @@
+export default function (atRule) {
+  let indexOffset = 1 + atRule.name.length
+  if (atRule.raw("afterName")) {
+    indexOffset += atRule.raw("afterName").length
+  }
+  return indexOffset
+}

--- a/src/utils/rawNodeString.js
+++ b/src/utils/rawNodeString.js
@@ -1,7 +1,7 @@
 export default function (node) {
   var result = ""
-  if (node.raws && node.raws.before) {
-    result += node.raws.before
+  if (node.raw("before")) {
+    result += node.raw("before")
   }
   result += node.toString()
   return result


### PR DESCRIPTION
@jeddy3 This isn't done, so don't merge. But I thought I'd throw it up in case you felt like working on it. I made a lot of revisions but I haven't been very systematic about it yet, and `indentation` and `rule-trailing-semicolon` tests are failing — most likely because of the revealed truth that `raw("after")` will not always be the same as `raws.after`. Anyway, I have to go to work, so won't get to finishing this for at least the rest of the day. Just thought I'd post it.