### PR TITLE
docs(readme): rule-non-nested-empty-line-before

### DIFF
--- a/src/rules/rule-non-nested-empty-line-before/README.md
+++ b/src/rules/rule-non-nested-empty-line-before/README.md
@@ -117,16 +117,18 @@ Ignore rules that come after a comment.
 The following patterns are *not* considered warnings:
 
 ```css
-@media {
-  /* comment */
-  a {}
-}
+a
+{}
+/* comment */
+b
+{}
 ```
 
 ```css
-@media {
-  /* comment */
+a
+{}
+/* comment */
 
-  a {}
-}
+b
+{}
 ```


### PR DESCRIPTION
Fix readme for rule-non-nested-empty-line-before (http://stylelint.io/?/src/rules/rule-non-nested-empty-line-before/README.md).

Last part was the same as http://stylelint.io/?/src/rules/rule-nested-empty-line-before/README.md