### PR TITLE
`no-descending-specificity` now ignores selectors ending on `,`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed: `function-url-quotes` now ignores spaces within `url()`.
 - Fixed: `value-list-comma-*` rules now ignore SCSS maps.
 - Fixed: `no-descending-specificity` now ignores selectors ending on `,`.
+- Fixed: `no-descending-specificity` now ignores trailing colons within selectors.
 
 # 6.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed: string formatter no longer outputs an empty line if there are no problems.
 - Fixed: `function-url-quotes` now ignores spaces within `url()`.
 - Fixed: `value-list-comma-*` rules now ignore SCSS maps.
+- Fixed: `no-descending-specificity` now ignores selectors ending on `,`.
 
 # 6.2.2
 

--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -5,6 +5,7 @@ import rule, { ruleName, messages } from ".."
 testRule(rule, {
   ruleName,
   config: [true],
+  skipBasicChecks: true,
 
   accept: [ {
     code: "a {} b a {}",
@@ -35,6 +36,8 @@ testRule(rule, {
     code: ".menu:hover {} .burger {}",
   }, {
     code: ".foo.bar, .foo.bar:focus { @mixin: foo; } .baz.bar, .baz.bar:focus {}",
+  }, {
+    code: ".selector, { }",
   } ],
 
   reject: [ {

--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -46,6 +46,11 @@ testRule(rule, {
     line: 1,
     column: 8,
   }, {
+    code: "b a, {} a, {}",
+    message: messages.rejected("a", "b a"),
+    line: 1,
+    column: 9,
+  }, {
     code: "a + a {} a {}",
     message: messages.rejected("a", "a + a"),
     line: 1,

--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -29,8 +29,12 @@ export default function (actual) {
       const comparisonContext = selectorContextLookup.getContext(rule, findAtRuleContext(rule))
 
       rule.selectors.forEach(selector => {
+        const trimSelector = selector.trim()
+        // Ignore `.selector, { }`
+        if (trimSelector === "") { return }
+
         // The edge-case of duplicate selectors will act acceptably
-        const index = rule.selector.indexOf(selector.trim())
+        const index = rule.selector.indexOf(trimSelector)
         // Resolve any nested selectors before checking
         resolvedNestedSelector(selector, rule).forEach(resolvedSelector => {
           selectorParser(s => checkSelector(s, rule, index, comparisonContext)).process(resolvedSelector)


### PR DESCRIPTION
https://github.com/stylelint/stylelint/issues/1156