### PR TITLE
Updated Atom linter-stylelint repo link

### DIFF
--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -4,7 +4,7 @@ The linter works well with:
 
 ## Editor plugins
 
-* [linter-stylelint](https://github.com/1000ch/linter-stylelint) - An Atom Linter plugin for stylelint.
+* [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - An Atom Linter plugin for stylelint.
 * [SublimeLinter-contrib-stylelint](https://github.com/kungfusheep/SublimeLinter-contrib-stylelint) - A Sublime Text plugin for stylelint.
 * [vscode-stylelint](https://github.com/shinnn/vscode-stylelint) - A Visual Studio Code extension for stylelint.
 


### PR DESCRIPTION
The Atom linter-stylelint plugin is now part of the @AtomLinter GitHub organization, even though this happened in July and the URL redirects have been working fine this updates the URL to the new URL.

See https://github.com/AtomLinter/linter-stylelint/issues/3