### PR TITLE
Add a tip to submit PR's with failing tests GH issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,6 @@
+<!-- Here are the best ways to help resolve your issue:
+1. Figure out what needs to be done, propose it, and then write the code and submit a PR.
+2. If your issue is a bug, consider at least submitting a PR with failing tests. -->
 > Describe the issue. Is it a bug or a feature request (new rule, new option, etc.)?
 
 e.g. "A bug where..."
@@ -56,5 +59,3 @@ test.css
 ```
 
 <!--- Note: stackoverflow is our preferred QA forum - http://stackoverflow.com/questions/tagged/stylelint -->
-
-<!--- Tip: If you can submit a pull request that includes a failing test this would be really helpful -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -56,3 +56,5 @@ test.css
 ```
 
 <!--- Note: stackoverflow is our preferred QA forum - http://stackoverflow.com/questions/tagged/stylelint -->
+
+<!--- Tip: If you can submit a pull request that includes a failing test this would be really helpful -->


### PR DESCRIPTION
I was linked to this a couple of days ago, I think a hidden comment at the end of the GitHUb issue template would be a great.

> https://twitter.com/sindresorhus/status/579306280495357953
> > _"OSS tip: If you want a bug fixed faster, submit a PR with a failing test rather than an issue."_

Currently I've got the text slightly modified reading:
> _"Tip: If you can submit a pull request that includes a failing test this would be really helpful"_