### PR TITLE
Add support for prefixed nesting selector

### DIFF
--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -16,6 +16,8 @@ testRule(true, tr => {
 
   tr.ok(".foo { & {} }")
   tr.ok(".foo { &.bar {} }")
+  tr.ok(".foo { &-bar {} }")
+  tr.ok(".foo { &__bar {} }")
   tr.ok(".foo { [&] {} }")
   tr.ok(".foo { & [class*=bar] {} }")
   tr.ok(".foo { @nest & {} }")

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -43,8 +43,8 @@ export default function (on, options) {
             return
           }
 
-          // & is not a type selector: it's used for nesting
-          if (tag.value === "&") { return }
+          // & is not a type selector: it's used for nesting 
+          if (tag.value[0] === "&") { return }
 
           if (optionsHaveIgnored(options, "descendant")  && isCombinator(tag.prev())) {
             return


### PR DESCRIPTION
Closes #834.

Simply changes the behaviour from testing the whole value to just the 1st character. This accounts for when the nesting selector is used as a prefix.

I think we now cover off how [scss nesting can be used](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_rules).

P.S. Will update changelog once https://github.com/stylelint/stylelint/pull/833 is in.