### PR TITLE
Change emptyLineBefore to take a never option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Head
 
+- Deprecated `"boolean"` option for `emptyLineBefore` when using property groups in `rule-properties-order`. Use the new `"always"` or `"never"` option, instead.
+- Added: `"always"` and `"never"` option to `rule-properties-order` `emptyLineBefore` when using property groups
 - Added: `no-browser-hacks` rule.
 - Added: `string-no-newline` rule.
 - Added: `unspecified: "bottomAlphabetical"` option for `rule-properties-order`.

--- a/src/rules/rule-properties-order/README.md
+++ b/src/rules/rule-properties-order/README.md
@@ -65,7 +65,7 @@ Within an order array, you can include
 - group objects with these properties:
 
   - `order ("strict"|"flexible")`: If `"strict"` (the default), the properties in this group must come in the order specified. If `"flexible"`, the properties can be in any order as long as they are grouped correctly.
-  - `emptyLineBefore (boolean)`: If `true`, this group must be separated from other properties by an empty newline. By default (or if emptyLineBefore is `false`), the rule doesn't care if there are empty newlines or not before this group's properties.
+  - `emptyLineBefore ("always|"never")`: If `always`, this group must be separated from other properties by an empty newline. By default (or if emptyLineBefore is `never`), the group must have no empty lines separating it from other properties. 
   - `properties (array of strings)`: The properties in this group.
 
 There are some important details to keep in mind:
