### PR TITLE
Reads `.stylelintignore` for files to ignore in the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Head
+- Added: Handling of `.stylelintignore` file to add more ignored patterns
+- Added: Notice that a file is ignored
+- Fixed: configuration is initialized only once in the PostCSS plugin
+- Fixed: PostCSS is initialized only once in cli	
+	
 # 6.0.3
 
 - Fixed: CRLF (`\r\n`) warning positioning in `max-empty-lines` and `function-max-empty-lines`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Head
-- Added: Handling of `.stylelintignore` file to add more ignored patterns
-- Added: Notice that a file is ignored
-- Fixed: configuration is initialized only once in the PostCSS plugin
-- Fixed: PostCSS is initialized only once in cli	
+- Added: handling of `.stylelintignore` file to add more ignored patterns.
+- Added: notice that a file is ignored.
+- Fixed: configuration is initialized only once in the PostCSS plugin.
+- Fixed: PostCSS is initialized only once in cli.	
 	
 # 6.0.3
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -207,6 +207,6 @@ The `ignoreFiles` property is stripped from extended configs: only the root-leve
 
 Like `ignoreFiles` in the configuration object, you can specify a list of files or patterns that will be ignored.
 
-Stylelint will check for the `.stylelintignore` file in `configBasedir` if it's provided or in `process.cwd()`
+stylelint will check for the `.stylelintignore` file in `configBasedir` if it's provided or in `process.cwd()`
 
 You must put only one pattern per line, the patterns are the same as for `ignoreFiles`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -202,3 +202,11 @@ If the globs are absolute paths, they are used as is. If they are relative, they
 - or `process.cwd()`.
 
 The `ignoreFiles` property is stripped from extended configs: only the root-level config can ignore files.
+
+## `.stylelintignore`
+
+Like `ignoreFiles` in the configuration object, you can specify a list of files or patterns that will be ignored.
+
+Stylelint will check for the `.stylelintignore` file in `configBasedir` if it's provided or in `process.cwd()`
+
+You must put only one pattern per line.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -209,4 +209,4 @@ Like `ignoreFiles` in the configuration object, you can specify a list of files 
 
 Stylelint will check for the `.stylelintignore` file in `configBasedir` if it's provided or in `process.cwd()`
 
-You must put only one pattern per line.
+You must put only one pattern per line, the patterns are the same as for `ignoreFiles`

--- a/src/__tests__/fixtures/ignore_config/.stylelintignore
+++ b/src/__tests__/fixtures/ignore_config/.stylelintignore
@@ -1,0 +1,4 @@
+# we need to go up one folder as the paths are
+# resolved absolutely to the directory the file's in
+../**/*.css
+!../**/invalid-hex.css

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -310,6 +310,29 @@ test("standalone with extending config with ignoreFiles glob ignoring one by neg
   t.plan(7)
 })
 
