### PR TITLE
Ignore less mixins within selector-max-compound-selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: `selector-max-compound-selectors` no longer errors on Less mixins.
+
 # 6.5.0
 
 - Added: `selector-max-compound-selectors` rule.

--- a/src/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/src/rules/selector-max-compound-selectors/__tests__/index.js
@@ -176,8 +176,14 @@ testRule(rule, {
   config: [1],
   syntax: "less",
 
-  accept: [{
+  accept: [ {
     code: "#hello @{test} {}",
     description: "ignore rules with variable interpolation",
-  }],
+  }, {
+    code: ".setFont(@size) { font-size: @size; }",
+    description: "ignore mixins",
+  }, {
+    code: ".test { .setFont(12px) }",
+    description: "ignore called mixins",
+  } ],
 })

--- a/src/rules/selector-max-compound-selectors/index.js
+++ b/src/rules/selector-max-compound-selectors/index.js
@@ -51,13 +51,12 @@ export default function (max) {
     }
 
     root.walkRules(rule => {
+      if (!isStandardRule(rule)) { return }
+      if (!isStandardSelector(rule.selector)) { return }
+
       // Nested selectors are processed in steps, as nesting levels are resolved.
       // Here we skip processing the intermediate parts of selectors (to process only fully resolved selectors)
       if (rule.nodes.some(node => node.type === "rule" || node.type === "atrule")) { return }
-      // Skip custom rules, Less selectors, etc.
-      if (!isStandardRule(rule)) { return }
-      // Skip selectors with interpolation
-      if (!isStandardSelector(rule.selector)) { return }
 
       // Using `rule.selectors` gets us each selector if there is a comma separated set
       rule.selectors.forEach((selector) => {


### PR DESCRIPTION
Closes #1348

We were checking properties of the node *before* checking that it was a standard rule.