### PR TITLE
Ignore color names in URLs in no-indistinguishable-colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "autoprefixer": "^6.0.0",
     "balanced-match": "^0.4.0",
     "chalk": "^1.1.1",
-    "colorguard": "^1.1.1",
+    "colorguard": "^1.2.0",
     "cosmiconfig": "^1.1.0",
     "doiuse": "^2.3.0",
     "execall": "^1.0.0",

--- a/src/rules/no-indistinguishable-colors/__tests__/index.js
+++ b/src/rules/no-indistinguishable-colors/__tests__/index.js
@@ -6,9 +6,11 @@ testRule(rule, {
   ruleName,
   config: [true],
 
-  accept: [{
+  accept: [ {
     code: "a { color: #fff; } b { color: #000; }",
-  }],
+  }, {
+    code: "a {\n  background-image: url(../images/white.png);\n  color: #fff;\n}",
+  } ],
 
   reject: [ {
     code: "h1 {\n  color: black;\n  color: #010101;\n}",


### PR DESCRIPTION
Ref #970 