### PR TITLE
Lint markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Head
 
-* Fixed: accuracy of warning positions are `//` comments when using SCSS parser.
-* Fixed: `no-unknown-animations` ignores variables.
-* Fixed: `no-unknown-animations` does not erroneously flag functions like `steps()` and `cubic-bezier()`.
-* Fixed: clarified error message in `time-no-imperceptible`.
-* Fixed: `font-family-name-quotes` and `font-weight-notation` ignore variables.
-* Fixed: `media-feature-no-missing-punctuation` handles space-padded media features.
+- Fixed: accuracy of warning positions are `//` comments when using SCSS parser.
+- Fixed: `no-unknown-animations` ignores variables.
+- Fixed: `no-unknown-animations` does not erroneously flag functions like `steps()` and `cubic-bezier()`.
+- Fixed: clarified error message in `time-no-imperceptible`.
+- Fixed: `font-family-name-quotes` and `font-weight-notation` ignore variables.
+- Fixed: `media-feature-no-missing-punctuation` handles space-padded media features.
 
 # 4.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,410 +9,412 @@
 
 # 4.3.3
 
-* Fixed: again removed `stylelint.utils.ruleTester` because its dependencies broke things.
+- Fixed: again removed `stylelint.utils.ruleTester` because its dependencies broke things.
 
 # 4.3.2
 
-* Fixed: move `tape` to dependencies to support `testUtils`.
+- Fixed: move `tape` to dependencies to support `testUtils`.
 
 # 4.3.1
 
-* Fixed: include `testUtils` in npm package whitelist.
+- Fixed: include `testUtils` in npm package whitelist.
 
 # 4.3.0
 
-* Added: `font-family-name-quotes` rule.
-* Added: `font-weight-notation` rule.
-* Added: `media-feature-no-missing-punctuation` rule.
-* Added: `no-duplicate-selectors` rule.
-* Added: `no-invalid-double-slash-comments` rule.
-* Added: `no-unknown-animations` rule.
-* Added: `property-value-blacklist` rule.
-* Added: `property-value-whitelist` rule.
-* Added: `time-no-imperceptible` rule.
-* Added: `ignore: "descendant"` and `ignore: "compounded"` options for `selector-no-type`.
-* Added: support for regular expression property identification in `property-blacklist`, `property-unit-blacklist`, `property-unit-whitelist`, `property-value-blacklist`, and `property-whitelist`.
-* Added: better handling of vendor prefixes in `property-unit-blacklist` and `property-unit-whitelist`, e.g. if you enter `animation` it now also checks `-webkit-animation`.
-* Added: support for using names of modules for the CLI's `--config` argument, not just paths.
-* Added: `codeFilename` option to Node API.
-* Added: exposed rules at `stylelint.rules` to make stylelint even more extensible.
-* Added: brought `stylelint-rule-tester` into this repo, and exposed it at `stylelint.utils.ruleTester`.
-* Fixed: bug in `rule-properties-order` empty line detection when the two newlines were separated
+- Added: `font-family-name-quotes` rule.
+- Added: `font-weight-notation` rule.
+- Added: `media-feature-no-missing-punctuation` rule.
+- Added: `no-duplicate-selectors` rule.
+- Added: `no-invalid-double-slash-comments` rule.
+- Added: `no-unknown-animations` rule.
+- Added: `property-value-blacklist` rule.
+- Added: `property-value-whitelist` rule.
+- Added: `time-no-imperceptible` rule.
+- Added: `ignore: "descendant"` and `ignore: "compounded"` options for `selector-no-type`.
+- Added: support for regular expression property identification in `property-blacklist`, `property-unit-blacklist`, `property-unit-whitelist`, `property-value-blacklist`, and `property-whitelist`.
+- Added: better handling of vendor prefixes in `property-unit-blacklist` and `property-unit-whitelist`, e.g. if you enter `animation` it now also checks `-webkit-animation`.
+- Added: support for using names of modules for the CLI's `--config` argument, not just paths.
+- Added: `codeFilename` option to Node API.
+- Added: exposed rules at `stylelint.rules` to make stylelint even more extensible.
+- Added: brought `stylelint-rule-tester` into this repo, and exposed it at `stylelint.utils.ruleTester`.
+- Fixed: bug in `rule-properties-order` empty line detection when the two newlines were separated
   by some other whitespace.
-* Fixed: option parsing bug that caused problems when using the `"alphabetical"` primary option
+- Fixed: option parsing bug that caused problems when using the `"alphabetical"` primary option
   with `rule-properties-order`.
-* Fixed: regard an empty string as a valid CSS code.
-* Fixed: `ignoreFiles` handling of absolute paths.
-* Fixed: `ignoreFiles` uses the `configBasedir` option to interpret relative paths.
+- Fixed: regard an empty string as a valid CSS code.
+- Fixed: `ignoreFiles` handling of absolute paths.
+- Fixed: `ignoreFiles` uses the `configBasedir` option to interpret relative paths.
 
 # 4.2.0
 
-* Added: support for custom messages with a `message` secondary property on any rule.
-* Fixed: CLI always ignores contents of `node_modules` and `bower_components` directories.
-* Fixed: bug preventing CLI from understanding absolute paths in `--config` argument.
-* Fixed: bug causing `indentation` to stumble over declarations with semicolons on their own lines.
+- Added: support for custom messages with a `message` secondary property on any rule.
+- Fixed: CLI always ignores contents of `node_modules` and `bower_components` directories.
+- Fixed: bug preventing CLI from understanding absolute paths in `--config` argument.
+- Fixed: bug causing `indentation` to stumble over declarations with semicolons on their own lines.
 
 # 4.1.0
 
-* Added: helpful option validation message when object is expected but non-object provided.
-* Fixed: `selector-no-id` no longer warns about Sass interpolation when multiple interpolations are used in a selector.
+- Added: helpful option validation message when object is expected but non-object provided.
+- Fixed: `selector-no-id` no longer warns about Sass interpolation when multiple interpolations are used in a selector.
 
 # 4.0.0
 
-* Removed: support for legacy numbered severities.
-* Added: support for extensions on `.stylelintrc` files (by upgrading cosmiconfig).
-* Added: `ignore: "non-comments"` option to `max-line-length`.
-* Fixed: `function-whitespace-after` does not expect space between `)` and `}`, so it handles Sass interpolation better.
+- Removed: support for legacy numbered severities.
+- Added: support for extensions on `.stylelintrc` files (by upgrading cosmiconfig).
+- Added: `ignore: "non-comments"` option to `max-line-length`.
+- Fixed: `function-whitespace-after` does not expect space between `)` and `}`, so it handles Sass interpolation better.
 
 # 3.2.3
 
-* Fixed: `selector-no-vendor-prefix` now handles custom-property-sets.
+- Fixed: `selector-no-vendor-prefix` now handles custom-property-sets.
 
 # 3.2.2
 
-* Fixed: `selector-no-type` ignores `nth-child` pseudo-classes and `@keyframes` selectors.
+- Fixed: `selector-no-type` ignores `nth-child` pseudo-classes and `@keyframes` selectors.
 
 # 3.2.1
 
-* Fixed: `max-line-length` handles `url()` functions better.
-* Fixed: `block-opening-brace-newline-after` and `declaration-block-semicolon-newline-after` handle end-of-line comments better.
+- Fixed: `max-line-length` handles `url()` functions better.
+- Fixed: `block-opening-brace-newline-after` and `declaration-block-semicolon-newline-after` handle end-of-line comments better.
 
 # 3.2.0
 
-* Added: `legacyNumberedSeverities` config property to force the legacy severity system.
-* Added: `selector-no-id` ignores Sass-style interpolation.
-* Fixed: bug causing extended config to override the config that extends it.
+- Added: `legacyNumberedSeverities` config property to force the legacy severity system.
+- Added: `selector-no-id` ignores Sass-style interpolation.
+- Fixed: bug causing extended config to override the config that extends it.
 
 # 3.1.4
 
-* Fixed: stopped hijacking `--config` property in PostCSS and Node.js APIs. Still using it in the CLI.
+- Fixed: stopped hijacking `--config` property in PostCSS and Node.js APIs. Still using it in the CLI.
 
 # 3.1.3
 
-* Fixed: bug preventing the disabling of rules analyzing the `root` node, including: `max-line-length`, `max-empty-lines`, `no-eol-whitespace`, `no-missing-eof-newline`, and `string-quotes`.
-* Fixed: bug causing `rule-properties-order` to get confused by properties with an unspecified order.
+- Fixed: bug preventing the disabling of rules analyzing the `root` node, including: `max-line-length`, `max-empty-lines`, `no-eol-whitespace`, `no-missing-eof-newline`, and `string-quotes`.
+- Fixed: bug causing `rule-properties-order` to get confused by properties with an unspecified order.
 
 # 3.1.2
 
-* Fixed: bug causing an error when `null` was used on rules whose primary options are arrays.
+- Fixed: bug causing an error when `null` was used on rules whose primary options are arrays.
 
 # 3.1.1
 
-* Fixed: Documentation improvements.
+- Fixed: Documentation improvements.
 
 # 3.1.0
 
-* Added: `stylelint-commands` `ignore` option to `comment-empty-line-before`.
-* Fixed: v3 regression causing bug in `rule-properties-order` and potentially other rules that accept arrays as primary options.
-* Fixed: `no-missing-eof-newline` no longer complains about completely empty files.
+- Added: `stylelint-commands` `ignore` option to `comment-empty-line-before`.
+- Fixed: v3 regression causing bug in `rule-properties-order` and potentially other rules that accept arrays as primary options.
+- Fixed: `no-missing-eof-newline` no longer complains about completely empty files.
 
 # 3.0.3
 
-* Fixed: list of rules within documentation.
+- Fixed: list of rules within documentation.
 
 # 3.0.0-3.0.2
 
-* Removed: `nesting-block-opening-brace-space-before` and `nesting-block-opening-brace-newline-before` rules.
-* Deprecated: numbered severities (0, 1, 2) and will be disabled in `4.0`.
-* Changed: renamed `rule-single-line-max-declarations` to `declaration-block-single-line-max-declarations` and changed scope of the single-line to the declaration block.
-* Changed: renamed `rule-no-single-line` to `declaration-block-no-single-line` and changed scope of the single-line to the declaration block.
-* Changed: renamed the `function-space-after` rule to `function-whitespace-after`.
-* Changed: renamed the `comment-space-inside` rule to `comment-whitespace-inside`.
-* Changed: renamed the `no-multiple-empty-lines` rule to `max-empty-lines` (takes an `int` as option).
-* Changed: `plugins` is now an array instead of an object. And plugins should be created with `stylelint.createPlugin()`.
-* Added: cosmiconfig, which means the following:
-  * support for YAML `.stylelintrc`
-  * support for `stylelint.config.js`
-  * support for `stylelint` property in `package.json`
-  * alternate config loading system, which stops at the first config found
-* Added: asynchronicity to the PostCSS plugin.
-* Added: `ignoreFiles` option to config.
-* Added: `configFile` option to Node.js API.
-* Fixed: `comment-whitespace-inside` now ignores ignores copyright (`/*! `) and sourcemap (`/*# `) comments.
-* Fixed: `rule-no-duplicate-properties` now ignores the `src` property.
+- Removed: `nesting-block-opening-brace-space-before` and `nesting-block-opening-brace-newline-before` rules.
+- Deprecated: numbered severities (0, 1, 2) and will be disabled in `4.0`.
+- Changed: renamed `rule-single-line-max-declarations` to `declaration-block-single-line-max-declarations` and changed scope of the single-line to the declaration block.
+- Changed: renamed `rule-no-single-line` to `declaration-block-no-single-line` and changed scope of the single-line to the declaration block.
+- Changed: renamed the `function-space-after` rule to `function-whitespace-after`.
+- Changed: renamed the `comment-space-inside` rule to `comment-whitespace-inside`.
+- Changed: renamed the `no-multiple-empty-lines` rule to `max-empty-lines` (takes an `int` as option).
+- Changed: `plugins` is now an array instead of an object. And plugins should be created with `stylelint.createPlugin()`.
+- Added: cosmiconfig, which means the following:
+
+  - support for YAML `.stylelintrc`
+  - support for `stylelint.config.js`
+  - support for `stylelint` property in `package.json`
+  - alternate config loading system, which stops at the first config found
+
+- Added: asynchronicity to the PostCSS plugin.
+- Added: `ignoreFiles` option to config.
+- Added: `configFile` option to Node.js API.
+- Fixed: `comment-whitespace-inside` now ignores ignores copyright (`/*! `) and sourcemap (`/*# `) comments.
+- Fixed: `rule-no-duplicate-properties` now ignores the `src` property.
 
 # 2.3.7
 
-* Fixed: `function-calc-no-unspaced-operator` ignores characters in `$sass` and `@less` variables.
-* Fixed: `rule-properties-order` allows comments at the top of groups that expect newlines before them.
-* Fixed: `styleSearch()` and the rules it powers will not trip up on single-line (`//`) comments.
-* Fixed: `selector-combinator-space-before` now better handles nested selectors starting with combinators.
-* Fixed: `rule-properties-order` now deals property with `-moz-osx-font-smoothing`.
+- Fixed: `function-calc-no-unspaced-operator` ignores characters in `$sass` and `@less` variables.
+- Fixed: `rule-properties-order` allows comments at the top of groups that expect newlines before them.
+- Fixed: `styleSearch()` and the rules it powers will not trip up on single-line (`//`) comments.
+- Fixed: `selector-combinator-space-before` now better handles nested selectors starting with combinators.
+- Fixed: `rule-properties-order` now deals property with `-moz-osx-font-smoothing`.
 
 # 2.3.6
 
-* Fixed: improved documentation of CLI globbing possibilities.
-* Fixed: `rule-properties-order` now accounts for property names containing multiple hyphens.
-* Fixed: `rule-properties-order` grouping bug.
+- Fixed: improved documentation of CLI globbing possibilities.
+- Fixed: `rule-properties-order` now accounts for property names containing multiple hyphens.
+- Fixed: `rule-properties-order` grouping bug.
 
 # 2.3.5
 
-* Added: error about undefined severities blaming stylelint for the bug.
-* Fixed: `selector-pseudo-element-colon-notation` typo in rule name resulting in undefined severity.
+- Added: error about undefined severities blaming stylelint for the bug.
+- Fixed: `selector-pseudo-element-colon-notation` typo in rule name resulting in undefined severity.
 
 # 2.3.4
 
-* Fixed: `dist/` build.
+- Fixed: `dist/` build.
 
 # 2.3.3
 
-* Fixed: `property-whitelist`, `rule-no-duplicate-properties`, and `rule-properties-order` ignore variables (`$sass`, `@less`, and `--custom-property`).
-* Fixed: `root-no-standard-properties` ignores `$sass` and `@less` variables.
-* Fixed: `comment-empty-line-before` and `comment-space-inside` no longer complain about `//` comments.
+- Fixed: `property-whitelist`, `rule-no-duplicate-properties`, and `rule-properties-order` ignore variables (`$sass`, `@less`, and `--custom-property`).
+- Fixed: `root-no-standard-properties` ignores `$sass` and `@less` variables.
+- Fixed: `comment-empty-line-before` and `comment-space-inside` no longer complain about `//` comments.
 
 # 2.3.2
 
