### PR TITLE
Add advice severity in secondaryOptions

### DIFF
--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -79,7 +79,7 @@ export default postcss.plugin("stylelint", (options = {}) => {
           } else if (secondaryOptions.advice) {
             ruleSeverity = "advice"
           } else if (secondaryOptions.warn) {
-            ruleSeverity = "warn"
+            ruleSeverity = "warning"
           }
         }
 

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -72,7 +72,16 @@ export default postcss.plugin("stylelint", (options = {}) => {
         // Ignore the rule
         if (primaryOption === null) { return }
 
-        const ruleSeverity = (secondaryOptions && secondaryOptions.warn) ? "warning" : "error"
+        let ruleSeverity = "error"
+        if (secondaryOptions) {
+          if (secondaryOptions.advice && secondaryOptions.warn) {
+            throw configurationError(`${ruleName} cannot have both advice and warning severity`)
+          } else if (secondaryOptions.advice) {
+            ruleSeverity = "advice"
+          } else if (secondaryOptions.warn) {
+            ruleSeverity = "warn"
+          }
+        }
 
         // Log the rule's severity in the PostCSS result
         result.stylelint.ruleSeverities[ruleName] = ruleSeverity

--- a/src/utils/validateOptions.js
+++ b/src/utils/validateOptions.js
@@ -1,6 +1,7 @@
 import { isPlainObject, isFunction } from "lodash"
 
 const ignoredOptions = [
+  "advice",
   "warn",
   "message",
 ]


### PR DESCRIPTION
Per https://github.com/stylelint/stylelint/pull/666, this adds `advice` severity as an option, similarly to `warn`.  They are considered mutually exclusive -- that is, you can't both warn and give advice -- and this change is fully backwards compatible.