### PR TITLE
Indentation and lonesome semicolons; fixes #646

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 4.0.1
+# Head
 
 - Fixed: bug causing `indentation` to stumble over declarations with semicolons on their own lines.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.0.1
+
+- Fixed: bug causing `indentation` to stumble over declarations with semicolons on their own lines.
+
 # 4.1.0
 
 * Added: helpful option validation message when object is expected but non-object provided.

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -75,6 +75,14 @@ tr.ok(
   color: pink;
 }`)
 
+tr.ok(
+`a {
+  background-position: top left,
+    top right,
+    bottom left
+  ;
+}`)
+
 // Rule start/end errors
 tr.notOk(
 `\ta {

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -208,15 +208,17 @@ export default function (space, options) {
     function checkMultilineBit(source, newlineIndentLevel, node) {
       if (source.indexOf("\n") === -1) { return }
       styleSearch({ source, target: "\n" }, (match) => {
-        // Starting at the index after the newline, we want to
-        // check that the whitespace characters before the first
-        // non-whitespace character equal the expected indentation
-        const postNewlineActual = /^(\s*)\S/.exec(source.slice(match.startIndex + 1))[1]
-
         // Function arguments are ignored to allow for arbitrary indentation
         if (match.insideFunction) { return }
 
-        if (postNewlineActual !== repeat(indentChar, newlineIndentLevel)) {
+        // Starting at the index after the newline, we want to
+        // check that the whitespace characters before the first
+        // non-whitespace character equal the expected indentation
+        const afterNewlineSpaceMatches = /^(\s*)\S/.exec(source.slice(match.startIndex + 1))
+        if (!afterNewlineSpaceMatches) { return }
+        const afterNewlineSpace = afterNewlineSpaceMatches[1]
+
+        if (afterNewlineSpace !== repeat(indentChar, newlineIndentLevel)) {
           report({
             message: messages.expected(legibleExpectation(newlineIndentLevel)),
             node,


### PR DESCRIPTION
The indentation rule is now going to ignore semicolons appearing on their own line after declarations. That should enable @MoOx to do whatever crazy stuff he wants :)