### PR TITLE
Remove babel-polyfill and spread usage; fixes #1316

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: `babel-polyfill` removed so it doesn't clash with other processes using `babel-polyfill`.
+
 # 6.4.2
 
 - Fixed: `selector-pseudo-class-case`, `selector-pseudo-class-no-unknown`, `selector-pseudo-element-case`, `selector-pseudo-element-no-unknown` rules now ignore SCSS variable interpolation.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   ],
   "dependencies": {
     "autoprefixer": "^6.0.0",
-    "babel-polyfill": "^6.8.0",
     "balanced-match": "^0.4.0",
     "chalk": "^1.1.1",
     "colorguard": "^1.2.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-// Polyfill is required as long as we support Node 0.12, because
-// use of the spread operator Babel plugin requires `Array.from()`
-import "babel-polyfill"
 import meow from "meow"
 import path from "path"
 import { assign, includes } from "lodash"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-// Polyfill is required as long as we support Node 0.12, because
-// use of the spread operator Babel plugin requires `Array.from()`
-import "babel-polyfill"
 import postcssPlugin from "./postcssPlugin"
 import standalone from "./standalone"
 import createPlugin from "./createPlugin"

--- a/src/reference/keywordSets.js
+++ b/src/reference/keywordSets.js
@@ -1,3 +1,5 @@
+import _ from "lodash"
+
 export const nonLengthUnits = new Set([
   // Relative length units
   "%",
@@ -40,10 +42,10 @@ export const lengthUnits = new Set([
   "q",
 ])
 
-export const units = new Set([
-  ...nonLengthUnits,
-  ...lengthUnits,
-])
+export const units = uniteSets(
+  nonLengthUnits,
+  lengthUnits
+)
 
 export const colorFunctionNames = new Set([
   "rgb",
@@ -73,10 +75,10 @@ export const fontWeightAbsoluteKeywords = new Set([
   "bold",
 ])
 
-export const fontWeightKeywords = new Set([
-  ...fontWeightRelativeKeywords,
-  ...fontWeightAbsoluteKeywords,
-])
+export const fontWeightKeywords = uniteSets(
+  fontWeightRelativeKeywords,
+  fontWeightAbsoluteKeywords
+)
 
 export const camelCaseFunctionNames = new Set([
   "translateX",
@@ -148,10 +150,10 @@ export const levelThreePseudoElements = new Set([
   "content",
 ])
 
-export const pseudoElements = new Set([
-  ...levelOneAndTwoPseudoElements,
-  ...levelThreePseudoElements,
-])
+export const pseudoElements = uniteSets(
+  levelOneAndTwoPseudoElements,
+  levelThreePseudoElements
+)
 
 export const pseudoClasses = new Set([
   "active",
@@ -220,10 +222,10 @@ export const longhandTimeProperties = new Set([
   "animation-delay",
 ])
 
-export const timeProperties = new Set([
-  ...shorthandTimeProperties,
-  ...longhandTimeProperties,
-])
+export const timeProperties = uniteSets(
+  shorthandTimeProperties,
+  longhandTimeProperties
+)
 
 export const camelCaseKeywords = new Set([
   "optimizeSpeed",
@@ -327,3 +329,9 @@ export const listStyleTypeKeywords = new Set([
   "hangul-consonant",
   "urdu",
 ])
+
+function uniteSets(...sets) {
+  return new Set(sets.reduce((result, set) => {
+    return result.concat(_.toArray(set))
+  }, []))
+}


### PR DESCRIPTION
I removed `babel-polyfill` and replaced the spread operator usage with a simple function.

Tested to ensure I didn't repeat bug #1243, and I do think it's not coming back. We just have to not use spread operators.