### PR TITLE
Recategorise keyfame-declaration-no-important

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -97,6 +97,10 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 - [`property-value-whitelist`](../../src/rules/property-value-whitelist/README.md): Specify a whitelist of allowed values for specific properties.
 - [`property-whitelist`](../../src/rules/property-whitelist/README.md): Specify a whitelist of allowed properties.
 
+### Keyframe declaration
+
+- [`keyframe-declaration-no-important`](../../src/rules/keyframe-declaration-no-important/README.md): Disallow `!important` within keyframe declarations.
+
 ### Declaration
 
 - [`declaration-bang-space-after`](../../src/rules/declaration-bang-space-after/README.md): Require a single space or disallow whitespace after the bang of declarations.
@@ -213,10 +217,6 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 - [`comment-empty-line-before`](../../src/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
 - [`comment-whitespace-inside`](../../src/rules/comment-whitespace-inside/README.md): Require or disallow whitespace on the inside of comment markers.
 - [`comment-word-blacklist`](../../src/rules/comment-word-blacklist/README.md): Specify a blacklist of disallowed words within comments.
-
-### Keyframe rule
-
-- [`keyframe-declaration-no-important`](../../src/rules/keyframe-declaration-no-important/README.md): Disallow `!important` within declarations in a keyframe rule.
 
 ### General / Sheet
 

--- a/src/rules/keyframe-declaration-no-important/README.md
+++ b/src/rules/keyframe-declaration-no-important/README.md
@@ -1,47 +1,47 @@
 # keyframe-declaration-no-important
 
-Disallow `!important` within declarations in a keyframe rule.
+Disallow `!important` within keyframe declarations.
 
 ```css
 @keyframes important2 {
   from { margin: 10px }
-  to   { margin: 20px !important }
-}                  /* ↑ */
-/**                   ↑
- *            This !important */
+  to { margin: 20px !important }
+}                /* ↑ */
+/**                 ↑
+*     This !important */
 ```
 
 The following patterns are considered warnings:
 
 ```css
 @keyframes important1 {
-  from { 
-    margin-top: 50px; 
+  from {
+    margin-top: 50px;
   }
-  to { 
-    margin-top: 100px !important; 
-  }
-}
-```
-
-```css
-@keyframes important1 {
-  from { 
-    margin-top: 50px; 
-  }
-  to { 
-    margin-top: 100px!important; 
+  to {
+    margin-top: 100px !important;
   }
 }
 ```
 
 ```css
 @keyframes important1 {
-  from { 
-    margin-top: 50px; 
+  from {
+    margin-top: 50px;
   }
-  to { 
-    margin-top: 100px ! important; 
+  to {
+    margin-top: 100px!important;
+  }
+}
+```
+
+```css
+@keyframes important1 {
+  from {
+    margin-top: 50px;
+  }
+  to {
+    margin-top: 100px ! important;
   }
 }
 ```
@@ -54,11 +54,11 @@ a { color: pink !important; }
 
 ```css
 @keyframes important1 {
-  from { 
-    margin-top: 50px; 
+  from {
+    margin-top: 50px;
   }
-  to { 
-    margin-top: 100px; 
+  to {
+    margin-top: 100px;
   }
 }
 ```

--- a/src/rules/keyframe-declaration-no-important/index.js
+++ b/src/rules/keyframe-declaration-no-important/index.js
@@ -7,7 +7,7 @@ import {
 export const ruleName = "keyframe-declaration-no-important"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: "Unexpected !important within declarations in a keyframe",
+  rejected: "Unexpected !important",
 })
 
 export default function (actual) {
@@ -17,10 +17,7 @@ export default function (actual) {
 
     root.walkAtRules(/^keyframes$/i, atRuleKeyframes => {
       atRuleKeyframes.walkDecls(decl => {
-        if (!decl.important) {
-          return
-        }
-
+        if (!decl.important) { return }
         report({
           message: messages.rejected,
           node: decl,


### PR DESCRIPTION
This PR puts this rule into a “Keyframe declaration” section (above the “Declaration” section), so that the *general to specific* organisation is maintained i.e.  `keyfame-declaration-no-important` is specific to keyframe declarations, where as `declaration-no-important` (which now appears below it) is applicable to *all* declarations.

Please excuse the end-of-line noise in the diff. I'm going to update the stylelint eslint rules to catch these things.