### PR TITLE
add example usage to cli readme

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -13,7 +13,7 @@ using rc to look in various places (cf. https://github.com/dominictarr/rc#standa
 Alternately, you can specify a configuration file via --config.
 
 Input
-  File glob(s) (passed to node-glob).
+  Files
   You can also pass no input and use stdin.
 
 Options

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -7,13 +7,16 @@ Modern CSS linter
 
 Usage
   stylelint [input] [options]
+  
+Example
+  stylelint 'css/**/*.css' 'styles/*.css' --quiet
 
 By default, stylelint will look for a .stylelintrc file in JSON format,
 using rc to look in various places (cf. https://github.com/dominictarr/rc#standards).
 Alternately, you can specify a configuration file via --config.
 
 Input
-  Files
+  File glob(s) (passed to node-glob).
   You can also pass no input and use stdin.
 
 Options


### PR DESCRIPTION
files are not passed to `node-glob`

__update:__ they are when passed as a string