### PR TITLE
Fix `block-opening-brace-newline-before` docs option `always-multi-line`

### DIFF
--- a/src/rules/block-opening-brace-newline-before/README.md
+++ b/src/rules/block-opening-brace-newline-before/README.md
@@ -98,7 +98,8 @@ color: pink; }
 The following patterns are *not* considered warnings:
 
 ```css
-a{ color: pink; }
+a
+{ color: pink; }
 ```
 
 ```css


### PR DESCRIPTION
Ref: #1148