### PR TITLE
Add ignoreAtRules option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Added: `no-browser-hacks` rule.
 - Added: `string-no-newline` rule.
 - Added: `color-named` rule.
-- Added: `unspecified: "bottomAlphabetical"` option for `rule-properties-order`.
+- Added: `unspecified: "bottomAlphabetical"` option to the `rule-properties-order` rule.
+- Added: `ignoreAtRules: []` option to the `block-opening-brace-space-before` and `block-closing-brace-newline-after` rules.
 - Added: `stylelint-disable-line` feature.
 - Added: `withinComments`, `withinStrings`, and `checkStrings` options to `styleSearch`, and `insideString` property to the `styleSearch` match object.
 - Fixed: `font-weight-notation` does not throw false warnings when `normal` is used in certain ways.

--- a/src/rules/block-closing-brace-newline-after/README.md
+++ b/src/rules/block-closing-brace-newline-after/README.md
@@ -127,15 +127,20 @@ a { color: pink;
 
 ### `ignoreAtRules: ["/regex/", "non-regex"]`
 
-Given `["/i/"]` or `["if"]`:
+Given `["if", "else"]`:
 
 The following patterns are *not* considered warnings:
 
 ```css
-@if (...) {} @else {...}
+@if ... {
+  color: pink;
+} @else if ... {
+  color: red;
+} @else {
+  color: blue;
+}
 ```
 
 ```css
-@if (...) {
-} @else {...}
+@if ... { color: pink; } @else { color: blue; }
 ```

--- a/src/rules/block-closing-brace-newline-after/README.md
+++ b/src/rules/block-closing-brace-newline-after/README.md
@@ -122,3 +122,20 @@ a { color: pink; } b { color: red; }
 a { color: pink;
 }b { color: red; }
 ```
+
+## Optional options
+
+### `ignoreAtRules: ["/regex/", "non-regex"]`
+
+Given `["/i/"]` or `["if"]`:
+
+The following patterns are *not* considered warnings:
+
+```css
+@if (...) {} @else {...}
+```
+
+```css
+@if (...) {
+} @else {...}
+```

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -53,11 +53,13 @@ testRule("always", tr => {
   })
 })
 
-testRule("always", { ignoreAtRules: ["if"] }, tr => {
+testRule("always", { ignoreAtRules: [ "if", "else" ] }, tr => {
   warningFreeBasics(tr)
 
   tr.ok("a { color: pink; }\nb {}")
   tr.ok("@if ... { color: pink; } @else {}")
+  tr.ok("@if ... { color: pink; } @else if {} else {}")
+  tr.ok("@if ... {\r\n  color: pink; \n} @else if {\n  color: pink;\n} else {}")
 
   tr.notOk("a { color: pink; }b{}", {
     message: messages.expectedAfter(),

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -53,6 +53,32 @@ testRule("always", tr => {
   })
 })
 
+testRule("always", { ignoreAtRules: ["if"] }, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }\nb {}")
+  tr.ok("@if ... { color: pink; } @else {}")
+
+  tr.notOk("a { color: pink; }b{}", {
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 19,
+  })
+})
+
+testRule("always", { ignoreAtRules: "/if/" }, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }\nb {}")
+  tr.ok("@if ... { color: pink; } @else {}")
+
+  tr.notOk("a { color: pink; }b{}", {
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 19,
+  })
+})
+
 testRule("always-single-line", tr => {
   warningFreeBasics(tr)
 

--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -1,3 +1,5 @@
+import { isString } from "lodash"
+
 import {
   cssStatementBlockString,
   cssStatementHasBlock,
@@ -7,6 +9,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import { cssStatementIsIgnoredAtRule } from "../block-opening-brace-space-before"
 
 export const ruleName = "block-closing-brace-newline-after"
 
@@ -18,7 +21,7 @@ export const messages = ruleMessages(ruleName, {
   rejectedAfterMultiLine: () => `Unexpected whitespace after "}" of a multi-line block`,
 })
 
-export default function (expectation) {
+export default function (expectation, options) {
   const checker = whitespaceChecker("newline", expectation, messages)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -30,6 +33,12 @@ export default function (expectation) {
         "always-multi-line",
         "never-multi-line",
       ],
+    }, {
+      actual: options,
+      possible: {
+        ignoreAtRules: [isString],
+      },
+      optional: true,
     })
     if (!validOptions) { return }
 
@@ -41,6 +50,7 @@ export default function (expectation) {
       const nextNode = statement.next()
       if (!nextNode) { return }
       if (!cssStatementHasBlock(statement)) { return }
+      if (cssStatementIsIgnoredAtRule(statement, options)) { return }
 
       // Only check one after, because there might be other
       // spaces handled by the indentation rule

--- a/src/rules/block-opening-brace-space-before/README.md
+++ b/src/rules/block-opening-brace-space-before/README.md
@@ -149,3 +149,20 @@ a { color: pink; }
 a{
 color: pink;}
 ```
+
+## Optional options
+
+### `ignoreAtRules: ["/regex/", "non-regex"]`
+
+Given `["/fo/"]` or `["for"]`:
+
+The following patterns are *not* considered warnings:
+
+```css
+@for ...
+{}
+```
+
+```css
+@for ...{}
+```

--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -53,6 +53,34 @@ testRule("always", tr => {
   })
 })
 
+testRule("always", { ignoreAtRules: ["for"] }, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }")
+  tr.ok("@for ...\n{ color: pink; }")
+  tr.ok("@for ...\r\n{ color: pink; }")
+
+  tr.notOk("a{ color: pink; }", {
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 1,
+  })
+})
+
+testRule("always", { ignoreAtRules: "/fo/" }, tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a { color: pink; }")
+  tr.ok("@for ...\n{ color: pink; }")
+  tr.ok("@for ...\r\n{ color: pink; }")
+
+  tr.notOk("a{ color: pink; }", {
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 1,
+  })
+})
+
 testRule("never", tr => {
   warningFreeBasics(tr)
 

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -81,6 +81,6 @@ export function cssStatementIsIgnoredAtRule(statement, options) {
     options &&
     options.ignoreAtRules &&
     statement.type === "atrule" &&
-    matchesStringOrRegExp(statement.name, [].concat(options.ignoreAtRules))
+    matchesStringOrRegExp(statement.name, options.ignoreAtRules)
   )
 }


### PR DESCRIPTION
Closes #561

Figured I’d square away some of the older issues.

These changes will *allow* (but not *enforce*) a code style of:

```css
a {
  @if $x = 1 {
    color: green;
  } @else if $y = 2 {
    color: blue;
  } @else {
    color: red;
  }
}

@for $i from 1 to 3 
{
  .b-$i { 
    width: $(i)px; 
  }
}

@media (color) {
  a {
    color: red;
  }
}
```