### PR TITLE
Ignore less mixins in selector-class-pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# HEAD
+# Head
 
 - Fixed: `number-leading-zero` will not check `@import` at-rules.
+- Fixed: `selector-class-pattern` now ignores non-ouputting Less mixin definitions and called Less mixins.
 
 # 6.1.1
 

--- a/src/rules/selector-class-pattern/README.md
+++ b/src/rules/selector-class-pattern/README.md
@@ -8,6 +8,8 @@ Specify a pattern for class selectors.
  * These class selectors */
 ```
 
+This rule ignores non-ouputting Less mixin definitions and called Less mixins.
+
 ## Options
 
 `regex` or `string`
@@ -22,7 +24,13 @@ The following patterns are considered warnings:
 
 ```css
 .foop {}
+```
+
+```css
 .foo-BAR {}
+```
+
+```css
 div > #zing + .foo-BAR {}
 ```
 
@@ -30,9 +38,28 @@ The following patterns are *not* considered warnings:
 
 ```css
 .foo-bar {}
+```
+
+```css
 div > #zing + .foo-bar {}
+```
+
+```css
 #foop {}
+```
+
+```css
 [foo='bar'] {}
+```
+
+```less
+.foop() {}
+```
+
+```less
+.foo-bar {
+  .foop;
+}
 ```
 
 ## Optional options

--- a/src/rules/selector-class-pattern/__tests__/index.js
+++ b/src/rules/selector-class-pattern/__tests__/index.js
@@ -121,3 +121,38 @@ testRule(rule, {
     description: "ignore sass interpolation of nested selector inside @for",
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: [/^[A-Z]+$/],
+
+  accept:[ {
+    code: ".mixin-name() { }",
+    description: "ignore non-ouputting Less class mixin definition",
+  }, {
+    code: ".A { .mixin-name; }",
+    description: "ignore called Less class mixin",
+  }, {
+    code: ".A { .mixin-name(@var); }",
+    description: "ignore called Less class parametric mixin",
+  }, {
+    code: "#mixin-name() { }",
+    description: "ignore non-ouputting Less id mixin definition",
+  }, {
+    code: ".A { #mixin-name; }",
+    description: "ignore called Less id mixin",
+  }, {
+    code: "#namespace { .mixin-name() { } }",
+    description: "ignore namespaced non-ouputting Less class mixin definition",
+  }, {
+    code: ".A { #namespace > .mixin-name; }",
+    description: "ignore called namespaced Less mixin (child)",
+  }, {
+    code: ".A { #namespace .mixin-name; }",
+    description: "ignore called namespaced Less mixin (decendant)",
+  }, {
+    code: ".A { #namespace.mixin-name; }",
+    description: "ignore called namespaced Less mixin (compounded)",
+  } ],
+})

--- a/src/rules/selector-class-pattern/index.js
+++ b/src/rules/selector-class-pattern/index.js
@@ -39,6 +39,12 @@ export default function (pattern, options) {
       // Ignore Sass intepolation possibilities
       if (/#{.+}/.test(rule.selector)) { return }
 
+      // Ignore called Less mixins
+      if (rule.ruleWithoutBody) { return }
+
+      // Ignore non-outputting Less mixin definitions
+      if (_.endsWith(rule.selector, ")")) { return }
+
       // Only bother resolving selectors that have an interpolating &
       if (shouldResolveNestedSelectors && hasInterpolatingAmpersand(rule.selector)) {
         resolveNestedSelector(rule.selector, rule).forEach(selector => {


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/issues/1077

We can’t do much about “outputting” Less mixin definitions, but we can ignore “non-outputting” definitions and when mixins are called.