### PR TITLE
Integrate coverage and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
+coverage
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ node_js:
   - '4'
   - '0.12'
 
+script: npm run coverage
+
+after_success:
+    - npm run coveralls
+
 notifications:
   webhooks:
     - https://webhooks.gitter.im/e/d763493612da45967361

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stylelint
 
-[![NPM version](http://img.shields.io/npm/v/stylelint.svg)](https://www.npmjs.org/package/stylelint) [![Build Status](https://travis-ci.org/stylelint/stylelint.svg?branch=master)](https://travis-ci.org/stylelint/stylelint) [![Build status](https://ci.appveyor.com/api/projects/status/wwajr0886e00g8je/branch/master?svg=true)](https://ci.appveyor.com/project/stylelint/stylelint/branch/master) [![NPM Downloads](https://img.shields.io/npm/dm/stylelint.svg)](https://www.npmjs.org/package/stylelint)
+[![NPM version](http://img.shields.io/npm/v/stylelint.svg)](https://www.npmjs.org/package/stylelint) [![Build Status](https://travis-ci.org/stylelint/stylelint.svg?branch=master)](https://travis-ci.org/stylelint/stylelint) [![Build status](https://ci.appveyor.com/api/projects/status/wwajr0886e00g8je/branch/master?svg=true)](https://ci.appveyor.com/project/stylelint/stylelint/branch/master) [![Coverage Status](https://coveralls.io/repos/github/stylelint/stylelint/badge.svg?branch=coverage)](https://coveralls.io/github/stylelint/stylelint?branch=coverage) [![NPM Downloads](https://img.shields.io/npm/dm/stylelint.svg)](https://www.npmjs.org/package/stylelint)
 
 A mighty, modern CSS linter that helps you enforce consistent conventions and avoid errors in your stylesheets.
 

--- a/package.json
+++ b/package.json
@@ -59,10 +59,13 @@
     "table": "^3.7.8"
   },
   "devDependencies": {
-    "babel-cli": "^6.1.18",
+    "babel-cli": "^6.8.0",
+    "babel-polyfill": "^6.8.0",
+    "babel-istanbul": "^0.8.0",
     "babel-preset-es2015": "^6.1.18",
     "babel-tape-runner": "^2.0.0",
     "benchmark": "^2.1.0",
+    "coveralls": "^2.11.4",
     "eslint": "^2.4.0",
     "eslint-config-stylelint": "^1.0.0",
     "npm-run-all": "^1.8.0",
@@ -81,12 +84,14 @@
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",
     "pretest": "npm run lint",
+    "coverage": "rm -rf coverage && babel-node node_modules/.bin/babel-istanbul cover babel-tape-runner \"src/**/__tests__/*.js\"",
     "tape": "babel-tape-runner \"src/**/__tests__/*.js\"",
     "test": "npm run tape",
     "prebuild": "rimraf dist",
     "build": "babel src --out-dir dist",
     "prepublish": "npm run build",
-    "release": "npmpub"
+    "release": "npmpub",
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
1. What do you think guys, `babel-istanbul` good choice (other solution I could not find)?
2. Should we include check coverage inside `npm test` (`npm run tape` always run with `babel-istanbul`)?

/cc @davidtheclark @jeddy3 