### PR TITLE
Accept 0 byte CSS code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   by some other whitespace.
 * Fixed: option parsing bug that caused problems when using the `"alphabetical"` primary option
   with `rule-properties-order`.
+* Fixed: regard an empty string as a valid CSS code
 
 # 4.2.0
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -21,7 +21,8 @@ export default function ({
   syntax,
   formatter = "json",
 } = {}) {
-  if (!files && !code || files && code) {
+  const isValidCode = typeof code === "string"
+  if (!files && !isValidCode || files && (code || isValidCode)) {
     throw new Error("You must pass stylelint a `files` glob or a `code` string, though not both")
   }
 


### PR DESCRIPTION
When we pass an empty string to `code`,

```js
const stylelint = require('stylelint');

stylelint.lint({code: '', config: {
  rules: {
    indentation: [2]
  }
}}).lint().catch(console.error);
```

We get the error like this:

```
Error: You must pass stylelint a `files` glob or a `code` string, though not both
```

I think it's not a proper behavior because 0 byte CSS is also a valid CSS. Due to this [I must include a workaround in a VSCode plugin](https://github.com/shinnn/stylelint-vscode/blob/7b008e4a7f6ea28bedf517e578e8de4895bf7f81/index.js#L22-L26) currently.

This pull request lets stylelint regard an empty string as a valid CSS.
