### PR TITLE
Refactor to return early

### DIFF
--- a/src/rules/at-rule-no-vendor-prefix/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/index.js
@@ -21,14 +21,14 @@ export default function (actual) {
 
       if (name[0] !== "-") { return }
 
-      if (isAutoprefixable.atRuleName(name)) {
-        report({
-          message: messages.rejected(name),
-          node: atRule,
-          result,
-          ruleName,
-        })
-      }
+      if (!isAutoprefixable.atRuleName(name)) { return }
+
+      report({
+        message: messages.rejected(name),
+        node: atRule,
+        result,
+        ruleName,
+      })
     })
   }
 }

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -22,15 +22,15 @@ export default function (actual) {
     root.walkAtRules(check)
 
     function check(statement) {
-      if (cssStatementHasEmptyBlock(statement)) {
-        report({
-          message: messages.rejected,
-          node: statement,
-          index: cssStatementStringBeforeBlock(statement, { noBefore: true }).length,
-          result,
-          ruleName,
-        })
-      }
+      if (!cssStatementHasEmptyBlock(statement)) { return }
+
+      report({
+        message: messages.rejected,
+        node: statement,
+        index: cssStatementStringBeforeBlock(statement, { noBefore: true }).length,
+        result,
+        ruleName,
+      })
     }
   }
 }

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -28,17 +28,17 @@ export default function (actual) {
 
         const hexMatch = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))
         if (!hexMatch) { return }
-        const hexValue = hexMatch[0]
 
-        if (!isValidHex(hexValue)) {
-          report({
-            message: messages.rejected(hexValue),
-            node: decl,
-            index: match.startIndex,
-            result,
-            ruleName,
-          })
-        }
+        const hexValue = hexMatch[0]
+        if (isValidHex(hexValue)) { return }
+
+        report({
+          message: messages.rejected(hexValue),
+          node: decl,
+          index: match.startIndex,
+          result,
+          ruleName,
+        })
       })
     })
   }

--- a/src/rules/custom-media-pattern/index.js
+++ b/src/rules/custom-media-pattern/index.js
@@ -29,15 +29,15 @@ export default function (pattern) {
 
       const customMediaName = atRule.params.match(/^--(\S+)\b/)[1]
 
-      if (!regexpPattern.test(customMediaName)) {
-        report({
-          message: messages.expected,
-          node: atRule,
-          index: mediaQueryParamIndexOffset(atRule),
-          result,
-          ruleName,
-        })
-      }
+      if (regexpPattern.test(customMediaName)) { return }
+
+      report({
+        message: messages.expected,
+        node: atRule,
+        index: mediaQueryParamIndexOffset(atRule),
+        result,
+        ruleName,
+      })
     })
   }
 }

--- a/src/rules/custom-property-no-outside-root/index.js
+++ b/src/rules/custom-property-no-outside-root/index.js
@@ -20,14 +20,13 @@ export default function (actual) {
       if (rule.selector.trim() === ":root") { return }
 
       rule.walkDecls(decl => {
-        if (decl.prop.substr(0, 2) === "--") {
-          report({
-            message: messages.rejected,
-            node: decl,
-            result,
-            ruleName,
-          })
-        }
+        if (decl.prop.substr(0, 2) !== "--") { return }
+        report({
+          message: messages.rejected,
+          node: decl,
+          result,
+          ruleName,
+        })
       })
     })
   }

--- a/src/rules/custom-property-pattern/index.js
+++ b/src/rules/custom-property-pattern/index.js
@@ -24,17 +24,16 @@ export default function (pattern) {
       : pattern
 
     root.walkDecls(decl => {
-      const prop = decl.prop
+      const { prop } = decl
       if (prop.slice(0, 2) !== "--") { return }
+      if (regexpPattern.test(prop.slice(2))) { return }
 
-      if (!regexpPattern.test(prop.slice(2))) {
-        report({
-          message: messages.expected,
-          node: decl,
-          result,
-          ruleName,
-        })
-      }
+      report({
+        message: messages.expected,
+        node: decl,
+        result,
+        ruleName,
+      })
     })
   }
 }

