### PR TITLE
Swap config-suitcss to config-standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ With stylelint, it's easy to start linting your CSS:
 
 1. Install stylelint: `npm install stylelint`.
 2. Choose whether you want to craft your own config or extend a pre-written, shared config.
-  * If you want to use a pre-written config, just find one and extend it. We recommend trying [`stylelint-config-suitcss`](https://github.com/stylelint/stylelint-config-suitcss), which includes over 70 of stylelint's rules with sensible defaults. (You can always override specific rules after extending a config.)
+  * If you want to use a pre-written config, just find one and extend it. We recommend trying [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard), which includes around 60 of stylelint's rules with sensible defaults. (You can always override specific rules after extending a config.)
   * To craft your own from the ground up, just learn about [some rules](/docs/user-guide/rules.md). _All of the rules are off by default_, so you only have to learn about the rules you want to turn on and enforce. That way you can start small, growing your config over time as you have a chance to explore more of the rules. Alternately, copy-paste [this example configuration](/docs/user-guide/rules.json), which lists all of stylelint's rules and their primary options, then remove (or turn off) the rules you don't want and edit the primary option of each rule to your liking.
 3. Create your [configuration](/docs/user-guide/configuration.md), probably as a `.stylelintrc` file.
 4. Decide whether to use the [CLI](/docs/user-guide/cli.md), [Node API](/docs/user-guide/node-api.md), or [PostCSS plugin](/docs/user-guide/postcss-plugin.md).


### PR DESCRIPTION
A standard config was mentioned over in https://github.com/stylelint/stylelint.github.io/issues/3#issuecomment-164299883. It doesn’t looks like it’s been started by anyone in the last month, and so I figured I’d take a stab at it.

It’s a looser version of the currently recommended `config-suitcss`, and it is based on the most common rules I found across a number of style guides. SuitCSS is an excellent framework/methodology, but I’m unsure how well-known it is, and so figured we might as well recommend something else on the home page.

@davidtheclark It’s up to you if this one goes in now, or if we should wait for (or if you have any) feedback on the `config-standard` [repo itself](https://github.com/stylelint/stylelint-config-standard)?