### PR TITLE
Add syntax config with scss option to API and CLI; closes #410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added: `string` and `json` formatters.
 * Added: support for using `.stylelintrc` JSON file.
 * Added: support for extending existing configs using the `extends` property.
+* Added: support for SCSS syntax parsing to CLI and Node API.
 
 # 1.2.1
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -3,25 +3,27 @@
 `stylelint --help` prints the following documentation:
 
 ```
-  Modern CSS linter
+Modern CSS linter
 
-  Usage
-    stylelint [input] [options]
+Usage
+  stylelint [input] [options]
 
-  By default, stylelint will look for a .stylelintrc file in JSON format,
-  using rc to look in various places (cf. https://github.com/dominictarr/rc#standards).
-  Alternately, you can specify a configuration file via --config.
+By default, stylelint will look for a .stylelintrc file in JSON format,
+using rc to look in various places (cf. https://github.com/dominictarr/rc#standards).
+Alternately, you can specify a configuration file via --config.
 
-  Input
-    File glob(s) (passed to node-glob).
-    You can also pass no input and use stdin.
+Input
+  File glob(s) (passed to node-glob).
+  You can also pass no input and use stdin.
 
-  Options
-    --config            Path to a JSON configuration file.
-    --version           Get the currently installed version of stylelint.
-    -f, --formatter     Specify a formatter: "json" or "string". Default is "string".
-    --custom-formatter  Path to a JS file exporting a custom formatting function
-    -q, --quiet         Only register warnings for rules with a severity of 2 (ignore level 1)
+Options
+  --config            Path to a JSON configuration file.
+  --version           Get the currently installed version of stylelint.
+  --custom-formatter  Path to a JS file exporting a custom formatting function
+  -f, --formatter     Specify a formatter: "json" or "string". Default is "string".
+  -q, --quiet         Only register warnings for rules with a severity of 2 (ignore level 1)
+  -s, --syntax        Specify a non-standard syntax that should be used to
+                      parse source stylesheets. Options: "scss"
 ```
 
 The CLI outputs formatted results into `process.stdout`, which you can read with your human eyes or pipe elsewhere (e.g. write the information to a file).

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -13,15 +13,15 @@ Options is an object with the following properties.
 
 Though both `files` and `css` are "optional," you *must* have one and *cannot* have both. All other options are optional._
 
