### PR TITLE
Fix testUtils and exposed createRuleTester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed: `number-leading-zero` will not check `@import` at-rules.
 - Fixed: `selector-class-pattern` now ignores non-ouputting Less mixin definitions and called Less mixins.
 - Fixed: `value-keyword-case` now accounts for camelCase keywords (e.g. `optimizeSpeed`, `optimizeLegibility` and `geometricPrecision`) when the `lower` option is used.
+- Fixed: `testUtils` and `stylelint.createRuleTester` module mistakes.
 
 # 6.1.1
 

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import { mergeTestDescriptions } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."

--- a/src/rules/at-rule-name-case/__test__/index.js
+++ b/src/rules/at-rule-name-case/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/at-rule-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/at-rule-semicolon-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-closing-brace-space-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-no-empty/__tests__/index.js
+++ b/src/rules/block-no-empty/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-no-single-line/__tests__/index.js
+++ b/src/rules/block-no-single-line/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-space-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/color-hex-case/__tests__/index.js
+++ b/src/rules/color-hex-case/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import { mergeTestDescriptions } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."

--- a/src/rules/color-hex-length/__tests__/index.js
+++ b/src/rules/color-hex-length/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import { mergeTestDescriptions } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."

--- a/src/rules/color-named/__tests__/index.js
+++ b/src/rules/color-named/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/color-no-hex/__tests__/index.js
+++ b/src/rules/color-no-hex/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import { mergeTestDescriptions } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."

