### PR TITLE
Fix false positives in url() arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fixed: nested selector handling for `no-duplicate-selectors`.
 - Fixed: `selector-no-id` does not warn about Sass interpolation inside an `:nth-child()` argument.
 - Fixed: handling of mixed line endings in `rule-nested-empty-line-before`, `rule-non-nested-empty-line-before`, `comment-empty-line-before` and `at-rule-empty-line-before`.
+- Fixed: `number-leading-zero` and `function-comma-space-*` do not throw false positives in `url()` arguments.
 
 # 4.4.0
 

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -15,6 +15,8 @@ testRule("always", tr => {
   tr.ok("a { transform: translate(1 , 1); }")
   tr.ok("a { transform: translate(1, 1); }")
   tr.ok("a { transform: color(rgb(0 , 0, 0) lightness(50%)); }")
+  tr.ok("a { background: url(data:image/svg+xml;charset=utf8,%3Csvg%20xmlns); }",
+    "data URI with spaceless comma")
 
   tr.notOk("a { transform: translate(1,1); }", {
     message: messages.expectedAfter(),

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -45,6 +45,9 @@ export function functionCommaSpaceChecker({ locationChecker, root, result, check
     valueParser(decl.value).walk(valueNode => {
       if (valueNode.type !== "function") { return }
 
+      // Ignore `url()` arguments, which may contain data URIs or other funky stuff
+      if (valueNode.value === "url") { return }
+
       let functionArguments = (() => {
         let result = valueParser.stringify(valueNode)
         // Remove function name and opening paren

--- a/src/rules/function-comma-space-before/__tests__/index.js
+++ b/src/rules/function-comma-space-before/__tests__/index.js
@@ -15,6 +15,8 @@ testRule("always", tr => {
   tr.ok("a { transform: translate(1 , 1); }")
   tr.ok("a { transform: translate(1 ,1); }")
   tr.ok("a { transform: color(rgb(0 , 0 ,0) lightness(50%)); }")
+  tr.ok("a { background: url(data:image/svg+xml;charset=utf8,%3Csvg%20xmlns); }",
+    "data URI with spaceless comma")
 
   tr.notOk("a { transform: translate(1, 1); }", {
     message: messages.expectedBefore(),

--- a/src/rules/number-leading-zero/__tests__/index.js
+++ b/src/rules/number-leading-zero/__tests__/index.js
@@ -35,6 +35,8 @@ testRule("always", tr => {
     "multiple fractional values with leading zeros in a function"
   )
   tr.ok("@media (min-width: 0.01em)", "media feature")
+  tr.ok("a { background: url(data:image/svg+xml;...0.5); }",
+    "data URI containing leading zero")
 
   tr.notOk(
     "a { line-height: .5; }",

--- a/src/utils/__tests__/blurFunctionArguments-test.js
+++ b/src/utils/__tests__/blurFunctionArguments-test.js
@@ -1,0 +1,9 @@
+import test from "tape"
+import blurFunctionArguments from "../blurFunctionArguments"
+
+test("blurFunctionArguments", t => {
+  t.equal(blurFunctionArguments("abc abc", "url"), "abc abc")
+  t.equal(blurFunctionArguments("abc url(abc) abc", "url"), "abc url(```) abc")
+  t.equal(blurFunctionArguments("abc url(abc) url(xx)", "url", "#"), "abc url(###) url(##)")
+  t.end()
+})

--- a/src/utils/blurFunctionArguments.js
+++ b/src/utils/blurFunctionArguments.js
@@ -1,0 +1,36 @@
+import _ from "lodash"
+import balancedMatch from "balanced-match"
+
+/**
+ * Replace all of the characters that are arguments to a certain
+ * CSS function with some innocuous character.
+ *
+ * This is useful if you need to use a RegExp to find a string
+ * but want to ignore matches in certain functions (e.g. `url()`,
+ * which might contain all kinds of false positives).
+ *
+ * For example:
+ * blurFunctionArguments("abc url(abc) abc", "url") === "abc url(```) abc"
+ *
+ * @param {string} source
+ * @param {string} functionName
+ * @param {[string]} blurChar="`"
+ * @return {string} - The result string, with the function arguments "blurred"
+ */
+export default function (source, functionName, blurChar="`") {
+  const nameWithParen = `${functionName}(`
+  if (!_.includes(source, nameWithParen)) { return source }
+
+  const functionNameLength = functionName.length
+
+  let result = source
+  let searchStartIndex = 0
+  while (source.indexOf(nameWithParen, searchStartIndex) !== -1) {
+    const openingParenIndex = source.indexOf(nameWithParen, searchStartIndex) + functionNameLength
+    const closingParenIndex = balancedMatch("(", ")", source.slice(openingParenIndex)).end + openingParenIndex
+    const argumentsLength = closingParenIndex - openingParenIndex - 1
+    result = result.slice(0, openingParenIndex + 1) + _.repeat(blurChar, argumentsLength) + result.slice(closingParenIndex)
+    searchStartIndex = closingParenIndex
+  }
+  return result
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 export { default as blurComments } from "./blurComments"
+export { default as blurFunctionArguments } from "./blurFunctionArguments"
 export { default as configurationError } from "./configurationError"
 export { default as cssDeclarationIsMap } from "./cssDeclarationIsMap"
 export { default as cssFunctionArguments } from "./cssFunctionArguments"


### PR DESCRIPTION
Addresses #841.

To make number-leading-zero work I created a `blurFunctionArguments()` util, which makes it easier to use regular expressions without getting false positives within function arguments.

@ntwb: Does this address all of the problems in #841 or is there something I missed?