### PR TITLE
Ignore nesting selectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: `selector-type-no-unknown` now ignores nested selectors.
+
 # 6.4.1
 
 - Fixed: `shorthand-property-no-redundant-values` now ignores `background`, `font`, `border`, `border-top`, `border-bottom`, `border-left`, `border-right`, `list-style`, `transition` properties.

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -7,6 +7,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
   config: [true],
+  skipBasicChecks: true,
 
   accept: [ {
     code: "a {}",
@@ -67,10 +68,28 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
+    code: "unknown:nth-child(even) {}",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 1,
+  }, {
     code: "@media only screen and (min-width: 35em) { unknown {} }",
     message: messages.rejected("unknown"),
     line: 1,
     column: 44,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [ {
+    code: ".foo { &-bar {} }",
+  }, {
+    code: "#{$variable} {}",
   } ],
 })
 

--- a/src/rules/selector-type-no-unknown/index.js
+++ b/src/rules/selector-type-no-unknown/index.js
@@ -2,6 +2,10 @@ import { isString } from "lodash"
 import htmlTags from "html-tags"
 import svgTags from "svg-tags"
 import {
+  isStandardRule,
+  isKeyframeRule,
+  isStandardSelector,
+  isStandardTypeSelector,
   parseSelector,
   report,
   ruleMessages,
@@ -26,10 +30,15 @@ export default function (actual, options) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
-      const selector = rule.selector
+      if (!isStandardRule(rule)) { return }
+      if (isKeyframeRule(rule)) { return }
+      const { selector } = rule
+      if (!isStandardSelector(selector)) { return }
 
       parseSelector(selector, result, rule, selectorTree => {
         selectorTree.walkTags(tagNode => {
+          if (!isStandardTypeSelector(tagNode)) { return }
+
           const tagName = tagNode.value
           const tagNameLowerCase = tagName.toLowerCase()
 


### PR DESCRIPTION
Why we use `if (isKeyframeRule(rule)) { return }` in selectors rule?
/cc @davidtheclark @jeddy3 