### PR TITLE
Ignore obsolete HTML tags and hgroup selector-type-no-unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Deprecated: `"emptyLineBefore"` option for `declaration-block-properties-order`. If you use this option, please consider creating a plugin for the community.
 - Deprecated: `"hierarchicalSelectors"` option for `indentation`.  If you use this option, please consider creating a plugin for the community.
 - Fixed: the string formatter no longer errors on non-rule errors.
+- Fixed: `selector-type-no-unknown` now ignores obsolete HTML tags and `<hgroup>`.
 - Fixed: `selector-max-compound-selectors` no longer errors on Less mixins.
 - Fixed: `selector-list-comma-*` rules now ignore Less mixins.
 - Fixed: `selector-type-no-unknown` now ignores all *An+B notation* and linguistic pseudo-classes.

--- a/src/rules/selector-type-no-unknown/README.md
+++ b/src/rules/selector-type-no-unknown/README.md
@@ -3,8 +3,8 @@
 Disallow unknown type selectors.
 
 ```css
-       input {}
-/**    ↑
+    unknown {}
+/** ↑
  * This type selector */
 ```
 
@@ -15,25 +15,13 @@ unknown { }
 ```
 
 ```css
-uNkNoWn { }
-```
-
-```css
-UNKNOWN { }
+tag { }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
 input { }
-```
-
-```css
-iNpUt { }
-```
-
-```css
-INPUT { }
 ```
 
 ```css
@@ -62,22 +50,10 @@ The following patterns are considered warnings:
 tag
 ```
 
-```css
-tAg
-```
-
-```css
-TAG
-```
-
 The following patterns are *not* considered warnings:
 
 ```css
 unknown { }
-```
-
-```css
-uNkNoWn { }
 ```
 
 ```css

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -14,6 +14,10 @@ testRule(rule, {
   }, {
     code: "input {}",
   }, {
+    code: "acronym {}",
+  }, {
+    code: "HGrOuP {}",
+  }, {
     code: "iNpUt {}",
   }, {
     code: "INPUT {}",

--- a/src/rules/selector-type-no-unknown/index.js
+++ b/src/rules/selector-type-no-unknown/index.js
@@ -18,6 +18,32 @@ export const messages = ruleMessages(ruleName, {
   rejected: (selector) => `Unexpected unknown type selector "${selector}"`,
 })
 
+// htmlTags includes only "standard" tags. So we augment it with older tags etc.
+const nonStandardHtmlTags = new Set([
+  "acronym",
+  "applet",
+  "basefont",
+  "big",
+  "blink",
+  "center",
+  "content",
+  "dir",
+  "font",
+  "frame",
+  "frameset",
+  "hgroup",
+  "isindex",
+  "keygen",
+  "listing",
+  "marquee",
+  "noembed",
+  "plaintext",
+  "spacer",
+  "strike",
+  "tt",
+  "xmp",
+])
+
 export default function (actual, options) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, { actual }, {
@@ -44,6 +70,7 @@ export default function (actual, options) {
 
           if (htmlTags.indexOf(tagNameLowerCase) !== -1
             || svgTags.indexOf(tagNameLowerCase) !== -1
+            || nonStandardHtmlTags.has(tagNameLowerCase)
           ) { return }
 
           const ignoreTypes = options && options.ignoreTypes || []


### PR DESCRIPTION
Ref: #1352

Slightly odd rule this btw. I think it’s the only one where we checking against HTML specs, rather than CSS ones.

I guess no biggy as this rule can be “finished” if we don’t distinguish obsolete tags.