### PR TITLE
Clarify which patterns aren't warnings

### DIFF
--- a/src/rules/color-hex-length/README.md
+++ b/src/rules/color-hex-length/README.md
@@ -35,6 +35,10 @@ a { color: #fff; }
 a { color: #fffa; }
 ```
 
+```css
+a { color: #a4a4a4; }
+```
+
 ### `"long"`
 
 The following patterns are considered warnings:


### PR DESCRIPTION
If it's not possible to write a color any shorter, stylelint will rightly not report it as an error. That's the expected behaviour, but maybe this can be explicitely stated in the docs.