### PR TITLE
Newlines for function-calc-no-unspaced-operator; closes #857

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed: `selector-class-pattern` now ignores selectors with Sass interpolation.
 - Fixed: `no-unknown-animations` now ignores `none`, `initial`, `inherit`, `unset` values.
 - Fixed: `max-line-length` options validation.
+- Fixed: `function-calc-no-unspaced-operator` accepts newlines.
 
 # 5.2.1
 

--- a/src/rules/function-calc-no-unspaced-operator/README.md
+++ b/src/rules/function-calc-no-unspaced-operator/README.md
@@ -8,6 +8,8 @@ a { top: calc(1px + 2px); }
  * The space around this operator */
 ```
 
+Before the operator, there must be a single whitespace or a newline plus indentation. After the operator, there must be a single whitespace or a newline.
+
 The following patterns are considered warnings:
 
 ```css
@@ -26,4 +28,14 @@ a { top: calc(1px + 2px); }
 
 ```css
 a { top: calc(calc(1em * 2) / 3); }
+```
+
+```css
+margin-top: calc(var(--some-variable) +
+  var(--some-other-variable));
+```
+
+```css
+margin-top: calc(var(--some-variable)
+  + var(--some-other-variable));
 ```

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -69,14 +69,26 @@ testRule(rule, {
     code: "margin-top: calc(var(--some-variable) +\n  var(--some-other-variable));",
     description: "newline and spaces after operator",
   }, {
+    code: "margin-top: calc(var(--some-variable) +\r\n  var(--some-other-variable));",
+    description: "CRLF newline and spaces after operator",
+  }, {
     code: "margin-top: calc(var(--some-variable) +\n\tvar(--some-other-variable));",
     description: "newline and tab after operator",
+  }, {
+    code: "margin-top: calc(var(--some-variable) +\r\n\tvar(--some-other-variable));",
+    description: "CRLF newline and tab after operator",
   }, {
     code: "margin-top: calc(var(--some-variable)\n  + var(--some-other-variable));",
     description: "newline and spaces before operator",
   }, {
+    code: "margin-top: calc(var(--some-variable)\r\n  + var(--some-other-variable));",
+    description: "CRLF newline and spaces before operator",
+  }, {
     code: "margin-top: calc(var(--some-variable)\n\t+ var(--some-other-variable));",
     description: "newline and tab before operator",
+  }, {
+    code: "margin-top: calc(var(--some-variable)\r\n\t+ var(--some-other-variable));",
+    description: "CRLF newline and tab before operator",
   } ],
 
   reject: [ {

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -65,6 +65,18 @@ testRule(rule, {
   }, {
     code: "a { padding: rem-calc(10px+ 10px) rem-calc(10px+ 10px); }",
     description: "ignore function have calc in name",
+  }, {
+    code: "margin-top: calc(var(--some-variable) +\n  var(--some-other-variable));",
+    description: "newline and spaces after operator",
+  }, {
+    code: "margin-top: calc(var(--some-variable) +\n\tvar(--some-other-variable));",
+    description: "newline and tab after operator",
+  }, {
+    code: "margin-top: calc(var(--some-variable)\n  + var(--some-other-variable));",
+    description: "newline and spaces before operator",
+  }, {
+    code: "margin-top: calc(var(--some-variable)\n\t+ var(--some-other-variable));",
+    description: "newline and tab before operator",
   } ],
 
   reject: [ {


### PR DESCRIPTION
Tried to explain what I did in the readme.

Any objections to a release after this is merged? I noticed that the changelog includes a lot of things.