### PR TITLE
Change max-empty-lines error position; fixes #1100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Head
 
-- Added: `selector-pseudo-class-parentheses-space-inside` rule.
 - Added: `selector-attribute-brackets-space-inside` rule.
-- Added: `.stylelintignore` file.
-- Added: warning message in ouput when a file is ignored.
+- Added: `selector-pseudo-class-parentheses-space-inside` rule.
 - Added: `shorthand-property-no-redundant-values` rule.
 - Added: `ignoreKeywords` option for `value-keyword-case`.
+- Added: support for `.stylelintignore` file.
+- Added: warning message in output when a file is ignored.
 - Fixed: CRLF (`\r\n`) warning positioning in `string-no-newline`.
 - Fixed: parsing problems when using `///`-SassDoc-style comments.
+- Fixed: `max-empty-lines` places warning at the end of the violating newlines to avoid positioning confusions.
 
 # 6.0.3
 

--- a/src/rules/max-empty-lines/__tests__/index.js
+++ b/src/rules/max-empty-lines/__tests__/index.js
@@ -27,33 +27,33 @@ testRule(rule, {
   reject: [ {
     code: "a {}\n\n\nb{}",
     message: messages.rejected,
-    line: 1,
-    column: 5,
+    line: 4,
+    column: 1,
   }, {
     code: "a {}\r\n\r\n\r\nb{}",
     message: messages.rejected,
-    line: 1,
-    column: 5,
+    line: 4,
+    column: 1,
   }, {
     code: "a {}\n\n/** horse */\n\n\nb{}",
     message: messages.rejected,
-    line: 3,
-    column: 13,
+    line: 6,
+    column: 1,
   }, {
     code: "a {}\r\n\r\n/** horse */\r\n\r\n\r\nb{}",
     message: messages.rejected,
-    line: 3,
-    column: 13,
+    line: 6,
+    column: 1,
   }, {
     code: "/* horse\n\n\n */\na{}",
     message: messages.rejected,
-    line: 1,
-    column: 9,
+    line: 4,
+    column: 1,
   }, {
     code: "/* horse\r\n\r\n\r\n */\r\na{}",
     message: messages.rejected,
-    line: 1,
-    column: 9,
+    line: 4,
+    column: 1,
   } ],
 })
 
@@ -78,32 +78,50 @@ testRule(rule, {
   reject: [ {
     code: "a {}\n\n\n\nb{}",
     message: messages.rejected,
-    line: 1,
-    column: 5,
+    line: 5,
+    column: 1,
   }, {
     code: "a {}\r\n\r\n\r\n\r\nb{}",
     message: messages.rejected,
-    line: 1,
-    column: 5,
+    line: 5,
+    column: 1,
   }, {
     code: "a {}\n\n/** horse */\n\n\n\nb{}",
     message: messages.rejected,
-    line: 3,
-    column: 13,
+    line: 7,
+    column: 1,
   }, {
     code: "a {}\r\n\r\n/** horse */\r\n\r\n\r\n\r\nb{}",
     message: messages.rejected,
-    line: 3,
-    column: 13,
+    line: 7,
+    column: 1,
   }, {
     code: "/* horse\n\n\n\n */\na{}",
     message: messages.rejected,
-    line: 1,
-    column: 9,
+    line: 5,
+    column: 1,
   }, {
     code: "/* horse\r\n\r\n\r\n\r\n */\r\na{}",
     message: messages.rejected,
-    line: 1,
-    column: 9,
+    line: 5,
+    column: 1,
   } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [2],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [{
+    code: "// one\n\n\n// two\n",
+  }],
+
+  reject: [{
+    code: "// one\n\n\n\n// two\n",
+    message: messages.rejected,
+    line: 5,
+    column: 1,
+  }],
 })

--- a/src/rules/max-empty-lines/index.js
+++ b/src/rules/max-empty-lines/index.js
@@ -26,23 +26,38 @@ export default function (max) {
     const repeatLFNewLines = repeat("\n", maxAdjacentNewlines)
     const repeatCRLFNewLines = repeat("\r\n", maxAdjacentNewlines)
 
-    styleSearch({ source: rootString, target: "\n", checkComments: true }, match => {
-      if (
-        rootString.substr(match.startIndex + 1, maxAdjacentNewlines) === repeatLFNewLines
-        || rootString.substr(match.startIndex + 1, maxAdjacentNewlines * 2) === repeatCRLFNewLines
-      ) {
-        // Put index at `\r` if it's CRLF, otherwise leave it at `\n`
-        let index = match.startIndex
-        if (rootString[index - 1] === "\r") { index -= 1 }
-
-        report({
-          message: messages.rejected,
-          node: root,
-          index,
-          result,
-          ruleName,
-        })
-      }
+    styleSearch({ source: rootString, target: "\n" }, match => {
+      checkMatch(rootString, match.endIndex, root)
     })
+
+    // We must check comments separately in order to accommodate stupid
+    // `//`-comments from SCSS, which postcss-scss converts to `/* ... */`,
+    // which adds to extra characters at the end, which messes up our
+    // warning position
+    root.walkComments(comment => {
+      const source = comment.raw("left") + comment.text + comment.raw("right")
+      styleSearch({ source, target: "\n" }, match => {
+        checkMatch(source, match.endIndex, comment, 2)
+      })
+    })
+
+    function checkMatch(source, matchEndIndex, node, offset = 0) {
+      let violationIndex = false
+      if (source.substr(matchEndIndex, maxAdjacentNewlines) === repeatLFNewLines) {
+        violationIndex = matchEndIndex + maxAdjacentNewlines
+      } else if (source.substr(matchEndIndex, maxAdjacentNewlines * 2) === repeatCRLFNewLines) {
+        violationIndex = matchEndIndex + (maxAdjacentNewlines * 2)
+      }
+
+      if (!violationIndex) { return }
+
+      report({
+        message: messages.rejected,
+        node,
+        index: violationIndex + offset,
+        result,
+        ruleName,
+      })
+    }
   }
 }


### PR DESCRIPTION
The only good way I could think of to fix all the problems associated with positioning the warning was to move the warning from *before* the violation (where it currently resides) to *after* the violation. That way it should be in the same place whether there are `\n`s or `\r\n`s and whether a comment is `/*` or `//`.

I think that since only the positioning of the error changes I would not consider it a "breaking change" that demands a major release. Any disagreement?