### PR TITLE
Improve handling of end-of-line comment exceptions; fixes #598

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+* Fixed: `block-opening-brace-newline-after` and `declaration-block-semicolon-newline-after` handle end-of-line comments better.
+
 # 3.2.0
 
 * Added: `legacyNumberedSeverities` config property to force the legacy severity system.

--- a/src/rules/block-opening-brace-newline-after/README.md
+++ b/src/rules/block-opening-brace-newline-after/README.md
@@ -9,6 +9,15 @@ Require a newline after the opening brace of blocks.
  * The newline after this brace */
 ```
 
+This rule allows an end-of-line comment separated from the opening brace by spaces,
+as long as the comment contains no newlines. For example,
+
+```css
+a { /* end-of-line comment */
+  color: pink;
+}
+```
+
 ## Options
 
 `string`: `"always"|"always-multi-line"|"never-multi-line`
@@ -28,6 +37,13 @@ a{ color: pink;
 }
 ```
 
+```css
+a{ /* end-of-line comment
+  with a newline */
+  color: pink;
+}
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
@@ -39,6 +55,12 @@ color: pink; }
 a
 {
 color: pink; }
+```
+
+```css
+a { /* end-of-line comment */
+  color: pink;
+}
 ```
 
 ### `"always-multi-line"`
@@ -84,4 +106,3 @@ a { color: pink; }
 a {color: pink;
 }
 ```
