### PR TITLE
Add rule-single-line-max-declarations rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Added: `rule-single-line-max-declarations` rule.
+
 # 2.0.0
 
 * Added: CLI.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -119,6 +119,7 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 * [`rule-no-single-line`](../../src/rules/rule-no-single-line/README.md): Disallow single-line rules.
 * [`rule-non-nested-empty-line-before`](../../src/rules/rule-non-nested-empty-line-before/README.md): Require or disallow an empty line before non-nested rules.
 * [`rule-properties-order`](../../src/rules/rule-properties-order/README.md): Specify the order of properties within rules.
+* [`rule-single-line-max-declarations`](../../src/rules/rule-single-line-max-declarations/README.md): Limit the number of declaration within a single line rule.
 * [`rule-trailing-semicolon`](../../src/rules/rule-trailing-semicolon/README.md): Require or disallow a trailing semicolon within rules.
 
 ### Root

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -66,6 +66,7 @@ import ruleNonNestedEmptyLineBefore from "./rule-non-nested-empty-line-before"
 import ruleNoShorthandPropertyOverrides from "./rule-no-shorthand-property-overrides"
 import ruleNoSingleLine from "./rule-no-single-line"
 import rulePropertiesOrder from "./rule-properties-order"
+import ruleSingleLineMaxDeclarations from "./rule-single-line-max-declarations"
 import ruleTrailingSemicolon from "./rule-trailing-semicolon"
 import selectorCombinatorSpaceAfter from "./selector-combinator-space-after"
 import selectorCombinatorSpaceBefore from "./selector-combinator-space-before"
@@ -157,6 +158,7 @@ export default {
   "rule-no-single-line": ruleNoSingleLine,
   "rule-non-nested-empty-line-before": ruleNonNestedEmptyLineBefore,
   "rule-properties-order": rulePropertiesOrder,
+  "rule-single-line-max-declarations": ruleSingleLineMaxDeclarations,
   "rule-trailing-semicolon": ruleTrailingSemicolon,
   "selector-combinator-space-after": selectorCombinatorSpaceAfter,
   "selector-combinator-space-before": selectorCombinatorSpaceBefore,

--- a/src/rules/rule-single-line-max-declarations/README.md
+++ b/src/rules/rule-single-line-max-declarations/README.md
@@ -1,0 +1,28 @@
+# rule-single-line-max-declarations
+
+Limit the number of declaration within a single line rule.
+
+## Options
+
+`int`: Maximum number of declarations allowed.
+
+For example, with `1`:
+
+The following patterns are considered warnings:
+
+```css
+a { color: pink; top: 3px; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: pink; }
+```
+
+```css
+a {
+  color: pink;
+  top: 3px;
+}
+```

--- a/src/rules/rule-single-line-max-declarations/__tests__/index.js
+++ b/src/rules/rule-single-line-max-declarations/__tests__/index.js
@@ -1,0 +1,48 @@
+import {
+  ruleTester,
+  warningFreeBasics,
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(1, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; }\n")
+  tr.ok("a \n{ color: pink; top: 3px; }")
+  tr.ok("a {\n color: pink; top: 3px; }")
+  tr.ok("a { color: pink;\n top: 3px; }")
+  tr.ok("a,\nb { color: pink; top: 3px; }")
+  tr.ok("@media screen {\na { color: pink; }}")
+  tr.ok("a { color: pink; }\r\n")
+  tr.ok("a \r\n{ color: pink; top: 3px; }")
+  tr.ok("a {\r\n color: pink; top: 3px; }")
+  tr.ok("a { color: pink;\r\n top: 3px; }")
+
+  tr.notOk(
+    "a { color: pink; top: 3px; }",
+    messages.expected(1),
+    "single-line rule with 2 declarations"
+  )
+
+  tr.notOk(
+    "@media screen {\na { color: pink; top: 3px; }}",
+    messages.expected(1),
+    "single-line rule with 2 declarations within nested multi-line"
+  )
+})
+
+testRule(2, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }")
+  tr.ok("a { color: pink; top: 1px; }")
+
+  tr.notOk(
+    "a { color: pink; top: 3px; right: 2px; }",
+    messages.expected(2),
+    "single-line rule with 3 declarations"
+  )
+})

--- a/src/rules/rule-single-line-max-declarations/index.js
+++ b/src/rules/rule-single-line-max-declarations/index.js
@@ -1,0 +1,41 @@
+import { isNumber } from "lodash"
+import {
+  isSingleLineString,
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "rule-no-single-line"
+
+export const messages = ruleMessages(ruleName, {
+  expected: (quantity) => `Expected a maxiumn of ${quantity} declaration(s)`,
+})
+
+export default function (quantity) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: quantity,
+      possible: [isNumber],
+    })
+    if (!validOptions) { return }
+
+    root.walkRules(rule => {
+
+      if (!isSingleLineString(rule.toString())) { return }
+
+      const decls = []
+      rule.walkDecls(function (decl) {
+        decls.push(decl)
+      })
+      if (decls.length <= quantity) { return }
+
+      report({
+        message: messages.expected(quantity),
+        node: rule,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/rule-single-line-max-declarations/index.js
+++ b/src/rules/rule-single-line-max-declarations/index.js
@@ -9,7 +9,7 @@ import {
 export const ruleName = "rule-no-single-line"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (quantity) => `Expected a maxiumn of ${quantity} declaration(s)`,
+  expected: (quantity) => `Expected a maximum of ${quantity} declaration(s)`,
 })
 
 export default function (quantity) {

--- a/src/rules/rule-single-line-max-declarations/index.js
+++ b/src/rules/rule-single-line-max-declarations/index.js
@@ -24,10 +24,8 @@ export default function (quantity) {
 
       if (!isSingleLineString(rule.toString())) { return }
 
-      const decls = []
-      rule.walkDecls(function (decl) {
-        decls.push(decl)
-      })
+      const decls = rule.nodes.filter(node => node.type === "decl")
+      
       if (decls.length <= quantity) { return }
 
       report({


### PR DESCRIPTION
Thought I’d make a start on the rules that don't need `postcss-value-parser`, while we wait to see what happens with https://github.com/TrySound/postcss-value-parser/issues/12