### PR TITLE
Add rule: max-line-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+* Added: `max-line-length` rule.
 * Added: `rule-single-line-max-declarations` rule.
 * Added: `color-no-hex` rule.
 * Added: `function-blacklist` rule.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -164,6 +164,7 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 ### General / Sheet
 
 * [`indentation`](../../src/rules/indentation/README.md): Specify indentation.
+* [`max-line-length`](../../src/rules/max-line-length/README.md): Limit the length of a line.
 * [`no-eol-whitespace`](../../src/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
 * [`no-missing-eof-newline`](../../src/rules/no-missing-eof-newline/README.md): Disallow missing end-of-file newline.
 * [`no-multiple-empty-lines`](../../src/rules/no-multiple-empty-lines/README.md): Disallow multiple empty lines.

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -39,6 +39,7 @@ import functionParenthesesSpaceInside from "./function-parentheses-space-inside"
 import functionSpaceAfter from "./function-space-after"
 import functionUrlQuotes from "./function-url-quotes"
 import indentation from "./indentation"
+import maxLineLength from "./max-line-length"
 import mediaFeatureColonSpaceAfter from "./media-feature-colon-space-after"
 import mediaFeatureColonSpaceBefore from "./media-feature-colon-space-before"
 import mediaFeatureNameNoVendorPrefix from "./media-feature-name-no-vendor-prefix"
@@ -133,6 +134,7 @@ export default {
   "function-space-after": functionSpaceAfter,
   "function-url-quotes": functionUrlQuotes,
   "indentation": indentation,
+  "max-line-length": maxLineLength,
   "media-feature-colon-space-after": mediaFeatureColonSpaceAfter,
   "media-feature-colon-space-before": mediaFeatureColonSpaceBefore,
   "media-feature-name-no-vendor-prefix": mediaFeatureNameNoVendorPrefix,

--- a/src/rules/max-line-length/README.md
+++ b/src/rules/max-line-length/README.md
@@ -8,7 +8,7 @@ Limit the length of a line.
  *           The end */
 ```
 
-Lines that exceed the maximum length, but contain no whitespace (other than at the beginning of the line) are ignored.
+Lines that exceed the maximum length but contain no whitespace (other than at the beginning of the line) are ignored.
 
 ## Options
 

--- a/src/rules/max-line-length/README.md
+++ b/src/rules/max-line-length/README.md
@@ -1,1 +1,44 @@
 # max-line-length
+
+Limit the length of a line.
+
+```css
+    a { color: red }
+/**                ↑
+ *           The end */
+```
+
+Lines that exceed the maximum length, but contain no whitespace (other than at the beginning of the line) are ignored.
+
+## Options
+
+`int`: Maximum number of characters allowed.
+
+For example, with `20`:
+
+The following patterns are considered warnings:
+
+```css
+a { color: 0; top: 0; }
+```
+
+```css
+a {
+  background: url(a-url-that-is-over-20-characters-long);
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  color: 0;
+  top: 0;
+}
+```
+
+```css
+a {
+  background:
+    url(a-url-that-is-over-20-characters-long);
+}

--- a/src/rules/max-line-length/README.md
+++ b/src/rules/max-line-length/README.md
@@ -1,0 +1,1 @@
+# max-line-length

--- a/src/rules/max-line-length/__tests__/index.js
+++ b/src/rules/max-line-length/__tests__/index.js
@@ -1,0 +1,65 @@
+import {
+  ruleTester,
+  warningFreeBasics,
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule("20", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: 0; }")
+  tr.ok("a {  color   : 0 ; }")
+  tr.ok("a { color: 0;\n  top: 0; }")
+  tr.ok("@media print {\n  a {\n    color: pink;\n }\n}")
+
+  tr.ok("a {\n  background: url(\n  somethingsomethingsomethingsomething\n  );\n}")
+
+  tr.notOk("a {   color   : 0  ;}", {
+    message: messages.expected(20),
+    line: 1,
+    column: 21,
+  })
+  tr.notOk("a { color: 0; top: 0; }", {
+    message: messages.expected(20),
+    line: 1,
+    column: 23,
+  })
+  tr.notOk("a { color: 0;\n  top: 0; bottom: 0; right: 0; \n  left: 0; }", {
+    message: messages.expected(20),
+    line: 2,
+    column: 31,
+  })
+  tr.notOk("a { color: 0;\n  top: 0;\n  left: 0; bottom: 0; right: 0; }", {
+    message: messages.expected(20),
+    line: 3,
+    column: 33,
+  })
+  tr.notOk("@media print {\n  a {\n    color: pink; background: orange;\n }\n}", {
+    message: messages.expected(20),
+    line: 3,
+    column: 36,
+  })
+  tr.notOk("@media (min-width: 30px) and screen {}", {
+    message: messages.expected(20),
+    line: 1,
+    column: 38,
+  })
+  tr.notOk("a {\n  background: url(somethingsomethingsomethingsomething);\n}", {
+    message: messages.expected(20),
+    line: 2,
+    column: 56,
+  })
+})
+
+testRule("30", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: 0;\n  top: 0; left: 0; right: 0; \n  bottom: 0; }")
+  tr.notOk("a { color: 0;\n  top: 0; left: 0; right: 0; background: pink; \n  bottom: 0; }", {
+    message: messages.expected(30),
+    line: 2,
+    column: 47,
+  })
+})

--- a/src/rules/max-line-length/index.js
+++ b/src/rules/max-line-length/index.js
@@ -1,0 +1,52 @@
+import { isNumber } from "lodash"
+import {
+  ruleMessages,
+  styleSearch,
+  report,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "max-line-length"
+
+export const messages = ruleMessages(ruleName, {
+  expected: l => `Expected line length equal to or less than ${l} characters`,
+})
+
+export default function (length) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      length: isNumber,
+    })
+    if (!validOptions) { return }
+
+    const rootString = root.source.input.css
+
+    // Check first line
+    checkNewline({ endIndex: 0 })
+
+    // Check subsequent lines
+    styleSearch({ source: rootString, target: ["\n"], checkComments: true }, checkNewline)
+
+    function checkNewline(match) {
+      let nextNewlineIndex = rootString.indexOf("\n", match.endIndex)
+
+      // Accommodate last line
+      if (nextNewlineIndex === -1) nextNewlineIndex = rootString.length
+
+      if (nextNewlineIndex - match.endIndex <= length) { return }
+
+      // If there are no spaces besides initial (indent) spaces, ignore
+      if (rootString.slice(match.endIndex, nextNewlineIndex).replace(/^\s+/, "").indexOf(" ") === -1) {
+        return
+      }
+
+      report({
+        message: messages.expected(length),
+        node: root,
+        index: nextNewlineIndex - 1,
+        result,
+        ruleName,
+      })
+    }
+  }
+}


### PR DESCRIPTION
Addresses #423.

Here's a draft of the rule. While working out the tests I decided that the only long lines I thought should be accommodated were those with no whitespace except at the line's start. I think that in all the other situations you actually could make something multiline --- and the purpose of the rule is to force that, so I didn't want to make a limited set of punctuation marks that evaded the rule.

I did not write documentation. First I just wanted to see what @jeddy3 and @MadLittleMods thought of what's there. Thanks!