### PR TITLE
Set errored to true on CssSyntaxError

### DIFF
--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -430,6 +430,16 @@ test("standalone passing file with syntax error", t => {
   t.plan(1)
 })
 
+test("syntax error sets errored to true", t => {
+  standalone({
+    code: "a { color: 'red; }",
+  }).then(({ errored }) => {
+    t.ok(errored, "errored is true")
+  }).catch(logError)
+
+  t.plan(1)
+})
+
 function logError(err) {
   console.log(err.stack) // eslint-disable-line no-console
 }

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -140,6 +140,7 @@ export default function ({
     function cssSyntaxError(error) {
       if (error.name !== "CssSyntaxError") { throw error }
 
+      errored = true
       return {
         source: error.file || "<input css 1>",
         deprecations: [],


### PR DESCRIPTION
CssSyntaxErrors are reported as a linting error (see #1023). Errors
should set errored to true. The error handler for CssSyntaxErrors did
not set errored to true which lead to unwanted behavior (e.g. the CLI
returns 0 instead of 2 although an error occured).

See: https://github.com/stylelint/stylelint/pull/1023#issuecomment-212418375