### PR TITLE
fixes #1022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed: `function-url-quotes` now ignores spaces within `url()`.
 - Fixed: `value-list-comma-*` rules now ignore SCSS maps.
 - Fixed: `no-descending-specificity` now ignores trailing colons within selectors.
+- Fixed: `function-comma-newline-after` now allows comments at the end of a line.
 
 # 6.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixed: `function-url-quotes` now ignores spaces within `url()`.
 - Fixed: `value-list-comma-*` rules now ignore SCSS maps.
 - Fixed: `no-descending-specificity` now ignores trailing colons within selectors.
-- Fixed: `function-comma-newline-after` now allows comments at the end of a line.
+- Fixed: `function-comma-newline-after` now allows end-of-line comments.
 
 # 6.2.2
 

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -24,11 +24,15 @@ testRule(rule, {
   }, {
     code: "a { background: linear-gradient(45deg,\n rgba(0,\n 0,\n 0,\n 1),\n red); }",
   }, {
-    code: "$map: (key: value, key2: value2)",
-    description: "Sass map ignored",
-  }, {
-    code: "$list: (value, value2)",
-    description: "Sass list ignored",
+    code: `
+      a {
+        transform: translate(
+          1px, /* comment */
+          1px
+        );
+      }
+    `,
+    description: "eol comments",
   } ],
 
   reject: [ {
@@ -71,6 +75,40 @@ testRule(rule, {
     message: messages.expectedAfter(),
     line: 2,
     column: 4,
+  }, {
+    code: `
+      a {
+        transform: translate(
+          1px,  /* comment (with trailing space) */ 
+          1px
+        );
+      }
+    `,
+    description: "eol comments",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value, key2: value2)",
+    description: "sass map ignored",
+  }, {
+    code: "$list: (value, value2)",
+    description: "sass list ignored",
+  }, {
+    code: `
+      a {
+        transform: translate(
+          1px, // line comment   
+          1px
+        );
+      }
+    `,
+    description: "eol comments",
   } ],
 })
 
@@ -122,8 +160,15 @@ testRule(rule, {
         }
     `,
   }, {
-    code: "$map: (key: value\n, key2: value2)",
-    description: "SCSS map",
+    code: `
+      a {
+        transform: translate(
+          1px, /* comment */
+          1px
+        );
+      }
+    `,
+    description: "eol comments",
   } ],
 
   reject: [ {
@@ -151,6 +196,37 @@ testRule(rule, {
     message: messages.expectedAfterMultiLine(),
     line: 2,
     column: 4,
+  }, {
+    code: `
+      a {
+        transform: translate(
+          1px, /* comment (with trailing space) */ 
+          1px
+        );
+      }
+    `,
+    description: "eol comments",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["always-multi-line"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value\n, key2: value2)",
+    description: "sass map",
+  }, {
+    code: `
+      a {
+        transform: translate(
+          1px, // line comment   
+          1px
+        );
+      }
+    `,
+    description: "eol comments",
   } ],
 })
 
@@ -180,8 +256,12 @@ testRule(rule, {
   }, {
     code: "a { background: linear-gradient(45deg\n,rgba(0, 0, 0, 1),red); }",
   }, {
-    code: "$map: (key: value,\nkey2: value2)",
-    description: "SCSS map",
+    code: `
+      a {
+        transform: translate(1px, 1px); /* comment */  
+      }
+    `,
+    description: "eol comments",
   } ],
 
   reject: [ {
@@ -211,3 +291,21 @@ testRule(rule, {
     column: 18,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["never-multi-line"],
+  syntax: "scss",
+
+  accept: [{
+    code: "$map: (key: value,\nkey2: value2)",
+    description: "sass map",
+  }, {
+    code: `
+      a {
+        transform: translate(1px, 1px); // line comment  
+      }
+    `,
+    description: "eol comments",
+  } ],
+});

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -297,7 +297,7 @@ testRule(rule, {
   config: ["never-multi-line"],
   syntax: "scss",
 
-  accept: [{
+  accept: [ {
     code: "$map: (key: value,\nkey2: value2)",
     description: "sass map",
   }, {
@@ -308,4 +308,4 @@ testRule(rule, {
     `,
     description: "eol comments",
   } ],
-});
+})

