### PR TITLE
Add rule : color-no-named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added: `rule-single-line-max-declarations` rule.
 * Added: `color-no-hex` rule.
 * Added: `function-blacklist` rule.
+* Added: `color-no-named` rule.
 
 # 2.0.0
 

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -16,6 +16,7 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 * [`color-hex-length`](../../src/rules/color-hex-length/README.md): Specify short or long notation for hex colors.
 * [`color-no-hex`](../../src/rules/color-no-hex/README.md): Disallow hex colors.
 * [`color-no-invalid-hex`](../../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
+* [`color-no-named`](../../src/rules/color-no-named/README.md): Disallow named colors.
 
 ### Number
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "execall": "^1.0.0",
     "get-stdin": "^5.0.0",
     "globby": "^3.0.1",
+    "is-css-color-name": "^0.1.1",
     "lodash": "^3.10.1",
     "meow": "^3.3.0",
     "postcss": "^5.0.4",

--- a/src/rules/color-no-named/README.md
+++ b/src/rules/color-no-named/README.md
@@ -1,0 +1,37 @@
+# color-no-named
+
+Disallow named colors.
+
+```css
+    a { color: black }
+/**              ↑
+ * These named colors */
+```
+
+The following patterns are considered warnings:
+
+```css
+a { color: black; }
+```
+
+```css
+a { color: rebeccapurple; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: #000; }
+```
+
+```css
+a { color: rgb(0, 0, 0); }
+```
+
+```css
+a { color: var(--foo-color-white); }
+```
+
+```scss
+a { color: $blue; }
+```

--- a/src/rules/color-no-named/__tests__/index.js
+++ b/src/rules/color-no-named/__tests__/index.js
@@ -1,0 +1,53 @@
+import {
+  ruleTester,
+  warningFreeBasics,
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(undefined, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: #000; }")
+  tr.ok("a { color: #ababab; }")
+  tr.ok("a { color: rgba(0, 0, 0, 0); }")
+  tr.ok("a { something: #000, #fff, #333; }")
+
+  tr.ok("a { padding: 000; }")
+  tr.ok("a::before { content: \"#ababa\"; }")
+
+  tr.ok("a { border-#$side: 0; }", "ignore sass-like interpolation")
+  tr.ok("a { box-sizing: #$type-box; }", "ignore sass-like interpolation")
+  tr.ok("a { color: $black; }", "ignore sass-like interpolation")
+
+  tr.ok("a { color: var(--some-color-blue); }", "ignore css variable named with color")
+
+  tr.notOk("a { color: red; }", {
+    message: messages.rejected("red"),
+    line: 1,
+    column: 12,
+  })
+  tr.notOk("a { color: rebeccapurple; }", {
+    message: messages.rejected("rebeccapurple"),
+    line: 1,
+    column: 12,
+  })
+  tr.notOk("a { something: #00c, red, #fff; }", {
+    message: messages.rejected("red"),
+    line: 1,
+    column: 22,
+  })
+  tr.notOk("a { something: #fff1a1, rgb(250, 250, 0), black; }", {
+    message: messages.rejected("black"),
+    line: 1,
+    column: 43,
+  })
+
+  // No supplementary spaces after colon or comma
+  tr.notOk("a { something:#cccccc,white,#12345a; }", {
+    message: messages.rejected("white"),
+    line: 1,
+    column: 23,
+  })
+})

--- a/src/rules/color-no-named/__tests__/index.js
+++ b/src/rules/color-no-named/__tests__/index.js
@@ -14,14 +14,21 @@ testRule(undefined, tr => {
   tr.ok("a { color: rgba(0, 0, 0, 0); }")
   tr.ok("a { something: #000, #fff, #333; }")
 
+  tr.ok("/** color: black; */", "ignore color names within comments")
+
+  tr.ok("a::before { content: \"orange\" }", "ignore color names within doubl quotes")
+  tr.ok("a::before { content: 'orange' }", "ignore color names within single quotes")
+
+  tr.ok("a { background-image: url(./black.png); }", "ignore color names within urls")
+
   tr.ok("a { padding: 000; }")
   tr.ok("a::before { content: \"#ababa\"; }")
 
-  tr.ok("a { border-#$side: 0; }", "ignore sass-like interpolation")
-  tr.ok("a { box-sizing: #$type-box; }", "ignore sass-like interpolation")
-  tr.ok("a { color: $black; }", "ignore sass-like interpolation")
+  tr.ok("a { color: $black; }", "ignore sass variable named with color")
 
   tr.ok("a { color: var(--some-color-blue); }", "ignore css variable named with color")
+
+  tr.ok("a { animation: spin-blue 2s linear; }", "ignore keyframe animation name that includes colors")
 
   tr.notOk("a { color: red; }", {
     message: messages.rejected("red"),

--- a/src/rules/color-no-named/index.js
+++ b/src/rules/color-no-named/index.js
@@ -1,0 +1,41 @@
+import valueParser from "postcss-value-parser"
+import isCssColorName from "is-css-color-name"
+
+import {
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "color-no-named"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: c => `Unexpected named color "${c}"`,
+})
+
+export default function (actual) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, { actual })
+    if (!validOptions) { return }
+
+    root.walkDecls(decl => {
+      const { value } = decl
+
+      valueParser(value).walk(function (node) {
+        const charsBeforeColon = decl.toString().indexOf(":")
+        const charsAfterColon = decl.raw("between").length - decl.raw("between").indexOf(":")
+
+        if (isCssColorName(node.value)) {
+          report({
+            message: messages.rejected(node.value),
+            node: decl,
+            index: charsBeforeColon + charsAfterColon + node.sourceIndex,
+            result,
+            ruleName,
+          })
+        }
+      })
+    })
+  }
+}
+

--- a/src/rules/color-no-named/index.js
+++ b/src/rules/color-no-named/index.js
@@ -25,7 +25,7 @@ export default function (actual) {
         const charsBeforeColon = decl.toString().indexOf(":")
         const charsAfterColon = decl.raw("between").length - decl.raw("between").indexOf(":")
 
-        if (isCssColorName(node.value)) {
+        if (isCssColorName(node.value) && !node.quote) {
           report({
             message: messages.rejected(node.value),
             node: decl,

--- a/src/rules/color-no-named/index.js
+++ b/src/rules/color-no-named/index.js
@@ -2,6 +2,7 @@ import valueParser from "postcss-value-parser"
 import isCssColorName from "is-css-color-name"
 
 import {
+  declarationValueIndexOffset,
   report,
   ruleMessages,
   validateOptions,
@@ -22,14 +23,12 @@ export default function (actual) {
       const { value } = decl
 
       valueParser(value).walk(function (node) {
-        const charsBeforeColon = decl.toString().indexOf(":")
-        const charsAfterColon = decl.raw("between").length - decl.raw("between").indexOf(":")
 
         if (isCssColorName(node.value) && !node.quote) {
           report({
             message: messages.rejected(node.value),
             node: decl,
-            index: charsBeforeColon + charsAfterColon + node.sourceIndex,
+            index: declarationValueIndexOffset(decl) + node.sourceIndex,
             result,
             ruleName,
           })

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -13,6 +13,7 @@ import colorHexCase from "./color-hex-case"
 import colorHexLength from "./color-hex-length"
 import colorNoHex from "./color-no-hex"
 import colorNoInvalidHex from "./color-no-invalid-hex"
+import colorNoNamed from "./color-no-named"
 import commentEmptyLineBefore from "./comment-empty-line-before"
 import commentSpaceInside from "./comment-space-inside"
 import customMediaPattern from "./custom-media-pattern"
@@ -107,6 +108,7 @@ export default {
   "color-hex-length": colorHexLength,
   "color-no-hex": colorNoHex,
   "color-no-invalid-hex": colorNoInvalidHex,
+  "color-no-named": colorNoNamed,
   "comment-empty-line-before": commentEmptyLineBefore,
   "comment-space-inside": commentSpaceInside,
   "custom-media-pattern": customMediaPattern,

--- a/src/utils/declarationValueIndexOffset.js
+++ b/src/utils/declarationValueIndexOffset.js
@@ -1,0 +1,6 @@
+export default function (decl) {
+  const charsBeforeColon = decl.toString().indexOf(":")
+  const charsAfterColon = decl.raw("between").length - decl.raw("between").indexOf(":")
+
+  return charsBeforeColon + charsAfterColon
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,6 +6,7 @@ import cssStatementHasBlock from "./cssStatementHasBlock"
 import cssStatementHasEmptyBlock from "./cssStatementHasEmptyBlock"
 import cssStatementIsNestingBlock from "./cssStatementIsNestingBlock"
 import cssStatementStringBeforeBlock from "./cssStatementStringBeforeBlock"
+import declarationValueIndexOffset from "./declarationValueIndexOffset"
 import isAutoprefixable from "./isAutoprefixable"
 import isSingleLineString from "./isSingleLineString"
 import isWhitespace from "./isWhitespace"
@@ -29,6 +30,7 @@ export default {
   cssStatementHasEmptyBlock,
   cssStatementIsNestingBlock,
   cssStatementStringBeforeBlock,
+  declarationValueIndexOffset,
   isAutoprefixable,
   isSingleLineString,
   isWhitespace,


### PR DESCRIPTION
ref : #424
> is-named-css-color might be useful here.

I used [is-css-color-name](https://www.npmjs.com/package/is-css-color-name).
[is-named-css-color](https://www.npmjs.com/package/is-named-css-color) returns `true` if the color value such as `$color-name-black` and `var(--color-name-white)`. I think that the variables like `$color-name-black` should be valid in this rule because the variable that contains with color name is not always color name.
 