### PR TITLE
issue with case sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added: `no-extra-semicolons` rule.
 - Added: more flexible support for end-of-line comments in `at-rule-semicolon-newline-after`, `block-opening-brace-newline-after`, and `declaration-block-semicolon-newline-after`.
 - Added: `--stdin-filename` option to CLI.
+- Fixed: all rules and utils now handle case insensitive CSS identifiers.
 - Fixed: `no-indistinguishable-colors` now ignores keyword color names within `url()`.
 - Fixed: string and verbose formatters no longer use an ambiguous colour scheme.
 - Fixed: `selector-class-pattern` and `selector-id-pattern` rules now ignore SCSS variable interpolation.

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -86,6 +86,7 @@ And please *consider edge-cases.* These are where the bugs and shortcomings of r
 - How does your rule handle whitespace and punctuation (e.g. normalising strings before comparison)?
 - How does your rule handle `url()` functions, including data URIs?
 - How does your rule handle nesting?
+- How does your rule handle case sensitivity (e.g. many CSS identifiers are case insensitive)?
 
 #### Running tests
 

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -13,7 +13,15 @@ const sharedAlwaysTests = {
   }, {
     code: "a {}\n\n@media {}",
   }, {
+    code: "a {}\n\n@mEdIa {}",
+  }, {
+    code: "a {}\n\n@MEDIA {}",
+  }, {
     code: "@keyframes foo {}\n\n@media {}",
+  }, {
+    code: "@kEyFrAmEs foo {}\n\n@MeDia {}",
+  }, {
+    code: "@KEYFRAMES foo {}\n\n@MEDIA {}",
   }, {
     code: "a {}\r\n\r\n@media {}",
     description: "windows",
@@ -24,6 +32,12 @@ const sharedAlwaysTests = {
 
   reject: [ {
     code: "a {} @media {}",
+    message: messages.expected,
+  }, {
+    code: "a {} @mEdIa {}",
+    message: messages.expected,
+  }, {
+    code: "a {} @MEDIA {}",
     message: messages.expected,
   }, {
     code: "@keyframes foo {} @media {}",

--- a/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
@@ -16,6 +16,12 @@ testRule(rule, {
     code: "@-webkit-keyframes { 0% { top: 0; } }",
     message: messages.rejected("-webkit-keyframes"),
   }, {
+    code: "@-wEbKiT-kEyFrAmEs { 0% { top: 0; } }",
+    message: messages.rejected("-wEbKiT-kEyFrAmEs"),
+  },  {
+    code: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
+    message: messages.rejected("-WEBKIT-KEYFRAMES"),
+  }, {
     code: "@-moz-keyframes { 0% { top: 0; } }",
     message: messages.rejected("-moz-keyframes"),
   }, {

--- a/src/rules/at-rule-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/at-rule-semicolon-newline-after/__tests__/index.js
@@ -12,6 +12,10 @@ testRule(rule, {
   }, {
     code: "@import 'x.css';\na {}",
   }, {
+    code: "@iMpOrT 'x.css';\na {}",
+  }, {
+    code: "@IMPORT 'x.css';\na {}",
+  }, {
     code: "@charset 'UTF-8';\na {}",
   }, {
     code: "@charset 'UTF-8';\n@import 'x.css'",
@@ -50,6 +54,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@mixin foo; a {}",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 12,
+  }, {
+    code: "@mIxIn foo; a {}",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 12,
+  }, {
+    code: "@MIXIN foo; a {}",
     message: messages.expectedAfter(),
     line: 1,
     column: 12,

--- a/src/rules/color-named/__tests__/index.js
+++ b/src/rules/color-named/__tests__/index.js
@@ -11,6 +11,10 @@ testRule(rule, {
   }, {
     code: "a { color: #ababab; }",
   }, {
+    code: "a { color: #AbAbAb; }",
+  }, {
+    code: "a { color: #ABABAB; }",
+  }, {
     code: "a { color: rgba(0, 0, 0, 0); }",
   }, {
     code: "a { background: #000, #fff, #333; }",
@@ -47,6 +51,16 @@ testRule(rule, {
     line: 1,
     column: 12,
   }, {
+    code: "a { color: rEd; }",
+    message: messages.rejected("rEd"),
+    line: 1,
+    column: 12,
+  }, {
+    code: "a { color: RED; }",
+    message: messages.rejected("RED"),
+    line: 1,
+    column: 12,
+  }, {
     code: "a { color: rebeccapurple; }",
     message: messages.rejected("rebeccapurple"),
     line: 1,
@@ -75,6 +89,10 @@ testRule(rule, {
 
   accept: [ {
     code: "a { color: black; }",
+  }, {
+    code: "a { color: bLaCk; }",
+  }, {
+    code: "a { color: BLACK; }",
   }, {
     code: "a { color: rgb(0,0,1); }",
   }, {
@@ -105,6 +123,16 @@ testRule(rule, {
     line: 1,
     column: 12,
   }, {
+    code: "a { color: #fFfFfF }",
+    message: messages.expected("white", "#fFfFfF"),
+    line: 1,
+    column: 12,
+  }, {
+    code: "a { color: #FFFFFF }",
+    message: messages.expected("white", "#FFFFFF"),
+    line: 1,
+    column: 12,
+  }, {
     code: "a { background: #f000 }",
     message: messages.expected("black", "#f000"),
     line: 1,
@@ -117,6 +145,16 @@ testRule(rule, {
   }, {
     code: "a { color: rgb(0, 0, 0) }",
     message: messages.expected("black", "rgb(0,0,0)"),
+    line: 1,
+    column: 12,
+  }, {
+    code: "a { color: rGb(0, 0, 0) }",
+    message: messages.expected("black", "rGb(0,0,0)"),
+    line: 1,
+    column: 12,
+  }, {
+    code: "a { color: RGB(0, 0, 0) }",
+    message: messages.expected("black", "RGB(0,0,0)"),
     line: 1,
     column: 12,
   }, {

--- a/src/rules/color-named/index.js
+++ b/src/rules/color-named/index.js
@@ -19,6 +19,7 @@ export const messages = ruleMessages(ruleName, {
   ),
 })
 
+// Todo tested on case insensivity
 const FUNC_REPRESENTATIONS = [ "rgb", "rgba", "hsl", "hsla", "hwb", "gray" ]
 const NODE_TYPES = [ "word", "function" ]
 
@@ -46,7 +47,7 @@ export default function (expectation) {
         if (
           expectation === "never"
           && type === "word"
-          && namedColors.indexOf(value) !== -1
+          && namedColors.indexOf(value.toLowerCase()) !== -1
         ) {
           complain(
             messages.rejected(value),
@@ -62,14 +63,14 @@ export default function (expectation) {
         // First by checking for alternative color function representations ...
         if (
           type === "function"
-          && FUNC_REPRESENTATIONS.indexOf(value) !== -1
+          && FUNC_REPRESENTATIONS.indexOf(value.toLowerCase()) !== -1
         ) {
           // Remove all spaces to match what's in `representations`
           const normalizedFunctionString = valueParser.stringify(node).replace(/\s+/g, "")
           let namedColor
           for (let i = 0, l = namedColors.length; i < l; i++) {
             namedColor = namedColors[i]
-            if (representations[namedColor].func.indexOf(normalizedFunctionString) !== -1) {
+            if (representations[namedColor].func.indexOf(normalizedFunctionString.toLowerCase()) !== -1) {
               complain(
                 messages.expected(namedColor, normalizedFunctionString),
                 decl,
@@ -85,7 +86,7 @@ export default function (expectation) {
         let namedColor
         for (let i = 0, l = namedColors.length; i < l; i++) {
           namedColor = namedColors[i]
-          if (representations[namedColor].hex.indexOf(value) !== -1) {
+          if (representations[namedColor].hex.indexOf(value.toLowerCase()) !== -1) {
             complain(
               messages.expected(namedColor, value),
               decl,

--- a/src/rules/custom-media-pattern/__tests__/index.js
+++ b/src/rules/custom-media-pattern/__tests__/index.js
@@ -12,10 +12,24 @@ testRule(rule, {
     code: "@custom-media --foo-bar (min-width: 0);",
   }, {
     code: "@custom-media --foo-foofoo (min-width: 0);",
+  }, {
+    code: "@cUsToM-mEdIa --foo-foofoo (min-width: 0);",
+  }, {
+    code: "@CUSTOM-MEDIA --foo-foofoo (min-width: 0);",
   } ],
 
   reject: [ {
     code: "@custom-media --foa-bar (min-width: 0);",
+    message: messages.expected,
+    line: 1,
+    column: 15,
+  }, {
+    code: "@cUsToM-mEdIa --foa-bar (min-width: 0);",
+    message: messages.expected,
+    line: 1,
+    column: 15,
+  }, {
+    code: "@CUSTOM-MEDIA --foa-bar (min-width: 0);",
     message: messages.expected,
     line: 1,
     column: 15,

--- a/src/rules/custom-media-pattern/index.js
+++ b/src/rules/custom-media-pattern/index.js
@@ -25,7 +25,7 @@ export default function (pattern) {
       : pattern
 
     root.walkAtRules(atRule => {
-      if (atRule.name !== "custom-media") { return }
+      if (atRule.name.toLowerCase() !== "custom-media") { return }
 
       const customMediaName = atRule.params.match(/^--(\S+)\b/)[1]
 

--- a/src/rules/custom-property-no-outside-root/__tests__/index.js
+++ b/src/rules/custom-property-no-outside-root/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: ":root { --foo-bar: 1px; }",
   }, {
+    code: ":rOoT { --foo-bar: 1px; }",
+  }, {
+    code: ":ROOT { --foo-bar: 1px; }",
+  }, {
     code: "a { color: pink; }",
   }, {
     code: "a { -webkit-transform: 1px; }",
@@ -25,6 +29,12 @@ testRule(rule, {
     message: messages.rejected,
   }, {
     code: ":root a { --foo-bar: 1px; }",
+    message: messages.rejected,
+  }, {
+    code: ":rOoT a { --foo-bar: 1px; }",
+    message: messages.rejected,
+  }, {
+    code: ":ROOT a { --foo-bar: 1px; }",
     message: messages.rejected,
   } ],
 })

--- a/src/rules/custom-property-no-outside-root/index.js
+++ b/src/rules/custom-property-no-outside-root/index.js
@@ -17,7 +17,7 @@ export default function (actual) {
 
     root.walkRules(rule => {
       // Ignore rules whose selector is just `:root`
-      if (rule.selector.trim() === ":root") { return }
+      if (rule.selector.toLowerCase().trim() === ":root") { return }
 
       rule.walkDecls(decl => {
         if (decl.prop.substr(0, 2) !== "--") { return }

--- a/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -27,11 +27,30 @@ testRule(rule, {
     code: "a { --custom-property: 0; --custom-property: 1; }",
   }, {
     code: "@fontface { src: url(font.eof); src: url(font.woff) }",
+  }, {
+    code: "@fontface { sRc: url(font.eof); sRc: url(font.woff) }",
+  }, {
+    code: "@fontface { SRC: url(font.eof); SRC: url(font.woff) }",
   } ],
 
   reject: [ {
     code: "a { color: pink; color: orange }",
     message: messages.rejected("color"),
+  }, {
+    code: "a { cOlOr: pink; color: orange }",
+    message: messages.rejected("color"),
+  }, {
+    code: "a { color: pink; cOlOr: orange }",
+    message: messages.rejected("cOlOr"),
+  }, {
+    code: "a { cOlOr: pink; cOlOr: orange }",
+    message: messages.rejected("cOlOr"),
+  }, {
+    code: "a { COLOR: pink; color: orange }",
+    message: messages.rejected("color"),
+  }, {
+    code: "a { color: pink; COLOR: orange }",
+    message: messages.rejected("COLOR"),
   }, {
     code: "a { color: pink; background: orange; color: orange }",
     message: messages.rejected("color"),

--- a/src/rules/declaration-block-no-duplicate-properties/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/index.js
@@ -50,9 +50,9 @@ export default function (on, options) {
         if (isCustomProperty(prop)) { return }
 
         // Ignore the src property as commonly duplicated in at-fontface
-        if (prop === "src") { return }
+        if (prop.toLowerCase() === "src") { return }
 
-        const indexDuplicate = decls.indexOf(prop)
+        const indexDuplicate = decls.indexOf(prop.toLowerCase())
 
         if (indexDuplicate !== -1) {
           if (
@@ -70,7 +70,7 @@ export default function (on, options) {
           })
         }
 
-        decls.push(prop)
+        decls.push(prop.toLowerCase())
       })
     }
   }

--- a/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
@@ -81,6 +81,18 @@ testRule(rule, {
     column: 22,
     description: "display: inline rules out width, height, margin-top and margin-bottom, and float",
   }, {
+    code: "a { dIsPlAy: iNlInE; wIdTh: 100pX; }",
+    message: messages.rejected("wIdTh", "dIsPlAy: iNlInE"),
+    line: 1,
+    column: 22,
+    description: "display: inline rules out width, height, margin-top and margin-bottom, and float",
+  }, {
+    code: "a { DISPLAY: INLINE; WIDTH: 100PX; }",
+    message: messages.rejected("WIDTH", "DISPLAY: INLINE"),
+    line: 1,
+    column: 22,
+    description: "display: inline rules out width, height, margin-top and margin-bottom, and float",
+  }, {
     code: "a { display: inline; height: 100px; }",
     message: messages.rejected("height", "display: inline"),
     line: 1,

--- a/src/rules/declaration-block-no-ignored-properties/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/index.js
@@ -82,15 +82,15 @@ export default function (actual) {
       const unprefixedValue = vendor.unprefixed(value)
 
       ignored.forEach(ignore => {
-        const matchProperty = matchesStringOrRegExp(unprefixedProp, ignore.property)
-        const matchValue = matchesStringOrRegExp(unprefixedValue, ignore.value)
+        const matchProperty = matchesStringOrRegExp(unprefixedProp.toLowerCase(), ignore.property)
+        const matchValue = matchesStringOrRegExp(unprefixedValue.toLowerCase(), ignore.value)
 
         if (!matchProperty || !matchValue) { return }
 
         const ignoredProperties = ignore.ignoredProperties
 
         decl.parent.nodes.forEach((node, nodeIndex) => {
-          if (ignoredProperties.indexOf(node.prop) === -1 || index === nodeIndex) { return }
+          if (ignoredProperties.indexOf(node.prop.toLowerCase()) === -1 || index === nodeIndex) { return }
 
           report({
             message: messages.rejected(node.prop, decl.toString()),

--- a/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -29,6 +29,12 @@ testRule(rule, {
     code: "a { padding-left: 10px; padding: 20px; }",
     message: messages.rejected("padding", "padding-left"),
   }, {
+    code: "a { pAdDiNg-lEfT: 10Px; pAdDiNg: 20Px; }",
+    message: messages.rejected("pAdDiNg", "pAdDiNg-lEfT"),
+  }, {
+    code: "a { PADDING-LEFT: 10PX; PADDING: 20PX; }",
+    message: messages.rejected("PADDING", "PADDING-LEFT"),
+  }, {
     code: "a { padding-left: 10px; { b { padding-top: 10px; padding: 20px; }}}",
     description: "override within nested rule",
     message: messages.rejected("padding", "padding-top"),

--- a/src/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/src/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -22,24 +22,24 @@ export default function (actual) {
     root.walkAtRules(check)
 
     function check(statement) {
-      const declarations = new Set()
+      const declarations = {}
       // Shallow iteration so nesting doesn't produce
       // false positives
       statement.each(node => {
         if (node.type !== "decl") { return }
         const { prop } = node
-        const overrideables = shorthands[prop]
+        const overrideables = shorthands[prop.toLowerCase()]
         if (!overrideables) {
-          declarations.add(prop)
+          declarations[prop.toLowerCase()] = prop
           return
         }
         overrideables.forEach(longhandProp => {
-          if (!declarations.has(longhandProp)) { return }
+          if (!declarations.hasOwnProperty(longhandProp)) { return }
           report({
             ruleName,
             result,
             node,
-            message: messages.rejected(prop, longhandProp),
+            message: messages.rejected(prop, declarations[longhandProp]),
           })
         })
       })

--- a/src/rules/font-weight-notation/__tests__/index.js
+++ b/src/rules/font-weight-notation/__tests__/index.js
@@ -18,6 +18,10 @@ testRule(rule, {
   }, {
     code: "a { font-weight: 100; }",
   }, {
+    code: "a { fOnT-wEiGhT: 100; }",
+  }, {
+    code: "a { FONT-WEIGHT: 100; }",
+  }, {
     code: "a { font-weight: 700; }",
   }, {
     code: "a { font-weight: 850; }",
@@ -25,6 +29,10 @@ testRule(rule, {
     code: "a { font-weight: 900; }",
   }, {
     code: "a { font: italic small-caps 400 16px/3 cursive; }",
+  }, {
+    code: "a { fOnT: italic small-caps 400 16px/3 cursive; }",
+  }, {
+    code: "a { FONT: italic small-caps 400 16px/3 cursive; }",
   }, {
     code: "a { font: italic small-caps 400 16px/500 cursive; }",
   }, {
@@ -46,10 +54,36 @@ testRule(rule, {
   }, {
     code: "a { font-weight: initial; }",
     description: "ignore initial value",
+  }, {
+    code: "a { font-weight: iNiTiAl; }",
+    description: "ignore initial value",
+  }, {
+    code: "a { font-weight: INITIAL; }",
+    description: "ignore initial value",
   } ],
 
   reject: [ {
     code: "a { font-weight: normal; }",
+    message: messages.expected("numeric"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { fOnT-wEiGhT: normal; }",
+    message: messages.expected("numeric"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { FONT-WEIGHT: normal; }",
+    message: messages.expected("numeric"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { font-weight: nOrMaL; }",
+    message: messages.expected("numeric"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { font-weight: NORMAL; }",
     message: messages.expected("numeric"),
     line: 1,
     column: 18,
@@ -88,6 +122,10 @@ testRule(rule, {
   }, {
     code: "a { font-weight: bolder; }",
   }, {
+    code: "a { font-weight: bOlDeR; }",
+  }, {
+    code: "a { font-weight: BOLDER; }",
+  }, {
     code: "a { font-weight: lighter; }",
   }, {
     code: "a { font: italic small-caps lighter 16px/3 cursive; }",
@@ -117,6 +155,10 @@ testRule(rule, {
   }, {
     code: "a { font-weight: bold; }",
   }, {
+    code: "a { font-weight: BoLd; }",
+  }, {
+    code: "a { font-weight: BOLD; }",
+  }, {
     code: "a { font-weight: bolder; }",
   }, {
     code: "a { font-weight: normal; }",
@@ -145,6 +187,12 @@ testRule(rule, {
     description: "another number without keyword equivalent",
   }, {
     code: "a { font-weight: inherit; }",
+    description: "ignore inherit value",
+  }, {
+    code: "a { font-weight: iNhErIt; }",
+    description: "ignore inherit value",
+  }, {
+    code: "a { font-weight: INHERIT; }",
     description: "ignore inherit value",
   } ],
 

--- a/src/rules/font-weight-notation/index.js
+++ b/src/rules/font-weight-notation/index.js
@@ -43,11 +43,11 @@ export default function (expectation, options) {
     if (!validOptions) { return }
 
     root.walkDecls(decl => {
-      if (decl.prop === "font-weight") {
+      if (decl.prop.toLowerCase() === "font-weight") {
         checkWeight(decl.value, decl)
       }
 
-      if (decl.prop === "font") {
+      if (decl.prop.toLowerCase() === "font") {
         checkFont(decl)
       }
     })
@@ -61,9 +61,9 @@ export default function (expectation, options) {
 
       for (const value of postcss.list.space(decl.value)) {
         if (
-          (value === NORMAL_KEYWORD && !hasNumericFontWeight)
+          (value.toLowerCase() === NORMAL_KEYWORD && !hasNumericFontWeight)
           || isNumbery(value)
-          || includes(WEIGHT_SPECIFIC_KEYWORDS, value)
+          || includes(WEIGHT_SPECIFIC_KEYWORDS, value.toLowerCase())
         ) {
           checkWeight(value, decl)
           return
@@ -74,10 +74,12 @@ export default function (expectation, options) {
     function checkWeight(weightValue, decl) {
       if (!isStandardValue(weightValue)) { return }
       if (isVariable(weightValue)) { return }
-      if (weightValue === INHERIT_KEYWORD || weightValue === INITIAL_KEYWORD) { return }
+      if (weightValue.toLowerCase() === INHERIT_KEYWORD
+        || weightValue.toLowerCase() === INITIAL_KEYWORD
+      ) { return }
 
       if (optionsHaveIgnored(options, "relative") &&
-        includes(RELATIVE_NAMED_WEIGHTS, weightValue)) { return }
+        includes(RELATIVE_NAMED_WEIGHTS, weightValue.toLowerCase())) { return }
 
       const weightValueOffset = decl.value.indexOf(weightValue)
 
@@ -89,13 +91,13 @@ export default function (expectation, options) {
 
       if (expectation === "named-where-possible") {
         if (isNumbery(weightValue)) {
-          if (includes(WEIGHTS_WITH_KEYWORD_EQUIVALENTS, weightValue)) {
+          if (includes(WEIGHTS_WITH_KEYWORD_EQUIVALENTS, weightValue.toLowerCase())) {
             complain(messages.expected("named"))
           }
           return
         }
-        if (!includes(WEIGHT_SPECIFIC_KEYWORDS, weightValue)
-          && weightValue !== NORMAL_KEYWORD
+        if (!includes(WEIGHT_SPECIFIC_KEYWORDS, weightValue.toLowerCase())
+          && weightValue.toLowerCase() !== NORMAL_KEYWORD
         ) {
           return complain(messages.invalidNamed(weightValue))
         }

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -15,6 +15,10 @@ testRule(rule, {
   }, {
     code: "a { top: calc(1px + 2px); }",
   }, {
+    code: "a { top: cAlC(1px + 2px); }",
+  }, {
+    code: "a { top: CALC(1px + 2px); }",
+  }, {
     code: "a { top: calc(1px - 2px); }",
   }, {
     code: "a { top: calc(1px * 2); }",
@@ -105,6 +109,16 @@ testRule(rule, {
     column: 19,
   }, {
     code: "a { top: calc(1px+ 2px); }",
+    message: messages.expectedBefore("+"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { top: cAlC(1px+ 2px); }",
+    message: messages.expectedBefore("+"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { top: CALC(1px+ 2px); }",
     message: messages.expectedBefore("+"),
     line: 1,
     column: 18,

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -27,7 +27,7 @@ export default function (actual) {
 
     root.walkDecls(decl => {
       valueParser(decl.value).walk(node => {
-        if (node.type !== "function" || node.value !== "calc") { return }
+        if (node.type !== "function" || node.value.toLowerCase() !== "calc") { return }
 
         const parensMatch = balancedMatch("(", ")", valueParser.stringify(node))
         const rawExpression = parensMatch.body

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -49,7 +49,7 @@ export function functionCommaSpaceChecker({ locationChecker, root, result, check
       if (!isStandardFunction(valueNode)) { return }
 
       // Ignore `url()` arguments, which may contain data URIs or other funky stuff
-      if (valueNode.value === "url") { return }
+      if (valueNode.value.toLowerCase() === "url") { return }
 
       const functionArguments = (() => {
         let result = valueParser.stringify(valueNode)

--- a/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: ".foo { background: linear-gradient(to top, #fff, #000; )}",
   }, {
+    code: ".foo { background: lInEaR-gRaDiEnT(to top, #fff, #000; )}",
+  }, {
+    code: ".foo { background: LINEAR-GRADIENT(to top, #fff, #000; )}",
+  }, {
     code: ".foo { background: linear-gradient(to bottom, #fff, #000; )}",
   }, {
     code: ".foo { background: linear-gradient(  to right, #fff, #000; )}",
@@ -40,6 +44,18 @@ testRule(rule, {
 
   reject: [ {
     code: ".foo { background: linear-gradient(bottom, #fff, #000; )}",
+    message: messages.rejected,
+  }, {
+    code: ".foo { background: lInEaR-gRaDiEnT(bottom, #fff, #000; )}",
+    message: messages.rejected,
+  }, {
+    code: ".foo { background: LINEAR-GRADIENT(bottom, #fff, #000; )}",
+    message: messages.rejected,
+  }, {
+    code: ".foo { background: linear-gradient(bOtToM, #fff, #000; )}",
+    message: messages.rejected,
+  }, {
+    code: ".foo { background: linear-gradient(BOTTOM, #fff, #000; )}",
     message: messages.rejected,
   }, {
     code: ".foo { background: linear-gradient(top, #fff, #000; )}",

--- a/src/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/src/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -26,7 +26,7 @@ export default function (actual) {
     if (!validOptions) { return }
 
     root.walkDecls(decl => {
-      functionArgumentsSearch(decl.toString(), "linear-gradient", (expression, expressionIndex) => {
+      functionArgumentsSearch(decl.toString().toLowerCase(), "linear-gradient", (expression, expressionIndex) => {
         const firstArg = expression.split(",")[0].trim()
 
         // If the first character is a number, we can assume the user intends an angle

--- a/src/rules/function-url-data-uris/__tests__/index.js
+++ b/src/rules/function-url-data-uris/__tests__/index.js
@@ -23,6 +23,14 @@ testRule(rule, {
   }, {
     code: "a { background: url('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
   }, {
+    code: "a { background: uRl('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
+  }, {
+    code: "a { background: URL('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
+  }, {
+    code: "a { background: url('dAtA:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
+  }, {
+    code: "a { background: url('DATA:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
+  }, {
     code: "a { cursor: url('data:image/ico;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
   }, {
     code: "a { background-image: url('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=') }",
@@ -85,6 +93,16 @@ testRule(rule, {
     column: 34,
   }, {
     code: "a { background: url('foo.png'); }",
+    message: messages.expected,
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { background: uRl('foo.png'); }",
+    message: messages.expected,
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { background: URL('foo.png'); }",
     message: messages.expected,
     line: 1,
     column: 5,
@@ -157,6 +175,10 @@ testRule(rule, {
   }, {
     code: "a { background: url('image.png'); }",
   }, {
+    code: "a { background: uRl('image.png'); }",
+  }, {
+    code: "a { background: URL('image.png'); }",
+  }, {
     code: "a { cursor: url('image.ico'); }",
   }, {
     code: "a { background-image: url('image.png') }",
@@ -219,6 +241,16 @@ testRule(rule, {
     column: 34,
   }, {
     code: "a { background: url('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
+    message: messages.rejected,
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { background: url('dAtA:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
+    message: messages.rejected,
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { background: url('DATA:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='); }",
     message: messages.rejected,
     line: 1,
     column: 5,

--- a/src/rules/function-url-data-uris/index.js
+++ b/src/rules/function-url-data-uris/index.js
@@ -27,7 +27,10 @@ export default function (expectation) {
 
     root.walkDecls(function (decl) {
       valueParser(decl.value).walk(valueNode => {
-        if (valueNode.type !== "function" || valueNode.value !== "url" || !valueNode.nodes[0]) { return }
+        if (valueNode.type !== "function"
+          || valueNode.value.toLowerCase() !== "url"
+          || !valueNode.nodes[0]
+        ) { return }
 
         const urlValueNode = valueNode.nodes[0]
 
@@ -36,7 +39,7 @@ export default function (expectation) {
           || isVariable(urlValueNode.value)
         ) { return }
 
-        const valueContainDataUris = urlValueNode.value.indexOf("data:") === 0
+        const valueContainDataUris = urlValueNode.value.toLowerCase().indexOf("data:") === 0
         const needUrlDataUris = expectation === "always"
 
         if (valueContainDataUris && needUrlDataUris

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -15,6 +15,22 @@ testRule(rule, {
       column: 14,
     },
   }, {
+    code: "@import uRl(\"foo.css\");",
+
+    description: {
+      message: messages.expected("double quotes"),
+      line: 1,
+      column: 14,
+    },
+  }, {
+    code: "@import URL(\"foo.css\");",
+
+    description: {
+      message: messages.expected("double quotes"),
+      line: 1,
+      column: 14,
+    },
+  }, {
     code: "@import url( \"foo.css\" );",
 
     description: {
@@ -41,6 +57,10 @@ testRule(rule, {
   }, {
     code: "a { background: url(\"foo.css\"); }",
   }, {
+    code: "a { background: uRl(\"foo.css\"); }",
+  }, {
+    code: "a { background: URL(\"foo.css\"); }",
+  }, {
     code: "a { background: url( \"foo.css\" ); }",
   }, {
     code: "a { background: url(  \"foo.css\"  ); }",
@@ -54,6 +74,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@import url('foo.css');",
+    message: messages.expected("double quotes"),
+    line: 1,
+    column: 13,
+  }, {
+    code: "@import uRl('foo.css');",
+    message: messages.expected("double quotes"),
+    line: 1,
+    column: 13,
+  }, {
+    code: "@import uRl('foo.css');",
     message: messages.expected("double quotes"),
     line: 1,
     column: 13,
@@ -118,6 +148,16 @@ testRule(rule, {
     line: 1,
     column: 21,
   }, {
+    code: "a { background: uRl('foo.css'); }",
+    message: messages.expected("double quotes"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { background: URL('foo.css'); }",
+    message: messages.expected("double quotes"),
+    line: 1,
+    column: 21,
+  }, {
     code: "a { background: url( 'foo.css' ); }",
     message: messages.expected("double quotes"),
     line: 1,
@@ -172,6 +212,10 @@ testRule(rule, {
   accept: [ {
     code: "@import url('foo.css');",
   }, {
+    code: "@import uRl('foo.css');",
+  }, {
+    code: "@import URL('foo.css');",
+  }, {
     code: "@import url( 'foo.css' );",
   }, {
     code: "@document url('http://www.w3.org/');",
@@ -192,6 +236,10 @@ testRule(rule, {
   }, {
     code: "a { background: url('foo.css'); }",
   }, {
+    code: "a { background: uRl('foo.css'); }",
+  }, {
+    code: "a { background: URL('foo.css'); }",
+  }, {
     code: "a { background: url( 'foo.css' ); }",
   }, {
     code: "a { background: url(  'foo.css'  ); }",
@@ -205,6 +253,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@import url(\"foo.css\");",
+    message: messages.expected("single quotes"),
+    line: 1,
+    column: 13,
+  },  {
+    code: "@import uRl(\"foo.css\");",
+    message: messages.expected("single quotes"),
+    line: 1,
+    column: 13,
+  }, {
+    code: "@import URL(\"foo.css\");",
     message: messages.expected("single quotes"),
     line: 1,
     column: 13,
@@ -269,6 +327,16 @@ testRule(rule, {
     line: 1,
     column: 21,
   }, {
+    code: "a { background: uRl(\"foo.css\"); }",
+    message: messages.expected("single quotes"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { background: URL(\"foo.css\"); }",
+    message: messages.expected("single quotes"),
+    line: 1,
+    column: 21,
+  }, {
     code: "a { background: url( \"foo.css\" ); }",
     message: messages.expected("single quotes"),
     line: 1,
@@ -322,7 +390,11 @@ testRule(rule, {
 
   accept: [ {
     code: "@import url(foo.css);",
-  },  {
+  }, {
+    code: "@import uRl(foo.css);",
+  }, {
+    code: "@import URL(foo.css);",
+  }, {
     code: "@import url( foo.css );",
   }, {
     code: "@document url(http://www.w3.org/);",
@@ -343,6 +415,10 @@ testRule(rule, {
   }, {
     code: "a { background: url(foo.css); }",
   }, {
+    code: "a { background: uRl(foo.css); }",
+  }, {
+    code: "a { background: URL(foo.css); }",
+  }, {
     code: "a { background: url( foo.css ); }",
   }, {
     code: "a { background: url(  foo.css  ); }",
@@ -356,6 +432,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@import url(\"foo.css\");",
+    message: messages.expected("no quotes"),
+    line: 1,
+    column: 13,
+  }, {
+    code: "@import uRl(\"foo.css\");",
+    message: messages.expected("no quotes"),
+    line: 1,
+    column: 13,
+  }, {
+    code: "@import URL(\"foo.css\");",
     message: messages.expected("no quotes"),
     line: 1,
     column: 13,
@@ -416,6 +502,16 @@ testRule(rule, {
     column: 42,
   }, {
     code: "a { background: url(\"foo.css\"); }",
+    message: messages.expected("no quotes"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { background: uRl(\"foo.css\"); }",
+    message: messages.expected("no quotes"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { background: URL(\"foo.css\"); }",
     message: messages.expected("no quotes"),
     line: 1,
     column: 21,

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -60,7 +60,7 @@ export default function (expectation) {
       }
 
       statement.walkDecls(function (decl) {
-        functionArgumentsSearch(decl.toString(), "url", (args, index) => {
+        functionArgumentsSearch(decl.toString().toLowerCase(), "url", (args, index) => {
           const trimLeftArgs = args.trimLeft()
           if (!strDefiesExpectation(trimLeftArgs.trimRight())) { return }
           complain(messages.expected(quoteMsg), decl, index + args.length - trimLeftArgs.length)
@@ -69,7 +69,8 @@ export default function (expectation) {
     }
 
     function checkAtRuleParams(atRule) {
-      functionArgumentsSearch(atRule.params, "url", (args, index) => {
+      const atRuleParamsLowerCase = atRule.params.toLowerCase()
+      functionArgumentsSearch(atRuleParamsLowerCase, "url", (args, index) => {
         const trimLeftArgs = args.trimLeft()
         if (!strDefiesExpectation(trimLeftArgs.trimRight())) { return }
         complain(
@@ -78,7 +79,7 @@ export default function (expectation) {
           index + args.length - trimLeftArgs.length + atRuleParamIndex(atRule)
         )
       })
-      functionArgumentsSearch(atRule.params, "url-prefix", (args, index) => {
+      functionArgumentsSearch(atRuleParamsLowerCase, "url-prefix", (args, index) => {
         const trimLeftArgs = args.trimLeft()
         if (!strDefiesExpectation(trimLeftArgs.trimRight())) { return }
         complain(
@@ -87,7 +88,7 @@ export default function (expectation) {
           index + args.length - trimLeftArgs.length + atRuleParamIndex(atRule)
         )
       })
-      functionArgumentsSearch(atRule.params, "domain", (args, index) => {
+      functionArgumentsSearch(atRuleParamsLowerCase, "domain", (args, index) => {
         const trimLeftArgs = args.trimLeft()
         if (!strDefiesExpectation(trimLeftArgs.trimRight())) { return }
         complain(

--- a/src/rules/max-line-length/__tests__/index.js
+++ b/src/rules/max-line-length/__tests__/index.js
@@ -17,7 +17,15 @@ testRule(rule, {
   }, {
     code: "a {\n background: url(somethingsomethingsomethingsomething);\n}",
   }, {
+    code: "a {\n background: uRl(somethingsomethingsomethingsomething);\n}",
+  }, {
+    code: "a {\n background: URL(somethingsomethingsomethingsomething);\n}",
+  }, {
     code: "a {\n  background: url(\n  somethingsomethingsomethingsomething\n  );\n}",
+  }, {
+    code: "a {\n  background: uRl(\n  somethingsomethingsomethingsomething\n  );\n}",
+  }, {
+    code: "a {\n  background: URL(\n  somethingsomethingsomethingsomething\n  );\n}",
   } ],
 
   reject: [ {

--- a/src/rules/max-line-length/index.js
+++ b/src/rules/max-line-length/index.js
@@ -29,7 +29,7 @@ export default function (maxLength, options) {
 
     // Collapse all urls into something nice and short,
     // so they do not throw the game
-    const rootString = root.toString().replace(/url\(.*\)/g, "url()")
+    const rootString = root.toString().replace(/url\(.*\)/ig, "url()")
 
     const ignoreNonComments = optionsHaveIgnored(options, "non-comments")
 

--- a/src/rules/media-feature-colon-space-after/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-after/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width: 600px) {}",
   }, {
+    code: "@mEdIa (max-width: 600px) {}",
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
+  }, {
     code: "@media (max-width : 600px) {}",
   }, {
     code: "@media (max-width: 600px) and (min-width: 3em) {}",
@@ -18,6 +22,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width:600px) {}",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@mEdIa (max-width:600px) {}",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@MEDIA (max-width:600px) {}",
     message: messages.expectedAfter(),
     line: 1,
     column: 18,
@@ -62,6 +76,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width:600px) {}",
   }, {
+    code: "@mEdIa (max-width:600px) {}",
+  }, {
+    code: "@MEDIA (max-width:600px) {}",
+  }, {
     code: "@media (max-width:600px) and (min-width:3em) {}",
   }, {
     code: "@custom-selector : --enter :hover;",
@@ -69,6 +87,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width: 600px) {}",
+    message: messages.rejectedAfter(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@mEdIa (max-width: 600px) {}",
+    message: messages.rejectedAfter(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
     message: messages.rejectedAfter(),
     line: 1,
     column: 18,

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -40,7 +40,7 @@ export function mediaFeatureColonSpaceChecker({ locationChecker, root, result, c
     const { name, params } = atRule
 
     // Only deal with @media at-rules
-    if (name !== "media") { return }
+    if (name.toLowerCase() !== "media") { return }
 
     styleSearch({ source: params, target: ":" }, match => {
       checkColon(params, match.startIndex, atRule)

--- a/src/rules/media-feature-colon-space-before/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-before/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width :600px) {}",
   }, {
+    code: "@mEdIa (max-width :600px) {}",
+  }, {
+    code: "@MEDIA (max-width :600px) {}",
+  }, {
     code: "@media (max-width : 600px) {}",
   }, {
     code: "@media (max-width :600px) and (min-width :3em) {}",
@@ -18,6 +22,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width:600px) {}",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@mEdIa (max-width:600px) {}",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@MEDIA (max-width:600px) {}",
     message: messages.expectedBefore(),
     line: 1,
     column: 18,
@@ -62,6 +76,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width:600px) {}",
   }, {
+    code: "@mEdIa (max-width:600px) {}",
+  }, {
+    code: "@MEDIA (max-width:600px) {}",
+  }, {
     code: "@media (max-width: 600px) {}",
   }, {
     code: "@media (max-width:600px) and (min-width:3em) {}",
@@ -71,6 +89,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width :600px) {}",
+    message: messages.rejectedBefore(),
+    line: 1,
+    column: 19,
+  }, {
+    code: "@mEdIa (max-width :600px) {}",
+    message: messages.rejectedBefore(),
+    line: 1,
+    column: 19,
+  }, {
+    code: "@MEDIA (max-width :600px) {}",
     message: messages.rejectedBefore(),
     line: 1,
     column: 19,

--- a/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
@@ -16,6 +16,16 @@ testRule(rule, {
     line: 1,
     column: 9,
   }, {
+    code: "@media (-wEbKiT-mIn-DeViCe-PiXeL-rAtIo: 1) {}",
+    message: messages.rejected,
+    line: 1,
+    column: 9,
+  }, {
+    code: "@media (-WEBKIT-MIN-DEVICE-PIXEL-RATIO: 1) {}",
+    message: messages.rejected,
+    line: 1,
+    column: 9,
+  }, {
     code: "@media\n\t(min--moz-device-pixel-ratio: 1) {}",
     message: messages.rejected,
     line: 2,

--- a/src/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/index.js
@@ -18,18 +18,17 @@ export default function (actual) {
 
     root.walkAtRules(atRule => {
       const { params } = atRule
-      if (isAutoprefixable.mediaFeatureName(params)) {
-        const matches = atRule.toString().match(/[a-z-]+device-pixel-ratio/g)
-        matches.forEach(match => {
-          report({
-            message: messages.rejected,
-            node: atRule,
-            word: match,
-            result,
-            ruleName,
-          })
+      if (!isAutoprefixable.mediaFeatureName(params)) { return }
+      const matches = atRule.toString().match(/[a-z-]+device-pixel-ratio/ig)
+      matches.forEach(match => {
+        report({
+          message: messages.rejected,
+          node: atRule,
+          word: match,
+          result,
+          ruleName,
         })
-      }
+      })
     })
   }
 }

--- a/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
+++ b/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
@@ -15,6 +15,10 @@ testRule(rule, {
   }, {
     code: "@media (min-width: 300px) {}",
   }, {
+    code: "@mEdIa (min-width: 300px) {}",
+  }, {
+    code: "@MEDIA (min-width: 300px) {}",
+  }, {
     code: "@media ( min-width: 300px ) {}",
   }, {
     code: "@media (min-width   :\t300px) {}",
@@ -44,6 +48,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (min-width 300px) {}",
+    message: messages.rejected,
+    line: 1,
+    column: 8,
+  }, {
+    code: "@mEdIa (min-width 300px) {}",
+    message: messages.rejected,
+    line: 1,
+    column: 8,
+  }, {
+    code: "@MEDIA (min-width 300px) {}",
     message: messages.rejected,
     line: 1,
     column: 8,

--- a/src/rules/media-feature-no-missing-punctuation/index.js
+++ b/src/rules/media-feature-no-missing-punctuation/index.js
@@ -31,7 +31,7 @@ export default function (actual) {
     const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
-    root.walkAtRules("media", atRule => {
+    root.walkAtRules(/media/i, atRule => {
       execall(/\((.*?)\)/g, atRule.params).forEach(mediaFeatureMatch => {
         const splitMediaFeature = mediaFeatureMatch.sub[0].trim().split(/\s+/)
         if (splitMediaFeature.length === 1) { return }

--- a/src/rules/media-feature-range-operator-space-after/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-after/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width= 600px) {}",
   }, {
+    code: "@mEdIa (max-width= 600px) {}",
+  }, {
+    code: "@MEDIA (max-width= 600px) {}",
+  }, {
     code: "@media (max-width > 600px) {}",
   }, {
     code: "@media (max-width>= 600px) and (min-width<= 3em) {}",
@@ -16,6 +20,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width<600px) {}",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 19,
+  }, {
+    code: "@mEdIa (max-width<600px) {}",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 19,
+  }, {
+    code: "@MEDIA (max-width<600px) {}",
     message: messages.expectedAfter(),
     line: 1,
     column: 19,
@@ -60,6 +74,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width =600px) {}",
   }, {
+    code: "@mEdIa (max-width =600px) {}",
+  }, {
+    code: "@MEDIA (max-width =600px) {}",
+  }, {
     code: "@media (max-width>600px) {}",
   }, {
     code: "@media (max-width >=600px) and (min-width <=3em) {}",
@@ -67,6 +85,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width < 600px) {}",
+    message: messages.rejectedAfter(),
+    line: 1,
+    column: 20,
+  }, {
+    code: "@mEdIa (max-width < 600px) {}",
+    message: messages.rejectedAfter(),
+    line: 1,
+    column: 20,
+  }, {
+    code: "@MEDIA (max-width < 600px) {}",
     message: messages.rejectedAfter(),
     line: 1,
     column: 20,

--- a/src/rules/media-feature-range-operator-space-after/index.js
+++ b/src/rules/media-feature-range-operator-space-after/index.js
@@ -52,7 +52,7 @@ export default function (expectation) {
 }
 
 export function findMediaOperator(atRule, cb) {
-  if (atRule.name !== "media") { return }
+  if (atRule.name.toLowerCase() !== "media") { return }
 
   const params = atRule.params
   let match

--- a/src/rules/media-feature-range-operator-space-before/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-before/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width = 600px) {}",
   }, {
+    code: "@mEdIa (max-width = 600px) {}",
+  }, {
+    code: "@MEDIA (max-width = 600px) {}",
+  }, {
     code: "@media (max-width >600px) {}",
   }, {
     code: "@media (max-width >= 600px) and (min-width <= 3em) {}",
@@ -16,6 +20,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width< 600px) {}",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 17,
+  }, {
+    code: "@mEdIa (max-width< 600px) {}",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 17,
+  }, {
+    code: "@MEDIA (max-width< 600px) {}",
     message: messages.expectedBefore(),
     line: 1,
     column: 17,
@@ -60,6 +74,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width= 600px) {}",
   }, {
+    code: "@mEdIa (max-width= 600px) {}",
+  }, {
+    code: "@MEDIA (max-width= 600px) {}",
+  }, {
     code: "@media (max-width>600px) {}",
   }, {
     code: "@media (max-width>= 600px) and (min-width<= 3em) {}",
@@ -67,6 +85,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width < 600px) {}",
+    message: messages.rejectedBefore(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@mEdIa (max-width < 600px) {}",
+    message: messages.rejectedBefore(),
+    line: 1,
+    column: 18,
+  }, {
+    code: "@MEDIA (max-width < 600px) {}",
     message: messages.rejectedBefore(),
     line: 1,
     column: 18,

--- a/src/rules/media-query-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-after/__tests__/index.js
@@ -11,6 +11,10 @@ testRule(rule, {
   }, {
     code: "@media (max-width: 600px) {}",
   }, {
+    code: "@mEdIa (max-width: 600px) {}",
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
+  }, {
     code: "@media screen and (color),\nprojection and (color) {}",
   }, {
     code: "@media screen and (color) ,\n  projection and (color) {}",
@@ -27,6 +31,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color),projection and (color)",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color),projection and (color)",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color),projection and (color)",
     message: messages.expectedAfter(),
     line: 1,
     column: 26,
@@ -56,6 +70,12 @@ testRule(rule, {
     code: "@media screen and (color),\nprojection and (color) {}",
     description: "multi-line list, single-line block",
   }, {
+    code: "@mEdIa screen and (color),\nprojection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
+    code: "@MEDIA screen and (color),\nprojection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
     code: "@media screen and (color),\r\nprojection and (color) {}",
     description: "multi-line list, single-line block and CRLF",
   }, {
@@ -74,6 +94,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color),projection and (color),\nprint {}",
+    message: messages.expectedAfterMultiLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color),projection and (color),\nprint {}",
+    message: messages.expectedAfterMultiLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color),projection and (color),\nprint {}",
     message: messages.expectedAfterMultiLine(),
     line: 1,
     column: 26,
@@ -99,6 +129,12 @@ testRule(rule, {
     code: "@media screen and (color)\n,projection and (color) {}",
     description: "multi-line list, single-line block",
   }, {
+    code: "@mEdIa screen and (color)\n,projection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
+    code: "@MEDIA screen and (color)\n,projection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
     code: "@media screen and (color)\r\n,projection and (color) {}",
     description: "multi-line list, single-line block and CRLF",
   }, {
@@ -117,6 +153,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color) ,projection and (color),\nprint {}",
+    message: messages.rejectedAfterMultiLine(),
+    line: 1,
+    column: 50,
+  }, {
+    code: "@mEdIa screen and (color) ,projection and (color),\nprint {}",
+    message: messages.rejectedAfterMultiLine(),
+    line: 1,
+    column: 50,
+  }, {
+    code: "@MEDIA screen and (color) ,projection and (color),\nprint {}",
     message: messages.rejectedAfterMultiLine(),
     line: 1,
     column: 50,

--- a/src/rules/media-query-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-before/__tests__/index.js
@@ -11,6 +11,10 @@ testRule(rule, {
   }, {
     code: "@media (max-width: 600px) {}",
   }, {
+    code: "@mEdIa (max-width: 600px) {}",
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
+  }, {
     code: "@media screen and (color)\n, projection and (color) {}",
   }, {
     code: "@media screen and (color)\r\n, projection and (color) {}",
@@ -29,6 +33,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color), projection and (color)",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color), projection and (color)",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color), projection and (color)",
     message: messages.expectedBefore(),
     line: 1,
     column: 26,
@@ -53,6 +67,12 @@ testRule(rule, {
     code: "@media screen and (color)\n, projection and (color) {}",
     description: "multi-line list, single-line block",
   }, {
+    code: "@mEdIa screen and (color)\n, projection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
+    code: "@MEDIA screen and (color)\n, projection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
     code: "@media screen and (color)\r\n, projection and (color) {}",
     description: "multi-line list, single-line block and CRLF",
   }, {
@@ -68,6 +88,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color),projection and (color)\n, print {}",
+    message: messages.expectedBeforeMultiLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color),projection and (color)\n, print {}",
+    message: messages.expectedBeforeMultiLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color),projection and (color)\n, print {}",
     message: messages.expectedBeforeMultiLine(),
     line: 1,
     column: 26,
@@ -93,6 +123,12 @@ testRule(rule, {
     code: "@media screen and (color),\nprojection and (color) {}",
     description: "multi-line list, single-line block",
   }, {
+    code: "@mEdIa screen and (color),\nprojection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
+    code: "@MEDIA screen and (color),\nprojection and (color) {}",
+    description: "multi-line list, single-line block",
+  }, {
     code: "@media screen and (color),\nprojection and (color) {\n}",
     description: "multi-line list, multi-line block",
   }, {
@@ -108,6 +144,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color) ,projection and (color),\nprint {}",
+    message: messages.rejectedBeforeMultiLine(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@mEdIa screen and (color) ,projection and (color),\nprint {}",
+    message: messages.rejectedBeforeMultiLine(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@MEDIA screen and (color) ,projection and (color),\nprint {}",
     message: messages.rejectedBeforeMultiLine(),
     line: 1,
     column: 27,

--- a/src/rules/media-query-list-comma-space-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-after/__tests__/index.js
@@ -11,6 +11,10 @@ testRule(rule, {
   }, {
     code: "@media (max-width: 600px) {}",
   }, {
+    code: "@mEdIa (max-width: 600px) {}",
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
+  }, {
     code: "@media screen and (color), projection and (color) {}",
   }, {
     code: "@media screen and (color) , projection and (color) {}",
@@ -23,6 +27,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color),projection and (color)",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color),projection and (color)",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color),projection and (color)",
     message: messages.expectedAfter(),
     line: 1,
     column: 26,
@@ -59,6 +73,10 @@ testRule(rule, {
   }, {
     code: "@media (max-width: 600px) {}",
   }, {
+    code: "@mEdIa (max-width: 600px) {}",
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
+  }, {
     code: "@media screen and (color),projection and (color) {}",
   }, {
     code: "@media screen and (color) ,projection and (color) {}",
@@ -71,6 +89,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color), projection and (color)",
+    message: messages.rejectedAfter(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color), projection and (color)",
+    message: messages.rejectedAfter(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color), projection and (color)",
     message: messages.rejectedAfter(),
     line: 1,
     column: 26,
@@ -105,6 +133,10 @@ testRule(rule, {
   accept: [ {
     code: "@media screen and (color), projection and (color) {}",
   }, {
+    code: "@mEdIa screen and (color), projection and (color) {}",
+  }, {
+    code: "@MEDIA screen and (color), projection and (color) {}",
+  }, {
     code: "@media screen and (color), projection and (color) {\n}",
     description: "single-line list, multi-line block",
   }, {
@@ -120,6 +152,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color) ,projection and (color) {}",
+    message: messages.expectedAfterSingleLine(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@mEdIa screen and (color) ,projection and (color) {}",
+    message: messages.expectedAfterSingleLine(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@MEDIA screen and (color) ,projection and (color) {}",
     message: messages.expectedAfterSingleLine(),
     line: 1,
     column: 27,
@@ -145,6 +187,10 @@ testRule(rule, {
   accept: [ {
     code: "@media screen and (color) ,projection and (color) {}",
   }, {
+    code: "@mEdIa screen and (color) ,projection and (color) {}",
+  }, {
+    code: "@MEDIA screen and (color) ,projection and (color) {}",
+  }, {
     code: "@media screen and (color) ,projection and (color) {\n}",
     description: "single-line list, multi-line block",
   }, {
@@ -160,6 +206,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color), projection and (color) {}",
+    message: messages.rejectedAfterSingleLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color), projection and (color) {}",
+    message: messages.rejectedAfterSingleLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color), projection and (color) {}",
     message: messages.rejectedAfterSingleLine(),
     line: 1,
     column: 26,

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -39,7 +39,7 @@ export default function (expectation) {
 }
 
 export function mediaQueryListCommaWhitespaceChecker({ locationChecker, root, result, checkedRuleName }) {
-  root.walkAtRules("media", atRule => {
+  root.walkAtRules(/media/i, atRule => {
     const params = atRule.params
     styleSearch({ source: params, target: "," }, match => {
       checkComma(params, match.startIndex, atRule)

--- a/src/rules/media-query-list-comma-space-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-before/__tests__/index.js
@@ -11,6 +11,10 @@ testRule(rule, {
   }, {
     code: "@media (max-width: 600px) {}",
   }, {
+    code: "@mEdIa (max-width: 600px) {}",
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
+  }, {
     code: "@media screen and (color) , projection and (color) {}",
   }, {
     code: "@media screen and (color) ,  projection and (color) {}",
@@ -23,6 +27,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color), projection and (color)",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color), projection and (color)",
+    message: messages.expectedBefore(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color), projection and (color)",
     message: messages.expectedBefore(),
     line: 1,
     column: 26,
@@ -59,6 +73,10 @@ testRule(rule, {
   }, {
     code: "@media (max-width: 600px) {}",
   }, {
+    code: "@mEdIa (max-width: 600px) {}",
+  }, {
+    code: "@MEDIA (max-width: 600px) {}",
+  }, {
     code: "@media screen and (color),projection and (color) {}",
   }, {
     code: "@media screen and (color), projection and (color) {}",
@@ -71,6 +89,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color) , projection and (color)",
+    message: messages.rejectedBefore(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@mEdIa screen and (color) , projection and (color)",
+    message: messages.rejectedBefore(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@MEDIA screen and (color) , projection and (color)",
     message: messages.rejectedBefore(),
     line: 1,
     column: 27,
@@ -105,6 +133,10 @@ testRule(rule, {
   accept: [ {
     code: "@media screen and (color) ,projection and (color) {}",
   }, {
+    code: "@mEdIa screen and (color) ,projection and (color) {}",
+  }, {
+    code: "@MEDIA screen and (color) ,projection and (color) {}",
+  }, {
     code: "@media screen and (color) ,projection and (color) {\n}",
     description: "single-line list, multi-line block",
   }, {
@@ -120,6 +152,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color), projection and (color) {}",
+    message: messages.expectedBeforeSingleLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@mEdIa screen and (color), projection and (color) {}",
+    message: messages.expectedBeforeSingleLine(),
+    line: 1,
+    column: 26,
+  }, {
+    code: "@MEDIA screen and (color), projection and (color) {}",
     message: messages.expectedBeforeSingleLine(),
     line: 1,
     column: 26,
@@ -145,6 +187,10 @@ testRule(rule, {
   accept: [ {
     code: "@media screen and (color), projection and (color) {}",
   }, {
+    code: "@mEdIa screen and (color), projection and (color) {}",
+  }, {
+    code: "@MEDIA screen and (color), projection and (color) {}",
+  }, {
     code: "@media screen and (color), projection and (color) {\n}",
     description: "single-line list, multi-line block",
   }, {
@@ -160,6 +206,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media screen and (color) ,projection and (color) {}",
+    message: messages.rejectedBeforeSingleLine(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@mEdIa screen and (color) ,projection and (color) {}",
+    message: messages.rejectedBeforeSingleLine(),
+    line: 1,
+    column: 27,
+  }, {
+    code: "@MEDIA screen and (color) ,projection and (color) {}",
     message: messages.rejectedBeforeSingleLine(),
     line: 1,
     column: 27,

--- a/src/rules/media-query-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/media-query-parentheses-space-inside/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: "@media ( max-width: 300px ) {}",
   }, {
+    code: "@mEdIa ( max-width: 300px ) {}",
+  }, {
+    code: "@MEDIA ( max-width: 300px ) {}",
+  }, {
     code: "@media screen and ( color ), projection and ( color ) {}",
   }, {
     code: "@media ( grid ) and ( max-width: 15em ) {}",
@@ -16,6 +20,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width: 300px ) {}",
+    message: messages.expectedOpening,
+    line: 1,
+    column: 9,
+  }, {
+    code: "@mEdIa (max-width: 300px ) {}",
+    message: messages.expectedOpening,
+    line: 1,
+    column: 9,
+  }, {
+    code: "@MEDIA (max-width: 300px ) {}",
     message: messages.expectedOpening,
     line: 1,
     column: 9,
@@ -59,6 +73,10 @@ testRule(rule, {
   accept: [ {
     code: "@media (max-width: 300px) {}",
   }, {
+    code: "@mEdIa (max-width: 300px) {}",
+  }, {
+    code: "@MEDIA (max-width: 300px) {}",
+  }, {
     code: "@media screen and (color), projection and (color) {}",
   }, {
     code: "@media (grid) and (max-width: 15em) {}",
@@ -66,6 +84,16 @@ testRule(rule, {
 
   reject: [ {
     code: "@media (max-width: 300px ) {}",
+    message: messages.rejectedClosing,
+    line: 1,
+    column: 25,
+  }, {
+    code: "@mEdIa (max-width: 300px ) {}",
+    message: messages.rejectedClosing,
+    line: 1,
+    column: 25,
+  }, {
+    code: "@MEDIA (max-width: 300px ) {}",
     message: messages.rejectedClosing,
     line: 1,
     column: 25,

--- a/src/rules/media-query-parentheses-space-inside/index.js
+++ b/src/rules/media-query-parentheses-space-inside/index.js
@@ -27,7 +27,7 @@ export default function (expectation) {
     if (!validOptions) { return }
 
     root.walkAtRules(atRule => {
-      if (atRule.name !== "media") { return }
+      if (atRule.name.toLowerCase() !== "media") { return }
 
       const params = atRule.params
       const indexBoost = atRuleParamIndex(atRule)

--- a/src/rules/no-unknown-animations/__tests__/index.js
+++ b/src/rules/no-unknown-animations/__tests__/index.js
@@ -69,10 +69,28 @@ testRule(rule, {
   }, {
     code: "@keyframes foo {} a { animation: foo 100ms cubic-bezier(0.1, 0.7, 1.0, 0.1); }",
     description: "ignores cubic-bezier() function",
+  }, {
+    code: "@keyframes fOo {} a { animation: fOo 100Ms CuBiC-bEzIeR(0.1, 0.7, 1.0, 0.1); }",
+    description: "ignores CuBiC-bEzIeR() function",
+  }, {
+    code: "@keyframes FOO {} a { animation: FOO 100MS CUBIC-BEZIER(0.1, 0.7, 1.0, 0.1); }",
+    description: "ignores CUBIC-BEZIER() function",
   } ],
 
   reject: [ {
     code: "a { animation-name: foo; }",
+    description: "no declaration",
+    message: messages.rejected("foo"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { aNiMaTiOn-NaMe: foo; }",
+    description: "no declaration",
+    message: messages.rejected("foo"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { ANIMATION-NAME: foo; }",
     description: "no declaration",
     message: messages.rejected("foo"),
     line: 1,
@@ -87,6 +105,18 @@ testRule(rule, {
     code: "a { animation: baz 100ms ease-in backwards; } @keyframes bar {}",
     description: "no matching declaration with animation shorthand",
     message: messages.rejected("baz"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { animation: bAz 100Ms EaSe-In BaCkWaRdS; } @keyframes bAr {}",
+    description: "no matching declaration with animation shorthand",
+    message: messages.rejected("bAz"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { animation: BAZ 100MS EASE-IN BACKWARDS; } @keyframes BAR {}",
+    description: "no matching declaration with animation shorthand",
+    message: messages.rejected("BAZ"),
     line: 1,
     column: 16,
   } ],

--- a/src/rules/no-unknown-animations/index.js
+++ b/src/rules/no-unknown-animations/index.js
@@ -37,11 +37,13 @@ export default function (actual) {
     })
 
     root.walkDecls(decl => {
-      if (decl.prop === "animation-name" && !animationNameKeywords.has(decl.value)) {
+      if (decl.prop.toLowerCase() === "animation-name"
+        && !animationNameKeywords.has(decl.value.toLowerCase())
+      ) {
         checkAnimationName(decl.value, decl)
       }
 
-      if (decl.prop === "animation") {
+      if (decl.prop.toLowerCase() === "animation") {
         const valueList = postcss.list.space(decl.value)
         for (const value of valueList) {
           // Ignore non standard syntax
@@ -51,7 +53,7 @@ export default function (actual) {
           // Ignore numbers with units
           if (postcssValueParser.unit(value)) { continue }
           // Ignore keywords for other animation parts
-          if (animationShorthandKeywords.has(value)) { continue }
+          if (animationShorthandKeywords.has(value.toLowerCase())) { continue }
           // Ignore functions
           if (value.indexOf("(") !== -1) { continue }
           checkAnimationName(value, decl, decl.value.indexOf(value))

--- a/src/rules/number-leading-zero/__tests__/index.js
+++ b/src/rules/number-leading-zero/__tests__/index.js
@@ -52,7 +52,19 @@ testRule(rule, {
     code: "a { background: url(data:image/svg+xml;...0.5); }",
     description: "data URI containing leading zero",
   }, {
+    code: "a { background: uRl(data:image/svg+xml;...0.5); }",
+    description: "data URI containing leading zero",
+  }, {
+    code: "a { background: URL(data:image/svg+xml;...0.5); }",
+    description: "data URI containing leading zero",
+  }, {
     code: "@import 'testfile.0.3.css'",
+    description: "ignore @import at-rules",
+  }, {
+    code: "@iMpOrT 'testfile.0.3.css'",
+    description: "ignore @import at-rules",
+  }, {
+    code: "@IMPORT 'testfile.0.3.css'",
     description: "ignore @import at-rules",
   } ],
 
@@ -145,7 +157,22 @@ testRule(rule, {
     code: "a { transform: translate(.4px, .8px); }",
     description: "multiple fractional values without leading zeros in a function",
   }, {
+    code: "a { background: url(data:image/svg+xml;...0.5); }",
+    description: "data URI containing leading zero",
+  }, {
+    code: "a { background: uRl(data:image/svg+xml;...0.5); }",
+    description: "data URI containing leading zero",
+  }, {
+    code: "a { background: URL(data:image/svg+xml;...0.5); }",
+    description: "data URI containing leading zero",
+  }, {
     code: "@import 'testfile.0.3.css'",
+    description: "ignore @import at-rules",
+  }, {
+    code: "@iMpOrT 'testfile.0.3.css'",
+    description: "ignore @import at-rules",
+  }, {
+    code: "@IMPORT 'testfile.0.3.css'",
     description: "ignore @import at-rules",
   } ],
 

--- a/src/rules/number-leading-zero/index.js
+++ b/src/rules/number-leading-zero/index.js
@@ -32,7 +32,7 @@ export default function (expectation) {
     })
 
     root.walkAtRules(atRule => {
-      if (atRule.name === "import") { return }
+      if (atRule.name.toLowerCase() === "import") { return }
 
       const source = (hasBlock(atRule))
         ? beforeBlockString(atRule, { noRawBefore: true })

--- a/src/rules/number-max-precision/__tests__/index.js
+++ b/src/rules/number-max-precision/__tests__/index.js
@@ -11,6 +11,10 @@ testRule(rule, {
   }, {
     code: "a::before { content: \"3.12345px\"; }",
   }, {
+    code: "a::before { cOnTeNt: \"3.12345px\"; }",
+  }, {
+    code: "a::before { CONTENT: \"3.12345px\"; }",
+  }, {
     code: "a { top: 3%; }",
   }, {
     code: "a { top: 3.1%; }",

--- a/src/rules/number-max-precision/index.js
+++ b/src/rules/number-max-precision/index.js
@@ -25,7 +25,7 @@ export default function (precision) {
 
     root.walkDecls(decl => {
       // Don't bother with strings
-      if (decl.prop === "content") { return }
+      if (decl.prop.toLowerCase() === "content") { return }
       check(decl.toString(), decl)
     })
 

--- a/src/rules/number-no-trailing-zeros/__tests__/index.js
+++ b/src/rules/number-no-trailing-zeros/__tests__/index.js
@@ -23,9 +23,19 @@ testRule(rule, {
   }, {
     code: "@import \"0.10.css\";",
   }, {
+    code: "@iMpOrT \"0.10.css\";",
+  }, {
+    code: "@IMPORT \"0.10.css\";",
+  }, {
     code: "@import url(0.10.css);",
   }, {
     code: "a { background: url(data:image/svg+xml;...1.0); }",
+    description: "data URI containing trailing zero",
+  }, {
+    code: "a { background: uRl(data:image/svg+xml;...1.0); }",
+    description: "data URI containing trailing zero",
+  }, {
+    code: "a { background: URL(data:image/svg+xml;...1.0); }",
     description: "data URI containing trailing zero",
   } ],
 

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -27,7 +27,7 @@ export default function (actual) {
     root.walkAtRules(atRule => {
 
       // Ignore @imports
-      if (atRule.name === "import") { return }
+      if (atRule.name.toLowerCase() === "import") { return }
 
       const source = (hasBlock(atRule))
         ? beforeBlockString(atRule, { noRawBefore: true })

--- a/src/rules/number-zero-length-no-unit/__tests__/index.js
+++ b/src/rules/number-zero-length-no-unit/__tests__/index.js
@@ -16,6 +16,12 @@ testRule(rule, {
     code: "a { top: 10px; }",
     description: "zero at end of non-zero value",
   }, {
+    code: "a { top: 10pX; }",
+    description: "zero at end of non-zero value",
+  }, {
+    code: "a { top: 10PX; }",
+    description: "zero at end of non-zero value",
+  }, {
     code: "a { top: 100.00px; }",
     description: "zero at end of non-zero value after decimal",
   }, {
@@ -78,6 +84,12 @@ testRule(rule, {
     code: "@media print and (min-resolution: 0dpi) { }",
     description: "ignore dpi",
   }, {
+    code: "@media print and (min-resolution: 0dPi) { }",
+    description: "ignore dpi",
+  }, {
+    code: "@media print and (min-resolution: 0DPI) { }",
+    description: "ignore dpi",
+  }, {
     code: "@media print and (min-resolution: 0dpcm) { }",
     description: "ignore dpcm",
   }, {
@@ -87,6 +99,16 @@ testRule(rule, {
 
   reject: [ {
     code: "a { top: 0px; }",
+    message: messages.rejected,
+    line: 1,
+    column: 11,
+  }, {
+    code: "a { top: 0pX; }",
+    message: messages.rejected,
+    line: 1,
+    column: 11,
+  }, {
+    code: "a { top: 0PX; }",
     message: messages.rejected,
     line: 1,
     column: 11,

--- a/src/rules/number-zero-length-no-unit/index.js
+++ b/src/rules/number-zero-length-no-unit/index.js
@@ -88,7 +88,7 @@ export default function (actual) {
         const valueWithZero = value.slice(valueWithZeroStart, valueWithZeroEnd)
         const parsedValue = valueParser.unit(valueWithZero)
 
-        if (parsedValue && parsedValue.unit && ignoredUnits.has(parsedValue.unit)) { return }
+        if (parsedValue && parsedValue.unit && ignoredUnits.has(parsedValue.unit.toLowerCase())) { return }
 
         // Add the indexes to ignorableIndexes so the same value will not
         // be checked multiple times.

--- a/src/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/property-no-vendor-prefix/__tests__/index.js
@@ -20,11 +20,27 @@ testRule(rule, {
   }, {
     code: "a { -webkit-touch-callout: none; }",
     description: "another non-standard prefixed property",
+  }, {
+    code: "a { -wEbKiT-tOuCh-CaLlOuT: none; }",
+    description: "another non-standard prefixed property",
+  }, {
+    code: "a { -WEBKIT-TOUCH-CALLOUT: none; }",
+    description: "another non-standard prefixed property",
   } ],
 
   reject: [ {
     code: "a { -webkit-transform: scale(1); }",
     message: messages.rejected("-webkit-transform"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { -wEbKiT-tRaNsFoRm: scale(1); }",
+    message: messages.rejected("-wEbKiT-tRaNsFoRm"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { -WEBKIT-TRANSFORM: scale(1); }",
+    message: messages.rejected("-WEBKIT-TRANSFORM"),
     line: 1,
     column: 5,
   }, {

--- a/src/rules/root-no-standard-properties/__tests__/index.js
+++ b/src/rules/root-no-standard-properties/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: ":root { --foo: 0; }",
   }, {
+    code: ":rOoT { --foo: 0; }",
+  }, {
+    code: ":ROOT { --foo: 0; }",
+  }, {
     code: "a, :root { --foo: 0; }",
   }, {
     code: "a { color: pink; } :root { --foo: 0; }",
@@ -18,6 +22,18 @@ testRule(rule, {
     code: ":root { @less: 0; }",
   }, {
     code: ":not(:root) { color: pink; }",
+    description: "negation pseudo-class",
+  }, {
+    code: ":nOt(:root) { color: pink; }",
+    description: "negation pseudo-class",
+  }, {
+    code: ":NOT(:root) { color: pink; }",
+    description: "negation pseudo-class",
+  }, {
+    code: ":not(:rOoT) { color: pink; }",
+    description: "negation pseudo-class",
+  }, {
+    code: ":not(:ROOT) { color: pink; }",
     description: "negation pseudo-class",
   }, {
     code: "svg:not(:root) { color: pink; }",
@@ -39,6 +55,16 @@ testRule(rule, {
     line: 1,
     column: 9,
   }, {
+    code: ":rOoT { top: 0; }",
+    message: messages.rejected("top"),
+    line: 1,
+    column: 9,
+  }, {
+    code: ":ROOT { top: 0; }",
+    message: messages.rejected("top"),
+    line: 1,
+    column: 9,
+  }, {
     code: ":root { -webkit-transform: scale(0); }",
     message: messages.rejected("-webkit-transform"),
     line: 1,
@@ -55,6 +81,16 @@ testRule(rule, {
     column: 28,
   }, {
     code: ":root, :not(a) { color: pink; }",
+    message: messages.rejected("color"),
+    line: 1,
+    column: 18,
+  }, {
+    code: ":rOoT, :nOt(a) { color: pink; }",
+    message: messages.rejected("color"),
+    line: 1,
+    column: 18,
+  }, {
+    code: ":ROOT, :NOT(a) { color: pink; }",
     message: messages.rejected("color"),
     line: 1,
     column: 18,

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -19,7 +19,7 @@ export default function (actual) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
-      if (rule.selector.indexOf(":root") === -1) { return }
+      if (rule.selector.toLowerCase().indexOf(":root") === -1) { return }
       selectorParser(checkSelector).process(rule.selector)
 
       function checkSelector(selectorAST) {
@@ -47,7 +47,11 @@ function ignoreRule(selectorAST) {
   let ignore = false
   selectorAST.walk(selectorNode => {
     // ignore `:root` selector inside a `:not()` selector
-    if (selectorNode.value === ":root" && selectorNode.parent.parent.value === ":not") {
+    if (selectorNode.value
+      && selectorNode.value.toLowerCase() === ":root"
+      && selectorNode.parent.parent.value
+      && selectorNode.parent.parent.value.toLowerCase() === ":not"
+    ) {
       ignore = true
     }
   })

--- a/src/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -29,6 +29,16 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
+    code: ":-wEbKiT-fUlL-sCrEeN a {}",
+    message: messages.rejected(":-wEbKiT-fUlL-sCrEeN"),
+    line: 1,
+    column: 1,
+  }, {
+    code: ":-WEBKIT-FULL-SCREEN a {}",
+    message: messages.rejected(":-WEBKIT-FULL-SCREEN"),
+    line: 1,
+    column: 1,
+  }, {
     code: "body, :-ms-fullscreen a {}",
     message: messages.rejected(":-ms-fullscreen"),
     line: 1,

--- a/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -36,6 +36,16 @@ testRule(rule, {
     line: 1,
     column: 3,
   }, {
+    code: "a::bEfOrE { color: pink; }",
+    message: messages.expected("single"),
+    line: 1,
+    column: 3,
+  }, {
+    code: "a::BEFORE { color: pink; }",
+    message: messages.expected("single"),
+    line: 1,
+    column: 3,
+  }, {
     code: "a::after { color: pink; }",
     message: messages.expected("single"),
     line: 1,

--- a/src/rules/selector-pseudo-element-colon-notation/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/index.js
@@ -30,21 +30,23 @@ export default function (expectation) {
       if (selector.indexOf(":") === -1) { return }
 
       // match only level 1 and 2 pseudo elements
-      styleSearch({ source: selector, target: [ ":before", ":after", ":first-line", ":first-letter" ] }, match => {
+      styleSearch({
+        source: selector.toLowerCase(),
+        target: [ ":before", ":after", ":first-line", ":first-letter" ] },
+        match => {
+          const prevCharIsColon = selector[match.startIndex - 1] === ":"
 
-        const prevCharIsColon = selector[match.startIndex - 1] === ":"
+          if (expectation === "single" && !prevCharIsColon) { return }
+          if (expectation === "double" && prevCharIsColon) { return }
 
-        if (expectation === "single" && !prevCharIsColon) { return }
-        if (expectation === "double" && prevCharIsColon) { return }
-
-        report({
-          message: messages.expected(expectation),
-          node: rule,
-          index: match.startIndex,
-          result,
-          ruleName,
+          report({
+            message: messages.expected(expectation),
+            node: rule,
+            index: match.startIndex,
+            result,
+            ruleName,
+          })
         })
-      })
     })
   }
 }

--- a/src/rules/selector-root-no-composition/__tests__/index.js
+++ b/src/rules/selector-root-no-composition/__tests__/index.js
@@ -9,11 +9,21 @@ testRule(rule, {
   accept: [ {
     code: ":root {}",
   }, {
+    code: ":rOoT {}",
+  }, {
+    code: ":ROOT {}",
+  }, {
     code: "   :root\n {}",
   } ],
 
   reject: [ {
     code: "a, :root {}",
+    message: messages.rejected,
+  }, {
+    code: "a, :rOoT {}",
+    message: messages.rejected,
+  }, {
+    code: "a, :ROOT {}",
     message: messages.rejected,
   }, {
     code: ":root, a {}",

--- a/src/rules/selector-root-no-composition/index.js
+++ b/src/rules/selector-root-no-composition/index.js
@@ -16,9 +16,10 @@ export default function (actual) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
-      if (rule.selector.indexOf(":root") === -1) { return }
-
-      if (rule.selector.trim() === ":root") { return }
+      if (rule.selector.toLowerCase().indexOf(":root") === -1
+      || rule.selector.toLowerCase().trim() === ":root") {
+        return
+      }
 
       report({
         message: messages.rejected,

--- a/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -63,6 +63,26 @@ testRule(rule, {
     line: 1,
     column: 5,
   }, {
+    code: "a { margin: 1Px 1pX; }",
+    message: messages.rejected("1Px 1pX", "1Px"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { margin: 1PX 1PX; }",
+    message: messages.rejected("1PX 1PX", "1PX"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { mArGiN: 1px 1px; }",
+    message: messages.rejected("1px 1px", "1px"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { MARGIN: 1px 1px; }",
+    message: messages.rejected("1px 1px", "1px"),
+    line: 1,
+    column: 5,
+  }, {
     code: "a { margin: 1px 1px 1px; }",
     message: messages.rejected("1px 1px 1px", "1px"),
     line: 1,
@@ -70,6 +90,16 @@ testRule(rule, {
   }, {
     code: "a { margin: 1px 2px 1px; }",
     message: messages.rejected("1px 2px 1px", "1px 2px"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { margin: 1px 2pX 1px; }",
+    message: messages.rejected("1px 2pX 1px", "1px 2pX"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { margin: 1px 2PX 1px; }",
+    message: messages.rejected("1px 2PX 1px", "1px 2PX"),
     line: 1,
     column: 5,
   }, {
@@ -120,6 +150,26 @@ testRule(rule, {
   }, {
     code: "a { border-color: transparent transparent transparent transparent; }",
     message: messages.rejected("transparent transparent transparent transparent", "transparent"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { border-color: transparent tRaNsPaReNt TRANSPARENT transparent; }",
+    message: messages.rejected("transparent tRaNsPaReNt TRANSPARENT transparent", "transparent"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { border-color: tRaNsPaReNt TRANSPARENT TRANSPARENT transparent; }",
+    message: messages.rejected("tRaNsPaReNt TRANSPARENT TRANSPARENT transparent", "tRaNsPaReNt"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { border-color: tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt; }",
+    message: messages.rejected("tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt", "tRaNsPaReNt"),
+    line: 1,
+    column: 5,
+  }, {
+    code: "a { border-color: TRANSPARENT TRANSPARENT TRANSPARENT TRANSPARENT; }",
+    message: messages.rejected("TRANSPARENT TRANSPARENT TRANSPARENT TRANSPARENT", "TRANSPARENT"),
     line: 1,
     column: 5,
   }, {

--- a/src/rules/shorthand-property-no-redundant-values/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/index.js
@@ -31,11 +31,16 @@ function isIgnoredCharacters(value) {
 }
 
 function canCondense(top, right, bottom = null, left = null) {
-  if (canCondenseToOneValue(top, right, bottom, left)) {
+  const lowerTop = top.toLowerCase()
+  const lowerRight = right.toLowerCase()
+  const lowerBottom = bottom && bottom.toLowerCase()
+  const lowerLeft = left && left.toLowerCase()
+
+  if (canCondenseToOneValue(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
     return [top]
-  } else if (canCondenseToTwoValues(top, right, bottom, left)) {
+  } else if (canCondenseToTwoValues(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
     return [ top, right ]
-  } else if (canCondenseToThreeValues(top, right, bottom, left)) {
+  } else if (canCondenseToThreeValues(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
     return [ top, right, bottom ]
   } else {
     return [ top, right, bottom, left ]
@@ -68,7 +73,7 @@ export default function (actual) {
       // ignore not shorthandable properties, and math operations
       if (
         isIgnoredCharacters(value) ||
-        !shorthandableProperties.has(vendor.unprefixed(prop))
+        !shorthandableProperties.has(vendor.unprefixed(prop.toLowerCase()))
       ) { return }
 
       const valuesToShorthand = []
@@ -87,7 +92,7 @@ export default function (actual) {
       const shortestFormString = shortestForm.filter((value) => { return value }).join(" ")
       const valuesFormString = valuesToShorthand.join(" ")
 
-      if (shortestFormString === valuesFormString) { return }
+      if (shortestFormString.toLowerCase() === valuesFormString) { return }
 
       report({
         message: messages.rejected(value, shortestFormString),

--- a/src/rules/time-no-imperceptible/__tests__/index.js
+++ b/src/rules/time-no-imperceptible/__tests__/index.js
@@ -9,6 +9,10 @@ testRule(rule, {
   accept: [ {
     code: "a { transition-delay: 0.2s; }",
   }, {
+    code: "a { tRaNsItIoN-dElAy: 0.2s; }",
+  }, {
+    code: "a { TRANSITION-DELAY: 0.2s; }",
+  }, {
     code: "a { transition-delay: 3s; }",
   }, {
     code: "a { transition-delay: 200ms; }",
@@ -24,6 +28,10 @@ testRule(rule, {
     code: "a { transition-duration: 4700ms; }",
   }, {
     code: "a { transition: foo 0.8s linear; }",
+  }, {
+    code: "a { tRaNsItIoN: foo 0.8s linear; }",
+  }, {
+    code: "a { TRANSITION: foo 0.8s linear; }",
   }, {
     code: "a { transition: foo 0.8s 200ms ease-in-out; }",
   }, {
@@ -54,8 +62,28 @@ testRule(rule, {
     line: 1,
     column: 23,
   }, {
+    code: "a { tRaNsItIoN-dElAy: 0.006s; }",
+    message: messages.rejected("0.006s"),
+    line: 1,
+    column: 23,
+  }, {
+    code: "a { TRANSITION-DELAY: 0.006s; }",
+    message: messages.rejected("0.006s"),
+    line: 1,
+    column: 23,
+  }, {
+    code: "a { transition-delay: 0.006S; }",
+    message: messages.rejected("0.006S"),
+    line: 1,
+    column: 23,
+  }, {
     code: "a { transition-delay: 3ms; }",
     message: messages.rejected("3ms"),
+    line: 1,
+    column: 23,
+  }, {
+    code: "a { transition-delay: 3MS; }",
+    message: messages.rejected("3MS"),
     line: 1,
     column: 23,
   }, {
@@ -70,6 +98,16 @@ testRule(rule, {
     column: 26,
   }, {
     code: "a { transition: foo 0.008s linear; }",
+    message: messages.rejected("0.008s"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { tRaNsItIoN: foo 0.008s linear; }",
+    message: messages.rejected("0.008s"),
+    line: 1,
+    column: 21,
+  }, {
+    code: "a { TRANSITION: foo 0.008s linear; }",
     message: messages.rejected("0.008s"),
     line: 1,
     column: 21,

--- a/src/rules/time-no-imperceptible/index.js
+++ b/src/rules/time-no-imperceptible/index.js
@@ -28,13 +28,13 @@ export default function (actual) {
     if (!validOptions) { return }
 
     root.walkDecls(decl => {
-      if (LONGHAND_PROPERTIES_TO_CHECK.indexOf(decl.prop) !== -1) {
+      if (LONGHAND_PROPERTIES_TO_CHECK.indexOf(decl.prop.toLowerCase()) !== -1) {
         if (isImperceptibleTime(decl.value)) {
           complain(messages.rejected(decl.value), decl)
         }
       }
 
-      if (SHORTHAND_PROPERTIES_TO_CHECK.indexOf(decl.prop) !== -1) {
+      if (SHORTHAND_PROPERTIES_TO_CHECK.indexOf(decl.prop.toLowerCase()) !== -1) {
         const valueList = postcss.list.space(decl.value)
         for (const value of valueList) {
           if (isImperceptibleTime(value)) {
@@ -47,8 +47,8 @@ export default function (actual) {
     function isImperceptibleTime(time) {
       const parsedTime = valueParser.unit(time)
       if (!parsedTime) return false
-      if (parsedTime.unit === "ms" && parsedTime.number <= MINIMUM_MILLISECONDS) { return true }
-      if (parsedTime.unit === "s" && parsedTime.number * 1000 <= MINIMUM_MILLISECONDS) { return true }
+      if (parsedTime.unit.toLowerCase() === "ms" && parsedTime.number <= MINIMUM_MILLISECONDS) { return true }
+      if (parsedTime.unit.toLowerCase() === "s" && parsedTime.number * 1000 <= MINIMUM_MILLISECONDS) { return true }
       return false
     }
 

--- a/src/rules/unit-blacklist/__tests__/index.js
+++ b/src/rules/unit-blacklist/__tests__/index.js
@@ -44,6 +44,12 @@ testRule(rule, {
     code: "a { background-url: url(10vmin); }",
     description: "ignore url function",
   }, {
+    code: "a { background-url: uRl(10vmin); }",
+    description: "ignore url function",
+  }, {
+    code: "a { background-url: URL(10vmin); }",
+    description: "ignore url function",
+  }, {
     code: "a { margin10px: 10em; }",
     description: "ignore property include wrong unit",
   }, {

--- a/src/rules/unit-blacklist/index.js
+++ b/src/rules/unit-blacklist/index.js
@@ -28,7 +28,7 @@ export default function (blacklistInput) {
       const { value } = decl
 
       valueParser(value).walk(function (node) {
-        if (node.type === "function" && node.value === "url") { return false }
+        if (node.type === "function" && node.value.toLowerCase() === "url") { return false }
         if (node.type !== "word" || isVariable(node.value)) { return }
 
         const parsedUnit = valueParser.unit(node.value)

--- a/src/rules/unit-case/__tests__/index.js
+++ b/src/rules/unit-case/__tests__/index.js
@@ -49,6 +49,12 @@ testRule(rule, {
     code: "a { margin: url(13PX); }",
     description: "ignore url function",
   }, {
+    code: "a { margin: uRl(13PX); }",
+    description: "ignore url function",
+  }, {
+    code: "a { margin: URL(13PX); }",
+    description: "ignore url function",
+  }, {
     code: "a { marginPX: 10px; }",
     description: "ignore property include unit",
   }, {

--- a/src/rules/unit-case/index.js
+++ b/src/rules/unit-case/index.js
@@ -29,7 +29,7 @@ export default function (expectation) {
 
       valueParser(value).walk((node) => {
         // Ignore wrong units within `url` function
-        if (node.type === "function" && node.value === "url") { return false }
+        if (node.type === "function" && node.value.toLowerCase() === "url") { return false }
         if (node.type !== "word" || !isStandardValue(node.value)) { return }
 
         const parsedUnit = valueParser.unit(node.value)

--- a/src/rules/unit-no-unknown/__tests__/index.js
+++ b/src/rules/unit-no-unknown/__tests__/index.js
@@ -15,6 +15,10 @@ testRule(rule, {
   }, {
     code: "a { margin: 1em; }",
   }, {
+    code: "a { margin: 1Em; }",
+  }, {
+    code: "a { margin: 1EM; }",
+  }, {
     code: "a { margin: 1ex; }",
   }, {
     code: "a { margin: 1%; }",
@@ -87,6 +91,12 @@ testRule(rule, {
     description: "ignore css variable includes wrong unit",
   }, {
     code: "a { margin: url(13pix); }",
+    description: "ignore url function",
+  }, {
+    code: "a { margin: uRl(13pix); }",
+    description: "ignore url function",
+  }, {
+    code: "a { margin: URL(13pix); }",
     description: "ignore url function",
   }, {
     code: "a { margin10px: 10px; }",

--- a/src/rules/unit-no-unknown/index.js
+++ b/src/rules/unit-no-unknown/index.js
@@ -32,7 +32,7 @@ export default function (actual, options) {
 
       valueParser(value).walk(function (node) {
         // Ignore wrong units within `url` function
-        if (node.type === "function" && node.value === "url") { return false }
+        if (node.type === "function" && node.value.toLowerCase() === "url") { return false }
         if (node.type !== "word" || !isStandardValue(node.value)) { return }
 
         const parsedUnit = valueParser.unit(node.value)

--- a/src/rules/unit-whitelist/README.md
+++ b/src/rules/unit-whitelist/README.md
@@ -47,5 +47,9 @@ a { height: 100px; }
 ```
 
 ```css
+a { height: 100PX; }
+```
+
+```css
 a { transform: rotate(30deg); }
 ```

--- a/src/rules/unit-whitelist/__tests__/index.js
+++ b/src/rules/unit-whitelist/__tests__/index.js
@@ -42,6 +42,12 @@ testRule(rule, {
     code: "a { background-url: url(10vmin); }",
     description: "ignore url function",
   }, {
+    code: "a { background-url: uRl(10vmin); }",
+    description: "ignore url function",
+  }, {
+    code: "a { background-url: URL(10vmin); }",
+    description: "ignore url function",
+  }, {
     code: "a { margin10rem: 10em; }",
     description: "ignore property include wrong unit",
   }, {

--- a/src/rules/unit-whitelist/index.js
+++ b/src/rules/unit-whitelist/index.js
@@ -28,7 +28,7 @@ export default function (whitelistInput) {
       const { value } = decl
 
       valueParser(value).walk(function (node) {
-        if (node.type === "function" && node.value === "url") { return false }
+        if (node.type === "function" && node.value.toLowerCase() === "url") { return false }
         if (node.type !== "word" || !isStandardValue(node.value)) { return }
 
         const parsedUnit = valueParser.unit(node.value)

--- a/src/rules/value-keyword-case/__tests__/index.js
+++ b/src/rules/value-keyword-case/__tests__/index.js
@@ -63,7 +63,19 @@ testRule(rule, {
     code: "a { font-size: var(--some-fs-BLOCK); }",
     description: "ignore css variable includes value keyword",
   }, {
+    code: "a { font-size: vAr(--some-fs-BLOCK); }",
+    description: "ignore css variable includes value keyword",
+  }, {
+    code: "a { font-size: VAR(--some-fs-BLOCK); }",
+    description: "ignore css variable includes value keyword",
+  }, {
     code: "a { background-url: url(BLOCK); }",
+    description: "ignore url function",
+  }, {
+    code: "a { background-url: uRl(BLOCK); }",
+    description: "ignore url function",
+  }, {
+    code: "a { background-url: URL(BLOCK); }",
     description: "ignore url function",
   }, {
     code: "a { displayBLOCK: block; }",
@@ -455,8 +467,20 @@ testRule(rule, {
   }, {
     code: "a { font-size: var(--some-fs-block); }",
     description: "ignore css variable includes value keyword",
+  },  {
+    code: "a { font-size: vAr(--some-fs-block); }",
+    description: "ignore css variable includes value keyword",
+  },  {
+    code: "a { font-size: VAR(--some-fs-block); }",
+    description: "ignore css variable includes value keyword",
   }, {
     code: "a { background-url: url(block); }",
+    description: "ignore url function",
+  }, {
+    code: "a { background-url: uRl(block); }",
+    description: "ignore url function",
+  }, {
+    code: "a { background-url: URL(block); }",
     description: "ignore url function",
   }, {
     code: "a { displayblock: BLOCK; }",

--- a/src/rules/value-keyword-case/index.js
+++ b/src/rules/value-keyword-case/index.js
@@ -51,8 +51,8 @@ export default function (expectation, options) {
         // Ignore keywords within `url` and `var` function
         if (
           node.type === "function" && (
-            node.value === "url" ||
-            node.value === "var"
+            node.value.toLowerCase() === "url" ||
+            node.value.toLowerCase() === "var"
           )
         ) { return false }
 

--- a/src/rules/value-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/value-no-vendor-prefix/__tests__/index.js
@@ -15,10 +15,36 @@ testRule(rule, {
   }, {
     code: ".foo { -webkit-transform: translate(0, 0); }",
     description: "ignores property vendor prefixes",
+  }, {
+    code: ".foo { -wEbKiT-tRaNsFoRm: translate(0, 0); }",
+    description: "ignores property vendor prefixes",
+  }, {
+    code: ".foo { -WEBKIT-TRANSFORM: translate(0, 0); }",
+    description: "ignores property vendor prefixes",
   } ],
 
   reject: [ {
     code: ".foo { display: -webkit-flex; }",
+    message: messages.rejected("-webkit-flex"),
+    line: 1,
+    column: 17,
+  }, {
+    code: ".foo { display: -wEbKiT-fLeX; }",
+    message: messages.rejected("-wEbKiT-fLeX"),
+    line: 1,
+    column: 17,
+  }, {
+    code: ".foo { display: -WEBKIT-FLEX; }",
+    message: messages.rejected("-WEBKIT-FLEX"),
+    line: 1,
+    column: 17,
+  }, {
+    code: ".foo { dIsPlAy: -webkit-flex; }",
+    message: messages.rejected("-webkit-flex"),
+    line: 1,
+    column: 17,
+  }, {
+    code: ".foo { DISPLAY: -webkit-flex; }",
     message: messages.rejected("-webkit-flex"),
     line: 1,
     column: 17,

--- a/src/rules/value-no-vendor-prefix/index.js
+++ b/src/rules/value-no-vendor-prefix/index.js
@@ -24,18 +24,18 @@ export default function (actual) {
       const { prop } = decl
 
       // Search the full declaration in order to get an accurate index
-      styleSearch({ source: declString, target: valuePrefixes }, match => {
+      styleSearch({ source: declString.toLowerCase(), target: valuePrefixes }, match => {
         if (match.startIndex <= prop.length) { return }
-        const fullIdentifier = /^(-[a-z-]+)\b/.exec(declString.slice(match.startIndex))[1]
-        if (isAutoprefixable.propertyValue(prop, fullIdentifier)) {
-          report({
-            message: messages.rejected(fullIdentifier),
-            node: decl,
-            index: match.startIndex,
-            result,
-            ruleName,
-          })
-        }
+        const fullIdentifier = /^(-[a-z-]+)\b/i.exec(declString.slice(match.startIndex))[1]
+        if (!isAutoprefixable.propertyValue(prop, fullIdentifier)) { return }
+
+        report({
+          message: messages.rejected(fullIdentifier),
+          node: decl,
+          index: match.startIndex,
+          result,
+          ruleName,
+        })
       })
     })
   }

--- a/src/utils/__tests__/blurFunctionArguments-test.js
+++ b/src/utils/__tests__/blurFunctionArguments-test.js
@@ -4,6 +4,8 @@ import blurFunctionArguments from "../blurFunctionArguments"
 test("blurFunctionArguments", t => {
   t.equal(blurFunctionArguments("abc abc", "url"), "abc abc")
   t.equal(blurFunctionArguments("abc url(abc) abc", "url"), "abc url(```) abc")
+  t.equal(blurFunctionArguments("abc uRl(abc) abc", "url"), "abc uRl(```) abc")
+  t.equal(blurFunctionArguments("abc URL(abc) abc", "url"), "abc URL(```) abc")
   t.equal(blurFunctionArguments("abc url(abc) url(xx)", "url", "#"), "abc url(###) url(##)")
   t.end()
 })

--- a/src/utils/__tests__/cssWordIsVariable-test.js
+++ b/src/utils/__tests__/cssWordIsVariable-test.js
@@ -8,6 +8,8 @@ test("cssWordIsVariable", t => {
   t.ok(cssWordIsVariable("$sass-variable"))
   t.ok(cssWordIsVariable("@less-variable"))
   t.ok(cssWordIsVariable("var(--something)"))
+  t.ok(cssWordIsVariable("vAr(--something)"))
+  t.ok(cssWordIsVariable("VAR(--something)"))
   t.ok(cssWordIsVariable("var(  --something  )"))
   t.end()
 })

--- a/src/utils/__tests__/isKeyframeRule-test.js
+++ b/src/utils/__tests__/isKeyframeRule-test.js
@@ -4,9 +4,15 @@ import test from "tape"
 
 test("isKeyframeRule", t => {
 
-  t.plan(9)
+  t.plan(11)
 
   rules("@keyframes identifier { to {} }", rule => {
+    t.ok(isKeyframeRule(rule), "to")
+  })
+  rules("@kEyFrAmEs identifier { to {} }", rule => {
+    t.ok(isKeyframeRule(rule), "to")
+  })
+  rules("@KEYFRAMES identifier { to {} }", rule => {
     t.ok(isKeyframeRule(rule), "to")
   })
   rules("@keyframes identifier { from {} }", rule => {

--- a/src/utils/__tests__/isKnownUnit-test.js
+++ b/src/utils/__tests__/isKnownUnit-test.js
@@ -5,6 +5,8 @@ test("isKnownUnit", t => {
   t.notOk(isKnownUnit("pix"))
   t.notOk(isKnownUnit("pixels"))
   t.ok(isKnownUnit("em"))
+  t.ok(isKnownUnit("Em"))
+  t.ok(isKnownUnit("EM"))
   t.ok(isKnownUnit("ex"))
   t.ok(isKnownUnit("ch"))
   t.ok(isKnownUnit("rem"))

--- a/src/utils/__tests__/isVariable-test.js
+++ b/src/utils/__tests__/isVariable-test.js
@@ -3,12 +3,14 @@ import isVariable from "../isVariable"
 
 test("isVariable", t => {
   t.ok(isVariable("var(--something)"))
+  t.ok(isVariable("vAr(--something)"))
+  t.ok(isVariable("VAR(--something)"))
   t.ok(isVariable("var(  --something  )"))
   t.notOk(isVariable("initial"))
   t.notOk(isVariable("currentColor"))
   t.notOk(isVariable("-webkit-appearance"))
   t.notOk(isVariable("--custom-property"))
   t.notOk(isVariable("$sass-variable"))
-  t.notOk(isVariable("@less-variable"))  
+  t.notOk(isVariable("@less-variable"))
   t.end()
 })

--- a/src/utils/__tests__/styleTagsFromHtmlExtracter-test.js
+++ b/src/utils/__tests__/styleTagsFromHtmlExtracter-test.js
@@ -35,6 +35,36 @@ test("iterateCodeForStyleTags found style tags call function with previous code 
   t.end()
 })
 
+test("iterateCodeForStyleTags found style tags call function with previous code and style code", t => {
+  let found = 0
+  const code = "<sTyLe>\na {}\n</sTyLe>\n<sTyLe></sTyLe>"
+  const expectedPreviousCodes = [ "<sTyLe>", "</sTyLe>\n<sTyLe>" ]
+  const expectedStyleCodes = [ "\na {}\n", "" ]
+  iterateCodeForStyleTags(code, (previousCode, styleCode) => {
+    t.equal(typeof previousCode, "string")
+    t.equal(previousCode, expectedPreviousCodes[found])
+    t.equal(typeof styleCode, "string")
+    t.equal(styleCode, expectedStyleCodes[found])
+    found++
+  })
+  t.end()
+})
+
+test("iterateCodeForStyleTags found style tags call function with previous code and style code", t => {
+  let found = 0
+  const code = "<STYLE>\na {}\n</STYLE>\n<STYLE></STYLE>"
+  const expectedPreviousCodes = [ "<STYLE>", "</STYLE>\n<STYLE>" ]
+  const expectedStyleCodes = [ "\na {}\n", "" ]
+  iterateCodeForStyleTags(code, (previousCode, styleCode) => {
+    t.equal(typeof previousCode, "string")
+    t.equal(previousCode, expectedPreviousCodes[found])
+    t.equal(typeof styleCode, "string")
+    t.equal(styleCode, expectedStyleCodes[found])
+    found++
+  })
+  t.end()
+})
+
 test("styleTagsFromHtmlExtracter returns extrated code and mapping of line and indentation", t => {
   const code = "<script></script>\n<style>\n  a { }\n</style>\n<style>\na {\n}\n</style>"
   const expected = "\na { }\n\na {\n}\n"

--- a/src/utils/blurFunctionArguments.js
+++ b/src/utils/blurFunctionArguments.js
@@ -18,16 +18,17 @@ import balancedMatch from "balanced-match"
  * @return {string} - The result string, with the function arguments "blurred"
  */
 export default function (source, functionName, blurChar="`") {
-  const nameWithParen = `${functionName}(`
-  if (!_.includes(source, nameWithParen)) { return source }
+  const nameWithParen = `${functionName.toLowerCase()}(`
+  const lowerCaseSource =  source.toLowerCase()
+  if (!_.includes(lowerCaseSource, nameWithParen)) { return source }
 
   const functionNameLength = functionName.length
 
   let result = source
   let searchStartIndex = 0
-  while (source.indexOf(nameWithParen, searchStartIndex) !== -1) {
-    const openingParenIndex = source.indexOf(nameWithParen, searchStartIndex) + functionNameLength
-    const closingParenIndex = balancedMatch("(", ")", source.slice(openingParenIndex)).end + openingParenIndex
+  while (lowerCaseSource.indexOf(nameWithParen, searchStartIndex) !== -1) {
+    const openingParenIndex = lowerCaseSource.indexOf(nameWithParen, searchStartIndex) + functionNameLength
+    const closingParenIndex = balancedMatch("(", ")", lowerCaseSource.slice(openingParenIndex)).end + openingParenIndex
     const argumentsLength = closingParenIndex - openingParenIndex - 1
     result = result.slice(0, openingParenIndex + 1) + _.repeat(blurChar, argumentsLength) + result.slice(closingParenIndex)
     searchStartIndex = closingParenIndex

--- a/src/utils/cssWordIsVariable.js
+++ b/src/utils/cssWordIsVariable.js
@@ -11,6 +11,6 @@ export default function (word) {
   if (word[0] === "$") return true
   if (word[0] === "@") return true
   if (word.slice(0, 2) === "--") return true
-  if (word.slice(0, 4) === "var(") return true
+  if (word.toLowerCase().slice(0, 4) === "var(") return true
   return false
 }

--- a/src/utils/isAutoprefixable.js
+++ b/src/utils/isAutoprefixable.js
@@ -23,27 +23,28 @@ const prefixes = new Prefixes(
 export default {
 
   atRuleName(identifier) {
-    return prefixes.remove[`@${identifier}`]
+    return prefixes.remove[`@${identifier.toLowerCase()}`]
   },
 
   selector(identifier) {
     return prefixes.remove.selectors.some(selectorObj => {
-      return identifier === selectorObj.prefixed
+      return identifier.toLowerCase() === selectorObj.prefixed
     })
   },
 
   mediaFeatureName(identifier) {
-    return identifier.indexOf("device-pixel-ratio") !== -1
+    return identifier.toLowerCase().indexOf("device-pixel-ratio") !== -1
   },
 
   property(identifier) {
-    return autoprefixer.data.prefixes[prefixes.unprefixed(identifier)]
+    return autoprefixer.data.prefixes[prefixes.unprefixed(identifier.toLowerCase())]
   },
 
   propertyValue(prop, value) {
-    const possiblePrefixableValues = prefixes.remove[prop] && prefixes.remove[prop].values
+    const possiblePrefixableValues = prefixes.remove[prop.toLowerCase()]
+      && prefixes.remove[prop.toLowerCase()].values
     return possiblePrefixableValues && possiblePrefixableValues.some(valueObj => {
-      return value === valueObj.prefixed
+      return value.toLowerCase() === valueObj.prefixed
     })
   },
 

--- a/src/utils/isKeyframeRule.js
+++ b/src/utils/isKeyframeRule.js
@@ -8,6 +8,6 @@ export default function (rule) {
   const { parent } = rule
   return (
     parent.type === "atrule"
-    && parent.name === "keyframes"
+    && parent.name.toLowerCase() === "keyframes"
   )
 }

--- a/src/utils/isKnownUnit.js
+++ b/src/utils/isKnownUnit.js
@@ -23,5 +23,5 @@ const knownUnits = new Set([
 ])
 
 export default function (unit) {
-  return knownUnits.has(unit)
+  return knownUnits.has(unit) || knownUnits.has(unit.toLowerCase())
 }

--- a/src/utils/isVariable.js
+++ b/src/utils/isVariable.js
@@ -5,5 +5,5 @@
  * @return {boolean} If `true`, the word is a variable
  */
 export default function (word) {
-  return (word.slice(0, 4) === "var(")
+  return (word.toLowerCase().slice(0, 4) === "var(")
 }


### PR DESCRIPTION
**READY TO MERGE!**
Rules:
- [x] at-rule-empty-line-before (add only tests)
- [x] at-rule-name-case (all OK, no change)
- [x] at-rule-no-vendor-prefix
- [x] at-rule-semicolon-newline-after (add only tests)
- [x] block-closing-brace-newline-after (all OK, no change)
- [x] block-closing-brace-newline-before (all OK, no change)
- [x] block-closing-brace-space-after (all OK, no change)
- [x] block-closing-brace-space-before (all OK, no change)
- [x] block-no-empty (all OK, no change)
- [x] block-no-single-line (all OK, no change)
- [x] block-opening-brace-newline-after (all OK, no change)
- [x] block-opening-brace-newline-before (all OK, no change)
- [x] block-opening-brace-space-after (all OK, no change)
- [x] block-opening-brace-space-before (all OK, no change)
- [x] color-hex-case (all OK, no change)
- [x] color-hex-length (all OK, no change)
- [x] color-named
- [x] color-no-hex (all OK, no change)
- [x] color-no-invalid-hex (all OK, no change)
- [x] comment-empty-line-before (all OK, no change)
- [x] comment-whitespace-inside (all OK, no change)
- [x] comment-word-blacklist (all OK, next PR should accept regex flags on `matchesStringOrRegExp`)
- [x] custom-media-pattern
- [x] custom-property-no-outside-root
- [x] custom-property-pattern (all OK, need PR to allow regex flags)
- [x] declaration-bang-space-after (all OK, no change)
- [x] declaration-bang-space-before (all OK, no change)
- [x] declaration-block-no-duplicate-properties
- [x] declaration-block-no-ignored-properties
- [x] declaration-block-no-shorthand-property-overrides
- [x] declaration-block-properties-order (all OK, no change)
- [x] declaration-block-semicolon-newline-after (all OK, no change)
- [x] declaration-block-semicolon-newline-before (all OK, no change)
- [x] declaration-block-semicolon-space-after (all OK, no change)
- [x] declaration-block-semicolon-space-before (all OK, no change)
- [x] declaration-block-single-line-max-declarations (all OK, no change)
- [x] declaration-block-trailing-semicolon (all OK, no change)
- [x] declaration-colon-newline-after (all OK, no change)
- [x] declaration-colon-space-after (all OK, no change)
- [x] declaration-colon-space-before (all OK, no change)
- [x] declaration-no-important (all OK, but postcss bugs parser `!iMpOrTaNt`, `!IMPORTANT` in v6 fixed)
- [x] font-family-name-quotes (all OK, no change)
- [x] font-weight-notation
- [x] function-blacklist (all OK, need change to use `matchesStringOrRegExp`)
- [x] function-calc-no-unspaced-operator
- [x] function-comma-space-after (change inside `functionCommaSpaceChecker`)
- [x] function-comma-newline-before (change inside `functionCommaSpaceChecker`)
- [x] function-comma-space-after (change inside `functionCommaSpaceChecker`)
- [x] function-comma-space-before (change inside `functionCommaSpaceChecker`)
- [x] function-linear-gradient-no-nonstandard-direction
- [x] function-max-empty-lines (all OK, no change)
- [x] function-name-case (all OK, no change)
- [x] function-parentheses-newline-inside (all OK, no change)
- [x] function-parentheses-space-inside (all OK, no change)
- [x] function-url-data-uris
- [x] function-url-quotes
- [x] function-whitelist (all OK, need change to use `matchesStringOrRegExp`)
- [x] function-whitespace-after (all OK, no change)
- [x] indentation (all OK, no change)
- [x] max-empty-lines (all OK, no change)
- [x] max-line-length
- [x] max-nesting-depth (all OK, no change)
- [x] media-feature-colon-space-after (inside `mediaFeatureColonSpaceChecker`)
- [x] media-feature-colon-space-before (inside `mediaFeatureColonSpaceChecker`)
- [x] media-feature-name-no-vendor-prefix
- [x] media-feature-no-missing-punctuation
- [x] media-feature-range-operator-space-after (inside `findMediaOperator`)
- [x] media-feature-range-operator-space-before (inside `findMediaOperator`)
- [x] media-query-list-comma-newline-after (inside `mediaQueryListCommaWhitespaceChecker`)
- [x] media-query-list-comma-newline-before (inside `mediaQueryListCommaWhitespaceChecker`)
- [x] media-query-list-comma-space-after (inside `mediaQueryListCommaWhitespaceChecker`)
- [x] media-query-list-comma-space-before (inside `mediaQueryListCommaWhitespaceChecker`)
- [x] media-query-parentheses-space-inside
- [x] no-browser-hacks (all OK, no change)
- [x] no-descending-specificity (all OK, no change)
- [x] no-duplicate-selectors (all OK, no change)
- [x] no-eol-whitespace (all OK, no change)
- [x] no-extra-semicolons (all OK, no change)
- [x] no-indistinguishable-colors (all OK, no change)
- [x] no-invalid-double-slash-comments (all OK, no change)
- [x] no-missing-eof-newline (all OK, no change)
- [x] no-unknown-animations
- [x] no-unsupported-browser-features (all OK, no change)
- [x] number-leading-zero
- [x] number-max-precision
- [x] number-no-trailing-zeros
- [x] number-zero-length-no-unit
- [x] property-blacklist (all OK, next PR should accept regex flags on `matchesStringOrRegExp`)
- [x] property-case (all OK, no change)
- [x] property-no-vendor-prefix 
- [x] property-unit-blacklist (all OK, next PR should accept regex flags on `matchesStringOrRegExp`)
- [x] property-unit-whitelist (all OK, next PR should accept regex flags on `matchesStringOrRegExp`)
- [x] property-value-blacklist (all OK, next PR should accept regex flags on `matchesStringOrRegExp`)
- [x] property-value-whitelist (all OK, next PR should accept regex flags on `matchesStringOrRegExp`)
- [x] property-whitelist (all OK, next PR should accept regex flags on `matchesStringOrRegExp`)
- [x] root-no-standard-properties
- [x] rule-nested-empty-line-before (all OK, no change)
- [x] rule-non-nested-empty-line-before (all OK, no change)
- [x] selector-attribute-brackets-space-inside (all OK, no change)
- [x] selector-attribute-operator-space-after (all OK, no change)
- [x] selector-attribute-operator-space-before (all OK, no change)
- [x] selector-class-pattern (all OK, need PR to allow regex flags)
- [x] selector-combinator-space-after (all OK, no change)
- [x] selector-combinator-space-before (all OK, no change)
- [x] selector-id-pattern (all OK, need PR to allow regex flags)
- [x] selector-list-comma-newline-after (all OK, no change)
- [x] selector-list-comma-newline-before (all OK, no change)
- [x] selector-list-comma-space-after (all OK, no change)
- [x] selector-list-comma-space-before (all OK, no change)
- [x] selector-max-empty-lines (all OK, no change)
- [x] selector-max-specificity (all OK, no change)
- [x] selector-no-attribute (all OK, no change)
- [x] selector-no-combinator (all OK, no change)
- [x] selector-no-id (all OK, no change)
- [x] selector-no-qualifying-type (all OK, no change)
- [x] selector-no-type (all OK, no change)
- [x] selector-no-universal (all OK, no change)
- [x] selector-no-vendor-prefix
- [x] selector-pseudo-class-case (all OK, no change)
- [x] selector-pseudo-class-parentheses-space-inside (all OK, no change)
- [x] selector-pseudo-element-case  (all OK, no change)
- [x] selector-pseudo-element-colon-notation
- [x] selector-root-no-composition
- [x] selector-type-case (all OK, no change)
- [x] shorthand-property-no-redundant-values
- [x] string-no-newline (all OK, no change)
- [x] string-quotes (all OK, no change)
- [x] stylelint-disable-reason (all OK, no change)
- [x] time-no-imperceptible
- [x] unit-blacklist
- [x] unit-case
- [x] unit-no-unknown
- [x] unit-whitelist
- [x] value-keyword-case
- [x] value-list-comma-newline-after (all OK, no change)
- [x] value-list-comma-newline-before (all OK, no change)
- [x] value-list-comma-space-after (all OK, no change)
- [x] value-list-comma-space-before (all OK, no change)
- [x] value-no-vendor-prefix

Utils:
- [x] atRuleParamIndex
- [x] beforeBlockString
- [x] blockString
- [x] blurComments
- [x] blurFunctionArguments
- [x] configurationError
- [x] cssWordIsVariable
- [x] declarationValueIndex
- [x] findAtRuleContext
- [x] functionArgumentsSearch
- [x] hasBlock
- [x] hasEmptyBlock
- [x] isAutoprefixable
- [x] isCustomProperty
- [x] isKeyframeRule
- [x] isKnownUnit
- [x] isLowerSpecificity
- [x] isSingleLineString
- [x] isStandardDeclaration
- [x] isStandardFunction
- [x] isStandardProperty
- [x] isStandardRule
- [x] isStandardSelector
- [x] isStandardTypeSelector
- [x] isStandardValue
- [x] isValidHex
- [x] isVariable
- [x] isWhitespace
- [x] matchesStringOrRegExp
- [x] nextNonCommentNode
- [x] nodeContextLookup
- [x] optionsHaveException
- [x] optionsHaveIgnored
- [x] rawNodeString
- [x] report
- [x] ruleMessages
- [x] styleSearch
- [x] styleTagsFromHtmlExtracter
- [x] validateOptions
- [x] whitespaceChecker

1. It is not all rules, if somebody have time to review rules and found problems, please add here list.
2. I think we should add feature to allow use regex flag to `matchesStringOrRegExp`, we will can use pattern 
```json
{
    "rules": {
       "comment-word-blacklist": [[
            "/todo/i",
            "/fixme/i"
        ]],
    }
}
```
now it is possibly only use `/(T|t)(O|o)(D|d)(O|o)/`
3. `isKnownUnit.js` must case insensitivity?