### PR TITLE
Only test node 5 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,7 @@
 environment:
   matrix:
     - nodejs_version: 5
-    - nodejs_version: 4
-    - nodejs_version: 0.12
-    
+
 version: "{build}"
 build: off
 deploy: off


### PR DESCRIPTION
Keeping it already as a safety net, but speeding up pull request green lights.