-

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -21,6 +21,7 @@ testRule("always", tr => {
   tr.ok("@media print{\r\na{\r\ncolor: pink; } }", "CRLF")
   tr.ok("@media print{\n\ta{\n  color: pink; } }")
   tr.ok("a { /* 1 */\n  color: pink;\n}", "end-of-line comment")
+  tr.ok("a {    /* 1 */\n  color: pink;\n}", "end-of-line comment with multiple spaces before")
   tr.ok("a {\n  /* 1 */\n  color: pink;\n}", "next-line comment")
   tr.ok("a {\r\n  /* 1 */\r\n  color: pink;\r\n}", "next-line comment and CRLF")
 
@@ -60,24 +61,6 @@ testRule("always", tr => {
     column: 4,
   }, "CRLF")
   tr.notOk(
-    "a {  /* 1 */\n  color: pink;\n}",
-    {
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 4,
-    },
-    "end-of-line comment with two spaces before"
-  )
-  tr.notOk(
-    "a {  /* 1 */\r\n  color: pink;\r\n}",
-    {
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 4,
-    },
-    "end-of-line comment with two spaces before and CRLF"
-  )
-  tr.notOk(
     "a { /* 1 */ color: pink; }",
     {
       message: messages.expectedAfter(),
@@ -85,6 +68,24 @@ testRule("always", tr => {
       column: 4,
     },
     "next node is comment without newline after"
+  )
+  tr.notOk(
+    "a {\t/* 1 */ color: pink; }",
+    {
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 4,
+    },
+    "next node is comment with tab before"
+  )
+  tr.notOk(
+    "a { /* 1\n2 */ color: pink; }",
+    {
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 4,
+    },
+    "next node is end-of-line comment containing newlines"
   )
 })
 

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -41,9 +41,14 @@ export default function (expectation) {
       // Return early if blockless or has an empty block
       if (!cssStatementHasBlock(statement) || cssStatementHasEmptyBlock(statement)) { return }
 
-      // Allow an end-of-line comment one space after the brace
+      // Allow an end-of-line comment x spaces after the semicolon
       const firstNode = statement.first
-      const nodeToCheck = (firstNode.type === "comment" && firstNode.raw("before") === " ")
+      const firstNodeIsAcceptableComment = (
+        firstNode.type === "comment"
+        && !/[^ ]/.test(firstNode.raw("before"))
+        && firstNode.toString().indexOf("\n") === -1
+      )
+      const nodeToCheck = (firstNodeIsAcceptableComment)
         ? firstNode.next()
         : firstNode
       if (!nodeToCheck) { return }

--- a/src/rules/declaration-block-semicolon-newline-after/README.md
+++ b/src/rules/declaration-block-semicolon-newline-after/README.md
@@ -11,11 +11,12 @@ Require a newline or disallow whitespace after the semicolons of declaration blo
  * The newline after this semicolon */
 ```
 
-End-of-line comments are allowed one space after the semicolon.
+This rule allows an end-of-line comment separated from the semicolon by spaces,
+as long as the comment contains no newlines. For example,
 
 ```css
 a {
-  color: pink; /* something to say */
+  color: pink; /* end-of-line comment */
   top: 0;
 }
 ```
@@ -34,11 +35,26 @@ The following patterns are considered warnings:
 a { color: pink; top: 0; }
 ```
 
+```css
+a {
+  color: pink; /* end-of-line comment
+    containing a newline */
+  top: 0;
+}
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
 a {
   color: pink;
+  top: 0;
+}
+```
+
+```css
+a {
+  color: pink; /* end-of-line comment */
   top: 0;
 }
 ```

--- a/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
@@ -21,6 +21,7 @@ testRule("always", tr => {
   tr.ok("a { color: pink;\r\ntop: 0;}", "no space between trailing semicolon and closing brace and CRLF")
   tr.ok("a { color: pink;\ntop: 0}")
   tr.ok("a {\n  color: pink; /* 1 */\n  top: 0\n}", "end-of-line comment")
+  tr.ok("a {\n  color: pink;    /* 1 */\n  top: 0\n}", "end-of-line comment a few spaces after")
   tr.ok("a {\r\n  color: pink; /* 1 */\r\n  top: 0\r\n}", "end-of-line comment and CRLF")
   tr.ok("a {\n  color: pink;\n  /* 1 */\n  top: 0\n}", "next-line comment")
   tr.ok("a,\nb { color: pink;\ntop: 0}", "multi-line rule, multi-line declaration-block")
@@ -47,15 +48,6 @@ testRule("always", tr => {
     column: 17,
   })
   tr.notOk(
-    "a {\n  color: pink;  /* 1 */\n  top: 0\n}",
-    {
-      message: messages.expectedAfter(),
-      line: 2,
-      column: 15,
-    },
-    "end-of-line comment with two spaces before"
-  )
-  tr.notOk(
     "a {\n  color: pink; /* 1 */ top: 0\n}",
     {
       message: messages.expectedAfter(),
@@ -72,6 +64,24 @@ testRule("always", tr => {
       column: 15,
     },
     "CRLF and next node is comment without newline after"
+  )
+  tr.notOk(
+    "a {\n  color: pink;\t/* 1 */\n  top: 0\n}",
+    {
+      message: messages.expectedAfter(),
+      line: 2,
+      column: 15,
+    },
+    "next node is comment with tab before"
+  )
+  tr.notOk(
+    "a {\n  color: pink; /* 1\n2 */\n  top: 0\n}",
+    {
+      message: messages.expectedAfter(),
+      line: 2,
+      column: 15,
+    },
+    "next node is end-of-line comment containing newline"
   )
 })
 

--- a/src/rules/declaration-block-semicolon-newline-after/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/index.js
@@ -38,8 +38,13 @@ export default function (expectation) {
       const nextNode = decl.next()
       if (!nextNode) { return }
 
-      // Allow end-of-line comments one space after the semicolon
-      let nodeToCheck = (nextNode.type === "comment" && nextNode.raw("before") === " ")
+      // Allow an end-of-line comment x spaces after the semicolon
+      const nextNodeIsAcceptableComment = (
+        nextNode.type === "comment"
+        && !/[^ ]/.test(nextNode.raw("before"))
+        && nextNode.toString().indexOf("\n") === -1
+      )
+      const nodeToCheck = (nextNodeIsAcceptableComment)
         ? nextNode.next()
         : nextNode
       if (!nodeToCheck) { return }


### PR DESCRIPTION
This allows for multiple spaces between the punctuation and the end-of-line comment.

It also enforces the implicit assumption that these exception-triggering end-of-line comments should themselves contain no newlines.