### PR TITLE
`comment-word-blacklist` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Added: `value-keyword-case` rule.
 - Added: `selector-pseudo-class-case` rule.
 - Added: `at-rule-name-case` rule.
+- Added: `comment-word-blacklist` rule.
 - Fixed: `block-no-empty` no longer delivers false positives for less syntax.
 - Fixed: `declaration-block-trailing-semicolon` better understands nested at-rules.
 - Fixed: `number-zero-length-no-unit` now work with `q` unit and ignores `s`, `ms`, `kHz`, `Hz`, `dpcm`, `dppx`, `dpi` units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added: `ignoreKeywords` option for `value-keyword-case`.
 - Added: support for `.stylelintignore` file.
 - Added: warning message in output when a file is ignored.
+- Added: `comment-word-blacklist` rule.
 - Fixed: CRLF (`\r\n`) warning positioning in `string-no-newline`.
 - Fixed: parsing problems when using `///`-SassDoc-style comments.
 - Fixed: `max-empty-lines` places warning at the end of the violating newlines to avoid positioning confusions.
@@ -37,7 +38,6 @@
 - Added: `value-keyword-case` rule.
 - Added: `selector-pseudo-class-case` rule.
 - Added: `at-rule-name-case` rule.
-- Added: `comment-word-blacklist` rule.
 - Fixed: `block-no-empty` no longer delivers false positives for less syntax.
 - Fixed: `declaration-block-trailing-semicolon` better understands nested at-rules.
 - Fixed: `number-zero-length-no-unit` now work with `q` unit and ignores `s`, `ms`, `kHz`, `Hz`, `dpcm`, `dppx`, `dpi` units

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -28,7 +28,7 @@ You might want to learn a little about [how rules are named and how they work to
     "color-no-invalid-hex": true,
     "comment-empty-line-before": "always"|"never",
     "comment-whitespace-inside": "always"|"never",
-    "comment-word-blacklist: string|[],
+    "comment-word-blacklist": string|[],
     "custom-media-pattern": string,
     "custom-property-no-outside-root": true,
     "custom-property-pattern": string,

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -28,6 +28,7 @@ You might want to learn a little about [how rules are named and how they work to
     "color-no-invalid-hex": true,
     "comment-empty-line-before": "always"|"never",
     "comment-whitespace-inside": "always"|"never",
+    "comment-word-blacklist: string|[],
     "custom-media-pattern": string,
     "custom-property-no-outside-root": true,
     "custom-property-pattern": string,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -204,7 +204,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 - [`comment-empty-line-before`](../../src/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
 - [`comment-whitespace-inside`](../../src/rules/comment-whitespace-inside/README.md): Require or disallow whitespace on the inside of comment markers.
-
+- [`comment-word-blacklist`](../../src/rules/comment-word-blacklist/README.md): Specify a blacklist of disallowed comments.
 ### General / Sheet
 
 - [`indentation`](../../src/rules/indentation/README.md): Specify indentation.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -204,7 +204,8 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 - [`comment-empty-line-before`](../../src/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
 - [`comment-whitespace-inside`](../../src/rules/comment-whitespace-inside/README.md): Require or disallow whitespace on the inside of comment markers.
-- [`comment-word-blacklist`](../../src/rules/comment-word-blacklist/README.md): Specify a blacklist of disallowed comments.
+- [`comment-word-blacklist`](../../src/rules/comment-word-blacklist/README.md): Specify a blacklist of disallowed words within comments.
+
 ### General / Sheet
 
 - [`indentation`](../../src/rules/indentation/README.md): Specify indentation.

--- a/src/rules/comment-word-blacklist/README.md
+++ b/src/rules/comment-word-blacklist/README.md
@@ -1,0 +1,39 @@
+# comment-word-blacklist
+
+Specify a blacklist of disallowed comments.
+
+```css
+    /* comment */
+/**    ↑
+ * These comments */
+```
+
+## Options
+
+`array`: `"["array", "of", "unprefixed", "functions"]`
+
+Given:
+
+```js
+["/todo/", "badword"]
+```
+
+The following patterns are considered warnings:
+
+```css
+/* todo */
+```
+
+```css
+/* todo: add fallback */
+```
+
+```css
+/* some todo */
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+/* comments */
+```

--- a/src/rules/comment-word-blacklist/README.md
+++ b/src/rules/comment-word-blacklist/README.md
@@ -1,39 +1,39 @@
 # comment-word-blacklist
 
-Specify a blacklist of disallowed comments.
+Specify a blacklist of disallowed words within comments.
 
 ```css
-    /* comment */
-/**    ↑
- * These comments */
+ /* words within comments */
+/** ↑     ↑      ↑
+ * These three words */
 ```
 
 ## Options
 
-`array`: `"["array", "of", "unprefixed", "functions"]`
+`array`: `["array", "of", "words", "or", "/regex/" ]`
 
 Given:
 
 ```js
-["/todo/", "badword"]
+["/^TODO:/", "badword"]
 ```
 
 The following patterns are considered warnings:
 
 ```css
-/* todo */
+/* TODO: */
 ```
 
 ```css
-/* todo: add fallback */
+/* TODO: add fallback */
 ```
 
 ```css
-/* some todo */
+/* some badword */
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-/* comments */
+/* comment */
 ```

--- a/src/rules/comment-word-blacklist/__test__/index.js
+++ b/src/rules/comment-word-blacklist/__test__/index.js
@@ -64,52 +64,52 @@ testRule(rule, {
 
   reject: [ {
     code: "/* TODO: */",
-    message: messages.rejected("TODO:"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/* TODO: comment */",
-    message: messages.rejected("TODO: comment"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/* TODO: comment\n next line */",
-    message: messages.rejected("TODO: comment\n next line"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/* TODO: comment\n next line */",
-    message: messages.rejected("TODO: comment\n next line"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/* TODO: comment\r\n next line */",
-    message: messages.rejected("TODO: comment\r\n next line"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/* TODO: comment\n\n next line */",
-    message: messages.rejected("TODO: comment\n\n next line"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/*\n TODO: comment */",
-    message: messages.rejected("TODO: comment"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/*\r\n TODO: comment */",
-    message: messages.rejected("TODO: comment"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/*\n\n TODO: comment */",
-    message: messages.rejected("TODO: comment"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "/*\r\n\r\n TODO: comment */",
-    message: messages.rejected("TODO: comment"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
@@ -142,12 +142,12 @@ testRule(rule, {
 
   reject: [ {
     code: "// TODO:",
-    message: messages.rejected("TODO:"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "// TODO: comment",
-    message: messages.rejected("TODO: comment"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
@@ -178,12 +178,12 @@ testRule(rule, {
 
   reject: [ {
     code: "// TODO:",
-    message: messages.rejected("TODO:"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {
     code: "// TODO: comment",
-    message: messages.rejected("TODO: comment"),
+    message: messages.rejected("/^TODO:/"),
     line: 1,
     column: 1,
   }, {

--- a/src/rules/comment-word-blacklist/__test__/index.js
+++ b/src/rules/comment-word-blacklist/__test__/index.js
@@ -4,10 +4,8 @@ import rule, { ruleName, messages } from ".."
 testRule(rule, {
   ruleName,
   config: [[
-    "/todo/",
-    "word",
-    "/copy/",
-    "/map/",
+    "/^TODO:/",
+    "bad-word",
   ]],
 
   accept: [ {
@@ -34,12 +32,164 @@ testRule(rule, {
     code: "a { color: pink; /* comment */\ntop: 0; }",
   }, {
     code: "a {} /* comment */",
+  }, {
+    code: "/* todo */",
+  }, {
+    code: "/* todo: */",
+  }, {
+    code: "/* todo: comment */",
+  }, {
+    code: "/* tOdO: comment */",
+  }, {
+    code: "/* Todo: comment */",
+  }, {
+    code: "/* Comment with bad-word */",
+  }, {
+    code: "/*! Todo: comment */",
+  }, {
+    code: "/*# Todo: comment */",
+  }, {
+    code: "/*! bad-word */",
+  }, {
+    code: "/*# bad-word */",
+  }, {
+    code: "/** bad-word **/",
+  }, {
+    code: "/*** bad-word ***/",
+  }, {
+    code: "/** TODO: comment **/",
+  }, {
+    code: "/*** TODO: comment ***/",
   } ],
 
-  reject: [{
-    code: "/* todo */",
-    message: messages.rejected("todo"),
+  reject: [ {
+    code: "/* TODO: */",
+    message: messages.rejected("TODO:"),
     line: 1,
     column: 1,
-  }],
+  }, {
+    code: "/* TODO: comment */",
+    message: messages.rejected("TODO: comment"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/* TODO: comment\n next line */",
+    message: messages.rejected("TODO: comment\n next line"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/* TODO: comment\n next line */",
+    message: messages.rejected("TODO: comment\n next line"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/* TODO: comment\r\n next line */",
+    message: messages.rejected("TODO: comment\r\n next line"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/* TODO: comment\n\n next line */",
+    message: messages.rejected("TODO: comment\n\n next line"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/*\n TODO: comment */",
+    message: messages.rejected("TODO: comment"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/*\r\n TODO: comment */",
+    message: messages.rejected("TODO: comment"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/*\n\n TODO: comment */",
+    message: messages.rejected("TODO: comment"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/*\r\n\r\n TODO: comment */",
+    message: messages.rejected("TODO: comment"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "/* bad-word */",
+    message: messages.rejected("bad-word"),
+    line: 1,
+    column: 1,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  syntax: "scss",
+  config: [[
+    "/^TODO:/",
+    "bad-word",
+  ]],
+
+  accept: [ {
+    code: "// comment",
+  }, {
+    code: "// todo",
+  }, {
+    code: "// todo:",
+  }, {
+    code: "// Todo:",
+  }, {
+    code: "// tOdO:",
+  } ],
+
+  reject: [ {
+    code: "// TODO:",
+    message: messages.rejected("TODO:"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "// TODO: comment",
+    message: messages.rejected("TODO: comment"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "// bad-word",
+    message: messages.rejected("bad-word"),
+    line: 1,
+    column: 1,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: [[
+    "/^TODO:/",
+    "bad-word",
+  ]],
+
+  accept: [ {
+    code: "// comment",
+  }, {
+    code: "// todo:",
+  }, {
+    code: "// Todo:",
+  }, {
+    code: "// tOdO:",
+  } ],
+
+  reject: [ {
+    code: "// TODO:",
+    message: messages.rejected("TODO:"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "// TODO: comment",
+    message: messages.rejected("TODO: comment"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "// bad-word",
+    message: messages.rejected("bad-word"),
+    line: 1,
+    column: 1,
+  } ],
 })

--- a/src/rules/comment-word-blacklist/__test__/index.js
+++ b/src/rules/comment-word-blacklist/__test__/index.js
@@ -1,0 +1,45 @@
+import testRule from "../../../testUtils/testRule"
+import rule, { ruleName, messages } from ".."
+
+testRule(rule, {
+  ruleName,
+  config: [[
+    "/todo/",
+    "word",
+    "/copy/",
+    "/map/",
+  ]],
+
+  accept: [ {
+    code: "/* comment */",
+  }, {
+    code: "/* comment comment */",
+  }, {
+    code: "/* comment\ncomment */",
+  }, {
+    code: "/* comment\n\ncomment */",
+  }, {
+    code: "/** comment */",
+  }, {
+    code: "/**** comment ***/",
+  }, {
+    code: "/*\ncomment\n*/",
+  }, {
+    code: "/*\tcomment   */",
+  }, {
+    code: "/*! copyright */",
+  }, {
+    code: "/*# sourcemap */",
+  }, {
+    code: "a { color: pink; /* comment */\ntop: 0; }",
+  }, {
+    code: "a {} /* comment */",
+  } ],
+
+  reject: [{
+    code: "/* todo */",
+    message: messages.rejected("todo"),
+    line: 1,
+    column: 1,
+  }],
+})

--- a/src/rules/comment-word-blacklist/index.js
+++ b/src/rules/comment-word-blacklist/index.js
@@ -1,0 +1,41 @@
+import { isString } from "lodash"
+import {
+  report,
+  ruleMessages,
+  validateOptions,
+  matchesStringOrRegExp,
+} from "../../utils"
+
+export const ruleName = "comment-word-blacklist"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: (word) => `Unexpected word "${word}"`,
+})
+
+export default function (blacklist) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: blacklist,
+      possible: [isString],
+    })
+    if (!validOptions) { return }
+
+    root.walkComments(comment => {
+      const text = comment.text
+      const rawComment = comment.toString()
+      const firstFourChars = rawComment.substr(0, 4)
+
+      // Return early if sourcemap or copyright comment
+      if (firstFourChars === "/*# " || firstFourChars === "/*! ") { return }
+
+      if (!matchesStringOrRegExp(text, blacklist)) { return }
+
+      report({
+        message: messages.rejected("todo"),
+        node: comment,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/comment-word-blacklist/index.js
+++ b/src/rules/comment-word-blacklist/index.js
@@ -9,7 +9,7 @@ import {
 export const ruleName = "comment-word-blacklist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (word) => `Unexpected word "${word}"`,
+  rejected: (pattern) => `Unexpected word matching pattern "${pattern}"`,
 })
 
 export default function (blacklist) {
@@ -33,7 +33,7 @@ export default function (blacklist) {
       if (!matchesWord) { return }
 
       report({
-        message: messages.rejected(matchesWord.match),
+        message: messages.rejected(matchesWord.pattern),
         node: comment,
         result,
         ruleName,

--- a/src/rules/comment-word-blacklist/index.js
+++ b/src/rules/comment-word-blacklist/index.js
@@ -28,10 +28,12 @@ export default function (blacklist) {
       // Return early if sourcemap or copyright comment
       if (firstFourChars === "/*# " || firstFourChars === "/*! ") { return }
 
-      if (!matchesStringOrRegExp(text, blacklist)) { return }
+      const matchesWord = matchesStringOrRegExp(text, blacklist)
+
+      if (!matchesWord) { return }
 
       report({
-        message: messages.rejected("todo"),
+        message: messages.rejected(matchesWord.match),
         node: comment,
         result,
         ruleName,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -19,6 +19,7 @@ import colorNoHex from "./color-no-hex"
 import colorNoInvalidHex from "./color-no-invalid-hex"
 import commentEmptyLineBefore from "./comment-empty-line-before"
 import commentWhitespaceInside from "./comment-whitespace-inside"
+import commentWordBlacklist from "./comment-word-blacklist"
 import customMediaPattern from "./custom-media-pattern"
 import customPropertyNoOutsideRoot from "./custom-property-no-outside-root"
 import customPropertyPattern from "./custom-property-pattern"
@@ -154,6 +155,7 @@ export default {
   "color-no-invalid-hex": colorNoInvalidHex,
   "comment-empty-line-before": commentEmptyLineBefore,
   "comment-whitespace-inside": commentWhitespaceInside,
+  "comment-word-blacklist": commentWordBlacklist,
   "custom-media-pattern": customMediaPattern,
   "custom-property-no-outside-root": customPropertyNoOutsideRoot,
   "custom-property-pattern": customPropertyPattern,


### PR DESCRIPTION
What best solution for search disallowed comment? Modify `matchesStringOrRegExp` function (example add param `meta`, which return object with position and founded string) or repeat logic from `matchesStringOrRegExp` inside in rule? What do you think guys?