### PR TITLE
fix upper case value in shorthand-property-no-redundant-values

### DIFF
--- a/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -55,6 +55,9 @@ testRule(rule, {
   }, {
     code: "a { margin: var(--margin) var(--margin); }",
     description: "ignore variables",
+  }, {
+    code: "a { border-color: #FFFFFF transparent transparent }",
+    description: "ignore upper case value",
   } ],
 
   reject: [ {

--- a/src/rules/shorthand-property-no-redundant-values/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/index.js
@@ -92,7 +92,7 @@ export default function (actual) {
       const shortestFormString = shortestForm.filter((value) => { return value }).join(" ")
       const valuesFormString = valuesToShorthand.join(" ")
 
-      if (shortestFormString.toLowerCase() === valuesFormString) { return }
+      if (shortestFormString.toLowerCase() === valuesFormString.toLowerCase()) { return }
 
       report({
         message: messages.rejected(value, shortestFormString),


### PR DESCRIPTION
Fix #1213