--- a/src/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/src/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -34,14 +34,13 @@ export default function (actual) {
           return
         }
         overrideables.forEach(longhandProp => {
-          if (declarations.has(longhandProp)) {
-            report({
-              ruleName,
-              result,
-              node,
-              message: messages.rejected(prop, longhandProp),
-            })
-          }
+          if (!declarations.has(longhandProp)) { return }
+          report({
+            ruleName,
+            result,
+            node,
+            message: messages.rejected(prop, longhandProp),
+          })
         })
       })
     }

--- a/src/rules/function-blacklist/index.js
+++ b/src/rules/function-blacklist/index.js
@@ -25,15 +25,17 @@ export default function (blacklist) {
     root.walkDecls(decl => {
       const { value } = decl
       valueParser(value).walk(function (node) {
-        if (node.type === "function" && blacklist.indexOf(vendor.unprefixed(node.value)) !== -1) {
-          report({
-            message: messages.rejected(node.value),
-            node: decl,
-            index: declarationValueIndexOffset(decl) + node.sourceIndex,
-            result,
-            ruleName,
-          })
-        }
+        if (node.type !== "function") { return }
+        if (blacklist.indexOf(vendor.unprefixed(node.value)) === -1) { return }
+
+        report({
+          message: messages.rejected(node.value),
+          node: decl,
+          index: declarationValueIndexOffset(decl) + node.sourceIndex,
+          result,
+          ruleName,
+        })
+
       })
     })
   }

--- a/src/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/src/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -32,7 +32,7 @@ export default function (actual) {
         // If the first character is a number, we can assume the user intends an angle
         if (/[\d\.]/.test(firstArg[0])) {
           if (/^[\d\.]+(?:deg|grad|rad|turn)$/.test(firstArg)) { return }
-          warn()
+          complain()
           return
         }
 
@@ -42,11 +42,11 @@ export default function (actual) {
         if (!/left|right|top|bottom/.test(firstArg)) { return }
 
         if (!isStandardDirection(firstArg)) {
-          warn()
+          complain()
           return
         }
 
-        function warn() {
+        function complain() {
           report({
             message: messages.rejected,
             node: decl,

--- a/src/rules/no-unknown-animations/index.js
+++ b/src/rules/no-unknown-animations/index.js
@@ -57,15 +57,14 @@ export default function (actual) {
     })
 
     function checkAnimationName(animationName, decl, offset = 0) {
-      if (!declaredAnimations.has(animationName)) {
-        report({
-          result,
-          ruleName,
-          message: messages.rejected(animationName),
-          node: decl,
-          index: declarationValueIndexOffset(decl) + offset,
-        })
-      }
+      if (declaredAnimations.has(animationName)) { return }
+      report({
+        result,
+        ruleName,
+        message: messages.rejected(animationName),
+        node: decl,
+        index: declarationValueIndexOffset(decl) + offset,
+      })
     }
   }
 }

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -17,20 +17,19 @@ export default function (actual) {
     if (!validOptions) { return }
 
     root.walkDecls(decl => {
-      const prop = decl.prop
+      const { prop } = decl
 
       // Make sure there's a vendor prefix,
       // but this isn't a custom property
       if (prop[0] !== "-" || prop[1] === "-") { return }
 
-      if (isAutoprefixable.property(prop)) {
-        report({
-          message: messages.rejected(prop),
-          node: decl,
-          result,
-          ruleName,
-        })
-      }
+      if (!isAutoprefixable.property(prop)) { return }
+      report({
+        message: messages.rejected(prop),
+        node: decl,
+        result,
+        ruleName,
+      })
     })
   }
 }

--- a/src/rules/property-unit-whitelist/index.js
+++ b/src/rules/property-unit-whitelist/index.js
@@ -38,15 +38,16 @@ export default function (whitelist) {
 
         const unit = valueParser.unit(node.value).unit
 
-        if (unit && propWhitelist.indexOf(unit) === -1) {
-          report({
-            message: messages.rejected(prop, unit),
-            node: decl,
-            index: declarationValueIndexOffset(decl) + node.sourceIndex,
-            result,
-            ruleName,
-          })
-        }
+        if (!unit) { return }
+        if (propWhitelist.indexOf(unit) !== -1) { return }
+        
+        report({
+          message: messages.rejected(prop, unit),
+          node: decl,
+          index: declarationValueIndexOffset(decl) + node.sourceIndex,
+          result,
+          ruleName,
+        })
       })
     })
   }

