### PR TITLE
Set default column width when stdout.columns is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed: selector-targeting rules ignore Less mixins and extends.
 - Fixed: `selector-type-no-unknown` ignores non-standard usage of percentage keyframe selectors (e.g. within an SCSS mixin).
 - Fixed: `no-extra-semicolons` reports errors on the correct line.
+- Fixed: crash when tty columns is reported as zero (fixes running stylelint on Travis CI using OSX)
 
 # 6.5.1
 

--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -52,7 +52,7 @@ function getMessageWidth(columnWidths) {
     return columnWidths[3]
   }
 
-  const availableWidth = process.stdout.columns
+  const availableWidth = process.stdout.columns || 80
   const fullWidth = _.sum(_.values(columnWidths))
 
   // If there is no reason to wrap the text, we won't align the last column to the right


### PR DESCRIPTION
Fixes #1405.

OSX on Travis reports `process.stdout.columns` and `rows` as 0, so it causes a "Error: Column width must be greater than 0." crash.