### PR TITLE
Fix comment-space-inside; considers newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+* Fixed: `comment-space-inside` now recognizes newlines as a "space"
+
 # 1.2.0
 
 * Added: `function-linear-gradient-no-nonstandard-direction` rule.

--- a/src/rules/comment-space-inside/__tests__/index.js
+++ b/src/rules/comment-space-inside/__tests__/index.js
@@ -13,6 +13,10 @@ testRule("always", tr => {
   tr.ok("/* comment comment */")
   tr.ok("/* comment\ncomment */")
   tr.ok("/* comment\n\ncomment */")
+  tr.ok("/*\ncomment */")
+  tr.ok("/* comment\n*/")
+  tr.ok("/*\ncomment\n*/")
+  tr.ok("/*\ncomment\n\ncomment\n*/")
 
   tr.notOk("/*comment */", {
     message: messages.expectedOpening,
@@ -52,6 +56,16 @@ testRule("always", tr => {
   tr.notOk("/* comment\n\ncomment*/", {
     message: messages.expectedClosing,
     line: 3,
+    column: 7,
+  })
+  tr.notOk("/*comment\n*/", {
+    message: messages.expectedOpening,
+    line: 1,
+    column: 3,
+  })
+  tr.notOk("/*\ncomment*/", {
+    message: messages.expectedClosing,
+    line: 2,
     column: 7,
   })
 })
@@ -103,5 +117,15 @@ testRule("never", tr => {
     message: messages.rejectedClosing,
     line: 3,
     column: 8,
+  })
+  tr.notOk("/*\ncomment*/", {
+    message: messages.rejectedOpening,
+    line: 1,
+    column: 3,
+  })
+  tr.notOk("/*comment\n*/", {
+    message: messages.rejectedClosing,
+    line: 1,
+    column: 10,
   })
 })

--- a/src/rules/comment-space-inside/index.js
+++ b/src/rules/comment-space-inside/index.js
@@ -7,11 +7,15 @@ import {
 export const ruleName = "comment-space-inside"
 
 export const messages = ruleMessages(ruleName, {
-  expectedOpening: `Expected single space after "/*"`,
+  expectedOpening: `Expected single space or newline after "/*"`,
   rejectedOpening: `Unexpected whitespace after "/*"`,
-  expectedClosing: `Expected single space before "*/"`,
+  expectedClosing: `Expected single space or newline before "*/"`,
   rejectedClosing: `Unexpected whitespace before "*/"`,
 })
+
+function isSpace(str) {
+  return str === " " || str === "\n" || str === "\r\n"
+}
 
 export default function (expectation) {
   return function (root, result) {
@@ -38,7 +42,7 @@ export default function (expectation) {
           ruleName,
         })
       }
-      if (left !== " " && expectation === "always") {
+      if (!isSpace(left) && expectation === "always") {
         report({
           message: messages.expectedOpening,
           node: comment,
@@ -57,7 +61,7 @@ export default function (expectation) {
           ruleName,
         })
       }
-      if (right !== " " && expectation === "always") {
+      if (!isSpace(right) && expectation === "always") {
         report({
           message: messages.expectedClosing,
           node: comment,


### PR DESCRIPTION
Fixes https://github.com/stylelint/stylelint/issues/403

`comment-space-inside: 'always'` now allows:

```
.foo {
    /*
    opacity: 0;
    pointer-events: none;
    */
}

.bar
    /*
    opacity: 0;
    pointer-events: none; */
}

.baz
    /* opacity: 0;
    pointer-events: none;
    */
}
```


