### PR TITLE
allow sass interpolation in color linters

### DIFF
--- a/src/rules/color-hex-case/__tests__/index.js
+++ b/src/rules/color-hex-case/__tests__/index.js
@@ -6,8 +6,15 @@ import rule, { ruleName, messages } from ".."
 
 const testRule = ruleTester(rule, ruleName)
 
-testRule("lower", tr => {
+function sharedTests(tr) {
   warningFreeBasics(tr)
+
+  tr.ok("a { border-#$side: 0; }", "ignore sass-like interpolation")
+  tr.ok("a { box-sizing: #$type-box; }", "ignore sass-like interpolation")
+}
+
+testRule("lower", tr => {
+  sharedTests(tr)
 
   tr.ok("a { color: pink; }")
   tr.ok("a { color: #000; }")
@@ -42,7 +49,7 @@ testRule("lower", tr => {
 })
 
 testRule("upper", tr => {
-  warningFreeBasics(tr)
+  sharedTests(tr)
 
   tr.ok("a { color: pink; }")
   tr.ok("a { color: #000; }")

--- a/src/rules/color-hex-case/index.js
+++ b/src/rules/color-hex-case/index.js
@@ -26,7 +26,9 @@ export default function (expectation) {
       const declString = decl.toString()
       styleSearch({ source: declString, target: "#" }, match => {
 
-        const hexValue = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))[0]
+        const hexMatch = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))
+        if (!hexMatch) { return }
+        const hexValue = hexMatch[0]
         const hexValueLower = hexValue.toLowerCase()
         const hexValueUpper = hexValue.toUpperCase()
 

--- a/src/rules/color-hex-length/__tests__/index.js
+++ b/src/rules/color-hex-length/__tests__/index.js
@@ -6,8 +6,15 @@ import rule, { ruleName, messages } from ".."
 
 const testRule = ruleTester(rule, ruleName)
 
-testRule("short", tr => {
+function sharedTests(tr) {
   warningFreeBasics(tr)
+
+  tr.ok("a { border-#$side: 0; }", "ignore sass-like interpolation")
+  tr.ok("a { box-sizing: #$type-box; }", "ignore sass-like interpolation")
+}
+
+testRule("short", tr => {
+  sharedTests(tr)
 
   tr.ok("a { color: pink; }")
   tr.ok("a { color: #000; }")
@@ -47,7 +54,7 @@ testRule("short", tr => {
 })
 
 testRule("long", tr => {
-  warningFreeBasics(tr)
+  sharedTests(tr)
 
   tr.ok("a { color: pink; }")
   tr.ok("a { color: #000000; }")

--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -27,7 +27,9 @@ export default function (expectation) {
 
       styleSearch({ source: declString, target: "#" }, match => {
 
-        const hexValue = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))[0]
+        const hexMatch = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))
+        if (!hexMatch) { return }
+        const hexValue = hexMatch[0]
 
         if (expectation === "long" && hexValue.length !== 4 && hexValue.length !== 5) { return }
 

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -18,6 +18,9 @@ testRule(undefined, tr => {
   tr.ok("a { padding: 000; }")
   tr.ok("a::before { content: \"#ababa\"; }")
 
+  tr.ok("a { border-#$side: 0; }", "ignore sass-like interpolation")
+  tr.ok("a { box-sizing: #$type-box; }", "ignore sass-like interpolation")
+
   tr.notOk("a { color: #ababa; }", {
     message: messages.rejected("#ababa"),
     line: 1,

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -21,7 +21,9 @@ export default function (actual) {
 
       styleSearch({ source: declString, target: "#" }, match => {
 
-        const hexValue = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))[0]
+        const hexMatch = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))
+        if (!hexMatch) { return }
+        const hexValue = hexMatch[0]
 
         if (!/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(hexValue)) {
           report({


### PR DESCRIPTION
In Sass, interpolation syntax is `#{$variable}`, which looks like the start of a hex code to the color linters, but fails to match the pattern for hex codes. This results in a "Cannot read property '0' of null" error

This just checks to make sure that the hex code pattern returns a match before proceeding