### PR TITLE
Add note about ignoring var interpolation

### DIFF
--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -8,6 +8,8 @@ Limit the specificity of selectors.
  * Each of these selectors */
 ```
 
+The rule ignores selectors with variable interpolation (`#{$var} {}`).
+
 Visit the [Specificity Calculator](https://specificity.keegan.st) for visual representation of selector specificity.
 
 ## Options

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -8,7 +8,7 @@ Limit the specificity of selectors.
  * Each of these selectors */
 ```
 
-The rule ignores selectors with variable interpolation (`#{$var} {}`).
+The rule ignores selectors with variable interpolation (`#{$var}`, `@{var}`, `$(var)`).
 
 Visit the [Specificity Calculator](https://specificity.keegan.st) for visual representation of selector specificity.
 


### PR DESCRIPTION
My bad. We *do* list css processor caveats e.g. [here](https://github.com/stylelint/stylelint/tree/master/src/rules/rule-no-duplicate-properties#rule-no-duplicate-properties). Not sure why I was convinced otherwise.

Anyhow, this PR adds a note to `selector-max-specificity` about variable interpolation.

@davidtheclark You were right. If I was a CSS Processor user, it’s likely one the first questions I’d ask.