### PR TITLE
refactoring unit rules

### DIFF
--- a/src/rules/unit-blacklist/index.js
+++ b/src/rules/unit-blacklist/index.js
@@ -2,6 +2,7 @@ import { isString } from "lodash"
 import valueParser from "postcss-value-parser"
 
 import {
+  cssWordIsVariable,
   declarationValueIndexOffset,
   report,
   ruleMessages,
@@ -28,9 +29,13 @@ export default function (blacklistInput) {
 
       valueParser(value).walk(function (node) {
         if (node.type === "function" && node.value === "url") { return false }
-        if (node.type !== "word") { return }
+        if (node.type !== "word" || cssWordIsVariable(node.value)) { return }
 
-        const unit = valueParser.unit(node.value).unit
+        const parsedUnit = valueParser.unit(node.value)
+
+        if (!parsedUnit) { return }
+
+        const unit = parsedUnit.unit
 
         if (!unit || blacklist.indexOf(unit) === -1) { return }
 

--- a/src/rules/unit-no-unknown/index.js
+++ b/src/rules/unit-no-unknown/index.js
@@ -33,9 +33,7 @@ export default function (actual, options) {
       valueParser(value).walk(function (node) {
         // Ignore wrong units within `url` function
         if (node.type === "function" && node.value === "url") { return false }
-        if (node.type !== "word"
-          || cssWordIsVariable(node.value)
-        ) { return }
+        if (node.type !== "word" || cssWordIsVariable(node.value)) { return }
 
         const parsedUnit = valueParser.unit(node.value)
 

--- a/src/rules/unit-whitelist/index.js
+++ b/src/rules/unit-whitelist/index.js
@@ -2,6 +2,7 @@ import { isString } from "lodash"
 import valueParser from "postcss-value-parser"
 
 import {
+  cssWordIsVariable,
   declarationValueIndexOffset,
   report,
   ruleMessages,
@@ -28,9 +29,13 @@ export default function (whitelistInput) {
 
       valueParser(value).walk(function (node) {
         if (node.type === "function" && node.value === "url") { return false }
-        if (node.type !== "word") { return }
+        if (node.type !== "word" || cssWordIsVariable(node.value)) { return }
 
-        const unit = valueParser.unit(node.value).unit
+        const parsedUnit = valueParser.unit(node.value)
+
+        if (!parsedUnit) { return }
+
+        const unit = parsedUnit.unit
 
         if (!unit || whitelist.indexOf(unit) !== -1) { return }
 


### PR DESCRIPTION
use `cssWordIsVariable` for skip check variables (best performance), also check on `false`  `valueParser.unit` https://github.com/TrySound/postcss-value-parser#valueparserunitquantity