### PR TITLE
New plugin API draft; closes #497

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+* Changed: `plugins` is now an array instead of an object. And plugins should be created with `stylelint.createPlugin()`.
 * Removed: `nesting-block-opening-brace-space-before` and `nesting-block-opening-brace-newline-before` rules.
 * Added: cosmiconfig, which means the following:
   * support for YAML `.stylelintrc`

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -5,7 +5,8 @@
 
 var stylelint = require("stylelint")
 
-var myPluginRule = function(expectationKeyword, optionsObject) {
+var myPluginRuleName = "foobar"
+var myPluginRule = stylelint.createPlugin(myPluginRuleName, function(expectationKeyword, optionsObject) {
   return function(postcssRoot, postcssResult) {
     // ... some logic ...
     stylelint.utils.report({ .. })
@@ -13,9 +14,12 @@ var myPluginRule = function(expectationKeyword, optionsObject) {
 }
 ```
 
-In order for your plugin rule to work with the standard configuration format, (e.g. `[2, "tab", { hierarchicalSelectors: true }]`), it should be a function that accepts 2 arguments: the expectation keyword (e.g. `"tab"`) and, optionally, an options object (e.g. `{ hierarchicalSelectors: true }`).
+`stylelint.createPlugin(ruleName, ruleFunction)` ensures that your plugin will be setup properly alongside other rules.
+*Make sure you document your plugin's rule name for users, because they will need to use it in their config.*
 
-It should return a function that is essentially a little PostCSS plugin: it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult.
+In order for your plugin rule to work with the standard configuration format, (e.g. `[2, "tab", { hierarchicalSelectors: true }]`), `ruleFunction` should accept 2 arguments: the expectation keyword (e.g. `"tab"`) and, optionally, an options object (e.g. `{ hierarchicalSelectors: true }`).
+
+`ruleFunction` should return a function that is essentially a little PostCSS plugin: it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult.
 You'll have to [learn about the PostCSS API](https://github.com/postcss/postcss/blob/master/docs/api.md).
 
 A few of stylelint's internal utilities are exposed publicly in `stylelint.utils`, to help you write plugin rules.
@@ -25,6 +29,7 @@ For details about the APIs of these functions, please look at comments in the so
 your plugin will respect disabled ranges and other possible future features of stylelint, so it will fit in better with the standard rules.
 - `ruleMessages`: Tailor your messages to look like the messages of other stylelint rules. Currently, this means that the name of the rule is appended, in parentheses, to the end of the message.
 - `styleSearch`: Search within CSS strings, and for every match found invoke a callback, passing a match object with details about the match. `styleSearch` ignores CSS strings (e.g. `content: "foo";`) and by default ignores comments. It can also be restricted to substrings within or outside of CSS functional notation.
+- `validateOptions`: Help your user's out by checking that the options they've submitted are valid.
 
 ## Testing plugins
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -86,16 +86,16 @@ Or starting with `stylelint-config-suitcss`, then extending layering `myExtendab
 
 ## `plugins`
 
-[Plugins](/docs/user-guide/plugins.md) are userland rules that support _non-standard_ CSS features, or very specific use cases. To use one, add a `"plugins"` object to your config. Each key is a new rule's name, and its value is a "locater" identifying the plugin.
+[Plugins](/docs/user-guide/plugins.md) are userland rules that support _non-standard_ CSS features, or very specific use cases. To use one, add a `"plugins"` array to your config, containing "locaters" identifying the plugins you want to use.
 As with `extends`, above, a "locater" can be either an npm module name, an absolute path, or a path relative to the invoking configuration file.
 
-Once the plugin is declared, within your `"rules"` object you can add settings for the plugin's rule just like any standard rule.
+Once the plugin is declared, within your `"rules"` object you can add settings for the plugin's rule just like any standard rule. You will have to look at the plugin's documentation to know what the rule name should be.
 
 ```json
 {
-  "plugins": {
-    "special-rule": "../special-rule.js",
-  },
+  "plugins": [
+    "../special-rule.js",
+  ],
   "rules": {
     "special-rule": [2, "everything"],
   },

--- a/src/__tests__/fixtures/config-relative-plugin.json
+++ b/src/__tests__/fixtures/config-relative-plugin.json
@@ -1,7 +1,7 @@
 {
-  "plugins": {
-    "warn-about-foo": "./plugin-warn-about-foo"
-  },
+  "plugins": [
+    "./plugin-warn-about-foo"
+  ],
   "rules": {
     "warn-about-foo": [ 2, "always" ]
   }

--- a/src/__tests__/fixtures/plugin-warn-about-foo.js
+++ b/src/__tests__/fixtures/plugin-warn-about-foo.js
@@ -1,11 +1,13 @@
 import stylelint from "../../"
 
+const ruleName = "warn-about-foo"
+
 const warnAboutFooMessages = stylelint.utils.ruleMessages("warn-about-foo", {
   found: "found .foo",
   notFound: "never found .foo",
 })
 
-export default function (expectation) {
+export default stylelint.createPlugin(ruleName, function (expectation) {
   return (root, result) => {
     let foundFoo
     root.walkRules(rule => {
@@ -13,7 +15,7 @@ export default function (expectation) {
         if (expectation === "always") {
           stylelint.utils.report({
             result,
-            ruleName: "warn-about-foo",
+            ruleName,
             message: warnAboutFooMessages.found,
             node: rule,
           })
@@ -25,9 +27,9 @@ export default function (expectation) {
       stylelint.utils.report({
         result,
         line: 1,
-        ruleName: "warn-about-foo",
+        ruleName,
         message: warnAboutFooMessages.notFound,
       })
     }
   }
-}
+})

--- a/src/__tests__/plugins-test.js
+++ b/src/__tests__/plugins-test.js
@@ -12,9 +12,9 @@ const cssB = (
 )
 
 const configRelative = {
-  plugins: {
-    "warn-about-foo": "./fixtures/plugin-warn-about-foo",
-  },
+  plugins: [
+    "./fixtures/plugin-warn-about-foo",
+  ],
   rules: {
     "warn-about-foo": [ 2, "always" ],
     "block-no-empty": 2,
@@ -22,9 +22,9 @@ const configRelative = {
 }
 
 const configAbsolute = {
-  plugins: {
-    "warn-about-foo": path.join(__dirname, "./fixtures/plugin-warn-about-foo"),
-  },
+  plugins: [
+    path.join(__dirname, "./fixtures/plugin-warn-about-foo"),
+  ],
   rules: {
     "warn-about-foo": [ 2, "always" ],
     "block-no-empty": 2,

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -1,7 +1,7 @@
 import path from "path"
 import cosmiconfig from "cosmiconfig"
 import resolveFrom from "resolve-from"
-import { assign, mapValues, merge, omit } from "lodash"
+import { assign, merge, omit } from "lodash"
 import { configurationError } from "./utils"
 
 export default function (options) {
@@ -66,7 +66,7 @@ function augmentConfig(config, configDir) {
 function absolutizePlugins(config, configDir) {
   if (!config.plugins) { return config }
   return assign({}, config, {
-    plugins: mapValues(config.plugins, lookup => getModulePath(configDir, lookup)),
+    plugins: config.plugins.map(lookup => getModulePath(configDir, lookup)),
   })
 }
 

--- a/src/createPlugin.js
+++ b/src/createPlugin.js
@@ -1,0 +1,6 @@
+export default function (ruleName, rule) {
+  return {
+    ruleName,
+    rule,
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,4 @@ module.exports.utils = {
 }
 
 module.exports.lint = require("./standalone")
+module.exports.createPlugin = require("./createPlugin")

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -1,5 +1,4 @@
 import postcss from "postcss"
-import { merge, mapValues } from "lodash"
 import { configurationError } from "./utils"
 import ruleDefinitions from "./rules"
 import disableRanges from "./disableRanges"
@@ -20,7 +19,10 @@ export default postcss.plugin("stylelint", (options = {}) => {
         throw configurationError("No rules found within configuration")
       }
       if (config.plugins) {
-        merge(ruleDefinitions, mapValues(config.plugins, plugin => require(plugin)))
+        config.plugins.forEach(pluginPath => {
+          const plugin = require(pluginPath)
+          ruleDefinitions[plugin.ruleName] = plugin.rule
+        })
       }
 
       // Register details about the configuration


### PR DESCRIPTION
This involves some change to the plugin API, so I'll have to refactor the two existing plugins :)

In order for plugin rules to work just like any other rules (including, e.g., being able to be disabled by comments), they need to have a standard rule name. Previously, config's `plugins` argument accepted an object, which gave the illusion that it would be a good idea to use whatever name you want to refer to your plugin rules. Instead, plugins need to document their names.

With that established I thought there was no reason not to use an array instead of an object. I did run across one bump, though, which I solved by making the `stylelint.createPlugin()` function. Much like `postcss.plugin()`, I figure this could be handy down the line if for any reason we need to add extra steps when "registering" a plugin.

So in sum, here are the changes:
- `plugins` in config is an array instead of an object.
- plugin authors need to make sure to document their rule names, as users have to be precise about it.
- plugin authors should use `stylelint.createPlugin(ruleName, ruleFunction)`.

What do you think?