### PR TITLE
Identify and ignore keyframe rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed: `max-line-length` options validation.
 - Fixed: `function-calc-no-unspaced-operator` accepts newlines.
 - Fixed: `block-closing-brace-newline-after` accepts single-line comments immediately after the closing brace.
+- Fixed: `selector-no-id` now ignores keyframe selectors.
 
 # 5.2.1
 

--- a/src/rules/no-duplicate-selectors/index.js
+++ b/src/rules/no-duplicate-selectors/index.js
@@ -3,6 +3,7 @@ import resolvedNestedSelector from "postcss-resolve-nested-selector"
 import normalizeSelector from "normalize-selector"
 import {
   cssNodeContextLookup,
+  cssRuleIsKeyframe,
   findAtRuleContext,
   ruleMessages,
   report,
@@ -28,8 +29,7 @@ export default function (actual) {
 
     root.walkRules(rule => {
 
-      // Return early if the rule contains a keyframe selector
-      if (rule.parent.type === "atrule" && rule.parent.name === "keyframes") { return }
+      if (cssRuleIsKeyframe(rule)) { return }
 
       const contextSelectorSet = selectorContextLookup.getContext(rule, findAtRuleContext(rule))
       const resolvedSelectors = rule.selectors.reduce((result, selector) => {

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -46,6 +46,8 @@ testRule(rule, {
   syntax: "scss",
 
   accept: [ {
+    code: "@keyframes spin { #{50% - $n} {} }",
+  }, {
     code: "@for $n from 1 through 10 { .n-#{$n} { content: \"n: #{1 + 1}\"; } }",
     description: "ignore sass interpolation inside @for",
   }, {

--- a/src/rules/selector-no-id/index.js
+++ b/src/rules/selector-no-id/index.js
@@ -1,6 +1,7 @@
 import selectorParser from "postcss-selector-parser"
 import {
   cssRuleHasSelectorEndingWithColon,
+  cssRuleIsKeyframe,
   report,
   ruleMessages,
   validateOptions,
@@ -18,7 +19,10 @@ export default function (actual) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
-      if (cssRuleHasSelectorEndingWithColon(rule)) { return }
+      if (
+        cssRuleHasSelectorEndingWithColon(rule)
+        || cssRuleIsKeyframe(rule)
+      ) { return }
       selectorParser(selectorAST => {
         selectorAST.eachId(idNode => {
           // Ignore Sass intepolation possibilities

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -2,6 +2,7 @@ import selectorParser from "postcss-selector-parser"
 import { get } from "lodash"
 import {
   cssRuleHasSelectorEndingWithColon,
+  cssRuleIsKeyframe,
   optionsHaveIgnored,
   report,
   ruleMessages,
@@ -26,12 +27,11 @@ export default function (on, options) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
-      // Ignore keyframe selectors
-      if (rule.parent.type === "atrule" && rule.parent.name === "keyframes") {
-        return
-      }
 
-      if (cssRuleHasSelectorEndingWithColon(rule)) { return }
+      if (
+        cssRuleHasSelectorEndingWithColon(rule)
+        || cssRuleIsKeyframe(rule)
+      ) { return }
 
       selectorParser(checkSelector).process(rule.selector)
 

--- a/src/rules/selector-type-case/index.js
+++ b/src/rules/selector-type-case/index.js
@@ -1,6 +1,7 @@
 import selectorParser from "postcss-selector-parser"
 import {
   cssRuleHasSelectorEndingWithColon,
+  cssRuleIsKeyframe,
   report,
   ruleMessages,
   validateOptions,
@@ -24,12 +25,11 @@ export default function (expectation) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
-      // Ignore keyframe selectors
-      if (rule.parent.type === "atrule" && rule.parent.name === "keyframes") {
-        return
-      }
 
-      if (cssRuleHasSelectorEndingWithColon(rule)) { return }
+      if (
+        cssRuleHasSelectorEndingWithColon(rule)
+        || cssRuleIsKeyframe(rule)
+      ) { return }
 
       function checkSelector(selectorAST) {
         selectorAST.eachTag(tag => {
@@ -44,7 +44,7 @@ export default function (expectation) {
             return
           }
 
-          // & is not a type selector: it's used for nesting 
+          // & is not a type selector: it's used for nesting
           if (value[0] === "&") { return }
 
           const expectedValue = expectation === "lower" ? value.toLowerCase() : value.toUpperCase()
@@ -60,7 +60,7 @@ export default function (expectation) {
           })
         })
       }
-      
+
       selectorParser(checkSelector).process(rule.selector)
     })
   }

--- a/src/utils/__tests__/cssRuleIsKeyframe-test.js
+++ b/src/utils/__tests__/cssRuleIsKeyframe-test.js
@@ -1,0 +1,36 @@
+import cssRuleIsKeyframe from "../cssRuleIsKeyframe"
+import postcss from "postcss"
+import test from "tape"
+
+test("cssRuleIsKeyframe", t => {
+  postcssOkCheck(t, "@keyframes identifier { to {} }", "to")
+  postcssOkCheck(t, "@keyframes identifier { from {} }", "from")
+  postcssOkCheck(t, "@keyframes identifier { 50% {} }", "percentage")
+
+  postcssNotOkCheck(t, "a {}", "rule")
+  postcssNotOkCheck(t, "a { & b {} }", "direct nested rule")
+  postcssNotOkCheck(t, "a { @nest b & {} }", "@nest nested rule")
+  postcssNotOkCheck(t, "@media print { a {} }", "@media")
+  postcssNotOkCheck(t, "@supports (animation-name: test) { a {} }", "@supports")
+  postcssNotOkCheck(t, "@document url(http://www.w3.org/) { a {} }", "@document")
+  postcssNotOkCheck(t, "@page :pseudo-class { a {} }", "page")
+  postcssNotOkCheck(t, "@font-face { src: url(x.woff) }", "font-face")
+
+  t.end()
+})
+
+function postcssOkCheck(t, css, desc) {
+  postcss().process(css).then(result => {
+    result.root.walkRules(rule => {
+      t.ok(cssRuleIsKeyframe(rule), desc)
+    })
+  })
+}
+
+function postcssNotOkCheck(t, css, desc) {
+  postcss().process(css).then(result => {
+    result.root.walkRules(rule => {
+      t.notOk(cssRuleIsKeyframe(rule), desc)
+    })
+  })
+}

--- a/src/utils/__tests__/cssRuleIsKeyframe-test.js
+++ b/src/utils/__tests__/cssRuleIsKeyframe-test.js
@@ -3,34 +3,38 @@ import postcss from "postcss"
 import test from "tape"
 
 test("cssRuleIsKeyframe", t => {
-  postcssOkCheck(t, "@keyframes identifier { to {} }", "to")
-  postcssOkCheck(t, "@keyframes identifier { from {} }", "from")
-  postcssOkCheck(t, "@keyframes identifier { 50% {} }", "percentage")
 
-  postcssNotOkCheck(t, "a {}", "rule")
-  postcssNotOkCheck(t, "a { & b {} }", "direct nested rule")
-  postcssNotOkCheck(t, "a { @nest b & {} }", "@nest nested rule")
-  postcssNotOkCheck(t, "@media print { a {} }", "@media")
-  postcssNotOkCheck(t, "@supports (animation-name: test) { a {} }", "@supports")
-  postcssNotOkCheck(t, "@document url(http://www.w3.org/) { a {} }", "@document")
-  postcssNotOkCheck(t, "@page :pseudo-class { a {} }", "page")
-  postcssNotOkCheck(t, "@font-face { src: url(x.woff) }", "font-face")
+  t.plan(9)
 
-  t.end()
+  rules("@keyframes identifier { to {} }", rule => {
+    t.ok(cssRuleIsKeyframe(rule), "to")
+  })
+  rules("@keyframes identifier { from {} }", rule => {
+    t.ok(cssRuleIsKeyframe(rule), "from")
+  })
+  rules("@keyframes identifier { 50% {} }", rule => {
+    t.ok(cssRuleIsKeyframe(rule), "50%")
+  })
+
+  rules("a {}", rule => {
+    t.notOk(cssRuleIsKeyframe(rule), "rule")
+  })
+  rules("a { & b {} }", rule => {
+    t.notOk(cssRuleIsKeyframe(rule), "rule and direct nested rule")
+  })
+  rules("a { @nest b & {} }", rule => {
+    t.notOk(cssRuleIsKeyframe(rule), "@nest nested rule")
+  })
+  rules("@media print { a {} }", rule => {
+    t.notOk(cssRuleIsKeyframe(rule), "@media")
+  })
+  rules("@supports (animation-name: test) { a {} }", rule => {
+    t.notOk(cssRuleIsKeyframe(rule), "@supports")
+  })
 })
 
-function postcssOkCheck(t, css, desc) {
+function rules(css, cb) {
   postcss().process(css).then(result => {
-    result.root.walkRules(rule => {
-      t.ok(cssRuleIsKeyframe(rule), desc)
-    })
-  })
-}
-
-function postcssNotOkCheck(t, css, desc) {
-  postcss().process(css).then(result => {
-    result.root.walkRules(rule => {
-      t.notOk(cssRuleIsKeyframe(rule), desc)
-    })
+    result.root.walkRules(cb)
   })
 }

--- a/src/utils/cssRuleIsKeyframe.js
+++ b/src/utils/cssRuleIsKeyframe.js
@@ -1,0 +1,13 @@
+/**
+ * Check if a rule is a keyframe one
+ *
+ * @param {Rule} rule - postcss rule node
+ * @return {boolean} True if the rule is a keyframe one
+ */
+export default function (rule) {
+  const { parent } = rule
+  return (
+    parent.type === "atrule"
+    && parent.name === "keyframes"
+  )
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,6 +8,7 @@ export { default as cssRuleHasSelectorEndingWithColon } from "./cssRuleHasSelect
 export { default as cssStatementBlockString } from "./cssStatementBlockString"
 export { default as cssStatementHasBlock } from "./cssStatementHasBlock"
 export { default as cssStatementHasEmptyBlock } from "./cssStatementHasEmptyBlock"
+export { default as cssRuleIsKeyframe } from "./cssRuleIsKeyframe"
 export { default as cssStatementStringBeforeBlock } from "./cssStatementStringBeforeBlock"
 export { default as cssWordIsVariable } from "./cssWordIsVariable"
 export { default as declarationValueIndexOffset } from "./declarationValueIndexOffset"


### PR DESCRIPTION
Closes #1005.

The structure of the test file for `cssRuleIsKeyframe` doesn’t feel right. Is there a neater way of structuring the tests when we need to use PostCSS’s `walkRules`?