### PR TITLE
selector-no-id: Don't warn about multiple interpolations in Sass loops

### DIFF
--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -42,6 +42,19 @@ const scssTestRule = ruleTester(rule, ruleName, {
 
 scssTestRule(undefined, tr => {
   tr.ok("@for $n from 1 through 10 { .n-#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore sass interpolation inside @for")
+  tr.ok("@for $n from 1 through 10 { .n#{$n}-#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore multiple sass interpolations in a selector inside @for")
+  tr.ok("@for $n from 1 through 10 { .n#{$n}n#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore multiple sass interpolations in a selector inside @for")
   tr.ok("@each $n in $vals { .n-#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore sass interpolation inside @each")
   tr.ok("@while $n < 10 { .n-#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore sass interpolation inside @while")
+
+  tr.notOk("@for $n from 1 through 10 { .n-#{$n} #foo { } }", {
+    message: messages.rejected,
+    line: 1,
+    column: 38,
+  }, "report sass interpolation + id inside @for")
+  tr.notOk("@for $n from 1 through 10 { .n#{$n}-#{$n} #foo { } }", {
+    message: messages.rejected,
+    line: 1,
+    column: 43,
+  }, "report sass interpolation + id inside @for")
 })

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -19,7 +19,7 @@ export default function (actual) {
     root.walkRules(rule => {
       selectorParser(selectorAST => {
         selectorAST.eachId(id => {
-          if (id.value[0] === "{" && id.value.slice(-1) === "}") { return }
+          if (/#{.+}/.test(id)) { return }
           report({
             message: messages.rejected,
             node: rule,


### PR DESCRIPTION
This fixes a problem where `selector-no-id` warns about Sass interpolation when multiple interpolations are used in a selector:

```scss
.n#{$n}-#{$n} {
}
```

The fix brings back the regex `/#{.+}/.test(id)` that was changed to `id.value[0] === "{" && id.value.slice(-1) === "}"` for better perf in PR #593. Too bad that checking for the first and last character did not work for all cases.