### PR TITLE
Remove unused `declaration-block-properties-order` messages

### DIFF
--- a/src/rules/declaration-block-properties-order/index.js
+++ b/src/rules/declaration-block-properties-order/index.js
@@ -12,8 +12,6 @@ export const ruleName = "declaration-block-properties-order"
 
 export const messages = ruleMessages(ruleName, {
   expected: (first, second) => `Expected property "${first}" to come before property "${second}"`,
-  expectedEmptyLineBetween: (first, second) => `Expected an empty line between property "${first}" and property "${second}"`,
-  rejectedEmptyLineBetween: (first, second) => `Unexpected empty line between property "${first} and property "${second}"`,
 })
 
 export default function (expectation, options) {


### PR DESCRIPTION
In the `declaration-block-properties-order` rule all instances of the messages `expectedEmptyLineBetween` and `rejectedEmptyLineBetween` were removed in https://github.com/stylelint/stylelint/pull/1385/commits/9919b34c3c0794321af876abb495cc8934ff9c31 as part of #1385, I don't believe these are required anymore, this PR removes these.