### PR TITLE
Docs: media-query-list-comma-newline-before typo

### DIFF
--- a/src/rules/media-query-list-comma-newline-before/README.md
+++ b/src/rules/media-query-list-comma-newline-before/README.md
@@ -71,7 +71,7 @@ projection and (color) {}
 
 ### `"never-multi-line"`
 
-There *must never* be a white before the commas in multi-line media query lists.
+There *must never* be whitespace before the commas in multi-line media query lists.
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
In `media-query-list-comma-newline-before`:

"There *must never* be a __white__ before the commas in multi-line media query lists."

I think this should probably be:

"There *must never* be a __newline__ before the commas in multi-line media query lists."