### PR TITLE
Add failing test for p-element following p-class

### DIFF
--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -18,6 +18,8 @@ testRule(true, tr => {
   tr.ok("b a {} @media print { a {} }")
   tr.ok("a {} a::after {}", "pseudo-element last")
   tr.ok("a {} a:hover {}", "pseudo-class last")
+  tr.ok("a:hover {} a::after {}", "pseudo-class and pseudo-element")
+  tr.ok("a::after {} a:hover {}", "pseudo-class and pseudo-element")
   tr.ok("a:hover {} a:hover::before {}")
   tr.ok(".m:hover {} .b {}")
   tr.ok(".menu:hover {} .burger {}")


### PR DESCRIPTION
Eeek, it looks like we’re got one more issue to iron out with `no-descending-specificity` before `4.5`.

It seems to mistakenly warns for puesdo-elements following puesdo-classes e.g. `a:hover {} a::after {}`.

Any ideas?