### PR TITLE
Docs: fix "empty before"

### DIFF
--- a/src/rules/at-rule-empty-line-before/README.md
+++ b/src/rules/at-rule-empty-line-before/README.md
@@ -41,7 +41,7 @@ a {}
 
 ### `"never"`
 
-There *must never* be an empty before at-rules.
+There *must never* be an empty line before at-rules.
 
 The following patterns are considered warnings:
 

--- a/src/rules/comment-empty-line-before/README.md
+++ b/src/rules/comment-empty-line-before/README.md
@@ -43,7 +43,7 @@ a {} /* comment */
 
 ### `"never"`
 
-There *must never* be an empty before comments.
+There *must never* be an empty line before comments.
 
 The following patterns are considered warnings:
 

--- a/src/rules/rule-nested-empty-line-before/README.md
+++ b/src/rules/rule-nested-empty-line-before/README.md
@@ -42,7 +42,7 @@ The following patterns are *not* considered warnings:
 
 ### `"never"`
 
-There *must never* be an empty before rules.
+There *must never* be an empty line before rules.
 
 The following patterns are considered warnings:
 

--- a/src/rules/rule-non-nested-empty-line-before/README.md
+++ b/src/rules/rule-non-nested-empty-line-before/README.md
@@ -41,7 +41,7 @@ b {}
 
 ### `"never"`
 
-There *must never* be an empty before rules.
+There *must never* be an empty line before rules.
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
A few rule docs have the text "There must never be an _empty before_ rules"

Presume these should all be "There must never be an _empty **line** before_ rules"?
