### PR TITLE
Change font-family-name-quotes options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 - Deprecated: `"single"`, `"double"` and `"none"` options for `function-url-quotes`. Instead, use the `"always"` or `"never"` options together with the `string-quotes` rule.
+- Deprecated: `"single-where-required"`, `"single-where-recommended"`, `"single-unless-keyword"`, `"double-where-required"`, `"double-where-recommended"` and `"double-unless-keyword"` options for `font-family-name-quotes`. Instead, use the `"always-unless-keyword"`, `always-where-recommended` and `always-where-required` or `"never"` options together with the `string-quotes` rule.
 - Deprecated: `"emptyLineBefore"` option for `declaration-block-properties-order`. If you use this option, please consider creating a plugin for the community.
 - Deprecated: `"hierarchicalSelectors"` option for `indentation`.  If you use this option, please consider creating a plugin for the community.
 - Fixed: `selector-max-compound-selectors` no longer errors on Less mixins.

--- a/src/rules/font-family-name-quotes/README.md
+++ b/src/rules/font-family-name-quotes/README.md
@@ -1,6 +1,6 @@
 # font-family-name-quotes
 
-Specify whether or not quotation marks should be used around font family names, and whether single or double.
+Specify whether or not quotation marks should be used around font family names.
 
 ```css
 a { font-family: "Times New Roman", 'Ancient Runes', serif; }
@@ -12,7 +12,7 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 ## Options
 
-`string`: `"single-where-required"|"single-where-recommended"|"single-unless-keyword"|"double-where-required"|"double-where-recommended|"double-unless-keyword"`
+`string`: `"always-where-required"|"always-where-recommended"|"always-unless-keyword"`
 
 *Please read the following to understand these options*:
 
