### PR TITLE
Eslint es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,14 @@
     ]
   },
   "eslintConfig": {
-    "extends": "stylelint"
+    "extends": "stylelint",
+    "rules": {
+      "arrow-spacing": 2,
+      "no-var": 2,
+      "object-shorthand": 2,
+      "prefer-const": 2,
+      "template-curly-spacing": 2
+    }
   },
   "remarkConfig": {
     "plugins": {

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -78,8 +78,8 @@ function augmentConfig(config, configDir) {
   })
 
   function loadExtendedConfig(config, extendLookup) {
-    var extendPath = getModulePath(configDir, extendLookup)
-    var extendDir = path.dirname(extendPath)
+    const extendPath = getModulePath(configDir, extendLookup)
+    const extendDir = path.dirname(extendPath)
     return cosmiconfig(null, {
       configPath: extendPath,
       // In case --config was used: do not pay attention to it again

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -67,7 +67,7 @@ export default function (expectation, options) {
       const message = expectEmptyLineBefore ? messages.expected : messages.rejected
 
       report({
-        message: message,
+        message,
         node: atRule,
         result,
         ruleName,

--- a/src/rules/color-named/index.js
+++ b/src/rules/color-named/index.js
@@ -61,7 +61,7 @@ export default function (expectation) {
             type === "function" &&
             FUNC_REPRESENTATION.indexOf(value) !== -1
           ) {
-            let cssString = valueParser.stringify(node).replace(/\s+/g, "")
+            const cssString = valueParser.stringify(node).replace(/\s+/g, "")
             namedColors.forEach(namedColor => {
               if (representations[namedColor].func.indexOf(cssString) !== -1) {
                 complain(

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -80,7 +80,7 @@ export default function (expectation, options) {
       const message = expectEmptyLineBefore ? messages.expected : messages.rejected
 
       report({
-        message: message,
+        message,
         node: comment,
         result,
         ruleName,

--- a/src/rules/declaration-block-no-duplicate-properties/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/index.js
@@ -28,7 +28,7 @@ export default function (actual) {
     })
 
     function checkRulesInNode(node) {
-      let decls = []
+      const decls = []
       node.each(child => {
         if (child.nodes && child.nodes.length) {
           checkRulesInNode(child)

--- a/src/rules/declaration-block-trailing-semicolon/index.js
+++ b/src/rules/declaration-block-trailing-semicolon/index.js
@@ -30,7 +30,7 @@ export default function (expectation) {
       if (!rule.last || rule.last.type !== "decl") { return }
 
       let errorIndexOffset = rule.toString().length
-      let after = rule.raw("after")
+      const after = rule.raw("after")
       if (after) {
         errorIndexOffset -= after.length
       }

--- a/src/rules/font-weight-notation/index.js
+++ b/src/rules/font-weight-notation/index.js
@@ -67,7 +67,7 @@ export default function (expectation, options) {
       // `font` values need to be part of a font-size/line-height pair
       const hasNumericFontWeight = valueList.some(isNumbery)
 
-      for (let value of postcss.list.space(decl.value)) {
+      for (let value of postcss.list.space(decl.value)) { // eslint-disable-line prefer-const
         if (
           (value === NORMAL_KEYWORD && !hasNumericFontWeight)
           || isNumbery(value)

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -48,7 +48,7 @@ export function functionCommaSpaceChecker({ locationChecker, root, result, check
       // Ignore `url()` arguments, which may contain data URIs or other funky stuff
       if (valueNode.value === "url") { return }
 
-      let functionArguments = (() => {
+      const functionArguments = (() => {
         let result = valueParser.stringify(valueNode)
         // Remove function name and opening paren
         result = result.slice(valueNode.value.length + 1)

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -81,7 +81,7 @@ export default function (space, options) {
       const expectedWhitespace = repeat(indentChar, nodeLevel)
 
       let before = node.raw("before")
-      let after = node.raw("after")
+      const after = node.raw("after")
 
       // Only inspect the spaces before the node
       // if this is the first node in root

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -175,7 +175,7 @@ export default {
   "function-url-quotes": functionUrlQuotes,
   "function-whitelist": functionWhitelist,
   "function-whitespace-after": functionWhitespaceAfter,
-  "indentation": indentation,
+  "indentation": indentation, // eslint-disable-line object-shorthand
   "max-empty-lines": maxEmptyLines,
   "max-line-length": maxLineLength,
   "max-nesting-depth": maxNestingDepth,

--- a/src/rules/no-duplicate-selectors/index.js
+++ b/src/rules/no-duplicate-selectors/index.js
@@ -18,7 +18,7 @@ export const messages = ruleMessages(ruleName, {
 // Each source maps to another map, which maps rule parents to a set of selectors.
 // This ensures that selectors are only checked against selectors
 // from other rules that share the same parent and the same source.
-var selectorContextLookup = cssNodeContextLookup()
+const selectorContextLookup = cssNodeContextLookup()
 
 export default function (actual) {
   return (root, result) => {

--- a/src/rules/no-unknown-animations/index.js
+++ b/src/rules/no-unknown-animations/index.js
@@ -38,7 +38,7 @@ export default function (actual) {
 
       if (decl.prop === "animation") {
         const valueList = postcss.list.space(decl.value)
-        for (let value of valueList) {
+        for (let value of valueList) { // eslint-disable-line prefer-const
           // Ignore numbers with units
           if (postcssValueParser.unit(value)) { continue }
           // Ignore keywords for other animation parts

--- a/src/rules/rule-no-duplicate-properties/index.js
+++ b/src/rules/rule-no-duplicate-properties/index.js
@@ -38,7 +38,7 @@ export default function (actual) {
     })
 
     function checkRulesInNode(node) {
-      let decls = []
+      const decls = []
       node.each(child => {
         if (child.nodes && child.nodes.length) {
           checkRulesInNode(child)

--- a/src/rules/rule-non-nested-empty-line-before/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/index.js
@@ -75,7 +75,7 @@ export function checkRuleEmptyLineBefore({ rule, expectation, options, result, m
   const message = expectEmptyLineBefore ? messages.expected : messages.rejected
 
   report({
-    message: message,
+    message,
     node: rule,
     result,
     ruleName: checkedRuleName,

--- a/src/rules/rule-trailing-semicolon/index.js
+++ b/src/rules/rule-trailing-semicolon/index.js
@@ -40,7 +40,7 @@ export default function (expectation) {
       if (!rule.last || rule.last.type !== "decl") { return }
 
       let errorIndexOffset = rule.toString().length
-      let after = rule.raw("after")
+      const after = rule.raw("after")
       if (after) {
         errorIndexOffset -= after.length
       }

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -19,7 +19,7 @@ export default function (max) {
       actual: max,
       possible: [function (max) {
         // Check that the max specificity is in the form "a,b,c"
-        var pattern = new RegExp("^\\d+,\\d+,\\d+$")
+        const pattern = new RegExp("^\\d+,\\d+,\\d+$")
         return pattern.test(max)
       }],
     })

--- a/src/rules/time-no-imperceptible/index.js
+++ b/src/rules/time-no-imperceptible/index.js
@@ -36,7 +36,7 @@ export default function (actual) {
 
       if (SHORTHAND_PROPERTIES_TO_CHECK.indexOf(decl.prop) !== -1) {
         const valueList = postcss.list.space(decl.value)
-        for (let value of valueList) {
+        for (let value of valueList) { // eslint-disable-line prefer-const
           if (isImperceptibleTime(value)) {
             complain(messages.rejected(value), decl, decl.value.indexOf(value))
           }

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -214,7 +214,7 @@ test("handles escaped double-quotes in single-quote strings", t => {
 })
 
 test("count", t => {
-  let endCounts = []
+  const endCounts = []
   styleSearch({ source: "123 123 123", target: "1" }, (index, count) => {
     endCounts.push(count)
   })

--- a/src/utils/rawNodeString.js
+++ b/src/utils/rawNodeString.js
@@ -5,7 +5,7 @@
  * @return {string}
  */
 export default function (node) {
-  var result = ""
+  let result = ""
   if (node.raw("before")) {
     result += node.raw("before")
   }

--- a/src/utils/report.js
+++ b/src/utils/report.js
@@ -42,7 +42,7 @@ export default function ({
   const startLine = line || node.positionBy({ index }).line
 
   if (result.stylelint.disabledRanges) {
-    for (let range of result.stylelint.disabledRanges) {
+    for (let range of result.stylelint.disabledRanges) { // eslint-disable-line prefer-const
       if (
         // If the violation is within a disabledRange,
         // and that disabledRange's rules include this one,


### PR DESCRIPTION
This adds a couple of es2015 specific eslint rules to the main stylelint repo. I’ve added them to catch a few idiomatic things we’ve pointed out in recent PRs, mainly:

- using `const` and `let` instead of `var`
- using shorthand object notation.