@@ -225,14 +225,14 @@ Given:
 ```js
 [
   {
-    emptyLineBefore: true,
+    emptyLineBefore: "always",
     properties: [
       "height",
       "width",
     ],
   },
   {
-    emptyLineBefore: true,
+    emptyLineBefore: "always",
     properties: [
       "font-size",
       "font-weight",
@@ -279,6 +279,70 @@ a {
   height: 1px;
   width: 2px;
 
+  font-size: 2px;
+  font-weight: bold;
+}
+```
+
+Given:
+
+```js
+[
+  {
+    emptyLineBefore: "false",
+    properties: [
+      "height",
+      "width",
+    ],
+  },
+  {
+    emptyLineBefore: "false",
+    properties: [
+      "font-size",
+      "font-weight",
+    ],
+  },
+]
+```
+
+The following patterns are considered warnings:
+
+```css
+a {
+  height: 1px;
+  width: 2px;
+  
+  font-size: 2px;
+  font-weight: bold;
+}
+```
+
+```css
+a {
+  height: 1px;
+  width: 2px;
+
+  font-weight: bold;
+  font-size: 2px;
+}
+```
+
+```css
+a {
+  width: 2px;
+
+  font-size: 2px;
+  font-weight: bold;
+  height: 1px;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  height: 1px;
+  width: 2px;
   font-size: 2px;
   font-weight: bold;
 }

--- a/src/rules/rule-properties-order/__tests__/grouped-flexible.js
+++ b/src/rules/rule-properties-order/__tests__/grouped-flexible.js
@@ -51,7 +51,7 @@ testRule([
   "height",
   {
     order: "flexible",
-    emptyLineBefore: true,
+    emptyLineBefore: "always",
     properties: [
       "color",
       "font-size",
@@ -120,6 +120,84 @@ testRule([
     {
       message: messages.expectedEmptyLineBetween("font-weight", "height"),
       line: 4,
+      column: 3,
+    }
+  )
+})
+
+testRule([
+  "height",
+  {
+    order: "flexible",
+    emptyLineBefore: "never",
+    properties: [
+      "color",
+      "font-size",
+      "font-weight",
+    ],
+  },
+], tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a {\n  height: 1px; color: pink;\n  font-size: 2px;\n  font-weight: bold;\n}")
+  tr.ok("a {\n  height: 1px; font-size: 2px;\n  color: pink;\n  font-weight: bold;\n}")
+  tr.ok("a {\n  height: 1px; font-size: 2px;\n  font-weight: bold;\n  color: pink;\n}")
+  tr.ok("a {\n  height: 1px; font-weight: bold;\n  font-size: 2px;\n  color: pink;\n}")
+  tr.ok("a {\n  height: 1px; /* something */\n  font-weight: bold;\n}", "comment before line break")
+
+  tr.notOk(
+    "a {\n  height: 1px;\n\n  color: pink;\n  font-size: 2px;\n  font-weight: bold;\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("color", "height"),
+      line: 4,
+      column: 3,
+    }
+  )
+  tr.notOk(
+    "a {\n  height: 1px;\n\n  font-size: 2px;\n  color: pink;\n  font-weight: bold;\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("font-size", "height"),
+      line: 4,
+      column: 3,
+    }
+  )
+  tr.notOk(
+    "a {\n  height: 1px;\n\n  font-weight: bold;\n  font-size: 2px;\n  color: pink;\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("font-weight", "height"),
+      line: 4,
+      column: 3,
+    }
+  )
+  tr.notOk(
+    "a {\n  height: 1px;\n\n  font-size: 2px;\n  color: pink;\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("font-size", "height"),
+      line: 4,
+      column: 3,
+    }
+  )
+  tr.notOk(
+    "a {\n  height: 1px;\n  width: 2px;\n\n  color: pink;\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("color", "width"),
+      line: 5,
+      column: 3,
+    }
+  )
+  tr.notOk(
+    "a {\n  height: 1px;\n  width: 2px;\n  border: 1px solid;\n\n  font-weight: pink;\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("font-weight", "border"),
+      line: 6,
+      column: 3,
+    }
+  )
+  tr.notOk(
+    "a {\n  height: 1px;\n\n  /* something */\n  font-weight: bold;\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("font-weight", "height"),
+      line: 5,
       column: 3,
     }
   )

--- a/src/rules/rule-properties-order/__tests__/grouped-strict.js
+++ b/src/rules/rule-properties-order/__tests__/grouped-strict.js
@@ -46,14 +46,14 @@ testRule([
 
 testRule([
   {
-    emptyLineBefore: true,
+    emptyLineBefore: "always",
     properties: [
       "height",
       "width",
     ],
   },
   {
-    emptyLineBefore: true,
+    emptyLineBefore: "always",
     properties: [
       "font-size",
       "font-weight",
@@ -86,7 +86,47 @@ testRule([
 
 testRule([
   {
-    emptyLineBefore: true,
+    emptyLineBefore: "never",
+    properties: [
+      "height",
+      "width",
+    ],
+  },
+  {
+    emptyLineBefore: "never",
+    properties: [
+      "font-size",
+      "font-weight",
+    ],
+  },
+], tr => {
+  warningFreeBasics(tr)
+
+  tr.ok("a {\r\n  height: 1px;\r\n  width: 2px;\r\n  font-size: 2px;\r\n  font-weight: bold;\r\n}")
+  tr.ok("a {\r\n  height: 1px;\r\n  font-weight: bold;\r\n}")
+  tr.ok("a {\r\n  height: 1px;  \r\n  font-weight: bold;\r\n}")
+
+  tr.notOk(
+    "a {\r\n  height: 1px;\r\n  width: 2px;\r\n\r\n  font-size: 2px;\r\n  font-weight: bold;\r\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("font-size", "width"),
+      line: 5,
+      column: 3,
+    }
+  )
+  tr.notOk(
+    "a {\r\n  height: 1px;\r\n\r\n  font-weight: bold;\r\n}",
+    {
+      message: messages.unexpectedEmptyLineBetween("font-weight", "height"),
+      line: 4,
+      column: 3,
+    }
+  )
+})
+
+testRule([
+  {
+    emptyLineBefore: "always",
     properties: [
       "margin-top",
       "margin-right",
@@ -94,7 +134,7 @@ testRule([
     ],
   },
   {
-    emptyLineBefore: true,
+    emptyLineBefore: "always",
     properties: [
       "font-size",
     ],
@@ -103,4 +143,25 @@ testRule([
   tr.ok(".foo { margin-bottom: 20px;\n\nfont-size: 26px; }")
   tr.notOk(".foo { margin-bottom: 20px; font-size: 26px; }",
     messages.expectedEmptyLineBetween("font-size", "margin-bottom"))
+})
+
+testRule([
+  {
+    emptyLineBefore: "never",
+    properties: [
+      "margin-top",
+      "margin-right",
+      "margin-bottom",
+    ],
+  },
+  {
+    emptyLineBefore: "never",
+    properties: [
+      "font-size",
+    ],
+  },
+], tr => {
+  tr.ok(".foo { margin-bottom: 20px; font-size: 26px; }")
+  tr.notOk(".foo { margin-bottom: 20px;\n\n font-size: 26px; }",
+    messages.unexpectedEmptyLineBetween("font-size", "margin-bottom"))
 })

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -118,7 +118,16 @@ export default function (expectation, options) {
           // secondProp seperatedGroups start at 2 so we minus 2 to get the 1st item
           // from our expectationGroups array
           const shouldBeSeperatedByNewLine = _.get(expectationGroups[secondPropData.orderData.separatedGroup - 2], "emptyLineBefore")
-          if (!hasEmptyLineBefore(secondPropData.node) && shouldBeSeperatedByNewLine === "always") {
+          if (!hasEmptyLineBefore(secondPropData.node) && shouldBeSeperatedByNewLine === true) {
+            result.warn((
+              "The value 'true' for 'emptyLineBefore has been deprecated, " +
+              "and in 5.0 it will be removed. " +
+              "Please use 'always' or 'never' instead."
+            ), {
+              stylelintType: "deprecation",
+              stylelintReference: "http://stylelint.io/user-guide/rules/font-weight-notation/",
+            })
+          } else if (!hasEmptyLineBefore(secondPropData.node) && shouldBeSeperatedByNewLine === "always") {
             report({
               message: messages.expectedEmptyLineBetween(secondPropData.name, firstPropData.name),
               node: secondPropData.node,

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -120,7 +120,7 @@ export default function (expectation, options) {
           const shouldBeSeperatedByNewLine = _.get(expectationGroups[secondPropData.orderData.separatedGroup - 2], "emptyLineBefore")
           if (!hasEmptyLineBefore(secondPropData.node) && shouldBeSeperatedByNewLine === true) {
             result.warn((
-              "The value 'true' for 'emptyLineBefore has been deprecated, " +
+              "The value 'true' for 'emptyLineBefore' has been deprecated, " +
               "and in 5.0 it will be removed. " +
               "Please use 'always' or 'never' instead."
             ), {

--- a/src/rules/rule-properties-order/index.js
+++ b/src/rules/rule-properties-order/index.js
@@ -23,7 +23,7 @@ export default function (expectation, options) {
     }, {
       actual: options,
       possible: {
-        unspecified: ["top", "bottom", "ignore", "bottomAlphabetical"],
+        unspecified: [ "top", "bottom", "ignore", "bottomAlphabetical" ],
       },
       optional: true,
     })
@@ -41,7 +41,7 @@ export default function (expectation, options) {
       }
     })
 
-    function checkNode (node) {
+    function checkNode(node) {
       const allPropData = []
       let lastKnownSeparatedGroup = 1
 
@@ -94,7 +94,7 @@ export default function (expectation, options) {
         })
       })
 
-      function checkOrder (firstPropData, secondPropData) {
+      function checkOrder(firstPropData, secondPropData) {
         // If the unprefixed property names are the same, resort to alphabetical ordering
         if (firstPropData.unprefixedName === secondPropData.unprefixedName) {
           return firstPropData.name <= secondPropData.name
@@ -113,7 +113,7 @@ export default function (expectation, options) {
 
         if (firstPropSeparatedGroup !== secondPropSeparatedGroup) {
           // Get an array of just the property groups, remove any solo properties
-          const expectationGroups = expectation.filter(item => typeof item !== 'string')
+          const expectationGroups = expectation.filter(item => typeof item !== "string")
 
           // secondProp seperatedGroups start at 2 so we minus 2 to get the 1st item
           // from our expectationGroups array
@@ -186,18 +186,18 @@ export default function (expectation, options) {
   }
 }
 
-function createExpectedOrder (input) {
+function createExpectedOrder(input) {
   const order = {}
   let separatedGroup = 1
   let expectedPosition = 0
 
   appendGroup(input, 1)
 
-  function appendGroup (items) {
+  function appendGroup(items) {
     items.forEach(item => appendItem(item, false))
   }
 
-  function appendItem (item, inFlexibleGroup) {
+  function appendItem(item, inFlexibleGroup) {
     if (_.isString(item)) {
       // In flexible groups, the expectedPosition does not ascend
       // to make that flexibility work;
@@ -226,7 +226,7 @@ function createExpectedOrder (input) {
   return order
 }
 
-function getOrderData (expectedOrder, propName) {
+function getOrderData(expectedOrder, propName) {
   let orderData = expectedOrder[propName]
   // If prop was not specified but has a hyphen
   // (e.g. `padding-top`), try looking for the segment preceding the hyphen
@@ -238,7 +238,7 @@ function getOrderData (expectedOrder, propName) {
   return orderData
 }
 
-function hasEmptyLineBefore (decl) {
+function hasEmptyLineBefore(decl) {
   if (/\r?\n\s*\r?\n/.test(decl.raw("before"))) { return true }
   const prevNode = decl.prev()
   if (!prevNode) { return false }
@@ -247,7 +247,7 @@ function hasEmptyLineBefore (decl) {
   return false
 }
 
-function checkAlpabeticalOrder (firstPropData, secondPropData) {
+function checkAlpabeticalOrder(firstPropData, secondPropData) {
   // If unprefixed prop names are the same, compare the prefixed versions
   if (firstPropData.unprefixedName === secondPropData.unprefixedName) {
     return firstPropData.name <= secondPropData.name
@@ -256,7 +256,7 @@ function checkAlpabeticalOrder (firstPropData, secondPropData) {
   return firstPropData.unprefixedName < secondPropData.unprefixedName
 }
 
-function validatePrimaryOption (actualOptions) {
+function validatePrimaryOption(actualOptions) {
 
   if (actualOptions === "alphabetical") { return true }
 
@@ -265,23 +265,23 @@ function validatePrimaryOption (actualOptions) {
   // Every item in the array must be a string or an object
   // with a "properties" property
   if (actualOptions.every(item => {
-      if (_.isString(item)) { return true }
-      return _.isPlainObject(item) && !_.isUndefined(item.properties)
-    })) { return true }
+    if (_.isString(item)) { return true }
+    return _.isPlainObject(item) && !_.isUndefined(item.properties)
+  })) { return true }
 
   const objectItems = actualOptions.filter(_.isPlainObject)
 
   // Every object-item's "emptyLineBefore" must be "always" or "never"
   if (objectItems.every(item => {
-      if (_.isUndefined(item.emptyLineBefore)) { return true }
-      return _.includes(["always", "never"], item.emptyLineBefore)
-    })) { return true }
+    if (_.isUndefined(item.emptyLineBefore)) { return true }
+    return _.includes([ "always", "never" ], item.emptyLineBefore)
+  })) { return true }
 
   // Every object-item's "type" property must be "strict" or "flexible"
   if (objectItems.every(item => {
-      if (_.isUndefined(item.type)) { return true }
-      return _.includes(["string", "flexible"], item.type)
-    })) { return true }
+    if (_.isUndefined(item.type)) { return true }
+    return _.includes([ "string", "flexible" ], item.type)
+  })) { return true }
 
   return false
 }


### PR DESCRIPTION
I have 355/355 tests passing at https://github.com/dan-gamble/stylelint/tree/feature/578

I basically duplicated every `emptyLineBefore` test i found and changed the option to `never` and then made the tests pass from there.