### PR TITLE
Add standard checks for property rules.

### DIFF
--- a/src/rules/property-unit-blacklist/index.js
+++ b/src/rules/property-unit-blacklist/index.js
@@ -1,7 +1,6 @@
 import { vendor } from "postcss"
 import { isObject, find } from "lodash"
 import valueParser from "postcss-value-parser"
-
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -35,6 +34,8 @@ export default function (blacklist) {
       if (!propBlacklist) { return }
 
       valueParser(value).walk(function (node) {
+        // Ignore wrong units within `url` function
+        if (node.type === "function" && node.value.toLowerCase() === "url") { return false }
         if (node.type === "string") { return }
 
         const unit = getUnitFromValueNode(node)

--- a/src/rules/property-unit-whitelist/index.js
+++ b/src/rules/property-unit-whitelist/index.js
@@ -1,7 +1,6 @@
 import { vendor } from "postcss"
 import { isObject, find } from "lodash"
 import valueParser from "postcss-value-parser"
-
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -35,6 +34,8 @@ export default function (whitelist) {
       if (!propWhitelist) { return }
 
       valueParser(value).walk(function (node) {
+        // Ignore wrong units within `url` function
+        if (node.type === "function" && node.value.toLowerCase() === "url") { return false }
         if (node.type === "string") { return }
 
         const unit = getUnitFromValueNode(node)


### PR DESCRIPTION
I can write tests for it, but I think it's a bit unnecessary as all the rules of the properties should not ignore the non standard syntax and it will clog the tests we have, where you can do it once in https://github.com/stylelint/stylelint/issues/1313  for all property rules.
/cc @davidtheclark @jeddy3 