### PR TITLE
Ignore variables when looking for operators; fixes #548

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+* Fixed: `function-calc-no-unspaced-operator` ignores characters in `$sass` and `@less` variables.
 * Fixed: `styleSearch()` and the rules it powers will not trip up on single-line (`//`) comments.
 * Fixed: `selector-combinator-space-before` now better handles nested selectors starting with combinators.
 * Fixed: `rule-properties-order` now deals property with `-moz-osx-font-smoothing`.

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -27,6 +27,8 @@ testRule(undefined, tr => {
 
   tr.ok("a { top: calc(-$x - 2rem); }", "postcss-simple-vars and SCSS variable syntax")
   tr.ok("a { top: calc(-@x - 2rem); }", "Less variable syntax")
+  tr.ok("a { top: calc($x-y-z - 2rem); }", "postcss-simple-vars and SCSS variable with hyphens")
+  tr.ok("a { top: calc(2rem + @fh+d*sf-as); }", "Less variable with symbols")
 
   tr.notOk("a { top: calc(1px +\t-1px)}", {
     message: messages.expectedAfter("+"),

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -23,7 +23,8 @@ export default function (actual) {
     if (!validOptions) { return }
 
     root.walkDecls(decl => {
-      cssFunctionArguments(decl.toString(), "calc", (expression, expressionIndex) => {
+      cssFunctionArguments(decl.toString(), "calc", (rawExpression, expressionIndex) => {
+        const expression = blurVariables(rawExpression)
 
         checkSymbol("+")
         checkSymbol("-")
@@ -79,4 +80,8 @@ export default function (actual) {
       })
     })
   }
+}
+
+function blurVariables(source) {
+  return source.replace(/[\$@][^\)\s]+/g, "0")
 }


### PR DESCRIPTION
This creates a simple little function to obfuscate Sass/Less-style variables, so their hyphens (or other special characters) don't confuse the rule. This rule already was making an exception for these specific types of variables, so I think this is appropriate.

(If it turns out that we need this functionality elsewhere, we could extract the function to a utility.)