### PR TITLE
Fix CRLF positioning for max-empty-lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: CRLF (`\r\n`) warning positioning in `max-empty-lines`.
+
 # 6.0.2
 
 - Fixed: `CssSyntaxError` sets `errored` on output to `true`.

--- a/src/rules/max-empty-lines/__tests__/index.js
+++ b/src/rules/max-empty-lines/__tests__/index.js
@@ -33,7 +33,7 @@ testRule(rule, {
     code: "a {}\r\n\r\n\r\nb{}",
     message: messages.rejected,
     line: 1,
-    column: 6,
+    column: 5,
   }, {
     code: "a {}\n\n/** horse */\n\n\nb{}",
     message: messages.rejected,
@@ -43,7 +43,7 @@ testRule(rule, {
     code: "a {}\r\n\r\n/** horse */\r\n\r\n\r\nb{}",
     message: messages.rejected,
     line: 3,
-    column: 14,
+    column: 13,
   }, {
     code: "/* horse\n\n\n */\na{}",
     message: messages.rejected,
@@ -53,7 +53,7 @@ testRule(rule, {
     code: "/* horse\r\n\r\n\r\n */\r\na{}",
     message: messages.rejected,
     line: 1,
-    column: 10,
+    column: 9,
   } ],
 })
 
@@ -84,7 +84,7 @@ testRule(rule, {
     code: "a {}\r\n\r\n\r\n\r\nb{}",
     message: messages.rejected,
     line: 1,
-    column: 6,
+    column: 5,
   }, {
     code: "a {}\n\n/** horse */\n\n\n\nb{}",
     message: messages.rejected,
@@ -94,7 +94,7 @@ testRule(rule, {
     code: "a {}\r\n\r\n/** horse */\r\n\r\n\r\n\r\nb{}",
     message: messages.rejected,
     line: 3,
-    column: 14,
+    column: 13,
   }, {
     code: "/* horse\n\n\n\n */\na{}",
     message: messages.rejected,
@@ -104,6 +104,6 @@ testRule(rule, {
     code: "/* horse\r\n\r\n\r\n\r\n */\r\na{}",
     message: messages.rejected,
     line: 1,
-    column: 10,
+    column: 9,
   } ],
 })

--- a/src/rules/max-empty-lines/index.js
+++ b/src/rules/max-empty-lines/index.js
@@ -31,10 +31,14 @@ export default function (max) {
         rootString.substr(match.startIndex + 1, maxAdjacentNewlines) === repeatLFNewLines
         || rootString.substr(match.startIndex + 1, maxAdjacentNewlines * 2) === repeatCRLFNewLines
       ) {
+        // Put index at `\r` if it's CRLF, otherwise leave it at `\n`
+        let index = match.startIndex
+        if (rootString[index - 1] === "\r") { index -= 1 }
+
         report({
           message: messages.rejected,
           node: root,
-          index: match.startIndex,
+          index,
           result,
           ruleName,
         })


### PR DESCRIPTION
Addresses #1081.

There are probably a bunch of other rules that need this same treatment. If we can identify them, we can either add them to this PR or create others.