### PR TITLE
Add ignore between comments option to comment-empty-line-before, closes #647

### DIFF
--- a/src/rules/comment-empty-line-before/README.md
+++ b/src/rules/comment-empty-line-before/README.md
@@ -116,3 +116,32 @@ a {
   color: pink;
 }
 ```
+
+### `ignore: ["between-comments"]`
+
+Don't require an empty line between comments.
+
+For example, with `"always"`:
+
+The following patterns are considered warnings:
+
+```css
+a {
+  background: pink;
+  /* comment */
+  /* comment */
+  color: #eee;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  background: pink;
+
+  /* comment */
+  /* comment */
+  color: #eee;
+}
+```

--- a/src/rules/comment-empty-line-before/README.md
+++ b/src/rules/comment-empty-line-before/README.md
@@ -123,17 +123,6 @@ Don't require an empty line between comments.
 
 For example, with `"always"`:
 
-The following patterns are considered warnings:
-
-```css
-a {
-  background: pink;
-  /* comment */
-  /* comment */
-  color: #eee;
-}
-```
-
 The following patterns are *not* considered warnings:
 
 ```css
@@ -141,6 +130,17 @@ a {
   background: pink;
 
   /* comment */
+  /* comment */
+  color: #eee;
+}
+```
+
+```css
+a {
+  background: pink;
+
+  /* comment */
+
   /* comment */
   color: #eee;
 }

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -7,7 +7,7 @@ import scssSyntax from "postcss-scss"
 
 const testRule = ruleTester(rule, ruleName)
 
-function alwaysTests(tr) {
+function alwaysTestsCommon(tr) {
   warningFreeBasics(tr)
 
   tr.ok("/** comment */", "first node ignored")
@@ -17,10 +17,14 @@ function alwaysTests(tr) {
   tr.ok("a {}\r\n\r\n/** comment */", "CRLF")
   tr.ok("a { color: pink;\n\n/** comment */\ntop: 0; }")
 
-  tr.notOk("/** comment */\n/** comment */", messages.expected)
-  tr.notOk("/** comment */\r\n/** comment */", messages.expected, "CRLF")
   tr.notOk("a { color: pink;\n/** comment */\ntop: 0; }", messages.expected)
   tr.notOk("a { color: pink;\r\n/** comment */\r\ntop: 0; }", messages.expected, "CRLF")
+}
+
+function alwaysTests(tr) {
+  alwaysTestsCommon(tr)
+  tr.notOk("/** comment */\n/** comment */", messages.expected)
+  tr.notOk("/** comment */\r\n/** comment */", messages.expected, "CRLF")
 }
 
 testRule("always", tr => {
@@ -65,6 +69,16 @@ testRule("always", { ignore: ["stylelint-commands"] }, tr => {
     "a {\ncolor: pink;\n/* stylelint-disable something */\ntop: 0;\n}",
     "no newline before a stylelint command comment"
   )
+})
+
+testRule("always", { ignore: ["between-comments"] }, tr => {
+  alwaysTestsCommon(tr)
+  tr.ok(
+    "/* a */\n/* b */\n/* c */\nbody {\n}",
+    "no newline between comments"
+  )
+  tr.ok("a { color: pink;\n\n/** comment */\n/** comment */\ntop: 0; }", "no newline between comments")
+  tr.notOk("a { color: pink;\n/** comment */\n/** comment */\ntop: 0; }", messages.expected)
 })
 
 testRule("never", tr => {

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -7,7 +7,7 @@ import scssSyntax from "postcss-scss"
 
 const testRule = ruleTester(rule, ruleName)
 
-function alwaysTestsCommon(tr) {
+function alwaysTests(tr) {
   warningFreeBasics(tr)
 
   tr.ok("/** comment */", "first node ignored")
@@ -17,14 +17,10 @@ function alwaysTestsCommon(tr) {
   tr.ok("a {}\r\n\r\n/** comment */", "CRLF")
   tr.ok("a { color: pink;\n\n/** comment */\ntop: 0; }")
 
-  tr.notOk("a { color: pink;\n/** comment */\ntop: 0; }", messages.expected)
-  tr.notOk("a { color: pink;\r\n/** comment */\r\ntop: 0; }", messages.expected, "CRLF")
-}
-
-function alwaysTests(tr) {
-  alwaysTestsCommon(tr)
   tr.notOk("/** comment */\n/** comment */", messages.expected)
   tr.notOk("/** comment */\r\n/** comment */", messages.expected, "CRLF")
+  tr.notOk("a { color: pink;\n/** comment */\ntop: 0; }", messages.expected)
+  tr.notOk("a { color: pink;\r\n/** comment */\r\ntop: 0; }", messages.expected, "CRLF")
 }
 
 testRule("always", tr => {
@@ -72,7 +68,6 @@ testRule("always", { ignore: ["stylelint-commands"] }, tr => {
 })
 
 testRule("always", { ignore: ["between-comments"] }, tr => {
-  alwaysTestsCommon(tr)
   tr.ok(
     "/* a */\n/* b */\n/* c */\nbody {\n}",
     "no newline between comments"

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -27,7 +27,10 @@ export default function (expectation, options) {
       actual: options,
       possible: {
         except: ["first-nested"],
-        ignore: ["stylelint-commands"],
+        ignore: [
+          "stylelint-commands",
+          "between-comments",
+        ],
       },
       optional: true,
     })
@@ -42,6 +45,13 @@ export default function (expectation, options) {
       if (
         comment.text.indexOf(stylelintCommandPrefix) === 0
         && optionsHaveIgnored(options, "stylelint-commands")
+      ) { return }
+
+      // Optionally ignore newlines between comments
+      const prev = comment.prev()
+      if (
+        prev && prev.type === "comment"
+        && optionsHaveIgnored(options, "between-comments")
       ) { return }
 
       if (comment.raws.inline) { return }


### PR DESCRIPTION
This PR adds a new `ignore: ["between-comments"]` option to `comment-empty-line-before` (#647).