-* Fixed: `number-no-trailing-zeros` no longer flags at-import at-rules.
+- Fixed: `number-no-trailing-zeros` no longer flags at-import at-rules.
 
 # 2.3.1
 
-* Fixed: `selector-no-type` no longer flags the _nesting selector_ (`&`).
+- Fixed: `selector-no-type` no longer flags the *nesting selector* (`&`).
 
 # 2.3.0
 
-* Added: `configFile` option to PostCSS plugin.
-* Fixed: `function-parentheses-newline-inside` and `function-parentheses-space-inside` bug with nested functions.
+- Added: `configFile` option to PostCSS plugin.
+- Fixed: `function-parentheses-newline-inside` and `function-parentheses-space-inside` bug with nested functions.
 
 # 2.2.0
 
-* Added: `selector-class-pattern` rule.
-* Added: `selector-id-pattern` rule.
-* Added: `function-parentheses-newline-inside` rule.
-* Added: `"always-single-line"` and `"never-single-line"` options to `function-parentheses-space-inside`.
-* Fixed: CLI `syntax` argument bug.
+- Added: `selector-class-pattern` rule.
+- Added: `selector-id-pattern` rule.
+- Added: `function-parentheses-newline-inside` rule.
+- Added: `"always-single-line"` and `"never-single-line"` options to `function-parentheses-space-inside`.
+- Fixed: CLI `syntax` argument bug.
 
 # 2.1.0
 
-* Added: `color-no-hex` rule.
-* Added: `color-no-named` rule.
-* Added: `function-blacklist` rule.
-* Added: `function-whitelist` rule.
-* Added: `unit-blacklist` rule.
-* Added: `unit-whitelist` rule.
-* Added: `property-unit-blacklist` rule.
-* Added: `property-unit-whitelist` rule.
-* Added: `rule-single-line-max-declarations` rule.
-* Added: `max-line-length` rule.
-* Added: `first-nested` exception to `comment-empty-line-before`.
-* Added: single value options to `*-blacklist` & `-*whitelist` rules e.g. `{ "function-blacklist": "calc"}`
-* Added: support for flexible groups to `rule-properties-order`.
-* Added: support for an optional empty line between each group to `rule-properties-order`.
-* Added: support for mathematical signs in front of Sass and Less variables in `function-calc-no-unspaced-operator`.
-* Added: support for arbitrary whitespace after function in `function-space-after`.
-* Added: support for arbitrary whitespace at the edge of comments in `comment-space-inside`.
-* Fixed: `comment-space-inside` allows any number of asterisks at the beginning and end of comments.
-* Fixed: bug causing `{ unspecified: "bottom }"` option not to be applied within `rule-properties-order`.
-* Fixed: bug causing `function-comma-*` whitespace rules to improperly judge whether to enforce single- or multi-line options.
-* Fixed: bug when loading plugins from an extended config
-* Fixed: indentation for function arguments, by ignoring them.
+- Added: `color-no-hex` rule.
+- Added: `color-no-named` rule.
+- Added: `function-blacklist` rule.
+- Added: `function-whitelist` rule.
+- Added: `unit-blacklist` rule.
+- Added: `unit-whitelist` rule.
+- Added: `property-unit-blacklist` rule.
+- Added: `property-unit-whitelist` rule.
+- Added: `rule-single-line-max-declarations` rule.
+- Added: `max-line-length` rule.
+- Added: `first-nested` exception to `comment-empty-line-before`.
+- Added: single value options to `*-blacklist` & `-*whitelist` rules e.g. `{ "function-blacklist": "calc"}`
+- Added: support for flexible groups to `rule-properties-order`.
+- Added: support for an optional empty line between each group to `rule-properties-order`.
+- Added: support for mathematical signs in front of Sass and Less variables in `function-calc-no-unspaced-operator`.
+- Added: support for arbitrary whitespace after function in `function-space-after`.
+- Added: support for arbitrary whitespace at the edge of comments in `comment-space-inside`.
+- Fixed: `comment-space-inside` allows any number of asterisks at the beginning and end of comments.
+- Fixed: bug causing `{ unspecified: "bottom }"` option not to be applied within `rule-properties-order`.
+- Fixed: bug causing `function-comma-*` whitespace rules to improperly judge whether to enforce single- or multi-line options.
+- Fixed: bug when loading plugins from an extended config
+- Fixed: indentation for function arguments, by ignoring them.
 
 # 2.0.0
 
-* Changed: plugins are now included and configured via a "locator", rather than either being `required` or being inserted directly into the configuration object as a function.
-* Added: CLI.
-* Added: standalone Node API.
-* Added: quiet mode to CLI and Node API.
-* Added: support for formatters, including custom ones, to CLI and Node API.
-* Added: `string` and `json` formatters.
-* Added: support for using `.stylelintrc` JSON file.
-* Added: support for extending existing configs using the `extends` property.
-* Added: support for SCSS syntax parsing to CLI and Node API.
-* Added: `function-comma-newline-after` rule.
-* Added: `function-comma-newline-before` rule.
-* Added: `"always-single-line"` and `"never-single-line"` options to `function-comma-space-after` rule.
-* Added: `"always-single-line"` and `"never-single-line"` options to `function-comma-space-before` rule.
+- Changed: plugins are now included and configured via a "locator", rather than either being `required` or being inserted directly into the configuration object as a function.
+- Added: CLI.
+- Added: standalone Node API.
+- Added: quiet mode to CLI and Node API.
+- Added: support for formatters, including custom ones, to CLI and Node API.
+- Added: `string` and `json` formatters.
+- Added: support for using `.stylelintrc` JSON file.
+- Added: support for extending existing configs using the `extends` property.
+- Added: support for SCSS syntax parsing to CLI and Node API.
+- Added: `function-comma-newline-after` rule.
+- Added: `function-comma-newline-before` rule.
+- Added: `"always-single-line"` and `"never-single-line"` options to `function-comma-space-after` rule.
+- Added: `"always-single-line"` and `"never-single-line"` options to `function-comma-space-before` rule.
 
 # 1.2.1
 
-* Fixed: the `media-query-list-comma-*` rules now only apply to `@media` statements.
+- Fixed: the `media-query-list-comma-*` rules now only apply to `@media` statements.
 
 # 1.2.0
 
-* Added: `function-linear-gradient-no-nonstandard-direction` rule.
-* Added: `rule-properties-order` now by default ignores the order of properties left out of your specified array; and the options `"top"`, `"bottom"`, and `"ignore"` are provided to change that behavior.
-* Added: `rule-properties-order` now looks for roots of hyphenated properties in custom arrays so each extension (e.g. `padding-top` as an extension of `padding`) does not need to be specified individually.
-* Added: `"always-single-line"` option to `declaration-colon-space-after`.
-* Added: support for declarations directly on root (e.g. Sass variable declarations).
-* Fixed: `declaration-colon-newline-after` `"always-multi-line"` warning message.
+- Added: `function-linear-gradient-no-nonstandard-direction` rule.
+- Added: `rule-properties-order` now by default ignores the order of properties left out of your specified array; and the options `"top"`, `"bottom"`, and `"ignore"` are provided to change that behavior.
+- Added: `rule-properties-order` now looks for roots of hyphenated properties in custom arrays so each extension (e.g. `padding-top` as an extension of `padding`) does not need to be specified individually.
+- Added: `"always-single-line"` option to `declaration-colon-space-after`.
+- Added: support for declarations directly on root (e.g. Sass variable declarations).
+- Fixed: `declaration-colon-newline-after` `"always-multi-line"` warning message.
 
 # 1.1.0
 
-* Added: `declaration-colon-newline-after` rule.
-* Added: the `indentation` rule now checks indentation of multi-line at-rule params, unless there's the `except` option of `param`.
-* Added: support for end-of-line comments in `selector-list-comma-newline-after`.
-* Added: protection against `#${sass-interpolation}` in rules checking for hex colors.
-* Added: support for strings (translated to RegExps) in `custom-property-pattern` and `custom-media-pattern`.
-* Fixed: bug preventing various rules from registering the correct rule names in their warnings, and therefore also preventing them from being disabled with comments.
-* Fixed: the `color-no-invalid-hex` rule no longer flags hashes in `url()` arguments.
-* Fixed: rules using `node.raw()` instead of `node.raws` to avoid expected errors.
+- Added: `declaration-colon-newline-after` rule.
+- Added: the `indentation` rule now checks indentation of multi-line at-rule params, unless there's the `except` option of `param`.
+- Added: support for end-of-line comments in `selector-list-comma-newline-after`.
+- Added: protection against `#${sass-interpolation}` in rules checking for hex colors.
+- Added: support for strings (translated to RegExps) in `custom-property-pattern` and `custom-media-pattern`.
+- Fixed: bug preventing various rules from registering the correct rule names in their warnings, and therefore also preventing them from being disabled with comments.
+- Fixed: the `color-no-invalid-hex` rule no longer flags hashes in `url()` arguments.
+- Fixed: rules using `node.raw()` instead of `node.raws` to avoid expected errors.
 
 # 1.0.1
 
-* Fixed: `postcss-selector-parser` updated to improve location accuracy for `selector-no-*` rules.
+- Fixed: `postcss-selector-parser` updated to improve location accuracy for `selector-no-*` rules.
 
 # 1.0.0
 
-* Removed: compatibility with PostCSS `4.x`.
-* Added: compatibility with PostCSS `5.0.2+`.
-* Fixed: the accuracy of reported line numbers and columns.
+- Removed: compatibility with PostCSS `4.x`.
+- Added: compatibility with PostCSS `5.0.2+`.
+- Fixed: the accuracy of reported line numbers and columns.
 
 # 0.8.0
 
-* Added: `after-comment` `ignore` option to the `at-rule-empty-line-before` rule.
-* Fixed: the `indentation` rule now correctly handles `*` hacks on property names.
-* Fixed: the `media-feature-colon-space-after` and `media-feature-colon-space-before` rules now only apply to `@media` statements.
-* Fixed: the `rule-no-shorthand-property-overrides` rule message is now consistent with the other messages.
+- Added: `after-comment` `ignore` option to the `at-rule-empty-line-before` rule.
+- Fixed: the `indentation` rule now correctly handles `*` hacks on property names.
+- Fixed: the `media-feature-colon-space-after` and `media-feature-colon-space-before` rules now only apply to `@media` statements.
+- Fixed: the `rule-no-shorthand-property-overrides` rule message is now consistent with the other messages.
 
 # 0.7.0
 
-* Added: invalid options cause the rule to abort instead of performing meaningless checks.
-* Added: special warning for missing required options from `validateOptions()`.
+- Added: invalid options cause the rule to abort instead of performing meaningless checks.
+- Added: special warning for missing required options from `validateOptions()`.
 
 # 0.6.2
 
-* Fixed: npm package no longer includes test files (reducing package size by 500KB).
+- Fixed: npm package no longer includes test files (reducing package size by 500KB).
 
 # 0.6.1
 
-* Fixed: the `rule-properties-order` and `rule-no-duplicate-properties` rules now correctly check inside @rules.
+- Fixed: the `rule-properties-order` and `rule-no-duplicate-properties` rules now correctly check inside @rules.
 
 # 0.6.0
 
-* Added: `validateOptions` to `stylelint.utils` for use by authors of custom rules.
-* Added: `custom-media-pattern` rule.
-* Added: `number-max-precision` rule.
+- Added: `validateOptions` to `stylelint.utils` for use by authors of custom rules.
+- Added: `custom-media-pattern` rule.
+- Added: `number-max-precision` rule.
 
 # 0.5.0
 
-* Added: validation of all rule options.
+- Added: validation of all rule options.
 
 # 0.4.1
 
-* Removed: `ruleTester` from `stylelint.utils` because of the additional dependencies it forces.
+- Removed: `ruleTester` from `stylelint.utils` because of the additional dependencies it forces.
 
 # 0.4.0
 
-* Removed: `jsesc` devDependency.
-* Added: `rule-no-shorthand-property-overrides` rule.
-* Added: `ruleTester` to `stylelint.utils` for use by authors of custom rules.
+- Removed: `jsesc` devDependency.
+- Added: `rule-no-shorthand-property-overrides` rule.
+- Added: `ruleTester` to `stylelint.utils` for use by authors of custom rules.
 
 # 0.3.2
 
-* Fixed: `hierarchicalSelectors` bug in `indentation` rule.
+- Fixed: `hierarchicalSelectors` bug in `indentation` rule.
 
 # 0.3.1
 
-* Fixed: `~=` is no longer mistaken for combinator in `selector-combinator-space-*`.
+- Fixed: `~=` is no longer mistaken for combinator in `selector-combinator-space-*`.
 
 # 0.3.0
 
-* Added: exposure of `report`, `ruleMessages`, and `styleSearch` in `stylelint.utils` for use by external plugin rules.
-* Added: plugin rule support.
-* Added: `hierarchicalSelectors` option to `indentation` rule.
-* Added: `nesting-block-opening-brace-space-before` rule.
-* Added: `nesting-block-opening-brace-newline-before` rule.
-* Fixed: the `color-hex-case` rule message is now consistent with the `color-hex-length` rule.
-* Fixed: the `property-blacklist` rule message is now consistent with the `property-whitelist` rule.
-* Fixed: a typo in the `comment-space-inside` rule message.
+- Added: exposure of `report`, `ruleMessages`, and `styleSearch` in `stylelint.utils` for use by external plugin rules.
+- Added: plugin rule support.
+- Added: `hierarchicalSelectors` option to `indentation` rule.
+- Added: `nesting-block-opening-brace-space-before` rule.
+- Added: `nesting-block-opening-brace-newline-before` rule.
+- Fixed: the `color-hex-case` rule message is now consistent with the `color-hex-length` rule.
+- Fixed: the `property-blacklist` rule message is now consistent with the `property-whitelist` rule.
+- Fixed: a typo in the `comment-space-inside` rule message.
 
 # 0.2.0
 
-* Added: `color-hex-case` rule.
-* Added: `color-hex-length` rule.
-* Fixed: formalized selector-indentation-checking within the `indentation` rule.
-* Fixed: allow for arbitrary whitespace after the newline in the `selector-list-comma-newline-*` rules.
-* Fixed: `selector-combinator-space-*` no longer checks `:nth-child()` arguments.
+- Added: `color-hex-case` rule.
+- Added: `color-hex-length` rule.
+- Fixed: formalized selector-indentation-checking within the `indentation` rule.
+- Fixed: allow for arbitrary whitespace after the newline in the `selector-list-comma-newline-*` rules.
+- Fixed: `selector-combinator-space-*` no longer checks `:nth-child()` arguments.
 
 # 0.1.2
 
-* Fixed: nesting support for the `block-opening-brace-newline-before` rule.
-* Fixed: nesting support for the `block-opening-brace-space-before` rule.
-* Fixed: nesting support for the `rule-trailing-semicolon` rule.
+- Fixed: nesting support for the `block-opening-brace-newline-before` rule.
+- Fixed: nesting support for the `block-opening-brace-space-before` rule.
+- Fixed: nesting support for the `rule-trailing-semicolon` rule.
 
 # 0.1.1
 
-* Fixed: nesting support for the `rule-no-duplicate-properties` rule.
-* Fixed: nesting support for the `rule-properties-order` rule.
-* Fixed: whitespace rules accommodate Windows CR-LF line endings.
+- Fixed: nesting support for the `rule-no-duplicate-properties` rule.
+- Fixed: nesting support for the `rule-properties-order` rule.
+- Fixed: whitespace rules accommodate Windows CR-LF line endings.
 
 # 0.1.0
 
