### PR TITLE
Ignore placeholder selectors; don't identify them as standard type selectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 6.4.2
 
 - Fixed: `selector-pseudo-class-case`, `selector-pseudo-class-no-unknown`, `selector-pseudo-element-case`, `selector-pseudo-element-no-unknown` rules now ignore SCSS variable interpolation.
-- Fixed: `selector-type-no-unknown` now ignores nested selectors and keyframe selectors.
+- Fixed: `selector-type-no-unknown` now ignores nested selectors, keyframe selectors, and placeholder selectors.
+- Fixed: `selector-type-case` now ignores placeholder selectors.
 
 # 6.4.1
 

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -40,6 +40,9 @@ testRule(rule, {
   }, {
     code: "circle {}",
     description: "svg tags",
+  }, {
+    code: "%foo",
+    description: "ignore placeholder selector",
   } ],
 
   reject: [ {
@@ -113,4 +116,3 @@ testRule(rule, {
     column: 1,
   }],
 })
-

--- a/src/utils/isStandardSelector.js
+++ b/src/utils/isStandardSelector.js
@@ -9,5 +9,8 @@ export default function (selector) {
   // SCSS or Less interpolation
   if (/#{.+?}|@{.+?}|\$\(.+?\)/.test(selector)) { return false }
 
+  // SCSS placeholder selectors
+  if (selector.indexOf("%") === 0) { return false }
+
   return true
 }

--- a/src/utils/isStandardTypeSelector.js
+++ b/src/utils/isStandardTypeSelector.js
@@ -20,5 +20,8 @@ export default function (node) {
   // &-bar is a nesting selector combined with a suffix
   if (node.prev() && node.prev().type === "nesting") { return false }
 
+  // %bar is a placeholder selector (from SCSS)
+  if (node.value.indexOf("%") === 0) { return false }
+
   return true
 }

--- a/src/utils/isStandardTypeSelector.js
+++ b/src/utils/isStandardTypeSelector.js
@@ -20,8 +20,5 @@ export default function (node) {
   // &-bar is a nesting selector combined with a suffix
   if (node.prev() && node.prev().type === "nesting") { return false }
 
-  // %bar is a placeholder selector (from SCSS)
-  if (node.value.indexOf("%") === 0) { return false }
-
   return true
 }


### PR DESCRIPTION
Fixes #1334 