### PR TITLE
Add failing test for `no-invalid-double-slash-comments` rule for end of line comments

### DIFF
--- a/src/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/src/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -72,6 +72,18 @@ testRule(rule, {
   ruleName,
   config: [undefined],
   skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [{
+    code: "a { color: pink; // }",
+    description: "single-line comment ignored",
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [undefined],
+  skipBasicChecks: true,
   syntax: "less",
 
   accept: [{


### PR DESCRIPTION
I just happened upon this:

CSS:
```css
a {
	color: pink; //
}
```

Rules:
```js
{
  "rules": {
    "no-invalid-double-slash-comments": true
  }
}
```

This results in error:
```
Failed to lint CSS! CssSyntaxError: :2:15: Unknown word a { color: pink; // ^ }
```

I expect this due to #883 and would be fixed by #1023 but wanted to include this complementary failing test case to coincide with the other 2 SCSS double slash comment tests in [/rules/no-invalid-double-slash-comments/__tests__/index.js](https://github.com/stylelint/stylelint/blob/master/src/rules/no-invalid-double-slash-comments/__tests__/index.js)