### PR TITLE
`number-zero-length-no-unit` refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added: `selector-pseudo-class-case` rule.
 - Fixed: `block-no-empty` no longer delivers false positives for less syntax.
 - Fixed: `declaration-block-trailing-semicolon` better understands nested at-rules.
+- Fixed: `number-zero-length-no-unit` now work with `q` unit and ignores `s`, `ms`, `kHz`, `Hz`, `dpcm`, `dppx`, `dpi` units
 
 # 5.4.0
 

--- a/src/rules/number-zero-length-no-unit/__tests__/index.js
+++ b/src/rules/number-zero-length-no-unit/__tests__/index.js
@@ -59,6 +59,30 @@ testRule(rule, {
   }, {
     code: "a { transform: translate(0); }",
     description: "transform function",
+  }, {
+    code: "a { transition-duration: 0s; }",
+    description: "ignore seconds",
+  }, {
+    code: "a { transition-duration: 0ms; }",
+    description: "ignore milliseconds",
+  }, {
+    code: "a { transition: top 0s; }",
+    description: "ignore seconds",
+  }, {
+    code: "a { transition: top 0ms; }",
+    description: "ignore milliseconds",
+  }, {
+    code: "a { margin: 0%; }",
+    description: "ignore percent unit",
+  }, {
+    code: "@media print and (min-resolution: 0dpi) { }",
+    description: "ignore dpi",
+  }, {
+    code: "@media print and (min-resolution: 0dpcm) { }",
+    description: "ignore dpcm",
+  }, {
+    code: "@media print and (min-resolution: 0dppx) { }",
+    description: "ignore dppx",
   } ],
 
   reject: [ {
@@ -108,5 +132,11 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 27,
+  }, {
+    code: "a { margin: 0q; }",
+    description: "work with q unit",
+    message: messages.rejected,
+    line: 1,
+    column: 14,
   } ],
 })

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -3,6 +3,7 @@ import {
   findLastIndex,
   range,
 } from "lodash"
+import valueParser from "postcss-value-parser"
 import {
   isKnownUnit,
   blurComments,
@@ -18,6 +19,13 @@ export const ruleName = "number-zero-length-no-unit"
 export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected unit on zero length number",
 })
+
+const ignoredUnits = new Set([
+  "dpcm", "dppx", "dpi",
+  "kHz", "Hz",
+  "s", "ms",
+  "%",
+])
 
 export default function (actual) {
   return (root, result) => {
@@ -78,6 +86,9 @@ export default function (actual) {
           : nextValueBreakIndex + valueWithZeroStart
 
         const valueWithZero = value.slice(valueWithZeroStart, valueWithZeroEnd)
+        const parsedValue = valueParser.unit(valueWithZero)
+
+        if (parsedValue && parsedValue.unit && ignoredUnits.has(parsedValue.unit)) { return }
 
         // Add the indexes to ignorableIndexes so the same value will not
         // be checked multiple times.
@@ -92,6 +103,7 @@ export default function (actual) {
           if (isKnownUnit(valueWithZero.slice(-4))) { return 4 }
           if (isKnownUnit(valueWithZero.slice(-3))) { return 3 }
           if (isKnownUnit(valueWithZero.slice(-2))) { return 2 }
+          if (isKnownUnit(valueWithZero.slice(-1))) { return 1 }
           return 0
         }())
 


### PR DESCRIPTION
`number-zero-length-no-unit` now work with `q` unit and ignores `s`, `ms`, `kHz`, `Hz`, `dpcm`, `dppx`, `dpi` units
https://developer.mozilla.org/ru/docs/Web/CSS/resolution
https://developer.mozilla.org/en-US/docs/Web/CSS/time
https://developer.mozilla.org/ru/docs/Web/CSS/frequency
see `incorrect uses`