### PR TITLE
Ignore @import at-rules for number-leading-zero rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+- Fixed: `number-leading-zero` will not check `@import` at-rules.
+
 # 6.1.1
 
 - Fixed: documentation links to `selector-pseudo-class-parentheses-space-inside` and `selector-attribute-brackets-space-inside`.

--- a/src/rules/number-leading-zero/__tests__/index.js
+++ b/src/rules/number-leading-zero/__tests__/index.js
@@ -51,6 +51,9 @@ testRule(rule, {
   }, {
     code: "a { background: url(data:image/svg+xml;...0.5); }",
     description: "data URI containing leading zero",
+  }, {
+    code: "@import 'testfile.0.3.css'",
+    description: "ignore @import at-rules",
   } ],
 
   reject: [ {
@@ -141,6 +144,9 @@ testRule(rule, {
   }, {
     code: "a { transform: translate(.4px, .8px); }",
     description: "multiple fractional values without leading zeros in a function",
+  }, {
+    code: "@import 'testfile.0.3.css'",
+    description: "ignore @import at-rules",
   } ],
 
   reject: [ {

--- a/src/rules/number-leading-zero/index.js
+++ b/src/rules/number-leading-zero/index.js
@@ -32,6 +32,8 @@ export default function (expectation) {
     })
 
     root.walkAtRules(atRule => {
+      if (atRule.name === "import") { return }
+
       const source = (cssStatementHasBlock(atRule))
         ? cssStatementStringBeforeBlock(atRule, { noBefore: true })
         : atRule.toString()


### PR DESCRIPTION
Just realized that this:

```css
@import "test-file.0.3.1.css"
```

Gets picked up at the `number-leading-zero` rule and might throw lint warnings/errors. Either we do a blacklist of at-rules with this PR or I can edit it to whitelist `@media` as the only at-rules checked with this perhaps?