### PR TITLE
Change registering of ignored files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Changed: `declaration-block-no-ignored-properties` now detects use of `min-width` and `max-width` with inline, table-row, table-row-group, table-column and table-column-group elements.
 - Changed: `declaration-block-no-ignored-properties` now detects use of `overflow`, `overflow-x` and `overflow-y` with inline elements.
 - Changed: `font-family-name-quotes` treats `-apple-*` and `BlinkMacSystemFont` system fonts as keywords that should never be wrapped in quotes.
+- Changed: files matching ignore patterns no longer receive an "info"-severity message, which was always printed by the string formatter. Instead, the file's stylelint result object receives an `ignored: true` property, which various formatters can use as needed. The standard string formatter prints nothing for ignored files; but in `--verbose` mode, ignored files are included in the filelist.
 - Added: non-standard syntaxes are automatically inferred from file extensions `.scss`, `.less`, and `.sss`.
 
 # Head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Added: `ignorePath` (for JS) and `--ignore-path` (for CLI) options.
 - Added: `at-rule-name-newline-after` rule.
+- Fixed: `function-whitespace-after` ignores `postcss-simple-vars`-style interpolation.
 - Fixed: `function-url-quotes` ignores values containing `$sass` and `@less` variables.
 - Fixed: selector-targeting rules ignore Less mixins and extends.
 

--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -27,6 +27,7 @@ A formatter is a function that accepts *an array of these stylelint result objec
     {
       text: "Invalid option X for rule Y",
     }
