### PR TITLE
Add grunt-postcss to build tools plugins docs

### DIFF
--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -8,6 +8,7 @@
 
 ## Build tool plugins
 
+- [grunt-postcss](https://github.com/nDmitry/grunt-postcss) - a grunt plugin for PostCSS that can be used with stylelint.
 - [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - a gulp plugin for stylelint.
 - [stylelint-webpack-plugin](https://github.com/vieron/stylelint-webpack-plugin) - a webpack plugin for stylelint.
 


### PR DESCRIPTION
In lieu of there not currently a `grunt-stylelint` plugin we should promote `grunt-postcss` as a workaround.

See also https://github.com/stylelint/stylelint/issues/858#issuecomment-195565942