### PR TITLE
New rules: at-rule-blacklist, at-rule-whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added: option `ignorePath` (for JS) and `--ignore-path` (for CLI).
 - Added: `at-rule-name-newline-after` rule.
 - Added: `at-rule-blacklist` rule.
+- Added: `at-rule-whitelist` rule.
 - Fixed: `function-whitespace-after` ignores `postcss-simple-vars`-style interpolation.
 - Fixed: `function-url-quotes` ignores values containing `$sass` and `@less` variables.
 - Fixed: selector-targeting rules ignore Less mixins and extends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 - Added: option `ignorePath` (for JS) and `--ignore-path` (for CLI).
 - Added: `at-rule-name-newline-after` rule.
+- Added: `at-rule-blacklist` rule.
 - Fixed: `function-whitespace-after` ignores `postcss-simple-vars`-style interpolation.
 - Fixed: `function-url-quotes` ignores values containing `$sass` and `@less` variables.
 - Fixed: selector-targeting rules ignore Less mixins and extends.
 - Fixed: `selector-type-no-unknown` ignores non-standard usage of percentage keyframe selectors (e.g. within an SCSS mixin).
 - Fixed: `no-extra-semicolons` reports errors on the correct line.
-- Added: `at-rule-blacklist` rule.
 
 # 6.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed: selector-targeting rules ignore Less mixins and extends.
 - Fixed: `selector-type-no-unknown` ignores non-standard usage of percentage keyframe selectors (e.g. within an SCSS mixin).
 - Fixed: `no-extra-semicolons` reports errors on the correct line.
