### PR TITLE
Fix selector-no-id false positive on Sass interpolation; closes #829

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed: `font-weight-notation` does not throw false warnings when `normal` is used in certain ways.
 - Fixed: `selector-no-*` and `selector-*-pattern` rules now ignore custom property sets.
 - Fixed: nested selector handling for `no-duplicate-selectors`.
+- Fixed: `selector-no-id` does not warn about Sass interpolation inside an `:nth-child()` argument.
 
 # 4.4.0
 

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -47,6 +47,7 @@ scssTestRule(undefined, tr => {
   tr.ok("@for $n from 1 through 10 { .n#{$n}n#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore multiple sass interpolations in a selector inside @for")
   tr.ok("@each $n in $vals { .n-#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore sass interpolation inside @each")
   tr.ok("@while $n < 10 { .n-#{$n} { content: \"n: #{1 + 1}\"; } }", "ignore sass interpolation inside @while")
+  tr.ok("div:nth-child(#{map-get($foo, bar)}) {}", "ignore sass map-get interpolation")
 
   tr.notOk("@for $n from 1 through 10 { .n-#{$n} #foo { } }", {
     message: messages.rejected,

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -20,12 +20,15 @@ export default function (actual) {
     root.walkRules(rule => {
       if (cssRuleHasSelectorEndingWithColon(rule)) { return }
       selectorParser(selectorAST => {
-        selectorAST.eachId(id => {
-          if (/#{.+}/.test(id)) { return }
+        selectorAST.eachId(idNode => {
+          // Ignore Sass intepolation possibilities
+          if (/#{.+}/.test(idNode.toString())) { return }
+          if (idNode.parent.parent.type === "pseudo") { return }
+
           report({
             message: messages.rejected,
             node: rule,
-            index: id.sourceIndex,
+            index: idNode.sourceIndex,
             ruleName,
             result,
           })


### PR DESCRIPTION
cc/ @alan-agius4