### PR TITLE
PoC for more powerful custom messages

### DIFF
--- a/src/__tests__/fixtures/config-color-no-named-custom-message.yaml
+++ b/src/__tests__/fixtures/config-color-no-named-custom-message.yaml
@@ -1,4 +1,4 @@
 rules:
   color-no-named:
     - true
-    - message: "Unacceptable"
+    - message: "Unacceptable! No \"<%= sourceCode %>\" allowed."

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -308,7 +308,7 @@ test("standalone loading YAML with custom message", t => {
   }).then(({ output }) => {
     const parsedOutput = JSON.parse(output)[0]
     t.equal(parsedOutput.warnings.length, 1)
-    t.equal(parsedOutput.warnings[0].text, "Unacceptable")
+    t.equal(parsedOutput.warnings[0].text, "Unacceptable! No \"pink\" allowed.")
   }).catch(logError)
 
   t.plan(2)

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -86,9 +86,10 @@ export default postcss.plugin("stylelint", (options = {}) => {
           ruleSeverity = get(secondaryOptions, "severity", "error")
         }
 
-        // Log the rule's severity in the PostCSS result
+        // Log the rule's severity and custom message in the PostCSS result
         result.stylelint.ruleSeverities[ruleName] = ruleSeverity
-        result.stylelint.customMessages[ruleName] = secondaryOptions && secondaryOptions.message
+        result.stylelint.customMessages[ruleName] = get(secondaryOptions, "message")
+          || get(options, [ "customMessages", ruleName ])
 
         // Run the rule with the primary and secondary options
         ruleDefinitions[ruleName](primaryOption, secondaryOptions)(root, result)

--- a/src/rules/color-no-named/index.js
+++ b/src/rules/color-no-named/index.js
@@ -33,11 +33,13 @@ export default function (actual) {
       valueParser(decl.value).walk(node => {
         if (isCssColorName(node.value) && !node.quote) {
           report({
+            result,
+            ruleName,
             message: messages.rejected(node.value),
             node: decl,
             index: declarationValueIndexOffset(decl) + node.sourceIndex,
-            result,
-            ruleName,
+            sourceCode: node.value,
+            primaryOption: actual,
           })
         }
       })


### PR DESCRIPTION
**Not to be merged as-is: right now just a proof of concept.**

Addresses #836 (and also the older #400).

What I've done here is modify the way custom messages work so that the custom message is interpreted as a lodash template, so you can interpolate key information from the warning object. 

(I went with lodash templates because we are already using lodash, and lodash templates are as flexible/extendable as anybody could possible want.)

My test-case message looks like this: `"Unacceptable! No \"<%= sourceCode %>\" allowed."`

In order to make that test-case work I modified color-no-named so that it reported the `sourceCode` and `primaryOption` of the violation.

We'd also include `secondaryOptions` when applicable. And I'm very open to a better name than `sourceCode` for that most important violation property — the string that triggered the violation.

This would enable people to really do whatever they want with custom messages. This would *also* enable people to build more powerful custom formatters, because they would have more information available in each warning object.

**HOWEVER**: If we want to do this, we will have to go through every rule and add information to the `report()` argument object. This could not be done with a codemod, unfortunately. Might take 30 seconds per rule ... with ~120 rules or something ... maybe an hour's worth of busywork. It would be *awesome* if anybody interested in improving the custom messages and formatters could help by modifying some rules accordingly, if we decide to follow through.

Pinging everyone involved in tickets about custom messages and formatters for feedback: @onigoetz, @kangax, @bluetidepro, @s10wen 