### PR TITLE
Ignore LESS blockless rules (mixin and extend calls) on rule-nested-empty-line-before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+- Fixed: `rule-nested-empty-line-before` ignores LESS blockless rules (mixin and extend calls).
+
 # 6.1.1
 
 - Fixed: documentation links to `selector-pseudo-class-parentheses-space-inside` and `selector-attribute-brackets-space-inside`.

--- a/src/rules/rule-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-nested-empty-line-before/__tests__/index.js
@@ -371,3 +371,17 @@ testRule(rule, {
     message: messages.rejected,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: ["always"],
+
+  accept: [ {
+    code: "a { .mixin-call(); }",
+    description: "LESS mixin call ignored",
+  }, {
+    code: "a { &:extend(.class); }",
+    description: "LESS extends ignored",
+  } ],
+})

--- a/src/rules/rule-nested-empty-line-before/index.js
+++ b/src/rules/rule-nested-empty-line-before/index.js
@@ -42,6 +42,9 @@ export default function (expectation, options) {
       // Only attend to nested rule sets
       if (rule.parent === root) { return }
 
+      // For LESS, ignore mixin and extend calls in the form of blockless rules
+      if (rule.ruleWithoutBody) { return }
+
       checkRuleEmptyLineBefore({ rule, expectation, options, result, messages, checkedRuleName: ruleName })
     })
   }


### PR DESCRIPTION
Apparently `rule-nested-empty-line-before` catches LESS mixin and extend calls. `postcss-less` has exposed [`rule.ruleWithoutBody`](https://github.com/webschik/postcss-less#rulerulewithoutbody) so we can use it to ignore blockless rules and assume they're normal declarations.