-### files
+### `files`
 
 A file glob, or array of file globs. Ultimately passed to [node-glob](https://github.com/isaacs/node-glob) to figure out what files you want to lint.
 
-### css
+### `code`
 
 A CSS string to be linted.
 
-### formatter
+### `formatter`
 
 `"json"`, `"string"`, or a function. Default is `"json"`.
 
@@ -29,41 +29,47 @@ Describes the formatter that you would like to use to format your results. `"jso
 
 If you pass a function, it must fit the signature described in the Developer Guide. TODO: LINK.
 
-### config
+### `config`
 
 A [stylelint configuration object](/docs/user-guide/configuration.md).
 
 If no `config` is passed, stylelint will look for a `.stylelintrc` configuration file in [standard rc-file places](https://github.com/dominictarr/rc#standards).
 
-### configBasedir
+### `configBasedir`
 
 An absolute path to the directory that relative paths defining `extends` and `plugins` are *relative to*.
 
 If the `config` object passed uses relative paths for `extends` or `plugins`, you are going to have to pass a `configBasedir`. If not, you do not need this.
 
-### configOverrides
+### `configOverrides`
 
 A partial stylelint configuration object whose properties will override the existing config object, whether that config was loaded via the `config` option or a `.stylelintrc` file.
 
 The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to _both_ load a `.stylelintrc` file _and_ override specific parts of it, `configOverrides` does just that.
 
+### `syntax`
+
+Options: `"scss"`.
+
+Specify a non-standard syntax that should be used to parse source stylesheets.
+
 ## The returned promise
 
 `stylelint.lint()` returns a Promise that resolves with an object containing the following properties:
 
-### output
+### `output`
 
 A string displaying the formatted warnings (using the default formatter or whichever you passed).
 
-### errored
+### `errored`
 
 Boolean. If `true`, at least one rule with a severity of 2 registered a warning.
 
-### results
+### `results`
 
 An array containing all the stylelint result objects (the objects that formatters consume).
 
-### postcssResults
+### `postcssResults`
 
 An array containing all the [PostCSS LazyResults](https://github.com/postcss/postcss/blob/master/docs/api.md#lazyresult-class) that were accumulated during processing.
 
@@ -100,17 +106,18 @@ Maybe I want to use a CSS string instead of a file glob, and I want to use the s
 
 ```js
 stylelint.lint({
-  css: 'a { color: pink; }',
+  code: 'a { color: pink; }',
   config: myConfig,
   formatter: "string"
 }).then(function() { .. });
 ```
 
-Maybe I want to use my own custom formatter function:
+Maybe I want to use my own custom formatter function and parse `.scss` source files:
 
 ```js
 stylelint.lint({
-  css: 'a { color: pink; }',
+  code: 'a { color: pink; }',
   config: myConfig,
+  syntax: "scss",
   formatter: function(stylelintResults) { .. }
 }).then(function() { .. });

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -15,19 +15,19 @@ _The stylelint plugin registers warnings via PostCSS_. Therefore, you'll want to
 
 The plugin accepts an options object as argument, with the following properties:
 
-### config
+### `config`
 
 A [stylelint configuration object](/docs/user-guide/configuration.md).
 
 If no `config` is passed, stylelint will look for a `.stylelintrc` configuration file in [standard rc-file places](https://github.com/dominictarr/rc#standards).
 
-### configBasedir
+### `configBasedir`
 
 An absolute path to the directory that relative paths defining `extends` and `plugins` are *relative to*.
 
 If the `config` object passed uses relative paths for `extends` or `plugins`, you are going to have to pass a `configBasedir`. If not, you do not need this.
 
-### configOverrides
+### `configOverrides`
 
 A partial stylelint configuration object whose properties will override the existing config object, whether that config was loaded via the `config` option or a `.stylelintrc` file.
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "meow": "^3.3.0",
     "postcss": "^5.0.4",
     "postcss-reporter": "^1.3.0",
+    "postcss-scss": "^0.1.3",
     "postcss-selector-parser": "^1.2.0",
     "queue-async": "^1.0.7",
     "rc": "^1.1.1",
@@ -53,7 +54,8 @@
     "tape": "^4.2.0"
   },
   "scripts": {
-    "prepublish": "babel src --out-dir dist",
+    "build": "babel src --out-dir dist",
+    "prepublish": "npm run build",
     "lint": "eslint . --ignore-path .gitignore",
     "tape": "babel-tape-runner \"src/**/__tests__/*.js\"",
     "test": "npm run lint && npm run tape"

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -54,7 +54,7 @@ test("standalone with input file(s)", t => {
 test("standalone with input css", t => {
   let planned = 0
 
-  standalone({ css: "a {}", config: configBlockNoEmpty })
+  standalone({ code: "a {}", config: configBlockNoEmpty })
     .then(({ output, results }) => {
       t.equal(typeof output, "string")
       t.equal(results.length, 1)
@@ -71,7 +71,7 @@ test("standalone with extending configuration and configBasedir", t => {
   let planned = 0
 
   standalone({
-    css: "a {}",
+    code: "a {}",
     config: configExtendingOne,
     configBasedir: path.join(__dirname, "fixtures"),
   })
@@ -86,7 +86,7 @@ test("standalone with extending configuration and configBasedir", t => {
 
   // Recursive extending
   standalone({
-    css: "a {}",
+    code: "a {}",
     config: configExtendingAnotherExtend,
     configBasedir: path.join(__dirname, "fixtures"),
   })
@@ -101,7 +101,7 @@ test("standalone with extending configuration and configBasedir", t => {
 
   // Extending with overrides
   standalone({
-    css: "a {}",
+    code: "a {}",
     config: configExtendingThreeWithOverride,
     configBasedir: path.join(__dirname, "fixtures"),
   })
@@ -118,7 +118,7 @@ test("standalone with extending configuration and no configBasedir", t => {
   let planned = 0
 
   standalone({
-    css: "a {}",
+    code: "a {}",
     config: configExtendingOne,
   })
     .then(() => {})
@@ -133,7 +133,7 @@ test("standalone with extending configuration and no configBasedir", t => {
 test("standalone with input css and alternate formatter specified by keyword", t => {
   let planned = 0
 
-  standalone({ css: "a {}", config: configBlockNoEmpty, formatter: "string" })
+  standalone({ code: "a {}", config: configBlockNoEmpty, formatter: "string" })
     .then(({ output }) => {
       const strippedOutput = chalk.stripColor(output)
       t.equal(typeof output, "string")
@@ -149,7 +149,7 @@ test("standalone with input css and alternate formatter specified by keyword", t
 test("standalone with input css and alternate formatter function", t => {
   let planned = 0
 
-  standalone({ css: "a {}", config: configBlockNoEmpty, formatter: stringFormatter })
+  standalone({ code: "a {}", config: configBlockNoEmpty, formatter: stringFormatter })
     .then(({ output }) => {
       const strippedOutput = chalk.stripColor(output)
       t.equal(typeof output, "string")
@@ -171,13 +171,39 @@ test("standalone with input css and quiet mode", t => {
     },
   }
 
-  standalone({ css: "a {}", config })
+  standalone({ code: "a {}", config })
     .then(({ output }) => {
       const parsedOutput = JSON.parse(output)
       t.deepEqual(parsedOutput[0].warnings, [])
     })
     .catch(logError)
   planned += 1
+
+  t.plan(planned)
+})
+
+test("standalone with scss syntax", t => {
+  let planned = 0
+  const config = {
+    rules: {
+      "block-no-empty": 2,
+    },
+  }
+
+  standalone({
+    config,
+    code: "$foo: bar; // foo;\nb {}",
+    syntax: "scss",
+    formatter: stringFormatter,
+  })
+    .then(({ output }) => {
+      const strippedOutput = chalk.stripColor(output)
+      t.equal(typeof output, "string")
+      t.ok(strippedOutput.indexOf("2:3") !== -1)
+      t.ok(strippedOutput.indexOf("block-no-empty") !== -1)
+    })
+    .catch(logError)
+  planned += 3
 
   t.plan(planned)
 })

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,7 @@
 
 import meow from "meow"
 import path from "path"
-import { assign } from "lodash"
+import { assign, includes } from "lodash"
 import getStdin from "get-stdin"
 import standalone from "./standalone"
 
@@ -16,6 +16,7 @@ const minimistOptions = {
     q: "quiet",
   },
 }
+const syntaxOptions = ["scss"]
 
 const meowOptions = {
   help: [
@@ -36,6 +37,8 @@ const meowOptions = {
     "  --custom-formatter  Path to a JS file exporting a custom formatting function",
     "  -f, --formatter     Specify a formatter: \"json\" or \"string\". Default is \"string\".",
     "  -q, --quiet         Only register warnings for rules with a severity of 2 (ignore level 1)",
+    "  -s, --syntax        Specify a non-standard syntax that should be used to ",
+    "                      parse source stylesheets. Options: \"scss\"",
   ],
   pkg: "../package.json",
 }
@@ -55,12 +58,16 @@ if (cli.flags.quiet) {
   optionsBase.configOverrides.quiet =  cli.flags.quiet
 }
 
+if (cli.flags.s && includes(syntaxOptions, cli.flags.s)) {
+  optionsBase.syntax = cli.flags.s
+}
+
 let optionsReady = (cli.input.length)
   ? Promise.resolve(assign({}, optionsBase, {
     files: cli.input,
   }))
   : getStdin().then(stdin => Promise.resolve(assign({}, optionsBase, {
-    css: stdin,
+    code: stdin,
   })))
 
 optionsReady.then(options => {


### PR DESCRIPTION
Additionally, I changed the `css` option to `code` (because it might be not straight CSS).

I also added ticks around some option headings in the api docs. @jeddy3, not sure if you want to do that consistently across the files?