### PR TITLE
Incorporate and expose ruleTester; closes #702

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Head
+* Added: brought `stylelint-rule-tester` into this repo, and exposed it at `stylelint.utils.ruleTester`.
 * Added: `codeFilename` option to Node API.
 * Added: `font-weight-notation` rule.
 * Added: `media-feature-no-missing-punctuation` rule.

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -32,6 +32,7 @@ your plugin will respect disabled ranges and other possible future features of s
 - `ruleMessages`: Tailor your messages to look like the messages of other stylelint rules. Currently, this means that the name of the rule is appended, in parentheses, to the end of the message.
 - `styleSearch`: Search within CSS strings, and for every match found invoke a callback, passing a match object with details about the match. `styleSearch` ignores CSS strings (e.g. `content: "foo";`) and by default ignores comments. It can also be restricted to substrings within or outside of CSS functional notation.
 - `validateOptions`: Help your user's out by checking that the options they've submitted are valid.
+- `ruleTester`: Test your rules with the same concise testing syntax that stylelint uses. Linter rules require lots of tests, so the easier it is for you to create those tests, the better.
 
 ## `stylelint.rules`
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "npmpub": "^3.0.1",
     "postcss-import": "^8.0.2",
     "sinon": "^1.16.1",
-    "stylelint-rule-tester": "^0.6.2",
     "tape": "^4.2.0"
   },
   "scripts": {

--- a/src/__tests__/importableApi-test.js
+++ b/src/__tests__/importableApi-test.js
@@ -1,0 +1,36 @@
+import stylelint from  ".."
+import test from "tape"
+
+import postcssPlugin from "../postcssPlugin"
+import standalone from "../standalone"
+import createPlugin from "../createPlugin"
+import rules from "../rules"
+import {
+  report,
+  ruleMessages,
+  styleSearch,
+  validateOptions,
+} from "../utils"
+import ruleTester from "../testUtils/ruleTester"
+
+test("`stylelint` itself", t => {
+  t.equal(stylelint, postcssPlugin, "is the PostCSS plugin")
+  t.end()
+})
+
+test("`stylelint.utils`", t => {
+  t.equal(Object.keys(stylelint.utils).length, 5, "correct `stylelint.utils.length`")
+  t.equal(stylelint.utils.report, report, "correct `stylelint.utils.report`")
+  t.equal(stylelint.utils.ruleMessages, ruleMessages, "correct `stylelint.utils.ruleMessages`")
+  t.equal(stylelint.utils.styleSearch, styleSearch, "correct `stylelint.utils.styleSearch`")
+  t.equal(stylelint.utils.validateOptions, validateOptions, "correct `stylelint.utils.validateOptions`")
+  t.equal(stylelint.utils.ruleTester, ruleTester, "correct `stylelint.utils.ruleTester`")
+  t.end()
+})
+
+test("other exposed features", t => {
+  t.equal(stylelint.lint, standalone, "correct `stylelint.lint`")
+  t.equal(stylelint.rules, rules, "correct `stylelint.rules`")
+  t.equal(stylelint.createPlugin, createPlugin, "correct `stylelint.createPlugin`")
+  t.end()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
   styleSearch,
   validateOptions,
 } from "./utils"
+import ruleTester from "./testUtils/ruleTester"
 
 const stylelint = postcssPlugin
 
@@ -16,6 +17,7 @@ stylelint.utils = {
   ruleMessages,
   styleSearch,
   validateOptions,
+  ruleTester,
 }
 
 stylelint.lint = standalone

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -1,2 +1,10 @@
-export { default as ruleTester } from "./ruleTester"
+import disableRanges from "../disableRanges"
+import genericRuleTester from "./ruleTester"
+
+export function ruleTester(rule, ruleName, options = {}) {
+  options.preceedingPlugins = [disableRanges]
+  options.printWarnings = true
+  return genericRuleTester(rule, ruleName, options)
+}
+
 export { default as warningFreeBasics } from "./warningFreeBasics"

--- a/src/testUtils/ruleTester.js
+++ b/src/testUtils/ruleTester.js
@@ -1,9 +1,145 @@
-import disableRanges from "../disableRanges"
-import ruleTester from "stylelint-rule-tester"
+import postcss from "postcss"
+import test from "tape"
 
-export default function (rule, ruleName, options) {
-  options = options || {}
-  options.preceedingPlugins = [disableRanges]
+/**
+ * Create a ruleTester for a specified rule.
+ *
+ * The ruleTester is a function accepting options and a callback.
+ * The callback is passed on object exposing `ok` and `notOk` functions,
+ * which check CSS strings against the rule configured with the specified options.
+ *
+ * @param {function} rule
+ * @param {string} ruleName
+ * @param {object} [testerOptions]
+ * @param {function[]} [testerOptions.preceedingPlugins] - Array of PostCSS plugins to
+ *   run the CSS string through *before* linting it
+ * @param {boolean} [testerOptions.escapeCss = true] - If `false`, the CSS string printed
+ *   to the console will not be escaped.
+ *   This is useful if you want to read newlines and indentation.
+ * @param {boolean} [testerOptions.printWarnings = false] - If `true`, the tester
+ *   will print all the warnings that each test case produces.
+ * @param {object} [testerOptions.postcssOptions] - An objects object passed
+ *   to postcssProcessor.process().
+ *   cf. https://github.com/postcss/postcss/blob/master/docs/api.md#processorprocesscss-opts
+ * @return {function} ruleTester for the specified rule/options
+ */
+export default function (rule, ruleName, testerOptions = {}) {
+  testerOptions.escapeCss = testerOptions.escapeCss !== false
 
-  return ruleTester.printWarnings(rule, ruleName, options)
+  return ruleTester
+
+  function ruleTester(rulePrimaryOptions, ruleSecondaryOptions, done) {
+    if (typeof ruleSecondaryOptions === "function") {
+      done = ruleSecondaryOptions
+      ruleSecondaryOptions = null
+    }
+
+    let ruleOptionsString = (rulePrimaryOptions) ? JSON.stringify(rulePrimaryOptions) : ""
+    if (ruleOptionsString && ruleSecondaryOptions) {
+      ruleOptionsString += ", " + JSON.stringify(ruleSecondaryOptions)
+    }
+
+    done({ ok, notOk })
+
+    /**
+     * Checks that a CSS string is valid according to the
+     * specified rule/options.
+     *
+     * @param {string} cssString
+     * @param {string} [description]
+     */
+    function ok(cssString, description) {
+      test(testTitleStr(cssString), t => {
+        t.plan(1)
+        postcssProcess(cssString).then(result => {
+          const warnings = result.warnings()
+          if (testerOptions.printWarnings) {
+            warnings.forEach(warning => {
+              t.comment("warning: " + warning.text)
+            })
+          }
+          t.equal(warnings.length, 0, prepender(description, "should pass"))
+        }).catch(err => { console.log(err.stack) })
+      })
+    }
+
+    /**
+     * Checks that a CSS string is INVALID according to the
+     * specified rule/options -- i.e. that a warning is registered
+     * with the expected warning message.
+     *
+     * @param {string} cssString
+     * @param {string|object} expectedWarning
+     * @param {string} [expectedWarning.message]
+     * @param {string} [expectedWarning.line]
+     * @param {string} [expectedWarning.column]
+     * @param {string} [description]
+     */
+    function notOk(cssString, expectedWarning, description) {
+      test(testTitleStr(cssString), t => {
+        const expectedWarningMessage = (typeof expectedWarning === "string")
+          ? expectedWarning
+          : expectedWarning.message
+        t.plan(4)
+        postcssProcess(cssString).then(result => {
+          const allActualWarnings = result.warnings()
+
+          if (testerOptions.printWarnings) {
+            allActualWarnings.forEach(warning => {
+              t.comment("warning: " + warning.text)
+            })
+          }
+          t.equal(allActualWarnings.length, 1, prepender(description, "should warn"))
+
+          const actualWarning = allActualWarnings[0]
+
+          if (actualWarning) {
+            t.equal(actualWarning.text, expectedWarningMessage,
+              prepender(description, "warning message should be \"" + expectedWarningMessage + "\""))
+          } else { t.pass("no warning to check") }
+          if (actualWarning && expectedWarning.line) {
+            t.equal(actualWarning.line, expectedWarning.line,
+              prepender(description, "warning should be at line " + expectedWarning.line))
+          } else { t.pass("no line number expected") }
+          if (actualWarning && expectedWarning.column) {
+            t.equal(actualWarning.column, expectedWarning.column,
+              prepender(description, "warning should be at column " + expectedWarning.column))
+          } else { t.pass("no column number expected") }
+        }).catch(err => { console.log(err.stack) })
+      })
+    }
+
+    function postcssProcess(cssString) {
+      const processor = postcss()
+
+      if (testerOptions.preceedingPlugins) {
+        testerOptions.preceedingPlugins.forEach(plugin => {
+          processor.use(plugin)
+        })
+      }
+
+      return processor
+        .use(rule(rulePrimaryOptions, ruleSecondaryOptions))
+        .process(cssString, testerOptions.postcssOptions)
+    }
+
+    function testTitleStr(css) {
+      let result = "\ncss: "
+      if (testerOptions.escapeCss) {
+        result += JSON.stringify(css)
+      } else {
+        result += "\n" + css
+      }
+      result += "\nrule: " + ruleName
+      result += "\noptions: " + ruleOptionsString
+      return result
+    }
+  }
+}
+
+function prepender(a, b) {
+  if (a) {
+    return a + " " + b
+  }
+  return b
 }


### PR DESCRIPTION
I also added tests to ensure that what you get when you import `stylelint` is what we expect it to be.

Once this is released, I will deprecate the stylelint-rule-tester package.