### PR TITLE
Change function-url-quote options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Head
 
-- Deprecated: `"emptyLineBefore"` option for `declaration-block-properties-order`.
-- Deprecated: `"hierarchicalSelectors"` option for `indentation`.
+- Deprecated: `"single"`, `"double"` and `"none"` options for `function-url-quotes`. Instead, use the `"always"` or `"never"` options together with the `string-quotes` rule.
+- Deprecated: `"emptyLineBefore"` option for `declaration-block-properties-order`. If you use this option, please consider creating a plugin for the community.
+- Deprecated: `"hierarchicalSelectors"` option for `indentation`.  If you use this option, please consider creating a plugin for the community.
 - Fixed: `selector-max-compound-selectors` no longer errors on Less mixins.
 
 # 6.5.0

--- a/src/rules/function-url-quotes/README.md
+++ b/src/rules/function-url-quotes/README.md
@@ -1,6 +1,6 @@
 # function-url-quotes
 
-Specify single, double or no quotes for urls.
+Require or disallow quotes for urls.
 
 ```css
 a { background: url("x.jpg") }
@@ -10,70 +10,30 @@ a { background: url("x.jpg") }
 
 ## Options
 
-`string`: `"single"|"double"|"none"`
+`string`: `"always"|"never"`
 
-### `"single"`
+### `"always"`
 
-Url quotes *must always* be single.
+Urls *must always* be quoted.
 
 The following patterns are considered warnings:
-
-```css
-a { background: url("x.jpg"); }
-```
 
 ```css
 @import url(foo.css);
 ```
 
 ```css
