### PR TITLE
Consistent whitespace

### DIFF
--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -69,7 +69,7 @@ function formatter(messages, source) {
   const orderedMessages = _.sortBy(
     messages,
     (m) => m.line ? 2 : 1, // positionless first
-    (m) => m.line ,
+    (m) => m.line,
     (m) => m.column
   )
 

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -174,7 +174,7 @@ testRule(rule, {
   ruleName,
   config: ["always"],
   syntax: "less",
-  
+
   accept: [ {
     code: "a { color: pink;\n// comment\ntop: 0; }",
     description: "single-line comment ignored",
@@ -188,7 +188,7 @@ testRule(rule, {
   ruleName,
   config: ["never"],
   syntax: "less",
-  
+
   accept: [{
     code: "a { color: pink;\n\n// comment\ntop: 0; }",
     description: "single-line comment ignored",

--- a/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
@@ -289,7 +289,7 @@ testRule(rule, {
     line: 1,
     column: 26,
     description: "display: table-* rules out margin",
-  },{
+  }, {
     code: "a { display: table-cell; margin-right: 10px; }",
     message: messages.rejected("margin-right", "display: table-cell"),
     line: 1,

--- a/src/rules/declaration-block-properties-order/index.js
+++ b/src/rules/declaration-block-properties-order/index.js
@@ -55,7 +55,7 @@ export default function (expectation, options) {
         }
 
         if (child.type !== "decl") { return }
-  
+
         const { prop } = child
         if (!isStandardProperty(prop)) { return }
         if (isCustomProperty(prop)) { return }

--- a/src/rules/font-weight-notation/index.js
+++ b/src/rules/font-weight-notation/index.js
@@ -35,7 +35,7 @@ export default function (expectation, options) {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [ "numeric", "named-where-possible" ],
-    } , {
+    }, {
       actual: options,
       possible: {
         ignore: ["relative"],

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -9,7 +9,7 @@ import {
 export const ruleName = "function-url-quotes"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (q, f="url") => `Expected ${q} around ${f} argument`,
+  expected: (q, f = "url") => `Expected ${q} around ${f} argument`,
 })
 
 export default function (expectation) {

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -146,7 +146,7 @@ export default function (space, options = {}) {
       }
     })
 
-    function indentationLevel(node, level=0) {
+    function indentationLevel(node, level = 0) {
       if (node.parent.type === "root") { return level }
 
       // In case by recursion we're checking a node that's

--- a/src/rules/no-extra-semicolons/__tests__/index.js
+++ b/src/rules/no-extra-semicolons/__tests__/index.js
@@ -86,7 +86,7 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 2,
-  },{
+  }, {
     code: "\t\t;",
     message: messages.rejected,
     line: 1,

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -47,7 +47,7 @@ export default function (actual) {
         report({
           message: messages.rejected,
           node,
-          index: error.index + error.match.length -2,
+          index: error.index + error.match.length - 2,
           result,
           ruleName,
         })

--- a/src/rules/selector-attribute-operator-space-after/index.js
+++ b/src/rules/selector-attribute-operator-space-after/index.js
@@ -74,7 +74,7 @@ export function selectorAttributeOperatorSpaceChecker({
         source,
         index,
         err: (m) => report({
-          message: m.replace(checkBeforeOperator ? operator[0] : operator[operator.length - 1] , operator),
+          message: m.replace(checkBeforeOperator ? operator[0] : operator[operator.length - 1], operator),
           node,
           index: attributeIndex + index,
           result,

--- a/src/rules/value-keyword-case/__tests__/index.js
+++ b/src/rules/value-keyword-case/__tests__/index.js
@@ -334,7 +334,7 @@ testRule(rule, {
     message: messages.expected("Block", "block"),
     line: 1,
     column: 24,
-  },{
+  }, {
     code: "$map: (Display-first: block, display-second: inline);",
     message: messages.expected("Display-first", "display-first"),
     line: 1,

--- a/src/utils/__tests__/beforeBlockString-test.js
+++ b/src/utils/__tests__/beforeBlockString-test.js
@@ -41,7 +41,7 @@ test("beforeBlockString with comment after selector", t => {
   t.end()
 })
 
-function postcssCheck(options={}, cssString) {
+function postcssCheck(options = {}, cssString) {
   if (typeof options === "string") {
     cssString = options
   }

--- a/src/utils/beforeBlockString.js
+++ b/src/utils/beforeBlockString.js
@@ -10,7 +10,7 @@
  * @param {boolean} [options.noRawBefore] - Leave out the `before` string
  * @return {string}
  */
-export default function (statement, { noRawBefore }={}) {
+export default function (statement, { noRawBefore } = {}) {
   let result = ""
   if (statement.type !== "rule" && statement.type !== "atrule") { return result }
 

--- a/src/utils/blurComments.js
+++ b/src/utils/blurComments.js
@@ -5,6 +5,6 @@
  * @param {[string]} blurChar="`"
  * @return {string} - The result string, with comments replaced
  */
-export default function (source, blurChar="`") {
+export default function (source, blurChar = "`") {
   return source.replace(/\/\*.*\*\//g, blurChar)
 }

--- a/src/utils/blurFunctionArguments.js
+++ b/src/utils/blurFunctionArguments.js
@@ -17,7 +17,7 @@ import balancedMatch from "balanced-match"
  * @param {[string]} blurChar="`"
  * @return {string} - The result string, with the function arguments "blurred"
  */
-export default function (source, functionName, blurChar="`") {
+export default function (source, functionName, blurChar = "`") {
   const nameWithParen = `${functionName.toLowerCase()}(`
   const lowerCaseSource =  source.toLowerCase()
   if (!_.includes(lowerCaseSource, nameWithParen)) { return source }

--- a/src/utils/blurInterpolation.js
+++ b/src/utils/blurInterpolation.js
@@ -7,6 +7,6 @@
  * @param {string} source
  * @return {string} - The result string, with the interpolation characters "blurred"
  */
-export default function (source, blurChar=" ") {
+export default function (source, blurChar = " ") {
   return source.replace(/[#@{}]+/g, blurChar)
 }

--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -69,8 +69,8 @@ export default function (targetWhitespace, expectation, messages) {
     err,
     errTarget,
     lineCheckStr,
-    onlyOneChar=false,
-    allowIndentation=false,
+    onlyOneChar = false,
+    allowIndentation = false,
   }) {
     activeArgs = { source, index, err, errTarget, onlyOneChar, allowIndentation }
     switch (expectation) {
@@ -107,7 +107,7 @@ export default function (targetWhitespace, expectation, messages) {
    * Parameters are pretty much the same as for `before()`, above, just substitute
    * the word "after" for "before".
    */
-  function after({ source, index, err, errTarget, lineCheckStr, onlyOneChar=false }) {
+  function after({ source, index, err, errTarget, lineCheckStr, onlyOneChar = false }) {
     activeArgs = { source, index, err, errTarget, onlyOneChar }
     switch (expectation) {
       case "always":
@@ -141,7 +141,7 @@ export default function (targetWhitespace, expectation, messages) {
     before(assign({}, obj, { allowIndentation: true }))
   }
 
-  function expectBefore(messageFunc=messages.expectedBefore) {
+  function expectBefore(messageFunc = messages.expectedBefore) {
     if (activeArgs.allowIndentation) {
       expectBeforeAllowingIndentation(messageFunc)
       return
@@ -172,7 +172,7 @@ export default function (targetWhitespace, expectation, messages) {
     activeArgs.err(messageFunc(activeArgs.errTarget ? activeArgs.errTarget : source[index]))
   }
 
-  function expectBeforeAllowingIndentation(messageFunc=messages.expectedBefore) {
+  function expectBeforeAllowingIndentation(messageFunc = messages.expectedBefore) {
     const { source, index, err } = activeArgs
     const expectedChar = (function () {
       if (targetWhitespace === "newline") { return "\n" }
@@ -189,7 +189,7 @@ export default function (targetWhitespace, expectation, messages) {
     }
   }
 
-  function rejectBefore(messageFunc=messages.rejectedBefore) {
+  function rejectBefore(messageFunc = messages.rejectedBefore) {
     const { source, index } = activeArgs
     const oneCharBefore = source[index - 1]
 
@@ -202,7 +202,7 @@ export default function (targetWhitespace, expectation, messages) {
     after(assign({}, obj, { onlyOneChar: true }))
   }
 
-  function expectAfter(messageFunc=messages.expectedAfter) {
+  function expectAfter(messageFunc = messages.expectedAfter) {
     const { source, index } = activeArgs
 
     const oneCharAfter = source[index + 1]
@@ -229,7 +229,7 @@ export default function (targetWhitespace, expectation, messages) {
     activeArgs.err(messageFunc(activeArgs.errTarget ? activeArgs.errTarget : source[index]))
   }
 
-  function rejectAfter(messageFunc=messages.rejectedAfter) {
+  function rejectAfter(messageFunc = messages.rejectedAfter) {
     const { source, index } = activeArgs
     const oneCharAfter = source[index + 1]
 


### PR DESCRIPTION
Brings codebase inline with new whitespace rules in https://github.com/stylelint/eslint-config-stylelint/pull/5

The majority of the new rules didn’t require any changes (good work everyone! 😄). Only spaces around operators and commas, and eol whitespace needed addressing.