### PR TITLE
Support single-line comments in styleSearch; fixes #547

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+* Fixed: `styleSearch()` and the rules it powers will not trip up on single-line (`//`) comments.
 * Fixed: `selector-combinator-space-before` now better handles nested selectors starting with combinators.
 * Fixed: `rule-properties-order` now deals property with `-moz-osx-font-smoothing`.
 

--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -1,6 +1,7 @@
 import {
   ruleTester,
 } from "../../../testUtils"
+import scss from "postcss-scss"
 import rule, { ruleName, messages } from ".."
 
 const testRule = ruleTester(rule, ruleName)
@@ -74,4 +75,17 @@ testRule("double", tr => {
 
   tr.ok(`a::before { content: "foo\"horse\"'cow'"; }`, "string in strings")
   tr.ok("a { /* 'horse' */ }", "ignores comment")
+})
+
+const scssTestRule = ruleTester(rule, ruleName, {
+  postcssOptions: { syntax: scss },
+})
+
+scssTestRule("double", tr => {
+  tr.ok("a {\n  // 'horse'\n}", "ignores single-line SCSS comment")
+  tr.notOk("a::before {\n  // 'horse'\n  content: 'thing'; }", {
+    message: messages.expected("double"),
+    line: 3,
+    column: 10,
+  }, "pays attention when single-line SCSS comment ends")
 })

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -137,6 +137,18 @@ test("ignores matches within comments", t => {
   t.end()
 })
 
+test("ignores matches within single-line comment", t => {
+  t.deepEqual(styleSearchResults({
+    source: "abc // comment",
+    target: "m",
+  }), [])
+  t.deepEqual(styleSearchResults({
+    source: "abc // command",
+    target: "a",
+  }), [0])
+  t.end()
+})
+
 test("handles escaped double-quotes in double-quote strings", t => {
   /* eslint-disable quotes */
   t.deepEqual(styleSearchResults({

--- a/src/utils/styleSearch.js
+++ b/src/utils/styleSearch.js
@@ -38,6 +38,7 @@ export default function (options, callback) {
 
   let insideString = false
   let insideComment = false
+  let insideSingleLineComment = false
   let insideFunction = false
   let openingParenCount = 0
   let matchCount = 0
@@ -94,21 +95,37 @@ export default function (options, callback) {
       !insideComment
       && currentChar === "/"
       && source[i - 1] !== "\\" // escaping
-      && source[i + 1] === "*"
     ) {
-      insideComment = true
-      continue
+      if (source[i + 1] === "*") {
+        insideComment = true
+        continue
+      }
+      // single-line
+      if (source[i + 1] === "/") {
+        insideComment = true
+        insideSingleLineComment = true
+        continue
+      }
     }
 
-    // Register the end of a comment
+    // Register the end of a (standard) comment
     if (
-      insideComment
+      insideComment && !insideSingleLineComment
       && currentChar === "*"
       && source[i - 1] !== "\\" // escaping
       && source[i + 1] === "/"
     ) {
       insideComment = false
       continue
+    }
+
+    // Register the end of a single-line comment
+    if (
+      insideComment && insideSingleLineComment
+      && currentChar === "\n"
+    ) {
+      insideComment = false
+      insideSingleLineComment = false
     }
 
     if (insideComment && !options.checkComments) { continue }


### PR DESCRIPTION
If `//` is not parsed, then it results in a syntax error; so I thought this simple little modification to `styleSearch()` was a safe bet. Any objections?