### PR TITLE
Add runners/loaders and remove bem-linter from comp tools

### DIFF
--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -1,15 +1,17 @@
 # Complementary tools
 
-The linter works well with:
-
 ## Editor plugins
 
 * [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - An Atom Linter plugin for stylelint.
 * [SublimeLinter-contrib-stylelint](https://github.com/kungfusheep/SublimeLinter-contrib-stylelint) - A Sublime Text plugin for stylelint.
 * [vscode-stylelint](https://github.com/shinnn/vscode-stylelint) - A Visual Studio Code extension for stylelint.
 
+## Runners/loaders
+
+* [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - A gulp plugin for stylelint.
+* [stylelint-loader](https://github.com/adrianhall/stylelint-loader) - A webpack loader for stylelint.
+
 ## Other linters & formatters
 
 * [cssfmt](https://github.com/morishitter/cssfmt) - A tool that automatically formats CSS and SCSS source code.
-* [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter) - A BEM linter for CSS.
 * [stylehacks](https://github.com/ben-eb/stylehacks) - Detect/remove browser hacks from CSS files.

--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -14,4 +14,5 @@
 ## Other linters & formatters
 
 * [cssfmt](https://github.com/morishitter/cssfmt) - A tool that automatically formats CSS and SCSS source code.
+* [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter) - A BEM linter for CSS.
 * [stylehacks](https://github.com/ben-eb/stylehacks) - Detect/remove browser hacks from CSS files.


### PR DESCRIPTION
I was catching up on the stylelint twitter feed when I saw there’s now a webpack loader and a gulp plugin for stylelint.

I also removed bem-linter as that’s on the plugin page.