### PR TITLE
Fix line judgment for function-comma whitespace rules; fixes #462

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added: `unit-whitelist` rule.
 * Added: `property-unit-blacklist` rule.
 * Fixed: bug when loading plugins from an extended config
+* Fixed: bug causing `function-comma-*` whitespace rules to improperly judge whether to enforce single- or multi-line options.
 
 # 2.0.0
 

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -62,6 +62,14 @@ testRule("always-multi-line", tr => {
   tr.ok("a { transform: translate(1,  1); }")
   tr.ok("a { transform: translate(1, 1); }")
   tr.ok("a { transform: translate(1,\t1); }")
+  tr.ok("a {\r\n  transform:\r\n    translate(1,1)\r\n  scale(3);\r\n}", "CRLF")
+  tr.ok(`
+    .foo {
+      box-shadow:
+        inset 0 8px 8px -8px rgba(0, 0, 0, 1)
+        inset 0 -10px 12px 0 #f00;
+    }
+  `)
 
   tr.notOk("a { transform: color(rgb(0 , 0 ,\n0) lightness(50%)); }", {
     message: messages.expectedAfterMultiLine(),

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -154,4 +154,9 @@ testRule("never-single-line", tr => {
     line: 1,
     column: 43,
   })
+  tr.notOk("a { transform: lightness(50%)\ncolor(rgb(0 , 0 ,0) ); }", {
+    message: messages.rejectedAfterSingleLine(),
+    line: 2,
+    column: 13,
+  })
 })


### PR DESCRIPTION
We needed to check the function string itself for whether to enforce single- or multi-line options. We were erroneously checking the whole declaration.