### PR TITLE
Add :global to basic tests

### DIFF
--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -71,6 +71,8 @@ export default function (actual) {
 function getLastNonPseudoSelectorNode(selectorNode) {
   let s = _.last(selectorNode.nodes[0].nodes)
   while (s.type === "pseudo") {
+    const prev = s.prev()
+    if (!prev) { return s.toString() }
     s = s.prev()
   }
   return s.toString()

--- a/src/testUtils/warningFreeBasics.js
+++ b/src/testUtils/warningFreeBasics.js
@@ -8,5 +8,6 @@
 export default function (tr) {
   tr.ok("", "empty stylesheet")
   tr.ok("a {}", "empty rule set")
+  tr.ok (":global {}", "CSS Modules global empty rule set")
   tr.ok("@import \"foo.css\";", "blockless statement")
 }


### PR DESCRIPTION
@davidtheclark When you have a moment, are you able to look into this?

`getLastNonPseudoSelectorNode` in `no-descending-selector` is tripping up (`TypeError: Cannot read property 'type' of undefined`) on `:global {}` [from CSS Modules](https://github.com/css-modules/css-modules#usage-with-preprocessors) - which we use in stylelint.io

I’ve added the test to `warningFreeBasics` as it’s a non-standard thing that I suspect we’ll easily forget about when building a new rule that handles pseudos in some way.


