### PR TITLE
Improve no-duplicate-selectors; closes #807

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added: `ignoreAtRules: []` option to the `block-opening-brace-space-before` and `block-closing-brace-newline-after` rules.
 - Added: `stylelint-disable-line` feature.
 - Added: `withinComments`, `withinStrings`, and `checkStrings` options to `styleSearch`, and `insideString` property to the `styleSearch` match object.
+- Fixed: `no-duplicate-selectors` rule is more intelligent.
 - Fixed: `font-weight-notation` does not throw false warnings when `normal` is used in certain ways.
 - Fixed: `selector-no-*` and `selector-*-pattern` rules now ignore custom property sets.
 

--- a/src/rules/no-duplicate-selectors/README.md
+++ b/src/rules/no-duplicate-selectors/README.md
@@ -8,19 +8,24 @@ Disallow duplicate selectors within a stylesheet.
  * These duplicates */
 ```
 
-This rule checks each compound selector within a complex selector, so in `.foo .bar, .bar .foo` there are no duplicates because each compound selector is actually different, though both have the same constituents.
+This rule checks for two types of duplication:
+
+- Duplication of a single selector with a rule's selector list, e.g. `a, b, a {}`.
+- Duplication of a selector list within a stylesheet, e.g. `a, b {} a, b {}`. Duplicates are found even if the selectors come in different orders or have different spacing, e.g. `a d, b > c {} b>c, a   d {}`.
 
 The same selector *is* allowed to repeat in the following circumstances:
 
+- It is used in different selector lists, e.g. `a {} a, b {}`.
 - The duplicates are determined to originate in different stylesheets, e.g. you have concatenated or compiled files in a way that produces sourcemaps for PostCSS to read, e.g. postcss-import).
 - The duplicates are in rules with different parent nodes, e.g. inside and outside of a media query.
 
-**If you are using a processor that modifies selectors, read this:** This rule will only compare the selectors that it sees, so as far as it's concerned, in `a { b {} & b {} }` there are no duplicate selectors. If you're using SCSS, though, you do have duplicates in the output: `a b {}` occurs twice. If you want this rule to analyze the selectors in *your output*, make sure it runs *after* you have compiled your stylesheets.
+**If you are using a processor that modifies selectors, read this:** This rule will only compare the selectors that it sees; so as far as it's concerned, in `a { b {} & b {} }` there are no duplicate selectors. If you're using SCSS, though, you *do* have duplicates in the output: `a b {} a b {}`. If you want this rule to analyze the selectors in *your output*, make sure it runs *after* you have compiled your stylesheets.
 
 The following patterns are considered warnings:
 
 ```css
 .foo,
+.bar,
 .foo {}
 ```
 
@@ -41,6 +46,18 @@ The following patterns are considered warnings:
   .foo {}
   .foo {}
 }
+```
+
+```css
+.foo, .bar {}
+.bar, .foo {}
+```
+
+```css
+a .foo, b + .bar {}
+b+.bar,
+a
+  .foo {}
 ```
 
 The following patterns are *not* considered warnings:

--- a/src/rules/no-duplicate-selectors/__tests__/index.js
+++ b/src/rules/no-duplicate-selectors/__tests__/index.js
@@ -13,31 +13,42 @@ const testRule = ruleTester(rule, ruleName)
 testRule(null, tr => {
   warningFreeBasics(tr)
 
-  tr.ok("a {}, b {}, c {}, d, e, f {}", "no duplicates")
+  tr.ok("a {} b {} c {} d, e, f {}", "no duplicates")
   tr.ok("a {}\n@media print { a {} }", "duplicate inside media query")
   tr.ok("a { a { a {} } }", "duplicates inside nested rules")
   tr.ok(".foo .bar {}\n .foo {}\n.bar {}\n.bar .foo {}", "selectors using parts of other selectors")
+  tr.ok("a {} a, b {}", "selectors reused in other non-equivalent selector lists")
 
   tr.notOk("a, a {}", {
     message: messages.rejected("a"),
     line: 1,
     column: 1,
-  }, "duplicate within one rule's selector")
-  tr.notOk("a {}, b {}, a {}", {
+  }, "duplicate within one rule's selector list")
+  tr.notOk("a {} b {} a {}", {
     message: messages.rejected("a"),
     line: 1,
-    column: 13,
-  }, "duplicates with another rule between")
+    column: 11,
+  }, "duplicate simple selectors with another rule between")
+  tr.notOk("a, b {} b, a {}", {
+    message: messages.rejected("b, a"),
+    line: 1,
+    column: 9,
+  }, "essentially duplicate selector lists")
+  tr.notOk(".foo   a, b\t> .bar,\n#baz {}\n  #baz,\n\n  .foo     a,b>.bar {}", {
+    message: messages.rejected("#baz,\n\n  .foo     a,b>.bar"),
+    line: 3,
+    column: 3,
+  }, "essentially duplicate selector lists with varied spacing")
   tr.notOk("a {}\n@media print { a, a {} }", {
     message: messages.rejected("a"),
     line: 2,
     column: 16,
-  }, "duplicate within a media query, in different rules")
+  }, "duplicate within a media query, in the same rule")
   tr.notOk("a {}\n@media print { a {} a {} }", {
     message: messages.rejected("a"),
     line: 2,
     column: 21,
-  }, "duplicate within a media query, in the same rule")
+  }, "duplicate within a media query, in different rules")
 })
 
 test("with postcss-import and duplicates within a file", t => {


### PR DESCRIPTION
I guess I'd consider this a bug fix even though it's a fairly substantial change, just because I don't think the rule was being very useful before this.