### PR TITLE
Make rule-properties-order account for property names containing multiple hyphens

### DIFF
--- a/src/rules/rule-properties-order/__tests__/flat.js
+++ b/src/rules/rule-properties-order/__tests__/flat.js
@@ -64,6 +64,9 @@ testRule([
   "padding-top",
   "padding-right",
   "padding-left",
+  "border",
+  "border-top",
+  "border-right",
   "color",
 ], tr => {
   warningFreeBasics(tr)
@@ -75,6 +78,8 @@ testRule([
   // `padding-bottom` was not specified, so it will be expected where `padding` was expected
   tr.ok("a { padding-bottom: 0; padding-top: 1px; padding-right: 0; padding-left: 0; color: pink; }")
   tr.ok("a { padding: 1px; padding-bottom: 0; padding-left: 0; color: pink; }")
+  tr.ok("a { border: 1px solid #fff; border-right: 2px solid #fff; border-right-color: #000; }")
+  tr.ok("a { border: 1px solid #fff; border-top: none; border-right-color: #000; }")
 
   tr.notOk("a { color: pink; padding: 1px; }", messages.expected("padding", "color"))
   tr.notOk("a { color: pink; padding-top: 1px; }", messages.expected("padding-top", "color"))

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -188,9 +188,9 @@ function getOrderValue(expectedOrder, propName) {
   // If prop was not specified but has a hyphen
   // (e.g. `padding-top`), try looking for the segment preceding the hyphen
   // and use that index
-  if (!orderValue && propName.indexOf("-") !== -1) {
-    const propNamePreHyphen = propName.slice(0, propName.indexOf("-"))
-    orderValue = expectedOrder[propNamePreHyphen]
+  if (!orderValue && propName.lastIndexOf("-") !== -1) {
+    const propNamePreHyphen = propName.slice(0, propName.lastIndexOf("-"))
+    orderValue = getOrderValue(expectedOrder, propNamePreHyphen)
   }
   return orderValue
 }


### PR DESCRIPTION
Fixes #535.