### PR TITLE
Ignore Less mixins `selector-list-comma-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Deprecated: `"emptyLineBefore"` option for `declaration-block-properties-order`.
 - Deprecated: `"hierarchicalSelectors"` option for `indentation`.
 - Fixed: `selector-max-compound-selectors` no longer errors on Less mixins.
+- Fixed: `selector-list-comma-*` rules now ignore Less mixins.
 
 # 6.5.0
 

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -195,8 +195,14 @@ testRule(rule, {
   skipBasicChecks: true,
   syntax: "less",
 
-  accept: [{
+  accept: [ {
     code: "a, // comment\nb {}",
     description: "with end-of-line // comment with newline after",
-  }],
+  }, {
+    code: ".col( @a, @b ) {}",
+    description: "mixin ending in a char",
+  }, {
+    code: ".col3( @a, @b ) {}",
+    description: "mixin ending in a number",
+  } ],
 })

--- a/src/rules/selector-list-comma-newline-after/index.js
+++ b/src/rules/selector-list-comma-newline-after/index.js
@@ -1,7 +1,8 @@
 import {
+  isStandardRule,
+  report,
   ruleMessages,
   styleSearch,
-  report,
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
@@ -28,6 +29,7 @@ export default function (expectation) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
+      if (!isStandardRule(rule)) { return }
       // Get raw selector so we can allow end-of-line comments, e.g.
       // a, /* comment */
       // b {}

--- a/src/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-after/__tests__/index.js
@@ -199,3 +199,18 @@ testRule(rule, {
     column: 2,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [ {
+    code: ".col( @a,@b ) {}",
+    description: "mixin ending in a char",
+  }, {
+    code: ".col3( @a,@b ) {}",
+    description: "mixin ending in a number",
+  } ],
+})

--- a/src/rules/selector-list-comma-space-after/index.js
+++ b/src/rules/selector-list-comma-space-after/index.js
@@ -1,4 +1,5 @@
 import {
+  isStandardRule,
   report,
   ruleMessages,
   styleSearch,
@@ -40,6 +41,7 @@ export default function (expectation) {
 
 export function selectorListCommaWhitespaceChecker({ locationChecker, root, result, checkedRuleName }) {
   root.walkRules(rule => {
+    if (!isStandardRule(rule)) { return }
     const selector = rule.selector
     styleSearch({ source: selector, target: ",", outsideFunctionalNotation: true }, match => {
       checkDelimiter(selector, match.startIndex, rule)

--- a/src/utils/__tests__/isStandardRule-test.js
+++ b/src/utils/__tests__/isStandardRule-test.js
@@ -4,7 +4,7 @@ import postcss from "postcss"
 import test from "tape"
 
 test("isStandardRule", t => {
-  t.plan(15)
+  t.plan(17)
 
   rules("a {}", rule => {
     t.ok(isStandardRule(rule), "type")
@@ -34,6 +34,12 @@ test("isStandardRule", t => {
   })
   lessRules(".mixin-name() {}", rule => {
     t.notOk(isStandardRule(rule), "non-ouputting Less class mixin definition")
+  })
+  lessRules(".mixin-name(@a, @b) {}", rule => {
+    t.notOk(isStandardRule(rule), "non-ouputting parametric Less class mixin definition")
+  })
+  lessRules(".mixin-name3(@a, @b) {}", rule => {
+    t.notOk(isStandardRule(rule), "non-ouputting parametric Less class mixin definition ending in number")
   })
   lessRules("#mixin-name() {}", rule => {
     t.notOk(isStandardRule(rule), "non-ouputting Less id mixin definition")


### PR DESCRIPTION
Closes #1321

`isStandardRule()` to the rescue :)