### PR TITLE
Remove trim from isSingleLineString and fix test bug; closes #893

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added: support for overlapping `stylelint-disable` commands.
 - Fixed: `max-nesting-depth` does not warn about blockless at-rules.
 - Fixed: `no-indistinguishable-colors` no longer errors on color functions containing spaces e.g. `rgb(0, 0, 0)`.
+- Fixed: `function-comma-newline-after` and related rules consider input to be multi-line (applying to "always-multi-line", etc.) when the newlines are at the beginning or end of the input.
 
 # 4.5.1
 

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -13,6 +13,7 @@ testRule("always", tr => {
   tr.ok("a::before { background: url('func(foo,bar,baz)'); }")
   tr.ok("a { background-size: 0,\n  0,\n  0; }")
   tr.ok("a { transform: translate(1 ,\n1); }")
+  tr.ok("a { transform: translate(\n  1,\n  1\n); }")
   tr.ok("a { transform: translate(1,\r\n1); }", "CRLF")
   tr.ok("a { transform: color(rgb(0 ,\n\t0,\n\t0) lightness(50%)); }")
   tr.ok("a { background: linear-gradient(45deg,\n rgba(0,\n 0,\n 0,\n 1),\n red); }")
@@ -51,6 +52,11 @@ testRule("always", tr => {
     message: messages.expectedAfter(),
     line: 3,
     column: 3,
+  })
+  tr.notOk("a { transform: translate(\n  1,1\n); }", {
+    message: messages.expectedAfter(),
+    line: 2,
+    column: 4,
   })
 })
 
@@ -106,6 +112,11 @@ testRule("always-multi-line", tr => {
     message: messages.expectedAfterMultiLine(),
     line: 1,
     column: 38,
+  })
+  tr.notOk("a { transform: translate(\n  1,1\n); }", {
+    message: messages.expectedAfterMultiLine(),
+    line: 2,
+    column: 4,
   })
 })
 

--- a/src/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/src/rules/no-unsupported-browser-features/__tests__/index.js
@@ -10,9 +10,8 @@ const testRule = ruleTester(rule, ruleName)
 // is working as expected: but that tool has its own tests.
 // The tests below are mostly copied from doiuse.
 //
-testRule(true,tr => {
+testRule(true, tr => {
   warningFreeBasics(tr)
-  tr.ok("a { opacity: 1; }")
 })
 
 testRule(true, { browsers: "last 2 versions" },tr => {

--- a/src/utils/__tests__/isSingleLineString-test.js
+++ b/src/utils/__tests__/isSingleLineString-test.js
@@ -9,8 +9,6 @@ bar`
 test("isSingleLineString", t => {
   t.ok(isSingleLineString("foo"))
   t.ok(isSingleLineString("foo bar"))
-  t.ok(isSingleLineString("\nfoo bar"), "ignores opening newline")
-  t.ok(isSingleLineString("foo bar\n"), "ignores closing newline")
   t.notOk(isSingleLineString("foo\nbar"))
   t.notOk(isSingleLineString("foo\rbar"))
   t.notOk(isSingleLineString(multiLineTemplate))

--- a/src/utils/isSingleLineString.js
+++ b/src/utils/isSingleLineString.js
@@ -1,13 +1,10 @@
 /**
- * Check if a *trimmed* string is a single line (i.e. does not contain
+ * Check if a string is a single line (i.e. does not contain
  * any newline characters).
- *
- * The fact that it's trimmed means that newline characters at the
- * beginning or end will be ignored.
  *
  * @param {string} input
  * @return {boolean}
  */
 export default function (input) {
-  return !/[\n\r]/.test(input.trim())
+  return !/[\n\r]/.test(input)
 }


### PR DESCRIPTION
`isSinglneLineString()` was trimming its input, and that caused the #893 bug. I do not remember why this was done --- and apparently it wasn't essential or its effect was poorly tested, because when I removed the trim all rule tests still passed. So I removed the trim to fix the bug.

I also had to fix another unrelated test to get the green light.