-* Added: ability to disable rules via comments in the CSS.
-* Added: `at-rule-empty-line-before` rule.
-* Added: `at-rule-no-vendor-prefix` rule.
-* Added: `block-closing-brace-newline-after` rule.
-* Added: `block-closing-brace-newline-before` rule.
-* Added: `block-closing-brace-space-after` rule.
-* Added: `block-closing-brace-space-before` rule.
-* Added: `block-no-empty` rule.
-* Added: `block-opening-brace-newline-after` rule.
-* Added: `block-opening-brace-newline-before` rule.
-* Added: `block-opening-brace-space-after` rule.
-* Added: `block-opening-brace-space-before` rule.
-* Added: `color-no-invalid-hex` rule.
-* Added: `comment-empty-line-before` rule.
-* Added: `comment-space-inside` rule.
-* Added: `custom-property-no-outside-root` rule.
-* Added: `custom-property-pattern` rule.
-* Added: `declaration-bang-space-after` rule.
-* Added: `declaration-bang-space-before` rule.
-* Added: `declaration-block-semicolon-newline-after` rule.
-* Added: `declaration-block-semicolon-newline-before` rule.
-* Added: `declaration-block-semicolon-space-after` rule.
-* Added: `declaration-block-semicolon-space-before` rule.
-* Added: `declaration-colon-space-after` rule.
-* Added: `declaration-colon-space-before` rule.
-* Added: `declaration-no-important` rule.
-* Added: `function-calc-no-unspaced-operator` rule.
-* Added: `function-comma-space-after` rule.
-* Added: `function-comma-space-before` rule.
-* Added: `function-parentheses-space-inside` rule.
-* Added: `function-space-after` rule.
-* Added: `function-url-quotes` rule.
-* Added: `indentation` rule.
-* Added: `media-feature-colon-space-after` rule.
-* Added: `media-feature-colon-space-before` rule.
-* Added: `media-feature-name-no-vendor-prefix` rule.
-* Added: `media-feature-range-operator-space-after` rule.
-* Added: `media-feature-range-operator-space-before` rule.
-* Added: `media-query-list-comma-newline-after` rule.
-* Added: `media-query-list-comma-newline-before` rule.
-* Added: `media-query-list-comma-space-after` rule.
-* Added: `media-query-list-comma-space-before` rule.
-* Added: `media-query-parentheses-space-inside` rule.
-* Added: `no-eol-whitespace` rule.
-* Added: `no-missing-eof-newline` rule.
-* Added: `no-multiple-empty-lines` rule.
-* Added: `number-leading-zero` rule.
-* Added: `number-no-trailing-zeros` rule.
-* Added: `number-zero-length-no-unit` rule.
-* Added: `property-blacklist` rule.
-* Added: `property-no-vendor-prefix` rule.
-* Added: `property-whitelist` rule.
-* Added: `root-no-standard-properties` rule.
-* Added: `rule-nested-empty-line-before` rule.
-* Added: `rule-no-duplicate-properties` rule.
-* Added: `rule-no-single-line` rule.
-* Added: `rule-non-nested-empty-line-before` rule.
-* Added: `rule-properties-order` rule.
-* Added: `rule-trailing-semicolon` rule.
-* Added: `selector-combinator-space-after` rule.
-* Added: `selector-combinator-space-before` rule.
-* Added: `selector-list-comma-newline-after` rule.
-* Added: `selector-list-comma-newline-before` rule.
-* Added: `selector-list-comma-space-after` rule.
-* Added: `selector-list-comma-space-before` rule.
-* Added: `selector-no-attribute` rule.
-* Added: `selector-no-combinator` rule.
-* Added: `selector-no-id` rule.
-* Added: `selector-no-type` rule.
-* Added: `selector-no-universal` rule.
-* Added: `selector-no-vendor-prefix` rule.
-* Added: `selector-pseudo-element-colon-notation` rule.
-* Added: `selector-root-no-composition` rule.
-* Added: `string-quotes` rule.
-* Added: `value-list-comma-newline-after` rule.
-* Added: `value-list-comma-newline-before` rule.
-* Added: `value-list-comma-space-after` rule.
-* Added: `value-list-comma-space-before` rule.
-* Added: `value-no-vendor-prefix` rule.
+- Added: ability to disable rules via comments in the CSS.
+- Added: `at-rule-empty-line-before` rule.
+- Added: `at-rule-no-vendor-prefix` rule.
+- Added: `block-closing-brace-newline-after` rule.
+- Added: `block-closing-brace-newline-before` rule.
+- Added: `block-closing-brace-space-after` rule.
+- Added: `block-closing-brace-space-before` rule.
+- Added: `block-no-empty` rule.
+- Added: `block-opening-brace-newline-after` rule.
+- Added: `block-opening-brace-newline-before` rule.
+- Added: `block-opening-brace-space-after` rule.
+- Added: `block-opening-brace-space-before` rule.
+- Added: `color-no-invalid-hex` rule.
+- Added: `comment-empty-line-before` rule.
+- Added: `comment-space-inside` rule.
+- Added: `custom-property-no-outside-root` rule.
+- Added: `custom-property-pattern` rule.
+- Added: `declaration-bang-space-after` rule.
+- Added: `declaration-bang-space-before` rule.
+- Added: `declaration-block-semicolon-newline-after` rule.
+- Added: `declaration-block-semicolon-newline-before` rule.
+- Added: `declaration-block-semicolon-space-after` rule.
+- Added: `declaration-block-semicolon-space-before` rule.
+- Added: `declaration-colon-space-after` rule.
+- Added: `declaration-colon-space-before` rule.
+- Added: `declaration-no-important` rule.
+- Added: `function-calc-no-unspaced-operator` rule.
+- Added: `function-comma-space-after` rule.
+- Added: `function-comma-space-before` rule.
+- Added: `function-parentheses-space-inside` rule.
+- Added: `function-space-after` rule.
+- Added: `function-url-quotes` rule.
+- Added: `indentation` rule.
+- Added: `media-feature-colon-space-after` rule.
+- Added: `media-feature-colon-space-before` rule.
+- Added: `media-feature-name-no-vendor-prefix` rule.
+- Added: `media-feature-range-operator-space-after` rule.
+- Added: `media-feature-range-operator-space-before` rule.
+- Added: `media-query-list-comma-newline-after` rule.
+- Added: `media-query-list-comma-newline-before` rule.
+- Added: `media-query-list-comma-space-after` rule.
+- Added: `media-query-list-comma-space-before` rule.
+- Added: `media-query-parentheses-space-inside` rule.
+- Added: `no-eol-whitespace` rule.
+- Added: `no-missing-eof-newline` rule.
+- Added: `no-multiple-empty-lines` rule.
+- Added: `number-leading-zero` rule.
+- Added: `number-no-trailing-zeros` rule.
+- Added: `number-zero-length-no-unit` rule.
+- Added: `property-blacklist` rule.
+- Added: `property-no-vendor-prefix` rule.
+- Added: `property-whitelist` rule.
+- Added: `root-no-standard-properties` rule.
+- Added: `rule-nested-empty-line-before` rule.
+- Added: `rule-no-duplicate-properties` rule.
+- Added: `rule-no-single-line` rule.
+- Added: `rule-non-nested-empty-line-before` rule.
+- Added: `rule-properties-order` rule.
+- Added: `rule-trailing-semicolon` rule.
+- Added: `selector-combinator-space-after` rule.
+- Added: `selector-combinator-space-before` rule.
+- Added: `selector-list-comma-newline-after` rule.
+- Added: `selector-list-comma-newline-before` rule.
+- Added: `selector-list-comma-space-after` rule.
+- Added: `selector-list-comma-space-before` rule.
+- Added: `selector-no-attribute` rule.
+- Added: `selector-no-combinator` rule.
+- Added: `selector-no-id` rule.
+- Added: `selector-no-type` rule.
+- Added: `selector-no-universal` rule.
+- Added: `selector-no-vendor-prefix` rule.
+- Added: `selector-pseudo-element-colon-notation` rule.
+- Added: `selector-root-no-composition` rule.
+- Added: `string-quotes` rule.
+- Added: `value-list-comma-newline-after` rule.
+- Added: `value-list-comma-newline-before` rule.
+- Added: `value-list-comma-space-after` rule.
+- Added: `value-list-comma-space-before` rule.
+- Added: `value-no-vendor-prefix` rule.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ Any help is welcome and appreciated.
 
 ## Ways to contribute
 
