### PR TITLE
Ignore line comments when checking comment-related rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^1.4.1",
     "eslint-config-stylelint": "^0.1.0",
     "sinon": "^1.16.1",
-    "stylelint-rule-tester": "git@github.com:borodean/stylelint-rule-tester.git#postcss-options",
+    "stylelint-rule-tester": "^0.6.0",
     "tape": "^4.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^1.4.1",
     "eslint-config-stylelint": "^0.1.0",
     "sinon": "^1.16.1",
-    "stylelint-rule-tester": "^0.4.0",
+    "stylelint-rule-tester": "git@github.com:borodean/stylelint-rule-tester.git#postcss-options",
     "tape": "^4.2.0"
   },
   "scripts": {

--- a/src/rules/comment-empty-line-before/README.md
+++ b/src/rules/comment-empty-line-before/README.md
@@ -12,6 +12,8 @@ Require or disallow an empty line before comments.
 
 If the comment is the very first node in a stylesheet then it is ignored. Inline comments are also ignored.
 
+If you're using a custom syntax which support single-line comments with `//`, those are ignored as well.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -83,6 +83,7 @@ const testRuleScss = ruleTester(rule, ruleName, {
 
 testRuleScss("always", tr => {
   tr.ok("a { color: pink;\n// comment\ntop: 0; }", "line comment ignored")
+  tr.ok("// first line\n// second line\na { color: pink; }", "subsequent line comments ingnored")
 })
 
 testRuleScss("never", tr => {

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -3,6 +3,7 @@ import {
   warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
+import scss from "postcss-scss"
 
 const testRule = ruleTester(rule, ruleName)
 
@@ -15,6 +16,7 @@ function alwaysTests(tr) {
   tr.ok("a {}\n\n/** comment */")
   tr.ok("a {}\r\n\r\n/** comment */", "CRLF")
   tr.ok("a { color: pink;\n\n/** comment */\ntop: 0; }")
+  tr.ok("a { color: pink;\n// comment\ntop: 0; }", "line comment ignored", { syntax: scss })
 
   tr.notOk("/** comment */\n/** comment */", messages.expected)
   tr.notOk("/** comment */\r\n/** comment */", messages.expected, "CRLF")
@@ -67,6 +69,7 @@ testRule("never", tr => {
   tr.ok("a {} /** comment */")
   tr.ok("a { color: pink;\n/** comment */\n\ntop: 0; }")
   tr.ok("a { color: pink;\r\n/** comment */\r\n\r\ntop: 0; }", "CRLF")
+  tr.ok("a { color: pink;\n\n// comment\ntop: 0; }", "line comment ignored", { syntax: scss })
 
   tr.notOk("/** comment */\n\n/** comment */", messages.rejected)
   tr.notOk("a {}\n\n\n/** comment */", messages.rejected)

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -3,7 +3,7 @@ import {
   warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
-import scss from "postcss-scss"
+import scssSyntax from "postcss-scss"
 
 const testRule = ruleTester(rule, ruleName)
 
@@ -16,7 +16,6 @@ function alwaysTests(tr) {
   tr.ok("a {}\n\n/** comment */")
   tr.ok("a {}\r\n\r\n/** comment */", "CRLF")
   tr.ok("a { color: pink;\n\n/** comment */\ntop: 0; }")
-  tr.ok("a { color: pink;\n// comment\ntop: 0; }", "line comment ignored", { syntax: scss })
 
   tr.notOk("/** comment */\n/** comment */", messages.expected)
   tr.notOk("/** comment */\r\n/** comment */", messages.expected, "CRLF")
@@ -69,10 +68,23 @@ testRule("never", tr => {
   tr.ok("a {} /** comment */")
   tr.ok("a { color: pink;\n/** comment */\n\ntop: 0; }")
   tr.ok("a { color: pink;\r\n/** comment */\r\n\r\ntop: 0; }", "CRLF")
-  tr.ok("a { color: pink;\n\n// comment\ntop: 0; }", "line comment ignored", { syntax: scss })
 
   tr.notOk("/** comment */\n\n/** comment */", messages.rejected)
   tr.notOk("a {}\n\n\n/** comment */", messages.rejected)
   tr.notOk("a {}\r\n\r\n\r\n/** comment */", messages.rejected, "CRLF")
   tr.notOk("a { color: pink;\n\n/** comment */\ntop: 0; }", messages.rejected)
+})
+
+const testRuleScss = ruleTester(rule, ruleName, {
+  postcssOptions: {
+    syntax: scssSyntax,
+  },
+})
+
+testRuleScss("always", tr => {
+  tr.ok("a { color: pink;\n// comment\ntop: 0; }", "line comment ignored")
+})
+
+testRuleScss("never", tr => {
+  tr.ok("a { color: pink;\n\n// comment\ntop: 0; }", "line comment ignored")
 })

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -82,10 +82,10 @@ const testRuleScss = ruleTester(rule, ruleName, {
 })
 
 testRuleScss("always", tr => {
-  tr.ok("a { color: pink;\n// comment\ntop: 0; }", "line comment ignored")
-  tr.ok("// first line\n// second line\na { color: pink; }", "subsequent line comments ingnored")
+  tr.ok("a { color: pink;\n// comment\ntop: 0; }", "single-line comment ignored")
+  tr.ok("// first line\n// second line\na { color: pink; }", "subsequent single-line comments ingnored")
 })
 
 testRuleScss("never", tr => {
-  tr.ok("a { color: pink;\n\n// comment\ntop: 0; }", "line comment ignored")
+  tr.ok("a { color: pink;\n\n// comment\ntop: 0; }", "single-line comment ignored")
 })

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -34,6 +34,8 @@ export default function (expectation, options) {
       // Ignore the first node
       if (comment === root.first) { return }
 
+      if (comment.raws.inline) { return }
+
       const before = comment.raw("before")
 
       // Ignore inline comments

--- a/src/rules/comment-space-inside/README.md
+++ b/src/rules/comment-space-inside/README.md
@@ -13,6 +13,8 @@ So `/** comment **/` is treated the same way as `/* comment */`.
 
 Unlike most other `*-space-*` rules, this one allow *any whitespace*, not just a single space.
 
+If you're using a custom syntax which support single-line comments with `//`, those are ignored.
+
 In a future release, this rule's name will be changed to `comment-whitespace-inside`.
 
 ## Options

--- a/src/rules/comment-space-inside/__tests__/index.js
+++ b/src/rules/comment-space-inside/__tests__/index.js
@@ -3,7 +3,7 @@ import {
   warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
-import scss from "postcss-scss"
+import scssSyntax from "postcss-scss"
 
 const testRule = ruleTester(rule, ruleName)
 
@@ -18,7 +18,6 @@ testRule("always", tr => {
   tr.ok("/**** comment ***/")
   tr.ok("/*\ncomment\n*/")
   tr.ok("/*\tcomment   */")
-  tr.ok("//comment", "line comment ignored", { syntax: scss })
 
   tr.notOk("/*comment */", {
     message: messages.expectedOpening,
@@ -66,7 +65,6 @@ testRule("never", tr => {
   tr.ok("/*comment\n\ncomment*/")
   tr.ok("/**comment*/")
   tr.ok("/****comment***/")
-  tr.ok("// comment", "line comment ignored", { syntax: scss })
 
   tr.notOk("/* comment*/", {
     message: messages.rejectedOpening,
@@ -123,4 +121,18 @@ testRule("never", tr => {
     line: 3,
     column: 8,
   })
+})
+
+const testRuleScss = ruleTester(rule, ruleName, {
+  postcssOptions: {
+    syntax: scssSyntax,
+  },
+})
+
+testRuleScss("always", tr => {
+  tr.ok("//comment", "line comment ignored")
+})
+
+testRuleScss("never", tr => {
+  tr.ok("// comment", "line comment ignored")
 })

--- a/src/rules/comment-space-inside/__tests__/index.js
+++ b/src/rules/comment-space-inside/__tests__/index.js
@@ -3,6 +3,7 @@ import {
   warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
+import scss from "postcss-scss"
 
 const testRule = ruleTester(rule, ruleName)
 
@@ -17,6 +18,7 @@ testRule("always", tr => {
   tr.ok("/**** comment ***/")
   tr.ok("/*\ncomment\n*/")
   tr.ok("/*\tcomment   */")
+  tr.ok("//comment", "line comment ignored", { syntax: scss })
 
   tr.notOk("/*comment */", {
     message: messages.expectedOpening,
@@ -64,6 +66,7 @@ testRule("never", tr => {
   tr.ok("/*comment\n\ncomment*/")
   tr.ok("/**comment*/")
   tr.ok("/****comment***/")
+  tr.ok("// comment", "line comment ignored", { syntax: scss })
 
   tr.notOk("/* comment*/", {
     message: messages.rejectedOpening,

--- a/src/rules/comment-space-inside/__tests__/index.js
+++ b/src/rules/comment-space-inside/__tests__/index.js
@@ -130,9 +130,9 @@ const testRuleScss = ruleTester(rule, ruleName, {
 })
 
 testRuleScss("always", tr => {
-  tr.ok("//comment", "line comment ignored")
+  tr.ok("//comment", "single-line comment ignored")
 })
 
 testRuleScss("never", tr => {
-  tr.ok("// comment", "line comment ignored")
+  tr.ok("// comment", "single-line comment ignored")
 })

--- a/src/rules/comment-space-inside/index.js
+++ b/src/rules/comment-space-inside/index.js
@@ -27,6 +27,8 @@ export default function (expectation) {
 
     root.walkComments(function (comment) {
 
+      if (comment.raws.inline) { return }
+
       const rawComment = comment.toString()
       const leftMatches = rawComment.match(/(^\/\*+)(\s)?/)
       const rightMatches = rawComment.match(/(\s)?(\*+\/)$/)


### PR DESCRIPTION
Implements what's proposed in https://github.com/stylelint/stylelint/pull/520

This PR uses my private fork of stylelint-rule-tester which allows usage of a custom parser. If something like https://github.com/stylelint/stylelint-rule-tester/pull/3 would be released I'll update the dependency.