### PR TITLE
Deprecate unprefixed plugin rule names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+- Deprecated: support for unprefixed plugin names i.e. only `your-prefix/your-rule-name` are supported. If your plugin exports a single rule then prefix your rule name with just a slash (e.g. `/your-rule-name`).
 - Added: support for plugin modules that provides an array of rules.
 - Added: support for extracting and linting CSS from within HTML sources.
 - Added: `selector-attribute-operator-space-after` rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Head
 
-- Deprecated: support for plugin names that aren't namedspaced i.e. only `your-namespace/your-rule-name` are supported. If your plugin exports a single rule then you may simply namespace your rule a slash (e.g. `/your-rule-name`).
+- Deprecated: support for plugin names that aren't namedspaced i.e. only `your-namespace/your-rule-name` are supported. If your plugin provides only a single rule or you can't think of a good namespace, you can simply use `plugin/my-rule`).
 - Added: support for plugin modules that provides an array of rules.
 - Added: support for extracting and linting CSS from within HTML sources.
 - Added: `selector-attribute-operator-space-after` rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Head
 
-- Deprecated: support for unprefixed plugin names i.e. only `your-prefix/your-rule-name` are supported. If your plugin exports a single rule then prefix your rule name with just a slash (e.g. `/your-rule-name`).
+- Deprecated: support for plugin names that aren't namedspaced i.e. only `your-namespace/your-rule-name` are supported. If your plugin exports a single rule then you may simply namespace your rule a slash (e.g. `/your-rule-name`).
 - Added: support for plugin modules that provides an array of rules.
 - Added: support for extracting and linting CSS from within HTML sources.
 - Added: `selector-attribute-operator-space-after` rule.

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -5,7 +5,7 @@
 
 var stylelint = require("stylelint")
 
