### PR TITLE
[option] Add consecutive-duplicates option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Added: `consecutive-duplicates` option for `declaration-block-no-duplicate-properties` rule.
+
 # 5.4.0
 
 - Added: `unit-no-unknown` rule.
@@ -13,7 +17,6 @@
 - Added: `function-max-empty-lines` rule.
 - Added: `declaration-block-no-ignored-properties` rule.
 - Added: `function-url-data-uris` rule.
-- Added: `consecutive-duplicates` option for `declaration-block-no-duplicate-properties` rule.
 - Fixed: `block-closing-brace-newline-after` use of "single space", rather than "newline", in its messages.
 - Fixed: `function-comma-space-after`, `function-comma-space-before`, `function-parentheses-newline-inside` and `function-parentheses-space-inside` now ignore SCSS maps.
 - Fixed: `property-value-blacklist` and `-whitelist` no longer error on properties without a corresponding list entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added: `function-max-empty-lines` rule.
 - Added: `declaration-block-no-ignored-properties` rule.
 - Added: `function-url-data-uris` rule.
+- Added: `consecutive-duplicates` option for `declaration-block-no-duplicate-properties` rule.
 - Fixed: `block-closing-brace-newline-after` use of "single space", rather than "newline", in its messages.
 - Fixed: `function-comma-space-after`, `function-comma-space-before`, `function-parentheses-newline-inside` and `function-parentheses-space-inside` now ignore SCSS maps.
 - Fixed: `property-value-blacklist` and `-whitelist` no longer error on properties without a corresponding list entry.

