### PR TITLE
Allow for custom messages; closes #400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+- Added: support for custom messages with a `message` secondary property on any rule.
 - Fixed: CLI always ignores contents of `node_modules` and `bower_components` directories.
 - Fixed: bug preventing CLI from understanding absolute paths in `--config` argument.
 - Fixed: bug causing `indentation` to stumble over declarations with semicolons on their own lines.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -78,6 +78,28 @@ Different reporters may use these severity levels in different way, e.g. display
 
 As of v4, the legacy numbered severities system is no longer supported. Please upgrade your config to use the syntax documented here.
 
+#### Custom Messages
+
+If you want to deliver a custom message when a rule is violated, you can do so in two ways:
+provide a `message` option for the rule, or write a custom formatter.
+
+All rules accept a `message` secondary option that, if provided, will be substituted
+for whatever standard message would be provided. For example, the following rule
+configuration would substitute in a couple of custom message:
+
+```json
+"color-hex-case": [ "lower", {
+  "message": "Lowercase letters are easier to distinguish from numbers"
+} ],
+"indentation": [ 2, {
+  "warn": true,
+  "except": ["param"],
+  "message": "Please use 2 spaces for indentation. Tabs make The Architect grumpy."
+} ]
+```
+
+Writing a [custom formatter](/docs/developer-guide/formatters.md) gives you maximum control if you need serious customization.
+
 ### `extends`
 
 Your configuration can *extend* an existing configuration (whether your own or a third-party config).

--- a/src/__tests__/fixtures/config-color-no-named-custom-message.yaml
+++ b/src/__tests__/fixtures/config-color-no-named-custom-message.yaml
@@ -1,0 +1,4 @@
+rules:
+  color-no-named:
+    - true
+    - message: "Unacceptable"

--- a/src/__tests__/integration.js
+++ b/src/__tests__/integration.js
@@ -5,7 +5,10 @@ import stylelint from "../"
 const config = {
   rules: {
     "block-opening-brace-newline-after": "always",
-    "color-no-invalid-hex": [ true, { "warn": true } ],
+    "color-no-invalid-hex": [ true, {
+      warn: true,
+      message: "You made a mistake",
+    } ],
     "function-blacklist": ["calc"],
     "rule-properties-order": [ [ "margin", "padding" ], { unspecified: "top" } ],
     "function-whitelist": null,
@@ -46,9 +49,9 @@ test("expected warnings", t => {
     t.ok(messages.every(m => m.plugin === "stylelint"))
     t.equal(messages[0].text, "Expected newline after \"{\" (block-opening-brace-newline-after)")
     t.equal(messages[0].severity, "error")
-    t.equal(messages[1].text, "Unexpected invalid hex color \"#zzz\" (color-no-invalid-hex)")
+    t.equal(messages[1].text, "You made a mistake")
     t.equal(messages[1].severity, "warning")
-    t.equal(messages[2].text, "Unexpected invalid hex color \"#mmm\" (color-no-invalid-hex)")
+    t.equal(messages[2].text, "You made a mistake")
     t.equal(messages[2].severity, "warning")
   }
 })

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -308,3 +308,16 @@ test("standalone extending a config that is overridden", t => {
     })
   t.plan(1)
 })
+
+test("standalone loading YAML with custom message", t => {
+  standalone({
+    code: "a { color: pink; }",
+    configFile: path.join(__dirname, "fixtures/config-color-no-named-custom-message.yaml"),
+  }).then(({ output }) => {
+    const parsedOutput = JSON.parse(output)[0]
+    t.equal(parsedOutput.warnings.length, 1)
+    t.equal(parsedOutput.warnings[0].text, "Unacceptable")
+  })
+
+  t.plan(2)
+})

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -16,6 +16,7 @@ export default postcss.plugin("stylelint", (options = {}) => {
     // configuration and data across sub-plugins via the PostCSS Result
     result.stylelint = result.stylelint || {}
     result.stylelint.ruleSeverities = {}
+    result.stylelint.customMessages = {}
 
     return configPromise.then(({ config, configDir }) => {
       if (!config) {
@@ -60,17 +61,20 @@ export default postcss.plugin("stylelint", (options = {}) => {
 
         const rawRuleSettings = config.rules[ruleName]
         const ruleSettings = normalizeRuleSettings(rawRuleSettings, ruleName)
+        const primaryOption = ruleSettings[0]
+        const secondaryOptions = ruleSettings[1]
 
         // Ignore the rule
-        if (ruleSettings[0] === null) { return }
+        if (primaryOption === null) { return }
 
-        const ruleSeverity = get(ruleSettings, "[1].warn") ? "warning" : "error"
+        const ruleSeverity = (secondaryOptions && secondaryOptions.warn) ? "warning" : "error"
 
         // Log the rule's severity in the PostCSS result
         result.stylelint.ruleSeverities[ruleName] = ruleSeverity
+        result.stylelint.customMessages[ruleName] = secondaryOptions && secondaryOptions.message
 
         // Run the rule with the primary and secondary options
-        ruleDefinitions[ruleName](ruleSettings[0], ruleSettings[1])(root, result)
+        ruleDefinitions[ruleName](primaryOption, secondaryOptions)(root, result)
       })
     })
   }

--- a/src/utils/report.js
+++ b/src/utils/report.js
@@ -1,3 +1,5 @@
+import { get } from "lodash"
+
 /**
  * Report a violation.
  *
@@ -52,9 +54,7 @@ export default function ({
     }
   }
 
-  const severity = (result.stylelint.ruleSeverities)
-    ? result.stylelint.ruleSeverities[ruleName]
-    : "ignore"
+  const severity = get(result.stylelint, [ "ruleSeverities", ruleName ], "ignore")
 
   if (typeof severity === "undefined") {
     throw new Error(
@@ -76,5 +76,6 @@ export default function ({
   if (index) { warningProperties.index = index }
   if (word) { warningProperties.word = word }
 
-  result.warn(message, warningProperties)
+  const warningMessage = get(result.stylelint, [ "customMessages", ruleName ], message)
+  result.warn(warningMessage, warningProperties)
 }

--- a/src/utils/validateOptions.js
+++ b/src/utils/validateOptions.js
@@ -1,5 +1,10 @@
 import { isPlainObject, isFunction } from "lodash"
 
+const ignoredOptions = [
+  "warn",
+  "message",
+]
+
 /**
  * Validate a rule's options.
  *
@@ -68,7 +73,7 @@ export default function (result, ruleName, ...optionDescriptions) {
     }
 
     Object.keys(actual).forEach(optionName => {
-      if (optionName === "warn") { return }
+      if (ignoredOptions.indexOf(optionName) !== -1) { return }
 
       if (!possible[optionName]) {
         complain(`Invalid option name "${optionName}" for rule "${ruleName}"`)


### PR DESCRIPTION
Easy custom messages: just add them as a secondary `message` option to any rule.

Anybody who feels like testing this out and trying to break it before we release --- that would be grand!

cc/ @bluetidepro, @kangax, @jeddy3 