### PR TITLE
Account for vendor prefixes when filtering on walk

### DIFF
--- a/src/rules/keyframe-declaration-no-important/__tests__/index.js
+++ b/src/rules/keyframe-declaration-no-important/__tests__/index.js
@@ -48,5 +48,11 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 44,
+  }, {
+    code: "@-webkit-keyframes important { from { margin: 1px !important; } }",
+    description: "with !important",
+    message: messages.rejected,
+    line: 1,
+    column: 52,
   } ],
 })

--- a/src/rules/keyframe-declaration-no-important/index.js
+++ b/src/rules/keyframe-declaration-no-important/index.js
@@ -1,3 +1,4 @@
+import { vendor } from "postcss"
 import {
   report,
   ruleMessages,
@@ -14,8 +15,9 @@ export default function (actual) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
+    root.walkAtRules(/keyframes$/i, atRuleKeyframes => {
+      if (vendor.unprefixed(atRuleKeyframes.name).toLowerCase() !== "keyframes") { return }
 
-    root.walkAtRules(/^keyframes$/i, atRuleKeyframes => {
       atRuleKeyframes.walkDecls(decl => {
         if (!decl.important) {
           return

--- a/src/rules/no-unknown-animations/__tests__/index.js
+++ b/src/rules/no-unknown-animations/__tests__/index.js
@@ -142,5 +142,11 @@ testRule(rule, {
     message: messages.rejected("BAZ"),
     line: 1,
     column: 16,
+  }, {
+    code: "a { animation-name: baz; } @-webkit-keyframes bar { }",
+    description: "working with vendor keyframes",
+    message: messages.rejected("baz"),
+    line: 1,
+    column: 21,
   } ],
 })

--- a/src/rules/no-unknown-animations/index.js
+++ b/src/rules/no-unknown-animations/index.js
@@ -32,7 +32,9 @@ export default function (actual) {
     if (!validOptions) { return }
 
     const declaredAnimations = new Set()
-    root.walkAtRules(/keyframes/i, atRule => {
+    root.walkAtRules(/keyframes$/i, atRule => {
+      if (postcss.vendor.unprefixed(atRule.name).toLowerCase() !== "keyframes") { return }
+
       declaredAnimations.add(atRule.params)
     })
 


### PR DESCRIPTION
1. Should we check vendor prefixes (at-rules, properties and etc)? If should some rules need change to working with vendor prefixes. If yes i PR this.

/cc @davidtheclark @jeddy3 