### PR TITLE
Ignore color hex in `unit-no-unknown`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: `unit-no-unknown` now ignores hex colors.
+
 # 6.4.0
 
 - Added: `keyframe-declaration-no-important` rule.

--- a/src/rules/unit-no-unknown/__tests__/index.js
+++ b/src/rules/unit-no-unknown/__tests__/index.js
@@ -121,6 +121,9 @@ testRule(rule, {
   }, {
     code: "a::before10pix { margin: 10px; }",
     description: "ignore pseudo-class include wrong unit",
+  }, {
+    code: "a { color: #1f1f1f; }",
+    description: "ignore color hex",
   } ],
 
   reject: [ {

--- a/src/utils/__tests__/getUnitFromValueNode-test.js
+++ b/src/utils/__tests__/getUnitFromValueNode-test.js
@@ -10,6 +10,8 @@ test("getUnitFromValueNode", t => {
   t.equal(getUnitFromValueNode(valueParser("1PX").nodes[0]), "PX")
   t.equal(getUnitFromValueNode(valueParser("100%").nodes[0]), "%")
   t.equal(getUnitFromValueNode(valueParser("100").nodes[0]), "")
+  t.equal(getUnitFromValueNode(valueParser("#fff").nodes[0]), null)
+  t.equal(getUnitFromValueNode(valueParser("#000").nodes[0]), null)
   t.equal(getUnitFromValueNode(valueParser("\"100\"").nodes[0]), null)
   t.equal(getUnitFromValueNode(valueParser(" ").nodes[0]), null)
   t.equal(getUnitFromValueNode(valueParser("/").nodes[0]), null)

--- a/src/utils/getUnitFromValueNode.js
+++ b/src/utils/getUnitFromValueNode.js
@@ -19,6 +19,7 @@ export default function (node) {
   if (node.type !== "word"
     || !isStandardValue(value)
     || !isFinite(parseInt(value))
+    || node.value[0] === "#"
   ) { return null }
 
   const parsedUnit = valueParser.unit(value)


### PR DESCRIPTION
New version have two bugs with `unit-no-unknown` and `shorthand-property-no-redundant-values`. Now i work on PR on two.
/cc @davidtheclark 