### PR TITLE
Add possibleArray to validateOptions

### DIFF
--- a/src/rules/function-whitelist/index.js
+++ b/src/rules/function-whitelist/index.js
@@ -19,7 +19,7 @@ export default function (whitelist) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: whitelist,
-      possible: [isString],
+      possibleArray: [isString],
     })
     if (!validOptions) { return }
     root.walkDecls(decl => {

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -201,3 +201,35 @@ test("validateOptions for multiple actual/possible pairs, checking return value"
 
   t.end()
 })
+
+test("validateOptions with `possibleArray`", t => {
+  const result = mockResult()
+
+  const validOptions = validateOptions(result, "foo", {
+    possibleArray: [ "one", "two" ],
+    actual: [ "one", "one", "two" ],
+  })
+  t.equal(validOptions, true)
+  t.notOk(result.warn.called)
+  result.warn.reset()
+
+  const invalidOptions1 = validateOptions(result, "bar", {
+    possibleArray: [ "three", "four" ],
+    actual: "three",
+  })
+  t.equal(invalidOptions1, false)
+  t.ok(result.warn.calledOnce)
+  t.ok(result.warn.calledWith("Expected an array option value for rule \"bar\""))
+  result.warn.reset()
+
+  const invalidOptions2 = validateOptions(result, "bar", {
+    possibleArray: [ "three", "four" ],
+    actual: ["five"],
+  })
+  t.equal(invalidOptions2, false)
+  t.ok(result.warn.calledOnce)
+  t.ok(result.warn.calledWith("Invalid option value \"five\" for rule \"bar\""))
+  result.warn.reset()
+
+  t.end()
+})


### PR DESCRIPTION
This is an effort to address #449, so that issue doesn't hold up releases.

I've made it so that `validateOptions` objects can be given a `possibleArray` property (in addition to the original `possible` property). If a `possibleArray` property is provided, the validator will complain if the actual option is not an array, and it will complain if any of the option array's items do not align with `possibleArray`'s value.

I tried this out in function-whitelist to see if it worked, and it seemed to.

The next step would be to apply it to the other relevant rules listed in #449 and double-check that it gives users the feedback that they would need.

@jeddy3 Any chance you could finish this one off?