### PR TITLE
Rule `declaration-block-no-ignored-properties` now detects use of `overflow`, `overflow-x` and `overflow-y` with inline elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `selector-pseudo-class-no-unknown` rule.
 - Fixed: `declaration-block-no-ignored-properties` now detects use of `min-width` and `max-width` with inline, table-row, table-row-group, table-column and table-column-group elements.
+- Fixed: `declaration-block-no-ignored-properties` now detects use of `overflow`, `overflow-x` and `overflow-y` with inline elements.
 
 # 6.3.3
 

--- a/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
@@ -112,8 +112,7 @@ testRule(rule, {
     line: 1,
     column: 22,
     description: "display: inline rules out min-width",
-  },
-  {
+  }, {
     code: "a { display: inline; max-width: 100px; }",
     message: messages.rejected("max-width", "display: inline"),
     line: 1,
@@ -162,6 +161,24 @@ testRule(rule, {
     line: 1,
     column: 22,
     description: "display: inline rules out width, height, margin-top and margin-bottom, and float",
+  }, {
+    code: "a { display: inline; overflow: scroll; }",
+    message: messages.rejected("overflow", "display: inline"),
+    line: 1,
+    column: 22,
+    description: "display: inline rules out overflow",
+  }, {
+    code: "a { display: inline; overflow-x: scroll; }",
+    message: messages.rejected("overflow-x", "display: inline"),
+    line: 1,
+    column: 22,
+    description: "display: inline rules out overflow-x",
+  }, {
+    code: "a { display: inline; overflow-y: scroll; }",
+    message: messages.rejected("overflow-y", "display: inline"),
+    line: 1,
+    column: 22,
+    description: "display: inline rules out overflow-x",
   }, {
     code: "a { display: inline-block; float: left; }",
     message: messages.rejected("float", "display: inline-block"),

--- a/src/rules/declaration-block-no-ignored-properties/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/index.js
@@ -26,6 +26,9 @@ const ignored = [ {
     "margin-top",
     "margin-bottom",
     "float",
+    "overflow",
+    "overflow-x",
+    "overflow-y",
   ],
 }, {
   property: "display",


### PR DESCRIPTION
/cc @davidtheclark 