### PR TITLE
Add tests for pseudos to no-descending-specificity

### DIFF
--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -16,6 +16,9 @@ testRule(true, tr => {
   tr.ok("a[foo] {} a {}", "only checks matching last compound selectors")
   tr.ok("a { b {} } c + b {}")
   tr.ok("b a {} @media print { a {} }")
+  tr.ok(".a:hover {} a::after {}") // fail
+  tr.ok(".m:hover {} .b {}") // pass
+  tr.ok(".menu:hover {} .burger {}") // fail?!
 
   tr.notOk("b a {} a {}", {
     message: messages.rejected("a", "b a"),

--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -18,6 +18,7 @@ testRule(true, tr => {
   tr.ok("b a {} @media print { a {} }")
   tr.ok("a {} a::after {}", "pseudo-element last")
   tr.ok("a {} a:hover {}", "pseudo-class last")
+  tr.ok("a:hover {} a:hover::before {}")
   tr.ok(".m:hover {} .b {}")
   tr.ok(".menu:hover {} .burger {}")
 
@@ -66,4 +67,9 @@ testRule(true, tr => {
     line: 1,
     column: 12,
   }, "pseudo-class first")
+  tr.notOk("a:hover::before {} a:hover {} ", {
+    message: messages.rejected("a:hover", "a:hover::before"),
+    line: 1,
+    column: 20,
+  })
 })

--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -16,9 +16,10 @@ testRule(true, tr => {
   tr.ok("a[foo] {} a {}", "only checks matching last compound selectors")
   tr.ok("a { b {} } c + b {}")
   tr.ok("b a {} @media print { a {} }")
-  tr.ok(".a:hover {} a::after {}") // fail
-  tr.ok(".m:hover {} .b {}") // pass
-  tr.ok(".menu:hover {} .burger {}") // fail?!
+  tr.ok("a {} a::after {}", "pseudo-element last")
+  tr.ok("a {} a:hover {}", "pseudo-class last")
+  tr.ok(".m:hover {} .b {}")
+  tr.ok(".menu:hover {} .burger {}")
 
   tr.notOk("b a {} a {}", {
     message: messages.rejected("a", "b a"),
@@ -55,4 +56,14 @@ testRule(true, tr => {
     line: 1,
     column: 31,
   })
+  tr.notOk("a::before {} a {} ", {
+    message: messages.rejected("a", "a::before"),
+    line: 1,
+    column: 14,
+  }, "pseudo-element first")
+  tr.notOk("a:hover {} a {} ", {
+    message: messages.rejected("a", "a:hover"),
+    line: 1,
+    column: 12,
+  }, "pseudo-class first")
 })

--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -40,19 +40,16 @@ export default function (actual) {
 
     function checkSelector(selectorNode, rule, sourceIndex, comparisonContext) {
       const selector = selectorNode.toString()
-      const lastSelectorNode = _.last(selectorNode.nodes[0].nodes)
-      const lastCompoundSelector = (lastSelectorNode.type === "pseudo")
-        ? lastSelectorNode.prev().toString()
-        : lastSelectorNode.toString()
+      const lastNonPseudoSelectorNode = getLastNonPseudoSelectorNode(selectorNode)
       const selectorSpecificity = calculate(selector)[0].specificity.split(",")
       const entry = { selector, specificity: selectorSpecificity }
 
-      if (!comparisonContext.has(lastCompoundSelector)) {
-        comparisonContext.set(lastCompoundSelector, [entry])
+      if (!comparisonContext.has(lastNonPseudoSelectorNode)) {
+        comparisonContext.set(lastNonPseudoSelectorNode, [entry])
         return
       }
 
-      const priorComparableSelectors = comparisonContext.get(lastCompoundSelector)
+      const priorComparableSelectors = comparisonContext.get(lastNonPseudoSelectorNode)
 
       priorComparableSelectors.forEach(priorEntry => {
         if (isLowerSpecificity(selectorSpecificity, priorEntry.specificity)) {
@@ -69,4 +66,12 @@ export default function (actual) {
       priorComparableSelectors.push(entry)
     }
   }
+}
+
+function getLastNonPseudoSelectorNode(selectorNode) {
+  let s = _.last(selectorNode.nodes[0].nodes)
+  while (s.type === "pseudo") {
+    s = s.prev()
+  }
+  return s.toString()
 }

--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -40,7 +40,7 @@ export default function (actual) {
 
     function checkSelector(selectorNode, rule, sourceIndex, comparisonContext) {
       const selector = selectorNode.toString()
-      const lastCompoundSelector = _.last(selectorNode.nodes.toString())
+      const lastCompoundSelector = _.last(selectorNode.nodes[0].nodes).toString()
       const selectorSpecificity = calculate(selector)[0].specificity.split(",")
       const entry = { selector, specificity: selectorSpecificity }
 

--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -40,7 +40,10 @@ export default function (actual) {
 
     function checkSelector(selectorNode, rule, sourceIndex, comparisonContext) {
       const selector = selectorNode.toString()
-      const lastCompoundSelector = _.last(selectorNode.nodes[0].nodes).toString()
+      const lastSelectorNode = _.last(selectorNode.nodes[0].nodes)
+      const lastCompoundSelector = (lastSelectorNode.type === "pseudo")
+        ? lastSelectorNode.prev().toString()
+        : lastSelectorNode.toString()
       const selectorSpecificity = calculate(selector)[0].specificity.split(",")
       const entry = { selector, specificity: selectorSpecificity }
 


### PR DESCRIPTION
I was testing `master` against the stylelint.io (in prep for the `4.5` release) when I ran into a issue with `no-descending-specificity` pseudos (and, bizarrely, specific class names).

I had a poke around and I’ve narrowed it down to two failing tests. I wanted to push this up in case you had any quick ideas, before I try to properly grok how this rule works.