### PR TITLE
Don't remove feature name from error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `ignorePath` (for JS) and `--ignore-path` (for CLI) options.
 - Added: `at-rule-name-newline-after` rule.
+- Added: `no-unsupported-browser-features` message now includes feature name.
 - Fixed: `function-whitespace-after` ignores `postcss-simple-vars`-style interpolation.
 - Fixed: `function-url-quotes` ignores values containing `$sass` and `@less` variables.
 - Fixed: selector-targeting rules ignore Less mixins and extends.

--- a/src/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/src/rules/no-unsupported-browser-features/__tests__/index.js
@@ -29,13 +29,13 @@ testRule(rule, {
   reject: [ {
     code: "a { opacity: 1; }",
     description: "opacity",
-    message: messages.rejected("CSS3 Opacity not supported by: IE (7,8)"),
+    message: messages.rejected("Unexpected browser feature \"css-opacity\" not supported by IE 7, 8"),
     line: 1,
     column: 5,
   }, {
     code: "a { outline: none; }",
     description: "outline",
-    message: messages.rejected("CSS outline not supported by: IE (7)"),
+    message: messages.rejected("Unexpected browser feature \"outline\" not supported by IE 7"),
     line: 1,
     column: 5,
   } ],
@@ -52,7 +52,7 @@ testRule(rule, {
   reject: [{
     code: "a { opacity: 1; }",
     description: "opacity",
-    message: messages.rejected("CSS3 Opacity not supported by: IE (7,8)"),
+    message: messages.rejected("Unexpected browser feature \"css-opacity\" not supported by IE 7, 8"),
     line: 1,
     column: 5,
   }],
@@ -71,7 +71,7 @@ testRule(rule, {
   reject: [{
     code: "a { background: linear-gradient(black, white); }",
     description: "gradient",
-    message: messages.rejected("CSS Gradients not supported by: IE (9)"),
+    message: messages.rejected("Unexpected browser feature \"css-gradients\" not supported by IE 9"),
     line: 1,
     column: 5,
   }],

--- a/src/rules/no-unsupported-browser-features/index.js
+++ b/src/rules/no-unsupported-browser-features/index.js
@@ -10,7 +10,7 @@ import {
 export const ruleName = "no-unsupported-browser-features"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: details => `Unexpected browser feature ${details}`,
+  rejected: (details) => `Unexpected browser feature ${details}`,
 })
 
 export default function (on, options) {
@@ -37,7 +37,7 @@ export default function (on, options) {
 
     const doiuseResult = new Result()
     doiuse(doiuseOptions).postcss(root, doiuseResult)
-    doiuseResult.warnings().forEach(doiuseWarning => {
+    doiuseResult.warnings().forEach((doiuseWarning) => {
       report({
         ruleName,
         result,
@@ -51,5 +51,9 @@ export default function (on, options) {
 }
 
 function cleanDoiuseWarningText(warningText) {
-  return warningText.replace(/\s*\(\S+?\)$/, "")
+  const featureRegex = /\s*\(\S+?\)$/
+  const regexResult = warningText.exec(featureRegex)
+  const featureName = regexResult ? `"${regexResult[1]}"` : ""
+  const endOfWarning = warningText.slice(warningText.indexOf("not supported by")).replace(featureRegex, "").replace(/:\(\)/g, "")
+  return `Unexpected browser feature ${featureName} ${endOfWarning}`
 }


### PR DESCRIPTION
Fixes #1388. Removing the name makes the message a bit nicer, but it makes adding ignore rules tough (as mentioned in the issue). 