### PR TITLE
Update `.scss` example in Node API docs

### DIFF
--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -125,7 +125,7 @@ Maybe I want to use my own custom formatter function and parse `.scss` source fi
 
 ```js
 stylelint.lint({
-  code: "a { color: pink; }",
+  files: "all/my/stylesheets/*.scss",
   config: myConfig,
   syntax: "scss",
   formatter: function(stylelintResults) { .. }


### PR DESCRIPTION
Code example now matches the example description, i.e. switch from a CSS string to .scss files glob