### PR TITLE
Support comments before hierarchical selectors in indentation

### DIFF
--- a/src/rules/indentation/__tests__/hierarchical.js
+++ b/src/rules/indentation/__tests__/hierarchical.js
@@ -97,6 +97,15 @@ testRule(rule, {
     "  .r-Grid-cell {\n" +
     "    text-align: center;\n" +
     "  }",
+  }, {
+    code: ".foo {}\n" +
+    "  /* Comment */\n" +
+    "  .foo-one {}\n",
+    description: "comment hierarchy",
+  }, {
+    code: ".foo {}\n" +
+    "  /* Comment */\n",
+    description: "comment hierarchy",
   } ],
 
   reject: [ {


### PR DESCRIPTION
These tests should help to track down the issue mentioned in #940 .

The rule itself looks quite gnarly, so I don't have any insights on how to fix the bug. Additional help is welcome.