### PR TITLE
Cleanup max-line-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed: `selector-id-pattern` now ignores selectors with Sass interpolation.
 - Fixed: `selector-class-pattern` now ignores selectors with Sass interpolation.
 - Fixed: `no-unknown-animations` now ignores `none`, `initial`, `inherit`, `unset` values.
+- Fixed: `max-line-length` options validation.
 
 # 5.2.1
 

--- a/src/rules/max-line-length/__tests__/index.js
+++ b/src/rules/max-line-length/__tests__/index.js
@@ -4,7 +4,7 @@ import rule, { ruleName, messages } from ".."
 
 testRule(rule, {
   ruleName,
-  config: ["20"],
+  config: [20],
 
   accept: [ {
     code: "a { color: 0; }",
@@ -55,7 +55,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: ["30"],
+  config: [30],
 
   accept: [{
     code: "a { color: 0;\n  top: 0; left: 0; right: 0; \n  bottom: 0; }",
@@ -71,7 +71,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [ "20", { ignore: "non-comments" } ],
+  config: [ 20, { ignore: "non-comments" } ],
 
   accept: [ {
     code: "a { color: 0; top: 0; bottom: 0; }",


### PR DESCRIPTION
I ran across some weird stuff in this rule, including completely faulty options validation, so I thought I'd fix it up a little.