### PR TITLE
Update README.md

### DIFF
--- a/src/rules/function-whitespace-after/README.md
+++ b/src/rules/function-whitespace-after/README.md
@@ -58,7 +58,7 @@ a { padding: calc(1 * 2px), calc(2 * 5px); }
 h1 {
   max-height: #{($line-height) * ($lines-to-show)}em;
 }
-```scss
+```
 
 ### `"never"`
 


### PR DESCRIPTION
Removed `scss` following the three tick-marks from line 61 because it was causing issues with the formatting of the rest of the document.