--- a/src/rules/comment-whitespace-inside/__tests__/index.js
+++ b/src/rules/comment-whitespace-inside/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/custom-media-pattern/__tests__/index.js
+++ b/src/rules/custom-media-pattern/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/custom-property-no-outside-root/__tests__/index.js
+++ b/src/rules/custom-property-no-outside-root/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/custom-property-pattern/__tests__/index.js
+++ b/src/rules/custom-property-pattern/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-bang-space-after/__tests__/index.js
+++ b/src/rules/declaration-bang-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-bang-space-before/__tests__/index.js
+++ b/src/rules/declaration-bang-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-no-ignored-properties/__test__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-properties-order/__tests__/alphabetical.js
+++ b/src/rules/declaration-block-properties-order/__tests__/alphabetical.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-properties-order/__tests__/flat.js
+++ b/src/rules/declaration-block-properties-order/__tests__/flat.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-properties-order/__tests__/grouped-flexible.js
+++ b/src/rules/declaration-block-properties-order/__tests__/grouped-flexible.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-properties-order/__tests__/grouped-strict.js
+++ b/src/rules/declaration-block-properties-order/__tests__/grouped-strict.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-semicolon-space-before/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-single-line-max-declarations/__tests__/index.js
+++ b/src/rules/declaration-block-single-line-max-declarations/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-block-trailing-semicolon/__tests__/index.js
+++ b/src/rules/declaration-block-trailing-semicolon/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-colon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-colon-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-colon-space-after/__tests__/index.js
+++ b/src/rules/declaration-colon-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-colon-space-before/__tests__/index.js
+++ b/src/rules/declaration-colon-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/declaration-no-important/__tests__/index.js
+++ b/src/rules/declaration-no-important/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/font-family-name-quotes/__tests__/index.js
+++ b/src/rules/font-family-name-quotes/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/font-weight-notation/__tests__/index.js
+++ b/src/rules/font-weight-notation/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-blacklist/__tests__/index.js
+++ b/src/rules/function-blacklist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-comma-newline-before/__tests__/index.js
+++ b/src/rules/function-comma-newline-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-comma-space-before/__tests__/index.js
+++ b/src/rules/function-comma-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-max-empty-lines/__test__/index.js
+++ b/src/rules/function-max-empty-lines/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 
 testRule(rule, {

--- a/src/rules/function-name-case/__test__/index.js
+++ b/src/rules/function-name-case/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-parentheses-newline-inside/__tests__/index.js
+++ b/src/rules/function-parentheses-newline-inside/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/function-parentheses-space-inside/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-url-data-uris/__test__/index.js
+++ b/src/rules/function-url-data-uris/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-whitelist/__tests__/index.js
+++ b/src/rules/function-whitelist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/function-whitespace-after/__tests__/index.js
+++ b/src/rules/function-whitespace-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/at-rules.js
+++ b/src/rules/indentation/__tests__/at-rules.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/comments.js
+++ b/src/rules/indentation/__tests__/comments.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/functions.js
+++ b/src/rules/indentation/__tests__/functions.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."
 
 testRule(rule, {

--- a/src/rules/indentation/__tests__/hierarchical.js
+++ b/src/rules/indentation/__tests__/hierarchical.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/indentation/__tests__/selectors.js
+++ b/src/rules/indentation/__tests__/selectors.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/max-empty-lines/__tests__/index.js
+++ b/src/rules/max-empty-lines/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/max-line-length/__tests__/index.js
+++ b/src/rules/max-line-length/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/max-nesting-depth/__tests__/index.js
+++ b/src/rules/max-nesting-depth/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-colon-space-after/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-colon-space-before/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
+++ b/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-range-operator-space-after/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-feature-range-operator-space-before/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-space-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-list-comma-space-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/media-query-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/media-query-parentheses-space-inside/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-browser-hacks/__tests__/index.js
+++ b/src/rules/no-browser-hacks/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-duplicate-selectors/__tests__/index.js
+++ b/src/rules/no-duplicate-selectors/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import postcss from "postcss"
 import postcssImport from "postcss-import"

--- a/src/rules/no-eol-whitespace/__tests__/index.js
+++ b/src/rules/no-eol-whitespace/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-indistinguishable-colors/__tests__/index.js
+++ b/src/rules/no-indistinguishable-colors/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/src/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-missing-eof-newline/__tests__/index.js
+++ b/src/rules/no-missing-eof-newline/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-unknown-animations/__tests__/index.js
+++ b/src/rules/no-unknown-animations/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/src/rules/no-unsupported-browser-features/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-leading-zero/__tests__/index.js
+++ b/src/rules/number-leading-zero/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-max-precision/__tests__/index.js
+++ b/src/rules/number-max-precision/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-no-trailing-zeros/__tests__/index.js
+++ b/src/rules/number-no-trailing-zeros/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/number-zero-length-no-unit/__tests__/index.js
+++ b/src/rules/number-zero-length-no-unit/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-blacklist/__tests__/index.js
+++ b/src/rules/property-blacklist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-case/__test__/index.js
+++ b/src/rules/property-case/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/property-no-vendor-prefix/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-unit-blacklist/__tests__/index.js
+++ b/src/rules/property-unit-blacklist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-unit-whitelist/__tests__/index.js
+++ b/src/rules/property-unit-whitelist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-value-blacklist/__tests__/index.js
+++ b/src/rules/property-value-blacklist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-value-whitelist/__tests__/index.js
+++ b/src/rules/property-value-whitelist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/property-whitelist/__tests__/index.js
+++ b/src/rules/property-whitelist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/root-no-standard-properties/__tests__/index.js
+++ b/src/rules/root-no-standard-properties/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-nested-empty-line-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-attribute-brackets-space-inside/__test__/index.js
+++ b/src/rules/selector-attribute-brackets-space-inside/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-class-pattern/__tests__/index.js
+++ b/src/rules/selector-class-pattern/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import { mergeTestDescriptions } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."

--- a/src/rules/selector-combinator-space-after/__tests__/index.js
+++ b/src/rules/selector-combinator-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-combinator-space-before/__tests__/index.js
+++ b/src/rules/selector-combinator-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-id-pattern/__tests__/index.js
+++ b/src/rules/selector-id-pattern/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import { mergeTestDescriptions } from "../../../testUtils"
 import rule, { ruleName, messages } from ".."

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-list-comma-space-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-attribute/__tests__/index.js
+++ b/src/rules/selector-no-attribute/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-combinator/__tests__/index.js
+++ b/src/rules/selector-no-combinator/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-universal/__tests__/index.js
+++ b/src/rules/selector-no-universal/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-pseudo-class-case/__test__/index.js
+++ b/src/rules/selector-pseudo-class-case/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-pseudo-class-parentheses-space-inside/__test__/index.js
+++ b/src/rules/selector-pseudo-class-parentheses-space-inside/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-pseudo-element-case/__test__/index.js
+++ b/src/rules/selector-pseudo-element-case/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-root-no-composition/__tests__/index.js
+++ b/src/rules/selector-root-no-composition/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/selector-type-case/__tests__/index.js
+++ b/src/rules/selector-type-case/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/string-no-newline/__tests__/index.js
+++ b/src/rules/string-no-newline/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/stylelint-disable-reason/__test__/index.js
+++ b/src/rules/stylelint-disable-reason/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/time-no-imperceptible/__tests__/index.js
+++ b/src/rules/time-no-imperceptible/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/unit-blacklist/__tests__/index.js
+++ b/src/rules/unit-blacklist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/unit-case/__test__/index.js
+++ b/src/rules/unit-case/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/unit-no-unknown/__test__/index.js
+++ b/src/rules/unit-no-unknown/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/unit-whitelist/__tests__/index.js
+++ b/src/rules/unit-whitelist/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-keyword-case/__test__/index.js
+++ b/src/rules/value-keyword-case/__test__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-space-after/__tests__/index.js
+++ b/src/rules/value-list-comma-space-after/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-list-comma-space-before/__tests__/index.js
+++ b/src/rules/value-list-comma-space-before/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/rules/value-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/value-no-vendor-prefix/__tests__/index.js
@@ -1,4 +1,4 @@
-import testRule from "../../../testUtils/testRule"
+import { testRule } from "../../../testUtils"
 
 import rule, { ruleName, messages } from ".."
 

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -1,1 +1,3 @@
 export { default as mergeTestDescriptions } from "./mergeTestDescriptions"
+export { default as createRuleTester } from "./createRuleTester"
+export { default as testRule } from "./testRule"


### PR DESCRIPTION
Relates to https://github.com/stylelint/stylelint-rule-tester/issues/9. Realized when trying to use `stylelint.createRuleTester` that I had flubbed it. While fixing that I fixed some apparent mistakes in the way we were exposing and using test utils.