### PR TITLE
Intelligent guessing with hyphenated properties in rule-properties-order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Added: `rule-properties-order` now looks for roots of hyphenated properties in custom arrays so each extension (e.g. `padding-top` as an extension of `padding`) does not need to be specified individually.
+
 # 1.1.0
 
 * Added: `declaration-colon-newline-after` rule.

--- a/src/rules/rule-properties-order/README.md
+++ b/src/rules/rule-properties-order/README.md
@@ -98,3 +98,120 @@ a {
   transform: scale(1);
 }
 ```
+
+If an (unprefixed) property name is not included in your array
+and it contains a hyphen (e.g. `padding-left`), the rule will look for the string
+before that first hyphen in your array (e.g. `padding`) and use that
+position. This means that you do not have to specify each extension of the root property;
+you can just specify the root property and the extensions will be accounted for.
+
+For example, if you have included `border` in your array but not
+`border-top`, the rule will expect `border-top` to appear in the same relative
+position as `border`.
+
+Other relevant rules include `margin`, `border`, `animation`, `transition`, etc.
+
+Using this fallback, the order of these hyphenated relative to their peer extensions
+(e.g. `border-top` to `border-bottom`) will be *arbitrary*. If you would like to
+enforce a specific ordering (e.g. always put `border-right` before `border-left`), you
+should specify those particular names in your array.
+
+Given:
+
+```js
+["padding", "color"]
+```
+
+The following patterns are considered warnings:
+
+```css
+a {
+  color: pink;
+  padding: 1em;
+}
+```
+
+```css
+a {
+  color: pink;
+  padding-top: 1em;
+}
+```
+
+```css
+a {
+  padding-left: 2em;
+  color: pink;
+  padding-top: 1em;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  padding: 1em;
+  color: pink;
+}
+```
+
+```css
+a {
+  padding-top: 1em;
+  color: pink;
+}
+```
+
+```css
+a {
+  padding-left: 2em;
+  padding-top: 1em;
+  color: pink;
+}
+```
+
+```css
+a {
+  padding-top: 1em;
+  padding-left: 2em;
+  color: pink;
+}
+```
+
+Given:
+
+```js
+["padding", "padding-top", "padding-right", "padding-bottom", "padding-left", "color"]
+```
+
+The following patterns are considered warnings:
+
+```css
+a {
+  padding-left: 2em;
+  padding-top: 1em;
+  padding: 1em;
+  color: pink;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  padding-top: 1em;
+  padding-right: 1em;
+  padding-bottom: 0.5em;
+  padding-left: 0.5em;
+  color: pink;
+}
+```
+
+```css
+a {
+  padding: 1em;
+  padding-right: 2em;
+  padding-left: 2.5em;
+  color: pink;
+}
+```

--- a/src/rules/rule-properties-order/__tests__/index.js
+++ b/src/rules/rule-properties-order/__tests__/index.js
@@ -52,6 +52,8 @@ testRule([
   "transform",
   "font-smoothing",
   "top",
+  "transition",
+  "border",
   "color",
 ], tr => {
   warningFreeBasics(tr)
@@ -81,4 +83,45 @@ testRule([
     messages.expected("color", "height"))
   tr.notOk("a { top: 0; height: 0; color: pink; width: 0 }",
     messages.expected("color", "height"))
+
+  // Longhand properties accounted for when shorthand is included
+  tr.ok("a { border: 1px solid; color: pink; }")
+  tr.ok("a { border-top: 1px solid; color: pink; }")
+  tr.ok("a { border-left: 1px solid; color: pink; }")
+  // Post-hyphen string doesn't affect order by default
+  tr.ok("a { border-left: 1px solid; border-right: 0; color: pink; }")
+  tr.ok("a { border-right: 1px solid; border-left: 0; color: pink; }")
+  tr.notOk("a { color: pink; border: 1px solid; }", messages.expected("border", "color"))
+  tr.notOk("a { color: pink; border-top: 1px solid; }", messages.expected("border-top", "color"))
+  tr.notOk("a { color: pink; border-bottom: 1px solid; }", messages.expected("border-bottom", "color"))
+  tr.notOk("a { border-right: 0; color: pink; border-bottom: 1px solid; }", messages.expected("border-bottom", "color"))
+
+  tr.ok("a { transition: none; border: 1px solid; }")
+  tr.ok("a { transition-name: 'foo'; border-top: 1px solid; }")
+  tr.notOk("a { border-top: 1px solid; transition-name: 'foo'; }",
+    messages.expected("transition-name", "border-top"))
+})
+
+// Longhand properties with specified order
+testRule([
+  "padding",
+  "padding-top",
+  "padding-right",
+  "padding-left",
+  "color",
+], tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { padding: 1px; color: pink; }")
+  tr.ok("a { padding-top: 1px; color: pink; }")
+  tr.ok("a { padding-left: 1px; color: pink; }")
+  tr.ok("a { padding-top: 1px; padding-right: 0; color: pink; }")
+  // `padding-bottom` was not specified, so it will be expected where `padding` was expected
+  tr.ok("a { padding-bottom: 0; padding-top: 1px; padding-right: 0; padding-left: 0; color: pink; }")
+  tr.ok("a { padding: 1px; padding-bottom: 0; padding-left: 0; color: pink; }")
+
+  tr.notOk("a { color: pink; padding: 1px; }", messages.expected("padding", "color"))
+  tr.notOk("a { color: pink; padding-top: 1px; }", messages.expected("padding-top", "color"))
+  tr.notOk("a { padding-right: 1px; padding-top: 0; color: pink;  }",
+    messages.expected("padding-top", "padding-right"))
 })

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -62,9 +62,8 @@ export default function (expectation) {
           return
         }
 
-        // Different unprefixed property names
+        // Different unprefixed property names ...
         if (prop.unprefixedName !== previousProp.unprefixedName) {
-
           // Alphabetical
           if (expectation === "alphabetical"
             && prop.unprefixedName >= previousProp.unprefixedName) {
@@ -75,8 +74,20 @@ export default function (expectation) {
           // Array of properties
           if (Array.isArray(expectation)) {
 
-            const propIndex = expectation.indexOf(prop.unprefixedName)
-            const previousPropIndex = expectation.indexOf(previousProp.unprefixedName)
+            let propIndex = expectation.indexOf(prop.unprefixedName)
+            let previousPropIndex = expectation.indexOf(previousProp.unprefixedName)
+
+            // If either this or prev prop was not found but they have a hyphen
+            // (e.g. `padding-top`), try looking for the segment preceding the hyphen
+            // and use that index
+            if (propIndex === -1 && prop.unprefixedName.indexOf("-") !== -1) {
+              const propPreHyphen = prop.unprefixedName.slice(0, prop.unprefixedName.indexOf("-"))
+              propIndex = expectation.indexOf(propPreHyphen)
+            }
+            if (previousPropIndex === -1 && previousProp.unprefixedName.indexOf("-") !== -1) {
+              const previousPropPreHyphen = previousProp.unprefixedName.slice(0, previousProp.unprefixedName.indexOf("-"))
+              previousPropIndex = expectation.indexOf(previousPropPreHyphen)
+            }
 
             // Check that two known properties are in order
             if (propIndex !== -1 && previousPropIndex !== -1


### PR DESCRIPTION
When given a custom array, the rule now assumes that "extension"
properties -- e.g. `border-top` as an "extension" or `border` --
should appear in the same relative position as their root
unless they are individually specified.

Closes #373.