### PR TITLE
Remove color-no-indistinguishable; closes #891

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Head
 
+- Removed: `no-indistinguishable-colors` because its dependencies were unusable in Atom. (To be re-evaluated and re-added later.)
 - Added: support for overlapping `stylelint-disable` commands.
 - Fixed: `max-nesting-depth` does not warn about blockless at-rules.
-- Fixed: `no-indistinguishable-colors` no longer errors on color functions containing spaces e.g. `rgb(0, 0, 0)`.
 - Fixed: `function-comma-newline-after` and related rules consider input to be multi-line (applying to "always-multi-line", etc.) when the newlines are at the beginning or end of the input.
+- Fixed: `no-indistinguishable-colors` no longer errors on color functions containing spaces e.g. `rgb(0, 0, 0)` -- but also removed the rule (see above).
 
 # 4.5.1
 

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -78,7 +78,6 @@ You might want to learn a little about [the conventions](https://github.com/styl
     "no-descending-specificity": true,
     "no-duplicate-selectors": true,
     "no-eol-whitespace": true,
-    "no-indistinguishable-colors": true,
     "no-invalid-double-slash-comments": true,
     "no-missing-eof-newline": true,
     "no-unknown-animations": true,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -198,7 +198,6 @@ Don't forget to look at the list of [plugins](/docs/user-guide/plugins.md) for m
 - [`no-descending-specificity`](../../src/rules/no-descending-specificity/README.md): Disallow selectors of lower specificity from coming after overriding selectors of higher specificity.
 - [`no-duplicate-selectors`](../../src/rules/no-duplicate-selectors/README.md): Disallow duplicate selectors.
 - [`no-eol-whitespace`](../../src/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
-- [`no-indistinguishable-colors`](../../src/rules/no-indistinguishable-colors/README.md): Disallow colors that are suspiciously close to being identical.
 - [`no-invalid-double-slash-comments`](../../src/rules/no-invalid-double-slash-comments/README.md): Disallow double-slash comments (`//...`) which are not supported by CSS.
 - [`no-missing-eof-newline`](../../src/rules/no-missing-eof-newline/README.md): Disallow missing end-of-file newline.
 - [`no-unknown-animations`](../../src/rules/no-unknown-animations/README.md): Disallow animation names that do not correspond to a `@keyframes` declaration.

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -70,7 +70,7 @@ import noBrowserHacks from "./no-browser-hacks"
 import noDescendingSpecificity from "./no-descending-specificity"
 import noDuplicateSelectors from "./no-duplicate-selectors"
 import noEolWhitespace from "./no-eol-whitespace"
-import noIndistinguisableColors from "./no-indistinguishable-colors"
+// import noIndistinguisableColors from "./no-indistinguishable-colors"
 import noInvalidDoubleSlashComments from "./no-invalid-double-slash-comments"
 import noMissingEofNewline from "./no-missing-eof-newline"
 import noSupportedBrowserFeatures from "./no-unsupported-browser-features"
@@ -194,7 +194,7 @@ export default {
   "no-descending-specificity": noDescendingSpecificity,
   "no-duplicate-selectors": noDuplicateSelectors,
   "no-eol-whitespace": noEolWhitespace,
-  "no-indistinguishable-colors": noIndistinguisableColors,
+  // "no-indistinguishable-colors": noIndistinguisableColors,
   "no-invalid-double-slash-comments": noInvalidDoubleSlashComments,
   "no-missing-eof-newline": noMissingEofNewline,
   "no-unknown-animations": noUnknownAnimations,


### PR DESCRIPTION
I am not sure if we need a major release or not for this. I guess we are removing a feature, even if it's been buggy and short-lived.

Seems that if we are removing the feature, maybe we should cut 5.0 and thereby fix the postcss-reporter problems caused by the deprecation warnings (deprecations causing build failure). Next time we can figure out a better way to do those.

Of the significant possible changes on the horizon -- the more powerful custom messages and the test-engine-agnostic stylelint assert -- neither of those should introduce breaking changes. So I don't know of anything in the pipeline that would force us into another breaking change soon. 

Do you? Thoughts?