### PR TITLE
Indentation ignores all parens; closes #1034

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `unit-no-unknown` rule.
 - Fixed: `no-descending-specificity` no longer gets confused when the last part of a selector is a compound selector.
+- Fixed: regression causing `indentation` to complain about Sass maps.
 
 # 5.3.0
 

--- a/src/rules/indentation/__tests__/functions.js
+++ b/src/rules/indentation/__tests__/functions.js
@@ -55,5 +55,11 @@ testRule(rule, {
     "      )\n" +
     "    );\n" +
     "}",
+  }, {
+    code: "$tooltip-default-settings: (\n" +
+    "    tooltip-gutter: 8px 10px,\n" +
+    "  tooltip-border: 1px solid,\n" +
+    ");",
+    description: "Sass maps ignored",
   } ],
 })

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -209,10 +209,9 @@ export default function (space, options) {
 
     function checkMultilineBit(source, newlineIndentLevel, node) {
       if (source.indexOf("\n") === -1) { return }
-      styleSearch({ source, target: "\n" }, (match) => {
-        // Function arguments are ignored to allow for arbitrary indentation
-        if (match.insideFunction) { return }
-
+      // `outsideParens` because function arguments and also non-standard parenthesized stuff like
+      // Sass maps are ignored to allow for arbitrary indentation
+      styleSearch({ source, target: "\n", outsideParens: true }, (match) => {
         // Starting at the index after the newline, we want to
         // check that the whitespace characters (excluding newlines) before the first
         // non-whitespace character equal the expected indentation

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -109,6 +109,40 @@ test("`outsideFunctionalNotation` option", t => {
   t.end()
 })
 
+test("`outsideParens` option", t => {
+  t.deepEqual(styleSearchResults({
+    source: "abc var(--cba)",
+    target: "c",
+    outsideParens: true,
+  }), [2])
+  t.deepEqual(styleSearchResults({
+    source: "abc var(--cba)",
+    target: "a",
+    outsideParens: true,
+  }), [0])
+  t.deepEqual(styleSearchResults({
+    source: "abc \"a var(--cba)\"",
+    target: "a",
+    outsideParens: true,
+  }), [0])
+  t.deepEqual(styleSearchResults({
+    source: "translate(1px, calc(1px * 2))",
+    target: "1",
+    outsideParens: true,
+  }), [])
+  t.deepEqual(styleSearchResults({
+    source: "var(--horse)",
+    target: "v",
+    outsideParens: true,
+  }), [])
+  t.deepEqual(styleSearchResults({
+    source: "abc (def)",
+    target: "e",
+    outsideParens: true,
+  }), [], "parens without function are still ignored")
+  t.end()
+})
+
 test("ignores matches within single-quote strings", t => {
   t.deepEqual(styleSearchResults({
     source: "abc 'abc'",


### PR DESCRIPTION
Added the `outsideParens` option to `styleSearch()` so indentation can ignore *anything* inside parens, whether its a function or not.