### PR TITLE
Fix issue 1241

### DIFF
--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -96,12 +96,16 @@ function formatter(messages, source) {
     (message) => {
       const location = utils.getLocation(message)
       const severity = message.severity
-
       const row = [
         location.line || "",
         location.column || "",
         symbols[severity] ? chalk[levelColors[severity]](symbols[severity]) : severity,
-        message.text.replace(/\.$/, "").replace(new RegExp(_.escapeRegExp("(" + message.rule + ")") + "$"), ""),
+        message
+          .text
+          // Remove all control characters (newline, tab and etc)
+          .replace(/[\x01-\x1A]+/g, " ") // eslint-disable-line
+          .replace(/\.$/, "")
+          .replace(new RegExp(_.escapeRegExp("(" + message.rule + ")") + "$"), ""),
         chalk.gray(message.rule || ""),
       ]
 


### PR DESCRIPTION
https://github.com/gajus/table/blob/master/src/validateTableData.js#L44
Inside cell all range this characters are invalid, because we remove their from message. Why? Some package used stylelint (example `stylehacks` and other) may return their error with characters in this range.
/cc @davidtheclark 