### PR TITLE
Update devDependency `npm-run-all` to `^2.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "benchmark": "^2.1.0",
     "eslint": "^2.4.0",
     "eslint-config-stylelint": "^1.0.0",
-    "npm-run-all": "^1.8.0",
+    "npm-run-all": "^2.1.0",
     "npmpub": "^3.0.1",
     "postcss-import": "^8.0.2",
     "remark": "^4.0.0",


### PR DESCRIPTION
I couldn't see any [breaking change](https://github.com/mysticatea/npm-run-all/releases) that would affect stylelint's use of this cool module :+1