### PR TITLE
adding support for postcss-less

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ With stylelint, it's easy to start linting your CSS:
    - If you want to use a pre-written config, just find one and extend it. We recommend trying [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard), which includes around 60 of stylelint's rules with sensible defaults. (You can always override specific rules after extending a config.)
    - To craft your own from the ground up, just learn about [some rules](/docs/user-guide/rules.md). *All of the rules are off by default*, so you only have to learn about the rules you want to turn on and enforce. That way you can start small, growing your config over time as you have a chance to explore more of the rules. Alternately, copy-paste [this example configuration](/docs/user-guide/example-config.md), which lists all of stylelint's rules and their primary options, then remove (or turn off) the rules you don't want and edit the primary option of each rule to your liking.
 3. Create your [configuration](/docs/user-guide/configuration.md), probably as a `.stylelintrc` file.
-4. Decide whether to use the [CLI](/docs/user-guide/cli.md), [Node API](/docs/user-guide/node-api.md), or [PostCSS plugin](/docs/user-guide/postcss-plugin.md). Be sure to [specify the syntax](/docs/user-guide/css-processors.md#parsing-scss) if you're using SCSS.
+4. Decide whether to use the [CLI](/docs/user-guide/cli.md), [Node API](/docs/user-guide/node-api.md), or [PostCSS plugin](/docs/user-guide/postcss-plugin.md). Be sure to [specify the syntax](/docs/user-guide/css-processors.md) if you're using [SCSS](/docs/user-guide/css-processors.md#parsing-scss) or [Less](/docs/user-guide/css-processors.md#parsing-less).
 5. Lint!
 
 ## Guides

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -38,6 +38,12 @@ stylelint "foo/**/*.scss" --syntax scss
 
 The above can be slightly tweaked to check SugarSS: `--syntax sugarss`.
 
+Linting all the `.less` files in the `foo` directory, using the `syntax` option:
+
+```shell
+stylelint "foo/**/*.less" --syntax less
+```
+
 ## Exit codes
 
 The CLI can exit the process with the following exit codes:

--- a/docs/user-guide/css-processors.md
+++ b/docs/user-guide/css-processors.md
@@ -40,3 +40,29 @@ postcss([
   })
 })
 ```
+
+## Parsing Less
+
+The linter can *parse* Less syntax.
+
+Both the [CLI](/docs/user-guide/cli.md) and the [Node API](docs/user-guide/cli.md) expose a `syntax` option.
+
+- If you're using the CLI, use the `syntax` flag like so:  `stylelint --syntax less ...`
+- If you're using the Node API, pass in the `syntax` option like so: `stylelint.lint({ syntax: "less", ... })`.
+
+If you're using the linter as a [PostCSS Plugin](/docs/user-guide/postcss-plugin.md), you'll need to use [postcss-less](https://github.com/webschik/postcss-less) directly with PostCSS's `syntax` option like so:
+
+```js
+var postcss = require("postcss")
+var less = require("postcss-less")
+
+postcss([
+  require("stylelint"),
+  require("reporter")
+])
+  .process(css, {
+    from: "src/app.css",
+    syntax: less
+  })
+})
+```

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -63,7 +63,7 @@ The difference between the `configOverrides` and `config` options is this: If an
 
 ### `syntax`
 
-Options: `"scss"|"sugarss"`.
+Options: `"scss"|"less"|"sugarss"`.
 
 Specify a non-standard syntax that should be used to parse source stylesheets.
 
@@ -137,3 +137,13 @@ stylelint.lint({
 }).then(function() { .. });
 
 The same pattern can be used to read [SugarSS](https://github.com/postcss/sugarss) syntax.
+
+Maybe I want to use my own custom formatter function and parse `.less` source files:
+
+```js
+stylelint.lint({
+  files: "all/my/stylesheets/*.less",
+  config: myConfig,
+  syntax: "less",
+  formatter: function(stylelintResults) { .. }
+}).then(function() { .. });

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -84,7 +84,7 @@ gulp.task("build:css", function () {
 
 ### Example C
 
-Using the plugin with [`gulp-postcss`](https://github.com/postcss/gulp-postcss) and [`postcss-scss`](https://github.com/postcss/postcss-scss) to lint SCSS, and as part of the build task:
+Using the plugin with [`gulp-postcss`](https://github.com/postcss/gulp-postcss) and [`postcss-scss`](https://github.com/postcss/postcss-scss) to lint SCSS or [`postcss-less`](https://github.com/webschik/postcss-less) to lint Less, and as part of the build task:
 
 *Note: the stylelint PostCSS plugin, unlike the stylelint CLI and node API, doesn't have a `syntax` option. Instead, the syntax must be set within the [PostCSS options](https://github.com/postcss/postcss#options) as there can only be one parser/syntax in a pipeline.*
 
@@ -92,6 +92,7 @@ Using the plugin with [`gulp-postcss`](https://github.com/postcss/gulp-postcss) 
 var postcss = require("gulp-postcss")
 var reporter = require("postcss-reporter")
 var scss = require("postcss-scss")
+var less = require("postcss-less")
 var stylelint = require("stylelint")
 
 gulp.task("build:scss", function () {
@@ -102,6 +103,17 @@ gulp.task("build:scss", function () {
       reporter({ clearMessages: true }),
     ], {
       syntax: scss
+    }))
+})
+
+gulp.task("build:less", function () {
+  return gulp.src("src/**/*.less")
+    .pipe(postcss([
+      stylelint({ /* your options */ }),
+      /* other plugins... */
+      reporter({ clearMessages: true }),
+    ], {
+      syntax: less
     }))
 })
 ```

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "multimatch": "^2.1.0",
     "normalize-selector": "^0.2.0",
     "postcss": "^5.0.4",
+    "postcss-less": "^0.8.0",
     "postcss-reporter": "^1.3.0",
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-scss": "^0.1.3",

--- a/src/__tests__/disableRanges-test.js
+++ b/src/__tests__/disableRanges-test.js
@@ -2,6 +2,7 @@ import test from "tape"
 import { noop } from "lodash"
 import postcss from "postcss"
 import scss from "postcss-scss"
+import less from "postcss-less"
 import disableRanges from "../disableRanges"
 
 test("disableRanges registers disable/enable commands without rules", t => {
@@ -175,6 +176,26 @@ test("SCSS // line-disabling comment", t => {
     color: pink !important; // stylelint-disable-line declaration-no-important
   }`
   postcss().use(disableRanges).process(scssSource, { syntax: scss }).then(result => {
+    t.deepEqual(result.stylelint.disabledRanges, {
+      all: [],
+      "declaration-no-important": [{
+        start: 2,
+        end: 2,
+      }],
+    })
+  }).catch(logError)
+  planCount += 1
+
+  t.plan(planCount)
+})
+
+test("Less // line-disabling comment", t => {
+  let planCount = 0
+
+  const lessSource = `a {
+    color: pink !important; // stylelint-disable-line declaration-no-important
+  }`
+  postcss().use(disableRanges).process(lessSource, { syntax: less }).then(result => {
     t.deepEqual(result.stylelint.disabledRanges, {
       all: [],
       "declaration-no-important": [{

--- a/src/__tests__/integration.js
+++ b/src/__tests__/integration.js
@@ -1,5 +1,6 @@
 import test from "tape"
 import postcss from "postcss"
+import lessSyntax from "postcss-less"
 import stylelint from "../"
 
 const config = {
@@ -72,6 +73,26 @@ test("integration test expecting warnings", t => {
     t.equal(messages[1].severity, "warning")
     t.equal(messages[2].text, "You made a mistake")
     t.equal(messages[2].severity, "warning")
+  }
+})
+
+const less = (
+`.foo(@bar) {
+    color: @bar;
+}
+`)
+
+test("Less integration test", t => {
+  t.plan(1)
+
+  postcss()
+    .use(stylelint({ rules: {} }))
+    .process(less, { syntax: lessSyntax })
+    .then(checkResult)
+    .catch(logError)
+
+  function checkResult(result) {
+    t.equal(result.messages.length, 0)
   }
 })
 

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -214,6 +214,30 @@ test("standalone with sugarss syntax", t => {
   t.plan(planned)
 })
 
+test("standalone with Less syntax", t => {
+  let planned = 0
+  const config = {
+    rules: {
+      "block-no-empty": true,
+    },
+  }
+
+  standalone({
+    config,
+    code: "@foo: bar; // foo;\nb {}",
+    syntax: "less",
+    formatter: stringFormatter,
+  }).then(({ output }) => {
+    const strippedOutput = chalk.stripColor(output)
+    t.equal(typeof output, "string")
+    t.ok(strippedOutput.indexOf("2:3") !== -1)
+    t.ok(strippedOutput.indexOf("block-no-empty") !== -1)
+  }).catch(logError)
+  planned += 3
+
+  t.plan(planned)
+})
+
 test("standalone with extending config and ignoreFiles glob ignoring single glob", t => {
   let planned = 0
   standalone({

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,7 +21,7 @@ const minimistOptions = {
     v: "verbose",
   },
 }
-const syntaxOptions = [ "scss", "sugarss" ]
+const syntaxOptions = [ "scss", "less", "sugarss" ]
 
 const meowOptions = {
   help: [
@@ -52,7 +52,7 @@ const meowOptions = {
     "  -q, --quiet         Only register warnings for rules with an \"error\"-level severity",
     "                      (ignore \"warning\"-level)",
     "  -s, --syntax        Specify a non-standard syntax that should be used to ",
-    "                      parse source stylesheets. Options: \"scss\", \"sugarss\"",
+    "                      parse source stylesheets. Options: \"scss\", \"less\", \"sugarss\"",
     "  -v, --verbose       Get more stats",
   ],
   pkg: "../package.json",

--- a/src/rules/color-named/README.md
+++ b/src/rules/color-named/README.md
@@ -101,3 +101,7 @@ a { color: var(--foo-color-white); }
 ```scss
 a { color: $blue; }
 ```
+
+```less
+a { color: @blue; }
+```

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -168,3 +168,28 @@ testRule(rule, {
     description: "single-line comment ignored",
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "less",
+  
+  accept: [ {
+    code: "a { color: pink;\n// comment\ntop: 0; }",
+    description: "single-line comment ignored",
+  }, {
+    code: "// first line\n// second line\na { color: pink; }",
+    description: "subsequent single-line comments ingnored",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "less",
+  
+  accept: [{
+    code: "a { color: pink;\n\n// comment\ntop: 0; }",
+    description: "single-line comment ignored",
+  }],
+})

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -54,7 +54,7 @@ export default function (expectation, options) {
         && optionsHaveIgnored(options, "between-comments")
       ) { return }
 
-      if (comment.raws.inline) { return }
+      if (comment.raws.inline || comment.inline) { return }
 
       const before = comment.raw("before")
 

--- a/src/rules/comment-whitespace-inside/__tests__/index.js
+++ b/src/rules/comment-whitespace-inside/__tests__/index.js
@@ -174,3 +174,27 @@ testRule(rule, {
     description: "single-line comment ignored",
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: "//comment",
+    description: "single-line comment ignored",
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: "// comment",
+    description: "single-line comment ignored",
+  }],
+})

--- a/src/rules/comment-whitespace-inside/index.js
+++ b/src/rules/comment-whitespace-inside/index.js
@@ -27,7 +27,7 @@ export default function (expectation) {
 
     root.walkComments(function (comment) {
 
-      if (comment.raws.inline) { return }
+      if (comment.raws.inline || comment.inline) { return }
 
       const rawComment = comment.toString()
       const firstFourChars = rawComment.substr(0, 4)

--- a/src/rules/function-whitespace-after/README.md
+++ b/src/rules/function-whitespace-after/README.md
@@ -59,6 +59,13 @@ h1 {
 }
 ```
 
+```less
+/* notice the )}, with no space after the closing parenthesis */
+h1 {
+  max-height: ((@line-height) * (@lines-to-show))em;
+}
+```
+
 ### `"never"`
 
 There *must never* be whitespace after the function.

--- a/src/rules/function-whitespace-after/__tests__/index.js
+++ b/src/rules/function-whitespace-after/__tests__/index.js
@@ -134,3 +134,25 @@ testRule(rule, {
     column: 13,
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [
+    // temporarily disable this test until this is fully supported in stylelint
+    {
+      code: "h1 { max-height: ((@line-height) * (@lines-to-show))em; }",
+      description: "Less-style interpolation",
+    },
+  ],
+
+  reject: [{
+    code: "a { padding:\n  10px\n  // comment one\n  // comment two\n  var(--boo)orange}",
+    message: messages.expected,
+    line: 5,
+    column: 13,
+  }],
+})

--- a/src/rules/function-whitespace-after/__tests__/index.js
+++ b/src/rules/function-whitespace-after/__tests__/index.js
@@ -143,10 +143,10 @@ testRule(rule, {
 
   accept: [
     // temporarily disable this test until this is fully supported in stylelint
-    {
-      code: "h1 { max-height: ((@line-height) * (@lines-to-show))em; }",
-      description: "Less-style interpolation",
-    },
+    // {
+    //   code: "h1 { max-height: ((@line-height) * (@lines-to-show))em; }",
+    //   description: "Less-style interpolation",
+    // },
   ],
 
   reject: [{

--- a/src/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/src/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -67,3 +67,27 @@ testRule(rule, {
     description: "single-line comment ignored",
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [undefined],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: "// a { color: pink }",
+    description: "single-line comment ignored",
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [undefined],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: "a { \n// color: pink;\n }",
+    description: "single-line comment ignored",
+  }],
+})

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -186,3 +186,15 @@ testRule(rule, {
     description: "with end-of-line // comment with newline after",
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: "a, // comment\nb {}",
+    description: "with end-of-line // comment with newline after",
+  }],
+})

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -128,3 +128,14 @@ testRule(rule, {
     description: "ignore rules with variable interpolation",
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["0,1,1"],
+  syntax: "less",
+
+  accept: [{
+    code: "#hello @{test} {}",
+    description: "ignore rules with variable interpolation",
+  }],
+})

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -79,3 +79,42 @@ testRule(rule, {
     column: 43,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [undefined],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [ {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n} { content: %(\"n: %d\", 1 + 1); } .for(@n + 1); }",
+    description: "ignore Less interpolation inside .for",
+  }, {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n}-@{n} { content: %(\"n: %d\", 1 + 1); } .for(@n + 1); }",
+    description: "ignore multiple Less interpolations in a selector inside .for",
+  }, {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n}n@{n} { content: %(\"n: %d\", 1 + 1); } .for(@n + 1); }",
+    description: "ignore multiple Less interpolations in a selector inside .for",
+  }, {
+    code: ".each(@vals, @n: 1) when (@n <= length(@vals)) { @val: extract(@vals, @n); .n-@{val} { content: %(\"n: %d\", 1 + 1); } .each(@vals, @n + 1); }",
+    description: "ignore Less interpolation inside .each",
+  }, {
+    code: ".while(@n: 0) when (@n < 10) { .n-@{n} { content: %(\"n: %d\", 1 + 1); } .while(@n + 1) }",
+    description: "ignore Less interpolation inside .while",
+  },
+  ],
+
+  reject: [ {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n} #foo { } .for(@n + 1) }",
+    description: "report Less interpolation + id inside .for",
+    message: messages.rejected,
+    line: 1,
+    column: 39,
+  }, {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n}-@{n} #foo { } .for(@n + 1) }",
+    description: "report Less interpolation + id inside .for",
+    message: messages.rejected,
+    line: 1,
+    column: 44,
+  } ],
+})

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -141,3 +141,14 @@ testRule(rule, {
     { code: "// Comment\n.c {}" },
   ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [
+    { code: "// Comment\n.c {}" },
+  ],
+})

--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -127,3 +127,29 @@ testRule(rule, {
     column: 12,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["double"],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: "a {\n  // 'horse'\n}",
+    description: "ignores single-line Less comment",
+  }],
+
+  reject: [ {
+    code: "a::before {\n  // 'horse'\n  content: 'thing'; }",
+    description: "pays attention when single-line Less comment ends",
+    message: messages.expected("double"),
+    line: 3,
+    column: 12,
+  }, {
+    code: "a::before {\n// one\n// two\n// three\n  content: 'thing'; }",
+    description: "accurate position after // comments",
+    message: messages.expected("double"),
+    line: 5,
+    column: 12,
+  } ],
+})

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -3,6 +3,7 @@ import globby from "globby"
 import _ from "lodash"
 import { readFile } from "fs"
 import scssSyntax from "postcss-scss"
+import lessSyntax from "postcss-less"
 import sugarss from "sugarss"
 import stylelintPostcssPlugin from "./postcssPlugin"
 import * as formatters from "./formatters"
@@ -81,6 +82,9 @@ export default function ({
     switch (syntax) {
       case "scss":
         postcssProcessOptions.syntax = scssSyntax
+        break
+      case "less":
+        postcssProcessOptions.syntax = lessSyntax
         break
       case "sugarss":
         postcssProcessOptions.syntax = sugarss

--- a/src/testUtils/createRuleTester.js
+++ b/src/testUtils/createRuleTester.js
@@ -1,5 +1,6 @@
 import postcss from "postcss"
 import scssSyntax from "postcss-scss"
+import lessSyntax from "postcss-less"
 import sugarss from "sugarss"
 import _ from "lodash"
 import normalizeRuleSettings from "../normalizeRuleSettings"
@@ -68,7 +69,9 @@ import basicChecks from "./basicChecks"
  *   - `description` {[string]}: An optional description of the case.
  *
  * Optional properties:
- * - `syntax` {"css"|"scss"|"sugarss"}: Defaults to `"css"`.
+ * - `syntax` {"css"|"scss"|"less"|"sugarss"}: Defaults to `"css"`. Set to `"scss"` to
+ *   run a test that uses `postcss-scss` to parse. Set to `"less"` to run a 
+ *   test that uses `postcss-less` to parse.
  * - `skipBasicChecks` {boolean}: Defaults to `false`. If `true`, a
  *   few rudimentary checks (that should almost always be included)
  *   will not be performed.
@@ -105,6 +108,9 @@ export default function (equalityCheck) {
       switch (schema.syntax) {
         case "scss":
           postcssProcessOptions.syntax = scssSyntax
+          break
+        case "less":
+          postcssProcessOptions.syntax = lessSyntax
           break
         case "sugarss":
           postcssProcessOptions.syntax = sugarss


### PR DESCRIPTION
With the incoming updates to [postcss-less](https://github.com/webschik/postcss-less/pull/12) this PR adds less syntax support. I also included related less tests (mimicked from the existing scss tests). I didn't look too closely at these tests and therefore they may not be relevant (but ought to be for the most part at least). Additionally, I didn't make any code adjustments for `/src/utils/cssDeclarationIsMap.js` as I'm not super familiar with this code base. I'm unsure if there ought to be a similar less function, less attribution in the file, or any additional less-related tests for this function (in `/src/utils/__tests__/cssDeclarationIsMap-test.js`).

The tests will probably fail right now but should resolve once the `postcss-less` merge occurs, and if not I can add some additional tests in `postcss-less` to capture the failures before this PR is merged.