### PR TITLE
Report CssSyntaxError alongside stylelint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `consecutive-duplicates` option for `declaration-block-no-duplicate-properties` rule.
 - Fixed: `block-no-empty` no longer delivers false positives for less syntax.
+- Fixed: `CssSyntaxError` is no longer thrown but reported alongside warnings.
 
 # 5.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Head
 
+- Changed: `CssSyntaxError` is no longer thrown but reported alongside warnings.
 - Added: `consecutive-duplicates` option for `declaration-block-no-duplicate-properties` rule.
 - Fixed: `block-no-empty` no longer delivers false positives for less syntax.
-- Fixed: `CssSyntaxError` is no longer thrown but reported alongside warnings.
 
 # 5.4.0
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -38,6 +38,12 @@ stylelint "foo/**/*.scss" --syntax scss
 
 The above can be slightly altered to read Less or SugarSS syntax: `--syntax less`, `--syntax sugarss`.
 
+## Syntax errors
+
+The CLI informs you about syntax errors in your CSS.
+It uses the same format as it uses for linting warnings.
+The error name is `CssSyntaxError`.
+
 ## Exit codes
 
 The CLI can exit the process with the following exit codes:

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -87,6 +87,11 @@ An array containing all the [PostCSS LazyResults](https://github.com/postcss/pos
 
 An array containing all the stylelint result objects (the objects that formatters consume).
 
+## Syntax errors
+
+`stylelint.lint()` does not reject the Promise when your CSS contains syntax errors. 
+It resolves with an object (see [The returned promise](#the-returned-promise)) that contains information about the syntax error.
+
 ## Usage examples
 
 If `myConfig` contains no relative paths for `extends` or `plugins`, I do not have to use `configBasedir`:

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -395,6 +395,41 @@ test("standalone using codeFilename and ignoreFiles with configBasedir", t => {
   t.plan(1)
 })
 
+test("standalone passing code with syntax error", t => {
+  standalone({
+    code: "a { color: 'red; }",
+  }).then(({ output }) => {
+    const parsedOutput = JSON.parse(output)[0]
+    t.equal(parsedOutput.source, "<input css 1>", "<input css 1> as source")
+    t.equal(parsedOutput.deprecations.length, 0, "empty deprecations")
+    t.equal(parsedOutput.invalidOptionWarnings.length, 0,
+            "empty invalidOptionWarnings")
+    t.ok(parsedOutput.errored, "errored true")
+    t.equal(parsedOutput.warnings.length, 1, "syntax error in warnings")
+    t.equal(parsedOutput.warnings[0].rule, "CssSyntaxError",
+            "syntax error rule is CssSyntaxError")
+    t.equal(parsedOutput.warnings[0].severity, "error",
+            "syntax error severity is error")
+    t.ok(parsedOutput.warnings[0].text.indexOf(" (CssSyntaxError)" !== -1),
+         "(CssSyntaxError) in warning text")
+  }).catch(logError)
+
+  t.plan(8)
+})
+
+test("standalone passing file with syntax error", t => {
+  standalone({
+    code: "a { color: 'red; }",
+    codeFilename: path.join(__dirname, "syntax-error.css"),
+  }).then(({ output }) => {
+    const parsedOutput = JSON.parse(output)[0]
+    t.ok(parsedOutput.source.indexOf("syntax-error.css") !== -1,
+         "filename as source")
+  }).catch(logError)
+
+  t.plan(1)
+})
+
 function logError(err) {
   console.log(err.stack) // eslint-disable-line no-console
 }

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -100,6 +100,7 @@ export default function ({
       }))
       .process(code, postcssProcessOptions)
       .then(handleResult)
+      .catch(cssSyntaxError)
 
     function handleResult(postcssResult) {
       const source = (!postcssResult.root.source)
@@ -133,6 +134,24 @@ export default function ({
           severity: message.severity,
           text: message.text,
         })),
+      }
+    }
+
+    function cssSyntaxError(error) {
+      if (error.name !== "CssSyntaxError") { throw error }
+
+      return {
+        source: error.file || "<input css 1>",
+        deprecations: [],
+        invalidOptionWarnings: [],
+        errored: true,
+        warnings: [{
+          line: error.line,
+          column: error.column,
+          rule: error.name,
+          severity: "error",
+          text: error.reason + " (" + error.name + ")",
+        }],
       }
     }
   }


### PR DESCRIPTION
stylelint would throw the postcss `CssSyntaxError` whenever a given code
(file) contained a syntax error. Since it rather is a problem in the
users CSS it makes sense to display this error alongside stylelint
warnings (with line and column information). This should also improve
third party IDE integrations where code is usually checked while typing,
which makes syntax errors more likely.

This code just catches a `CssSyntaxError` and translates it into a stylelint warning.
A typical `CssSyntaxError` object would look like this:

``` JavaScript
CssSyntaxError 
{
  name: 'CssSyntaxError',
  reason: 'Reason',
  file: '/path/syntax-error.css', // only defined when called with a file
  source: 'a { color: \'red; }',
  line: 2,
  column: 12,
  message: '/path/syntax-error.css:2:12: Reason',
  input: { 
    line: 2,
    column: 12,
    source: 'a { color: \'red; }',
    file: '/path/syntax-error.css'
  }
}
```

Let me know if you have any questions. Should I document this anywhere? If yes, where? :blush: 

Fixes #883 