### PR TITLE
`function-name-case` handling camel case function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: `function-name-case` now better handling functions `translateX`, `translateY`, `translateZ`, `scaleX`, `scaleY`, `scaleZ`, `rotateX`, `rotateY`, `rotateZ`, `skewX`, `skewY` with `lower` option.
+
 # 6.0.0
 
 - Changed: `CssSyntaxError` is no longer thrown but reported alongside warnings.

--- a/src/rules/function-name-case/__test__/index.js
+++ b/src/rules/function-name-case/__test__/index.js
@@ -32,6 +32,14 @@ testRule(rule, {
     code: "a { background: -webkit-radial-gradient(red, green, blue); }",
   }, {
     code: "@media (max-width: 10px) { a { color: color(rgb(0, 0, 0) lightness(50%)); } }",
+  }, {
+    code: "a { transform: translateX(0); }",
+  }, {
+    code: "a { transform: scaleX(0); }",
+  }, {
+    code: "a { transform: rotateX(0); }",
+  }, {
+    code: "a { transform: skewX(0); }",
   } ],
 
   reject: [ {
@@ -124,6 +132,21 @@ testRule(rule, {
     message: messages.expected("Lightness", "lightness"),
     line: 1,
     column: 58,
+  }, {
+    code: "a { transform: TranslateX(0); }",
+    message: messages.expected("TranslateX", "translateX"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { transform: tRaNsLaTeX(0); }",
+    message: messages.expected("tRaNsLaTeX", "translateX"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { transform: TRANSLATEX(0); }",
+    message: messages.expected("TRANSLATEX", "translateX"),
+    line: 1,
+    column: 16,
   } ],
 })
 
@@ -157,6 +180,8 @@ testRule(rule, {
     code: "a { background: -WEBKIT-RADIAL-GRADIENT(red, green, blue); }",
   }, {
     code: "@media (max-width: 10px) { a { color: COLOR(RGB(0, 0, 0) LIGHTNESS(50%)); } }",
+  }, {
+    code: "a { transform: TRANSLATEX(0); }",
   } ],
 
   reject: [ {
@@ -249,5 +274,20 @@ testRule(rule, {
     message: messages.expected("Lightness", "LIGHTNESS"),
     line: 1,
     column: 58,
+  }, {
+    code: "a { transform: TranslateX(0); }",
+    message: messages.expected("TranslateX", "TRANSLATEX"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { transform: tRaNsLaTeX(0); }",
+    message: messages.expected("tRaNsLaTeX", "TRANSLATEX"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { transform: translateX(0); }",
+    message: messages.expected("translateX", "TRANSLATEX"),
+    line: 1,
+    column: 16,
   } ],
 })

--- a/src/rules/function-name-case/index.js
+++ b/src/rules/function-name-case/index.js
@@ -12,6 +12,20 @@ export const messages = ruleMessages(ruleName, {
   expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 })
 
+const ignoredCamelCaseFunctionNames = {
+  "translatex": "translateX",
+  "translatey": "translateY",
+  "translatez": "translateZ",
+  "scalex": "scaleX",
+  "scaley": "scaleY",
+  "scalez": "scaleZ",
+  "rotatex": "rotateX",
+  "rotatey": "rotateY",
+  "rotatez": "rotateZ",
+  "skewx": "skewX",
+  "skewy": "skewY",
+}
+
 export default function (expectation) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -30,10 +44,19 @@ export default function (expectation) {
         if (node.type !== "function") { return }
 
         const functionName = node.value
+        const functionNameLowerCase = functionName.toLocaleLowerCase()
 
-        const expectedFunctionName = expectation === "lower"
-          ? functionName.toLowerCase()
-          : functionName.toUpperCase()
+        let expectedFunctionName = null
+
+        if (expectation === "lower"
+          && ignoredCamelCaseFunctionNames.hasOwnProperty(functionNameLowerCase)
+        ) {
+          expectedFunctionName = ignoredCamelCaseFunctionNames[functionNameLowerCase]
+        } else if (expectation === "lower") {
+          expectedFunctionName = functionNameLowerCase
+        } else {
+          expectedFunctionName = functionName.toUpperCase()
+        }
 
         if (functionName === expectedFunctionName) { return }
 


### PR DESCRIPTION
`function-name-case` now better handling functions `translateX`, `translateY`, `translateZ`, `scaleX`, `scaleY`, `scaleZ`, `rotateX`, `rotateY`, `rotateZ`, `skewX`, `skewY` with `lower` option.