### PR TITLE
Benfrain pr/selector max specificity

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "postcss-scss": "^0.1.3",
     "postcss-selector-parser": "^1.2.0",
     "postcss-value-parser": "^3.1.1",
-    "resolve-from": "^2.0.0"
+    "resolve-from": "^2.0.0",
+    "specificity": "0.1.5"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -1,0 +1,45 @@
+# selector-max-specificity
+
+Limit the specificity of selectors.
+
+````
+.foo, #bar.baz span, #hoo { color: pink; }
+/** ↑         ↑        ↑
+ * These selectors */
+````
+
+# Options
+
+`string`: Level of specificity allowed
+
+Format is id,class,type as computed by the [W3C specificity calculator](https://www.w3.org/TR/selectors/#specificity)
+
+For a visual representation of selector specificity, visit: [https://specificity.keegan.st](https://specificity.keegan.st)
+
+For example, with "0,2,0":
+
+The following patterns are considered warnings:
+
+````
+.thing .thing2 .thing3 {}
+````
+
+````
+.thing .thing2 {
+  .thing3 & {}
+}
+````
+
+The following are __not__ considered warnings:
+
+````
+.thing div {}
+````
+
+````
+.thing div {
+  a {}
+}
+````
+
+**Note**: currently [direct nesting](http://tabatkins.github.io/specs/css-nesting/#direct) is supported but the [@nest](http://tabatkins.github.io/specs/css-nesting/#at-nest) at-rule is not.

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -1,0 +1,69 @@
+import {
+  ruleTester,
+  warningFreeBasics,
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule("0,3,0", tr => {
+  warningFreeBasics(tr)
+  tr.ok(".ab {}")
+  tr.ok(".ab .cd {}")
+  tr.ok(".ab .cd span {}")
+  tr.ok(".cd div span {}")
+  tr.ok(".cd .de div span a {}")
+  tr.ok(".cd .de div span a > b {}")
+  tr.ok(".cd .de, .cd .ef > b {}")
+
+  tr.notOk("#jubjub {}", {
+    message: messages.expected("#jubjub", "0,3,0"),
+    line: 1,
+    column: 1,
+  })
+  tr.notOk(".thing div .thing .sausages {}", {
+    message: messages.expected(".thing div .thing .sausages", "0,3,0"),
+    line: 1,
+    column: 1,
+  })
+  tr.notOk(".thing div .thing, .sausages .burgers .bacon a {}", {
+    message: messages.expected(".sausages .burgers .bacon a", "0,3,0"),
+    line: 1,
+    column: 20,
+  })
+})
+
+testRule("0,2,1", tr => {
+  warningFreeBasics(tr)
+  tr.ok(".cd .de,\n.cd .ef > b {}")
+  tr.notOk(".thing div .thing,\n.sausages .burgers .bacon a {}", {
+    message: messages.expected(".sausages .burgers .bacon a", "0,2,1"),
+    line: 2,
+    column: 1,
+  })
+})
+
+// Some nesting examples
+testRule("0,4,1", tr => {
+  warningFreeBasics(tr)
+  // A pointless nest that includes a parent selector when it isn't needed
+  tr.ok(".cd .de {& .fg {}}")
+  // A nested combinator test
+  tr.notOk(".thing .thing2 {&.nested {#pop {}}}", {
+    message: messages.expected("#pop", "0,4,1"),
+    line: 1,
+    column: 27,
+  })
+  // A nested override of the key selector
+  tr.notOk(".thing .thing2 {#here & {}}", {
+    message: messages.expected("#here &", "0,4,1"),
+    line: 1,
+    column: 17,
+  })
+  // A nested override of the key selector which requires the nested selector to exceed the max
+  tr.notOk(".thing .thing2 .thing3 .thing4 {a.here & {}}", {
+    message: messages.expected("a.here &", "0,4,1"),
+    line: 1,
+    column: 32,
+  })
+})

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -43,27 +43,21 @@ testRule("0,2,1", tr => {
   })
 })
 
-// Some nesting examples
-testRule("0,4,1", tr => {
+// With nesting
+testRule("0,2,1", tr => {
   warningFreeBasics(tr)
-  // A pointless nest that includes a parent selector when it isn't needed
-  tr.ok(".cd .de {& .fg {}}")
-  // A nested combinator test
-  tr.notOk(".thing .thing2 {&.nested {#pop {}}}", {
-    message: messages.expected("#pop", "0,4,1"),
-    line: 1,
-    column: 27,
-  })
-  // A nested override of the key selector
-  tr.notOk(".thing .thing2 {#here & {}}", {
-    message: messages.expected("#here &", "0,4,1"),
-    line: 1,
-    column: 17,
-  })
-  // A nested override of the key selector which requires the nested selector to exceed the max
-  tr.notOk(".thing .thing2 .thing3 .thing4 {a.here & {}}", {
-    message: messages.expected("a.here &", "0,4,1"),
-    line: 1,
-    column: 32,
-  })
+
+  tr.ok(".cd { .de {} }", "standard nesting")
+  tr.ok("div:hover { .de {} }", "element, pseudo-class, nested class")
+  tr.ok(".ab, .cd { & > .de {} }", "initial (unnecessary) parent selector")
+  tr.ok(".cd { .de > & {} }", "necessary parent selector")
+  tr.ok(".cd { @media print { .de {} } }", "nested rule within nested media query")
+  tr.ok("@media print { .cd { .de {} } }", "media query > rule > rule")
+
+  tr.notOk(".cd { .de { .fg {} } }", messages.expected(".cd .de .fg", "0,2,1"))
+  tr.notOk(".cd { .de { & > .fg {} } }", messages.expected(".cd .de > .fg", "0,2,1"))
+  tr.notOk(".cd { .de { &:hover > .fg {} } }", messages.expected(".cd .de:hover > .fg", "0,2,1"))
+  tr.notOk(".cd { .de { .fg > & {} } }", messages.expected(".fg > .cd .de", "0,2,1"))
+  tr.notOk(".cd { @media print { .de { & + .fg {} } } }", messages.expected(".cd .de + .fg", "0,2,1"))
+  tr.notOk("@media print { li { & + .ab, .ef.ef { .cd {} } } }", messages.expected("li .ef.ef .cd", "0,2,1"))
 })

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -1,0 +1,48 @@
+// Bring in dependencies
+import { calculate }  from "specificity"
+import {
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "selector-max-specificity"
+
+export const messages = ruleMessages(ruleName, {
+  expected: (selector, specificity) => `Expected "${selector}" to have a specificity equal to or less than "${specificity}"`,
+})
+
+export default function (max) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: max,
+      possible: [function (max) {
+        // Check that the pattern matches
+        var pattern = new RegExp("^[0-9]+\,[0-9]+\,[0-9]+$")
+        return pattern.test(max)
+      }],
+    })
+    if (!validOptions) { return }
+
+    root.walkRules(checkSpecificity)
+
+    function checkSpecificity(rule) {
+      // using rule.selectors gets us each selector in the eventuality we have a comma separated set
+      rule.selectors.forEach(function (selector) {
+        // calculate() returns a four section string — we only need 3 so strip the first two characters:
+        const computedSpecificity = calculate(selector)[0].specificity.substring(2)
+        // Check if the selector specificity exceeds the allowed maximum
+        if (parseFloat(computedSpecificity.replace(/,/g, "")) > parseFloat(max.replace(/,/g, ""))) {
+          report({
+            ruleName: ruleName,
+            result: result,
+            node: rule,
+            message: messages.expected(selector, max),
+            word: selector,
+          })
+          return
+        }
+      })
+    }
+  }
+}


### PR DESCRIPTION
I could not figure out a more elegant way with git to just contribute commits to @benfrain's PR (anybody know of one? @stylelint/core?)

Don't know if we want to close the original #754 or just add the differences from here to there.

My addition is pretty much just about `resolveNestedSelector()`, and the tests for it. I have a set of test-cases working with no `&`, initial `&` (direct nesting), and non-initial `&` (indirect nesting) --- though I didn't yet mess with the at-rule `@nest`.

What would be really helpful here would be contributions of more tests to ensure that `resolveNestedSelector()` works as expected. In fact, I think that that function would make a good standalone, thoroughly tested module (`postcss-resolve-nested-selector`??). If anybody is interested in picking up this code as-is and writing lots more tests, thinking through edge cases, and documenting, it would be a worthy OSS project :)