### PR TITLE
Add string-no-newline; closes #739

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Head
 
+- Added: `string-no-newline` rule.
 - Added: `unspecified: "bottomAlphabetical"` option for `rule-properties-order`.
 - Added: `stylelint-disable-line` feature.
+- Added: `withinComments`, `withinStrings`, and `checkStrings` options to `styleSearch`, and `insideString` property to the `styleSearch` match object.
 - Fixed: `font-weight-notation` does not throw false warnings when `normal` is used in certain ways.
 
 # 4.4.0

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -50,6 +50,7 @@ Don't forget to look at the list of [plugins](/docs/user-guide/plugins.md) for m
 
 ### String
 
+- [`string-no-newline`](../../src/rules/string-no-newline/README.md): Disallow (unescaped) newlines in strings.
 - [`string-quotes`](../../src/rules/string-quotes/README.md): Specify single or double quotes around strings.
 
 ### Time

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -98,6 +98,7 @@ import selectorNoUniversal from "./selector-no-universal"
 import selectorNoVendorPrefix from "./selector-no-vendor-prefix"
 import selectorPseudoElementColonNotation from "./selector-pseudo-element-colon-notation"
 import selectorRootNoComposition from "./selector-root-no-composition"
+import stringNoNewline from "./string-no-newline"
 import stringQuotes from "./string-quotes"
 import timeNoImperceptible from "./time-no-imperceptible"
 import unitBlacklist from "./unit-blacklist"
@@ -209,6 +210,7 @@ export default {
   "selector-no-vendor-prefix": selectorNoVendorPrefix,
   "selector-pseudo-element-colon-notation": selectorPseudoElementColonNotation,
   "selector-root-no-composition": selectorRootNoComposition,
+  "string-no-newline": stringNoNewline,
   "string-quotes": stringQuotes,
   "time-no-imperceptible": timeNoImperceptible,
   "unit-blacklist": unitBlacklist,

--- a/src/rules/string-no-newline/README.md
+++ b/src/rules/string-no-newline/README.md
@@ -1,0 +1,61 @@
+# string-no-newline
+
+Disallow (unescaped) newlines in strings.
+
+```css
+a {
+  content: "first
+    second";     ↑
+}                ↑
+/**              ↑
+ * The newline here */
+```
+
+[The spec](https://www.w3.org/TR/CSS2/syndata.html#strings) says this: "A string cannot directly contain a newline. To include a newline in a string, use an escape representing the line feed character in ISO-10646 (U+000A), such as \"\A\" or \"\00000a\"." And also: "It is possible to break strings over several lines, for aesthetic or other reasons, but in such a case the newline itself has to be escaped with a backslash (\)."
+
+The following patterns are considered warnings:
+
+```css
+a {
+  content: "first
+    second";     
+}  
+```
+
+```css
+a[title="something
+is probably wrong"] {}  
+```
+
+```css
+.foo {
+  font-family: "Times
+    New
+    Roman";
+}  
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  content: "first\Asecond";     
+}  
+```
+
+```css
+a {
+  content: "first\\nsecond";     
+}  
+```
+
+```css
+a[title="nothing\
+  is wrong"] {}  
+```
+
+```css
+.foo {
+  font-family: "Times New Roman";
+}  
+```

--- a/src/rules/string-no-newline/__tests__/index.js
+++ b/src/rules/string-no-newline/__tests__/index.js
@@ -1,0 +1,30 @@
+import {
+  ruleTester,
+  warningFreeBasics,
+} from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+const testRule = ruleTester(rule, ruleName)
+
+testRule(undefined, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a::before { content: 'one'; }", "without newline")
+  tr.ok("a::before { content: 'one\\ntwo'; }", "with escaped slash-slash-n newline")
+  tr.ok("a::before { content: 'one\\Atwo'; }", "with escaped slash-A newline")
+  tr.ok(`a::before {
+    content: 'one\
+    two';
+  }`, "with escaped slash at end of real line")
+
+  tr.notOk("a::before { content: 'one\ntwo'; }", {
+    message: messages.rejected,
+    line: 1,
+    column: 26,
+  })
+  tr.notOk("a::before { content: 'one\r\ntwo'; }", {
+    message: messages.rejected,
+    line: 1,
+    column: 27,
+  }, "CRLF")
+})

--- a/src/rules/string-no-newline/index.js
+++ b/src/rules/string-no-newline/index.js
@@ -1,0 +1,31 @@
+import {
+  report,
+  ruleMessages,
+  styleSearch,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "string-no-newline"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: `Unexpected newline in string`,
+})
+
+export default function (actual) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, { actual })
+    if (!validOptions) { return }
+
+    const cssString = root.toString()
+    styleSearch({ source: cssString, target: "\n", withinStrings: true }, match => {
+      if (cssString[match.startIndex - 1] === "\\") { return }
+      report({
+        message: messages.rejected,
+        node: root,
+        index: match.startIndex,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -125,6 +125,26 @@ test("ignores matches within double-quote strings", t => {
   /* eslint-enable quotes */
 })
 
+test("`checkStrings` option", t => {
+  t.deepEqual(styleSearchResults({
+    source: "abc 'abc'",
+    target: "b",
+    checkStrings: true,
+  }), [ 1, 6 ])
+  t.end()
+})
+
+test("`withinStrings` option", t => {
+  /* eslint-disable quotes */
+  t.deepEqual(styleSearchResults({
+    source: 'abc "abc"',
+    target: "b",
+    withinStrings: true,
+  }), [6])
+  /* eslint-enable quotes */
+  t.end()
+})
+
 test("ignores matches within comments", t => {
   t.deepEqual(styleSearchResults({
     source: "abc/*comment*/",
@@ -134,6 +154,24 @@ test("ignores matches within comments", t => {
     source: "abc/*command*/",
     target: "a",
   }), [0])
+  t.end()
+})
+
+test("`checkComments` option", t => {
+  t.deepEqual(styleSearchResults({
+    source: "abc/*abc*/",
+    target: "b",
+    checkComments: true,
+  }), [ 1, 6 ])
+  t.end()
+})
+
+test("`withinComments` option", t => {
+  t.deepEqual(styleSearchResults({
+    source: "abc/*abc*/",
+    target: "b",
+    withinComments: true,
+  }), [6])
   t.end()
 })
 


### PR DESCRIPTION
This involved some enhancements to styleSearch, too. One that was necessary (adding `withinComments` option), and the rest for consistency.