### PR TITLE
Fix cosmiconfig config file detection

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -27,7 +27,10 @@ export default function (options) {
     })
   }
 
-  const cosmiconfigOptions = {}
+  const cosmiconfigOptions = {
+    argv: null
+  }
+
   if (options.configFile) {
     cosmiconfigOptions.configPath = path.resolve(process.cwd(), options.configFile)
   }

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -28,7 +28,7 @@ export default function (options) {
   }
 
   const cosmiconfigOptions = {
-    argv: null,
+    argv: options.cli ? "config" : null,
   }
 
   if (options.configFile) {

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -28,7 +28,7 @@ export default function (options) {
   }
 
   const cosmiconfigOptions = {
-    argv: null
+    argv: null,
   }
 
   if (options.configFile) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -80,7 +80,9 @@ Promise.resolve().then(() => {
     code: stdin,
   }))
 }).then(options => {
-  return standalone(options)
+  return standalone(assign({}, options, {
+    cli: true,
+  }))
 }).then(({ output, errored }) => {
   if (!output) { return }
   process.stdout.write(output)

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -8,6 +8,7 @@ import * as formatters from "./formatters"
 
 export default function ({
   files,
+  cli,
   code,
   config,
   configFile,
@@ -75,6 +76,7 @@ export default function ({
 
     return postcss()
       .use(stylelintPostcssPlugin({
+        cli,
         config,
         configFile,
         configBasedir,


### PR DESCRIPTION
Cosmic config evaluates the `process.argv` array, if an `--config` argument is available it takes precedence over other config sources. This has the consequence that my `.stylelintrc` file is no longer found. I run webpack with `--config`.

My pull request should fix this.