### PR TITLE
Remove `default` case from switch in `checkFamilyName`

### DIFF
--- a/src/rules/font-family-name-quotes/index.js
+++ b/src/rules/font-family-name-quotes/index.js
@@ -112,8 +112,6 @@ export default function (expectation) {
             return complain(messages.expected(family), family, decl)
           }
           return
-
-        default: return
       }
     }
 


### PR DESCRIPTION
There is no need for the `default` case statement in the switch statement in `checkFamilyName` as one of the three `always-unless-keyword`, `always-where-recommended`, or `always-where-required` options are always required by the `font-family-name-quotes` rule.

All going well and my thought process here isn't flawed this will update the `font-family-name-quotes` rule code coverage to 100% from 98.15% here in the `v7` branch 😄 