### PR TITLE
add ignore value and param to indentation

### DIFF
--- a/src/rules/indentation/README.md
+++ b/src/rules/indentation/README.md
@@ -120,7 +120,6 @@ For example, with `2`:
 The following patterns are considered warnings:
 
 ```css
-```css
 @media print,
   (-webkit-min-device-pixel-ratio: 1.25),
   (min-resolution: 120dpi) {
@@ -141,6 +140,38 @@ a {
 background-position: top left,
 top right;
 }
+}
+```
+
+### `ignore: ["value"]`
+
+Ignore the indentation of values.
+
+For example, with `2`:
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  background-position: top left,
+top right,
+  bottom left,
+    bottom right;
+}
+```
+
+### `ignore: ["param"]`
+
+Ignore the indentation of at-rule params.
+
+For example, with `2`:
+
+The following patterns are *not* considered warnings:
+
+```css
+@media print,
+  (-webkit-min-device-pixel-ratio: 1.25),
+    (min-resolution: 120dpi) {
 }
 ```
 

--- a/src/rules/indentation/__tests__/at-rules.js
+++ b/src/rules/indentation/__tests__/at-rules.js
@@ -162,3 +162,31 @@ tr.notOk(
 })
 
 })
+
+// spaces ignore param
+testRule(2, { ignore: ["param"] }, tr => {
+warningFreeBasics(tr)
+
+tr.ok(
+`@media print,
+(-webkit-min-device-pixel-ratio: 1.25),
+(min-resolution: 120dpi) {}`)
+
+tr.ok(
+`@media print,
+  (-webkit-min-device-pixel-ratio: 1.25),
+(min-resolution: 120dpi) {}`)
+
+tr.notOk(
+`
+  @media print {
+  a {
+    color: pink;
+  }
+}`, {
+  message: messages.expected("0 spaces"),
+  line: 2,
+  column: 3,
+})
+
+})

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -387,3 +387,49 @@ tr.notOk(
 })
 
 })
+
+// 2 spaces ignore value
+testRule(2, { ignore: ["value"] }, tr => {
+warningFreeBasics(tr)
+
+tr.ok(
+`a {
+  background-position: top left, top right, bottom left;
+  color: pink;
+}`)
+
+tr.ok(
+`a {
+  background-position: top left,
+  top right,
+  bottom left;
+  color: pink;
+}`)
+
+tr.ok(
+`a {
+  background-position: top left,
+    top right,
+  bottom left;
+  color: pink;
+}`)
+
+tr.ok(
+`a {
+  background-position: top left,
+  top right,
+    bottom left;
+  color: pink;
+}`)
+
+tr.notOk(
+`\ta {
+  color: pink;
+}`,
+{
+  message: messages.expected("0 spaces"),
+  line: 1,
+  column: 2,
+})
+
+})

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -1,6 +1,7 @@
 import { repeat, isNumber, isBoolean } from "lodash"
 import {
   optionsHaveException,
+  optionsHaveIgnored,
   report,
   ruleMessages,
   styleSearch,
@@ -48,6 +49,7 @@ export default function (space, options) {
       actual: options,
       possible: {
         except: [ "block", "value", "param" ],
+        ignore: [ "value", "param" ],
         hierarchicalSelectors: [isBoolean],
       },
       optional: true,
@@ -176,9 +178,10 @@ export default function (space, options) {
     }
 
     function checkValue(decl, declLevel) {
-      const declString = decl.toString()
       if (decl.value.indexOf("\n") === -1) { return }
+      if (optionsHaveIgnored(options, "value")) { return }
 
+      const declString = decl.toString()
       const valueLevel = (optionsHaveException(options, "value"))
         ? declLevel
         : declLevel + 1
@@ -227,6 +230,8 @@ export default function (space, options) {
     }
 
     function checkAtRuleParams(atRule, ruleLevel) {
+      if (optionsHaveIgnored(options, "param")) { return }
+
       const paramLevel = (optionsHaveException(options, "param"))
         ? ruleLevel
         : ruleLevel + 1


### PR DESCRIPTION
Sass has cases where the current rules for `value` and `param` might not make sense.

Maps:

```scss
$foo: (
    a: 1,
    b: 2
);
```

Mixin params:

```scss
@mixin foo(
    $a: 1,
    $b: 2
) {
    @content;
}
```

Also, *scss-lint* doesn't check for indentation in these cases, so ignoring helps migrating from there