### PR TITLE
Fix #1097

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added: warning message in ouput when a file is ignored.
 - Added: `shorthand-property-no-redundant-values` rule.
 - Added: `ignoreKeywords` option for `value-keyword-case`.
+- Fixed: CRLF (`\r\n`) warning positioning in `string-no-newline`.
+- Fixed: parsing problems when using `///`-SassDoc-style comments.
 
 # 6.0.3
 

--- a/src/rules/string-no-newline/__tests__/index.js
+++ b/src/rules/string-no-newline/__tests__/index.js
@@ -40,6 +40,17 @@ testRule(rule, {
     description: "CRLF",
     message: messages.rejected,
     line: 1,
-    column: 27,
+    column: 26,
   } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [],
+  syntax: "scss",
+  skipBasicChecks: true,
+
+  accept: [{
+    code: "/// it's not ok\na {}",
+  }],
 })

--- a/src/rules/string-no-newline/index.js
+++ b/src/rules/string-no-newline/index.js
@@ -18,11 +18,14 @@ export default function (actual) {
 
     const cssString = root.toString()
     styleSearch({ source: cssString, target: "\n", withinStrings: true }, match => {
-      if (cssString[match.startIndex - 1] === "\\") { return }
+      const charBefore = cssString[match.startIndex - 1]
+      let index = match.startIndex
+      if (charBefore === "\\") { return }
+      if (charBefore === "\r") index -= 1
       report({
         message: messages.rejected,
         node: root,
-        index: match.startIndex,
+        index,
         result,
         ruleName,
       })

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -229,7 +229,11 @@ test("`withinComments` option", t => {
     target: "b",
     withinComments: true,
   }), [6])
-
+  t.deepEqual(styleSearchResults({
+    source: "abc/*/abc*/",
+    target: "b",
+    withinComments: true,
+  }), [7])
   t.deepEqual(styleSearchResults({
     source: "ab'c/*abc*/c'",
     target: "b",
@@ -245,6 +249,11 @@ test("ignores matches within single-line comment", t => {
   }), [])
   t.deepEqual(styleSearchResults({
     source: "abc // command",
+    target: "a",
+  }), [0])
+  // Triple-slash comments are used for sassdoc
+  t.deepEqual(styleSearchResults({
+    source: "abc /// it's all ok",
     target: "a",
   }), [0])
   t.end()


### PR DESCRIPTION
There are two issues in #1097 that this fixes:

- `string-no-newline` should not have been reporting different positions for `\n` and `\r\n`
- `styleSearch()` should not have been consider `/*/` a complete (open and closed) comment. `postcss-scss` parsed `///` comments to that, e.g. `/// thing => /*/ thing */`; so that was the source of @MattDiMu's more tricky problem.