### PR TITLE
Anticipate single values in white- and blacklist rules

### DIFF
--- a/src/rules/function-whitelist/__tests__/index.js
+++ b/src/rules/function-whitelist/__tests__/index.js
@@ -67,3 +67,13 @@ testRule([
   })
 
 })
+
+// Simple test for non-array primary option
+testRule("translate", tr => {
+  tr.ok("a { transform: translate(1px); }")
+  tr.notOk("a { transform: scale(4); }", {
+    message: messages.rejected("scale"),
+    line: 1,
+    column: 16,
+  })
+})

--- a/src/rules/function-whitelist/index.js
+++ b/src/rules/function-whitelist/index.js
@@ -15,7 +15,8 @@ export const messages = ruleMessages(ruleName, {
   rejected: (name) => `Unexpected function "${name}"`,
 })
 
-export default function (whitelist) {
+export default function (whitelistInput) {
+  const whitelist = [].concat(whitelistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: whitelist,

--- a/src/rules/property-blacklist/index.js
+++ b/src/rules/property-blacklist/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
   rejected: (p) => `Unexpected property "${p}"`,
 })
 
-export default function (blacklist) {
+export default function (blacklistInput) {
+  const blacklist = [].concat(blacklistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: blacklist,

--- a/src/rules/property-whitelist/index.js
+++ b/src/rules/property-whitelist/index.js
@@ -12,7 +12,8 @@ export const messages = ruleMessages(ruleName, {
   rejected: (p) => `Unexpected property "${p}"`,
 })
 
-export default function (whitelist) {
+export default function (whitelistInput) {
+  const whitelist = [].concat(whitelistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: whitelist,

--- a/src/rules/unit-blacklist/index.js
+++ b/src/rules/unit-blacklist/index.js
@@ -14,7 +14,8 @@ export const messages = ruleMessages(ruleName, {
   rejected: (u) => `Unexpected unit "${u}"`,
 })
 
-export default function (blacklist) {
+export default function (blacklistInput) {
+  const blacklist = [].concat(blacklistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: blacklist,

--- a/src/rules/unit-whitelist/index.js
+++ b/src/rules/unit-whitelist/index.js
@@ -14,7 +14,8 @@ export const messages = ruleMessages(ruleName, {
   rejected: (u) => `Unexpected unit "${u}"`,
 })
 
-export default function (whitelist) {
+export default function (whitelistInput) {
+  const whitelist = [].concat(whitelistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: whitelist,


### PR DESCRIPTION
This address #449. As discussed: We don't need to validate for arrays because we have no reason not to accept single values. So this slight change to the code for the whitelist/blacklist rules allows it to accept single values or arrays.

The same logic could be applied to future rules, of course.