### PR TITLE
`declaration-block-no-ignored-properties` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 - Added: `unit-no-unknown` rule.
+- Fixed: `declaration-block-no-ignored-properties` now ignore `clear` for `position: absolute` and `position: relative` and not ignore `float` on `display: table-*`
 
 # 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Head
 
 - Added: `unit-no-unknown` rule.
-- Fixed: `declaration-block-no-ignored-properties` now ignore `clear` for `position: absolute` and `position: relative` and not ignore `float` on `display: table-*`
+- Fixed: `declaration-block-no-ignored-properties` now ignore `clear` for `position: absolute` and `position: relative` and does not ignore `float` on `display: table-*`.
 
 # 5.3.0
 

--- a/src/rules/declaration-block-no-ignored-properties/__test__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__test__/index.js
@@ -189,8 +189,20 @@ testRule(rule, {
     column: 25,
     description: "position: absolute rules out float",
   }, {
+    code: "a { position: absolute; clear: left; }",
+    message: messages.rejected("clear", "position: absolute"),
+    line: 1,
+    column: 25,
+    description: "position: absolute rules out clear",
+  }, {
     code: "a { position: fixed; float: left; }",
     message: messages.rejected("float", "position: fixed"),
+    line: 1,
+    column: 22,
+    description: "position: absolute rules out float",
+  }, {
+    code: "a { position: fixed; clear: left; }",
+    message: messages.rejected("clear", "position: fixed"),
     line: 1,
     column: 22,
     description: "position: absolute rules out float",

--- a/src/rules/declaration-block-no-ignored-properties/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/index.js
@@ -44,7 +44,6 @@ const ignored = [ {
     "margin-right",
     "margin-bottom",
     "margin-left",
-    "float",
   ],
 }, {
   property: "position",
@@ -60,12 +59,14 @@ const ignored = [ {
   value: "absolute",
   ignoredProperties: [
     "float",
+    "clear",
   ],
 }, {
   property: "position",
   value: "fixed",
   ignoredProperties: [
     "float",
+    "clear",
   ],
 } ]
 


### PR DESCRIPTION
`declaration-block-no-ignored-properties` now ignore `clear` for `position: absolute` and `position: relative` and not ignore `float` on `display: table-*`