### PR TITLE
Consistent phrasing for resolving nested selectors

### DIFF
--- a/src/rules/declaration-block-no-duplicate-properties/README.md
+++ b/src/rules/declaration-block-no-duplicate-properties/README.md
@@ -8,7 +8,7 @@ a { color: pink; color: orange; }
  * These duplicated properties */
 ```
 
-The rule ignores variables (`$sass`, `@less`, `--custom-property`).
+This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
 The following patterns are considered warnings:
 

--- a/src/rules/declaration-block-properties-order/README.md
+++ b/src/rules/declaration-block-properties-order/README.md
@@ -13,7 +13,7 @@ Specify the order of properties within declaration blocks.
 
 Prefixed properties *must always* be alphabetically ordered and *must always* precede the unprefixed version.
 
-The rule ignores variables (`$sass`, `@less`, `--custom-property`).
+This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
 ## Options
 
@@ -72,7 +72,7 @@ There are some important details to keep in mind:
 
 **By default, unlisted properties will be ignored.** So if you specify an array and do not include `display`, that means that the `display` property can be included before or after any other property. *This can be changed with the `unspecified` option* (see below).
 
-**If an (unprefixed) property name is not included in your array and it contains a hyphen (e.g. `padding-left`), the rule will look for the string before that first hyphen in your array (e.g. `padding`) and use that position.** This means that you do not have to specify each extension of the root property; you can just specify the root property and the extensions will be accounted for.
+**If an (unprefixed) property name is not included in your array and it contains a hyphen (e.g. `padding-left`), this rule will look for the string before that first hyphen in your array (e.g. `padding`) and use that position.** This means that you do not have to specify each extension of the root property; you can just specify the root property and the extensions will be accounted for.
 
 For example, if you have included `border` in your array but not `border-top`, the rule will expect `border-top` to appear in the same relative position as `border`.
 

--- a/src/rules/function-whitespace-after/README.md
+++ b/src/rules/function-whitespace-after/README.md
@@ -8,7 +8,7 @@ a { transform: translate(1, 1) scale(3); }
  *                   This space */
 ```
 
-The rule does not check for space immediately after `)` if the very next character is `,`, `)`, or `}`, allowing some of the patterns exemplified below.
+This rule does not check for space immediately after `)` if the very next character is `,`, `)`, or `}`, allowing some of the patterns exemplified below.
 
 ## Options
 

--- a/src/rules/no-duplicate-selectors/README.md
+++ b/src/rules/no-duplicate-selectors/README.md
@@ -19,7 +19,7 @@ The same selector *is* allowed to repeat in the following circumstances:
 - The duplicates are determined to originate in different stylesheets, e.g. you have concatenated or compiled files in a way that produces sourcemaps for PostCSS to read, e.g. postcss-import).
 - The duplicates are in rules with different parent nodes, e.g. inside and outside of a media query.
 
-Note that this rule does resolve nested selectors. So `a b {} a { & b {} }` counts as a warning, because the resolved selectors end up with a duplicate.
+This rule resolves nested selectors. So `a b {} a { & b {} }` counts as a warning, because the resolved selectors end up with a duplicate.
 
 The following patterns are considered warnings:
 

--- a/src/rules/property-value-whitelist/README.md
+++ b/src/rules/property-value-whitelist/README.md
@@ -15,7 +15,7 @@ a { text-transform: uppercase; }
   "unprefixed-property-name": ["/regex/", "non-regex"]
 }`
 
-If a property name is found in the object, only its whitelisted property values are allowed. The rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
+If a property name is found in the object, only its whitelisted property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 

--- a/src/rules/property-whitelist/README.md
+++ b/src/rules/property-whitelist/README.md
@@ -8,7 +8,7 @@ a { display: block; }
  * These properties */
 ```
 
-The rule ignores variables (`$sass`, `@less`, `--custom-property`).
+This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
 ## Options
 

--- a/src/rules/root-no-standard-properties/README.md
+++ b/src/rules/root-no-standard-properties/README.md
@@ -8,7 +8,7 @@ Disallow standard properties inside `:root` selectors.
  * This selector and these types of standard properties */
 ```
 
-The rule ignores `$sass` and `@less` variables.
+This rule ignores `$sass` and `@less` variables.
 
 The following patterns are considered warnings:
 

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -8,9 +8,11 @@ Limit the specificity of selectors.
  * Each of these selectors */
 ```
 
-The rule ignores selectors with variable interpolation (`#{$var}`, `@{var}`, `$(var)`).
-
 Visit the [Specificity Calculator](https://specificity.keegan.st) for visual representation of selector specificity.
+
+This rule ignores selectors with variable interpolation (`#{$var}`, `@{var}`, `$(var)`).
+
+This rule resolves nested selectors before before calculating the specificity of a selector.
 
 ## Options
 

--- a/src/rules/time-no-imperceptible/README.md
+++ b/src/rules/time-no-imperceptible/README.md
@@ -8,7 +8,7 @@ Disallow `animation` and `transition` times under 100ms.
  *                     This time */
 ```
 
-The rule checks `transition-duration`, `transition-delay`, `animation-duration`, `animation-delay`, and those times as they manifest in the `transition` and `animation` shorthands.
+This rule checks `transition-duration`, `transition-delay`, `animation-duration`, `animation-delay`, and those times as they manifest in the `transition` and `animation` shorthands.
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
And how we refer to the rule itself. I’ve gone with “This rule” as it was more prevalent. We also use “The rule” [in places](https://github.com/stylelint/stylelint/tree/master/src/rules/rule-non-nested-empty-line-before) to refer to *rule-sets*. This PR removes any ambiguity. 

Ref: https://github.com/stylelint/stylelint/issues/835#issuecomment-191840511