--- a/src/rules/property-value-blacklist/index.js
+++ b/src/rules/property-value-blacklist/index.js
@@ -29,14 +29,14 @@ export default function (blacklist) {
 
       if (isEmpty(propBlacklist)) { return }
 
-      if (matchesStringOrRegExp(value, propBlacklist)) {
-        report({
-          message: messages.rejected(prop, value),
-          node: decl,
-          result,
-          ruleName,
-        })
-      }
+      if (!matchesStringOrRegExp(value, propBlacklist)) { return }
+
+      report({
+        message: messages.rejected(prop, value),
+        node: decl,
+        result,
+        ruleName,
+      })
     })
   }
 }

--- a/src/rules/property-value-whitelist/index.js
+++ b/src/rules/property-value-whitelist/index.js
@@ -29,14 +29,14 @@ export default function (whitelist) {
 
       if (isEmpty(propWhitelist)) { return }
 
-      if (!matchesStringOrRegExp(value, propWhitelist)) {
-        report({
-          message: messages.rejected(prop, value),
-          node: decl,
-          result,
-          ruleName,
-        })
-      }
+      if (matchesStringOrRegExp(value, propWhitelist)) { return }
+
+      report({
+        message: messages.rejected(prop, value),
+        node: decl,
+        result,
+        ruleName,
+      })
     })
   }
 }

--- a/src/rules/property-whitelist/index.js
+++ b/src/rules/property-whitelist/index.js
@@ -29,14 +29,14 @@ export default function (whitelistInput) {
 
       if (cssWordIsVariable(prop)) { return }
 
-      if (!matchesStringOrRegExp(vendor.unprefixed(prop), whitelist)) {
-        report({
-          message: messages.rejected(prop),
-          node: decl,
-          result,
-          ruleName,
-        })
-      }
+      if (matchesStringOrRegExp(vendor.unprefixed(prop), whitelist)) { return }
+
+      report({
+        message: messages.rejected(prop),
+        node: decl,
+        result,
+        ruleName,
+      })
     })
   }
 }

--- a/src/rules/selector-class-pattern/index.js
+++ b/src/rules/selector-class-pattern/index.js
@@ -58,15 +58,14 @@ export default function (pattern, options) {
     function checkSelector(fullSelector, rule) {
       fullSelector.eachClass(classNode => {
         const { value, sourceIndex } = classNode
-        if (!normalizedPattern.test(value)) {
-          report({
-            result,
-            ruleName,
-            message: messages.expected(value),
-            node: rule,
-            index: sourceIndex,
-          })
-        }
+        if (normalizedPattern.test(value)) { return }
+        report({
+          result,
+          ruleName,
+          message: messages.expected(value),
+          node: rule,
+          index: sourceIndex,
+        })
       })
     }
   }

--- a/src/rules/selector-id-pattern/index.js
+++ b/src/rules/selector-id-pattern/index.js
@@ -35,15 +35,15 @@ export default function (pattern) {
           if (selectorNode.type !== "id") { return }
           const { value, sourceIndex } = selectorNode
 
-          if (!normalizedPattern.test(value)) {
-            report({
-              result,
-              ruleName,
-              message: messages.expected(value),
-              node: rule,
-              index: sourceIndex,
-            })
-          }
+          if (normalizedPattern.test(value)) { return }
+          
+          report({
+            result,
+            ruleName,
+            message: messages.expected(value),
+            node: rule,
+            index: sourceIndex,
+          })
         })
       }
     })


### PR DESCRIPTION
In the more recent rules we return early, mainly to reduce the amount of nesting.

I checked through the first 50 rules and this PR updates the older ones to use this pattern.

Going through the rest of the rules is a task for another time :)