### PR TITLE
Ignore order of properties unspecified in user array; provide options…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+* Added: `rule-properties-order` now by default ignores the order of properties left out of your specified array; and the options `"top"`, `"bottom"`, and `"ignore"` are provided to change that behavior.
 * Added: `rule-properties-order` now looks for roots of hyphenated properties in custom arrays so each extension (e.g. `padding-top` as an extension of `padding`) does not need to be specified individually.
 
 # 1.1.0

--- a/src/rules/rule-properties-order/README.md
+++ b/src/rules/rule-properties-order/README.md
@@ -59,6 +59,30 @@ a {
 
 Properties *must always* be ordered to match that of the array.
 
+There are some important details to keep in mind:
+
+**By default, unlisted properties will be ignored.** So if you specify an array
+and do not include `display`, that means that the `display` property can be
+included before or after any other property. *This can be changed with the
+`unspecified` option* (see below).
+
+**If an (unprefixed) property name is not included in your array
+and it contains a hyphen (e.g. `padding-left`), the rule will look for the string
+before that first hyphen in your array (e.g. `padding`) and use that
+position.** This means that you do not have to specify each extension of the root property;
+you can just specify the root property and the extensions will be accounted for.
+
+For example, if you have included `border` in your array but not
+`border-top`, the rule will expect `border-top` to appear in the same relative
+position as `border`.
+
+Other relevant rules include `margin`, `border`, `animation`, `transition`, etc.
+
+Using this fallback, the order of these hyphenated relative to their peer extensions
+(e.g. `border-top` to `border-bottom`) will be *arbitrary*. If you would like to
+enforce a specific ordering (e.g. always put `border-right` before `border-left`), you
+should specify those particular names in your array.
+
 Given:
 
 ```js
@@ -98,23 +122,6 @@ a {
   transform: scale(1);
 }
 ```
-
-If an (unprefixed) property name is not included in your array
-and it contains a hyphen (e.g. `padding-left`), the rule will look for the string
-before that first hyphen in your array (e.g. `padding`) and use that
-position. This means that you do not have to specify each extension of the root property;
-you can just specify the root property and the extensions will be accounted for.
-
-For example, if you have included `border` in your array but not
-`border-top`, the rule will expect `border-top` to appear in the same relative
-position as `border`.
-
-Other relevant rules include `margin`, `border`, `animation`, `transition`, etc.
-
-Using this fallback, the order of these hyphenated relative to their peer extensions
-(e.g. `border-top` to `border-bottom`) will be *arbitrary*. If you would like to
-enforce a specific ordering (e.g. always put `border-right` before `border-left`), you
-should specify those particular names in your array.
 
 Given:
 
@@ -213,5 +220,121 @@ a {
   padding-right: 2em;
   padding-left: 2.5em;
   color: pink;
+}
+```
+
+## Optional options
+
+### `unspecified: "top"|"bottom"|"ignore"`
+
+These options only apply if you've defined your own array of properties.
+
+Default behavior is the same as `"ignore"`: an unspecified property can appear before or after
+any other property.
+
+With `"top"`, unspecified properties are expected *before* any specified properties.
+With `"bottom"`, unspecified properties are expected *after* any specified properties.
+
+Given this configuration:
+
+```js
+[2, ["color", "background"], { unspecified: "ignore" }]
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  color: pink;
+  background: orange;
+  left: 0;
+}
+```
+
+```css
+a {
+  left: 0;
+  color: pink;
+  background: orange;
+}
+```
+
+```css
+a {
+  color: pink;
+  left: 0;
+  background: orange;
+}
+```
+
+Given this configuration:
+
+```js
+[2, ["color", "background"], { unspecified: "top" }]
+```
+
+The following patterns are considered warnings:
+
+
+```css
+a {
+  color: pink;
+  background: orange;
+  left: 0;
+}
+```
+
+```css
+a {
+  color: pink;
+  left: 0;
+  background: orange;
+}
+```
+
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  left: 0;
+  color: pink;
+  background: orange;
+}
+```
+
+Given this configuration:
+
+```js
+[2, ["color", "background"], { unspecified: "bottom" }]
+```
+
+The following patterns are considered warnings:
+
+
+```css
+a {
+  left: 0;
+  color: pink;
+  background: orange;
+}
+```
+
+```css
+a {
+  color: pink;
+  left: 0;
+  background: orange;
+}
+```
+
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  color: pink;
+  background: orange;
+  left: 0;
 }
 ```

--- a/src/rules/rule-properties-order/__tests__/index.js
+++ b/src/rules/rule-properties-order/__tests__/index.js
@@ -65,7 +65,6 @@ testRule([
   tr.ok("a { -webkit-font-smoothing: antialiased; top: 0; color: pink; }")
   tr.ok("a { top: 0; color: pink; width: 0; }")
   tr.ok("a { top: 0; color: pink; width: 0; height: 0; }")
-  tr.ok("a { top: 0; color: pink; width: 0; height: 0; display: none; }")
 
   tr.notOk("a { color: pink; top: 0;  }",
     messages.expected("top", "color"))
@@ -77,12 +76,6 @@ testRule([
     messages.expected("-moz-transform", "-webkit-transform"))
   tr.notOk("a { color: pink; -webkit-font-smoothing: antialiased; }",
     messages.expected("-webkit-font-smoothing", "color"))
-  tr.notOk("a { height: 0; color: pink; }",
-    messages.expected("color", "height"))
-  tr.notOk("a { top: 0; height: 0; color: pink; }",
-    messages.expected("color", "height"))
-  tr.notOk("a { top: 0; height: 0; color: pink; width: 0 }",
-    messages.expected("color", "height"))
 
   // Longhand properties accounted for when shorthand is included
   tr.ok("a { border: 1px solid; color: pink; }")
@@ -100,6 +93,11 @@ testRule([
   tr.ok("a { transition-name: 'foo'; border-top: 1px solid; }")
   tr.notOk("a { border-top: 1px solid; transition-name: 'foo'; }",
     messages.expected("transition-name", "border-top"))
+
+  // Position of unspecified `display` is arbitrary
+  tr.ok("a { top: 0; color: pink; width: 0; height: 0; display: none; }")
+  tr.ok("a { top: 0; color: pink; display: none; width: 0; height: 0; }")
+  tr.ok("a { display: none; top: 0; color: pink; width: 0; height: 0; }")
 })
 
 // Longhand properties with specified order
@@ -124,4 +122,30 @@ testRule([
   tr.notOk("a { color: pink; padding-top: 1px; }", messages.expected("padding-top", "color"))
   tr.notOk("a { padding-right: 1px; padding-top: 0; color: pink;  }",
     messages.expected("padding-top", "padding-right"))
+})
+
+// Forcing unspecified properties to the top
+testRule([
+  "height",
+  "color",
+], { unspecified: "top" }, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { top: 0; height: 1px; color: pink; }")
+  tr.ok("a { bottom: 0; top: 0; }")
+  tr.notOk("a { height: 1px; top: 0; }", messages.expected("top", "height"))
+  tr.notOk("a { color: 1px; top: 0; }", messages.expected("top", "color"))
+})
+
+// Forcing unspecified properties to the bottom
+testRule([
+  "height",
+  "color",
+], { unspecified: "bottom" }, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { height: 1px; color: pink; bottom: 0; }")
+  tr.ok("a { bottom: 0; top: 0; }")
+  tr.notOk("a { bottom: 0; height: 1px; }", messages.expected("bottom", "height"))
+  tr.notOk("a { bottom: 0; color: 1px; }", messages.expected("bottom", "color"))
 })


### PR DESCRIPTION
… to change behavior

Now rule-properties-order will by default ignore the order of unspecified properties
if the user has provided an array. This is a change to the default behavior previously,
so might be considered a breaking change.

The `unspecified` option has been added for the user to explicitly decide where
unspecified properties should go: "top", "bottom", or "ignore" (same as
default behavior).

Closes #374.

Notice that this branch is to be merged into `longhand-order`, not directly into master.