-* Adding new rules. Whether it's one of the [few](https://github.com/stylelint/stylelint/labels/type%3A%20rule) that we've still to do, or something that you need and we've not thought of yet.
-* Expanding the [documentation](https://github.com/stylelint/stylelint/tree/master/docs).
-* Working on other [open issues](https://github.com/stylelint/stylelint/issues).
+- Adding new rules. Whether it's one of the [few](https://github.com/stylelint/stylelint/labels/type%3A%20rule) that we've still to do, or something that you need and we've not thought of yet.
+- Expanding the [documentation](https://github.com/stylelint/stylelint/tree/master/docs).
+- Working on other [open issues](https://github.com/stylelint/stylelint/issues).
 
 ## Communication
 
@@ -24,10 +24,10 @@ We are committed to making participation in this project a harassment-free exper
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery
-* Personal attacks
-* Publishing other's private information, such as physical or electronic addresses, without explicit permission
-* Public or private harassment
+- The use of sexualized language or imagery
+- Personal attacks
+- Publishing other's private information, such as physical or electronic addresses, without explicit permission
+- Public or private harassment
 
 This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A mighty, modern CSS linter that helps you enforce consistent conventions and av
 
 ## Features
 
-* **Over a hundred rules:** From stylistic rules (e.g. checking the spacing around the colon in declarations) to rules that catch subtle coding mistakes (e.g. invalid hex colors or [overriding shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Tricky_edge_cases)).
-* **Support for the latest CSS syntax:** Including custom properties, range context for media features, calc() and nesting.
-* **Understands _CSS-like_ syntaxes:** The linter is powered by [PostCSS](https://github.com/postcss/postcss), so it understands any syntax that PostCSS can parse, including SCSS.
-* **Completely unopinionated:** Only enable the rules you want, and configure them with options that tailor the linter to your needs.
-* **Shareable configs:** If you don't want to craft your own config, you can extend a shareable config.
-* **Support for plugins:** It's easy to create your own rules and add them to the linter.
-* **Options validator:** So that you can be confident that your config is valid.
+- **Over a hundred rules:** From stylistic rules (e.g. checking the spacing around the colon in declarations) to rules that catch subtle coding mistakes (e.g. invalid hex colors or [overriding shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#Tricky_edge_cases)).
+- **Support for the latest CSS syntax:** Including custom properties, range context for media features, calc() and nesting.
+- **Understands *CSS-like* syntaxes:** The linter is powered by [PostCSS](https://github.com/postcss/postcss), so it understands any syntax that PostCSS can parse, including SCSS.
+- **Completely unopinionated:** Only enable the rules you want, and configure them with options that tailor the linter to your needs.
+- **Shareable configs:** If you don't want to craft your own config, you can extend a shareable config.
+- **Support for plugins:** It's easy to create your own rules and add them to the linter.
+- **Options validator:** So that you can be confident that your config is valid.
 
 ## Example output
 
@@ -24,8 +24,9 @@ With stylelint, it's easy to start linting your CSS:
 
 1. Install stylelint: `npm install stylelint`.
 2. Choose whether you want to craft your own config or extend a pre-written, shared config.
-    * If you want to use a pre-written config, just find one and extend it. We recommend trying [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard), which includes around 60 of stylelint's rules with sensible defaults. (You can always override specific rules after extending a config.)
-    * To craft your own from the ground up, just learn about [some rules](/docs/user-guide/rules.md). _All of the rules are off by default_, so you only have to learn about the rules you want to turn on and enforce. That way you can start small, growing your config over time as you have a chance to explore more of the rules. Alternately, copy-paste [this example configuration](/docs/user-guide/example-config.md), which lists all of stylelint's rules and their primary options, then remove (or turn off) the rules you don't want and edit the primary option of each rule to your liking.
+
+   - If you want to use a pre-written config, just find one and extend it. We recommend trying [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard), which includes around 60 of stylelint's rules with sensible defaults. (You can always override specific rules after extending a config.)
+   - To craft your own from the ground up, just learn about [some rules](/docs/user-guide/rules.md). *All of the rules are off by default*, so you only have to learn about the rules you want to turn on and enforce. That way you can start small, growing your config over time as you have a chance to explore more of the rules. Alternately, copy-paste [this example configuration](/docs/user-guide/example-config.md), which lists all of stylelint's rules and their primary options, then remove (or turn off) the rules you don't want and edit the primary option of each rule to your liking.
 3. Create your [configuration](/docs/user-guide/configuration.md), probably as a `.stylelintrc` file.
 4. Decide whether to use the [CLI](/docs/user-guide/cli.md), [Node API](/docs/user-guide/node-api.md), or [PostCSS plugin](/docs/user-guide/postcss-plugin.md).
 5. Lint!
@@ -34,8 +35,8 @@ With stylelint, it's easy to start linting your CSS:
 
 You'll find more detailed information on using the linter and tailoring it to your needs in our guides:
 
-* [User guide](docs/user-guide.md) - Usage, configuration and complementary tools.
-* [Developer guide](docs/developer-guide.md) - Contributing to stylelint and writing your own plugins & formatters.
+- [User guide](docs/user-guide.md) - Usage, configuration and complementary tools.
+- [Developer guide](docs/developer-guide.md) - Contributing to stylelint and writing your own plugins & formatters.
 
 ## Important Documents
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,5 +1,5 @@
 # Developer guide
 
-* [Rules](/docs/developer-guide/rules.md) - adding new rules to stylelint.
-* [Plugins](/docs/developer-guide/plugins.md) - writing your own plugins.
-* [Formatters](/docs/developer-guide/formatters.md) - writing your own formatters.
+- [Rules](/docs/developer-guide/rules.md) - adding new rules to stylelint.
+- [Plugins](/docs/developer-guide/plugins.md) - writing your own plugins.
+- [Formatters](/docs/developer-guide/formatters.md) - writing your own formatters.

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -11,24 +11,20 @@ var myPluginRule = stylelint.createPlugin(myPluginRuleName, function(expectation
     // ... some logic ...
     stylelint.utils.report({ .. })
   }
-}
+})
 ```
 
-`stylelint.createPlugin(ruleName, ruleFunction)` ensures that your plugin will be setup properly alongside other rules.
-*Make sure you document your plugin's rule name for users, because they will need to use it in their config.*
+`stylelint.createPlugin(ruleName, ruleFunction)` ensures that your plugin will be setup properly alongside other rules. *Make sure you document your plugin's rule name for users, because they will need to use it in their config.*
 
 In order for your plugin rule to work with the standard configuration format, (e.g. `["tab", { hierarchicalSelectors: true }]`), `ruleFunction` should accept 2 arguments: the expectation keyword (e.g. `"tab"`) and, optionally, an options object (e.g. `{ hierarchicalSelectors: true }`).
 
-`ruleFunction` should return a function that is essentially a little PostCSS plugin: it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult.
-You'll have to [learn about the PostCSS API](https://github.com/postcss/postcss/blob/master/docs/api.md).
+`ruleFunction` should return a function that is essentially a little PostCSS plugin: it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult. You'll have to [learn about the PostCSS API](https://github.com/postcss/postcss/blob/master/docs/api.md).
 
 ## `stylelint.utils`
 
-A few of stylelint's internal utilities are exposed publicly in `stylelint.utils`, to help you write plugin rules.
-For details about the APIs of these functions, please look at comments in the source code and examples in the standard rules.
+A few of stylelint's internal utilities are exposed publicly in `stylelint.utils`, to help you write plugin rules. For details about the APIs of these functions, please look at comments in the source code and examples in the standard rules.
 
-- `report`: Report your linting warnings. *You'll want to use this: do not use `node.warn()` directly.* If you use `report`,
-your plugin will respect disabled ranges and other possible future features of stylelint, so it will fit in better with the standard rules.
+- `report`: Report your linting warnings. *You'll want to use this: do not use `node.warn()` directly.* If you use `report`, your plugin will respect disabled ranges and other possible future features of stylelint, so it will fit in better with the standard rules.
 - `ruleMessages`: Tailor your messages to look like the messages of other stylelint rules. Currently, this means that the name of the rule is appended, in parentheses, to the end of the message.
 - `styleSearch`: Search within CSS strings, and for every match found invoke a callback, passing a match object with details about the match. `styleSearch` ignores CSS strings (e.g. `content: "foo";`) and by default ignores comments. It can also be restricted to substrings within or outside of CSS functional notation.
 - `validateOptions`: Help your user's out by checking that the options they've submitted are valid.

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -11,7 +11,7 @@ Have a look at the [rules guide](/docs/user-guide/rules.md) to familiarize yours
 
 Use explicit, rather than implicit, options. For example:
 
-* `color-hex-case: "upper"|"lower"` rather than `color-hex-uppercase: "always"|"never"`
+- `color-hex-case: "upper"|"lower"` rather than `color-hex-uppercase: "always"|"never"`
 
 As `color-hex-uppercase: "never"` *implies* always lowercase.
 
@@ -19,8 +19,8 @@ As `color-hex-uppercase: "never"` *implies* always lowercase.
 
 Take the form of:
 
-* "Expected a ... something"
-* "Unexpected ... something" (for rejection e.g. when something is disallowed)
+- "Expected a ... something"
+- "Unexpected ... something" (for rejection e.g. when something is disallowed)
 
 ## README
 
@@ -33,14 +33,14 @@ Each rule must be accompanied by a README, which takes the form of:
 5. Options (if applicable).
 6. Example patterns that are considered warnings (for each option value).
 7. Example patterns that are *not* considered warnings (for each option value).
-5. Optional options (if applicable).
+8. Optional options (if applicable).
 
 ## Tests
 
 Each rule must be accompanied by tests that contain:
 
-* All patterns that are considered warnings.
-* All patterns that should *not* be considered warnings.
+- All patterns that are considered warnings.
+- All patterns that should *not* be considered warnings.
 
 ### Running tests
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,15 +2,15 @@
 
 ## Usage
 
-* [The CLI](/docs/user-guide/cli.md) - options, examples and exit codes for using the CLI.
-* [The Node API](/docs/user-guide/node-api.md) - options and examples for using the Node API.
-* [The PostCSS Plugin](/docs/user-guide/postcss-plugin.md) - how to use the PostCSS plugin, either via a runner like `gulp-postcss` or via the PostCSS Node API.
+- [The CLI](/docs/user-guide/cli.md) - options, examples and exit codes for using the CLI.
+- [The Node API](/docs/user-guide/node-api.md) - options and examples for using the Node API.
+- [The PostCSS Plugin](/docs/user-guide/postcss-plugin.md) - how to use the PostCSS plugin, either via a runner like `gulp-postcss` or via the PostCSS Node API.
 
 ## Configuration
 
-* [Configuration](/docs/user-guide/configuration.md) - how to configure stylelint.
-* [Rules](/docs/user-guide/rules.md) - a list of all the rules that are available to you, and an explanation of the naming convention.
-* [Example config](/docs/user-guide/example-config.md) - an example config that you can use as a foundation for crafting your own config.
-* [Plugins](/docs/user-guide/plugins.md) - a brief introduction to plugins, followed by a list of what's available.
-* [CSS Processors](/docs/user-guide/css-processors.md) - how to use the linter with CSS processors.
-* [Complementary Tools](/docs/user-guide/complementary-tools.md) - editor plugins (e.g. Atom and Sublime) and other linters.
+- [Configuration](/docs/user-guide/configuration.md) - how to configure stylelint.
+- [Rules](/docs/user-guide/rules.md) - a list of all the rules that are available to you, and an explanation of the naming convention.
+- [Example config](/docs/user-guide/example-config.md) - an example config that you can use as a foundation for crafting your own config.
+- [Plugins](/docs/user-guide/plugins.md) - a brief introduction to plugins, followed by a list of what's available.
+- [CSS Processors](/docs/user-guide/css-processors.md) - how to use the linter with CSS processors.
+- [Complementary Tools](/docs/user-guide/complementary-tools.md) - editor plugins (e.g. Atom and Sublime) and other linters.

--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -2,17 +2,17 @@
 
 ## Editor plugins
 
-* [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - An Atom Linter plugin for stylelint.
-* [SublimeLinter-contrib-stylelint](https://github.com/kungfusheep/SublimeLinter-contrib-stylelint) - A Sublime Text plugin for stylelint.
-* [vscode-stylelint](https://github.com/shinnn/vscode-stylelint) - A Visual Studio Code extension for stylelint.
+- [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - An Atom Linter plugin for stylelint.
+- [SublimeLinter-contrib-stylelint](https://github.com/kungfusheep/SublimeLinter-contrib-stylelint) - A Sublime Text plugin for stylelint.
+- [vscode-stylelint](https://github.com/shinnn/vscode-stylelint) - A Visual Studio Code extension for stylelint.
 
 ## Runners/loaders
 
-* [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - A gulp plugin for stylelint.
-* [stylelint-loader](https://github.com/adrianhall/stylelint-loader) - A webpack loader for stylelint.
+- [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - A gulp plugin for stylelint.
+- [stylelint-loader](https://github.com/adrianhall/stylelint-loader) - A webpack loader for stylelint.
 
 ## Other linters & formatters
 
-* [cssfmt](https://github.com/morishitter/cssfmt) - A tool that automatically formats CSS and SCSS source code.
-* [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter) - A BEM linter for CSS.
-* [stylehacks](https://github.com/ben-eb/stylehacks) - Detect/remove browser hacks from CSS files.
+- [cssfmt](https://github.com/morishitter/cssfmt) - A tool that automatically formats CSS and SCSS source code.
+- [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter) - A BEM linter for CSS.
+- [stylehacks](https://github.com/ben-eb/stylehacks) - Detect/remove browser hacks from CSS files.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The linter _expects a configuration object_. You can either craft your own config or extend an existing one.
+The linter *expects a configuration object*. You can either craft your own config or extend an existing one.
 
 ## Loading Configuration
 
@@ -137,7 +137,7 @@ Or starting with `stylelint-config-standard`, then extending layering `myExtenda
 
 **The value of `"extends"` is a "locater" (or an array of "locaters") that is ultimately `require()`d, so can fit whatever format works with Node's `require.resolve()` algorithm.** That means the a "locater" can be:
 
-- The name of a module in `node_modules` (e.g. `stylelint-config-standard`; that module's `main` file must be a valid JSON configuration)
+- The name of a module in `node*modules` (e.g. `stylelint-config-standard`; that module's `main` file must be a valid JSON configuration)
 - An absolute path to a file (which makes sense if you're creating a JS object in a Node context and passing it in) with a `.js` or `.json` extension.
 - A relative path to a file with a `.js` or `.json` extension, relative to the referencing configuration (e.g. if configA has `extends: "../configB"`, we'll look for `configB` relative to configA).
 
@@ -145,7 +145,7 @@ Or starting with `stylelint-config-standard`, then extending layering `myExtenda
 
 ### `plugins`
 
-[Plugins](/docs/user-guide/plugins.md) are userland rules that support _non-standard_ CSS features, or very specific use cases. To use one, add a `"plugins"` array to your config, containing "locaters" identifying the plugins you want to use.
+[Plugins](/docs/user-guide/plugins.md) are userland rules that support *non-standard* CSS features, or very specific use cases. To use one, add a `"plugins"` array to your config, containing "locaters" identifying the plugins you want to use.
 As with `extends`, above, a "locater" can be either an npm module name, an absolute path, or a path relative to the invoking configuration file.
 
 Once the plugin is declared, within your `"rules"` object you can add settings for the plugin's rule just like any standard rule. You will have to look at the plugin's documentation to know what the rule name should be.
@@ -176,14 +176,14 @@ The `ignoreFiles` property is stripped from extended configs: only the root-leve
 
 ## Configuring rules
 
-[Rules](/docs/user-guide/rules.md) are built into the linter and focus on _standard_ CSS. They are configured within the `rules` key of the config.
+[Rules](/docs/user-guide/rules.md) are built into the linter and focus on *standard* CSS. They are configured within the `rules` key of the config.
 
 ### Turning rules on and off
 
 Each rule can be turned off or on:
 
-* `null` - turn the rule off.
-* `true|options` - turn the rule on.
+- `null` - turn the rule off.
+- `true|options` - turn the rule on.
 
 All turned-on rules error by default. You can reduce the severity of a rule, to a warning, by adding `"warn": true` to its secondary options.
 
@@ -220,7 +220,7 @@ Or you can turn off individual rules:
 
 ### Configuring options
 
-Only the `*-no-*` rules don't expect options. All the other rules must be explicitly configured as _there are no default values_.
+Only the `*-no-*` rules don't expect options. All the other rules must be explicitly configured as *there are no default values*.
 
 An example of explicitly configuring the options for three rules:
 
@@ -261,10 +261,10 @@ Some *things* (e.g. declaration blocks and value lists) can span more than one l
 
 For example, this is the complete set of `value-list-comma-*` rules and their options:
 
-* `value-list-comma-space-after`: `"always"|"never"|"always-single-line"|"never-single-line"`
-* `value-list-comma-space-before`: `"always"|"never"|"always-single-line"|"never-single-line"`
-* `value-list-comma-newline-after`: `"always"|"always-multi-line|"never-multi-line"`
-* `value-list-comma-newline-before`: `"always"|"always-multi-line"|"never-multi-line"`
+- `value-list-comma-space-after`: `"always"|"never"|"always-single-line"|"never-single-line"`
+- `value-list-comma-space-before`: `"always"|"never"|"always-single-line"|"never-single-line"`
+- `value-list-comma-newline-after`: `"always"|"always-multi-line|"never-multi-line"`
+- `value-list-comma-newline-before`: `"always"|"always-multi-line"|"never-multi-line"`
 
 Where `*-multi-line` and `*-single-line` are in reference to the value list (the *thing*). For example, given:
 
@@ -344,7 +344,6 @@ You can enforce that with:
 
 Lastly, the rules are flexible enough to enforce entirely different conventions for single-line and multi-line lists. Say you want to allow both single-line and multi-line value lists. You want the single-line lists to have a single space before and after the colons. Whereas you want the multi-line lists to have a single newline before the commas, but no space after:
 
-
 ```css
 a {
   font-family: sans , serif , monospace; /* single-line list with a single space before and after the comma */
@@ -355,7 +354,6 @@ a {
 ```
 
 You can enforce that with:
-
 
 ```js
 "value-list-comma-newline-after": "never-multi-line",

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -62,7 +62,7 @@ If the `config` object passed uses relative paths for `extends` or `plugins`, yo
 
 A partial stylelint configuration object whose properties will override the existing config object, whether that config was loaded via the `config` option or a `.stylelintrc` file.
 
-The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to _both_ load a `.stylelintrc` file _and_ override specific parts of it, `configOverrides` does just that.
+The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to *both* load a `.stylelintrc` file *and* override specific parts of it, `configOverrides` does just that.
 
 ### `syntax`
 
@@ -109,7 +109,7 @@ stylelint.lint({
   });;
 ```
 
-If `myConfig` _does_ contain relative paths for `extends` or `plugins`, I _do_ have to use `configBasedir`:
+If `myConfig` *does* contain relative paths for `extends` or `plugins`, I *do* have to use `configBasedir`:
 
 ```js
 stylelint.lint({

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -4,8 +4,8 @@ Plugins share all the same traits and conventions as [rules](/docs/user-guide/ru
 
 ## Selector
 
-* [`stylelint-selector-bem-pattern`](https://github.com/davidtheclark/stylelint-selector-bem-pattern): Specify a BEM pattern for selectors (incorporates [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter).)
+- [`stylelint-selector-bem-pattern`](https://github.com/davidtheclark/stylelint-selector-bem-pattern): Specify a BEM pattern for selectors (incorporates [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter).)
 
 ## Statement
 
-* [`stylelint-statement-max-nesting-depth`](https://github.com/davidtheclark/stylelint-statement-max-nesting-depth): Specify the maximum nested depth of statements.
+- [`stylelint-statement-max-nesting-depth`](https://github.com/davidtheclark/stylelint-statement-max-nesting-depth): Specify the maximum nested depth of statements.

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -32,13 +32,13 @@ If the `config` object passed uses relative paths for `extends` or `plugins`, yo
 
 A partial stylelint configuration object whose properties will override the existing config object, whether that config was loaded via the `config` option or a `.stylelintrc` file.
 
-The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to _both_ load a `.stylelintrc` file _and_ override specific parts of it, `configOverrides` does just that.
+The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to *both* load a `.stylelintrc` file *and* override specific parts of it, `configOverrides` does just that.
 
 ## Usage examples
 
 We recommend you lint your CSS before applying any transformations. You can do this by either placing stylelint at the beginning of your plugin pipeline, using a plugin like [`postcss-import`](https://github.com/postcss/postcss-import) or [`postcss-easy-import`](https://github.com/TrySound/postcss-easy-import) to lint the your files before any transformations, or by creating a separate lint process that is independent of your build one.
 
-You'll also need to use a reporter. _The stylelint plugin registers warnings via PostCSS_. Therefore, you'll want to use it with a PostCSS runner that prints warnings (e.g. [`gulp-postcss`](https://github.com/postcss/gulp-postcss)) or another PostCSS plugin whose purpose is to format and print warnings (e.g. [`postcss-reporter`](https://github.com/postcss/postcss-reporter)).
+You'll also need to use a reporter. *The stylelint plugin registers warnings via PostCSS*. Therefore, you'll want to use it with a PostCSS runner that prints warnings (e.g. [`gulp-postcss`](https://github.com/postcss/gulp-postcss)) or another PostCSS plugin whose purpose is to format and print warnings (e.g. [`postcss-reporter`](https://github.com/postcss/postcss-reporter)).
 
 Using the plugin with [`gulp-postcss`](https://github.com/postcss/gulp-postcss), and as a separate lint task:
 
@@ -81,7 +81,7 @@ gulp.task("build:css", function () {
 
 Using the plugin with [`gulp-postcss`](https://github.com/postcss/gulp-postcss) and [`postcss-scss`](https://github.com/postcss/postcss-scss) to lint SCSS, and as part of the build task:
 
-_Note: the stylelint PostCSS plugin, unlike the stylelint CLI and node API, doesn't have a `syntax` option. Instead, the syntax must be set within the [PostCSS options](https://github.com/postcss/postcss#options) as there can only be one parser/syntax in a pipeline._
+*Note: the stylelint PostCSS plugin, unlike the stylelint CLI and node API, doesn't have a `syntax` option. Instead, the syntax must be set within the [PostCSS options](https://github.com/postcss/postcss#options) as there can only be one parser/syntax in a pipeline.*
 
 ```js
 var postcss = require("gulp-postcss")
@@ -123,5 +123,5 @@ postcss([
 
 ## PostCSS version compatibility
 
-* Versions `1.0.0+` of the linter are compatible with PostCSS `5.0.2+`.
-* Versions `0.8.0 and below` of the linter are compatible with PostCSS `4.x`.
+- Versions `1.0.0+` of the linter are compatible with PostCSS `5.0.2+`.
+- Versions `0.8.0 and below` of the linter are compatible with PostCSS `4.x`.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -4,201 +4,202 @@ Every rule is standalone and turned off by default. None of the rules have defau
 
 ## List of rules
 
-Here are all the rules within stylelint, grouped by the [_thing_](http://apps.workflower.fi/vocabs/css/en) they apply to.
+Here are all the rules within stylelint, grouped by the [*thing*](http://apps.workflower.fi/vocabs/css/en) they apply to.
 
 ### Color
 
-* [`color-hex-case`](../../src/rules/color-hex-case/README.md): Specify lowercase or uppercase for hex colors.
-* [`color-hex-length`](../../src/rules/color-hex-length/README.md): Specify short or long notation for hex colors.
-* [`color-no-hex`](../../src/rules/color-no-hex/README.md): Disallow hex colors.
-* [`color-no-invalid-hex`](../../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
-* [`color-no-named`](../../src/rules/color-no-named/README.md): Disallow named colors.
+- [`color-hex-case`](../../src/rules/color-hex-case/README.md): Specify lowercase or uppercase for hex colors.
+- [`color-hex-length`](../../src/rules/color-hex-length/README.md): Specify short or long notation for hex colors.
+- [`color-no-hex`](../../src/rules/color-no-hex/README.md): Disallow hex colors.
+- [`color-no-invalid-hex`](../../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
+- [`color-no-named`](../../src/rules/color-no-named/README.md): Disallow named colors.
 
 ### Font family
 
-* [`font-family-name-quotes`](../../src/rules/font-family-name-quotes/README.md): Specify whether or not quotation marks should be used around font family names, and whether single or double.
+- [`font-family-name-quotes`](../../src/rules/font-family-name-quotes/README.md): Specify whether or not quotation marks should be used around font family names, and whether single or double.
 
 ### Font weight
 
-* [`font-weight-notation`](../../src/rules/font-weight-notation/README.md): Require consistent numeric or named `font-weight` values.
+- [`font-weight-notation`](../../src/rules/font-weight-notation/README.md): Require consistent numeric or named `font-weight` values.
 
 ### Function
 
-* [`function-blacklist`](../../src/rules/function-blacklist/README.md): Specify a blacklist of disallowed functions.
-* [`function-calc-no-unspaced-operator`](../../src/rules/function-calc-no-unspaced-operator/README.md): Disallow an unspaced operator within `calc` functions.
-* [`function-comma-newline-after`](../../src/rules/function-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of functions.
-* [`function-comma-newline-before`](../../src/rules/function-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of functions.
-* [`function-comma-space-after`](../../src/rules/function-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of functions.
-* [`function-comma-space-before`](../../src/rules/function-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of functions.
-* [`function-linear-gradient-no-nonstandard-direction`](../../src/rules/function-linear-gradient-no-nonstandard-direction/README.md): Disallow direction values in `linear-gradient()` calls that are not valid according to the [standard syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Syntax).
-* [`function-parentheses-newline-inside`](../../src/rules/function-parentheses-newline-inside/README.md): Require a newline or disallow whitespace on the inside of the parentheses of functions.
-* [`function-parentheses-space-inside`](../../src/rules/function-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses of functions.
-* [`function-url-quotes`](../../src/rules/function-url-quotes/README.md): Specify single, double or no quotes for urls.
-* [`function-whitelist`](../../src/rules/function-whitelist/README.md): Specify a whitelist of only allowed functions.
-* [`function-whitespace-after`](../../src/rules/function-whitespace-after/README.md): Require a single space or disallow whitespace after functions.
+- [`function-blacklist`](../../src/rules/function-blacklist/README.md): Specify a blacklist of disallowed functions.
+- [`function-calc-no-unspaced-operator`](../../src/rules/function-calc-no-unspaced-operator/README.md): Disallow an unspaced operator within `calc` functions.
+- [`function-comma-newline-after`](../../src/rules/function-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of functions.
+- [`function-comma-newline-before`](../../src/rules/function-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of functions.
+- [`function-comma-space-after`](../../src/rules/function-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of functions.
+- [`function-comma-space-before`](../../src/rules/function-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of functions.
+- [`function-linear-gradient-no-nonstandard-direction`](../../src/rules/function-linear-gradient-no-nonstandard-direction/README.md): Disallow direction values in `linear-gradient()` calls that are not valid according to the [standard syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Syntax).
+- [`function-parentheses-newline-inside`](../../src/rules/function-parentheses-newline-inside/README.md): Require a newline or disallow whitespace on the inside of the parentheses of functions.
+- [`function-parentheses-space-inside`](../../src/rules/function-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses of functions.
+- [`function-url-quotes`](../../src/rules/function-url-quotes/README.md): Specify single, double or no quotes for urls.
+- [`function-whitelist`](../../src/rules/function-whitelist/README.md): Specify a whitelist of only allowed functions.
+- [`function-whitespace-after`](../../src/rules/function-whitespace-after/README.md): Require a single space or disallow whitespace after functions.
 
 ### Number
 
-* [`number-leading-zero`](../../src/rules/number-leading-zero/README.md): Require or disallow a leading zero for fractional numbers less than 1.
-* [`number-max-precision`](../../src/rules/number-max-precision/README.md): Limit the number of decimal places allowed in numbers.
-* [`number-no-trailing-zeros`](../../src/rules/number-no-trailing-zeros/README.md): Disallow trailing zeros within numbers.
-* [`number-zero-length-no-unit`](../../src/rules/number-zero-length-no-unit/README.md): Disallow units for zero lengths.
+- [`number-leading-zero`](../../src/rules/number-leading-zero/README.md): Require or disallow a leading zero for fractional numbers less than 1.
+- [`number-max-precision`](../../src/rules/number-max-precision/README.md): Limit the number of decimal places allowed in numbers.
+- [`number-no-trailing-zeros`](../../src/rules/number-no-trailing-zeros/README.md): Disallow trailing zeros within numbers.
+- [`number-zero-length-no-unit`](../../src/rules/number-zero-length-no-unit/README.md): Disallow units for zero lengths.
 
 ### String
 
-* [`string-quotes`](../../src/rules/string-quotes/README.md): Specify single or double quotes around strings.
+- [`string-quotes`](../../src/rules/string-quotes/README.md): Specify single or double quotes around strings.
 
 ### Time
 
-* [`time-no-imperceptible`](../../src/rules/time-no-imperceptible/README.md): Disallow `animation` and `transition` times under 100ms.
+- [`time-no-imperceptible`](../../src/rules/time-no-imperceptible/README.md): Disallow `animation` and `transition` times under 100ms.
 
 ### Unit
 
-* [`unit-blacklist`](../../src/rules/unit-blacklist/README.md): Specify a blacklist of disallowed units.
-* [`unit-whitelist`](../../src/rules/unit-whitelist/README.md): Specify a whitelist of allowed units.
+- [`unit-blacklist`](../../src/rules/unit-blacklist/README.md): Specify a blacklist of disallowed units.
+- [`unit-whitelist`](../../src/rules/unit-whitelist/README.md): Specify a whitelist of allowed units.
 
 ### Value
 
-* [`value-no-vendor-prefix`](../../src/rules/value-no-vendor-prefix/README.md): Disallow vendor prefixes for values.
+- [`value-no-vendor-prefix`](../../src/rules/value-no-vendor-prefix/README.md): Disallow vendor prefixes for values.
 
 ### Value list
 
-* [`value-list-comma-newline-after`](../../src/rules/value-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of value lists.
-* [`value-list-comma-newline-before`](../../src/rules/value-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of value lists.
-* [`value-list-comma-space-after`](../../src/rules/value-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of value lists.
-* [`value-list-comma-space-before`](../../src/rules/value-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of value lists.
+- [`value-list-comma-newline-after`](../../src/rules/value-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of value lists.
+- [`value-list-comma-newline-before`](../../src/rules/value-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of value lists.
+- [`value-list-comma-space-after`](../../src/rules/value-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of value lists.
+- [`value-list-comma-space-before`](../../src/rules/value-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of value lists.
 
 ### Custom property
 
-* [`custom-property-no-outside-root`](../../src/rules/custom-property-no-outside-root/README.md): Disallow custom properties outside of `:root` selectors.
-* [`custom-property-pattern`](../../src/rules/custom-property-pattern/README.md): Specify pattern of custom properties.
+- [`custom-property-no-outside-root`](../../src/rules/custom-property-no-outside-root/README.md): Disallow custom properties outside of `:root` selectors.
+- [`custom-property-pattern`](../../src/rules/custom-property-pattern/README.md): Specify pattern of custom properties.
 
 ### Property
 
-* [`property-blacklist`](../../src/rules/property-blacklist/README.md): Specify a blacklist of disallowed properties.
-* [`property-no-vendor-prefix`](../../src/rules/property-no-vendor-prefix/README.md): Disallow vendor prefixes for properties.
-* [`property-unit-blacklist`](../../src/rules/property-unit-blacklist/README.md): Specify a blacklist of disallowed units for specific properties.
-* [`property-unit-whitelist`](../../src/rules/property-unit-whitelist/README.md): Specify a whitelist of disallowed units for specific properties.
-* [`property-value-blacklist`](../../src/rules/property-value-blacklist/README.md): Specify a blacklist of disallowed property-value pairs.
-* [`property-value-whitelist`](../../src/rules/property-value-blacklist/README.md): Specify a whitelist of allowed property-value pairs.
-* [`property-whitelist`](../../src/rules/property-whitelist/README.md): Specify a whitelist of allowed properties.
+- [`property-blacklist`](../../src/rules/property-blacklist/README.md): Specify a blacklist of disallowed properties.
+- [`property-no-vendor-prefix`](../../src/rules/property-no-vendor-prefix/README.md): Disallow vendor prefixes for properties.
+- [`property-unit-blacklist`](../../src/rules/property-unit-blacklist/README.md): Specify a blacklist of disallowed units for specific properties.
+- [`property-unit-whitelist`](../../src/rules/property-unit-whitelist/README.md): Specify a whitelist of disallowed units for specific properties.
+- [`property-value-blacklist`](../../src/rules/property-value-blacklist/README.md): Specify a blacklist of disallowed property-value pairs.
+- [`property-value-whitelist`](../../src/rules/property-value-blacklist/README.md): Specify a whitelist of allowed property-value pairs.
+- [`property-whitelist`](../../src/rules/property-whitelist/README.md): Specify a whitelist of allowed properties.
 
 ### Declaration
 
-* [`declaration-bang-space-after`](../../src/rules/declaration-bang-space-after/README.md): Require a single space or disallow whitespace after the bang of declarations.
-* [`declaration-bang-space-before`](../../src/rules/declaration-bang-space-before/README.md): Require a single space or disallow whitespace before the bang of declarations.
-* [`declaration-colon-newline-after`](../../src/rules/declaration-colon-newline-after/README.md): Require a newline or disallow whitespace after the colon of declarations.
-* [`declaration-colon-space-after`](../../src/rules/declaration-colon-space-after/README.md): Require a single space or disallow whitespace after the colon of declarations.
-* [`declaration-colon-space-before`](../../src/rules/declaration-colon-space-before/README.md): Require a single space or disallow whitespace before the colon of declarations.
-* [`declaration-no-important`](../../src/rules/declaration-no-important/README.md): Disallow `!important` within declarations.
+- [`declaration-bang-space-after`](../../src/rules/declaration-bang-space-after/README.md): Require a single space or disallow whitespace after the bang of declarations.
+- [`declaration-bang-space-before`](../../src/rules/declaration-bang-space-before/README.md): Require a single space or disallow whitespace before the bang of declarations.
+- [`declaration-colon-newline-after`](../../src/rules/declaration-colon-newline-after/README.md): Require a newline or disallow whitespace after the colon of declarations.
+- [`declaration-colon-space-after`](../../src/rules/declaration-colon-space-after/README.md): Require a single space or disallow whitespace after the colon of declarations.
+- [`declaration-colon-space-before`](../../src/rules/declaration-colon-space-before/README.md): Require a single space or disallow whitespace before the colon of declarations.
+- [`declaration-no-important`](../../src/rules/declaration-no-important/README.md): Disallow `!important` within declarations.
 
 ### Declaration block
 
-* [`declaration-block-no-single-line`](../../src/rules/declaration-block-no-single-line/README.md): Disallow single-line declaration blocks.
-* [`declaration-block-semicolon-newline-after`](../../src/rules/declaration-block-semicolon-newline-after/README.md): Require a newline or disallow whitespace after the semicolons of declaration blocks.
-* [`declaration-block-semicolon-newline-before`](../../src/rules/declaration-block-semicolon-newline-before/README.md): Require a newline or disallow whitespace before the semicolons of declaration blocks.
-* [`declaration-block-semicolon-space-after`](../../src/rules/declaration-block-semicolon-space-after/README.md): Require a single space or disallow whitespace after the semicolons of declaration blocks.
-* [`declaration-block-semicolon-space-before`](../../src/rules/declaration-block-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of declaration blocks.
-* [`declaration-block-single-line-max-declarations`](../../src/rules/declaration-block-single-line-max-declarations/README.md): Limit the number of declaration within single line declaration blocks.
+- [`declaration-block-no-single-line`](../../src/rules/declaration-block-no-single-line/README.md): Disallow single-line declaration blocks.
+- [`declaration-block-semicolon-newline-after`](../../src/rules/declaration-block-semicolon-newline-after/README.md): Require a newline or disallow whitespace after the semicolons of declaration blocks.
+- [`declaration-block-semicolon-newline-before`](../../src/rules/declaration-block-semicolon-newline-before/README.md): Require a newline or disallow whitespace before the semicolons of declaration blocks.
+- [`declaration-block-semicolon-space-after`](../../src/rules/declaration-block-semicolon-space-after/README.md): Require a single space or disallow whitespace after the semicolons of declaration blocks.
+- [`declaration-block-semicolon-space-before`](../../src/rules/declaration-block-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of declaration blocks.
+- [`declaration-block-single-line-max-declarations`](../../src/rules/declaration-block-single-line-max-declarations/README.md): Limit the number of declaration within single line declaration blocks.
 
 ### Block
 
-* [`block-closing-brace-newline-after`](../../src/rules/block-closing-brace-newline-after/README.md): Require a newline or disallow whitespace after the closing brace of blocks.
-* [`block-closing-brace-newline-before`](../../src/rules/block-closing-brace-newline-before/README.md): Require a newline or disallow whitespace before the closing brace of blocks.
-* [`block-closing-brace-space-after`](../../src/rules/block-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of blocks.
-* [`block-closing-brace-space-before`](../../src/rules/block-closing-brace-space-before/README.md): Require a single space or disallow whitespace before the closing brace of blocks.
-* [`block-no-empty`](../../src/rules/block-no-empty/README.md): Disallow empty blocks.
-* [`block-opening-brace-newline-after`](../../src/rules/block-opening-brace-newline-after/README.md): Require a newline after the opening brace of blocks.
-* [`block-opening-brace-newline-before`](../../src/rules/block-opening-brace-newline-before/README.md): Require a newline or disallow whitespace before the opening brace of blocks.
-* [`block-opening-brace-space-after`](../../src/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks.
-* [`block-opening-brace-space-before`](../../src/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks.
+- [`block-closing-brace-newline-after`](../../src/rules/block-closing-brace-newline-after/README.md): Require a newline or disallow whitespace after the closing brace of blocks.
+- [`block-closing-brace-newline-before`](../../src/rules/block-closing-brace-newline-before/README.md): Require a newline or disallow whitespace before the closing brace of blocks.
+- [`block-closing-brace-space-after`](../../src/rules/block-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of blocks.
+- [`block-closing-brace-space-before`](../../src/rules/block-closing-brace-space-before/README.md): Require a single space or disallow whitespace before the closing brace of blocks.
+- [`block-no-empty`](../../src/rules/block-no-empty/README.md): Disallow empty blocks.
+- [`block-opening-brace-newline-after`](../../src/rules/block-opening-brace-newline-after/README.md): Require a newline after the opening brace of blocks.
+- [`block-opening-brace-newline-before`](../../src/rules/block-opening-brace-newline-before/README.md): Require a newline or disallow whitespace before the opening brace of blocks.
+- [`block-opening-brace-space-after`](../../src/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks.
+- [`block-opening-brace-space-before`](../../src/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks.
 
 ### Root selector
 
-* [`root-no-standard-properties`](../../src/rules/root-no-standard-properties/README.md): Disallow standard properties inside `:root` selectors.
+- [`root-no-standard-properties`](../../src/rules/root-no-standard-properties/README.md): Disallow standard properties inside `:root` selectors.
 
 ### Selector
 
-* [`selector-class-pattern`](../../src/rules/selector-class-pattern/README.md): Specify a pattern for class selectors.
-* [`selector-combinator-space-after`](../../src/rules/selector-combinator-space-after/README.md): Require a single space or disallow whitespace after the combinators of selectors.
-* [`selector-combinator-space-before`](../../src/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors.
-* [`selector-id-pattern`](../../src/rules/selector-id-pattern/README.md): Specify a pattern for id selectors.
-* [`selector-no-attribute`](../../src/rules/selector-no-attribute/README.md): Disallow attribute selectors.
-* [`selector-no-combinator`](../../src/rules/selector-no-combinator/README.md): Disallow combinators in selectors.
-* [`selector-no-id`](../../src/rules/selector-no-id/README.md): Disallow id selectors.
-* [`selector-no-type`](../../src/rules/selector-no-type/README.md): Disallow type selectors.
-* [`selector-no-universal`](../../src/rules/selector-no-universal/README.md): Disallow universal selectors.
-* [`selector-no-vendor-prefix`](../../src/rules/selector-no-vendor-prefix/README.md): Disallow vendor prefixes for selectors.
-* [`selector-pseudo-element-colon-notation`](../../src/rules/selector-pseudo-element-colon-notation/README.md): Specify single or double colon notation for applicable pseudo-elements.
-* [`selector-root-no-composition`](../../src/rules/selector-root-no-composition/README.md): Disallow the composition of`:root` selectors.
+- [`selector-class-pattern`](../../src/rules/selector-class-pattern/README.md): Specify a pattern for class selectors.
+- [`selector-combinator-space-after`](../../src/rules/selector-combinator-space-after/README.md): Require a single space or disallow whitespace after the combinators of selectors.
+- [`selector-combinator-space-before`](../../src/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors.
+- [`selector-id-pattern`](../../src/rules/selector-id-pattern/README.md): Specify a pattern for id selectors.
+- [`selector-no-attribute`](../../src/rules/selector-no-attribute/README.md): Disallow attribute selectors.
+- [`selector-no-combinator`](../../src/rules/selector-no-combinator/README.md): Disallow combinators in selectors.
+- [`selector-no-id`](../../src/rules/selector-no-id/README.md): Disallow id selectors.
+- [`selector-no-type`](../../src/rules/selector-no-type/README.md): Disallow type selectors.
+- [`selector-no-universal`](../../src/rules/selector-no-universal/README.md): Disallow universal selectors.
+- [`selector-no-vendor-prefix`](../../src/rules/selector-no-vendor-prefix/README.md): Disallow vendor prefixes for selectors.
+- [`selector-pseudo-element-colon-notation`](../../src/rules/selector-pseudo-element-colon-notation/README.md): Specify single or double colon notation for applicable pseudo-elements.
+- [`selector-root-no-composition`](../../src/rules/selector-root-no-composition/README.md): Disallow the composition of`:root` selectors.
 
 ### Selector list
 
-* [`selector-list-comma-newline-after`](../../src/rules/selector-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of selector lists.
-* [`selector-list-comma-newline-before`](../../src/rules/selector-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of selector lists.
-* [`selector-list-comma-space-after`](../../src/rules/selector-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of selector lists.
-* [`selector-list-comma-space-before`](../../src/rules/selector-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of selector lists.
+- [`selector-list-comma-newline-after`](../../src/rules/selector-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of selector lists.
+- [`selector-list-comma-newline-before`](../../src/rules/selector-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of selector lists.
+- [`selector-list-comma-space-after`](../../src/rules/selector-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of selector lists.
+- [`selector-list-comma-space-before`](../../src/rules/selector-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of selector lists.
 
 ### Rule
 
-* [`rule-nested-empty-line-before`](../../src/rules/rule-nested-empty-line-before/README.md): Require or disallow an empty line before nested rules.
-* [`rule-no-duplicate-properties`](../../src/rules/rule-no-duplicate-properties/README.md): Disallow duplicate properties within rules.
-* [`rule-no-shorthand-property-overrides`](../../src/rules/rule-no-shorthand-property-overrides/README.md): Disallow shorthand properties that override related longhand properties.
-* [`rule-non-nested-empty-line-before`](../../src/rules/rule-non-nested-empty-line-before/README.md): Require or disallow an empty line before non-nested rules.
-* [`rule-properties-order`](../../src/rules/rule-properties-order/README.md): Specify the order of properties within rules.
-* [`rule-trailing-semicolon`](../../src/rules/rule-trailing-semicolon/README.md): Require or disallow a trailing semicolon within rules.
+- [`rule-nested-empty-line-before`](../../src/rules/rule-nested-empty-line-before/README.md): Require or disallow an empty line before nested rules.
+- [`rule-no-duplicate-properties`](../../src/rules/rule-no-duplicate-properties/README.md): Disallow duplicate properties within rules.
+- [`rule-no-shorthand-property-overrides`](../../src/rules/rule-no-shorthand-property-overrides/README.md): Disallow shorthand properties that override related longhand properties.
+- [`rule-non-nested-empty-line-before`](../../src/rules/rule-non-nested-empty-line-before/README.md): Require or disallow an empty line before non-nested rules.
+- [`rule-properties-order`](../../src/rules/rule-properties-order/README.md): Specify the order of properties within rules.
+- [`rule-trailing-semicolon`](../../src/rules/rule-trailing-semicolon/README.md): Require or disallow a trailing semicolon within rules.
 
 ### Media feature
 
-* [`media-feature-colon-space-after`](../../src/rules/media-feature-colon-space-after/README.md): Require a single space or disallow whitespace after the colon in media features.
-* [`media-feature-colon-space-before`](../../src/rules/media-feature-colon-space-before/README.md): Require a single space or disallow whitespace before the colon in media features.
-* [`media-feature-name-no-vendor-prefix`](../../src/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names.
-* [`media-feature-no-missing-punctuation`](../../src/rules/media-feature-no-missing-punctuation/README.md): Ensure that non-boolean media features have the punctuation they need: either a colon or a range-operator.
-* [`media-feature-range-operator-space-after`](../../src/rules/media-feature-range-operator-space-after/README.md): Require a single space or disallow whitespace after the range operator in media features.
-* [`media-feature-range-operator-space-before`](../../src/rules/media-feature-range-operator-space-before/README.md): Require a single space or disallow whitespace before the range operator in media features.
+- [`media-feature-colon-space-after`](../../src/rules/media-feature-colon-space-after/README.md): Require a single space or disallow whitespace after the colon in media features.
+- [`media-feature-colon-space-before`](../../src/rules/media-feature-colon-space-before/README.md): Require a single space or disallow whitespace before the colon in media features.
+- [`media-feature-name-no-vendor-prefix`](../../src/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names.
+- [`media-feature-no-missing-punctuation`](../../src/rules/media-feature-no-missing-punctuation/README.md): Ensure that non-boolean media features have the punctuation they need: either a colon or a range-operator.
+- [`media-feature-range-operator-space-after`](../../src/rules/media-feature-range-operator-space-after/README.md): Require a single space or disallow whitespace after the range operator in media features.
+- [`media-feature-range-operator-space-before`](../../src/rules/media-feature-range-operator-space-before/README.md): Require a single space or disallow whitespace before the range operator in media features.
 
 ### Custom media
 
-* [`custom-media-pattern`](../../src/rules/custom-media-pattern/README.md): Specify pattern of custom media query names.
+- [`custom-media-pattern`](../../src/rules/custom-media-pattern/README.md): Specify pattern of custom media query names.
 
 ### Media query
 
-* [`media-query-parentheses-space-inside`](../../src/rules/media-query-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within media queries.
+- [`media-query-parentheses-space-inside`](../../src/rules/media-query-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within media queries.
 
 ### Media query list
 
-* [`media-query-list-comma-newline-after`](../../src/rules/media-query-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of media query lists.
-* [`media-query-list-comma-newline-before`](../../src/rules/media-query-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of media query lists.
-* [`media-query-list-comma-space-after`](../../src/rules/media-query-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of media query lists.
-* [`media-query-list-comma-space-before`](../../src/rules/media-query-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of media query lists.
+- [`media-query-list-comma-newline-after`](../../src/rules/media-query-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of media query lists.
+- [`media-query-list-comma-newline-before`](../../src/rules/media-query-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of media query lists.
+- [`media-query-list-comma-space-after`](../../src/rules/media-query-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of media query lists.
+- [`media-query-list-comma-space-before`](../../src/rules/media-query-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of media query lists.
 
 ### At rule
 
-* [`at-rule-empty-line-before`](../../src/rules/at-rule-empty-line-before/README.md): Require or disallow an empty line before @rules.
-* [`at-rule-no-vendor-prefix`](../../src/rules/at-rule-no-vendor-prefix/README.md): Disallow vendor prefixes for @rules.
+- [`at-rule-empty-line-before`](../../src/rules/at-rule-empty-line-before/README.md): Require or disallow an empty line before @rules.
+- [`at-rule-no-vendor-prefix`](../../src/rules/at-rule-no-vendor-prefix/README.md): Disallow vendor prefixes for @rules.
 
 ### Comment
 
-* [`comment-empty-line-before`](../../src/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
-* [`comment-whitespace-inside`](../../src/rules/comment-whitespace-inside/README.md): Require a single space or disallow whitespace on the inside of comment markers.
+- [`comment-empty-line-before`](../../src/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
+- [`comment-whitespace-inside`](../../src/rules/comment-whitespace-inside/README.md): Require a single space or disallow whitespace on the inside of comment markers.
 
 ### General / Sheet
 
-* [`indentation`](../../src/rules/indentation/README.md): Specify indentation.
-* [`max-empty-lines`](../../src/rules/max-empty-lines/README.md): Disallow more than a specified number of adjacent empty lines.
-* [`max-line-length`](../../src/rules/max-line-length/README.md): Limit the length of a line.
-* [`no-duplicate-selectors`](../../src/rules/no-duplicate-selectors/README.md): Disallow duplicate selectors.
-* [`no-eol-whitespace`](../../src/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
-* [`no-invalid-double-slash-comments`](../../src/rules/no-invalid-double-slash-comments/README.md): Disallow double-slash comments (`//...`) which are not supported by CSS.
-* [`no-missing-eof-newline`](../../src/rules/no-missing-eof-newline/README.md): Disallow missing end-of-file newline.
-* [`no-unknown-animations`](../../src/rules/no-unknown-animations/README.md): Disallow animation names that do not correspond to a `@keyframes` declaration.
+- [`indentation`](../../src/rules/indentation/README.md): Specify indentation.
+- [`max-empty-lines`](../../src/rules/max-empty-lines/README.md): Disallow more than a specified number of adjacent empty lines.
+- [`max-line-length`](../../src/rules/max-line-length/README.md): Limit the length of a line.
+- [`no-duplicate-selectors`](../../src/rules/no-duplicate-selectors/README.md): Disallow duplicate selectors.
+- [`no-eol-whitespace`](../../src/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
+- [`no-invalid-double-slash-comments`](../../src/rules/no-invalid-double-slash-comments/README.md): Disallow double-slash comments (`//...`) which are not supported by CSS.
+- [`no-missing-eof-newline`](../../src/rules/no-missing-eof-newline/README.md): Disallow missing end-of-file newline.
+- [`no-unknown-animations`](../../src/rules/no-unknown-animations/README.md): Disallow animation names that do not correspond to a `@keyframes` declaration.
 
 ## About rule names
 
-* Made of lowercase words separated by hyphens.
-* Split into two parts:
-  * The first describes what [_thing_](http://apps.workflower.fi/vocabs/css/en) the rule applies to.
-  * The second describes what the rule is checking.
+- Made of lowercase words separated by hyphens.
+- Split into two parts:
+
+  - The first describes what [*thing*](http://apps.workflower.fi/vocabs/css/en) the rule applies to.
+  - The second describes what the rule is checking.
 
 ```shell
 "number-leading-zero"
@@ -206,7 +207,7 @@ Here are all the rules within stylelint, grouped by the [_thing_](http://apps.wo
 the thing   what the rule is checking
 ```
 
-* Except when the rule applies to the whole stylesheet:
+- Except when the rule applies to the whole stylesheet:
 
 ```shell
 "no-eol-whitespace"
@@ -217,13 +218,14 @@ the thing   what the rule is checking
 
 ### No rules
 
-Most rules allow you to choose whether you want to require *or* disallow something.
+Most rules allow you to choose whether you want to require *or- disallow something.
 
 For example, whether numbers *must* or *must not* have a leading zero:
 
-* `number-leading-zero`: `string - "always"|"never"`
-  * `"always"` - there *must always* be a leading zero.
-  * `"never"` - there *must never* be a leading zero.
+- `number-leading-zero`: `string - "always"|"never"`
+
+  - `"always"` - there *must always* be a leading zero.
+  - `"never"` - there *must never* be a leading zero.
 
 ```css
     a { line-height: 0.5; }
@@ -235,7 +237,7 @@ However, some rules *just disallow* something. `*-no-*` is used to identify thes
 
 For example, whether empty blocks should be disallowed:
 
-* `block-no-empty` - blocks *must not* be empty.
+- `block-no-empty` - blocks *must not* be empty.
 
 ```css
     a { }
@@ -251,7 +253,7 @@ Notice how, for a rule like this, it does not make sense to have an option to en
 
 For example, specifying the maximum number of digits after the "." in a number:
 
-* `number-max-precision`: `int`
+- `number-max-precision`: `int`
 
 ```css
     a { font-size: 1.333em; }
@@ -270,7 +272,7 @@ The whitespace rules combine two sets of keywords:
 
 For example, specifying if a single empty line or no space must come before all the comments in a stylesheet:
 
-* `comment-empty-line-before`: `string` - `"always"|"never"`
+- `comment-empty-line-before`: `string` - `"always"|"never"`
 
 ```css
     a {}
@@ -287,7 +289,7 @@ Additionally, some whitespace rule make use of another set of keywords:
 
 For example, specifying if a single space or no space must come after a comma in a function:
 
-* `function-comma-space-after`: `string` - `"always"|"never"`
+- `function-comma-space-after`: `string` - `"always"|"never"`
 
 ```css
     a { transform: translate(1, 1) }
@@ -297,7 +299,7 @@ For example, specifying if a single space or no space must come after a comma in
 
 The plural of the punctuation is used for `inside` rules. For example, specifying if a single space or no space must be inside the parentheses of a function:
 
-* `function-parentheses-space-inside`: `string` - `"always"|"never"`
+- `function-parentheses-space-inside`: `string` - `"always"|"never"`
 
 ```css
     a { transform: translate( 1, 1 ); }

--- a/identity/README.md
+++ b/identity/README.md
@@ -2,9 +2,7 @@
 
 ## stylelint-icon
 
-By [Kenneth Von Alt](https://thenounproject.com/KenVonAlt)
-
-https://thenounproject.com/term/tuxedo/2104/
+[Tuxedo](https://thenounproject.com/term/tuxedo/2104/) by [Kenneth Von Alt](https://thenounproject.com/KenVonAlt)
 
 ## stylelint-text
 

--- a/package.json
+++ b/package.json
@@ -56,17 +56,20 @@
     "eslint-config-stylelint": "^0.1.0",
     "npmpub": "^3.0.1",
     "postcss-import": "^8.0.2",
+    "remark": "^4.0.0",
+    "remark-lint": "^3.0.0",
     "sinon": "^1.16.1",
     "stylelint-rule-tester": "^0.6.2",
     "tape": "^4.2.0"
   },
   "scripts": {
-    "build": "babel src --out-dir dist",
-    "lint": "eslint . --ignore-path .gitignore",
-    "prepublish": "npm run build",
-    "release": "npmpub",
+    "lint": "eslint . --ignore-path .gitignore && remark . --quiet --frail",
     "tape": "babel-tape-runner \"src/**/__tests__/*.js\"",
-    "test": "npm run lint && npm run tape"
+    "pretest": "npm run lint",
+    "test": "npm run tape",
+    "build": "babel src --out-dir dist",
+    "prepublish": "npm run build",
+    "release": "npmpub"
   },
   "babel": {
     "presets": [
@@ -75,5 +78,19 @@
   },
   "eslintConfig": {
     "extends": "stylelint"
+  },
+  "remarkConfig": {
+    "plugins": {
+      "lint": {
+        "emphasis-marker": "*",
+        "list-item-indent": "space",
+        "list-item-spacing": false,
+        "maximum-heading-length": false,
+        "maximum-line-length": false,
+        "no-multiple-toplevel-headings": false,
+        "strong-marker": "*",
+        "unordered-list-marker-style": "-"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,14 +82,11 @@
   "remarkConfig": {
     "plugins": {
       "lint": {
-        "emphasis-marker": "*",
         "list-item-indent": "space",
         "list-item-spacing": false,
         "maximum-heading-length": false,
         "maximum-line-length": false,
-        "no-multiple-toplevel-headings": false,
-        "strong-marker": "*",
-        "unordered-list-marker-style": "-"
+        "no-multiple-toplevel-headings": false
       }
     }
   }

--- a/src/rules/block-opening-brace-newline-after/README.md
+++ b/src/rules/block-opening-brace-newline-after/README.md
@@ -9,8 +9,7 @@ Require a newline after the opening brace of blocks.
  * The newline after this brace */
 ```
 
-This rule allows an end-of-line comment separated from the opening brace by spaces,
-as long as the comment contains no newlines. For example,
+This rule allows an end-of-line comment separated from the opening brace by spaces, as long as the comment contains no newlines. For example,
 
 ```css
 a { /* end-of-line comment */

--- a/src/rules/color-hex-case/README.md
+++ b/src/rules/color-hex-case/README.md
@@ -22,7 +22,6 @@ a { color: #FFF; }
 
 The following patterns are *not* considered warnings:
 
-
 ```css
 a { color: #000; }
 ```
@@ -40,7 +39,6 @@ a { color: #fff; }
 ```
 
 The following patterns are *not* considered warnings:
-
 
 ```css
 a { color: #000; }

--- a/src/rules/color-hex-length/README.md
+++ b/src/rules/color-hex-length/README.md
@@ -26,7 +26,6 @@ a { color: #fffffaa; }
 
 The following patterns are *not* considered warnings:
 
-
 ```css
 a { color: #fff; }
 ```
@@ -52,7 +51,6 @@ a { color: #fffa; }
 ```
 
 The following patterns are *not* considered warnings:
-
 
 ```css
 a { color: #ffffff; }

--- a/src/rules/color-no-invalid-hex/README.md
+++ b/src/rules/color-no-invalid-hex/README.md
@@ -26,7 +26,6 @@ a { color: #12345aa; }
 
 The following patterns are *not* considered warnings:
 
-
 ```css
 a { color: #000; }
 ```

--- a/src/rules/comment-whitespace-inside/README.md
+++ b/src/rules/comment-whitespace-inside/README.md
@@ -8,8 +8,7 @@ Require or disallow whitespace on the inside of comment markers.
  * The space inside these two markers */
 ```
 
-Any number of asterisks are allowed at the beginning or end of the comment.
-So `/** comment **/` is treated the same way as `/* comment */`.
+Any number of asterisks are allowed at the beginning or end of the comment. So `/** comment **/` is treated the same way as `/* comment */`.
 
 ## Options
 

--- a/src/rules/declaration-block-semicolon-newline-after/README.md
+++ b/src/rules/declaration-block-semicolon-newline-after/README.md
@@ -11,8 +11,7 @@ a {
  * The newline after this semicolon */
 ```
 
-This rule allows an end-of-line comment separated from the semicolon by spaces,
-as long as the comment contains no newlines. For example,
+This rule allows an end-of-line comment separated from the semicolon by spaces, as long as the comment contains no newlines. For example,
 
 ```css
 a {

--- a/src/rules/font-family-name-quotes/README.md
+++ b/src/rules/font-family-name-quotes/README.md
@@ -1,7 +1,6 @@
 # font-family-name-quotes
 
-Specify whether or not quotation marks should be used around font family names,
-and whether single or double.
+Specify whether or not quotation marks should be used around font family names, and whether single or double.
 
 ```css
 a { font-family: "Times New Roman", 'Ancient Runes', serif; }
@@ -17,27 +16,13 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 *Please read the following to understand these options*:
 
-- The `font-family` property accepts a short list of special **keywords**:
-`inherit`, `serif`, `sans-serif`, `cursive`, `fantasy`, and `monospace`.
-If you wrap these words in quotes, the browser will not interpret
-them as keywords, but will instead look for a font by that name
-(e.g. will look for a `"sans-serif"` font) --
-which is almost *never* what you want. Instead, you use these keywords
-to point to the built-in, generic fallbacks (right?).
-Therefore, *all of the options below enforce no quotes around
-these keywords*. (If you actually want to use a font named `"sans-serif"`,
-turn this rule off.)
+- The `font-family` property accepts a short list of special **keywords**: `inherit`, `serif`, `sans-serif`, `cursive`, `fantasy`, and `monospace`. If you wrap these words in quotes, the browser will not interpret them as keywords, but will instead look for a font by that name (e.g. will look for a `"sans-serif"` font) -- which is almost *never* what you want. Instead, you use these keywords to point to the built-in, generic fallbacks (right?). Therefore, *all of the options below enforce no quotes around these keywords*. (If you actually want to use a font named `"sans-serif"`, turn this rule off.)
 - Quotes are **recommended** [in the spec](https://www.w3.org/TR/CSS2/fonts.html#font-family-prop) with "font family names that contain white space, digits, or punctuation characters other than hyphens".
-- Quotes are **required** around font-family names when they are not [valid CSS identifiers](https://www.w3.org/TR/CSS2/syndata.html#value-def-identifier).
-For example, a font family name requires quotes around it if it contains `$`, `!`, or `/`,
-but does not require quotes just because it contains spaces or a (non-initial) number or underscore.
-*You can probably bet that almost every font family name you use **will** be a valid CSS identifier*.
+- Quotes are **required** around font-family names when they are not [valid CSS identifiers](https://www.w3.org/TR/CSS2/syndata.html#value-def-identifier). For example, a font family name requires quotes around it if it contains `$`, `!`, or `/`, but does not require quotes just because it contains spaces or a (non-initial) number or underscore. *You can probably bet that almost every font family name you use **will** be a valid CSS identifier*.
 
 For more on these subtleties, read ["Unquoted font family names in CSS"](https://mathiasbynens.be/notes/unquoted-font-family), by Mathias Bynens.
 
-**Caveat:** This rule does not currently understand escape sequences such as those
-described by Mathias. If you want to use the font family name "Hawaii 5-0" you will
-need to wrap it in quotes, instead of escaping it as `Hawaii \35 -0` or `Hawaii\ 5-0`.
+**Caveat:** This rule does not currently understand escape sequences such as those described by Mathias. If you want to use the font family name "Hawaii 5-0" you will need to wrap it in quotes, instead of escaping it as `Hawaii \35 -0` or `Hawaii\ 5-0`.
 
 ### `"single-unless-keyword"` and `"double-unless-keyword"`
 
@@ -67,8 +52,7 @@ The same examples apply to `"double-unless-keyword"`, but with `"` quotes.
 
 ### `"single-where-required"` and `"double-where-required"`
 
-Expect quotes only when quotes are *required* according to the criteria above,
-and disallow quotes in all other cases.
+Expect quotes only when quotes are *required* according to the criteria above, and disallow quotes in all other cases.
 
 For example, with `"double-where-required"`, the following patterns are considered warnings:
 
@@ -98,8 +82,7 @@ The same examples apply to `"single-where-required"`, but with `'` quotes.
 
 ### `"single-where-recommended"` and `"double-where-recommended"`
 
-Expect quotes only when quotes are *recommended* according to the criteria above, and disallow quotes in all other cases. (This includes all cases where
-quotes are *required*, as well.)
+Expect quotes only when quotes are *recommended* according to the criteria above, and disallow quotes in all other cases. (This includes all cases where quotes are *required*, as well.)
 
 For example, with `"single-where-recommended"`, the following patterns are considered warnings:
 

--- a/src/rules/font-weight-notation/README.md
+++ b/src/rules/font-weight-notation/README.md
@@ -1,7 +1,6 @@
 # font-weight-notation
 
-Require consistent numeric or named `font-weight` values.
-Also, when named values are expected, require only valid names.
+Require consistent numeric or named `font-weight` values. Also, when named values are expected, require only valid names.
 
 ```css
 a { font-weight: bold }

--- a/src/rules/function-linear-gradient-no-nonstandard-direction/README.md
+++ b/src/rules/function-linear-gradient-no-nonstandard-direction/README.md
@@ -10,6 +10,7 @@ Disallow direction values in `linear-gradient()` calls that are not valid accord
 ```
 
 A valid and standard direction value is one of the following:
+
 - an angle
 - `to ` plus a side-or-corner (`to top`, `to bottom`, `to left`, `to right`; `to top right`, `to right top`, `to bottom left`, etc.)
 

--- a/src/rules/function-whitespace-after/README.md
+++ b/src/rules/function-whitespace-after/README.md
@@ -8,8 +8,7 @@ a { transform: translate(1, 1) scale(3); }
  *                   This space */
 ```
 
-The rule does not check for space immediately after `)` if the very next character
-is `,`, `)`, or `}`, allowing some of the patterns exemplified below.
+The rule does not check for space immediately after `)` if the very next character is `,`, `)`, or `}`, allowing some of the patterns exemplified below.
 
 ## Options
 

--- a/src/rules/indentation/README.md
+++ b/src/rules/indentation/README.md
@@ -179,13 +179,9 @@ The following patterns are *not* considered warnings:
 
 Add additional indentation levels for hierarchical relationships between selectors.
 
-The basic rule is this: If selectors are grouped in such a way that Rule A should be
-followed by other rules whose selectors *start* with the same characters as Rule A's
-(complete) selector, then Rule A is superordinate to those rules. This hierarchy can
-nest indefinitely.
+The basic rule is this: If selectors are grouped in such a way that Rule A should be followed by other rules whose selectors *start* with the same characters as Rule A's (complete) selector, then Rule A is superordinate to those rules. This hierarchy can nest indefinitely.
 
-If a `@media` statement only contains rules that are subordinate to the rule *before*
-the `@media` statement, it is considered subordinate to that rule (see example below).
+If a `@media` statement only contains rules that are subordinate to the rule *before* the `@media` statement, it is considered subordinate to that rule (see example below).
 
 Such a pattern can apply to combinators or BEM-style naming.
 
@@ -254,8 +250,7 @@ The following patterns are *not* considered warnings:
 
 ## Caveats
 
-Function arguments are simply ignored, to allow for arbitrary indentation.
-So any of the following are *not* considered warnings:
+Function arguments are simply ignored, to allow for arbitrary indentation. So any of the following are *not* considered warnings:
 
 ```css
 .foo {

--- a/src/rules/max-line-length/README.md
+++ b/src/rules/max-line-length/README.md
@@ -10,9 +10,7 @@ a { color: red }
 
 Lines that exceed the maximum length but contain no whitespace (other than at the beginning of the line) are ignored.
 
-When evaluating the line length, `url(...)` functions are collapsed into just `url()`,
-because typically you have no control over the length of its argument.
-This means that long `url()` functions should not contribute to warnings.
+When evaluating the line length, `url(...)` functions are collapsed into just `url()`, because typically you have no control over the length of its argument. This means that long `url()` functions should not contribute to warnings.
 
 ## Options
 

--- a/src/rules/no-duplicate-selectors/README.md
+++ b/src/rules/no-duplicate-selectors/README.md
@@ -8,25 +8,14 @@ Disallow duplicate selectors within a stylesheet.
  * These duplicates */
 ```
 
-This rule checks each compound selector within a complex selector,
-so in `.foo .bar, .bar .foo` there are no duplicates because
-each compound selector is actually different, though both have the same
-constituents.
+This rule checks each compound selector within a complex selector, so in `.foo .bar, .bar .foo` there are no duplicates because each compound selector is actually different, though both have the same constituents.
 
 The same selector *is* allowed to repeat in the following circumstances:
 
-- The duplicates are determined to originate in different stylesheets,
-  e.g. you have concatenated or compiled files in a way that produces
-  sourcemaps for PostCSS to read, e.g. postcss-import).
-- The duplicates are in rules with different parent nodes,
-  e.g. inside and outside of a media query.
+- The duplicates are determined to originate in different stylesheets, e.g. you have concatenated or compiled files in a way that produces sourcemaps for PostCSS to read, e.g. postcss-import).
+- The duplicates are in rules with different parent nodes, e.g. inside and outside of a media query.
 
-**If you are using a processor that modifies selectors, read this:**
-This rule will only compare the selectors that it sees, so as far as it's
-concerned, in `a { b {} & b {} }` there are no duplicate selectors. If you're
-using SCSS, though, you do have duplicates in the output: `a b {}` occurs twice.
-If you want this rule to analyze the selectors in *your output*, make sure
-it runs *after* you have compiled your stylesheets.
+**If you are using a processor that modifies selectors, read this:** This rule will only compare the selectors that it sees, so as far as it's concerned, in `a { b {} & b {} }` there are no duplicate selectors. If you're using SCSS, though, you do have duplicates in the output: `a b {}` occurs twice. If you want this rule to analyze the selectors in *your output*, make sure it runs *after* you have compiled your stylesheets.
 
 The following patterns are considered warnings:
 

--- a/src/rules/number-leading-zero/README.md
+++ b/src/rules/number-leading-zero/README.md
@@ -50,7 +50,6 @@ a { line-height: 0.5; }
 a { transform: translate(2px, 0.4px); }
 ```
 
-
 The following patterns are *not* considered warnings:
 
 ```css

--- a/src/rules/property-blacklist/README.md
+++ b/src/rules/property-blacklist/README.md
@@ -16,10 +16,7 @@ a { text-rendering: optimizeLegibility; }
 
 Blacklisted properties *must never* be used.
 
-If a string in the array is surrounded with `"/"` (e.g. `"/^background/"`),
-it is interpreted as a regular expression. This allows, for example,
-easy targeting of shorthands: `/^background/` will match `background`,
-`background-size`, `background-color`, etc.
+If a string in the array is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 
 Given:
 
@@ -28,7 +25,6 @@ Given:
 ```
 
 The following patterns are considered warnings:
-
 
 ```css
 a { text-rendering: optimizeLegibility; }

--- a/src/rules/property-no-vendor-prefix/README.md
+++ b/src/rules/property-no-vendor-prefix/README.md
@@ -8,16 +8,7 @@ a { -webkit-transform: scale(1); }
  * These prefixes */
 ```
 
-This rule does not blanketly condemn vendor prefixes.
-Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date
-data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should
-cause a warning or not.
-*If you've included a vendor prefixed property that has a standard alternative,
-one that Autoprefixer could take care of for you,
-this rule will warn about it*.
-If, however, you use a non-standard vendor-prefixed property,
-one that Autoprefixer would ignore and could not provide (such as `-webkit-touch-callout`), 
-this rule will ignore it.
+This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a warning or not. *If you've included a vendor prefixed property that has a standard alternative, one that Autoprefixer could take care of for you, this rule will warn about it*. If, however, you use a non-standard vendor-prefixed property, one that Autoprefixer would ignore and could not provide (such as `-webkit-touch-callout`), this rule will ignore it.
 
 The following patterns are considered warnings:
 

--- a/src/rules/property-unit-blacklist/README.md
+++ b/src/rules/property-unit-blacklist/README.md
@@ -14,10 +14,7 @@ a { width: 100px; }
   "unprefixed-property-name": ["array", "of", "units"]
 }`
 
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`),
-it is interpreted as a regular expression. This allows, for example,
-easy targeting of shorthands: `/^animation/` will match `animation`,
-`animation-duration`, `animation-timing-function`, etc.
+If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
 Given:
 

--- a/src/rules/property-unit-whitelist/README.md
+++ b/src/rules/property-unit-whitelist/README.md
@@ -14,10 +14,7 @@ a { width: 100px; }
   "unprefixed-property-name": ["array", "of", "units"]
 }`
 
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`),
-it is interpreted as a regular expression. This allows, for example,
-easy targeting of shorthands: `/^animation/` will match `animation`,
-`animation-duration`, `animation-timing-function`, etc.
+If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
 Given:
 
@@ -64,7 +61,6 @@ a { height: 100px; }
 ```css
 a { animation: animation-name 5s ease; }
 ```
-
 
 ```css
 a { -webkit-animation: animation-name 5s ease; }

--- a/src/rules/property-value-blacklist/README.md
+++ b/src/rules/property-value-blacklist/README.md
@@ -15,19 +15,11 @@ a { text-transform: uppercase; }
   "unprefixed-property-name": ["/regex/", "non-regex"]
 }`
 
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`),
-it is interpreted as a regular expression. This allows, for example,
-easy targeting of shorthands: `/^animation/` will match `animation`,
-`animation-duration`, `animation-timing-function`, etc.
+If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
-The same goes for values. Keep in mind that a regular expression value
-is matched against the entire value of the declaration, not specific parts of it.
-For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will *not* match `"/^solid/"`
-(notice beginning of the line boundary) but *will* match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
+The same goes for values. Keep in mind that a regular expression value is matched against the entire value of the declaration, not specific parts of it. For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will *not* match `"/^solid/"` (notice beginning of the line boundary) but *will* match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
 
-Be careful with regex matching not to accidentally consider quoted string values and `url()` arguments.
-For example, `"/red/"` will match value such as `"1px dotted red"` as well as `"\"foo\""`
-and `"white url(/mysite.com/red.png)"`.
+Be careful with regex matching not to accidentally consider quoted string values and `url()` arguments. For example, `"/red/"` will match value such as `"1px dotted red"` as well as `"\"foo\""` and `"white url(/mysite.com/red.png)"`.
 
 Given:
 
@@ -87,7 +79,6 @@ a { -webkit-transform: scale(2); }
 ```css
 a { color: lightgreen; }
 ```
-
 
 ```css
 a { animation: foo 2s linear; }

--- a/src/rules/property-value-whitelist/README.md
+++ b/src/rules/property-value-whitelist/README.md
@@ -15,23 +15,13 @@ a { text-transform: uppercase; }
   "unprefixed-property-name": ["/regex/", "non-regex"]
 }`
 
-If a property name is found in the object, only its whitelisted property values are allowed.
-The rule complains about all non-matching values. (If the property name is not included in
-the object, anything goes.)
+If a property name is found in the object, only its whitelisted property values are allowed. The rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`),
-it is interpreted as a regular expression. This allows, for example,
-easy targeting of shorthands: `/^animation/` will match `animation`,
-`animation-duration`, `animation-timing-function`, etc.
+If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
-The same goes for values. Keep in mind that a regular expression value
-is matched against the entire value of the declaration, not specific parts of it.
-For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will *not* match `"/^solid/"`
-(notice beginning of the line boundary) but *will* match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
+The same goes for values. Keep in mind that a regular expression value is matched against the entire value of the declaration, not specific parts of it. For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will *not* match `"/^solid/"` (notice beginning of the line boundary) but *will* match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
 
-Be careful with regex matching not to accidentally consider quoted string values and `url()` arguments.
-For example, `"/red/"` will match value such as `"1px dotted red"` as well as `"\"foo\""`
-and `"white url(/mysite.com/red.png)"`.
+Be careful with regex matching not to accidentally consider quoted string values and `url()` arguments. For example, `"/red/"` will match value such as `"1px dotted red"` as well as `"\"foo\""` and `"white url(/mysite.com/red.png)"`.
 
 Given:
 

--- a/src/rules/property-whitelist/README.md
+++ b/src/rules/property-whitelist/README.md
@@ -31,7 +31,6 @@ Given:
 
 The following patterns are considered warnings:
 
-
 ```css
 a { color: pink; }
 ```

--- a/src/rules/rule-no-shorthand-property-overrides/README.md
+++ b/src/rules/rule-no-shorthand-property-overrides/README.md
@@ -8,8 +8,7 @@ a { background-repeat: repeat; background: green; }
  * This overrides the longhand property before it */
 ```
 
-In almost every case, this is just an authorial oversight.
-For more about this behavior, see [MDN's documentation of shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties).
+In almost every case, this is just an authorial oversight. For more about this behavior, see [MDN's documentation of shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties).
 
 The following patterns are considered warnings:
 

--- a/src/rules/rule-properties-order/README.md
+++ b/src/rules/rule-properties-order/README.md
@@ -61,35 +61,24 @@ a {
 
 Within an order array, you can include
 
-* unprefixed property names
-* group objects with these properties:
-  * `order ("strict"|"flexible")`: If `"strict"` (the default), the properties in this group must come in the order specified. If `"flexible"`, the properties can be in any order as long as they are grouped correctly.
-  * `emptyLineBefore (boolean)`: If `true`, this group must be separated from other properties by an empty newline. By default (or if emptyLineBefore is `false`), the rule doesn't care if there are empty newlines or not before this group's properties.
-  * `properties (array of strings)`: The properties in this group.
+- unprefixed property names
+- group objects with these properties:
+
+  - `order ("strict"|"flexible")`: If `"strict"` (the default), the properties in this group must come in the order specified. If `"flexible"`, the properties can be in any order as long as they are grouped correctly.
+  - `emptyLineBefore (boolean)`: If `true`, this group must be separated from other properties by an empty newline. By default (or if emptyLineBefore is `false`), the rule doesn't care if there are empty newlines or not before this group's properties.
+  - `properties (array of strings)`: The properties in this group.
 
 There are some important details to keep in mind:
 
-**By default, unlisted properties will be ignored.** So if you specify an array
-and do not include `display`, that means that the `display` property can be
-included before or after any other property. *This can be changed with the
-`unspecified` option* (see below).
+**By default, unlisted properties will be ignored.** So if you specify an array and do not include `display`, that means that the `display` property can be included before or after any other property. *This can be changed with the `unspecified` option* (see below).
 
-**If an (unprefixed) property name is not included in your array
-and it contains a hyphen (e.g. `padding-left`), the rule will look for the string
-before that first hyphen in your array (e.g. `padding`) and use that
-position.** This means that you do not have to specify each extension of the root property;
-you can just specify the root property and the extensions will be accounted for.
+**If an (unprefixed) property name is not included in your array and it contains a hyphen (e.g. `padding-left`), the rule will look for the string before that first hyphen in your array (e.g. `padding`) and use that position.** This means that you do not have to specify each extension of the root property; you can just specify the root property and the extensions will be accounted for.
 
-For example, if you have included `border` in your array but not
-`border-top`, the rule will expect `border-top` to appear in the same relative
-position as `border`.
+For example, if you have included `border` in your array but not `border-top`, the rule will expect `border-top` to appear in the same relative position as `border`.
 
 Other relevant rules include `margin`, `border`, `animation`, `transition`, etc.
 
-Using this fallback, the order of these hyphenated relative to their peer extensions
-(e.g. `border-top` to `border-bottom`) will be *arbitrary*. If you would like to
-enforce a specific ordering (e.g. always put `border-right` before `border-left`), you
-should specify those particular names in your array.
+Using this fallback, the order of these hyphenated relative to their peer extensions (e.g. `border-top` to `border-bottom`) will be *arbitrary*. If you would like to enforce a specific ordering (e.g. always put `border-right` before `border-left`), you should specify those particular names in your array.
 
 Given:
 
@@ -367,11 +356,9 @@ a {
 
 These options only apply if you've defined your own array of properties.
 
-Default behavior is the same as `"ignore"`: an unspecified property can appear before or after
-any other property.
+Default behavior is the same as `"ignore"`: an unspecified property can appear before or after  any other property.
 
-With `"top"`, unspecified properties are expected *before* any specified properties.
-With `"bottom"`, unspecified properties are expected *after* any specified properties.
+With `"top"`, unspecified properties are expected *before* any specified properties. With `"bottom"`, unspecified properties are expected *after* any specified properties.
 
 Given this configuration:
 
@@ -413,7 +400,6 @@ Given this configuration:
 
 The following patterns are considered warnings:
 
-
 ```css
 a {
   color: pink;
@@ -447,7 +433,6 @@ Given this configuration:
 ```
 
 The following patterns are considered warnings:
-
 
 ```css
 a {

--- a/src/rules/selector-list-comma-space-after/README.md
+++ b/src/rules/selector-list-comma-space-after/README.md
@@ -12,7 +12,6 @@ Require a single space or disallow whitespace after the commas of selector lists
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"`
 
-
 ### `"always"`
 
 There *must always* be a single space after the commas.

--- a/src/rules/selector-list-comma-space-before/README.md
+++ b/src/rules/selector-list-comma-space-before/README.md
@@ -12,7 +12,6 @@ Require a single space or disallow whitespace before the commas of selector list
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"`
 
-
 ### `"always"`
 
 There *must always* be a single space before the commas.

--- a/src/rules/selector-no-id/README.md
+++ b/src/rules/selector-no-id/README.md
@@ -24,7 +24,6 @@ The following patterns are considered warnings:
 
 The following patterns are *not* considered warnings:
 
-
 ```css
 a {}
 ```

--- a/src/rules/selector-no-vendor-prefix/README.md
+++ b/src/rules/selector-no-vendor-prefix/README.md
@@ -8,16 +8,7 @@ input::-moz-placeholder {}
  * These prefixes */
 ```
 
-This rule does not blanketly condemn vendor prefixes.
-Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date
-data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should
-cause a warning or not.
-*If you've included a vendor prefixed selector that has a standard alternative,
-one that Autoprefixer could take care of for you,
-this rule will warn about it*.
-If, however, you use a non-standard vendor-prefixed selector,
-one that Autoprefixer would ignore and could not provide, 
-this rule will ignore it.
+This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a warning or not. *If you've included a vendor prefixed selector that has a standard alternative, one that Autoprefixer could take care of for you, this rule will warn about it*. If, however, you use a non-standard vendor-prefixed selector, one that Autoprefixer would ignore and could not provide, this rule will ignore it.
 
 The following patterns are considered warnings:
 

--- a/src/rules/time-no-imperceptible/README.md
+++ b/src/rules/time-no-imperceptible/README.md
@@ -8,8 +8,7 @@ Disallow `animation` and `transition` times under 100ms.
  *                     This time */
 ```
 
-The rule checks `transition-duration`, `transition-delay`, `animation-duration`, `animation-delay`,
-and those times as they manifest in the `transition` and `animation` shorthands.
+The rule checks `transition-duration`, `transition-delay`, `animation-duration`, `animation-delay`, and those times as they manifest in the `transition` and `animation` shorthands.
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
@davidtheclark I was working on this this morning before I went for a swim, and then came back to see you busy addressing the edge-cases from the 4.3 release. I would of focused on the bugs-at-hand otherwise.

Anyway, to this PR…

I figured it would be useful to lint our markdown files. We have over 120 of them now and they are consumed in the generation of the website. 

I’ve gone with the default `remark` config… which usual means “consistent”. We weren’t very consistent though and so I’ve bought things like list markers and emphasises inline with your last commit i.e. `- ` for lists and `*` for emphasis.

The linter also caught lots of other issues e.g. extra empty lines and unclosed code fences. Which I’ve fixed in this PR.

I’ve disabled the max line length rules though as the vast the majority of the files were written with soft-wrapping in mind. And those that weren’t written that way were very inconsistently wrapped around the 80 char mark. I’ve normalised them all for soft-wrapping as that was, by far, the easier task.