@@ -24,11 +24,11 @@ For more on these subtleties, read ["Unquoted font family names in CSS"](https:/
 
 **Caveat:** This rule does not currently understand escape sequences such as those described by Mathias. If you want to use the font family name "Hawaii 5-0" you will need to wrap it in quotes, instead of escaping it as `Hawaii \35 -0` or `Hawaii\ 5-0`.
 
-### `"single-unless-keyword"` and `"double-unless-keyword"`
+### `"always-unless-keyword"`
 
 Expect quotes around every font family name that is not a keyword.
 
-For example, with `"single-unless-keyword"`, the following patterns are considered warnings:
+The following patterns are considered warnings:
 
 ```css
 a { font-family: Arial, sans-serif; }
@@ -45,23 +45,21 @@ a { font-family: 'Arial', sans-serif; }
 ```
 
 ```css
-a { font-family: 'Times New Roman', 'Times', serif; }
+a { font-family: "Times New Roman", "Times", serif; }
 ```
 
-The same examples apply to `"double-unless-keyword"`, but with `"` quotes.
-
-### `"single-where-required"` and `"double-where-required"`
+### `"always-where-required"`
 
 Expect quotes only when quotes are *required* according to the criteria above, and disallow quotes in all other cases.
 
-For example, with `"double-where-required"`, the following patterns are considered warnings:
+The following patterns are considered warnings:
 
 ```css
 a { font-family: "Arial", sans-serif; }
 ```
 
 ```css
-a { font-family: "Times New Roman", Times, serif; }
+a { font-family: 'Times New Roman', Times, serif; }
 ```
 
 And the following patterns are *not* considered warnings:
@@ -78,13 +76,11 @@ a { font-family: Times New Roman, Times, serif; }
 a { font-family: "Hawaii 5-0"; }
 ```
 
-The same examples apply to `"single-where-required"`, but with `'` quotes.
-
-### `"single-where-recommended"` and `"double-where-recommended"`
+### `"always-where-recommended"`
 
 Expect quotes only when quotes are *recommended* according to the criteria above, and disallow quotes in all other cases. (This includes all cases where quotes are *required*, as well.)
 
-For example, with `"single-where-recommended"`, the following patterns are considered warnings:
+The following patterns are considered warnings:
 
 ```css
 a { font-family: Times New Roman, Times, serif; }
@@ -105,11 +101,9 @@ a { font-family: 'Times New Roman', Times, serif; }
 ```
 
 ```css
-a { font-family: 'MyFontVersion6', 'sake_case_font'; }
+a { font-family: "MyFontVersion6", "sake_case_font"; }
 ```
 
 ```css
 a { font-family: Arial, sans-serif; }
 ```
-
-The same examples apply to `"double-where-recommended"`, but with `"` quotes.

--- a/src/rules/font-family-name-quotes/__tests__/index.js
+++ b/src/rules/font-family-name-quotes/__tests__/index.js
@@ -2,479 +2,15 @@ import { testRule } from "../../../testUtils"
 import rules from "../../../rules"
 import { ruleName, messages } from ".."
 
+import postcss from "postcss"
+import test from "tape"
+import stylelint from "../../.."
+
 const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: ["single-where-required"],
-
-  accept: [ {
-    code: "a { font-family: $sassy-font-family; }",
-    description: "ignores sass variables",
-  }, {
-    code: "a { font-family: @less-666; }",
-    description: "ignores less variables",
-  }, {
-    code: "a { font-family: var(--ff1); }",
-    description: "ignores custom properties",
-  }, {
-    code: "$font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$default-font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@default-font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$font-family-variable: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family-variable: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "a { font-family: Lucida Grande, Arial, sans-serif; }",
-  }, {
-    code: "a { fOnT-fAmIlY: Lucida Grande, Arial, sans-serif; }",
-  }, {
-    code: "a { FONT-FAMILY: Lucida Grande, Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: 'Red/Black', Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: Arial, 'Ahem!', sans-serif; }",
-  }, {
-    code: "a { font-family: 'Hawaii 5-0', Arial, sans-serif; }",
-  } ],
-
-  reject: [ {
-    code: "a { font-family: 'Lucida Grande', Arial, sans-serif; }",
-    message: messages.expected("no", "Lucida Grande"),
-    line: 1,
-    column: 19,
-  }, {
-    code: "a { fOnT-fAmIlY: 'Lucida Grande', Arial, sans-serif; }",
-    message: messages.expected("no", "Lucida Grande"),
-    line: 1,
-    column: 19,
-  }, {
-    code: "a { FONT-FAMILY: 'Lucida Grande', Arial, sans-serif; }",
-    message: messages.expected("no", "Lucida Grande"),
-    line: 1,
-    column: 19,
-  }, {
-    code: "a { font-family: Lucida Grande, Arial, 'sans-serif'; }",
-    message: messages.expected("no", "sans-serif"),
-    line: 1,
-    column: 41,
-  }, {
-    code: "a { font-family: Red/Black, Arial, sans-serif; }",
-    message: messages.expected("single", "Red/Black"),
-  }, {
-    code: "a { font-family: \"Red/Black\", Arial, sans-serif; }",
-    message: messages.expected("single", "Red/Black"),
-  }, {
-    code: "a { font-family: Arial, Ahem!, sans-serif; }",
-    message: messages.expected("single", "Ahem!"),
-  }, {
-    code: "a { font-family: Arial, \"Ahem!\", sans-serif; }",
-    message: messages.expected("single", "Ahem!"),
-  }, {
-    code: "a { font-family: Hawaii 5-0, Arial, sans-serif; }",
-    message: messages.expected("single", "Hawaii 5-0"),
-  }, {
-    code: "a { font-family: \"Hawaii 5-0\", Arial, sans-serif; }",
-    message: messages.expected("single", "Hawaii 5-0"),
-  } ],
-})
-
-testRule(rule, {
-  ruleName,
-  config: ["double-where-required"],
-
-  accept: [ {
-    code: "a { font-family: $sassy-font-family; }",
-    description: "ignores sass variables",
-  }, {
-    code: "a { font-family: @less-666; }",
-    description: "ignores less variables",
-  }, {
-    code: "a { font-family: var(--ff1); }",
-    description: "ignores custom properties",
-  }, {
-    code: "$font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$default-font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@default-font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$font-family-variable: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family-variable: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "a { font-family: Lucida Grande, Arial, sans-serif; }",
-  }, {
-    code: "a { fOnT-fAmIlY: Lucida Grande, Arial, sans-serif; }",
-  }, {
-    code: "a { FONT-FAMILY: Lucida Grande, Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: \"Red/Black\", Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: Arial, \"Ahem!\", sans-serif; }",
-  }, {
-    code: "a { font-family: \"Hawaii 5-0\", Arial, sans-serif; }",
-  } ],
-
-  reject: [ {
-    code: "a { font-family: \"Lucida Grande\", Arial, sans-serif; }",
-    message: messages.expected("no", "Lucida Grande"),
-    line: 1,
-    column: 19,
-  }, {
-    code: "a { fOnT-fAmIlY: \"Lucida Grande\", Arial, sans-serif; }",
-    message: messages.expected("no", "Lucida Grande"),
-    line: 1,
-    column: 19,
-  }, {
-    code: "a { FONT-FAMILY: \"Lucida Grande\", Arial, sans-serif; }",
-    message: messages.expected("no", "Lucida Grande"),
-    line: 1,
-    column: 19,
-  }, {
-    code: "a { font-family: Lucida Grande, Arial, \"sans-serif\"; }",
-    message: messages.expected("no", "sans-serif"),
-    line: 1,
-    column: 41,
-  }, {
-    code: "a { font-family: Red/Black, Arial, sans-serif; }",
-    message: messages.expected("double", "Red/Black"),
-  }, {
-    code: "a { font-family: 'Red/Black', Arial, sans-serif; }",
-    message: messages.expected("double", "Red/Black"),
-  }, {
-    code: "a { font-family: Arial, Ahem!, sans-serif; }",
-    message: messages.expected("double", "Ahem!"),
-  }, {
-    code: "a { font-family: Arial, 'Ahem!', sans-serif; }",
-    message: messages.expected("double", "Ahem!"),
-  }, {
-    code: "a { font-family: Hawaii 5-0, Arial, sans-serif; }",
-    message: messages.expected("double", "Hawaii 5-0"),
-  }, {
-    code: "a { font-family: 'Hawaii 5-0', Arial, sans-serif; }",
-    message: messages.expected("double", "Hawaii 5-0"),
-  } ],
-})
-
-testRule(rule, {
-  ruleName,
-  config: ["single-where-recommended"],
-
-  accept: [ {
-    code: "a { font-family: $sassy-font-family; }",
-    description: "ignores sass variables",
-  }, {
-    code: "a { font-family: @less-666; }",
-    description: "ignores less variables",
-  }, {
-    code: "a { font-family: var(--ff1); }",
-    description: "ignores custom properties",
-  }, {
-    code: "$font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$default-font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@default-font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$font-family-variable: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family-variable: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "a { font-family: 'Lucida Grande', Arial, sans-serif; }",
-  }, {
-    code: "a { fOnT-fAmIlY: 'Lucida Grande', Arial, sans-serif; }",
-  }, {
-    code: "a { FONT-FAMILY: 'Lucida Grande', Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: Times, 'Times New Roman', serif; }",
-  }, {
-    code: "a { font-family: 'Something6'; }",
-  }, {
-    code: "a { font-family: 'snake_case'; }",
-  }, {
-    code: "a { font-family: 'Red/Black', Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: Arial, 'Ahem!', sans-serif; }",
-  }, {
-    code: "a { font-family: 'Hawaii 5-0', Arial, sans-serif; }",
-  } ],
-
-  reject: [ {
-    code: "a { font-family: Lucida Grande, Arial, sans-serif; }",
-    message: messages.expected("single", "Lucida Grande"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "a { fOnT-fAmIlY: Lucida Grande, Arial, sans-serif; }",
-    message: messages.expected("single", "Lucida Grande"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "a { FONT-FAMILY: Lucida Grande, Arial, sans-serif; }",
-    message: messages.expected("single", "Lucida Grande"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "a { font-family: 'Lucida Grande', Arial, 'sans-serif'; }",
-    message: messages.expected("no", "sans-serif"),
-    line: 1,
-    column: 43,
-  }, {
-    code: "a { font-family: Red/Black, Arial, sans-serif; }",
-    message: messages.expected("single", "Red/Black"),
-  }, {
-    code: "a { font-family: \"Red/Black\", Arial, sans-serif; }",
-    message: messages.expected("single", "Red/Black"),
-  }, {
-    code: "a { font-family: Arial, Ahem!, sans-serif; }",
-    message: messages.expected("single", "Ahem!"),
-  }, {
-    code: "a { font-family: Arial, \"Ahem!\", sans-serif; }",
-    message: messages.expected("single", "Ahem!"),
-  }, {
-    code: "a { font-family: Hawaii 5-0, Arial, sans-serif; }",
-    message: messages.expected("single", "Hawaii 5-0"),
-  }, {
-    code: "a { font-family: \"Hawaii 5-0\", Arial, sans-serif; }",
-    message: messages.expected("single", "Hawaii 5-0"),
-  }, {
-    code: "a { font-family: Times, Times New Roman, serif; }",
-    message: messages.expected("single", "Times New Roman"),
-  }, {
-    code: "a { font-family: Times, \"Times New Roman\", serif; }",
-    message: messages.expected("single", "Times New Roman"),
-  }, {
-    code: "a { font-family: Something6; }",
-    message: messages.expected("single", "Something6"),
-  }, {
-    code: "a { font-family: \"Something6\"; }",
-    message: messages.expected("single", "Something6"),
-  }, {
-    code: "a { font-family: snake_case; }",
-    message: messages.expected("single", "snake_case"),
-  }, {
-    code: "a { font-family: \"snake_case\"; }",
-    message: messages.expected("single", "snake_case"),
-  }, {
-    code: "a { font-family: 'Arial'; }",
-    message: messages.expected("no", "Arial"),
-  } ],
-})
-
-testRule(rule, {
-  ruleName,
-  config: ["double-where-recommended"],
-
-  accept: [ {
-    code: "a { font-family: $sassy-font-family; }",
-    description: "ignores sass variables",
-  }, {
-    code: "a { font-family: @less-666; }",
-    description: "ignores less variables",
-  }, {
-    code: "a { font-family: var(--ff1); }",
-    description: "ignores custom properties",
-  }, {
-    code: "$font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$default-font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@default-font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$font-family-variable: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family-variable: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "a { font-family: \"Lucida Grande\", Arial, sans-serif; }",
-  }, {
-    code: "a { fOnT-fAmIlY: \"Lucida Grande\", Arial, sans-serif; }",
-  }, {
-    code: "a { FONT-FAMILY: \"Lucida Grande\", Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: Times, \"Times New Roman\", serif; }",
-  }, {
-    code: "a { font-family: \"Something6\"; }",
-  }, {
-    code: "a { font-family: \"snake_case\"; }",
-  }, {
-    code: "a { font-family: \"Red/Black\", Arial, sans-serif; }",
-  }, {
-    code: "a { font-family: Arial, \"Ahem!\", sans-serif; }",
-  }, {
-    code: "a { font-family: \"Hawaii 5-0\", Arial, sans-serif; }",
-  } ],
-
-  reject: [ {
-    code: "a { font-family: Lucida Grande, Arial, sans-serif; }",
-    message: messages.expected("double", "Lucida Grande"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "a { fOnT-fAmIlY: Lucida Grande, Arial, sans-serif; }",
-    message: messages.expected("double", "Lucida Grande"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "a { FONT-FAMILY: Lucida Grande, Arial, sans-serif; }",
-    message: messages.expected("double", "Lucida Grande"),
-    line: 1,
-    column: 18,
-  }, {
-    code: "a { font-family: \"Lucida Grande\", Arial, \"sans-serif\"; }",
-    message: messages.expected("no", "sans-serif"),
-    line: 1,
-    column: 43,
-  }, {
-    code: "a { font-family: Red/Black, Arial, sans-serif; }",
-    message: messages.expected("double", "Red/Black"),
-  }, {
-    code: "a { font-family: 'Red/Black', Arial, sans-serif; }",
-    message: messages.expected("double", "Red/Black"),
-  }, {
-    code: "a { font-family: Arial, Ahem!, sans-serif; }",
-    message: messages.expected("double", "Ahem!"),
-  }, {
-    code: "a { font-family: Arial, 'Ahem!', sans-serif; }",
-    message: messages.expected("double", "Ahem!"),
-  }, {
-    code: "a { font-family: Hawaii 5-0, Arial, sans-serif; }",
-    message: messages.expected("double", "Hawaii 5-0"),
-  }, {
-    code: "a { font-family: 'Hawaii 5-0', Arial, sans-serif; }",
-    message: messages.expected("double", "Hawaii 5-0"),
-  }, {
-    code: "a { font-family: Times, Times New Roman, serif; }",
-    message: messages.expected("double", "Times New Roman"),
-  }, {
-    code: "a { font-family: Times, 'Times New Roman', serif; }",
-    message: messages.expected("double", "Times New Roman"),
-  }, {
-    code: "a { font-family: Something6; }",
-    message: messages.expected("double", "Something6"),
-  }, {
-    code: "a { font-family: 'Something6'; }",
-    message: messages.expected("double", "Something6"),
-  }, {
-    code: "a { font-family: snake_case; }",
-    message: messages.expected("double", "snake_case"),
-  }, {
-    code: "a { font-family: 'snake_case'; }",
-    message: messages.expected("double", "snake_case"),
-  }, {
-    code: "a { font-family: \"Arial\"; }",
-    message: messages.expected("no", "Arial"),
-  } ],
-})
-
-testRule(rule, {
-  ruleName,
-  config: ["single-unless-keyword"],
-
-  accept: [ {
-    code: "a { font-family: $sassy-font-family; }",
-    description: "ignores sass variables",
-  }, {
-    code: "a { font-family: @less-666; }",
-    description: "ignores less variables",
-  }, {
-    code: "a { font-family: var(--ff1); }",
-    description: "ignores custom properties",
-  }, {
-    code: "$font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$default-font-family: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@default-font-family: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "$font-family-variable: map-get($font-stacks, default);",
-    description: "ignores scss variable contain font-family in name",
-  }, {
-    code: "@font-family-variable: map-get($font-stacks, default);",
-    description: "ignores less variable contain font-family in name",
-  }, {
-    code: "a { font-family: 'Lucida Grande', 'Arial', sans-serif; }",
-  }, {
-    code: "a { fOnT-fAmIlY: 'Lucida Grande', 'Arial', sans-serif; }",
-  }, {
-    code: "a { FONT-FAMILY: 'Lucida Grande', 'Arial', sans-serif; }",
-  }, {
-    code: "a { font-family: 'Hawaii 5-0', 'Arial', cursive; }",
-  }, {
-    code: "a { font-family: 'Times', 'Arial', serif; }",
-  }, {
-    code: "a { font-family: 'Times', 'Arial', fantasy; }",
-  }, {
-    code: "a { font-family: 'Times', 'Arial', cursive; }",
-  }, {
-    code: "a { font-family: inherit; }",
-  } ],
-
-  reject: [ {
-    code: "a { font-family: 'Lucida Grande', 'Arial', 'sans-serif'; }",
-    message: messages.expected("no", "sans-serif"),
-  }, {
-    code: "a { fOnT-fAmIlY: 'Lucida Grande', 'Arial', 'sans-serif'; }",
-    message: messages.expected("no", "sans-serif"),
-  }, {
-    code: "a { FONT-FAMILY: 'Lucida Grande', 'Arial', 'sans-serif'; }",
-    message: messages.expected("no", "sans-serif"),
-  }, {
-    code: "a { font-family: 'inherit'; }",
-    message: messages.expected("no", "inherit"),
-  }, {
-    code: "a { font-family: \"Lucida Grande\", 'Arial', sans-serif; }",
-    message: messages.expected("single", "Lucida Grande"),
-  }, {
-    code: "a { font-family: 'Lucida Grande', \"Arial\", sans-serif; }",
-    message: messages.expected("single", "Arial"),
-  } ],
-})
-
-testRule(rule, {
-  ruleName,
-  config: ["double-unless-keyword"],
+  config: ["always-unless-keyword"],
 
   accept: [ {
     code: "a { font-family: $sassy-font-family; }",
@@ -519,6 +55,10 @@ testRule(rule, {
     code: "a { font-family: \"Times\", \"Arial\", cursive; }",
   }, {
     code: "a { font-family: inherit; }",
+  }, {
+    code: "a { font-family: 'Lucida Grande', \"Arial\", sans-serif; }",
+  }, {
+    code: "a { font-family: \"Lucida Grande\", 'Arial', sans-serif; }",
   } ],
 
   reject: [ {
@@ -533,11 +73,313 @@ testRule(rule, {
   }, {
     code: "a { font-family: \"inherit\"; }",
     message: messages.expected("no", "inherit"),
-  }, {
-    code: "a { font-family: 'Lucida Grande', \"Arial\", sans-serif; }",
-    message: messages.expected("double", "Lucida Grande"),
-  }, {
-    code: "a { font-family: \"Lucida Grande\", 'Arial', sans-serif; }",
-    message: messages.expected("double", "Arial"),
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["always-where-recommended"],
+
+  accept: [ {
+    code: "a { font-family: $sassy-font-family; }",
+    description: "ignores sass variables",
+  }, {
+    code: "a { font-family: @less-666; }",
+    description: "ignores less variables",
+  }, {
+    code: "a { font-family: var(--ff1); }",
+    description: "ignores custom properties",
+  }, {
+    code: "$font-family: map-get($font-stacks, default);",
+    description: "ignores scss variable contain font-family in name",
+  }, {
+    code: "@font-family: map-get($font-stacks, default);",
+    description: "ignores less variable contain font-family in name",
+  }, {
+    code: "$default-font-family: map-get($font-stacks, default);",
+    description: "ignores scss variable contain font-family in name",
+  }, {
+    code: "@default-font-family: map-get($font-stacks, default);",
+    description: "ignores less variable contain font-family in name",
+  }, {
+    code: "$font-family-variable: map-get($font-stacks, default);",
+    description: "ignores scss variable contain font-family in name",
+  }, {
+    code: "@font-family-variable: map-get($font-stacks, default);",
+    description: "ignores less variable contain font-family in name",
+  }, {
+    code: "a { font-family: \"Lucida Grande\", Arial, sans-serif; }",
+  }, {
+    code: "a { fOnT-fAmIlY: \"Lucida Grande\", Arial, sans-serif; }",
+  }, {
+    code: "a { FONT-FAMILY: \"Lucida Grande\", Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: Times, \"Times New Roman\", serif; }",
+  }, {
+    code: "a { font-family: \"Something6\"; }",
+  }, {
+    code: "a { font-family: \"snake_case\"; }",
+  }, {
+    code: "a { font-family: \"Red/Black\", Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: Arial, \"Ahem!\", sans-serif; }",
+  }, {
+    code: "a { font-family: \"Hawaii 5-0\", Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: 'Red/Black', Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: Arial, 'Ahem!', sans-serif; }",
+  }, {
+    code: "a { font-family: 'Hawaii 5-0', Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: Times, 'Times New Roman', serif; }",
+  }, {
+    code: "a { font-family: 'Something6'; }",
+  }, {
+    code: "a { font-family: 'snake_case'; }",
+  } ],
+
+  reject: [ {
+    code: "a { font-family: Lucida Grande, Arial, sans-serif; }",
+    message: messages.expected("", "Lucida Grande"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { fOnT-fAmIlY: Lucida Grande, Arial, sans-serif; }",
+    message: messages.expected("", "Lucida Grande"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { FONT-FAMILY: Lucida Grande, Arial, sans-serif; }",
+    message: messages.expected("", "Lucida Grande"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { font-family: \"Lucida Grande\", Arial, \"sans-serif\"; }",
+    message: messages.expected("no", "sans-serif"),
+    line: 1,
+    column: 43,
+  }, {
+    code: "a { font-family: Red/Black, Arial, sans-serif; }",
+    message: messages.expected("", "Red/Black"),
+  }, {
+    code: "a { font-family: Arial, Ahem!, sans-serif; }",
+    message: messages.expected("", "Ahem!"),
+  }, {
+    code: "a { font-family: Hawaii 5-0, Arial, sans-serif; }",
+    message: messages.expected("", "Hawaii 5-0"),
+  }, {
+    code: "a { font-family: Times, Times New Roman, serif; }",
+    message: messages.expected("", "Times New Roman"),
+  }, {
+    code: "a { font-family: Something6; }",
+    message: messages.expected("", "Something6"),
+  }, {
+    code: "a { font-family: snake_case; }",
+    message: messages.expected("", "snake_case"),
+  }, {
+    code: "a { font-family: \"Arial\"; }",
+    message: messages.expected("no", "Arial"),
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["always-where-required"],
+
+  accept: [ {
+    code: "a { font-family: $sassy-font-family; }",
+    description: "ignores sass variables",
+  }, {
+    code: "a { font-family: @less-666; }",
+    description: "ignores less variables",
+  }, {
+    code: "a { font-family: var(--ff1); }",
+    description: "ignores custom properties",
+  }, {
+    code: "$font-family: map-get($font-stacks, default);",
+    description: "ignores scss variable contain font-family in name",
+  }, {
+    code: "@font-family: map-get($font-stacks, default);",
+    description: "ignores less variable contain font-family in name",
+  }, {
+    code: "$default-font-family: map-get($font-stacks, default);",
+    description: "ignores scss variable contain font-family in name",
+  }, {
+    code: "@default-font-family: map-get($font-stacks, default);",
+    description: "ignores less variable contain font-family in name",
+  }, {
+    code: "$font-family-variable: map-get($font-stacks, default);",
+    description: "ignores scss variable contain font-family in name",
+  }, {
+    code: "@font-family-variable: map-get($font-stacks, default);",
+    description: "ignores less variable contain font-family in name",
+  }, {
+    code: "a { font-family: Lucida Grande, Arial, sans-serif; }",
+  }, {
+    code: "a { fOnT-fAmIlY: Lucida Grande, Arial, sans-serif; }",
+  }, {
+    code: "a { FONT-FAMILY: Lucida Grande, Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: \"Red/Black\", Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: Arial, \"Ahem!\", sans-serif; }",
+  }, {
+    code: "a { font-family: \"Hawaii 5-0\", Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: 'Red/Black', Arial, sans-serif; }",
+  }, {
+    code: "a { font-family: Arial, 'Ahem!', sans-serif; }",
+  }, {
+    code: "a { font-family: 'Hawaii 5-0', Arial, sans-serif; }",
+  } ],
+
+  reject: [ {
+    code: "a { font-family: \"Lucida Grande\", Arial, sans-serif; }",
+    message: messages.expected("no", "Lucida Grande"),
+    line: 1,
+    column: 19,
+  }, {
+    code: "a { fOnT-fAmIlY: \"Lucida Grande\", Arial, sans-serif; }",
+    message: messages.expected("no", "Lucida Grande"),
+    line: 1,
+    column: 19,
+  }, {
+    code: "a { FONT-FAMILY: \"Lucida Grande\", Arial, sans-serif; }",
+    message: messages.expected("no", "Lucida Grande"),
+    line: 1,
+    column: 19,
+  }, {
+    code: "a { font-family: Lucida Grande, Arial, \"sans-serif\"; }",
+    message: messages.expected("no", "sans-serif"),
+    line: 1,
+    column: 41,
+  }, {
+    code: "a { font-family: Red/Black, Arial, sans-serif; }",
+    message: messages.expected("", "Red/Black"),
+  }, {
+    code: "a { font-family: Arial, Ahem!, sans-serif; }",
+    message: messages.expected("", "Ahem!"),
+  }, {
+    code: "a { font-family: Hawaii 5-0, Arial, sans-serif; }",
+    message: messages.expected("", "Hawaii 5-0"),
+  } ],
+})
+
+test("deprecation warning for single-unless-keyword", t => {
+  const config = {
+    rules: {
+      "font-family-name-quotes": "single-unless-keyword",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("a { font-family: \"inherit\"; }").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'single-unless-keyword' option for 'font-family-name-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always-where-required', 'always-where-recommended' or 'always-unless-keyword' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected no quotes around font-family name \"inherit\" (font-family-name-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+test("deprecation warning for single-where-required", t => {
+  const config = {
+    rules: {
+      "font-family-name-quotes": "single-where-required",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("a { font-family: Hawaii 5-0; }").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'single-where-required' option for 'font-family-name-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always-where-required', 'always-where-recommended' or 'always-unless-keyword' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected single quotes around font-family name \"Hawaii 5-0\" (font-family-name-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+test("deprecation warning for single-where-recommended", t => {
+  const config = {
+    rules: {
+      "font-family-name-quotes": "single-where-recommended",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("a { font-family: Something6; }").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'single-where-recommended' option for 'font-family-name-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always-where-required', 'always-where-recommended' or 'always-unless-keyword' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected single quotes around font-family name \"Something6\" (font-family-name-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+test("deprecation warning for double-unless-keyword", t => {
+  const config = {
+    rules: {
+      "font-family-name-quotes": "double-unless-keyword",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("a { font-family: 'inherit'; }").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'double-unless-keyword' option for 'font-family-name-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always-where-required', 'always-where-recommended' or 'always-unless-keyword' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected no quotes around font-family name \"inherit\" (font-family-name-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+test("deprecation warning for double-where-required", t => {
+  const config = {
+    rules: {
+      "font-family-name-quotes": "double-where-required",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("a { font-family: Hawaii 5-0; }").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'double-where-required' option for 'font-family-name-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always-where-required', 'always-where-recommended' or 'always-unless-keyword' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected double quotes around font-family name \"Hawaii 5-0\" (font-family-name-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+test("deprecation warning for double-where-recommended", t => {
+  const config = {
+    rules: {
+      "font-family-name-quotes": "double-where-recommended",
+    },
+  }
+  let planned = 0
+
+  postcss().use(stylelint(config)).process("a { font-family: Something6; }").then(result => {
+    t.equal(result.warnings().length, 2)
+    t.equal(result.warnings()[0].text, "The 'double-where-recommended' option for 'font-family-name-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always-where-required', 'always-where-recommended' or 'always-unless-keyword' options together with the 'string-quotes' rule.")
+    t.equal(result.warnings()[0].stylelintType, "deprecation")
+    t.equal(result.warnings()[1].text, "Expected double quotes around font-family name \"Something6\" (font-family-name-quotes)")
+  }).catch(logError)
+  planned += 4
+
+  t.plan(planned)
+})
+
+function logError(err) {
+  console.log(err.stack) // eslint-disable-line no-console
+}

--- a/src/rules/font-family-name-quotes/index.js
+++ b/src/rules/font-family-name-quotes/index.js
@@ -49,9 +49,30 @@ export default function (expectation) {
         "double-where-required",
         "double-where-recommended",
         "double-unless-keyword",
+
+        "always-where-required",
+        "always-where-recommended",
+        "always-unless-keyword",
       ],
     })
     if (!validOptions) { return }
+
+    if (
+      expectation === "single-where-required"
+      || expectation === "single-where-recommended"
+      || expectation === "single-unless-keyword"
+      || expectation === "double-where-required"
+      || expectation === "double-where-recommended"
+      || expectation === "double-unless-keyword"
+    ) {
+      result.warn((
+        "The '" + expectation + "' option for 'font-family-name-quotes' has been deprecated, "
+          + "and will be removed in '7.0'. Instead, use the 'always-where-required', 'always-where-recommended' or 'always-unless-keyword' options together with the 'string-quotes' rule."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/font-family-name-quotes/",
+      })
+    }
 
     root.walkDecls(/^font-family$/i, decl => {
       postcss.list.comma(decl.value).forEach(familyName => {
@@ -121,6 +142,25 @@ export default function (expectation) {
             return complain(messages.expected("double", family), family, decl)
           }
           return
+
+        case "always-where-recommended":
+          if (!recommended && quoteType !== "none") {
+            return complain(messages.expected("no", family), family, decl)
+          }
+          if (recommended && quoteType === "none") {
+            return complain(messages.expected("", family), family, decl)
+          }
+          return
+
+        case "always-where-required":
+          if (!required && quoteType !== "none") {
+            return complain(messages.expected("no", family), family, decl)
+          }
+          if (required && quoteType === "none") {
+            return complain(messages.expected("", family), family, decl)
+          }
+          return
+
         default: return
       }
     }


### PR DESCRIPTION
Ref: #1331

@davidtheclark Here’s the other contextual quote rule (other one in https://github.com/stylelint/stylelint/pull/1354). I think once these are in we can defo release `6.5.1` :)

As with the other rule changes, I’m testing the original options alongside the deprecation warnings.

Once `7.0` comes around and we strip out all the deprecated options code, this rule is going to look very neat and tidy :)