### PR TITLE
Add font-weight-notation rule; closes #595

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+- Added: `font-weight-notation` rule.
 - Fixed: bug in `rule-properties-order` empty line detection when the two newlines were separated
   by some other whitespace.
 - Fixed: option parsing bug that caused problems when using the `"alphabetical"` primary option

--- a/docs/user-guide/rules.json
+++ b/docs/user-guide/rules.json
@@ -33,6 +33,7 @@
     "declaration-colon-space-after": "always"|"never"|"always-single-line",
     "declaration-colon-space-before": "always"|"never",
     "declaration-no-important": true,
+    "font-weight-notation": "numeric"|"named",
     "function-blacklist": string|[],
     "function-calc-no-unspaced-operator": true,
     "function-comma-newline-after": "always"|"always-multi-line"|"never-multi-line",

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -18,6 +18,10 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 * [`color-no-invalid-hex`](../../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
 * [`color-no-named`](../../src/rules/color-no-named/README.md): Disallow named colors.
 
+### Font weight
+
+* [`font-weight-notation`](../../src/rules/font-weight-notation/README.md): Require consistent numeric or named `font-weight` values.
+
 ### Number
 
 * [`number-leading-zero`](../../src/rules/number-leading-zero/README.md): Require or disallow a leading zero for fractional numbers less than 1.
@@ -40,6 +44,11 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 * [`function-whitelist`](../../src/rules/function-whitelist/README.md): Specify a whitelist of only allowed functions.
 * [`function-whitespace-after`](../../src/rules/function-whitespace-after/README.md): Require a single space or disallow whitespace after functions.
 
+### Unit
+
+* [`unit-blacklist`](../../src/rules/unit-blacklist/README.md): Specify a blacklist of disallowed units.
+* [`unit-whitelist`](../../src/rules/unit-whitelist/README.md): Specify a whitelist of allowed units.
+
 ### Value
 
 * [`value-no-vendor-prefix`](../../src/rules/value-no-vendor-prefix/README.md): Disallow vendor prefixes for values.
@@ -50,11 +59,6 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 * [`value-list-comma-newline-before`](../../src/rules/value-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of value lists.
 * [`value-list-comma-space-after`](../../src/rules/value-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of value lists.
 * [`value-list-comma-space-before`](../../src/rules/value-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of value lists.
-
-### Unit
-
-* [`unit-blacklist`](../../src/rules/unit-blacklist/README.md): Specify a blacklist of disallowed units.
-* [`unit-whitelist`](../../src/rules/unit-whitelist/README.md): Specify a whitelist of allowed units.
 
 ### Property
 
@@ -99,6 +103,10 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 * [`block-opening-brace-space-after`](../../src/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks.
 * [`block-opening-brace-space-before`](../../src/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks.
 
+### Root
+
+* [`root-no-standard-properties`](../../src/rules/root-no-standard-properties/README.md): Disallow standard properties inside `:root` selectors.
+
 ### Selector
 
 * [`selector-class-pattern`](../../src/rules/selector-class-pattern/README.md): Specify a pattern for class selectors.
@@ -130,10 +138,6 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 * [`rule-non-nested-empty-line-before`](../../src/rules/rule-non-nested-empty-line-before/README.md): Require or disallow an empty line before non-nested rules.
 * [`rule-properties-order`](../../src/rules/rule-properties-order/README.md): Specify the order of properties within rules.
 * [`rule-trailing-semicolon`](../../src/rules/rule-trailing-semicolon/README.md): Require or disallow a trailing semicolon within rules.
-
-### Root
-
-* [`root-no-standard-properties`](../../src/rules/root-no-standard-properties/README.md): Disallow standard properties inside `:root` selectors.
 
 ### Media feature
 

--- a/src/rules/font-weight-notation/README.md
+++ b/src/rules/font-weight-notation/README.md
@@ -6,11 +6,11 @@ Also, when named values are expected, require only valid names.
 ```css
 a { font-weight: bold }
 /**               ↑
- * This notation    */
+ *    This notation */
 
 a { font: italic small-caps 600 16px/3 cursive; }
 /**                          ↑
-* And this notation, too       */
+*       And this notation, too */
 ```
 
 Valid font-weight names are `normal`, `bold`, `bolder`, and `lighter`.
@@ -45,7 +45,7 @@ a { font: italic 900 20px; }
 
 ### `"named"`
 
-`font-weight` values` *must always* be keyword names.
+`font-weight` values *must always* be keyword names.
 
 The following patterns are considered warnings:
 

--- a/src/rules/font-weight-notation/README.md
+++ b/src/rules/font-weight-notation/README.md
@@ -1,0 +1,68 @@
+# font-weight-notation
+
+Require consistent numeric or named `font-weight` values.
+Also, when named values are expected, require only valid names.
+
+```css
+a { font-weight: bold }
+/**               ↑
+ * This notation    */
+
+a { font: italic small-caps 600 16px/3 cursive; }
+/**                          ↑
+* And this notation, too       */
+```
+
+Valid font-weight names are `normal`, `bold`, `bolder`, and `lighter`.
+
+## Options
+
+`string`: `"numeric"|"named"`
+
+### `"numeric"`
+
+`font-weight` values *must always* be numbers.
+
+The following patterns are considered warnings:
+
+```css
+a { font-weight: bold; }
+```
+
+```css
+a { font: italic normal 20px; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { font-weight: 700; }
+```
+
+```css
+a { font: italic 900 20px; }
+```
+
+### `"named"`
+
+`font-weight` values` *must always* be keyword names.
+
+The following patterns are considered warnings:
+
+```css
+a { font-weight: 700; }
+```
+
+```css
+a { font: italic 900 20px; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { font-weight: bold; }
+```
+
+```css
+a { font: italic normal 20px; }
+```

--- a/src/rules/font-weight-notation/__tests__/index.js
+++ b/src/rules/font-weight-notation/__tests__/index.js
@@ -1,0 +1,50 @@
+import {
+  ruleTester,
+  warningFreeBasics,
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule("numeric", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { font-weight: 100; }")
+  tr.ok("a { font-weight: 700; }")
+  tr.ok("a { font-weight: 850; }")
+  tr.ok("a { font-weight: 900; }")
+  tr.ok("a { font: italic small-caps 400 16px/3 cursive; }")
+  tr.ok("a { font: italic small-caps 400 16px/500 cursive; }")
+
+  tr.notOk("a { font-weight: normal; }", {
+    message: messages.expected("numeric"),
+    line: 1,
+    column: 18,
+  })
+  tr.notOk("a { font: italic small-caps bolder 16px/3 cursive; }", {
+    message: messages.expected("numeric"),
+    line: 1,
+    column: 29,
+  })
+})
+
+testRule("named", tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { font-weight: bold; }")
+  tr.ok("a { font-weight: bolder; }")
+  tr.ok("a { font-weight: normal; }")
+  tr.ok("a { font-weight: lighter; }")
+  tr.ok("a { font: italic small-caps bold 16px/500 cursive; }")
+
+  tr.notOk("a { font-weight: 400; }", {
+    message: messages.expected("named"),
+    line: 1,
+    column: 18,
+  })
+  tr.notOk("a { font: italic small-caps 700 16px/3 cursive; }", {
+    message: messages.expected("named"),
+    line: 1,
+    column: 29,
+  })
+})

--- a/src/rules/font-weight-notation/__tests__/index.js
+++ b/src/rules/font-weight-notation/__tests__/index.js
@@ -15,6 +15,8 @@ testRule("numeric", tr => {
   tr.ok("a { font-weight: 900; }")
   tr.ok("a { font: italic small-caps 400 16px/3 cursive; }")
   tr.ok("a { font: italic small-caps 400 16px/500 cursive; }")
+  tr.ok("a { font: italic small-caps 400 16px/500 \"bold font name\"; }")
+  tr.ok("a { font: italic small-caps 400 16px/500 boldfontname; }")
 
   tr.notOk("a { font-weight: normal; }", {
     message: messages.expected("numeric"),
@@ -36,6 +38,8 @@ testRule("named", tr => {
   tr.ok("a { font-weight: normal; }")
   tr.ok("a { font-weight: lighter; }")
   tr.ok("a { font: italic small-caps bold 16px/500 cursive; }")
+  tr.ok("a { font: italic small-caps bold 16px/500 \"cursive 100 font\"; }")
+  tr.ok("a { font: italic small-caps bold 16px/500 100cursivefont; }")
 
   tr.notOk("a { font-weight: 400; }", {
     message: messages.expected("named"),

--- a/src/rules/font-weight-notation/index.js
+++ b/src/rules/font-weight-notation/index.js
@@ -1,0 +1,81 @@
+import postcss from "postcss"
+import {
+  declarationValueIndexOffset,
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "font-weight-notation"
+
+export const messages = ruleMessages(ruleName, {
+  expected: type => `Expected ${type} font-weight notation`,
+  invalidNamed: name => `Unexpected invalid font-weight name "${name}"`,
+})
+
+const NAMED_WEIGHTS = [ "normal", "bold", "bolder", "lighter" ]
+function isNumbery(x) {
+  return Number(x) == x
+}
+
+export default function (expectation) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: [ "numeric", "named" ],
+    })
+    if (!validOptions) { return }
+
+    root.walkDecls(decl => {
+      if (decl.prop === "font-weight") {
+        checkWeight(decl.value, decl)
+      }
+
+      if (decl.prop === "font") {
+        checkFont(decl)
+      }
+    })
+
+    function checkFont(decl) {
+      for (let value of postcss.list.space(decl.value)) {
+        // We do not need to more carefully distinguish font-weight
+        // numbers from unitless line-heights because line-heights in
+        // `font` values need to be part of a font-size/line-height pair
+        if (isNumbery(value) || NAMED_WEIGHTS.indexOf(value) !== -1) {
+          checkWeight(value, decl)
+          return
+        }
+      }
+    }
+
+    function checkWeight(weightValue, decl) {
+      const weightValueOffset = decl.value.indexOf(weightValue)
+
+      if (expectation === "numeric") {
+        if (!isNumbery(weightValue)) {
+          return complain(messages.expected("numeric"))
+        }
+      }
+
+      if (expectation === "named") {
+        if (isNumbery(weightValue)) {
+          return complain(messages.expected("named"))
+        }
+        if (NAMED_WEIGHTS.indexOf(weightValue) === -1) {
+          return complain(messages.invalidNamed(weightValue))
+        }
+        return
+      }
+
+      function complain(message) {
+        report({
+          ruleName,
+          result,
+          message,
+          node: decl,
+          index: declarationValueIndexOffset(decl) + weightValueOffset,
+        })
+      }
+    }
+  }
+}


### PR DESCRIPTION
@jeddy3: I did not add this to the rule index because there was not an obvious category for it. Where would you like to put it?