### PR TITLE
Pr/selector max specificity take2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "execall": "^1.0.0",
     "lodash": "^3.9.3",
     "postcss": "^4.1.12",
-    "postcss-selector-parser": "^1.0.1"
+    "postcss-selector-parser": "^1.0.1",
+    "specificity": "0.1.5"
   },
   "devDependencies": {
     "babel": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint",
-  "version": "0.7.0",
+  "version": "4.2.0",
   "description": "Modern CSS linter",
   "keywords": [
     "css",
@@ -20,34 +20,54 @@
     "url": "https://github.com/stylelint/stylelint.git"
   },
   "main": "dist/index.js",
+  "bin": "dist/cli.js",
   "files": [
+    "CONTRIBUTING.md",
     "dist",
     "src",
+    "docs",
     "!**/__tests__",
     "!**/testUtils"
   ],
   "dependencies": {
-    "autoprefixer-core": "^5.2.1",
-    "balanced-match": "^0.2.0",
+    "autoprefixer": "^6.0.0",
+    "balanced-match": "^0.3.0",
+    "chalk": "^1.1.1",
+    "cosmiconfig": "^1.1.0",
     "execall": "^1.0.0",
-    "lodash": "^3.9.3",
-    "postcss": "^4.1.12",
-    "postcss-selector-parser": "^1.0.1",
+    "get-stdin": "^5.0.0",
+    "globby": "^4.0.0",
+    "globjoin": "^0.1.2",
+    "is-css-color-name": "^0.1.1",
+    "lodash": "^4.0.0",
+    "meow": "^3.3.0",
+    "multimatch": "^2.1.0",
+    "postcss": "^5.0.4",
+    "postcss-reporter": "^1.3.0",
+    "postcss-scss": "^0.1.3",
+    "postcss-selector-parser": "^1.2.0",
+    "postcss-value-parser": "^3.1.1",
+    "resolve-from": "^2.0.0",
     "specificity": "0.1.5"
   },
   "devDependencies": {
-    "babel": "^5.6.3",
-    "babel-tape-runner": "^1.1.0",
-    "eslint": "^1.0.0",
+    "babel-cli": "^6.1.18",
+    "babel-preset-es2015": "^6.1.18",
+    "babel-tape-runner": "^2.0.0",
+    "eslint": "^1.4.1",
     "eslint-config-stylelint": "^0.1.0",
-    "sinon": "^1.15.3",
-    "stylelint-rule-tester": "^0.1.0",
-    "tape": "^4.0.1"
+    "npmpub": "^3.0.1",
+    "postcss-import": "^8.0.2",
+    "postcss-resolve-nested-selector": "^0.1.1",
+    "sinon": "^1.16.1",
+    "stylelint-rule-tester": "^0.6.2",
+    "tape": "^4.2.0"
   },
   "scripts": {
-    "prepublish": "babel src --out-dir dist",
-    "docs-build": "babel-node scripts/rules",
+    "build": "babel src --out-dir dist",
     "lint": "eslint . --ignore-path .gitignore",
+    "prepublish": "npm run build",
+    "release": "npmpub",
     "tape": "babel-tape-runner \"src/**/__tests__/*.js\"",
     "test": "npm run lint && npm run tape"
   }

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -1,0 +1,29 @@
+# selector-max-specificity
+
+Control the specificity of selectors.
+
+First define the maximum allowable selector specificity as computed by the [W3C specificity calculator](https://www.w3.org/TR/selectors/#specificity):
+
+For example:
+
+| inline | ID | Class | type
+|---------|----|---------|-------
+| 0 | 0 | 2 | 0
+
+Set this as a 4 digit value in your Stylelint configuration:
+
+````
+"max-selector-specificity": 0020
+````
+
+Then any selectors that exceed that specificity e.g.
+
+````
+.thing .thing .thing {
+    width: 100%;
+}
+````
+
+Would fail with the message:
+
+`"Expected ".thing .thing .thing" to have a specificity equal to or less than "0020""`

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -41,5 +41,3 @@ The following are __not__ considered warnings:
   a {}
 }
 ````
-
-**Note**: currently [direct nesting](http://tabatkins.github.io/specs/css-nesting/#direct) is supported but the [@nest](http://tabatkins.github.io/specs/css-nesting/#at-nest) at-rule is not.

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -25,8 +25,21 @@ The following patterns are considered warnings:
 ````
 
 ````
+#hi {}
+````
+
+````
 .thing .thing2 {
   .thing3 & {}
+}
+````
+
+````
+.thing {
+  color: red;
+  @nest .parent .thing2 & {
+    color: blue;
+  }
 }
 ````
 
@@ -39,5 +52,20 @@ The following are __not__ considered warnings:
 ````
 .thing div {
   a {}
+}
+````
+
+````
+.thing {
+  .override & {}
+}
+````
+
+````
+.foo {
+  color: red;
+  @nest .parent & {
+    color: blue;
+  }
 }
 ````

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -1,29 +1,45 @@
 # selector-max-specificity
 
-Control the specificity of selectors.
-
-First define the maximum allowable selector specificity as computed by the [W3C specificity calculator](https://www.w3.org/TR/selectors/#specificity):
-
-For example:
-
-| inline | ID | Class | type
-|---------|----|---------|-------
-| 0 | 0 | 2 | 0
-
-Set this as a 4 digit value in your Stylelint configuration:
+Limit the specificity of selectors.
 
 ````
-"max-selector-specificity": 0020
+.foo, #bar.baz span, #hoo { color: pink; }
+/** ↑         ↑        ↑
+ * These selectors */
 ````
 
-Then any selectors that exceed that specificity e.g.
+# Options
+
+`string`: Level of specificity allowed
+
+Format is id,class,type as computed by the [W3C specificity calculator](https://www.w3.org/TR/selectors/#specificity)
+
+For a visual representation of selector specificity, visit: [https://specificity.keegan.st](https://specificity.keegan.st)
+
+For example, with "0,2,0":
+
+The following patterns are considered warnings:
 
 ````
-.thing .thing .thing {
-    width: 100%;
+.thing .thing2 .thing3 {}
+````
+
+````
+.thing .thing2 {
+  .thing3 & {}
 }
 ````
 
-Would fail with the message:
+The following are __not__ considered warnings:
 
-`"Expected ".thing .thing .thing" to have a specificity equal to or less than "0020""`
+````
+.thing div {}
+````
+
+````
+.thing div {
+  a {}
+}
+````
+
+**Note**: currently [direct nesting](http://tabatkins.github.io/specs/css-nesting/#direct) is supported but the [@nest](http://tabatkins.github.io/specs/css-nesting/#at-nest) at-rule is not.

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -87,8 +87,7 @@ const scssTestRule = ruleTester(rule, ruleName, {
 })
 
 // Interpolation to check we will skip
-scssTestRule("1,1,1", tr => {
+scssTestRule("0,1,1", tr => {
   warningFreeBasics(tr)
   tr.ok("#hello #{$test} {}", "ignore rules with variable interpolation")
 })
-

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -1,0 +1,35 @@
+import {
+  ruleTester,
+  warningFreeBasics,
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(30, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok(".ab {}")
+  tr.ok(".ab .cd {}")
+  tr.ok(".ab .cd span {}")
+  tr.ok(".cd div span {}")
+  tr.ok(".cd .de div span a {}")
+  tr.ok(".cd .de div span a > b {}")
+  tr.ok(".cd .de, .cd .ef > b {}")
+
+  tr.notOk("#jubjub {}", {
+    message: messages.expected("#jubjub", 30),
+    line: 1,
+    column: 1,
+  })
+  tr.notOk(".thing div .thing .sausages {}", {
+    message: messages.expected(".thing div .thing .sausages", 30),
+    line: 1,
+    column: 1,
+  })
+  tr.notOk(".thing div .thing, .sausages .burgers .bacon a {}", {
+    message: messages.expected(".sausages .burgers .bacon a", 30),
+    line: 1,
+    column: 20,
+  })
+})

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -35,9 +35,35 @@ testRule("0,3,0", tr => {
 
 testRule("0,2,1", tr => {
   warningFreeBasics(tr)
+  tr.ok(".cd .de,\n.cd .ef > b {}")
   tr.notOk(".thing div .thing,\n.sausages .burgers .bacon a {}", {
     message: messages.expected(".sausages .burgers .bacon a", "0,2,1"),
     line: 2,
     column: 1,
+  })
+})
+
+// Some nesting examples
+testRule("0,4,1", tr => {
+  warningFreeBasics(tr)
+  // A pointless nest that includes a parent selector when it isn't needed
+  tr.ok(".cd .de {& .fg {}}")
+  // A nested combinator test
+  tr.notOk(".thing .thing2 {&.nested {#pop {}}}", {
+    message: messages.expected("#pop", "0,4,1"),
+    line: 1,
+    column: 27,
+  })
+  // A nested override of the key selector
+  tr.notOk(".thing .thing2 {#here & {}}", {
+    message: messages.expected("#here &", "0,4,1"),
+    line: 1,
+    column: 17,
+  })
+  // A nested override of the key selector which requires the nested selector to exceed the max
+  tr.notOk(".thing .thing2 .thing3 .thing4 {a.here & {}}", {
+    message: messages.expected("a.here &", "0,4,1"),
+    line: 1,
+    column: 32,
   })
 })

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -41,6 +41,19 @@ testRule("0,2,1", tr => {
     line: 2,
     column: 1,
   })
+  tr.ok(".cd { .de {} }", "standard nesting")
+  tr.ok("div:hover { .de {} }", "element, pseudo-class, nested class")
+  tr.ok(".ab, .cd { & > .de {} }", "initial (unnecessary) parent selector")
+  tr.ok(".cd { .de > & {} }", "necessary parent selector")
+  tr.ok(".cd { @media print { .de {} } }", "nested rule within nested media query")
+  tr.ok("@media print { .cd { .de {} } }", "media query > rule > rule")
+
+  tr.notOk(".cd { .de { .fg {} } }", messages.expected(".cd .de .fg", "0,2,1"))
+  tr.notOk(".cd { .de { & > .fg {} } }", messages.expected(".cd .de > .fg", "0,2,1"))
+  tr.notOk(".cd { .de { &:hover > .fg {} } }", messages.expected(".cd .de:hover > .fg", "0,2,1"))
+  tr.notOk(".cd { .de { .fg > & {} } }", messages.expected(".fg > .cd .de", "0,2,1"))
+  tr.notOk(".cd { @media print { .de { & + .fg {} } } }", messages.expected(".cd .de + .fg", "0,2,1"))
+  tr.notOk("@media print { li { & + .ab, .ef.ef { .cd {} } } }", messages.expected("li .ef.ef .cd", "0,2,1"))
 })
 
 // Some nesting examples

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -3,6 +3,7 @@ import {
   warningFreeBasics,
 } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
+import scss from "postcss-scss"
 
 const testRule = ruleTester(rule, ruleName)
 
@@ -79,5 +80,15 @@ testRule("0,4,1", tr => {
     line: 1,
     column: 33,
   })
+})
+
+const scssTestRule = ruleTester(rule, ruleName, {
+  postcssOptions: { syntax: scss },
+})
+
+// Interpolation to check we will skip
+scssTestRule("1,1,1", tr => {
+  warningFreeBasics(tr)
+  tr.ok("#hello #{$test} {}", "ignore rules with variable interpolation")
 })
 

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -50,20 +50,21 @@ testRule("0,4,1", tr => {
   tr.ok(".cd .de {& .fg {}}")
   // A nested combinator test
   tr.notOk(".thing .thing2 {&.nested {#pop {}}}", {
-    message: messages.expected("#pop", "0,4,1"),
+    message: messages.expected(".thing .thing2.nested #pop", "0,4,1"),
     line: 1,
     column: 27,
   })
   // A nested override of the key selector
   tr.notOk(".thing .thing2 {#here & {}}", {
-    message: messages.expected("#here &", "0,4,1"),
+    message: messages.expected("#here .thing .thing2", "0,4,1"),
     line: 1,
     column: 17,
   })
   // A nested override of the key selector which requires the nested selector to exceed the max
   tr.notOk(".thing .thing2 .thing3 .thing4 {a.here & {}}", {
-    message: messages.expected("a.here &", "0,4,1"),
+    message: messages.expected("a.here .thing .thing2 .thing3 .thing4", "0,4,1"),
     line: 1,
-    column: 32,
+    column: 33,
   })
 })
+

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -6,9 +6,8 @@ import rule, { ruleName, messages } from ".."
 
 const testRule = ruleTester(rule, ruleName)
 
-testRule(30, tr => {
+testRule("0,3,0", tr => {
   warningFreeBasics(tr)
-
   tr.ok(".ab {}")
   tr.ok(".ab .cd {}")
   tr.ok(".ab .cd span {}")
@@ -18,18 +17,27 @@ testRule(30, tr => {
   tr.ok(".cd .de, .cd .ef > b {}")
 
   tr.notOk("#jubjub {}", {
-    message: messages.expected("#jubjub", 30),
+    message: messages.expected("#jubjub", "0,3,0"),
     line: 1,
     column: 1,
   })
   tr.notOk(".thing div .thing .sausages {}", {
-    message: messages.expected(".thing div .thing .sausages", 30),
+    message: messages.expected(".thing div .thing .sausages", "0,3,0"),
     line: 1,
     column: 1,
   })
   tr.notOk(".thing div .thing, .sausages .burgers .bacon a {}", {
-    message: messages.expected(".sausages .burgers .bacon a", 30),
+    message: messages.expected(".sausages .burgers .bacon a", "0,3,0"),
     line: 1,
     column: 20,
+  })
+})
+
+testRule("0,2,1", tr => {
+  warningFreeBasics(tr)
+  tr.notOk(".thing div .thing,\n.sausages .burgers .bacon a {}", {
+    message: messages.expected(".sausages .burgers .bacon a", "0,2,1"),
+    line: 2,
+    column: 1,
   })
 })

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -1,0 +1,46 @@
+// Bring in dependencies
+import { isNumber } from "lodash"
+import { calculate }  from "specificity"
+import {
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "selector-max-specificity"
+
+export const messages = ruleMessages(ruleName, {
+  expected: (selector, specificity) => `Expected "${selector}" to have a specificity equal to or less than "${specificity}"`,
+})
+
+export default function (max) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: max,
+      possible: [isNumber],
+    })
+
+    if (!validOptions) { return }
+
+    root.walkRules(checkSpecificity)
+
+    function checkSpecificity(rule) {
+      // using rule.selectors gets us each selector in the eventuality we have a comma separated set
+      rule.selectors.forEach(function (selector) {
+        let computedSpecificity = calculate(selector)[0].specificity.replace(/,/g, "")
+        // Check if the selector specificity exceeds the allowed maximum
+        if (computedSpecificity > max) {
+          // Use report to output any messages
+          report({ 
+            ruleName: ruleName,
+            result: result,
+            node: rule,
+            message: messages.expected(selector, max),
+            word: selector,
+          })
+          return
+        }
+      })
+    }
+  }
+}

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -19,7 +19,7 @@ export default function (max) {
       actual: max,
       possible: [function (max) {
         // Check that the pattern matches
-        var pattern = new RegExp("^[0-9]+\,[0-9]+\,[0-9]+$")
+        var pattern = new RegExp("^\\d+,\\d+,\\d+$")
         return pattern.test(max)
       }],
     })
@@ -29,20 +29,17 @@ export default function (max) {
 
     function checkSpecificity(rule) {
       // using rule.selectors gets us each selector in the eventuality we have a comma separated set
-      rule.selectors.forEach(function (selector) {
-        // Resolve any nested selectors
-        const resolved = resolvedNestedSelector(selector, rule)
-        resolved.forEach(function (selector) {
-
+      rule.selectors.forEach(selector => {
+        resolvedNestedSelector(selector, rule).forEach(resolvedSelector => {
           // calculate() returns a four section string — we only need 3 so strip the first two characters:
-          const computedSpecificity = calculate(selector)[0].specificity.substring(2)
+          const computedSpecificity = calculate(resolvedSelector)[0].specificity.substring(2)
           // Check if the selector specificity exceeds the allowed maximum
           if (parseFloat(computedSpecificity.replace(/,/g, "")) > parseFloat(max.replace(/,/g, ""))) {
             report({
               ruleName: ruleName,
               result: result,
               node: rule,
-              message: messages.expected(selector, max),
+              message: messages.expected(resolvedSelector, max),
               word: selector,
             })
             return

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -19,9 +19,7 @@ export default function (max) {
       possible: [function (max) {
         // Check that the pattern matches
         var pattern = new RegExp("^[0-9]+\,[0-9]+\,[0-9]+$")
-        if (pattern.test(max)) {
-          return true
-        }
+        return pattern.test(max)
       }],
     })
     if (!validOptions) { return }
@@ -35,7 +33,7 @@ export default function (max) {
         const computedSpecificity = calculate(selector)[0].specificity.substring(2)
         // Check if the selector specificity exceeds the allowed maximum
         if (parseFloat(computedSpecificity.replace(/,/g, "")) > parseFloat(max.replace(/,/g, ""))) {
-          report({ 
+          report({
             ruleName: ruleName,
             result: result,
             node: rule,

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -1,5 +1,4 @@
 // Bring in dependencies
-import { isNumber } from "lodash"
 import { calculate }  from "specificity"
 import {
   report,
@@ -17,9 +16,14 @@ export default function (max) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: max,
-      possible: [isNumber],
+      possible: [function (max) {
+        // Check that the pattern matches
+        var pattern = new RegExp("^[0-9]+\,[0-9]+\,[0-9]+$")
+        if (pattern.test(max)) {
+          return true
+        }
+      }],
     })
-
     if (!validOptions) { return }
 
     root.walkRules(checkSpecificity)
@@ -27,10 +31,10 @@ export default function (max) {
     function checkSpecificity(rule) {
       // using rule.selectors gets us each selector in the eventuality we have a comma separated set
       rule.selectors.forEach(function (selector) {
-        let computedSpecificity = calculate(selector)[0].specificity.replace(/,/g, "")
+        // calculate() returns a four section string — we only need 3 so strip the first two characters:
+        const computedSpecificity = calculate(selector)[0].specificity.substring(2)
         // Check if the selector specificity exceeds the allowed maximum
-        if (computedSpecificity > max) {
-          // Use report to output any messages
+        if (parseFloat(computedSpecificity.replace(/,/g, "")) > parseFloat(max.replace(/,/g, ""))) {
           report({ 
             ruleName: ruleName,
             result: result,

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -30,6 +30,10 @@ export default function (max) {
     function checkSpecificity(rule) {
       // using rule.selectors gets us each selector in the eventuality we have a comma separated set
       rule.selectors.forEach(selector => {
+        // If we hit interpolation on the rule we run away
+        if (/#{.+?}|@{.+?}|\$\(.+?\)/.test(selector)) {
+          return
+        }
         resolvedNestedSelector(selector, rule).forEach(resolvedSelector => {
           // calculate() returns a four section string — we only need 3 so strip the first two characters:
           const computedSpecificity = calculate(resolvedSelector)[0].specificity.substring(2)


### PR DESCRIPTION
Right, once more! 

This PR should include README.md including `@nest` examples, the rule itself making use of @davidtheclark postcss-resolve-nested-selector and tests including direct nesting.