--- a/src/rules/declaration-block-no-duplicate-properties/README.md
+++ b/src/rules/declaration-block-no-duplicate-properties/README.md
@@ -54,5 +54,6 @@ The following patterns are *not* considered warnings:
 p {
   font-size: 16px;
   font-size: 1rem;
+  font-weight: 400;
 }
 ```

--- a/src/rules/declaration-block-no-duplicate-properties/README.md
+++ b/src/rules/declaration-block-no-duplicate-properties/README.md
@@ -29,3 +29,30 @@ a { color: pink; }
 ```css
 a { color: pink; background: orange; }
 ```
+
+## Options
+
+### `ignore: ["consecutive-duplicates"]`
+
+Ignore consecutive duplicated properties.
+
+They can prove to be useful fallbacks for older browsers.
+
+The following patterns are considered warnings:
+
+```css
+p {
+  font-size: 16px;
+  font-weight: 400;
+  font-size: 1rem;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+p {
+  font-size: 16px;
+  font-size: 1rem;
+}
+```

--- a/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -67,13 +67,13 @@ testRule(rule, {
   skipBasicChecks: true,
 
   accept: [ {
-    code: "p {font-size: 16px; font-size: 1rem; }"
+    code: "p {font-size: 16px; font-size: 1rem; }",
   }, {
-    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; }"
+    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; }",
   }, {
-    code: "p {font-size: 16px; font-size: 1rem; color: red; }"
+    code: "p {font-size: 16px; font-size: 1rem; color: red; }",
   }, {
-    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; color: red; }"
+    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; color: red; }",
   } ],
 
   reject: [ {

--- a/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -67,26 +67,26 @@ testRule(rule, {
   skipBasicChecks: true,
 
   accept: [ {
-    code: "p {font-size: 16px; font-size: 1rem; }",
+    code: "p { font-size: 16px; font-size: 1rem; }",
   }, {
-    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; }",
+    code: "p { display: inline-block; font-size: 16px; font-size: 1rem; }",
   }, {
-    code: "p {font-size: 16px; font-size: 1rem; color: red; }",
+    code: "p { font-size: 16px; font-size: 1rem; color: red; }",
   }, {
-    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; color: red; }",
+    code: "p { display: inline-block; font-size: 16px; font-size: 1rem; color: red; }",
   } ],
 
   reject: [ {
-    code: "p {font-size: 16px; font-weight: 400; font-size: 1rem; }",
+    code: "p { font-size: 16px; font-weight: 400; font-size: 1rem; }",
     message: messages.rejected("font-size"),
   }, {
-    code: "p {display: inline-block; font-size: 16px; font-weight: 400; font-size: 1rem; }",
+    code: "p { display: inline-block; font-size: 16px; font-weight: 400; font-size: 1rem; }",
     message: messages.rejected("font-size"),
   }, {
-    code: "p {font-size: 16px; font-weight: 400; font-size: 1rem; color: red; }",
+    code: "p { font-size: 16px; font-weight: 400; font-size: 1rem; color: red; }",
     message: messages.rejected("font-size"),
   }, {
-    code: "p {display: inline-block; font-size: 16px; font-weight: 400; font-size: 1rem; color: red; }",
+    code: "p { display: inline-block; font-size: 16px; font-weight: 400; font-size: 1rem; color: red; }",
     message: messages.rejected("font-size"),
   } ],
 })

--- a/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -60,3 +60,33 @@ testRule(rule, {
     message: messages.rejected("color"),
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignore: ["consecutive-duplicates"] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "p {font-size: 16px; font-size: 1rem; }"
+  }, {
+    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; }"
+  }, {
+    code: "p {font-size: 16px; font-size: 1rem; color: red; }"
+  }, {
+    code: "p {display: inline-block; font-size: 16px; font-size: 1rem; color: red; }"
+  } ],
+
+  reject: [ {
+    code: "p {font-size: 16px; font-weight: 400; font-size: 1rem; }",
+    message: messages.rejected("font-size"),
+  }, {
+    code: "p {display: inline-block; font-size: 16px; font-weight: 400; font-size: 1rem; }",
+    message: messages.rejected("font-size"),
+  }, {
+    code: "p {font-size: 16px; font-weight: 400; font-size: 1rem; color: red; }",
+    message: messages.rejected("font-size"),
+  }, {
+    code: "p {display: inline-block; font-size: 16px; font-weight: 400; font-size: 1rem; color: red; }",
+    message: messages.rejected("font-size"),
+  } ],
+})

--- a/src/rules/declaration-block-no-duplicate-properties/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/index.js
@@ -17,7 +17,7 @@ export default function (on, options) {
     const validOptions = validateOptions(result, ruleName, { actual: on }, {
       actual: options,
       possible: {
-        ignore: [ "consecutive-duplicates" ],
+        ignore: ["consecutive-duplicates"],
       },
       optional: true,
     })
@@ -51,7 +51,7 @@ export default function (on, options) {
         // Ignore the src property as commonly duplicated in at-fontface
         if (prop === "src") { return }
 
-        const indexDuplicate = decls.indexOf(prop);
+        const indexDuplicate = decls.indexOf(prop)
 
         if (indexDuplicate !== -1) {
           if (

--- a/src/rules/declaration-block-no-duplicate-properties/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/index.js
@@ -1,9 +1,9 @@
 import {
+  cssWordIsVariable,
+  optionsHaveIgnored,
   report,
   ruleMessages,
-  cssWordIsVariable,
   validateOptions,
-  optionsHaveIgnored,
 } from "../../utils"
 
 export const ruleName = "declaration-block-no-duplicate-properties"

--- a/src/rules/declaration-block-no-duplicate-properties/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/index.js
@@ -3,6 +3,7 @@ import {
   ruleMessages,
   cssWordIsVariable,
   validateOptions,
+  optionsHaveIgnored,
 } from "../../utils"
 
 export const ruleName = "declaration-block-no-duplicate-properties"
@@ -11,9 +12,15 @@ export const messages = ruleMessages(ruleName, {
   rejected: p => `Unexpected duplicate property "${p}"`,
 })
 
-export default function (actual) {
+export default function (on, options) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual })
+    const validOptions = validateOptions(result, ruleName, { actual: on }, {
+      actual: options,
+      possible: {
+        ignore: [ "consecutive-duplicates" ],
+      },
+      optional: true,
+    })
     if (!validOptions) { return }
 
     // In order to accommodate nested blocks (postcss-nested),
@@ -29,11 +36,14 @@ export default function (actual) {
 
     function checkRulesInNode(node) {
       const decls = []
+
       node.each(child => {
         if (child.nodes && child.nodes.length) {
           checkRulesInNode(child)
         }
+
         if (child.type !== "decl") { return }
+
         const prop = child.prop
 
         if (cssWordIsVariable(prop)) { return }
@@ -41,7 +51,16 @@ export default function (actual) {
         // Ignore the src property as commonly duplicated in at-fontface
         if (prop === "src") { return }
 
-        if (decls.indexOf(prop) !== -1) {
+        const indexDuplicate = decls.indexOf(prop);
+
+        if (indexDuplicate !== -1) {
+          if (
+            optionsHaveIgnored(options, "consecutive-duplicates")
+            && indexDuplicate === decls.length - 1
+          ) {
+            return
+          }
+
           report({
             message: messages.rejected(prop),
             node: child,
@@ -49,6 +68,7 @@ export default function (actual) {
             ruleName,
           })
         }
+
         decls.push(prop)
       })
     }


### PR DESCRIPTION
[Add ignore: ["consecutive-duplicates"] option to declaration-block-no-duplicate-properties](https://github.com/stylelint/stylelint/issues/1021).

I didn’t go into much code. Mostly tried to make it work first. :)

So I’m not sure at all if the [modification to the option validation](https://github.com/stylelint/stylelint/pull/1038/files#diff-fedff11957046c1b70142988dde39426R17) is OK, for example.

If you have any comments on the format or the logic, please fire comments!