### PR TITLE
Remove declaration-block-no-single-line

### DIFF
--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -33,7 +33,6 @@ You might want to learn a little about [the conventions](https://github.com/styl
     "declaration-bang-space-before": "always"|"never",
     "declaration-block-no-duplicate-properties": true,
     "declaration-block-no-shorthand-property-overrides": true,
-    "declaration-block-no-single-line": true,
     "declaration-block-properties-order": "alphabetical"|[],
     "declaration-block-semicolon-newline-after": "always"|"always-multi-line"|"never-multi-line",
     "declaration-block-semicolon-newline-before": "always"|"always-multi-line"|"never-multi-line",


### PR DESCRIPTION
Just set up stylelint for work and got an error about this depreciated rule. Figured I'd submit a PR for anyone else who was looking for the comprehensive list of rules as they exist today.