### PR TITLE
Exclude at-import from number-no-trailing-zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Fixed: `number-no-trailing-zeros` no longer flags at-import at-rules.
+
 # 2.3.1
 
 * Fixed: `selector-no-type` no longer flags the _nesting selector_ (`&`).

--- a/src/rules/number-no-trailing-zeros/__tests__/index.js
+++ b/src/rules/number-no-trailing-zeros/__tests__/index.js
@@ -16,6 +16,8 @@ testRule(undefined, tr => {
   tr.ok("a { padding: 0.01px; }")
   tr.ok("a { padding: .01px; }")
   tr.ok("@media (min-width: 100px) {}")
+  tr.ok("@import \"0.10.css\";")
+  tr.ok("@import url(0.10.css);")
 
   tr.notOk("a { padding: 1.0px; }", {
     message: messages.rejected,

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -24,6 +24,10 @@ export default function (actual) {
     })
 
     root.walkAtRules(atRule => {
+
+      // Ignore @imports
+      if (atRule.name === "import") { return }
+
       const source = (cssStatementHasBlock(atRule))
         ? cssStatementStringBeforeBlock(atRule, { noBefore: true })
         : atRule.toString()


### PR DESCRIPTION
Best way to deal with https://github.com/stylelint/stylelint/issues/516 ?