### PR TITLE
Add stylelint-webpack-plugin to the list of Complementary tools

### DIFF
--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -10,6 +10,7 @@
 
 - [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - A gulp plugin for stylelint.
 - [stylelint-loader](https://github.com/adrianhall/stylelint-loader) - A webpack loader for stylelint.
+- [stylelint-webpack-plugin](https://github.com/vieron/stylelint-webpack-plugin) - A webpack plugin for stylelint.
 
 ## Other linters & formatters
 


### PR DESCRIPTION
**stylelint-loader** lints the files you `require` or the ones you define as an `entry`  in your webpack config. But `@imports` in those files are not followed, so just the main file is linted (for each require/entry).

Instead, with **stylelint-webpack-plugin** you just define file globs, like stylelint does by default. So you get all your files linted.