### PR TITLE
Fix syntax of grunt postcss example

### DIFF
--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -62,9 +62,7 @@ grunt.initConfig({
         ]
       },
       // start at the entry file
-      dist: {
-        src: 'css/entry.css'
-      }
+      src: 'css/entry.css'
     },
     // separate lint task
     lint: {
@@ -75,9 +73,7 @@ grunt.initConfig({
         ]
       },
       // lint all the .css files in the css directory
-      dist: {
-        src: 'css/**/*.css'
-      }
+      src: 'css/**/*.css'
     }
   }
 })


### PR DESCRIPTION
See https://github.com/nDmitry/grunt-postcss/blob/master/Gruntfile.js#L26-L32 - if there are subtasks the syntax is different then without subtasks, you do not need to wrap `src` and `dest` in `dist`