### PR TITLE
Add ignore non-comments option to max-line-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 * Added: support for extensions on `.stylelintrc` files (by upgrading cosmiconfig).
+* Added: `ignore: "non-comments"` option to `max-line-length`.
 
 # 3.2.3
 

--- a/src/rules/max-line-length/README.md
+++ b/src/rules/max-line-length/README.md
@@ -45,3 +45,30 @@ a {
 a {
   background: url(a-url-that-is-over-20-characters-long);
 }
+
+## Optional options
+
+### `ignore: ["non-comments"]`
+
+Only enforce the line-length limit for lines within comments.
+
+This does not apply to comments that are stuck in between other stuff,
+only to lines that begin at the beginning or in the middle of a comment.
+
+For example, with a maximum length of `30`, the following each have only one warning:
+
+```css
+/* This line is too long for my rule */
+a { color: pink; background: orange; }
+a { color: pink; /* this comment is also long but not on its own line */ }
+```
+
+```css
+a { color: pink; background: orange; }
+/**
+ * This line is short,
+ * but this line is too long for my liking,
+ * though this one is fine
+ */
+a { color: pink; /* this comment is also long but not on its own line */ }
+```

--- a/src/rules/max-line-length/__tests__/index.js
+++ b/src/rules/max-line-length/__tests__/index.js
@@ -59,3 +59,40 @@ testRule("30", tr => {
     column: 47,
   })
 })
+
+testRule("20", { ignore: "non-comments" }, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: 0; top: 0; bottom: 0; }")
+  tr.ok("a { color: 0; top: 0; /* too long comment here */ bottom: 0; }")
+  tr.ok("/* short nuff */")
+  tr.ok("/* short\nnuff */")
+  tr.ok("/**\n * each line\n * short nuff\n */")
+  tr.ok("a { color: 0; }\n/* short nuff */\nb {}")
+  tr.ok("a {}\n/**\n * each line\n * short nuff\n */\nb {}")
+
+  // Currently this only catches problems if the comment
+  // starts at the beginning of a line
+  tr.ok("a { /* this comment is too long for the max length */ }")
+
+  tr.notOk("/* comment that is too long */", {
+    message: messages.expected(20),
+    line: 1,
+    column: 30,
+  })
+  tr.notOk("a {}\n  /* comment that is too long */\nb {}", {
+    message: messages.expected(20),
+    line: 2,
+    column: 30,
+  })
+  tr.notOk("/* this comment is too long for the max length */", {
+    message: messages.expected(20),
+    line: 1,
+    column: 49,
+  })
+  tr.notOk("a {}\n/**\n * each line\n * short nuff\n * except this one which is too long\n */\nb {}", {
+    message: messages.expected(20),
+    line: 5,
+    column: 36,
+  })
+})

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -303,6 +303,14 @@ test("match object", t => {
     })
   })
 
+  t.test("match within a block comment", st => {
+    styleSearch({ source: "a { color:\n/**\n * 0\n * 1\n */\npink; }", target: "1", checkComments: true }, match => {
+      st.equal(match.insideFunction, false)
+      st.equal(match.insideComment, true)
+      st.end()
+    })
+  })
+
   t.test("match within a comment within function", st => {
     styleSearch({ source: "a { color: rgb(0, 0, 0 /* 1 */); }", target: "1", checkComments: true }, match => {
       st.equal(match.insideFunction, true)


### PR DESCRIPTION
Closes #617.

I ran into a difficult conundrum with this one, and ended up accepting the limitation the it will only enforce the rule for lines that *start* with comments (either the beginning of a comment or the middle of one).

See the docs and tests for more examples.

@ntwb, it would be great if you could try this branch out and see if it works the way you would want it to.