### PR TITLE
Convert absolute documentation urls to relative urls

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -55,4 +55,4 @@ For testing your plugin, you might consider using the same rule-testing function
 
 ## Adding plugins to the list
 
-Once your plugin is published, please send us a Pull Request to add your plugin to [the list](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/plugins.md).
+Once your plugin is published, please send us a Pull Request to add your plugin to [the list](/docs/user-guide/plugins.md).

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -22,7 +22,7 @@ Once you have something to show, you'll create a [pull request](https://github.c
 
 ### Come up with a name
 
-Have a look at the [rules guide](/docs/user-guide/rules.md) to familiarize yourself the rule naming conventions. In particular, the section [about rule names](https://github.com/stylelint/stylelint/blob/contribution-docs/docs/user-guide/rules.md#about-rule-names).
+Have a look at the [rules guide](/docs/user-guide/rules.md) to familiarize yourself the rule naming conventions. In particular, the section [about rule names](/docs/user-guide/rules.md#about-rule-names).
 
 We take care to ensure that all the rules are named accurately and consistently. Our goals in that effort are to ensure that rules are easy to find and understand, and to prevent us from wanting to change the name later.
 
@@ -126,9 +126,9 @@ Take the form of:
 The final step is to add references to the new rule in the following places:
 
 - [The rules `index.js` file](https://github.com/stylelint/stylelint/blob/master/src/rules/index.js)
-- [The CHANGELOG](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md)
-- [The list of rules](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md)
-- [The example config](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/example-config.md)
+- [The CHANGELOG](/CHANGELOG.md)
+- [The list of rules](/docs/user-guide/rules.md)
+- [The example config](/docs/user-guide/example-config.md)
 
 ## Adding options to existing rules
 

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -1,8 +1,8 @@
 # Example config
 
-This example config lists all of the [rules](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md) and their primary options. You can remove ([or turn off](http://stylelint.io/user-guide/configuration/#configuring-rules)) the rules you don't want and edit the primary option of each rule to your liking.
+This example config lists all of the [rules](/docs/user-guide/rules.md) and their primary options. You can remove ([or turn off](./configuration.md#configuring-rules)) the rules you don't want and edit the primary option of each rule to your liking.
 
-You might want to learn a little about [the conventions](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md#about-rule-names) the rule names follow, to get a better idea of what each rule does.
+You might want to learn a little about [the conventions](/docs/user-guide/rules.md#about-rule-names) the rule names follow, to get a better idea of what each rule does.
 
 ```json
 {


### PR DESCRIPTION
Fixes #944

I used the regex `/stylelint/stylelint((\/[\w\-]+)*)\.md` to find urls that needed updating.