### PR TITLE
Fix stringFormatter bug with multi-byte error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed: `declaration-block-no-ignored-properties` now detects use of `overflow`, `overflow-x` and `overflow-y` with inline elements.
 - Fixed: some rules now better handle case insensitive CSS identifiers.
 - Fixed: `font-family-name-quotes`, `media-feature-no-missing-punctuation`, `media-query-list-comma-newline-after`, `media-query-list-comma-newline-before`, `media-query-list-comma-space-after` and `media-query-list-comma-space-before` rules now better ignore SCSS, Less variables and nonstandard at-rules.
+- Fixed: string formatter no longer errors on multi-byte `message`.
 
 # 6.3.3
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "postcss-value-parser": "^3.1.1",
     "resolve-from": "^2.0.0",
     "specificity": "^0.1.5",
+    "string-width": "^1.0.1",
     "stylehacks": "^2.3.0",
     "sugarss": "^0.1.2",
     "table": "^3.7.8"

--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -2,6 +2,7 @@ import chalk from "chalk"
 import path from "path"
 import _ from "lodash"
 import symbols from "log-symbols"
+import stringWidth from "string-width"
 import table, { getBorderCharacters } from "table"
 import utils from "postcss-reporter/lib/util"
 
@@ -79,7 +80,7 @@ function formatter(messages, source) {
   const calculateWidths = function (columns) {
 
     _.forOwn(columns, (value, key) => {
-      columnWidths[key] = Math.max(columnWidths[key], chalk.stripColor(value).toString().length)
+      columnWidths[key] = Math.max(columnWidths[key], stringWidth(value))
     })
 
     return columns


### PR DESCRIPTION
I found stringFormatter bug with multi-byte message.

For example, this rule setting got error.

```json
  "rules":{
    "declaration-no-important": [ true, {
      severity: "warning",
      message: "間違っています"
    } ],
```

```
Error: Subject parameter value width cannot be greater than the container width.
    at exports.default (/project/node_modules/table/dist/alignString.js:100:15)
    at /project/node_modules/table/dist/alignTableData.js:37:50
    at arrayMap (/project/node_modules/lodash/_arrayMap.js:16:21)
    at map (/project/node_modules/lodash/map.js:51:10)
    at /project/node_modules/table/dist/alignTableData.js:29:34
    at arrayMap (/project/node_modules/lodash/_arrayMap.js:16:21)
    at map (/project/node_modules/lodash/map.js:51:10)
    at exports.default (/project/node_modules/table/dist/alignTableData.js:28:30)
    at exports.default (/project/node_modules/table/dist/table.js:131:39)
    at formatter (/project/node_modules/stylelint/dist/formatters/stringFormatter.js:157:33)
```

And I fix this to use `string-width` module same as [table](https://github.com/gajus/table/blob/master/src/alignString.js#L73) module.