### PR TITLE
Ignore An+B notation and linguistic pseudo-classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Deprecated: `"hierarchicalSelectors"` option for `indentation`.  If you use this option, please consider creating a plugin for the community.
 - Fixed: `selector-max-compound-selectors` no longer errors on Less mixins.
 - Fixed: `selector-list-comma-*` rules now ignore Less mixins.
+- Fixed: `selector-type-no-unknown` now ignores all *An+B notation* and linguistic pseudo-classes.
 
 # 6.5.0
 

--- a/src/reference/keywordSets.js
+++ b/src/reference/keywordSets.js
@@ -155,7 +155,21 @@ export const pseudoElements = uniteSets(
   levelThreePseudoElements
 )
 
-export const pseudoClasses = new Set([
+export const aNPlusBNotationPseudoClasses = new Set([
+  "nth-child",
+  "nth-column",
+  "nth-last-child",
+  "nth-last-column",
+  "nth-last-of-type",
+  "nth-of-type",
+])
+
+export const linguisticPseudoClasses = new Set([
+  "dir",
+  "lang",
+])
+
+export const otherPseudoClasses = new Set([
   "active",
   "any-link",
   "blank",
@@ -163,7 +177,6 @@ export const pseudoClasses = new Set([
   "contains",
   "current",
   "default",
-  "dir",
   "disabled",
   "drop",
   "empty",
@@ -179,18 +192,11 @@ export const pseudoClasses = new Set([
   "indeterminate",
   "in-range",
   "invalid",
-  "lang",
   "last-child",
   "last-of-type",
   "link",
   "matches",
   "not",
-  "nth-child",
-  "nth-column",
-  "nth-last-child",
-  "nth-last-column",
-  "nth-last-of-type",
-  "nth-of-type",
   "only-child",
   "only-of-type",
   "optional",
@@ -209,6 +215,12 @@ export const pseudoClasses = new Set([
   "valid",
   "visited",
 ])
+
+export const pseudoClasses = uniteSets(
+  aNPlusBNotationPseudoClasses,
+  linguisticPseudoClasses,
+  otherPseudoClasses
+)
 
 export const shorthandTimeProperties = new Set([
   "transition",

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -38,6 +38,12 @@ testRule(rule, {
   }, {
     code: "a[target] {}",
   }, {
+    code: ":lang(en) {}",
+  }, {
+    code: "a:nth-of-type(n) {}",
+  }, {
+    code: "a:nth-child(n) {}",
+  }, {
     code: "circle {}",
     description: "svg tags",
   } ],

--- a/src/utils/__tests__/isStandardTypeSelector-test.js
+++ b/src/utils/__tests__/isStandardTypeSelector-test.js
@@ -4,14 +4,30 @@ import test from "tape"
 import selectorParser from "postcss-selector-parser"
 
 test("isStandardTypeSelector", t => {
-  t.plan(4)
+  t.plan(8)
 
   rules("a {}", func => {
     t.ok(isStandardTypeSelector(func), "tag")
   })
 
   rules(".foo:nth-child(n) {}", func => {
-    t.notOk(isStandardTypeSelector(func), "pseudo selector")
+    t.notOk(isStandardTypeSelector(func), "nth-child pseudo selector")
+  })
+
+  rules(".foo:nth-last-child(n) {}", func => {
+    t.notOk(isStandardTypeSelector(func), "nth-last-child pseudo selector")
+  })
+
+  rules(".foo:nth-of-type(n) {}", func => {
+    t.notOk(isStandardTypeSelector(func), "nth-of-type pseudo selector")
+  })
+
+  rules(":lang(en) {}", func => {
+    t.notOk(isStandardTypeSelector(func), "lang pseudo selector")
+  })
+
+  rules(":dir(ltr) {}", func => {
+    t.notOk(isStandardTypeSelector(func), "dir pseudo selector")
   })
 
   rules(".foo { &-bar {} }", func => {
@@ -32,5 +48,7 @@ function rules(css, cb) {
         })
       }).process(rule.selector)
     })
+  }).catch(error => {
+    console.log(error) // eslint-disable-line no-console
   })
 }

--- a/src/utils/isStandardTypeSelector.js
+++ b/src/utils/isStandardTypeSelector.js
@@ -4,17 +4,27 @@
  * @param {Node} postcss-selector-parser node (of type tag)
  * @return {boolean} If `true`, the type selector is standard
  */
+
+import {
+  aNPlusBNotationPseudoClasses,
+  linguisticPseudoClasses,
+} from "../reference/keywordSets"
+
 export default function (node) {
 
   // postcss-selector-parser includes the arguments to nth-child() functions
   // as "tags", so we need to ignore them ourselves.
   // The fake-tag's "parent" is actually a selector node, whose parent
   // should be the :nth-child pseudo node.
-  if (
-    node.parent.parent.type === "pseudo" &&
-    node.parent.parent.value === ":nth-child"
-  ) {
-    return false
+  const { parent: { parent: { type: parentType, value: parentValue } } } = node
+  if (parentValue) {
+    const normalisedParentName = parentValue.toLowerCase().replace(/:+/, "")
+    if (
+      parentType === "pseudo" && (
+        aNPlusBNotationPseudoClasses.has(normalisedParentName)
+        || linguisticPseudoClasses.has(normalisedParentName)
+      )
+    ) { return false }
   }
 
   // &-bar is a nesting selector combined with a suffix


### PR DESCRIPTION
Ref: #1352

FYI, sets names [from spec](https://drafts.csswg.org/selectors-4/)

P.S. I'm loving the reference sets. That was a great initiative :)