-@document domain("http://www.w3.org/");
+@document domain(http://www.w3.org/);
 ```
 
 ```css
-@font-face { font-family: 'foo'; src: url("foo.ttf"); }
+@font-face { font-family: 'foo'; src: url(foo.ttf); }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
 a { background: url('x.jpg'); }
-```
-
-```css
-@import url('foo.css');
-```
-
-```css
-@document domain('http://www.w3.org/');
-```
-
-```css
-@font-face { font-family: "foo"; src: url('foo.ttf'); }
-```
-
-### `"double"`
-
-Url quotes *must always* be double.
-
-The following patterns are considered warnings:
-
-```css
-a { background: url('x.jpg'); }
-```
-
-```css
-@import url(foo.css);
-```
-
-```css
-@font-face { font-family: "foo"; src: url('foo.ttf'); }
-```
-
-The following patterns are *not* considered warnings:
-
-```css
-a { background: url("x.jpg"); }
 ```
 
 ```css
@@ -81,12 +41,16 @@ a { background: url("x.jpg"); }
 ```
 
 ```css
-@font-face { font-family: 'foo'; src: url("foo.ttf"); }
+@document domain('http://www.w3.org/');
 ```
 
-### `"none"`
+```css
+@font-face { font-family: "foo"; src: url("foo.ttf"); }
+```
 
-Urls *must not* be quoted.
+### `"never"`
+
+Urls *must never* be quoted.
 
 The following patterns are considered warnings:
 

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -2,17 +2,21 @@ import { testRule } from "../../../testUtils"
 import rules from "../../../rules"
 import { ruleName, messages } from ".."
 
+import postcss from "postcss"
+import test from "tape"
+import stylelint from "../../.."
+
 const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: ["double"],
+  config: ["always"],
 
   accept: [ {
     code: "@import url(\"foo.css\");",
 
     description: {
-      message: messages.expected("double quotes"),
+      message: messages.expected("quotes"),
       line: 1,
       column: 14,
     },
@@ -20,7 +24,7 @@ testRule(rule, {
     code: "@import uRl(\"foo.css\");",
 
     description: {
-      message: messages.expected("double quotes"),
+      message: messages.expected("quotes"),
       line: 1,
       column: 14,
     },
@@ -28,7 +32,7 @@ testRule(rule, {
     code: "@import URL(\"foo.css\");",
 
     description: {
-      message: messages.expected("double quotes"),
+      message: messages.expected("quotes"),
       line: 1,
       column: 14,
     },
@@ -36,7 +40,7 @@ testRule(rule, {
     code: "@import url( \"foo.css\" );",
 
     description: {
-      message: messages.expected("double quotes"),
+      message: messages.expected("quotes"),
       line: 1,
       column: 15,
     },
@@ -72,146 +76,7 @@ testRule(rule, {
     code: "a { background-image: url(\"foo.css\"), url(\"bar.css\"), url(\"baz.css\"); }",
   }, {
     code: "a { background-image: url( \"foo.css\" ), url( \"bar.css\" ), url( \"baz.css\" ); }",
-  } ],
-
-  reject: [ {
-    code: "@import url('foo.css');",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 13,
   }, {
-    code: "@import uRl('foo.css');",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 13,
-  }, {
-    code: "@import uRl('foo.css');",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 13,
-  }, {
-    code: "@import url( 'foo.css' );",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 14,
-  }, {
-    code: "@import url(foo.css);",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 13,
-  }, {
-    code: "@import url( foo.css );",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 14,
-  }, {
-    code: "@document url('http://www.w3.org/');",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 15,
-  }, {
-    code: "@document url( 'http://www.w3.org/' );",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 16,
-  }, {
-    code: "@document url-prefix(http://www.w3.org/Style);",
-    message: messages.expected("double quotes", "url-prefix"),
-    line: 1,
-    column: 22,
-  }, {
-    code: "@document url-prefix( http://www.w3.org/Style );",
-    message: messages.expected("double quotes", "url-prefix"),
-    line: 1,
-    column: 23,
-  }, {
-    code: "@document domain('mozilla.org');",
-    message: messages.expected("double quotes", "domain"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "@document domain( 'mozilla.org' );",
-    message: messages.expected("double quotes", "domain"),
-    line: 1,
-    column: 19,
-  }, {
-    code: "@font-face { font-family: 'foo'; src: url(foo.ttf); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 43,
-  }, {
-    code: "@font-face { font-family: 'foo'; src: url( foo.ttf ); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 44,
-  }, {
-    code: "a { background: url('foo.css'); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 21,
-  }, {
-    code: "a { background: uRl('foo.css'); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 21,
-  }, {
-    code: "a { background: URL('foo.css'); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 21,
-  }, {
-    code: "a { background: url( 'foo.css' ); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 22,
-  }, {
-    code: "a { background: url(  'foo.css'  ); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 23,
-  }, {
-    code: "a { cursor: url(foo.png); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 17,
-  }, {
-    code: "a { background-image: url(foo.css), url(\"bar.css\"), url(\"baz.css\"); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 27,
-  }, {
-    code: "a { background-image: url( foo.css ), url(\"bar.css\"), url(\"baz.css\"); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 28,
-  }, {
-    code: "a { background-image: url(\"foo.css\"), url(bar.css), url(\"baz.css\"); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 43,
-  }, {
-    code: "a { background-image: url(\"foo.css\"), url( bar.css ), url(\"baz.css\"); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 44,
-  }, {
-    code: "a { background-image: url(\"foo.css\"), url(\"bar.css\"), url(baz.css); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 59,
-  }, {
-    code: "a { background-image: url(\"foo.css\"), url(\"bar.css\"), url( baz.css ); }",
-    message: messages.expected("double quotes"),
-    line: 1,
-    column: 60,
-  } ],
-})
-
-testRule(rule, {
-  ruleName,
-  config: ["single"],
-
-  accept: [ {
     code: "@import url('foo.css');",
   }, {
     code: "@import uRl('foo.css');",
@@ -254,133 +119,68 @@ testRule(rule, {
   } ],
 
   reject: [ {
-    code: "@import url(\"foo.css\");",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 13,
-  },  {
-    code: "@import uRl(\"foo.css\");",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 13,
-  }, {
-    code: "@import URL(\"foo.css\");",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 13,
-  }, {
-    code: "@import url( \"foo.css\" );",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 14,
-  }, {
     code: "@import url(foo.css);",
-    message: messages.expected("single quotes"),
+    message: messages.expected("quotes"),
     line: 1,
     column: 13,
   }, {
     code: "@import url( foo.css );",
-    message: messages.expected("single quotes"),
+    message: messages.expected("quotes"),
     line: 1,
     column: 14,
   }, {
-    code: "@document url(\"http://www.w3.org/\");",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 15,
-  }, {
-    code: "@document url( \"http://www.w3.org/\" );",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 16,
-  }, {
     code: "@document url-prefix(http://www.w3.org/Style);",
-    message: messages.expected("single quotes", "url-prefix"),
+    message: messages.expected("quotes", "url-prefix"),
     line: 1,
     column: 22,
   }, {
     code: "@document url-prefix( http://www.w3.org/Style );",
-    message: messages.expected("single quotes", "url-prefix"),
+    message: messages.expected("quotes", "url-prefix"),
     line: 1,
     column: 23,
   }, {
-    code: "@document domain(\"mozilla.org\");",
-    message: messages.expected("single quotes", "domain"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "@document domain( \"mozilla.org\" );",
-    message: messages.expected("single quotes", "domain"),
-    line: 1,
-    column: 19,
-  }, {
     code: "@font-face { font-family: 'foo'; src: url(foo.ttf); }",
-    message: messages.expected("single quotes"),
+    message: messages.expected("quotes"),
     line: 1,
     column: 43,
   }, {
     code: "@font-face { font-family: 'foo'; src: url( foo.ttf ); }",
-    message: messages.expected("single quotes"),
+    message: messages.expected("quotes"),
     line: 1,
     column: 44,
   }, {
-    code: "a { background: url(\"foo.css\"); }",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 21,
-  }, {
-    code: "a { background: uRl(\"foo.css\"); }",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 21,
-  }, {
-    code: "a { background: URL(\"foo.css\"); }",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 21,
-  }, {
-    code: "a { background: url( \"foo.css\" ); }",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 22,
-  }, {
-    code: "a { background: url(  \"foo.css\"  ); }",
-    message: messages.expected("single quotes"),
-    line: 1,
-    column: 23,
-  }, {
     code: "a { cursor: url(foo.png); }",
-    message: messages.expected("single quotes"),
+    message: messages.expected("quotes"),
     line: 1,
     column: 17,
   }, {
-    code: "a { background-image: url(foo.css), url('bar.css'), url('baz.css'); }",
-    message: messages.expected("single quotes"),
+    code: "a { background-image: url(foo.css), url(\"bar.css\"), url(\"baz.css\"); }",
+    message: messages.expected("quotes"),
     line: 1,
     column: 27,
   }, {
-    code: "a { background-image: url( foo.css ), url('bar.css'), url('baz.css'); }",
-    message: messages.expected("single quotes"),
+    code: "a { background-image: url( foo.css ), url(\"bar.css\"), url(\"baz.css\"); }",
+    message: messages.expected("quotes"),
     line: 1,
     column: 28,
   }, {
-    code: "a { background-image: url('foo.css'), url(bar.css), url('baz.css'); }",
-    message: messages.expected("single quotes"),
+    code: "a { background-image: url(\"foo.css\"), url(bar.css), url(\"baz.css\"); }",
+    message: messages.expected("quotes"),
     line: 1,
     column: 43,
   }, {
-    code: "a { background-image: url('foo.css'), url( bar.css ), url('baz.css'); }",
-    message: messages.expected("single quotes"),
+    code: "a { background-image: url(\"foo.css\"), url( bar.css ), url(\"baz.css\"); }",
+    message: messages.expected("quotes"),
     line: 1,
     column: 44,
   }, {
-    code: "a { background-image: url('foo.css'), url('bar.css'), url(baz.css); }",
-    message: messages.expected("single quotes"),
+    code: "a { background-image: url(\"foo.css\"), url(\"bar.css\"), url(baz.css); }",
+    message: messages.expected("quotes"),
     line: 1,
     column: 59,
   }, {
-    code: "a { background-image: url('foo.css'), url('bar.css'), url( baz.css ); }",
-    message: messages.expected("single quotes"),
+    code: "a { background-image: url(\"foo.css\"), url(\"bar.css\"), url( baz.css ); }",
+    message: messages.expected("quotes"),
     line: 1,
     column: 60,
   } ],
@@ -388,7 +188,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: ["none"],
+  config: ["never"],
 
   accept: [ {
     code: "@import url(foo.css);",
@@ -564,3 +364,64 @@ testRule(rule, {
     column: 56,
   } ],
 })
+
+test("deprecation warning for single", t => {
+  const config = {
+    rules: {
+      "function-url-quotes": "single",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("@import url(\"foo.css\");").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'single' option for 'function-url-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always' or 'never' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected single quotes around url argument (function-url-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+test("deprecation warning for double", t => {
+  const config = {
+    rules: {
+      "function-url-quotes": "double",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("@import url('foo.css');").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'double' option for 'function-url-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always' or 'never' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected double quotes around url argument (function-url-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+test("deprecation warning for none", t => {
+  const config = {
+    rules: {
+      "function-url-quotes": "none",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("@import url(\"foo.css\");").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'none' option for 'function-url-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always' or 'never' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected no quotes around url argument (function-url-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+function logError(err) {
+  console.log(err.stack) // eslint-disable-line no-console
+}

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -22,6 +22,11 @@ export default function (expectation) {
         return "double quotes"
       case "none":
         return "no quotes"
+
+      case "always":
+        return "quotes"
+      case "never":
+        return "no quotes"
     }
   }())
 
@@ -33,6 +38,11 @@ export default function (expectation) {
         return c => c !== "\""
       case "none":
         return c => c === "'" || c === "\""
+
+      case "never":
+        return c => c === "'" || c === "\""
+      case "always":
+        return c => c !== "'" && c !== "\""
     }
   }())
 
@@ -47,9 +57,26 @@ export default function (expectation) {
         "single",
         "double",
         "none",
+
+        "always",
+        "never",
       ],
     })
     if (!validOptions) { return }
+
+    if (
+      expectation === "single"
+      || expectation === "double"
+      || expectation === "none"
+    ) {
+      result.warn((
+        "The '" + expectation + "' option for 'function-url-quotes' has been deprecated, "
+          + "and will be removed in '7.0'. Instead, use the 'always' or 'never' options together with the 'string-quotes' rule."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/function-url-quotes/",
+      })
+    }
 
     root.walkAtRules(check)
     root.walkRules(check)


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/issues/1331

Whoops… I forgot that changing the behaviour of the contextual quotes rules was in this milestone.

As with `declaration-block-properties-order` I’m testing that the original options still work alongside the deprecation notices.

I smoke tested this one. It’s nice not having duplicated warnings :)