### PR TITLE
Deprecate color-no-named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+- Deprecated: `color-no-named` rule. Use the new `color-named` rule, with the `"never"` option.
 - Added: `no-browser-hacks` rule.
 - Added: `string-no-newline` rule.
 - Added: `color-named` rule.

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -24,7 +24,6 @@ You might want to learn a little about [the conventions](https://github.com/styl
     "color-no-hex": true,
     "color-no-indistinguishable": true,
     "color-no-invalid-hex": true,
-    "color-no-named": true,
     "comment-empty-line-before": "always"|"never",
     "comment-whitespace-inside": "always"|"never",
     "custom-media-pattern": string,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -18,7 +18,6 @@ Don't forget to look at the list of [plugins](/docs/user-guide/plugins.md) for m
 - [`color-no-hex`](../../src/rules/color-no-hex/README.md): Disallow hex colors.
 - [`color-no-indistinguishable`](../../src/rules/color-no-indistinguishable/README.md): Disallow colors that are suspiciously close to being identical.
 - [`color-no-invalid-hex`](../../src/rules/color-no-invalid-hex/README.md): Disallow invalid hex colors.
-- [`color-no-named`](../../src/rules/color-no-named/README.md): Disallow named colors.
 
 ### Font family
 

--- a/src/rules/color-no-named/README.md
+++ b/src/rules/color-no-named/README.md
@@ -1,6 +1,6 @@
 # color-no-named
 
-**Deprecated: use `color-named: "never"` instead.**
+**Deprecated: use the [`color-named`](../color-named/README.md) rule with the [`"never"`](../color-named/README.md#never) option instead.**
 
 Disallow named colors.
 

--- a/src/rules/color-no-named/README.md
+++ b/src/rules/color-no-named/README.md
@@ -1,5 +1,7 @@
 # color-no-named
 
+**Deprecated: use `color-named: "never"` instead.**
+
 Disallow named colors.
 
 ```css

--- a/src/rules/color-no-named/__tests__/index.js
+++ b/src/rules/color-no-named/__tests__/index.js
@@ -1,60 +1,60 @@
-import {
-  ruleTester,
-  warningFreeBasics,
-} from "../../../testUtils"
-import rule, { ruleName, messages } from ".."
-
-const testRule = ruleTester(rule, ruleName)
-
-testRule(undefined, tr => {
-  warningFreeBasics(tr)
-
-  tr.ok("a { color: #000; }")
-  tr.ok("a { color: #ababab; }")
-  tr.ok("a { color: rgba(0, 0, 0, 0); }")
-  tr.ok("a { something: #000, #fff, #333; }")
-
-  tr.ok("/** color: black; */", "ignore color names within comments")
-
-  tr.ok("a::before { content: \"orange\" }", "ignore color names within doubl quotes")
-  tr.ok("a::before { content: 'orange' }", "ignore color names within single quotes")
-
-  tr.ok("a { background-image: url(./black.png); }", "ignore color names within urls")
-
-  tr.ok("a { padding: 000; }")
-  tr.ok("a::before { content: \"#ababa\"; }")
-
-  tr.ok("a { color: $black; }", "ignore sass variable named with color")
-
-  tr.ok("a { color: var(--some-color-blue); }", "ignore css variable named with color")
-
-  tr.ok("a { animation: spin-blue 2s linear; }", "ignore keyframe animation name that includes colors")
-
-  tr.notOk("a { color: red; }", {
-    message: messages.rejected("red"),
-    line: 1,
-    column: 12,
-  })
-  tr.notOk("a { color: rebeccapurple; }", {
-    message: messages.rejected("rebeccapurple"),
-    line: 1,
-    column: 12,
-  })
-  tr.notOk("a { something: #00c, red, #fff; }", {
-    message: messages.rejected("red"),
-    line: 1,
-    column: 22,
-  })
-  tr.notOk("a { something: #fff1a1, rgb(250, 250, 0), black; }", {
-    message: messages.rejected("black"),
-    line: 1,
-    column: 43,
-  })
-
-  // No supplementary spaces after colon or comma
-  tr.notOk("a { something:#cccccc,white,#12345a; }", {
-    message: messages.rejected("white"),
-    line: 1,
-    column: 23,
-  })
-})
+// import {
+//   ruleTester,
+//   warningFreeBasics,
+// } from "../../../testUtils"
+// import rule, { ruleName, messages } from ".."
+//
+// const testRule = ruleTester(rule, ruleName)
+//
+// testRule(undefined, tr => {
+//   warningFreeBasics(tr)
+//
+//   tr.ok("a { color: #000; }")
+//   tr.ok("a { color: #ababab; }")
+//   tr.ok("a { color: rgba(0, 0, 0, 0); }")
+//   tr.ok("a { something: #000, #fff, #333; }")
+//
+//   tr.ok("/** color: black; */", "ignore color names within comments")
+//
+//   tr.ok("a::before { content: \"orange\" }", "ignore color names within doubl quotes")
+//   tr.ok("a::before { content: 'orange' }", "ignore color names within single quotes")
+//
+//   tr.ok("a { background-image: url(./black.png); }", "ignore color names within urls")
+//
+//   tr.ok("a { padding: 000; }")
+//   tr.ok("a::before { content: \"#ababa\"; }")
+//
+//   tr.ok("a { color: $black; }", "ignore sass variable named with color")
+//
+//   tr.ok("a { color: var(--some-color-blue); }", "ignore css variable named with color")
+//
+//   tr.ok("a { animation: spin-blue 2s linear; }", "ignore keyframe animation name that includes colors")
+//
+//   tr.notOk("a { color: red; }", {
+//     message: messages.rejected("red"),
+//     line: 1,
+//     column: 12,
+//   })
+//   tr.notOk("a { color: rebeccapurple; }", {
+//     message: messages.rejected("rebeccapurple"),
+//     line: 1,
+//     column: 12,
+//   })
+//   tr.notOk("a { something: #00c, red, #fff; }", {
+//     message: messages.rejected("red"),
+//     line: 1,
+//     column: 22,
+//   })
+//   tr.notOk("a { something: #fff1a1, rgb(250, 250, 0), black; }", {
+//     message: messages.rejected("black"),
+//     line: 1,
+//     column: 43,
+//   })
+//
+//   // No supplementary spaces after colon or comma
+//   tr.notOk("a { something:#cccccc,white,#12345a; }", {
+//     message: messages.rejected("white"),
+//     line: 1,
+//     column: 23,
+//   })
+// })

--- a/src/rules/color-no-named/index.js
+++ b/src/rules/color-no-named/index.js
@@ -16,6 +16,16 @@ export const messages = ruleMessages(ruleName, {
 
 export default function (actual) {
   return (root, result) => {
+
+    result.warn((
+      "'color-no-named' has been deprecated, " +
+      "and in 5.0 it will be removed. " +
+      "Use 'color-named: \"never\"' instead."
+    ), {
+      stylelintType: "deprecation",
+      stylelintReference: "http://stylelint.io/user-guide/rules/color-named/",
+    })
+
     const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 


### PR DESCRIPTION
Removes it from the examples config and the rules list in the docs. The README will still generate a page at http://stylelint.io/user-guide/rules/color-no-named/ (with a deprecated note added)- so that we remain accessible until the rule is removed in `5.0`.