### PR TITLE
Add caveats section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ You'll find more detailed information on using the linter and tailoring it to yo
 - [Changelog](CHANGELOG.md)
 - [Contributing Guidelines](CONTRIBUTING.md)
 - [License](https://raw.githubusercontent.com/stylelint/stylelint/master/LICENSE)
+
+## Caveats
+
+- stylelint works very well via the CLI, but editor support is fairly shaky right now. Be sure to try out stylelint with your preferred editor(s) to see if it works for you.


### PR DESCRIPTION
Alright, I'm seriously not trying to be a jerk with this one, and this is literally the last time I come to the stylelint repo for weeks/months.

I think this PR is a nice compromise that perhaps **all projects should do** -- just provide a little caveats section toward the bottom of the README so people know exactly what they're getting themselves into.

If you don't want to merge because you don't like me, I get that and I'm sorry for offending everyone, but please look past that for future users who haven't done anything.