### PR TITLE
Less empty blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "multimatch": "^2.1.0",
     "normalize-selector": "^0.2.0",
     "postcss": "^5.0.4",
-    "postcss-less": "^0.8.0",
+    "postcss-less": "^0.9.0",
     "postcss-reporter": "^1.3.0",
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-scss": "^0.1.3",

--- a/src/rules/declaration-block-single-line-max-declarations/__tests__/index.js
+++ b/src/rules/declaration-block-single-line-max-declarations/__tests__/index.js
@@ -65,3 +65,16 @@ testRule(rule, {
     column: 3,
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [2],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: "a { .tab-focus(); }",
+    description: "single mixin",
+  },
+  ],
+})

--- a/src/rules/declaration-block-single-line-max-declarations/index.js
+++ b/src/rules/declaration-block-single-line-max-declarations/index.js
@@ -25,6 +25,7 @@ export default function (quantity) {
     root.walkRules(rule => {
 
       if (!isSingleLineString(cssStatementBlockString(rule))) { return }
+      if (!rule.nodes) { return }
 
       const decls = rule.nodes.filter(node => node.type === "decl")
 


### PR DESCRIPTION
Closes #1040 

I added a defensive property check into `declaration-block-single-line-max-declarations` as it tripped up using `0.9.0`.

This rules appears to be the only place we don’t check of the existence of the `nodes` property before using it.