### PR TITLE
Adding the option to pass in --ignore-disable-comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added: `--ignore-disable-comments` option to CLI to skip any inline disable comments
+
 # 6.3.1
 
 - Fixed: `declaration-block-no-ignored-properties` now longer crashes on nested rules.

--- a/src/__tests__/postcssPlugin-test.js
+++ b/src/__tests__/postcssPlugin-test.js
@@ -14,6 +14,21 @@ test("`configFile` option with absolute path", t => {
   })
 })
 
+test("checks with ignore-disable-comments should have undefined disabledRanges", t => {
+  const source = `/* stylelint-disable block-no-empty */
+    a {}`
+  const config = {
+    configFile: path.join(__dirname, "fixtures/config-block-no-empty.json"),
+    ignoreDisableComments: true,
+  }
+  t.plan(1)
+  postcssPlugin.process(source, config).then(result => {
+    t.equal(result.stylelint.disabledRanges, undefined)
+  }).catch(err => {
+    t.equal(err.code, "ENOENT")
+  })
+})
+
 test("`configFile` with bad path", t => {
   t.plan(1)
   postcssPlugin.process("a {}", { configFile: "./herby.json" }).catch(err => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -37,26 +37,27 @@ const meowOptions = {
     "  You can also pass no input and use stdin, instead.",
     "",
     "Options",
-    "  --config            Path to a specific configuration file (JSON, YAML, or CommonJS),",
-    "                      or the name of a module in `node_modules` that points to one.",
-    "                      If no `--config` argument is provided, stylelint will search for",
-    "                      configuration  files in the following places, in this order:",
-    "                        - a `stylelint` property in `package.json`",
-    "                        - a `.stylelintrc` file (with or without filename extension:",
-    "                          `.json`, `.yaml`, and `.js` are available)",
-    "                        - a `stylelint.config.js` file exporting a JS object",
-    "                      The search will begin in the working directory and move up the",
-    "                      directory tree until a configuration file is found.",
-    "  --version           Get the currently installed version of stylelint.",
-    "  --custom-formatter  Path to a JS file exporting a custom formatting function",
-    "  --stdin-filename    Specify a filename to assign stdin input",
-    "  -f, --formatter     Specify a formatter: \"json\" or \"string\". Default is \"string\".",
-    "  -q, --quiet         Only register warnings for rules with an \"error\"-level severity",
-    "                      (ignore \"warning\"-level)",
-    "  -s, --syntax        Specify a non-standard syntax that should be used to ",
-    "                      parse source stylesheets. Options: \"scss\", \"less\", \"sugarss\"",
-    "  -e, --extract       Extract and lint CSS from style tags in HTML structures",
-    "  -v, --verbose       Get more stats",
+    "  --config                   Path to a specific configuration file (JSON, YAML, or CommonJS),",
+    "                             or the name of a module in `node_modules` that points to one.",
+    "                             If no `--config` argument is provided, stylelint will search for",
+    "                             configuration  files in the following places, in this order:",
+    "                               - a `stylelint` property in `package.json`",
+    "                               - a `.stylelintrc` file (with or without filename extension:",
+    "                                 `.json`, `.yaml`, and `.js` are available)",
+    "                               - a `stylelint.config.js` file exporting a JS object",
+    "                             The search will begin in the working directory and move up the",
+    "                             directory tree until a configuration file is found.",
+    "  --version                  Get the currently installed version of stylelint.",
+    "  --custom-formatter         Path to a JS file exporting a custom formatting function",
+    "  --stdin-filename           Specify a filename to assign stdin input",
+    "  --ignore-disable-comments  Ignores disable comments in files",
+    "  -f, --formatter            Specify a formatter: \"json\" or \"string\". Default is \"string\".",
+    "  -q, --quiet                Only register warnings for rules with an \"error\"-level severity",
+    "                             (ignore \"warning\"-level)",
+    "  -s, --syntax               Specify a non-standard syntax that should be used to ",
+    "                             parse source stylesheets. Options: \"scss\", \"less\", \"sugarss\"",
+    "  -e, --extract              Extract and lint CSS from style tags in HTML structures",
+    "  -v, --verbose              Get more stats",
   ],
   pkg: "../package.json",
 }
@@ -77,6 +78,10 @@ const optionsBase = {
 
 if (cli.flags.quiet) {
   optionsBase.configOverrides.quiet =  cli.flags.quiet
+}
+
+if (cli.flags.ignoreDisableComments) {
+  optionsBase.ignoreDisableComments = true
 }
 
 if (cli.flags.syntax && includes(syntaxOptions, cli.flags.syntax)) {

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -74,7 +74,7 @@ export default postcss.plugin("stylelint", (options = {}) => {
       result.stylelint.quiet = config.quiet
 
       // First check for disabled ranges, adding them to the result object
-      disableRanges(root, result)
+      if (options.ignoreDisableComments != true) { disableRanges(root, result) }
 
       Object.keys(config.rules).forEach(ruleName => {
         if (!ruleDefinitions[ruleName]) {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -25,6 +25,7 @@ export default function ({
   syntax,
   formatter = "json",
   extractStyleTagsFromHtml,
+  ignoreDisableComments,
 } = {}) {
   const isValidCode = typeof code === "string"
   if (!files && !isValidCode || files && (code || isValidCode)) {
@@ -85,6 +86,7 @@ export default function ({
           configFile,
           configBasedir,
           configOverrides,
+          ignoreDisableComments,
         }))
     }
 


### PR DESCRIPTION
closes https://github.com/stylelint/stylelint/issues/1184

This pull allows an argument `--ignore-disable-comments` to be passed in from the `cli` This will tell the linter to ignore any disable comments like this:

```css
/* stylelint-disable */
a {
}
```

I wanted to open this pull up early to get feedback from @jeddy3 and @davidtheclark. I have a test added but I'm unsure if `postcssPlugin-test.js` is the appropriate place? Also, is there anything I need to do for the Node api or does this take care of it?

-
to @jeddy3 @davidtheclark