### PR TITLE
Use clearer parameter names in rule messages

### DIFF
--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -8,7 +8,7 @@ import {
 export const ruleName = "color-hex-length"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (h, v) => `Expected "${h}" to be "${v}"`,
+  expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 })
 
 export default function (expectation) {

--- a/src/rules/color-no-hex/index.js
+++ b/src/rules/color-no-hex/index.js
@@ -8,7 +8,7 @@ import {
 export const ruleName = "color-no-hex"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: c => `Unexpected hex color "${c}"`,
+  rejected: hex => `Unexpected hex color "${hex}"`,
 })
 
 export default function (actual) {

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -9,7 +9,7 @@ import {
 export const ruleName = "color-no-invalid-hex"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: c => `Unexpected invalid hex color "${c}"`,
+  rejected: hex => `Unexpected invalid hex color "${hex}"`,
 })
 
 export default function (actual) {

--- a/src/rules/declaration-block-no-duplicate-properties/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/index.js
@@ -10,7 +10,7 @@ import {
 export const ruleName = "declaration-block-no-duplicate-properties"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: p => `Unexpected duplicate property "${p}"`,
+  rejected: property => `Unexpected duplicate property "${property}"`,
 })
 
 export default function (on, options) {

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -11,9 +11,9 @@ import balancedMatch from "balanced-match"
 export const ruleName = "function-calc-no-unspaced-operator"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: o => `Expected single space before "${o}" operator`,
-  expectedAfter: o => `Expected single space after "${o}" operator`,
-  expectedOperatorBeforeSign: o => `Expected an operator before sign "${o}"`,
+  expectedBefore: operator => `Expected single space before "${operator}" operator`,
+  expectedAfter: operator => `Expected single space after "${operator}" operator`,
+  expectedOperatorBeforeSign: operator => `Expected an operator before sign "${operator}"`,
 })
 
 export default function (actual) {

--- a/src/rules/property-blacklist/index.js
+++ b/src/rules/property-blacklist/index.js
@@ -12,7 +12,7 @@ import {
 export const ruleName = "property-blacklist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (p) => `Unexpected property "${p}"`,
+  rejected: (property) => `Unexpected property "${property}"`,
 })
 
 export default function (blacklistInput) {

--- a/src/rules/property-no-vendor-prefix/index.js
+++ b/src/rules/property-no-vendor-prefix/index.js
@@ -8,7 +8,7 @@ import {
 export const ruleName = "property-no-vendor-prefix"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: p => `Unexpected vendor-prefixed property "${p}"`,
+  rejected: property => `Unexpected vendor-prefixed property "${property}"`,
 })
 
 export default function (actual) {

--- a/src/rules/property-unit-blacklist/index.js
+++ b/src/rules/property-unit-blacklist/index.js
@@ -13,7 +13,7 @@ import {
 export const ruleName = "property-unit-blacklist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (p, u) => `Unexpected unit "${u}" for property "${p}"`,
+  rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 })
 
 export default function (blacklist) {

--- a/src/rules/property-unit-whitelist/index.js
+++ b/src/rules/property-unit-whitelist/index.js
@@ -13,7 +13,7 @@ import {
 export const ruleName = "property-unit-whitelist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (p, u) => `Unexpected unit "${u}" for property "${p}"`,
+  rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 })
 
 export default function (whitelist) {

--- a/src/rules/property-value-blacklist/index.js
+++ b/src/rules/property-value-blacklist/index.js
@@ -10,7 +10,7 @@ import {
 export const ruleName = "property-value-blacklist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (p, u) => `Unexpected value "${u}" for property "${p}"`,
+  rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 })
 
 export default function (blacklist) {

--- a/src/rules/property-value-whitelist/index.js
+++ b/src/rules/property-value-whitelist/index.js
@@ -10,7 +10,7 @@ import {
 export const ruleName = "property-value-whitelist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (p, u) => `Unexpected value "${u}" for property "${p}"`,
+  rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 })
 
 export default function (whitelist) {

--- a/src/rules/property-whitelist/index.js
+++ b/src/rules/property-whitelist/index.js
@@ -12,7 +12,7 @@ import {
 export const ruleName = "property-whitelist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (p) => `Unexpected property "${p}"`,
+  rejected: (property) => `Unexpected property "${property}"`,
 })
 
 export default function (whitelistInput) {

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -10,7 +10,7 @@ import {
 export const ruleName = "root-no-standard-properties"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: p => `Unexpected standard property "${p}" applied to ":root"`,
+  rejected: property => `Unexpected standard property "${property}" applied to ":root"`,
 })
 
 export default function (actual) {

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -11,8 +11,8 @@ import { nonSpaceCombinators } from "../../reference/punctuationSets"
 export const ruleName = "selector-combinator-space-after"
 
 export const messages = ruleMessages(ruleName, {
-  expectedAfter: c => `Expected single space after "${c}" combinator `,
-  rejectedAfter: c => `Unexpected whitespace after "${c}" combinator`,
+  expectedAfter: combinator => `Expected single space after "${combinator}" combinator`,
+  rejectedAfter: combinator => `Unexpected whitespace after "${combinator}" combinator`,
 })
 
 export default function (expectation) {

--- a/src/rules/selector-combinator-space-before/index.js
+++ b/src/rules/selector-combinator-space-before/index.js
@@ -9,8 +9,8 @@ import { selectorCombinatorSpaceChecker } from "../selector-combinator-space-aft
 export const ruleName = "selector-combinator-space-before"
 
 export const messages = ruleMessages(ruleName, {
-  expectedBefore: c => `Expected single space before "${c}" combinator`,
-  rejectedBefore: c => `Unexpected whitespace before "${c}" combinator`,
+  expectedBefore: combinator => `Expected single space before "${combinator}" combinator`,
+  rejectedBefore: combinator => `Unexpected whitespace before "${combinator}" combinator`,
 })
 
 export default function (expectation) {

--- a/src/rules/selector-no-vendor-prefix/index.js
+++ b/src/rules/selector-no-vendor-prefix/index.js
@@ -11,7 +11,7 @@ import {
 export const ruleName = "selector-no-vendor-prefix"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: p => `Unexpected vendor-prefixed selector "${p}"`,
+  rejected: property => `Unexpected vendor-prefixed selector "${property}"`,
 })
 
 export default function (actual) {

--- a/src/rules/selector-pseudo-class-no-unknown/index.js
+++ b/src/rules/selector-pseudo-class-no-unknown/index.js
@@ -14,7 +14,7 @@ import {
 export const ruleName = "selector-pseudo-class-no-unknown"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (u) => `Unexpected unknown pseudo-class selector "${u}"`,
+  rejected: (selector) => `Unexpected unknown pseudo-class selector "${selector}"`,
 })
 
 export default function (actual, options) {

--- a/src/rules/selector-pseudo-element-no-unknown/index.js
+++ b/src/rules/selector-pseudo-element-no-unknown/index.js
@@ -11,7 +11,7 @@ import { pseudoElements } from "../../reference/keywordSets"
 export const ruleName = "selector-pseudo-element-no-unknown"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (u) => `Unexpected unknown pseudo-element selector "${u}"`,
+  rejected: (selector) => `Unexpected unknown pseudo-element selector "${selector}"`,
 })
 
 export default function (actual, options) {

--- a/src/rules/selector-type-no-unknown/index.js
+++ b/src/rules/selector-type-no-unknown/index.js
@@ -11,7 +11,7 @@ import {
 export const ruleName = "selector-type-no-unknown"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (u) => `Unexpected unknown type selector "${u}"`,
+  rejected: (selector) => `Unexpected unknown type selector "${selector}"`,
 })
 
 export default function (actual, options) {

--- a/src/rules/unit-blacklist/index.js
+++ b/src/rules/unit-blacklist/index.js
@@ -11,7 +11,7 @@ import {
 export const ruleName = "unit-blacklist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (u) => `Unexpected unit "${u}"`,
+  rejected: (unit) => `Unexpected unit "${unit}"`,
 })
 
 export default function (blacklistInput) {

--- a/src/rules/unit-no-unknown/index.js
+++ b/src/rules/unit-no-unknown/index.js
@@ -12,7 +12,7 @@ import { units } from "../../reference/keywordSets"
 export const ruleName = "unit-no-unknown"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (u) => `Unexpected unknown unit "${u}"`,
+  rejected: (unit) => `Unexpected unknown unit "${unit}"`,
 })
 
 export default function (actual, options) {

--- a/src/rules/unit-whitelist/index.js
+++ b/src/rules/unit-whitelist/index.js
@@ -11,7 +11,7 @@ import {
 export const ruleName = "unit-whitelist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (u) => `Unexpected unit "${u}"`,
+  rejected: (unit) => `Unexpected unit "${unit}"`,
 })
 
 export default function (whitelistInput) {

--- a/src/rules/value-no-vendor-prefix/index.js
+++ b/src/rules/value-no-vendor-prefix/index.js
@@ -9,7 +9,7 @@ import {
 export const ruleName = "value-no-vendor-prefix"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: p => `Unexpected vendor-prefixed value "${p}"`,
+  rejected: property => `Unexpected vendor-prefixed value "${property}"`,
 })
 
 const valuePrefixes = [ "-webkit-", "-moz-", "-ms-", "-o-" ]


### PR DESCRIPTION
I noticed in a couple of the new rules the parameters in the rule messages weren’t very clear, mainly `u` being used when the thing being passed in was a value or a selector.

I’ve quickly gone through the rules and replace the use of single letter parameters where appropriate.