-var myPluginRuleName = "/foobar"
+var myPluginRuleName = "plugin/foobar"
 var myPluginRule = stylelint.createPlugin(myPluginRuleName, function(expectationKeyword, optionsObject) {
   return function(postcssRoot, postcssResult) {
     // ... some logic ...

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -5,7 +5,7 @@
 
 var stylelint = require("stylelint")
 
-var myPluginRuleName = "foobar"
+var myPluginRuleName = "/foobar"
 var myPluginRule = stylelint.createPlugin(myPluginRuleName, function(expectationKeyword, optionsObject) {
   return function(postcssRoot, postcssResult) {
     // ... some logic ...
@@ -15,6 +15,8 @@ var myPluginRule = stylelint.createPlugin(myPluginRuleName, function(expectation
 ```
 
 `stylelint.createPlugin(ruleName, ruleFunction)` ensures that your plugin will be setup properly alongside other rules. *Make sure you document your plugin's rule name for users, because they will need to use it in their config.*
+
+Your plugin's rule name must be prefixed e.g. `your-prefix/your-rule-name`. If your plugin exports a single rule then prefix your rule name with just a slash (e.g. `/your-rule-name`)
 
 In order for your plugin rule to work with the standard configuration format, (e.g. `["tab", { hierarchicalSelectors: true }]`), `ruleFunction` should accept 2 arguments: the expectation keyword (e.g. `"tab"`) and, optionally, an options object (e.g. `{ hierarchicalSelectors: true }`).
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -16,7 +16,7 @@ var myPluginRule = stylelint.createPlugin(myPluginRuleName, function(expectation
 
 `stylelint.createPlugin(ruleName, ruleFunction)` ensures that your plugin will be setup properly alongside other rules. *Make sure you document your plugin's rule name for users, because they will need to use it in their config.*
 
-Your plugin's rule name must be prefixed e.g. `your-prefix/your-rule-name`. If your plugin exports a single rule then prefix your rule name with just a slash (e.g. `/your-rule-name`)
+Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`. If your plugin exports a single rule, you may simply namespace your rule a slash (e.g. `/your-rule-name`). This namespace ensures that plugin rules will never clash with core rules.
 
 In order for your plugin rule to work with the standard configuration format, (e.g. `["tab", { hierarchicalSelectors: true }]`), `ruleFunction` should accept 2 arguments: the expectation keyword (e.g. `"tab"`) and, optionally, an options object (e.g. `{ hierarchicalSelectors: true }`).
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -16,7 +16,7 @@ var myPluginRule = stylelint.createPlugin(myPluginRuleName, function(expectation
 
 `stylelint.createPlugin(ruleName, ruleFunction)` ensures that your plugin will be setup properly alongside other rules. *Make sure you document your plugin's rule name for users, because they will need to use it in their config.*
 
-Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`. If your plugin exports a single rule, you may simply namespace your rule a slash (e.g. `/your-rule-name`). This namespace ensures that plugin rules will never clash with core rules.
+Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`. If your plugin provides only a single rule or you can't think of a good namespace, you can simply use `plugin/my-rule`. This namespace ensures that plugin rules will never clash with core rules.
 
 In order for your plugin rule to work with the standard configuration format, (e.g. `["tab", { hierarchicalSelectors: true }]`), `ruleFunction` should accept 2 arguments: the expectation keyword (e.g. `"tab"`) and, optionally, an options object (e.g. `{ hierarchicalSelectors: true }`).
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -188,7 +188,7 @@ Once the plugin is declared, within your `"rules"` object *you'll need to add op
     "../special-rule.js"
   ],
   "rules": {
-    "/special-rule": "everything"
+    "plugin/special-rule": "everything"
   },
 }
 ```

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -188,7 +188,7 @@ Once the plugin is declared, within your `"rules"` object *you'll need to add op
     "../special-rule.js"
   ],
   "rules": {
-    "special-rule": "everything"
+    "/special-rule": "everything"
   },
 }
 ```
@@ -201,9 +201,9 @@ A "plugin" can provide a single rule or a set of rules. If the plugin you use pr
     "../some-rule-set.js"
   ],
   "rules": {
-    "first-rule": "everything",
-    "second-rule": "nothing",
-    "third-rule": "everything"
+    "some-rule-set/first-rule": "everything",
+    "some-rule-set/second-rule": "nothing",
+    "some-rule-set/third-rule": "everything"
   },
 }
 ```

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -1,6 +1,6 @@
 # Plugins
 
-Plugins are rules and sets of rules built by the community that support methodologies, toolsets, *non-standard* CSS features, or very specific use cases. Their names are prefixed with "stylelint".
+Plugins are rules and sets of rules built by the community that support methodologies, toolsets, *non-standard* CSS features, or very specific use cases. Their *package* names are prefixed with "stylelint" and their *rule* names must be prefixed to distinguish them from stylelint's core rules.
 
 ## Methodologies
 

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -1,6 +1,6 @@
 # Plugins
 
-Plugins are rules and sets of rules built by the community that support methodologies, toolsets, *non-standard* CSS features, or very specific use cases. Their *package* names are prefixed with "stylelint" and their *rule* names must be prefixed to distinguish them from stylelint's core rules.
+Plugins are rules and sets of rules built by the community that support methodologies, toolsets, *non-standard* CSS features, or very specific use cases. Their *package* names are prefixed with "stylelint". Their *rule* names must be namespaced so that they do not clash with stylelint's core rules.
 
 ## Methodologies
 

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -1,6 +1,6 @@
 # Plugins
 
-Plugins are rules and sets of rules built by the community that support methodologies, toolsets, *non-standard* CSS features, or very specific use cases. Their *package* names are prefixed with "stylelint". Their *rule* names must be namespaced so that they do not clash with stylelint's core rules.
+Plugins are rules and sets of rules built by the community that support methodologies, toolsets, *non-standard* CSS features, or very specific use cases. Their *package* names are prefixed with "stylelint". Their *rule* names are namespaced so that they do not clash with stylelint's core rules.
 
 ## Methodologies
 

--- a/src/__tests__/fixtures/config-relative-plugin.json
+++ b/src/__tests__/fixtures/config-relative-plugin.json
@@ -3,6 +3,6 @@
     "./plugin-warn-about-foo"
   ],
   "rules": {
-    "warn-about-foo": "always"
+    "/warn-about-foo": "always"
   }
 }

--- a/src/__tests__/fixtures/config-relative-plugin.json
+++ b/src/__tests__/fixtures/config-relative-plugin.json
@@ -3,6 +3,6 @@
     "./plugin-warn-about-foo"
   ],
   "rules": {
-    "/warn-about-foo": "always"
+    "plugin/warn-about-foo": "always"
   }
 }

--- a/src/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
+++ b/src/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
@@ -1,6 +1,6 @@
 import stylelint from "../../"
 
-const ruleName = "/conditionally-check-color-hex-case"
+const ruleName = "plugin/conditionally-check-color-hex-case"
 
 export default stylelint.createPlugin(ruleName, function (expectation) {
   const colorHexCaseRule = stylelint.rules["color-hex-case"](expectation)

--- a/src/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
+++ b/src/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
@@ -1,6 +1,6 @@
 import stylelint from "../../"
 
-const ruleName = "conditionally-check-color-hex-case"
+const ruleName = "/conditionally-check-color-hex-case"
 
 export default stylelint.createPlugin(ruleName, function (expectation) {
   const colorHexCaseRule = stylelint.rules["color-hex-case"](expectation)

--- a/src/__tests__/fixtures/plugin-slashless-warn-about-foo.js
+++ b/src/__tests__/fixtures/plugin-slashless-warn-about-foo.js
@@ -1,8 +1,8 @@
 import stylelint from "../../"
 
-const ruleName = "/warn-about-foo"
+const ruleName = "slashless-warn-about-foo"
 
-const warnAboutFooMessages = stylelint.utils.ruleMessages("/warn-about-foo", {
+const warnAboutFooMessages = stylelint.utils.ruleMessages("slashless-warn-about-foo", {
   found: "found .foo",
 })
 

--- a/src/__tests__/fixtures/plugin-warn-about-foo.js
+++ b/src/__tests__/fixtures/plugin-warn-about-foo.js
@@ -1,8 +1,8 @@
 import stylelint from "../../"
 
-const ruleName = "/warn-about-foo"
+const ruleName = "plugin/warn-about-foo"
 
-const warnAboutFooMessages = stylelint.utils.ruleMessages("/warn-about-foo", {
+const warnAboutFooMessages = stylelint.utils.ruleMessages("plugin/warn-about-foo", {
   found: "found .foo",
 })
 

--- a/src/__tests__/plugins-test.js
+++ b/src/__tests__/plugins-test.js
@@ -16,7 +16,7 @@ const configRelative = {
     "./fixtures/plugin-warn-about-foo",
   ],
   rules: {
-    "/warn-about-foo": "always",
+    "plugin/warn-about-foo": "always",
     "block-no-empty": true,
   },
 }
@@ -26,7 +26,7 @@ const configAbsolute = {
     path.join(__dirname, "./fixtures/plugin-warn-about-foo"),
   ],
   rules: {
-    "/warn-about-foo": "always",
+    "plugin/warn-about-foo": "always",
     "block-no-empty": true,
   },
 }
@@ -47,7 +47,7 @@ test("plugin runs", t => {
   processorRelative.process(cssWithFoo)
     .then(result => {
       t.equal(result.warnings().length, 2)
-      t.equal(result.warnings()[0].text, "found .foo (/warn-about-foo)")
+      t.equal(result.warnings()[0].text, "found .foo (plugin/warn-about-foo)")
       t.ok(result.warnings()[0].node)
     })
     .catch(logError)
@@ -70,7 +70,7 @@ test("plugin with absolute path and no configBasedir", t => {
   processorAbsolute.process(cssWithFoo)
     .then(result => {
       t.equal(result.warnings().length, 2)
-      t.equal(result.warnings()[0].text, "found .foo (/warn-about-foo)")
+      t.equal(result.warnings()[0].text, "found .foo (plugin/warn-about-foo)")
       t.ok(result.warnings()[0].node)
     })
     .catch(logError)
@@ -85,7 +85,7 @@ test("config extending another config that invokes a plugin with a relative path
   processorExtendRelative.process(cssWithFoo)
     .then(result => {
       t.equal(result.warnings().length, 1)
-      t.equal(result.warnings()[0].text, "found .foo (/warn-about-foo)")
+      t.equal(result.warnings()[0].text, "found .foo (plugin/warn-about-foo)")
       t.ok(result.warnings()[0].node)
     })
     .catch(logError)
@@ -105,7 +105,7 @@ test("plugin using exposed rules via stylelint.rules", t => {
     config: {
       plugins: [path.join(__dirname, "fixtures/plugin-conditionally-check-color-hex-case")],
       rules: {
-        "/conditionally-check-color-hex-case": expectation,
+        "plugin/conditionally-check-color-hex-case": expectation,
       },
     },
   })
@@ -149,8 +149,8 @@ test("module providing an array of plugins", t => {
   const config = {
     plugins: [path.join(__dirname, "fixtures/plugin-array")],
     rules: {
-      "/conditionally-check-color-hex-case": "upper",
-      "/warn-about-foo": "always",
+      "plugin/conditionally-check-color-hex-case": "upper",
+      "plugin/warn-about-foo": "always",
     },
   }
 
@@ -164,7 +164,7 @@ test("module providing an array of plugins", t => {
 
   postcss().use(stylelint(config)).process(".foo {}").then(result => {
     t.equal(result.warnings().length, 1)
-    t.equal(result.warnings()[0].text, "found .foo (/warn-about-foo)")
+    t.equal(result.warnings()[0].text, "found .foo (plugin/warn-about-foo)")
   }).catch(logError)
   planned += 2
 

--- a/src/__tests__/plugins-test.js
+++ b/src/__tests__/plugins-test.js
@@ -183,7 +183,7 @@ test("deprecation warning for slashless plugin rule names", t => {
 
   postcss().use(stylelint(config)).process(".foo {}").then(result => {
     t.equal(result.warnings().length, 2)
-    t.equal(result.warnings()[0].text, "Unprefixed plugin rules have been deprecated, and in 7.0 they will be disallowed.")
+    t.equal(result.warnings()[0].text, "Plugin rules that aren't namespaced have been deprecated, and in 7.0 they will be disallowed.")
     t.equal(result.warnings()[0].stylelintType, "deprecation")
     t.equal(result.warnings()[1].text, "found .foo (slashless-warn-about-foo)")
   }).catch(logError)

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -58,7 +58,7 @@ export default postcss.plugin("stylelint", (options = {}) => {
             }
             if (!_.includes(plugin.ruleName, "/")) {
               result.warn((
-                "Unprefixed plugin rules have been deprecated, " +
+                "Plugin rules that aren't namespaced have been deprecated, " +
                 "and in 7.0 they will be disallowed."
               ), {
                 stylelintType: "deprecation",

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -1,7 +1,7 @@
 import postcss from "postcss"
 import multimatch from "multimatch"
 import globjoin from "globjoin"
-import { get } from "lodash"
+import _ from "lodash"
 import path from "path"
 import { configurationError } from "./utils"
 import ruleDefinitions from "./rules"
@@ -36,7 +36,7 @@ export default postcss.plugin("stylelint", (options = {}) => {
           if (path.isAbsolute(glob)) return glob
           return globjoin(configDir, glob)
         })
-        const sourcePath = get(root, "source.input.file", "")
+        const sourcePath = _.get(root, "source.input.file", "")
         if (multimatch(sourcePath, absoluteIgnoreFiles).length) {
           result.warn("This file is ignored", { severity: "info" })
           return
@@ -55,6 +55,15 @@ export default postcss.plugin("stylelint", (options = {}) => {
                 `The plugin "${pluginPath}" is not doing this, so will not work ` +
                 "with stylelint v3+. Please file an issue with the plugin."
               )
+            }
+            if (!_.includes(plugin.ruleName, "/")) {
+              result.warn((
+                "Unprefixed plugin rules have been deprecated, " +
+                "and in 7.0 they will be disallowed."
+              ), {
+                stylelintType: "deprecation",
+                stylelintReference: "http://stylelint.io/developer-guide/plugins/",
+              })
             }
             ruleDefinitions[plugin.ruleName] = plugin.rule
           })
@@ -81,7 +90,7 @@ export default postcss.plugin("stylelint", (options = {}) => {
         if (primaryOption === null) { return }
 
         // Log the rule's severity in the PostCSS result
-        result.stylelint.ruleSeverities[ruleName] = get(secondaryOptions, "severity", "error")
+        result.stylelint.ruleSeverities[ruleName] = _.get(secondaryOptions, "severity", "error")
         result.stylelint.customMessages[ruleName] = secondaryOptions && secondaryOptions.message
 
         // Run the rule with the primary and secondary options


### PR DESCRIPTION
Closes #1174

@davidtheclark Is this what you had in mind?

When `7.0` comes around we can replace the deprecation warning with a `configurationError`