### PR TITLE
JavaScript Coding Standards: eslint comma-dangle

### DIFF
--- a/src/__tests__/disableRanges-integration-test.js
+++ b/src/__tests__/disableRanges-integration-test.js
@@ -1,7 +1,7 @@
 import { ruleTester } from "../testUtils"
 import blockNoEmpty, {
   ruleName as blockNoEmptyName,
-  messages as blockNoEmptyMessages
+  messages as blockNoEmptyMessages,
 } from "../rules/block-no-empty"
 
 const testBlockNoEmpty = ruleTester(blockNoEmpty, blockNoEmptyName)

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -4,7 +4,7 @@ import {
   optionsHaveIgnored,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "at-rule-empty-line-before"

--- a/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/at-rule-no-vendor-prefix/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/index.js
@@ -2,7 +2,7 @@ import {
   isAutoprefixable,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "at-rule-no-vendor-prefix"

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -5,7 +5,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "block-closing-brace-newline-after"

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -5,7 +5,7 @@ import {
   isSingleLineString,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "block-closing-brace-newline-before"

--- a/src/rules/block-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -5,7 +5,7 @@ import {
   rawNodeString,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "block-closing-brace-space-after"

--- a/src/rules/block-closing-brace-space-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-space-before/index.js
+++ b/src/rules/block-closing-brace-space-before/index.js
@@ -5,7 +5,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "block-closing-brace-space-before"

--- a/src/rules/block-no-empty/__tests__/index.js
+++ b/src/rules/block-no-empty/__tests__/index.js
@@ -1,5 +1,5 @@
 import {
-  ruleTester
+  ruleTester,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -3,7 +3,7 @@ import {
   cssStatementStringBeforeBlock,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "block-no-empty"

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -7,7 +7,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "block-opening-brace-newline-after"

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -6,7 +6,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "block-opening-brace-newline-before"

--- a/src/rules/block-opening-brace-space-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-space-after/index.js
+++ b/src/rules/block-opening-brace-space-after/index.js
@@ -6,7 +6,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "block-opening-brace-space-after"

--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -7,7 +7,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "block-opening-brace-space-before"

--- a/src/rules/color-hex-case/__tests__/index.js
+++ b/src/rules/color-hex-case/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/color-hex-case/index.js
+++ b/src/rules/color-hex-case/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "color-hex-case"

--- a/src/rules/color-hex-length/__tests__/index.js
+++ b/src/rules/color-hex-length/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "color-hex-length"

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "color-no-invalid-hex"

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "comment-empty-line-before"

--- a/src/rules/comment-space-inside/__tests__/index.js
+++ b/src/rules/comment-space-inside/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/comment-space-inside/index.js
+++ b/src/rules/comment-space-inside/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "comment-space-inside"

--- a/src/rules/custom-media-pattern/__tests__/index.js
+++ b/src/rules/custom-media-pattern/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/custom-media-pattern/index.js
+++ b/src/rules/custom-media-pattern/index.js
@@ -3,7 +3,7 @@ import {
   mediaQueryParamIndexOffset,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "custom-media-pattern"

--- a/src/rules/custom-property-no-outside-root/__tests__/index.js
+++ b/src/rules/custom-property-no-outside-root/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/custom-property-no-outside-root/index.js
+++ b/src/rules/custom-property-no-outside-root/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "custom-property-no-outside-root"

--- a/src/rules/custom-property-pattern/__tests__/index.js
+++ b/src/rules/custom-property-pattern/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/custom-property-pattern/index.js
+++ b/src/rules/custom-property-pattern/index.js
@@ -2,7 +2,7 @@ import { isRegExp, isString } from "lodash"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "custom-property-pattern"

--- a/src/rules/declaration-bang-space-after/__tests__/index.js
+++ b/src/rules/declaration-bang-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-bang-space-after/index.js
+++ b/src/rules/declaration-bang-space-after/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "declaration-bang-space-after"

--- a/src/rules/declaration-bang-space-before/__tests__/index.js
+++ b/src/rules/declaration-bang-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-bang-space-before/index.js
+++ b/src/rules/declaration-bang-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { declarationBangSpaceChecker } from "../declaration-bang-space-after"
 

--- a/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-newline-after/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/index.js
@@ -4,7 +4,7 @@ import {
   rawNodeString,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "declaration-block-semicolon-newline-after"

--- a/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-newline-before/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "declaration-block-semicolon-newline-before"

--- a/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-space-after/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/index.js
@@ -4,7 +4,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "declaration-block-semicolon-space-after"

--- a/src/rules/declaration-block-semicolon-space-before/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-space-before/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "declaration-block-semicolon-space-before"

--- a/src/rules/declaration-colon-space-after/__tests__/index.js
+++ b/src/rules/declaration-colon-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-colon-space-after/index.js
+++ b/src/rules/declaration-colon-space-after/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "declaration-colon-space-after"

--- a/src/rules/declaration-colon-space-before/__tests__/index.js
+++ b/src/rules/declaration-colon-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-colon-space-before/index.js
+++ b/src/rules/declaration-colon-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { declarationColonSpaceChecker } from "../declaration-colon-space-after"
 

--- a/src/rules/declaration-no-important/__tests__/index.js
+++ b/src/rules/declaration-no-important/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-no-important/index.js
+++ b/src/rules/declaration-no-important/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "declaration-no-important"

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -4,7 +4,7 @@ import {
   ruleMessages,
   styleSearch,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "function-calc-no-unspaced-operator"

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -3,7 +3,7 @@ import {
   ruleMessages,
   styleSearch,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "function-comma-space-after"

--- a/src/rules/function-comma-space-before/__tests__/index.js
+++ b/src/rules/function-comma-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-comma-space-before/index.js
+++ b/src/rules/function-comma-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { functionCommaSpaceChecker } from "../function-comma-space-after"
 

--- a/src/rules/function-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/function-parentheses-space-inside/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-parentheses-space-inside/index.js
+++ b/src/rules/function-parentheses-space-inside/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "function-parentheses-space-inside"

--- a/src/rules/function-space-after/__tests__/index.js
+++ b/src/rules/function-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-space-after/index.js
+++ b/src/rules/function-space-after/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "function-space-after"

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -3,7 +3,7 @@ import {
   mediaQueryParamIndexOffset,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "function-url-quotes"

--- a/src/rules/indentation/__tests__/at-rules.js
+++ b/src/rules/indentation/__tests__/at-rules.js
@@ -2,7 +2,7 @@
 
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/comments.js
+++ b/src/rules/indentation/__tests__/comments.js
@@ -2,7 +2,7 @@
 
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/hierarchical.js
+++ b/src/rules/indentation/__tests__/hierarchical.js
@@ -2,7 +2,7 @@
 
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -2,7 +2,7 @@
 
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/selectors.js
+++ b/src/rules/indentation/__tests__/selectors.js
@@ -1,7 +1,7 @@
 /* eslint-disable indent, no-multiple-empty-lines */
 
 import {
-  ruleTester
+  ruleTester,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -5,7 +5,7 @@ import {
   ruleMessages,
   styleSearch,
   cssStatementHasBlock,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "indentation"

--- a/src/rules/media-feature-colon-space-after/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -4,7 +4,7 @@ import {
   ruleMessages,
   styleSearch,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "media-feature-colon-space-after"

--- a/src/rules/media-feature-colon-space-before/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-colon-space-before/index.js
+++ b/src/rules/media-feature-colon-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 import { mediaFeatureColonSpaceChecker } from "../media-feature-colon-space-after"

--- a/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/index.js
@@ -2,7 +2,7 @@ import {
   isAutoprefixable,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "media-feature-name-no-vendor-prefix"

--- a/src/rules/media-feature-range-operator-space-after/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-range-operator-space-after/index.js
+++ b/src/rules/media-feature-range-operator-space-after/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "media-feature-range-operator-space-after"

--- a/src/rules/media-feature-range-operator-space-before/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-range-operator-space-before/index.js
+++ b/src/rules/media-feature-range-operator-space-before/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 import { findMediaOperator } from "../media-feature-range-operator-space-after"

--- a/src/rules/media-query-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-newline-after/index.js
+++ b/src/rules/media-query-list-comma-newline-after/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { mediaQueryListCommaWhitespaceChecker } from "../media-query-list-comma-space-after"
 

--- a/src/rules/media-query-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-newline-before/index.js
+++ b/src/rules/media-query-list-comma-newline-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { mediaQueryListCommaWhitespaceChecker } from "../media-query-list-comma-space-after"
 

--- a/src/rules/media-query-list-comma-space-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -4,7 +4,7 @@ import {
   ruleMessages,
   styleSearch,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "media-query-list-comma-space-after"

--- a/src/rules/media-query-list-comma-space-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-space-before/index.js
+++ b/src/rules/media-query-list-comma-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { mediaQueryListCommaWhitespaceChecker } from "../media-query-list-comma-space-after"
 

--- a/src/rules/media-query-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/media-query-parentheses-space-inside/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-parentheses-space-inside/index.js
+++ b/src/rules/media-query-parentheses-space-inside/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "media-query-parentheses-space-inside"

--- a/src/rules/nesting-block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/nesting-block-opening-brace-newline-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/nesting-block-opening-brace-newline-before/index.js
+++ b/src/rules/nesting-block-opening-brace-newline-before/index.js
@@ -5,7 +5,7 @@ import {
   report,
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "nesting-block-opening-brace-newline-before"

--- a/src/rules/nesting-block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/nesting-block-opening-brace-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/nesting-block-opening-brace-space-before/index.js
+++ b/src/rules/nesting-block-opening-brace-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { checkNestingBlockOpeningBraceBefore } from "../nesting-block-opening-brace-newline-before"
 

--- a/src/rules/no-eol-whitespace/__tests__/index.js
+++ b/src/rules/no-eol-whitespace/__tests__/index.js
@@ -1,5 +1,5 @@
 import {
-  ruleTester
+  ruleTester,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-eol-whitespace/index.js
+++ b/src/rules/no-eol-whitespace/index.js
@@ -2,7 +2,7 @@ import {
   ruleMessages,
   styleSearch,
   report,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "no-eol-whitespace"

--- a/src/rules/no-missing-eof-newline/__tests__/index.js
+++ b/src/rules/no-missing-eof-newline/__tests__/index.js
@@ -1,5 +1,5 @@
 import {
-  ruleTester
+  ruleTester,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-missing-eof-newline/index.js
+++ b/src/rules/no-missing-eof-newline/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "no-missing-eof-newline"

--- a/src/rules/no-multiple-empty-lines/__tests__/index.js
+++ b/src/rules/no-multiple-empty-lines/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-multiple-empty-lines/index.js
+++ b/src/rules/no-multiple-empty-lines/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "no-multiple-empty-lines"

--- a/src/rules/number-leading-zero/__tests__/index.js
+++ b/src/rules/number-leading-zero/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-leading-zero/index.js
+++ b/src/rules/number-leading-zero/index.js
@@ -3,7 +3,7 @@ import {
   cssStatementStringBeforeBlock,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "number-leading-zero"

--- a/src/rules/number-max-precision/__tests__/index.js
+++ b/src/rules/number-max-precision/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-max-precision/index.js
+++ b/src/rules/number-max-precision/index.js
@@ -6,7 +6,7 @@ import {
   cssStatementStringBeforeBlock,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "number-max-precision"

--- a/src/rules/number-no-trailing-zeros/__tests__/index.js
+++ b/src/rules/number-no-trailing-zeros/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -5,7 +5,7 @@ import {
   cssStatementStringBeforeBlock,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "number-no-trailing-zeros"

--- a/src/rules/number-zero-length-no-unit/__tests__/index.js
+++ b/src/rules/number-zero-length-no-unit/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -1,7 +1,7 @@
 import {
   findIndex,
   findLastIndex,
-  range
+  range,
 } from "lodash"
 import {
   blurComments,
@@ -10,7 +10,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "number-zero-length-no-unit"

--- a/src/rules/property-blacklist/__tests__/index.js
+++ b/src/rules/property-blacklist/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-blacklist/index.js
+++ b/src/rules/property-blacklist/index.js
@@ -3,7 +3,7 @@ import { isString } from "lodash"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "property-blacklist"

--- a/src/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/property-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -2,7 +2,7 @@ import {
   isAutoprefixable,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "property-no-vendor-prefix"

--- a/src/rules/property-whitelist/__tests__/index.js
+++ b/src/rules/property-whitelist/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-whitelist/index.js
+++ b/src/rules/property-whitelist/index.js
@@ -3,7 +3,7 @@ import { vendor } from "postcss"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "property-whitelist"

--- a/src/rules/root-no-standard-properties/__tests__/index.js
+++ b/src/rules/root-no-standard-properties/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "root-no-standard-properties"

--- a/src/rules/rule-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-nested-empty-line-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-nested-empty-line-before/index.js
+++ b/src/rules/rule-nested-empty-line-before/index.js
@@ -1,6 +1,6 @@
 import {
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 import { checkRuleEmptyLineBefore } from "../rule-non-nested-empty-line-before"

--- a/src/rules/rule-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/rule-no-duplicate-properties/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "rule-no-duplicate-properties"

--- a/src/rules/rule-no-shorthand-property-overrides/__tests__/index.js
+++ b/src/rules/rule-no-shorthand-property-overrides/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-no-shorthand-property-overrides/index.js
+++ b/src/rules/rule-no-shorthand-property-overrides/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 import shorthands from "./shorthands"
 

--- a/src/rules/rule-no-single-line/__tests__/index.js
+++ b/src/rules/rule-no-single-line/__tests__/index.js
@@ -1,5 +1,5 @@
 import {
-  ruleTester
+  ruleTester,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-no-single-line/index.js
+++ b/src/rules/rule-no-single-line/index.js
@@ -2,7 +2,7 @@ import {
   isSingleLineString,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "rule-no-single-line"

--- a/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-non-nested-empty-line-before/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/index.js
@@ -4,7 +4,7 @@ import {
   optionsHaveIgnored,
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "rule-non-nested-empty-line-before"

--- a/src/rules/rule-properties-order/__tests__/index.js
+++ b/src/rules/rule-properties-order/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -3,7 +3,7 @@ import { vendor } from "postcss"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "rule-properties-order"

--- a/src/rules/rule-trailing-semicolon/__tests__/index.js
+++ b/src/rules/rule-trailing-semicolon/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-trailing-semicolon/index.js
+++ b/src/rules/rule-trailing-semicolon/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   cssStatementHasEmptyBlock,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "rule-trailing-semicolon"

--- a/src/rules/selector-combinator-space-after/__tests__/index.js
+++ b/src/rules/selector-combinator-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -3,7 +3,7 @@ import {
   ruleMessages,
   styleSearch,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "selector-combinator-space-after"

--- a/src/rules/selector-combinator-space-before/__tests__/index.js
+++ b/src/rules/selector-combinator-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-combinator-space-before/index.js
+++ b/src/rules/selector-combinator-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 import { selectorCombinatorSpaceChecker } from "../selector-combinator-space-after"

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-list-comma-newline-after/index.js
+++ b/src/rules/selector-list-comma-newline-after/index.js
@@ -3,7 +3,7 @@ import {
   styleSearch,
   report,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "selector-list-comma-newline-after"

--- a/src/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-list-comma-newline-before/index.js
+++ b/src/rules/selector-list-comma-newline-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 import { selectorListCommaWhitespaceChecker } from "../selector-list-comma-space-after"

--- a/src/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-list-comma-space-after/index.js
+++ b/src/rules/selector-list-comma-space-after/index.js
@@ -3,7 +3,7 @@ import {
   ruleMessages,
   styleSearch,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "selector-list-comma-space-after"

--- a/src/rules/selector-list-comma-space-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-list-comma-space-before/index.js
+++ b/src/rules/selector-list-comma-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 import { selectorListCommaWhitespaceChecker } from "../selector-list-comma-space-after"

--- a/src/rules/selector-no-attribute/__tests__/index.js
+++ b/src/rules/selector-no-attribute/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-attribute/index.js
+++ b/src/rules/selector-no-attribute/index.js
@@ -2,7 +2,7 @@ import selectorParser from "postcss-selector-parser"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-no-attribute"

--- a/src/rules/selector-no-combinator/__tests__/index.js
+++ b/src/rules/selector-no-combinator/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-combinator/index.js
+++ b/src/rules/selector-no-combinator/index.js
@@ -2,7 +2,7 @@ import selectorParser from "postcss-selector-parser"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-no-combinator"

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -2,7 +2,7 @@ import selectorParser from "postcss-selector-parser"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-no-id"

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -1,5 +1,5 @@
 import {
-  ruleTester
+  ruleTester,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -2,7 +2,7 @@ import selectorParser from "postcss-selector-parser"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-no-type"

--- a/src/rules/selector-no-universal/__tests__/index.js
+++ b/src/rules/selector-no-universal/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-universal/index.js
+++ b/src/rules/selector-no-universal/index.js
@@ -2,7 +2,7 @@ import selectorParser from "postcss-selector-parser"
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-no-universal"

--- a/src/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-vendor-prefix/index.js
+++ b/src/rules/selector-no-vendor-prefix/index.js
@@ -3,7 +3,7 @@ import {
   ruleMessages,
   styleSearch,
   isAutoprefixable,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-no-vendor-prefix"

--- a/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-pseudo-element-colon-notation/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-psuedo-element-colon-notation"

--- a/src/rules/selector-root-no-composition/__tests__/index.js
+++ b/src/rules/selector-root-no-composition/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-root-no-composition/index.js
+++ b/src/rules/selector-root-no-composition/index.js
@@ -1,7 +1,7 @@
 import {
   report,
   ruleMessages,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "selector-root-no-composition"

--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -1,5 +1,5 @@
 import {
-  ruleTester
+  ruleTester,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/string-quotes/index.js
+++ b/src/rules/string-quotes/index.js
@@ -2,7 +2,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "string-quotes"

--- a/src/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-newline-after/index.js
+++ b/src/rules/value-list-comma-newline-after/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { valueListCommaWhitespaceChecker } from "../value-list-comma-space-after"
 

--- a/src/rules/value-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-newline-before/index.js
+++ b/src/rules/value-list-comma-newline-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { valueListCommaWhitespaceChecker } from "../value-list-comma-space-after"
 

--- a/src/rules/value-list-comma-space-after/__tests__/index.js
+++ b/src/rules/value-list-comma-space-after/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-space-after/index.js
+++ b/src/rules/value-list-comma-space-after/index.js
@@ -3,7 +3,7 @@ import {
   ruleMessages,
   styleSearch,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 
 export const ruleName = "value-list-comma-space-after"

--- a/src/rules/value-list-comma-space-before/__tests__/index.js
+++ b/src/rules/value-list-comma-space-before/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-space-before/index.js
+++ b/src/rules/value-list-comma-space-before/index.js
@@ -1,7 +1,7 @@
 import {
   ruleMessages,
   validateOptions,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils"
 import { valueListCommaWhitespaceChecker } from "../value-list-comma-space-after"
 

--- a/src/rules/value-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/value-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,6 @@
 import {
   ruleTester,
-  warningFreeBasics
+  warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-no-vendor-prefix/index.js
+++ b/src/rules/value-no-vendor-prefix/index.js
@@ -3,7 +3,7 @@ import {
   report,
   ruleMessages,
   styleSearch,
-  validateOptions
+  validateOptions,
 } from "../../utils"
 
 export const ruleName = "value-no-vendor-prefix"


### PR DESCRIPTION
Seeing as `"comma-dangle": [ 2, "always-multiline" ],` is defined per [eslint-config-stylelint/blob/master/eslintrc.json#L14](https://github.com/stylelint/eslint-config-stylelint/blob/master/eslintrc.json#L14) this pull requests fixes up all these instances in `.js` files.