### PR TITLE
Ignore postcss-simple-var interpolation; fixes #1370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `ignorePath` (for JS) and `--ignore-path` (for CLI) options.
 - Added: `at-rule-name-newline-after` rule.
+- Fixed: `function-whitespace-after` ignores `postcss-simple-vars`-style interpolation.
 - Fixed: `function-url-quotes` ignores values containing `$sass` and `@less` variables.
 - Fixed: selector-targeting rules ignore Less mixins and extends.
 

--- a/src/rules/function-whitespace-after/__tests__/index.js
+++ b/src/rules/function-whitespace-after/__tests__/index.js
@@ -45,6 +45,12 @@ testRule(rule, {
   }, {
     code: "$list: (value, value2);$thingTwo: 0px",
     description: "Sass list ignored",
+  }, {
+    code: ".foo { $(x): calc(1px + 0px); }",
+    description: "postcss-simple-vars interpolation as property name",
+  }, {
+    code: ".foo { border-$(x)-left: 10px; }",
+    description: "postcss-simple-vars interpolation within property name",
   } ],
 
   reject: [ {

--- a/src/rules/function-whitespace-after/index.js
+++ b/src/rules/function-whitespace-after/index.js
@@ -13,6 +13,8 @@ export const messages = ruleMessages(ruleName, {
   rejected: "Unexpected whitespace after \")\"",
 })
 
+const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([ ")", ",", "}", ":", undefined ])
+
 export default function (expectation) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -40,7 +42,7 @@ export default function (expectation) {
         if (nextChar === " ") { return }
         if (nextChar === "\n") { return }
         if (source.substr(index + 1, 2) === "\r\n") { return }
-        if ([ ")", ",", "}", undefined ].indexOf(nextChar) !== -1) { return }
+        if (ACCEPTABLE_AFTER_CLOSING_PAREN.has(nextChar)) { return }
         report({
           message: messages.expected,
           node,

--- a/src/utils/__tests__/styleSearch-test.js
+++ b/src/utils/__tests__/styleSearch-test.js
@@ -72,6 +72,16 @@ test("`withinFunctionalNotation` option", t => {
     target: "b",
     withinFunctionalNotation: true,
   }), [], "parens without function is not interpreted as a function")
+  t.deepEqual(styleSearchResults({
+    source: "de$(abc)fg",
+    target: "b",
+    withinFunctionalNotation: true,
+  }), [], "parens preceded by `$`, for postcss-simple-vars interpolation, not interpreted as a function")
+  t.deepEqual(styleSearchResults({
+    source: "de$(abc)fg",
+    target: ")",
+    withinFunctionalNotation: true,
+  }), [], "closing paren of non-function is ignored")
   t.end()
 })
 

--- a/src/utils/styleSearch.js
+++ b/src/utils/styleSearch.js
@@ -209,17 +209,16 @@ export default function (options, callback) {
     const match = getMatch(i)
 
     if (!match) { continue }
-
-    if (options.outsideParens && insideParens) { continue }
-    if (options.withinFunctionalNotation && !insideFunction) { continue }
-    if (options.outsideFunctionalNotation && insideFunction) { continue }
-    if (options.withinStrings && !insideString) { continue }
-    if (options.withinComments && !insideComment) { continue }
     handleMatch(match)
     if (options.onlyOne) { return }
   }
 
   function handleMatch(match) {
+    if (options.outsideParens && insideParens) { return }
+    if (options.withinFunctionalNotation && !insideFunction) { return }
+    if (options.outsideFunctionalNotation && insideFunction) { return }
+    if (options.withinStrings && !insideString) { return }
+    if (options.withinComments && !insideComment) { return }
     matchCount++
     callback(match, matchCount)
   }


### PR DESCRIPTION
Addresses #1370.

Turns out this helped us find a subtle bug in styleSearch, where the options about which matches to attend to and which to ignore were themselves being ignored when `(` or `)` were being targeted.

While debugging this I fixed a problem with `createRuleTester`.