### PR TITLE
Fix block-opening-brace-newline-before documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed: `unit-blacklist`, `unit-case`, `unit-no-unknown`, `unit-whitelist` now better accounts interpolation.
 - Fixed: `unit-no-unknown` no longer breaks Node 0.12 (because we've included the Babel polyfill).
 - Fixed: catch errors thrown by `postcss-selector-parser` and register them as PostCSS warnings, providing a better UX for editor plugins.
+- Fixed: Wrong example for `always-multi-line` in rule `block-opening-brace-newline-before`.
 
 # 6.3.3
 

--- a/src/rules/block-opening-brace-newline-before/README.md
+++ b/src/rules/block-opening-brace-newline-before/README.md
@@ -102,6 +102,11 @@ a{
 color: pink; }
 ```
 
+```css
+a {
+color: pink; }
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
@@ -110,7 +115,8 @@ a
 ```
 
 ```css
-a {
+a
+{
 color: pink; }
 ```
 

--- a/src/rules/block-opening-brace-newline-before/README.md
+++ b/src/rules/block-opening-brace-newline-before/README.md
@@ -110,6 +110,14 @@ color: pink; }
 The following patterns are *not* considered warnings:
 
 ```css
+a{ color: pink; }
+```
+
+```css
+a { color: pink; }
+```
+
+```css
 a
 { color: pink; }
 ```


### PR DESCRIPTION
The `block-opening-brace-newline-before` contained a wrong example for the `always-multi-line section` that showed a pattern that would be considered a warning as not being considered a warning:

```css
a {
color: pink; }
```

That's why I moved it to the considered as a warning section and replaced it with a pattern that is actually not considered a warning.

I also added two single-line version that are not considered a warning to make it extra clear that single line whitespace does not matter with this setting.