+- Added: `at-rule-blacklist` rule.
 
 # 6.5.1
 

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -14,6 +14,7 @@ You might want to learn a little about [how rules are named and how they work to
     "at-rule-name-space-after": "always"|"always-single-line",
     "at-rule-no-vendor-prefix": true,
     "at-rule-semicolon-newline-after": "always",
+    "at-rule-whitelist": string|[],
     "block-closing-brace-newline-after": "always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line",
     "block-closing-brace-newline-before": "always"|"always-multi-line"|"never-multi-line",
     "block-closing-brace-space-after": "always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line",

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -7,6 +7,7 @@ You might want to learn a little about [how rules are named and how they work to
 ```json
 {
   "rules": {
+    "at-rule-blacklist": string|[],
     "at-rule-empty-line-before": "always"|"never",
     "at-rule-name-case": "lower"|"upper",
     "at-rule-name-newline-after": "always"|"always-multi-line",

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -209,6 +209,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 ### At rule
 
+- [`at-rule-blacklist`](../../src/rules/at-rule-blacklist/README.md): Specify a blacklist of disallowed at-rules.
 - [`at-rule-empty-line-before`](../../src/rules/at-rule-empty-line-before/README.md): Require or disallow an empty line before at-rules.
 - [`at-rule-name-case`](../../src/rules/at-rule-name-case/README.md): Specify lowercase or uppercase for at-rules names.
 - [`at-rule-name-newline-after`](../../src/rules/at-rule-name-newline-after/README.md): Require a newline after at-rule names.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -216,7 +216,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 - [`at-rule-name-space-after`](../../src/rules/at-rule-name-space-after/README.md): Require a single space after at-rule names.
 - [`at-rule-no-vendor-prefix`](../../src/rules/at-rule-no-vendor-prefix/README.md): Disallow vendor prefixes for at-rules.
 - [`at-rule-semicolon-newline-after`](../../src/rules/at-rule-semicolon-newline-after/README.md): Require a newline after the semicolon of at-rules.
-- [`at-rule-whitelist`](../../src/rules/at-rule-whitelist/README.md): Specify a whitelist of disallowed at-rules.
+- [`at-rule-whitelist`](../../src/rules/at-rule-whitelist/README.md): Specify a whitelist of allowed at-rules.
 
 ### `stylelint-disable` comment
 

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -216,6 +216,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 - [`at-rule-name-space-after`](../../src/rules/at-rule-name-space-after/README.md): Require a single space after at-rule names.
 - [`at-rule-no-vendor-prefix`](../../src/rules/at-rule-no-vendor-prefix/README.md): Disallow vendor prefixes for at-rules.
 - [`at-rule-semicolon-newline-after`](../../src/rules/at-rule-semicolon-newline-after/README.md): Require a newline after the semicolon of at-rules.
+- [`at-rule-whitelist`](../../src/rules/at-rule-whitelist/README.md): Specify a whitelist of disallowed at-rules.
 
 ### `stylelint-disable` comment
 

--- a/src/rules/at-rule-blacklist/README.md
+++ b/src/rules/at-rule-blacklist/README.md
@@ -1,0 +1,49 @@
+# at-rule-blacklist
+
+Specify a blacklist of disallowed at-rules.
+
+```scss
+      @keyframes name {
+/**   ↑
+ *    Rules like this */
+```
+
+## Options
+
+`array`: `"["array", "of", "unprefixed", "at-rules"]`
+
+The rule's search is case insensitive, and it also takes vendor prefixes into account.
+
+Given:
+
+```js
+["extend", "keyframes"]
+```
+
+The following patterns are considered warnings:
+
+```scss
+a { @extend placeholder; }
+```
+
+```scss
+@keyframes name {
+  from { top: 10px; }
+  to { top: 20px; }
+}
+```
+
+```scss
+@-moz-keyframes name {
+  from { top: 10px; }
+  to { top: 20px; }
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@mixin name ($p) {
+  ...
+}
+```

--- a/src/rules/at-rule-blacklist/README.md
+++ b/src/rules/at-rule-blacklist/README.md
@@ -2,17 +2,15 @@
 
 Specify a blacklist of disallowed at-rules.
 
-```scss
-      @keyframes name {
-/**   ↑
- *    Rules like this */
+```css
+    @keyframes name {}
+/** ↑
+ * At-rules like this */
 ```
 
 ## Options
 
 `array`: `"["array", "of", "unprefixed", "at-rules"]`
-
-The rule's search is case insensitive, and it also takes vendor prefixes into account.
 
 Given:
 
@@ -22,18 +20,18 @@ Given:
 
 The following patterns are considered warnings:
 
-```scss
+```css
 a { @extend placeholder; }
 ```
 
-```scss
+```css
 @keyframes name {
   from { top: 10px; }
   to { top: 20px; }
 }
 ```
 
-```scss
+```css
 @-moz-keyframes name {
   from { top: 10px; }
   to { top: 20px; }
@@ -42,7 +40,7 @@ a { @extend placeholder; }
 
 The following patterns are *not* considered warnings:
 
-```scss
+```css
 @mixin name ($p) {
   ...
 }

--- a/src/rules/at-rule-blacklist/README.md
+++ b/src/rules/at-rule-blacklist/README.md
@@ -41,7 +41,5 @@ a { @extend placeholder; }
 The following patterns are *not* considered warnings:
 
 ```css
-@mixin name ($p) {
-  ...
-}
+@import "path/to/file.css";
 ```

--- a/src/rules/at-rule-blacklist/__tests__/index.js
+++ b/src/rules/at-rule-blacklist/__tests__/index.js
@@ -63,5 +63,71 @@ testRule(rule, {
     message: messages.rejected("-moz-keyframes"),
     line: 2,
     description: "@rule from a blacklist; independent rule; has vendor prefix.",
+  }, {
+    code: `
+      @-WEBKET-KEYFRAMES name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("-WEBKET-KEYFRAMES"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule; has vendor prefix.",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+
+  config: ["keyframes"],
+
+  accept: [ {
+    code: "a { color: pink; }",
+    description: "Some random code.",
+  }, {
+    code: "@mixin name ($p) {}",
+    description: "@rule not from a blacklist.",
+  } ],
+
+  reject: [ {
+    code: `
+      @keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("keyframes"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule.",
+  }, {
+    code: `
+      @Keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("Keyframes"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule; messed case.",
+  }, {
+    code: `
+      @-moz-keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("-moz-keyframes"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule; has vendor prefix.",
+  }, {
+    code: `
+      @-WEBKET-KEYFRAMES name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("-WEBKET-KEYFRAMES"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule; has vendor prefix.",
   } ],
 })

--- a/src/rules/at-rule-blacklist/__tests__/index.js
+++ b/src/rules/at-rule-blacklist/__tests__/index.js
@@ -1,0 +1,67 @@
+import { testRule } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+testRule(rule, {
+  ruleName,
+
+  config: [[
+    "extend",
+    "supports",
+    "keyframes",
+  ]],
+
+  accept: [ {
+    code: "a { color: pink; }",
+    description: "Some random code.",
+  }, {
+    code: "@mixin name ($p) {}",
+    description: "@rule not from a blacklist.",
+  } ],
+
+  reject: [ {
+    code: "a { @extend %placeholder; }",
+    message: messages.rejected("extend"),
+    line: 1,
+    description: "@rule from a blacklist, is a Sass directive.",
+  }, {
+    code: `
+      a {
+        @extend
+        %placeholder;
+      }
+    `,
+    message: messages.rejected("extend"),
+    line: 3,
+    description: "@rule from a blacklist; newline after its name.",
+  }, {
+    code: `
+      @keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("keyframes"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule.",
+  }, {
+    code: `
+      @Keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("Keyframes"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule; messed case.",
+  }, {
+    code: `
+      @-moz-keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    message: messages.rejected("-moz-keyframes"),
+    line: 2,
+    description: "@rule from a blacklist; independent rule; has vendor prefix.",
+  } ],
+})

--- a/src/rules/at-rule-blacklist/__tests__/index.js
+++ b/src/rules/at-rule-blacklist/__tests__/index.js
@@ -22,6 +22,7 @@ testRule(rule, {
     code: "a { @extend %placeholder; }",
     message: messages.rejected("extend"),
     line: 1,
+    column: 5,
     description: "@rule from a blacklist, is a Sass directive.",
   }, {
     code: `
@@ -32,6 +33,7 @@ testRule(rule, {
     `,
     message: messages.rejected("extend"),
     line: 3,
+    column: 9,
     description: "@rule from a blacklist; newline after its name.",
   }, {
     code: `
@@ -52,6 +54,7 @@ testRule(rule, {
     `,
     message: messages.rejected("Keyframes"),
     line: 2,
+    column: 7,
     description: "@rule from a blacklist; independent rule; messed case.",
   }, {
     code: `
@@ -62,6 +65,7 @@ testRule(rule, {
     `,
     message: messages.rejected("-moz-keyframes"),
     line: 2,
+    column: 7,
     description: "@rule from a blacklist; independent rule; has vendor prefix.",
   }, {
     code: `
@@ -72,6 +76,7 @@ testRule(rule, {
     `,
     message: messages.rejected("-WEBKET-KEYFRAMES"),
     line: 2,
+    column: 7,
     description: "@rule from a blacklist; independent rule; has vendor prefix.",
   } ],
 })
@@ -98,6 +103,7 @@ testRule(rule, {
     `,
     message: messages.rejected("keyframes"),
     line: 2,
+    column: 7,
     description: "@rule from a blacklist; independent rule.",
   }, {
     code: `
@@ -108,6 +114,7 @@ testRule(rule, {
     `,
     message: messages.rejected("Keyframes"),
     line: 2,
+    column: 7,
     description: "@rule from a blacklist; independent rule; messed case.",
   }, {
     code: `
@@ -118,6 +125,7 @@ testRule(rule, {
     `,
     message: messages.rejected("-moz-keyframes"),
     line: 2,
+    column: 7,
     description: "@rule from a blacklist; independent rule; has vendor prefix.",
   }, {
     code: `
@@ -128,6 +136,7 @@ testRule(rule, {
     `,
     message: messages.rejected("-WEBKET-KEYFRAMES"),
     line: 2,
+    column: 7,
     description: "@rule from a blacklist; independent rule; has vendor prefix.",
   } ],
 })

--- a/src/rules/at-rule-blacklist/index.js
+++ b/src/rules/at-rule-blacklist/index.js
@@ -1,0 +1,35 @@
+import { isString } from "lodash"
+import { vendor } from "postcss"
+
+import {
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "at-rule-blacklist"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: (name) => `Unexpected function "${name}"`,
+})
+
+export default function (blacklist) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: blacklist,
+      possible: [isString],
+    })
+    if (!validOptions) { return }
+
+    root.walkAtRules(atRule => {
+      if (blacklist.indexOf(vendor.unprefixed(atRule.name).toLowerCase()) === -1) { return }
+
+      report({
+        message: messages.rejected(atRule.name),
+        node: atRule,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/at-rule-blacklist/index.js
+++ b/src/rules/at-rule-blacklist/index.js
@@ -10,7 +10,7 @@ import {
 export const ruleName = "at-rule-blacklist"
 
 export const messages = ruleMessages(ruleName, {
-  rejected: (name) => `Unexpected function "${name}"`,
+  rejected: (name) => `Unexpected at-rule "${name}"`,
 })
 
 export default function (blacklist) {

--- a/src/rules/at-rule-blacklist/index.js
+++ b/src/rules/at-rule-blacklist/index.js
@@ -13,7 +13,9 @@ export const messages = ruleMessages(ruleName, {
   rejected: (name) => `Unexpected at-rule "${name}"`,
 })
 
-export default function (blacklist) {
+export default function (blacklistInput) {
+  // To allow for just a string as a parameter (not only arrays of strings)
+  const blacklist = [].concat(blacklistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: blacklist,
@@ -22,10 +24,11 @@ export default function (blacklist) {
     if (!validOptions) { return }
 
     root.walkAtRules(atRule => {
-      if (blacklist.indexOf(vendor.unprefixed(atRule.name).toLowerCase()) === -1) { return }
+      const { name } = atRule
+      if (blacklist.indexOf(vendor.unprefixed(name).toLowerCase()) === -1) { return }
 
       report({
-        message: messages.rejected(atRule.name),
+        message: messages.rejected(name),
         node: atRule,
         result,
         ruleName,

--- a/src/rules/at-rule-whitelist/README.md
+++ b/src/rules/at-rule-whitelist/README.md
@@ -26,7 +26,7 @@ The following patterns are considered warnings:
 
 ```css
 @media screen and (max-width: 1024px) {
-  ...
+  .a { display: none; }
 }
 ```
 

--- a/src/rules/at-rule-whitelist/README.md
+++ b/src/rules/at-rule-whitelist/README.md
@@ -1,0 +1,57 @@
+# at-rule-whitelist
+
+Specify a whitelist of allowed at-rules.
+
+```css
+    @keyframes name {}
+/** ↑
+ * At-rules like this */
+```
+
+## Options
+
+`array`: `"["array", "of", "unprefixed", "at-rules"]`
+
+Given:
+
+```js
+["extend", "keyframes"]
+```
+
+The following patterns are considered warnings:
+
+```css
+@import "path/to/file.css";
+```
+
+```css
+@media screen and (max-width: 1024px) {
+  ...
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { @extend placeholder; }
+```
+
+```css
+@keyframes name {
+  from { top: 10px; }
+  to { top: 20px; }
+}
+```
+
+```css
+@KEYFRAMES name {
+  from { top: 10px; }
+  to { top: 20px; }
+}
+```
+
+```css
+@-moz-keyframes name {
+  from { top: 10px; }
+  to { top: 20px; }
+}

--- a/src/rules/at-rule-whitelist/__tests__/index.js
+++ b/src/rules/at-rule-whitelist/__tests__/index.js
@@ -1,0 +1,131 @@
+import { testRule } from "../../../testUtils"
+import rule, { ruleName, messages } from ".."
+
+testRule(rule, {
+  ruleName,
+
+  config: [[
+    "extend",
+    "import",
+    "keyframes",
+  ]],
+
+  accept: [ {
+    code: "a { color: pink; }",
+    description: "Some random code.",
+  }, {
+    code: "a { @extend %placeholder; }",
+    description: "@rule from a whitelist, is a Sass directive.",
+  }, {
+    code: `
+      a {
+        @extend
+        %placeholder;
+      }
+    `,
+    description: "@rule from a whitelist; newline after its name.",
+  }, {
+    code: `
+      @keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule.",
+  }, {
+    code: `
+      @Keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule; messed case.",
+  }, {
+    code: `
+      @-moz-keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule; has vendor prefix.",
+  }, {
+    code: `
+      @-WEBKET-KEYFRAMES name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule; has vendor prefix.",
+  } ],
+
+  reject: [{
+    code: `
+      @mixin name () {}
+    `,
+    line: 2,
+    columt: 7,
+    message: messages.rejected("mixin"),
+    description: "@rule not from a whitelist; independent rule.",
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  skipBasicChecks: true,
+
+  config: ["keyframes"],
+
+  accept: [ {
+    code: `
+      @keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule.",
+  }, {
+    code: `
+      @Keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule; messed case.",
+  }, {
+    code: `
+      @-moz-keyframes name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule; has vendor prefix.",
+  }, {
+    code: `
+      @-WEBKET-KEYFRAMES name {
+        from { top: 10px; }
+        to { top: 20px; }
+      }
+    `,
+    description: "@rule from a whitelist; independent rule; has vendor prefix.",
+  } ],
+
+  reject: [ {
+    code: "@mixin name ($p) {}",
+    message: messages.rejected("mixin"),
+    line: 1,
+    column: 1,
+    description: "@rule not from a whitelist.",
+  }, {
+    code: "@import 'path/to/file.css';",
+    message: messages.rejected("import"),
+    line: 1,
+    column: 1,
+    description: "@rule not from a whitelist.",
+  }, {
+    code: "@media screen and (max-witdh: 1000px) {}",
+    message: messages.rejected("media"),
+    line: 1,
+    column: 1,
+    description: "@rule not from a whitelist.",
+  } ],
+})

--- a/src/rules/at-rule-whitelist/__tests__/index.js
+++ b/src/rules/at-rule-whitelist/__tests__/index.js
@@ -110,10 +110,12 @@ testRule(rule, {
   } ],
 
   reject: [ {
-    code: "@mixin name ($p) {}",
+    code: `
+      @mixin name ($p) {}
+    `,
     message: messages.rejected("mixin"),
-    line: 1,
-    column: 1,
+    line: 2,
+    column: 7,
     description: "@rule not from a whitelist.",
   }, {
     code: "@import 'path/to/file.css';",

--- a/src/rules/at-rule-whitelist/index.js
+++ b/src/rules/at-rule-whitelist/index.js
@@ -1,0 +1,38 @@
+import { isString } from "lodash"
+import { vendor } from "postcss"
+
+import {
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "at-rule-whitelist"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: (name) => `Unexpected at-rule "${name}"`,
+})
+
+export default function (whitelistInput) {
+  // To allow for just a string as a parameter (not only arrays of strings)
+  const whitelist = [].concat(whitelistInput)
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: whitelist,
+      possible: [isString],
+    })
+    if (!validOptions) { return }
+
+    root.walkAtRules(atRule => {
+      const { name } = atRule
+      if (whitelist.indexOf(vendor.unprefixed(name).toLowerCase()) !== -1) { return }
+
+      report({
+        message: messages.rejected(name),
+        node: atRule,
+        result,
+        ruleName,
+      })
+    })
+  }
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -5,6 +5,7 @@ import atRuleNameNewlineAfter from "./at-rule-name-newline-after"
 import atRuleNameSpaceAfter from "./at-rule-name-space-after"
 import atRuleNoVendorPrefix from "./at-rule-no-vendor-prefix"
 import atRuleSemicolonNewlineAfter from "./at-rule-semicolon-newline-after"
+import atRuleWhitelist from "./at-rule-whitelist"
 import blockClosingBraceNewlineAfter from "./block-closing-brace-newline-after"
 import blockClosingBraceNewlineBefore from "./block-closing-brace-newline-before"
 import blockClosingBraceSpaceAfter from "./block-closing-brace-space-after"
@@ -156,6 +157,7 @@ export default {
   "at-rule-name-space-after": atRuleNameSpaceAfter,
   "at-rule-no-vendor-prefix": atRuleNoVendorPrefix,
   "at-rule-semicolon-newline-after": atRuleSemicolonNewlineAfter,
+  "at-rule-whitelist": atRuleWhitelist,
   "block-closing-brace-newline-after": blockClosingBraceNewlineAfter,
   "block-closing-brace-newline-before": blockClosingBraceNewlineBefore,
   "block-closing-brace-space-after": blockClosingBraceSpaceAfter,

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,3 +1,4 @@
+import atRuleBlacklist from "./at-rule-blacklist"
 import atRuleEmptyLineBefore from "./at-rule-empty-line-before"
 import atRuleNameCase from "./at-rule-name-case"
 import atRuleNameNewlineAfter from "./at-rule-name-newline-after"
@@ -148,6 +149,7 @@ import valueListCommaSpaceBefore from "./value-list-comma-space-before"
 import valueNoVendorPrefix from "./value-no-vendor-prefix"
 
 export default {
+  "at-rule-blacklist": atRuleBlacklist,
   "at-rule-empty-line-before": atRuleEmptyLineBefore,
   "at-rule-name-case": atRuleNameCase,
   "at-rule-name-newline-after": atRuleNameNewlineAfter,


### PR DESCRIPTION
Implements [this](https://github.com/kristerkari/stylelint-scss/issues/30).

The rule is pretty simple, so it's quite fast.
```
> npm run benchmark-rule -- at-rule-blacklist "[\"keyframes\", \"mixin\"]"

Warnings: 3
Mean: 40.16598237096774 ms
Deviation: 10.709398564161553 ms
```

Upd: added `at-rule-whitelist`, benchmark results:
```
> npm run benchmark-rule -- at-rule-whitelist "[\"keyframes\", \"mixin\"]"

Warnings: 70
Mean: 38.29609341406251 ms
Deviation: 11.236083995586682 ms
```