+test("standalone with .stylelintignore file ignoring one by negation", t => {
+  standalone({
+    files: [`${fixturesPath}/*.css`],
+    config: {
+      extends: [
+        `${fixturesPath}/config-block-no-empty`,
+        `${fixturesPath}/config-color-no-invalid-hex`,
+      ],
+    },
+    configBasedir: path.join(__dirname, "fixtures/ignore_config"),
+  }).then(({ output }) => {
+    const parsedOutput = JSON.parse(output)
+    t.equal(parsedOutput.length, 2)
+    t.ok(parsedOutput[0].source.indexOf("empty-block.css") !== -1)
+    t.equal(parsedOutput[0].warnings.length, 1)
+    t.equal(parsedOutput[0].warnings[0].severity, "info", "must be an information")
+    t.equal(parsedOutput[0].warnings[0].text, "This file is ignored")
+    t.ok(parsedOutput[1].source.indexOf("invalid-hex.css") !== -1)
+    t.equal(parsedOutput[1].warnings.length, 1)
+  }).catch(logError)
+  t.plan(7)
+})
+
 test("standalone extending a config that ignores files", t => {
   let planned = 0
   standalone({

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -239,7 +239,6 @@ test("standalone with Less syntax", t => {
 })
 
 test("standalone with extending config and ignoreFiles glob ignoring single glob", t => {
-  let planned = 0
   standalone({
     files: [`${fixturesPath}/*.css`],
     config: {
@@ -256,14 +255,14 @@ test("standalone with extending config and ignoreFiles glob ignoring single glob
     t.ok(parsedOutput[0].source.indexOf("empty-block.css") !== -1)
     t.equal(parsedOutput[0].warnings.length, 1)
     t.ok(parsedOutput[1].source.indexOf("invalid-hex.css") !== -1)
-    t.equal(parsedOutput[1].warnings.length, 0)
+    t.equal(parsedOutput[1].warnings.length, 1)
+    t.equal(parsedOutput[1].warnings[0].severity, "info", "must be an information")
+    t.equal(parsedOutput[1].warnings[0].text, "This file is ignored")
   }).catch(logError)
-  planned += 5
-  t.plan(planned)
+  t.plan(7)
 })
 
 test("standalone with absolute ignoreFiles glob path", t => {
-  let planned = 0
   standalone({
     files: [ `${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css` ],
     config: {
@@ -276,15 +275,15 @@ test("standalone with absolute ignoreFiles glob path", t => {
   }).then(({ output }) => {
     const parsedOutput = JSON.parse(output)
     t.equal(parsedOutput.length, 2)
-    t.equal(parsedOutput[0].warnings.length, 0)
+    t.equal(parsedOutput[0].warnings.length, 1)
+    t.equal(parsedOutput[0].warnings[0].severity, "info", "must be an information")
+    t.equal(parsedOutput[0].warnings[0].text, "This file is ignored")
     t.equal(parsedOutput[1].warnings.length, 0)
   }).catch(logError)
-  planned += 3
-  t.plan(planned)
+  t.plan(5)
 })
 
 test("standalone with extending config with ignoreFiles glob ignoring one by negation", t => {
-  let planned = 0
   standalone({
     files: [`${fixturesPath}/*.css`],
     config: {
@@ -302,12 +301,13 @@ test("standalone with extending config with ignoreFiles glob ignoring one by neg
     const parsedOutput = JSON.parse(output)
     t.equal(parsedOutput.length, 2)
     t.ok(parsedOutput[0].source.indexOf("empty-block.css") !== -1)
-    t.equal(parsedOutput[0].warnings.length, 0)
+    t.equal(parsedOutput[0].warnings.length, 1)
+    t.equal(parsedOutput[0].warnings[0].severity, "info", "must be an information")
+    t.equal(parsedOutput[0].warnings[0].text, "This file is ignored")
     t.ok(parsedOutput[1].source.indexOf("invalid-hex.css") !== -1)
     t.equal(parsedOutput[1].warnings.length, 1)
   }).catch(logError)
-  planned += 5
-  t.plan(planned)
+  t.plan(7)
 })
 
 test("standalone extending a config that ignores files", t => {
@@ -372,10 +372,12 @@ test("standalone using codeFilename and ignoreFiles together", t => {
     },
   }).then(({ output }) => {
     const parsedOutput = JSON.parse(output)[0]
-    t.equal(parsedOutput.warnings.length, 0, "no warnings")
+    t.equal(parsedOutput.warnings.length, 1, "Must have one warning that is an information")
+    t.equal(parsedOutput.warnings[0].severity, "info", "must be an information")
+    t.equal(parsedOutput.warnings[0].text, "This file is ignored")
   }).catch(logError)
 
-  t.plan(1)
+  t.plan(3)
 })
 
 test("standalone using codeFilename and ignoreFiles with configBasedir", t => {
@@ -389,10 +391,12 @@ test("standalone using codeFilename and ignoreFiles with configBasedir", t => {
     configBasedir: __dirname,
   }).then(({ output }) => {
     const parsedOutput = JSON.parse(output)[0]
-    t.equal(parsedOutput.warnings.length, 0, "no warnings")
+    t.equal(parsedOutput.warnings.length, 1, "Must have one warning that is an information")
+    t.equal(parsedOutput.warnings[0].severity, "info", "must be an information")
+    t.equal(parsedOutput.warnings[0].text, "This file is ignored")
   }).catch(logError)
 
-  t.plan(1)
+  t.plan(3)
 })
 
 test("standalone passing code with syntax error", t => {

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -112,10 +112,10 @@ function getModulePath(basedir, lookup) {
 }
 
 function findIgnorePatterns(configDir) {
-  var ignoreFilePath = path.resolve(configDir, ".stylelintignore");
+  const ignoreFilePath = path.resolve(configDir, ".stylelintignore")
 
   if (!fs.existsSync(ignoreFilePath)) {
-    return [];
+    return []
   }
 
   return fs.readFileSync(ignoreFilePath, "utf8")

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -1,4 +1,5 @@
 import path from "path"
+import fs from "fs"
 import cosmiconfig from "cosmiconfig"
 import resolveFrom from "resolve-from"
 import {
@@ -59,6 +60,10 @@ function augmentConfig(config, configDir) {
   // Absolutize the plugins here, because here is the place
   // where we know the basedir for this particular config
   const configWithAbsolutePlugins = absolutizePlugins(config, configDir)
+
+  // Get ignore patterns from .stylelintignore
+  config.ignoreFiles = [].concat(findIgnorePatterns(configDir), config.ignoreFiles || [])
+
   if (!config.extends) {
     return Promise.resolve(configWithAbsolutePlugins)
   }
@@ -104,6 +109,18 @@ function getModulePath(basedir, lookup) {
   throw configurationError(
     `Could not find "${lookup}". Do you need a \`configBasedir\`?`
   )
+}
+
+function findIgnorePatterns(configDir) {
+  var ignoreFilePath = path.resolve(configDir, ".stylelintignore");
+
+  if (!fs.existsSync(ignoreFilePath)) {
+    return [];
+  }
+
+  return fs.readFileSync(ignoreFilePath, "utf8")
+    .split(/\r?\n/g)
+    .filter(val => val.trim() !== "")
 }
 
 // The `ignoreFiles` option only works with the

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -34,7 +34,10 @@ export default postcss.plugin("stylelint", (options = {}) => {
           return globjoin(configDir, glob)
         })
         const sourcePath = get(root, "source.input.file", "")
-        if (multimatch(sourcePath, absoluteIgnoreFiles).length) { return }
+        if (multimatch(sourcePath, absoluteIgnoreFiles).length) {
+          result.warn("This file is ignored", {severity: "info"})
+          return
+        }
       }
 
       if (config.plugins) {

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -10,8 +10,11 @@ import buildConfig from "./buildConfig"
 import normalizeRuleSettings from "./normalizeRuleSettings"
 
 export default postcss.plugin("stylelint", (options = {}) => {
+  let configPromise
   return (root, result) => {
-    const configPromise = buildConfig(options)
+    if (!configPromise) {
+      configPromise = buildConfig(options)
+    }
 
     // result.stylelint is the namespace for passing stylelint-related
     // configuration and data across sub-plugins via the PostCSS Result

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -35,7 +35,7 @@ export default postcss.plugin("stylelint", (options = {}) => {
         })
         const sourcePath = get(root, "source.input.file", "")
         if (multimatch(sourcePath, absoluteIgnoreFiles).length) {
-          result.warn("This file is ignored", {severity: "info"})
+          result.warn("This file is ignored", { severity: "info" })
           return
         }
       }

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -35,6 +35,8 @@ export default function ({
 
   let errored = false
 
+  let initialisedPostcss
+
   if (!files) {
     return lintString(code, codeFilename).then(result => {
       const results = [result]
@@ -73,6 +75,20 @@ export default function ({
     }).then(code => lintString(code, filepath))
   }
 
+  function getPostcss() {
+    if (!initialisedPostcss) {
+      initialisedPostcss = postcss()
+        .use(stylelintPostcssPlugin({
+          config,
+          configFile,
+          configBasedir,
+          configOverrides,
+        }))
+    }
+
+    return initialisedPostcss
+  }
+
   function lintString(code, filepath) {
     const postcssProcessOptions = {}
     if (filepath) {
@@ -91,13 +107,7 @@ export default function ({
         break
     }
 
-    return postcss()
-      .use(stylelintPostcssPlugin({
-        config,
-        configFile,
-        configBasedir,
-        configOverrides,
-      }))
+    return getPostcss()
       .process(code, postcssProcessOptions)
       .then(handleResult)
       .catch(cssSyntaxError)


### PR DESCRIPTION
Hi,

This change adds the ability to create a `.stylelintignore` file in the CWD of stylelint and the patterns will be added to `ignoreFiles`

Also, it will add a small notice to say that a file is ignored.

Finally, two small things that I discovered while testing : the configuration and postcss plugin where re-instantiated for each file that was linted, this isn't useful the configuration doesn't change between runs.