### PR TITLE
Rule `shorthand-property-no-redundant-values` ignore some properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 - Fixed: `unit-no-unknown` now ignores hex colors.
+- Fixed: `shorthand-property-no-redundant-values` now ignores `background`, `font`, `border`, `border-top`, `border-bottom`, `border-left`, `border-right`, `list-style`, `transition` properties.
 
 # 6.4.0
 

--- a/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -61,6 +61,21 @@ testRule(rule, {
   }, {
     code: "a { border-color: #FFFFFF transparent transparent }",
     description: "ignore upper case value",
+  }, {
+    code: "a { background: url(img.gif), url(img.gif); }",
+    description: "ignore background property",
+  }, {
+    code: "a { font: 12pt/10pt 'Font', 'Font', 'Font'; }",
+    description: "ignore font property",
+  }, {
+    code: "a { border: 5px solid red; }",
+    description: "ignore border property",
+  }, {
+    code: "a { list-style: square outside; }",
+    description: "ignore list-style property",
+  }, {
+    code: "a { transition: opacity 0.35s, transform 0.35s; }",
+    description: "ignore transition property",
   } ],
 
   reject: [ {

--- a/src/rules/shorthand-property-no-redundant-values/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/index.js
@@ -20,6 +20,18 @@ const ignoredCharacters = [
   "$", "@", "--", "var(",
 ]
 
+const ignoredShorthandProperties = new Set([
+  "background",
+  "font",
+  "border",
+  "border-top",
+  "border-bottom",
+  "border-left",
+  "border-right",
+  "list-style",
+  "transition",
+])
+
 function isIgnoredCharacters(value) {
   return ignoredCharacters.some(char => value.indexOf(char) !== -1)
 }
@@ -63,11 +75,13 @@ export default function (actual) {
     root.walkDecls(decl => {
 
       const { prop, value } = decl
+      const normalizedProp = vendor.unprefixed(prop.toLowerCase())
 
-      // ignore not shorthandable properties, and math operations
+      // Ignore not shorthandable properties, and math operations
       if (
-        isIgnoredCharacters(value) ||
-        !shorthandableProperties.has(vendor.unprefixed(prop.toLowerCase()))
+        isIgnoredCharacters(value)
+        || !shorthandableProperties.has(normalizedProp)
+        || ignoredShorthandProperties.has(normalizedProp)
       ) { return }
 
       const valuesToShorthand = []


### PR DESCRIPTION
/cc @davidtheclark @jeddy3 