-  ]
+  ],
+  ignored: false // This is `true` if the file's path matches a provided ignore pattern
 }
 ```

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -157,9 +157,8 @@ test("standalone with input css and quiet mode", t => {
     },
   }
 
-  standalone({ code: "a {}", config }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.deepEqual(parsedOutput[0].warnings, [])
+  standalone({ code: "a {}", config }).then(({ results }) => {
+    t.deepEqual(results[0].warnings, [])
   }).catch(logError)
   planned += 1
 
@@ -249,17 +248,15 @@ test("standalone with extending config and ignoreFiles glob ignoring single glob
       ],
     },
     configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.equal(parsedOutput.length, 2)
-    t.ok(parsedOutput[0].source.indexOf("empty-block.css") !== -1)
-    t.equal(parsedOutput[0].warnings.length, 1)
-    t.ok(parsedOutput[1].source.indexOf("invalid-hex.css") !== -1)
-    t.equal(parsedOutput[1].warnings.length, 1)
-    t.equal(parsedOutput[1].warnings[0].severity, "info", "must be an information")
-    t.equal(parsedOutput[1].warnings[0].text, "This file is ignored")
+  }).then(({ results }) => {
+    t.equal(results.length, 2)
+    t.ok(results[0].source.indexOf("empty-block.css") !== -1)
+    t.equal(results[0].warnings.length, 1)
+    t.ok(results[1].source.indexOf("invalid-hex.css") !== -1)
+    t.equal(results[1].warnings.length, 0)
+    t.ok(results[1].ignored)
   }).catch(logError)
-  t.plan(7)
+  t.plan(6)
 })
 
 test("standalone with absolute ignoreFiles glob path", t => {
@@ -272,13 +269,12 @@ test("standalone with absolute ignoreFiles glob path", t => {
       },
     },
     configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.equal(parsedOutput.length, 2)
-    t.equal(parsedOutput[0].warnings.length, 1)
-    t.equal(parsedOutput[0].warnings[0].severity, "info", "must be an information")
-    t.equal(parsedOutput[0].warnings[0].text, "This file is ignored")
-    t.equal(parsedOutput[1].warnings.length, 0)
+  }).then(({ results }) => {
+    t.equal(results.length, 2)
+    t.equal(results[0].warnings.length, 0)
+    t.ok(results[0].ignored)
+    t.equal(results[1].warnings.length, 0)
+    t.notOk(results[1].ignored)
   }).catch(logError)
   t.plan(5)
 })
@@ -297,15 +293,14 @@ test("standalone with extending config with ignoreFiles glob ignoring one by neg
       ],
     },
     configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.equal(parsedOutput.length, 2)
-    t.ok(parsedOutput[0].source.indexOf("empty-block.css") !== -1)
-    t.equal(parsedOutput[0].warnings.length, 1)
-    t.equal(parsedOutput[0].warnings[0].severity, "info", "must be an information")
-    t.equal(parsedOutput[0].warnings[0].text, "This file is ignored")
-    t.ok(parsedOutput[1].source.indexOf("invalid-hex.css") !== -1)
-    t.equal(parsedOutput[1].warnings.length, 1)
+  }).then(({ results }) => {
+    t.equal(results.length, 2)
+    t.ok(results[0].source.indexOf("empty-block.css") !== -1)
+    t.equal(results[0].warnings.length, 0)
+    t.ok(results[0].ignored)
+    t.ok(results[1].source.indexOf("invalid-hex.css") !== -1)
+    t.equal(results[1].warnings.length, 1)
+    t.notOk(results[1].ignored)
   }).catch(logError)
   t.plan(7)
 })
@@ -320,16 +315,15 @@ test("standalone with .stylelintignore file ignoring one file", t => {
       ],
     },
     configBasedir: path.join(__dirname, "fixtures/ignore_config"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.equal(parsedOutput.length, 2)
-    t.ok(parsedOutput[0].source.indexOf("empty-block.css") !== -1)
-    t.equal(parsedOutput[0].warnings.length, 1)
-    t.equal(parsedOutput[0].warnings[0].severity, "info", "must be an information")
-    t.equal(parsedOutput[0].warnings[0].text, "This file is ignored")
-    t.ok(parsedOutput[1].source.indexOf("invalid-hex.css") !== -1,
+  }).then(({ results }) => {
+    t.equal(results.length, 2)
+    t.ok(results[0].source.indexOf("empty-block.css") !== -1)
+    t.equal(results[0].warnings.length, 0)
+    t.ok(results[0].ignored)
+    t.ok(results[1].source.indexOf("invalid-hex.css") !== -1,
       "violation is for block-no-empty, not color-no-invalid-hex")
-    t.equal(parsedOutput[1].warnings.length, 1)
+    t.equal(results[1].warnings.length, 1)
+    t.notOk(results[1].ignored)
   }).catch(logError)
   t.plan(7)
 })
@@ -344,10 +338,9 @@ test("standalone with specified `ignorePath` file ignoring one file", t => {
     },
     ignorePath: path.join(__dirname, "fixtures/ignore_config/foo.txt"),
     configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.equal(parsedOutput[0].warnings.length, 1)
-    t.equal(parsedOutput[0].warnings[0].text, "This file is ignored")
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 0)
+    t.ok(results[0].ignored)
   }).catch(logError)
   t.plan(2)
 })
@@ -362,14 +355,13 @@ test("standalone extending a config that ignores files", t => {
       ],
     },
     configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.equal(parsedOutput.length, 2)
-    t.ok(parsedOutput[0].source.indexOf("empty-block.css") !== -1,
+  }).then(({ results }) => {
+    t.equal(results.length, 2)
+    t.ok(results[0].source.indexOf("empty-block.css") !== -1,
       "ignoreFiles in extended config has no effect")
-    t.equal(parsedOutput[0].warnings.length, 1)
-    t.ok(parsedOutput[1].source.indexOf("invalid-hex.css") !== -1)
-    t.equal(parsedOutput[1].warnings.length, 0)
+    t.equal(results[0].warnings.length, 1)
+    t.ok(results[1].source.indexOf("invalid-hex.css") !== -1)
+    t.equal(results[1].warnings.length, 0)
   }).catch(logError)
   planned += 5
   t.plan(planned)
@@ -384,9 +376,8 @@ test("standalone extending a config that is overridden", t => {
       ],
       rules: { "string-quotes": "double" },
     },
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)
-    t.equal(parsedOutput[0].warnings.length, 0)
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 0)
   }).catch(logError)
   t.plan(1)
 })
@@ -395,10 +386,9 @@ test("standalone loading YAML with custom message", t => {
   standalone({
     code: "a { color: pink; }",
     configFile: path.join(__dirname, "fixtures/config-color-named-custom-message.yaml"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)[0]
-    t.equal(parsedOutput.warnings.length, 1)
-    t.equal(parsedOutput.warnings[0].text, "Unacceptable")
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 1)
+    t.equal(results[0].warnings[0].text, "Unacceptable")
   }).catch(logError)
 
   t.plan(2)
@@ -412,14 +402,12 @@ test("standalone using codeFilename and ignoreFiles together", t => {
       ignoreFiles: ["**/foo.css"],
       rules: { "block-no-empty": true },
     },
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)[0]
-    t.equal(parsedOutput.warnings.length, 1, "Must have one warning that is an information")
-    t.equal(parsedOutput.warnings[0].severity, "info", "must be an information")
-    t.equal(parsedOutput.warnings[0].text, "This file is ignored")
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 0)
+    t.ok(results[0].ignored)
   }).catch(logError)
 
-  t.plan(3)
+  t.plan(2)
 })
 
 test("standalone using codeFilename and ignoreFiles with configBasedir", t => {
@@ -431,32 +419,30 @@ test("standalone using codeFilename and ignoreFiles with configBasedir", t => {
       rules: { "block-no-empty": true },
     },
     configBasedir: __dirname,
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)[0]
-    t.equal(parsedOutput.warnings.length, 1, "Must have one warning that is an information")
-    t.equal(parsedOutput.warnings[0].severity, "info", "must be an information")
-    t.equal(parsedOutput.warnings[0].text, "This file is ignored")
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 0)
+    t.ok(results[0].ignored)
   }).catch(logError)
 
-  t.plan(3)
+  t.plan(2)
 })
 
 test("standalone passing code with syntax error", t => {
   standalone({
     code: "a { color: 'red; }",
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)[0]
-    t.equal(parsedOutput.source, "<input css 1>", "<input css 1> as source")
-    t.equal(parsedOutput.deprecations.length, 0, "empty deprecations")
-    t.equal(parsedOutput.invalidOptionWarnings.length, 0,
+  }).then(({ results }) => {
+    const result = results[0]
+    t.equal(result.source, "<input css 1>", "<input css 1> as source")
+    t.equal(result.deprecations.length, 0, "empty deprecations")
+    t.equal(result.invalidOptionWarnings.length, 0,
       "empty invalidOptionWarnings")
-    t.ok(parsedOutput.errored)
-    t.equal(parsedOutput.warnings.length, 1, "syntax error in warnings")
-    t.equal(parsedOutput.warnings[0].rule, "CssSyntaxError",
+    t.ok(result.errored)
+    t.equal(result.warnings.length, 1, "syntax error in warnings")
+    t.equal(result.warnings[0].rule, "CssSyntaxError",
       "syntax error rule is CssSyntaxError")
-    t.equal(parsedOutput.warnings[0].severity, "error",
+    t.equal(result.warnings[0].severity, "error",
       "syntax error severity is error")
-    t.ok(parsedOutput.warnings[0].text.indexOf(" (CssSyntaxError)" !== -1),
+    t.ok(result.warnings[0].text.indexOf(" (CssSyntaxError)" !== -1),
       "(CssSyntaxError) in warning text")
   }).catch(logError)
 
@@ -467,9 +453,8 @@ test("standalone passing file with syntax error", t => {
   standalone({
     code: "a { color: 'red; }",
     codeFilename: path.join(__dirname, "syntax-error.css"),
-  }).then(({ output }) => {
-    const parsedOutput = JSON.parse(output)[0]
-    t.ok(parsedOutput.source.indexOf("syntax-error.css") !== -1,
+  }).then(({ results }) => {
+    t.ok(results[0].source.indexOf("syntax-error.css") !== -1,
       "filename as source")
   }).catch(logError)
 

--- a/src/formatters/verboseFormatter.js
+++ b/src/formatters/verboseFormatter.js
@@ -15,8 +15,12 @@ export default function (results) {
       formatting = "red"
     } else if (result.warnings.length) {
       formatting = "yellow"
+    } else if (result.ignored) {
+      formatting = "gray"
     }
-    output += _.get(chalk, formatting)(` ${result.source}\n`)
+    let sourceText = ` ${result.source}`
+    if (result.ignored) { sourceText += " (ignored)" }
+    output += _.get(chalk, formatting)(` ${sourceText}\n`)
   })
 
   const warnings = _.flatten(results.map(r => r.warnings))

--- a/src/formatters/verboseFormatter.js
+++ b/src/formatters/verboseFormatter.js
@@ -8,7 +8,11 @@ export default function (results) {
   if (output === "") { output = "\n" }
 
   const sourceWord = (results.length > 1) ? "sources" : "source"
-  output += chalk.underline(`${results.length} ${sourceWord} checked\n`)
+  const ignoredCount = results.filter(result => result.ignored).length
+  const checkedDisplay = (ignoredCount)
+    ? `${results.length - ignoredCount} of ${results.length}`
+    : results.length
+  output += chalk.underline(`${checkedDisplay} ${sourceWord} checked\n`)
   results.forEach(result => {
     let formatting = "green"
     if (result.errored) {

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -36,9 +36,8 @@ export default postcss.plugin("stylelint", (options = {}) => {
           if (path.isAbsolute(glob)) return glob
           return globjoin(configDir, glob)
         })
-        const sourcePath = _.get(root, "source.input.file", "")
-        if (multimatch(sourcePath, absoluteIgnoreFiles).length) {
-          result.warn("This file is ignored", { severity: "info" })
+        if (multimatch(_.get(root, "source.input.file", ""), absoluteIgnoreFiles).length) {
+          result.stylelint.ignored = true
           return
         }
       }

--- a/src/rules/function-whitespace-after/__tests__/index.js
+++ b/src/rules/function-whitespace-after/__tests__/index.js
@@ -45,6 +45,12 @@ testRule(rule, {
   }, {
     code: "$list: (value, value2);$thingTwo: 0px",
     description: "Sass list ignored",
+  }, {
+    code: ".foo { $(x): calc(1px + 0px); }",
+    description: "postcss-simple-vars interpolation as property name",
+  }, {
+    code: ".foo { border-$(x)-left: 10px; }",
+    description: "postcss-simple-vars interpolation within property name",
   } ],
 
   reject: [ {

--- a/src/rules/function-whitespace-after/index.js
+++ b/src/rules/function-whitespace-after/index.js
@@ -13,6 +13,8 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected whitespace after \")\"",
 })
 
+const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([ ")", ",", "}", ":", undefined ])
+
 export default function (expectation) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -40,7 +42,7 @@ export default function (expectation) {
         if (nextChar === " ") { return }
         if (nextChar === "\n") { return }
         if (source.substr(index + 1, 2) === "\r\n") { return }
-        if ([ ")", ",", "}", undefined ].indexOf(nextChar) !== -1) { return }
+        if (ACCEPTABLE_AFTER_CLOSING_PAREN.has(nextChar)) { return }
         report({
           message: messages.expected,
           node,

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -141,6 +141,7 @@ export default function ({
         return { text: w.text }
       })
 
+      // This defines the stylelint result object that formatters receive
       return {
         source,
         deprecations,
@@ -156,6 +157,7 @@ export default function ({
             text: message.text,
           }
         }),
+        ignored: postcssResult.stylelint.ignored,
         _postcssResult: postcssResult,
       }
     }

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -72,6 +72,16 @@ test("`withinFunctionalNotation` option", t => {
     target: "b",
     withinFunctionalNotation: true,
   }), [], "parens without function is not interpreted as a function")
+  t.deepEqual(styleSearchResults({
+    source: "de$(abc)fg",
+    target: "b",
+    withinFunctionalNotation: true,
+  }), [], "parens preceded by `$`, for postcss-simple-vars interpolation, not interpreted as a function")
+  t.deepEqual(styleSearchResults({
+    source: "de$(abc)fg",
+    target: ")",
+    withinFunctionalNotation: true,
+  }), [], "closing paren of non-function is ignored")
   t.end()
 })
 

--- a/src/utils/styleSearch.js
+++ b/src/utils/styleSearch.js
@@ -209,17 +209,16 @@ export default function (options, callback) {
     const match = getMatch(i)
 
     if (!match) { continue }
-
-    if (options.outsideParens && insideParens) { continue }
-    if (options.withinFunctionalNotation && !insideFunction) { continue }
-    if (options.outsideFunctionalNotation && insideFunction) { continue }
-    if (options.withinStrings && !insideString) { continue }
-    if (options.withinComments && !insideComment) { continue }
     handleMatch(match)
     if (options.onlyOne) { return }
   }
 
   function handleMatch(match) {
+    if (options.outsideParens && insideParens) { return }
+    if (options.withinFunctionalNotation && !insideFunction) { return }
+    if (options.outsideFunctionalNotation && insideFunction) { return }
+    if (options.withinStrings && !insideString) { return }
+    if (options.withinComments && !insideComment) { return }
     matchCount++
     callback(match, matchCount)
   }


### PR DESCRIPTION
Addresses #1144.

While going through this I also noticed that many `standalone-test.js` cases were needlessly grabbing the `output` object, which is a JSON string, and parsing it, when they should have just been looking at the `results` objects, independent of the formatter.

Here is an screenshot showing what this does. The first is verbose mode, the second regular:

<img width="484" alt="screen shot 2016-05-30 at 9 34 40 am" src="https://cloud.githubusercontent.com/assets/628431/15731997/6524b2a8-2847-11e6-83c3-4a702b76572c.png">