--- a/src/rules/function-comma-newline-before/__tests__/index.js
+++ b/src/rules/function-comma-newline-before/__tests__/index.js
@@ -144,10 +144,10 @@ testRule(rule, {
   config: ["always-multi-line"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value,\nkey2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })
 
 testRule(rule, {
@@ -206,8 +206,8 @@ testRule(rule, {
   config: ["never-multi-line"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value\n,key2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })

--- a/src/rules/function-comma-newline-before/__tests__/index.js
+++ b/src/rules/function-comma-newline-before/__tests__/index.js
@@ -22,11 +22,15 @@ testRule(rule, {
   }, {
     code: "a { transform: color(rgb(0\n  , 0\n  ,0) lightness(50%)); }",
   }, {
-    code: "$map: (key: value, key2: value2)",
-    description: "Sass map ignored",
-  }, {
-    code: "$list: (value, value2)",
-    description: "Sass list ignored",
+    code: `
+      a {
+        transform: translate(
+          1px /* comment */
+          ,1px
+        );
+      }
+    `,
+    description: "eol comments",
   } ],
 
   reject: [ {
@@ -64,6 +68,20 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["always"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value, key2: value2)",
+    description: "Sass map ignored",
+  }, {
+    code: "$list: (value, value2)",
+    description: "Sass list ignored",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: ["always-multi-line"],
 
   accept: [ {
@@ -92,8 +110,15 @@ testRule(rule, {
   }, {
     code: "a { background: linear-gradient(45deg\n, rgba(0, 0, 0, 1)\n, red); }",
   }, {
-    code: "$map: (key: value,\nkey2: value2)",
-    description: "SCSS map",
+    code: `
+      a {
+        transform: translate(
+          1px /* comment */
+          ,1px
+        );
+      }
+    `,
+    description: "eol comments",
   } ],
 
   reject: [ {
@@ -116,6 +141,17 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["always-multi-line"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value,\nkey2: value2)",
+    description: "SCSS map",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: ["never-multi-line"],
 
   accept: [ {
@@ -130,9 +166,6 @@ testRule(rule, {
     code: "a { transform: translate(1 , 1); }",
   }, {
     code: "a { transform: translate(1\t,1); }",
-  }, {
-    code: "$map: (key: value\n,key2: value2)",
-    description: "SCSS map",
   } ],
 
   reject: [ {
@@ -155,5 +188,26 @@ testRule(rule, {
     message: messages.rejectedBeforeMultiLine(),
     line: 3,
     column: 1,
+  }, {
+    code: `
+      a {
+        transform: translate(
+          1px /* comment */
+          , 1px
+        );
+      }
+    `,
+    description: "eol comments",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["never-multi-line"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value\n,key2: value2)",
+    description: "SCSS map",
   } ],
 })

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -150,10 +150,10 @@ testRule(rule, {
   config: ["never"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value, key2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })
 
 testRule(rule, {
@@ -212,10 +212,10 @@ testRule(rule, {
   config: ["always-single-line"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value,key2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })
 
 testRule(rule, {
@@ -272,8 +272,8 @@ testRule(rule, {
   config: ["never-single-line"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value, key2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -22,11 +22,8 @@ testRule(rule, {
     code: "a { background: url(data:image/svg+xml;charset=utf8,%3Csvg%20xmlns); }",
     description: "data URI with spaceless comma",
   }, {
-    code: "$map: (key: value,key2: value2)",
-    description: "Sass map ignored",
-  }, {
-    code: "$list: (value,value2)",
-    description: "Sass list ignored",
+    code: "a { transform: translate(1, /* comment */1); }",
+    description: "comments",
   } ],
 
   reject: [ {
@@ -65,6 +62,23 @@ testRule(rule, {
     message: messages.expectedAfter(),
     line: 1,
     column: 47,
+  }, {
+    code: "a { transform: translate(1,/* comment */1); }",
+    description: "comments",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value,key2: value2)",
+    description: "Sass map ignored",
+  }, {
+    code: "$list: (value,value2)",
+    description: "Sass list ignored",
   } ],
 })
 
@@ -85,8 +99,8 @@ testRule(rule, {
   }, {
     code: "a { transform: color(rgb(0 ,0,0) lightness(50%)); }",
   }, {
-    code: "$map: (key: value, key2: value2)",
-    description: "SCSS map",
+    code: "a { transform: translate(1,/* comment */1); }",
+    description: "comments",
   } ],
 
   reject: [ {
@@ -125,6 +139,20 @@ testRule(rule, {
     message: messages.rejectedAfter(),
     line: 1,
     column: 43,
+  }, {
+    code: "a { transform: translate(1, /* comment */1); }",
+    description: "comments",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value, key2: value2)",
+    description: "SCSS map",
   } ],
 })
 
@@ -159,9 +187,6 @@ testRule(rule, {
     description: "CRLF",
   }, {
     code: "a { background: linear-gradient(45deg\n,rgba(0, 0, 0, 1)\n,red); }",
-  }, {
-    code: "$map: (key: value,key2: value2)",
-    description: "SCSS map",
   } ],
 
   reject: [ {
@@ -179,6 +204,17 @@ testRule(rule, {
     message: messages.expectedAfterSingleLine(),
     line: 2,
     column: 11,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["always-single-line"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value,key2: value2)",
+    description: "SCSS map",
   } ],
 })
 
@@ -211,9 +247,6 @@ testRule(rule, {
   }, {
     code: "a { color: rgba(0\n, 0, 0); }",
     description: "CRLF",
-  }, {
-    code: "$map: (key: value, key2: value2)",
-    description: "SCSS map",
   } ],
 
   reject: [ {
@@ -231,5 +264,16 @@ testRule(rule, {
     message: messages.rejectedAfterSingleLine(),
     line: 2,
     column: 13,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["never-single-line"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value, key2: value2)",
+    description: "SCSS map",
   } ],
 })

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -43,9 +43,9 @@ export default function (expectation) {
 
 export function functionCommaSpaceChecker({ locationChecker, root, result, checkedRuleName }) {
   root.walkDecls(decl => {
-    let declValue = (() => {
-      let raws = decl.raws.value;
-      return (raws && raws.raw) || decl.value;
+    const declValue = (() => {
+      const raws = decl.raws.value
+      return (raws && raws.raw) || decl.value
     })()
 
     valueParser(declValue).walk(valueNode => {
@@ -64,7 +64,7 @@ export function functionCommaSpaceChecker({ locationChecker, root, result, check
         result = result.slice(0, result.length - 1)
         // 1. Remove comments including preceeding whitespace (when only succeeded by whitespace)
         // 2. Remove all other comments, but leave adjacent whitespace intact
-        result = result.replace(/(\ *\/(\*.*\*\/(?!\S)|\/.*)|(\/(\*.*\*\/|\/.*)))/, '')
+        result = result.replace(/(\ *\/(\*.*\*\/(?!\S)|\/.*)|(\/(\*.*\*\/|\/.*)))/, "")
         return result
       })()
 

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -1,3 +1,4 @@
+import _ from "lodash"
 import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
@@ -43,10 +44,7 @@ export default function (expectation) {
 
 export function functionCommaSpaceChecker({ locationChecker, root, result, checkedRuleName }) {
   root.walkDecls(decl => {
-    const declValue = (() => {
-      const raws = decl.raws.value
-      return (raws && raws.raw) || decl.value
-    })()
+    const declValue = _.get(decl, "raws.value.raw", decl.value)
 
     valueParser(declValue).walk(valueNode => {
       if (valueNode.type !== "function") { return }

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -43,7 +43,12 @@ export default function (expectation) {
 
 export function functionCommaSpaceChecker({ locationChecker, root, result, checkedRuleName }) {
   root.walkDecls(decl => {
-    valueParser(decl.value).walk(valueNode => {
+    let declValue = (() => {
+      let raws = decl.raws.value;
+      return (raws && raws.raw) || decl.value;
+    })()
+
+    valueParser(declValue).walk(valueNode => {
       if (valueNode.type !== "function") { return }
 
       if (!isStandardFunction(valueNode)) { return }
@@ -57,6 +62,9 @@ export function functionCommaSpaceChecker({ locationChecker, root, result, check
         result = result.slice(valueNode.value.length + 1)
         // Remove closing paren
         result = result.slice(0, result.length - 1)
+        // 1. Remove comments including preceeding whitespace (when only succeeded by whitespace)
+        // 2. Remove all other comments, but leave adjacent whitespace intact
+        result = result.replace(/(\ *\/(\*.*\*\/(?!\S)|\/.*)|(\/(\*.*\*\/|\/.*)))/, '')
         return result
       })()
 

--- a/src/rules/function-comma-space-before/__tests__/index.js
+++ b/src/rules/function-comma-space-before/__tests__/index.js
@@ -21,12 +21,6 @@ testRule(rule, {
   }, {
     code: "a { background: url(data:image/svg+xml;charset=utf8,%3Csvg%20xmlns); }",
     description: "data URI with spaceless comma",
-  }, {
-    code: "$map: (key: value,key2: value2)",
-    description: "Sass map ignored",
-  }, {
-    code: "$list: (value, value2)",
-    description: "Sass list ignored",
   } ],
 
   reject: [ {
@@ -65,6 +59,30 @@ testRule(rule, {
     message: messages.expectedBefore(),
     line: 1,
     column: 46,
+  }, {
+    code: `
+      a {
+        transform: translate(
+          1px /* comment */
+          ,1px
+        );
+      }
+    `,
+    description: "eol comments",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value,key2: value2)",
+    description: "Sass map ignored",
+  }, {
+    code: "$list: (value, value2)",
+    description: "Sass list ignored",
   } ],
 })
 
@@ -84,9 +102,6 @@ testRule(rule, {
     code: "a { transform: translate(1,1); }",
   }, {
     code: "a { transform: color(rgb(0, 0,0) lightness(50%)); }",
-  }, {
-    code: "$map: (key: value ,key2: value2)",
-    description: "SCSS map",
   } ],
 
   reject: [ {
@@ -130,6 +145,17 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["never"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value ,key2: value2)",
+    description: "SCSS map",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: ["always-single-line"],
 
   accept: [ {
@@ -157,9 +183,6 @@ testRule(rule, {
     code: "a { transform: translate(1\n,\n1); }",
   }, {
     code: "a { background: linear-gradient(45deg,\nrgba(0 , 0 , 0 ,1)\n,red); }",
-  }, {
-    code: "$map: (key: value,key2: value2)",
-    description: "SCSS map",
   } ],
 
   reject: [ {
@@ -177,6 +200,17 @@ testRule(rule, {
     message: messages.expectedBeforeSingleLine(),
     line: 2,
     column: 11,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["always-single-line"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value,key2: value2)",
+    description: "SCSS map",
   } ],
 })
 
@@ -207,9 +241,6 @@ testRule(rule, {
     code: "a { transform: translate(1\n, 1); }",
   }, {
     code: "a { transform: translate(1\n,\n1); }",
-  }, {
-    code: "$map: (key: value ,key2: value2)",
-    description: "SCSS map",
   } ],
 
   reject: [ {
@@ -222,5 +253,16 @@ testRule(rule, {
     message: messages.rejectedBeforeSingleLine(),
     line: 1,
     column: 46,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["never-single-line"],
+  syntax: "scss",
+
+  accept: [ {
+    code: "$map: (key: value ,key2: value2)",
+    description: "SCSS map",
   } ],
 })

--- a/src/rules/function-comma-space-before/__tests__/index.js
+++ b/src/rules/function-comma-space-before/__tests__/index.js
@@ -148,10 +148,10 @@ testRule(rule, {
   config: ["never"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value ,key2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })
 
 testRule(rule, {
@@ -208,10 +208,10 @@ testRule(rule, {
   config: ["always-single-line"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value,key2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })
 
 testRule(rule, {
@@ -261,8 +261,8 @@ testRule(rule, {
   config: ["never-single-line"],
   syntax: "scss",
 
-  accept: [ {
+  accept: [{
     code: "$map: (key: value ,key2: value2)",
     description: "SCSS map",
-  } ],
+  }],
 })

--- a/src/rules/string-no-newline/__tests__/index.js
+++ b/src/rules/string-no-newline/__tests__/index.js
@@ -51,6 +51,6 @@ testRule(rule, {
   skipBasicChecks: true,
 
   accept: [{
-    code: "/// it's not ok\na {}",
+    code: "/// it's within a comment\na {}",
   }],
 })


### PR DESCRIPTION
@evilebottnawi 
Does this look better?

This should fix #1022 and following rule with it:
- `function-comma-newline-after`

Fix location:
- `functionCommaSpaceChecker`

As this method is also used in some other places, I've added some tests to ensure that nothing is broken in following rules:
- `function-comma-space-after`
- `function-comma-newline-before`
- `function-comma-space-before`

I've also extracted all tests related to syntax `scss` into separate testing blocks.