### PR TITLE
Nested function comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 * Added: `configFile` option to PostCSS plugin.
+* Fixed: `function-parentheses-newline-inside` and `function-parentheses-space-inside` bug with nested functions.
 
 # 2.2.0
 

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -70,6 +70,16 @@ testRule("always-multi-line", tr => {
         inset 0 -10px 12px 0 #f00;
     }
   `)
+  tr.ok(`
+    .foo {
+      background-image:
+        repeating-linear-gradient(
+          -45deg,
+          transparent,
+          rgba(0, 0, 0, 1) 5px
+        );
+      }
+  `)
 
   tr.notOk("a { transform: color(rgb(0 , 0 ,\n0) lightness(50%)); }", {
     message: messages.expectedAfterMultiLine(),
@@ -80,6 +90,11 @@ testRule("always-multi-line", tr => {
     message: messages.expectedAfterMultiLine(),
     line: 2,
     column: 4,
+  })
+  tr.notOk("a { background-image: repeating-linear-gradient(\n-45deg,\ntransparent, rgba(0, 0, 0, 1) 5px\n);}", {
+    message: messages.expectedAfterMultiLine(),
+    line: 3,
+    column: 12,
   })
 })
 

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -15,6 +15,7 @@ testRule("always", tr => {
   tr.ok("a { transform: translate(1 ,\n1); }")
   tr.ok("a { transform: translate(1,\r\n1); }", "CRLF")
   tr.ok("a { transform: color(rgb(0 ,\n\t0,\n\t0) lightness(50%)); }")
+  tr.ok("a { background: linear-gradient(45deg,\n rgba(0,\n 0,\n 0,\n 1),\n red); }")
 
   tr.notOk("a { transform: translate(1,1); }", {
     message: messages.expectedAfter(),
@@ -45,6 +46,11 @@ testRule("always", tr => {
     message: messages.expectedAfter(),
     line: 2,
     column: 4,
+  })
+  tr.notOk("a { background: linear-gradient(45deg,\n rgba(0,\n 0, 0,\n 1),\n red); }", {
+    message: messages.expectedAfter(),
+    line: 3,
+    column: 3,
   })
 })
 
@@ -96,6 +102,11 @@ testRule("always-multi-line", tr => {
     line: 3,
     column: 12,
   })
+  tr.notOk("a { background: linear-gradient(45deg,rgba(0,\n0 ,\n 0 ,\n 1)); }", {
+    message: messages.expectedAfterMultiLine(),
+    line: 1,
+    column: 38,
+  })
 })
 
 testRule("never-multi-line", tr => {
@@ -111,6 +122,7 @@ testRule("never-multi-line", tr => {
   tr.ok("a { transform: translate(1,  1); }")
   tr.ok("a { transform: translate(1, 1); }")
   tr.ok("a { transform: translate(1,\t1); }")
+  tr.ok("a { background: linear-gradient(45deg\n,rgba(0, 0, 0, 1),red); }")
 
   tr.notOk("a { transform: color(rgb(0 ,0 ,\n0) lightness(50%)); }", {
     message: messages.rejectedAfterMultiLine(),
@@ -131,5 +143,10 @@ testRule("never-multi-line", tr => {
     message: messages.rejectedAfterMultiLine(),
     line: 1,
     column: 43,
+  })
+  tr.notOk("a { background: linear-gradient(45deg\n,rgba(0,0 , 0, 1), red); }", {
+    message: messages.rejectedAfterMultiLine(),
+    line: 2,
+    column: 18,
   })
 })

--- a/src/rules/function-comma-newline-after/index.js
+++ b/src/rules/function-comma-newline-after/index.js
@@ -9,8 +9,8 @@ export const ruleName = "function-comma-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected newline after ","`,
-  expectedAfterMultiLine: () => `Expected newline after "," in a multi-line list`,
-  rejectedAfterMultiLine: () => `Unexpected whitespace after "," in a multi-line list`,
+  expectedAfterMultiLine: () => `Expected newline after "," in a multi-line function`,
+  rejectedAfterMultiLine: () => `Unexpected whitespace after "," in a multi-line function`,
 })
 
 export default function (expectation) {

--- a/src/rules/function-comma-newline-before/__tests__/index.js
+++ b/src/rules/function-comma-newline-before/__tests__/index.js
@@ -65,6 +65,8 @@ testRule("always-multi-line", tr => {
   tr.ok("a { transform: translate(1 , 1); }")
   tr.ok("a { transform: translate(1\t,1); }")
 
+  tr.ok("a { background: linear-gradient(45deg\n, rgba(0, 0, 0, 1)\n, red); }")
+
   tr.notOk("a { transform: color(rgb(0\n, 0, 0) lightness(50%)); }", {
     message: messages.expectedBeforeMultiLine(),
     line: 2,
@@ -74,6 +76,11 @@ testRule("always-multi-line", tr => {
     message: messages.expectedBeforeMultiLine(),
     line: 1,
     column: 42,
+  })
+  tr.notOk("a { background: linear-gradient(45deg\n, rgba(0\n, 0, 0\n, 1)\n, red); }", {
+    message: messages.expectedBeforeMultiLine(),
+    line: 3,
+    column: 4,
   })
 })
 

--- a/src/rules/function-comma-newline-before/index.js
+++ b/src/rules/function-comma-newline-before/index.js
@@ -9,8 +9,8 @@ export const ruleName = "function-comma-newline-before"
 
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected newline before ","`,
-  expectedBeforeMultiLine: () => `Expected newline before "," in a multi-line list`,
-  rejectedBeforeMultiLine: () => `Unexpected whitespace before "," in a multi-line list`,
+  expectedBeforeMultiLine: () => `Expected newline before "," in a multi-line function`,
+  rejectedBeforeMultiLine: () => `Unexpected whitespace before "," in a multi-line function`,
 })
 
 export default function (expectation) {

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -116,6 +116,8 @@ testRule("always-single-line", tr => {
   tr.ok("a { color: rgba(0,0\n,0); }", "CRLF")
   tr.ok("a { color: rgba(0\n,0,0); }", "CRLF")
 
+  tr.ok("a { background: linear-gradient(45deg\n,rgba(0, 0, 0, 1)\n,red); }")
+
   tr.notOk("a { transform: color(rgb(0 , 0 ,0) lightness(50%)); }", {
     message: messages.expectedAfterSingleLine(),
     line: 1,
@@ -125,6 +127,11 @@ testRule("always-single-line", tr => {
     message: messages.expectedAfterSingleLine(),
     line: 1,
     column: 47,
+  })
+  tr.notOk("a { background: linear-gradient(45deg\n,rgba(0, 0,0, 1),red); }", {
+    message: messages.expectedAfterSingleLine(),
+    line: 2,
+    column: 11,
   })
 })
 

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -13,8 +13,8 @@ export const ruleName = "function-comma-space-after"
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => `Expected single space after ","`,
   rejectedAfter: () => `Unexpected whitespace after ","`,
-  expectedAfterSingleLine: () => `Expected single space after "," in a single-line list`,
-  rejectedAfterSingleLine: () => `Unexpected whitespace after "," in a single-line list`,
+  expectedAfterSingleLine: () => `Expected single space after "," in a single-line function`,
+  rejectedAfterSingleLine: () => `Unexpected whitespace after "," in a single-line function`,
 })
 
 export default function (expectation) {

--- a/src/rules/function-comma-space-before/__tests__/index.js
+++ b/src/rules/function-comma-space-before/__tests__/index.js
@@ -116,6 +116,8 @@ testRule("always-single-line", tr => {
   tr.ok("a { transform: translate(1\n, 1); }")
   tr.ok("a { transform: translate(1\n,\n1); }")
 
+  tr.ok("a { background: linear-gradient(45deg,\nrgba(0 , 0 , 0 ,1)\n,red); }")
+
   tr.notOk("a { transform: color(rgb(0 , 0, 0) lightness(50%)); }", {
     message: messages.expectedBeforeSingleLine(),
     line: 1,
@@ -125,6 +127,11 @@ testRule("always-single-line", tr => {
     message: messages.expectedBeforeSingleLine(),
     line: 1,
     column: 46,
+  })
+  tr.notOk("a { background: linear-gradient(45deg,\nrgba(0 , 0,0 ,1),red); }", {
+    message: messages.expectedBeforeSingleLine(),
+    line: 2,
+    column: 11,
   })
 })
 

--- a/src/rules/function-comma-space-before/index.js
+++ b/src/rules/function-comma-space-before/index.js
@@ -10,8 +10,8 @@ export const ruleName = "function-comma-space-before"
 export const messages = ruleMessages(ruleName, {
   expectedBefore: () => `Expected single space before ","`,
   rejectedBefore: () => `Unexpected whitespace before ","`,
-  expectedBeforeSingleLine: () => `Expected single space before "," in a single-line list`,
-  rejectedBeforeSingleLine: () => `Unexpected whitespace before "," in a single-line list`,
+  expectedBeforeSingleLine: () => `Expected single space before "," in a single-line function`,
+  rejectedBeforeSingleLine: () => `Unexpected whitespace before "," in a single-line function`,
 })
 
 export default function (expectation) {


### PR DESCRIPTION
A failing test to go along with #494.

I briefly tried to find a resolution to this one, but I ended up abusing the `outsideFunctionalNotation` option of `styleSearch`. So, I was hoping you’d be able to take a look at it.

P.S. Also updates the messages.