### PR TITLE
Add babel polyfill; fixes #1243

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed: `value-keyword-case` now ignores custom idents of property `counter-increment`.
 - Fixed: `value-keyword-case` now ignores custom idents of property `animation-name`.
 - Fixed: `unit-no-unknown` now ignores interpolation inside functions.
+- Fixed: `unit-no-unknown` no longer breaks Node 0.12 (because we've included the Babel polyfill).
 
 # 6.3.3
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "autoprefixer": "^6.0.0",
+    "babel-polyfill": "^6.8.0",
     "balanced-match": "^0.4.0",
     "chalk": "^1.1.1",
     "colorguard": "^1.2.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Polyfill is required as long as we support Node 0.12, because
+// use of the spread operator Babel plugin requires `Array.from()`
+import "babel-polyfill"
 import meow from "meow"
 import path from "path"
 import { assign, includes } from "lodash"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+// Polyfill is required as long as we support Node 0.12, because
+// use of the spread operator Babel plugin requires `Array.from()`
+import "babel-polyfill"
 import postcssPlugin from "./postcssPlugin"
 import standalone from "./standalone"
 import createPlugin from "./createPlugin"


### PR DESCRIPTION
Looks like #1243 resulted from the apparently unprecedented use the ES2015 spread operator in a recent feature — which [needs `Array.from()`](http://babeljs.io/docs/usage/caveats/), which [Node 0.12 (only) doesn't support](http://node.green/#Array-static-methods).

So we have two choices: don't use spread, or include the Babel polyfill.

I think we're less likely to run into similar confusion in the future if we just include the polyfill, so that's the path I chose.

cc/ @Lucas-C