### PR TITLE
Fix stringFormatter

### DIFF
--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -80,7 +80,7 @@ function formatter(messages, source) {
   const calculateWidths = function (columns) {
 
     _.forOwn(columns, (value, key) => {
-      columnWidths[key] = Math.max(columnWidths[key], stringWidth(value))
+      columnWidths[key] = Math.max(columnWidths[key], stringWidth(value.toString()))
     })
 
     return columns


### PR DESCRIPTION
Before:
```shell
test.css
 2:3  ✖  Expected single quotes around font-family name "冬青黑体简体中文"   font-family-name-quotes
   4
```
After:
```shell
test.css
 2:34  ✖  Expected single quotes around font-family name "冬青黑体简体中文"   font-family-name-quotes
```
/cc @davidtheclark 