### PR TITLE
Fix no-descending-specificity bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 - Added: `unit-no-unknown` rule.
+- Fixed: `no-descending-specificity` no longer gets confused when the last part of a selector is a compound selector.
 
 # 5.3.0
 

--- a/src/rules/no-descending-specificity/README.md
+++ b/src/rules/no-descending-specificity/README.md
@@ -14,7 +14,7 @@ The clashes of these two mechanisms for prioritization, source order and specifi
 
 This rule enforces that practice *as best it can*. (It cannot catch every actual overriding selector (because it does not know the DOM structure, for one), but it can catch certain common mistakes.)
 
-Here's how it works: This rule looks at the last *compound selector* in every full selector, and then compares it with other selectors in the stylesheet that end in the same way.
+Here's how it works: **This rule looks at the last *compound selector* in every full selector, and then compares it with other selectors in the stylesheet that end in the same way.**
 
 So `.foo .bar` (whose last compound selector is `.bar`) will be compared to `.bar` and `#baz .bar`, but not to `#baz .foo` or `.bar .foo`.
 

--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -33,6 +33,8 @@ testRule(rule, {
     code: ".m:hover {} .b {}",
   }, {
     code: ".menu:hover {} .burger {}",
+  }, {
+    code: ".foo.bar, .foo.bar:focus { @mixin: foo; } .baz.bar, .baz.bar:focus {}",
   } ],
 
   reject: [ {

--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -40,7 +40,7 @@ export default function (actual) {
 
     function checkSelector(selectorNode, rule, sourceIndex, comparisonContext) {
       const selector = selectorNode.toString()
-      const lastNonPseudoSelectorNode = getLastNonPseudoSelectorNode(selectorNode)
+      const lastNonPseudoSelectorNode = lastCompoundSelectorWithoutPseudo(selectorNode)
       const selectorSpecificity = calculate(selector)[0].specificity.split(",")
       const entry = { selector, specificity: selectorSpecificity }
 
@@ -68,12 +68,14 @@ export default function (actual) {
   }
 }
 
-function getLastNonPseudoSelectorNode(selectorNode) {
-  let s = _.last(selectorNode.nodes[0].nodes)
-  while (s.type === "pseudo") {
-    const prev = s.prev()
-    if (!prev) { return s.toString() }
-    s = s.prev()
-  }
-  return s.toString()
+function lastCompoundSelectorWithoutPseudo(selectorNode) {
+  const nodesAfterLastCombinator = _.last(selectorNode.nodes[0].split(node => {
+    return node.type === "combinator"
+  }))
+
+  const nodesWithoutPseudos = nodesAfterLastCombinator.filter(node => {
+    return node.type !== "pseudo"
+  })
+
+  return nodesWithoutPseudos.toString()
 }

--- a/src/testUtils/createRuleTester.js
+++ b/src/testUtils/createRuleTester.js
@@ -149,7 +149,6 @@ export default function (equalityCheck) {
           comparisonCount: 1,
           caseDescription: createCaseDescription(acceptedCase.code),
           completeAssertionDescription: assertionDescription,
-          only: acceptedCase.only,
         })
       })
     }


### PR DESCRIPTION
Ran into this bug while trying to use this rule on my codebase.

I think the intention was right to isolate the last compound selector and strip it of pseudos, but the logic was wrong.