### PR TITLE
Fix string formatter handling of parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Deprecated: `"single-where-required"`, `"single-where-recommended"`, `"single-unless-keyword"`, `"double-where-required"`, `"double-where-recommended"` and `"double-unless-keyword"` options for `font-family-name-quotes`. Instead, use the `"always-unless-keyword"`, `always-where-recommended` and `always-where-required` or `"never"` options together with the `string-quotes` rule.
 - Deprecated: `"emptyLineBefore"` option for `declaration-block-properties-order`. If you use this option, please consider creating a plugin for the community.
 - Deprecated: `"hierarchicalSelectors"` option for `indentation`.  If you use this option, please consider creating a plugin for the community.
+- Fixed: the string formatter no longer errors on non-rule errors.
 - Fixed: `selector-max-compound-selectors` no longer errors on Less mixins.
 - Fixed: `selector-list-comma-*` rules now ignore Less mixins.
 - Fixed: `selector-type-no-unknown` now ignores all *An+B notation* and linguistic pseudo-classes.

--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -80,7 +80,8 @@ function formatter(messages, source) {
   const calculateWidths = function (columns) {
 
     _.forOwn(columns, (value, key) => {
-      columnWidths[key] = Math.max(columnWidths[key], stringWidth(value.toString()))
+      const normalisedValue = value ? value.toString() : value
+      columnWidths[key] = Math.max(columnWidths[key], stringWidth(normalisedValue))
     })
 
     return columns


### PR DESCRIPTION
Closes: #1347 

Value can sometimes be undefined if displaying a parse error e.g. “selector can not be parsed”