### PR TITLE
Util `isStandardRule` now ignore Less mixins and extends.

### DIFF
--- a/src/rules/selector-no-combinator/__tests__/index.js
+++ b/src/rules/selector-no-combinator/__tests__/index.js
@@ -60,3 +60,56 @@ testRule(rule, {
     column: 7,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [undefined],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [ {
+    code: "@keyframes spin { #{50% - $n} {} }",
+  }, {
+    code: "@for $n from 1 through 10 { .n-#{$n} { content: \"n: #{1 + 1}\"; } }",
+    description: "ignore sass interpolation inside @for",
+  }, {
+    code: "@for $n from 1 through 10 { .n#{$n}-#{$n} { content: \"n: #{1 + 1}\"; } }",
+    description: "ignore multiple sass interpolations in a selector inside @for",
+  }, {
+    code: "@for $n from 1 through 10 { .n#{$n}n#{$n} { content: \"n: #{1 + 1}\"; } }",
+    description: "ignore multiple sass interpolations in a selector inside @for",
+  }, {
+    code: "@each $n in $vals { .n-#{$n} { content: \"n: #{1 + 1}\"; } }",
+    description: "ignore sass interpolation inside @each",
+  }, {
+    code: "@while $n < 10 { .n-#{$n} { content: \"n: #{1 + 1}\"; } }",
+    description: "ignore sass interpolation inside @while",
+  }, {
+    code: "div:nth-child(#{map-get($foo, bar)}) {}",
+    description: "ignore sass map-get interpolation",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [undefined],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [ {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n} { content: %(\"n: %d\", 1 + 1); } .for(@n + 1); }",
+    description: "ignore Less interpolation inside .for",
+  }, {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n}-@{n} { content: %(\"n: %d\", 1 + 1); } .for(@n + 1); }",
+    description: "ignore multiple Less interpolations in a selector inside .for",
+  }, {
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n}n@{n} { content: %(\"n: %d\", 1 + 1); } .for(@n + 1); }",
+    description: "ignore multiple Less interpolations in a selector inside .for",
+  }, {
+    code: ".each(@vals, @n: 1) when (@n <= length(@vals)) { @val: extract(@vals, @n); .n-@{val} { content: %(\"n: %d\", 1 + 1); } .each(@vals, @n + 1); }",
+    description: "ignore Less interpolation inside .each",
+  }, {
+    code: ".while(@n: 0) when (@n < 10) { .n-@{n} { content: %(\"n: %d\", 1 + 1); } .while(@n + 1) }",
+    description: "ignore Less interpolation inside .while",
+  } ],
+})

--- a/src/utils/__tests__/isStandardRule-test.js
+++ b/src/utils/__tests__/isStandardRule-test.js
@@ -4,7 +4,7 @@ import postcss from "postcss"
 import test from "tape"
 
 test("isStandardRule", t => {
-  t.plan(17)
+  t.plan(19)
 
   rules("a {}", rule => {
     t.ok(isStandardRule(rule), "type")
@@ -58,6 +58,12 @@ test("isStandardRule", t => {
   })
   lessRules("#namespace.mixin-name;", rule => {
     t.notOk(isStandardRule(rule), "called namespaced Less mixin (compound)")
+  })
+  lessRules(".box-shadow(@style, @c) when (iscolor(@c)) {}", rule => {
+    t.notOk(isStandardRule(rule), "less mixin")
+  })
+  lessRules("&:extend(.inline);", rule => {
+    t.notOk(isStandardRule(rule), "less extend")
   })
 })
 

--- a/src/utils/isStandardRule.js
+++ b/src/utils/isStandardRule.js
@@ -17,6 +17,10 @@ export default function (rule) {
   // Called Less mixin (e.g. a { .mixin() })
   if (rule.ruleWithoutBody) { return false }
 
+  // Ignore mixin or &:extend rule
+  // https://github.com/webschik/postcss-less/blob/master/lib/less-parser.js#L52
+  if (rule.params && rule.params[0]) { return false }
+
   // Non-outputting Less mixin definition (e.g. .mixin() {})
   if (_.endsWith(selector, ")") && !_.includes(selector, ":")) { return false }
 


### PR DESCRIPTION
https://github.com/stylelint/stylelint/issues/1342
Now a lot of rules(especially `selector-*` rules) not correctly.
/cc @davidtheclark @jeddy3 