### PR TITLE
Fix example documentation for selector-pseudo-element-colon-notation.

### DIFF
--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -109,7 +109,7 @@ You might want to learn a little about [the conventions](https://github.com/styl
     "selector-no-type": true,
     "selector-no-universal": true,
     "selector-no-vendor-prefix": true,
-    "selector-pseudo-element-colon-notation": true,
+    "selector-pseudo-element-colon-notation": "single"|"double",
     "selector-root-no-composition": true,
     "string-no-newline": true,
     "string-quotes": true,

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -112,7 +112,7 @@ You might want to learn a little about [the conventions](https://github.com/styl
     "selector-pseudo-element-colon-notation": "single"|"double",
     "selector-root-no-composition": true,
     "string-no-newline": true,
-    "string-quotes": true,
+    "string-quotes": "single"|"double",
     "time-no-imperceptible": true,
     "unit-blacklist": string|[],
     "unit-whitelist": string|[],


### PR DESCRIPTION
Resolves #927.