### PR TITLE
Use absolute plugin path in configs

### DIFF
--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -63,8 +63,8 @@ function augmentConfig(config, configDir) {
     return Promise.resolve(configWithAbsolutePlugins)
   }
 
-  const extendLookups = [].concat(config.extends)
-  const origConfig = omit(config, "extends")
+  const extendLookups = [].concat(configWithAbsolutePlugins.extends)
+  const origConfig = omit(configWithAbsolutePlugins, "extends")
   const resultPromise = extendLookups.reduce((mergeConfigs, extendLookup) => {
     return mergeConfigs.then(mergedConfig => {
       return loadExtendedConfig(mergedConfig, extendLookup).then(extendedConfig => {


### PR DESCRIPTION
There were some isntances where a plugin could be specified by name, and end up not being resolved as a later merge of extended configs would drop the fixed path.

I'm not sure of the best way to write a spec for this, as this will only show up when a module name is used for the plugin, where currently all the specs seem to test relative paths.

This was originally reported by @davidtheclark [over here](https://github.com/AtomLinter/linter-stylelint/issues/104), which provides a nice setup of how to expose this issue.