### PR TITLE
Add `ignore: "blockless-group"` option for `at-rule-empty-line-before`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: option `ignorePath` (for JS) and `--ignore-path` (for CLI).
 - Added: `at-rule-name-newline-after` rule.
+- Added: `ignore: "blockless-group"` option for `at-rule-empty-line-before`.
 - Fixed: `selector-combinator-space-*` rules now ignore escaped combinator-like characters.
 - Fixed: `function-whitespace-after` ignores `postcss-simple-vars`-style interpolation.
 - Fixed: `function-url-quotes` ignores values containing `$sass` and `@less` variables.

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -121,6 +121,23 @@ testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { ignore: ["blockless-group"] } ],
+
+  accept: [{
+    code: "@media {}; @import 'x.css';",
+  }],
+
+  reject: [ {
+    code: "@import 'x.css'; @media {};",
+    message: messages.expected,
+  }, {
+    code: "@import 'test'; @include mixin(1) { @content; };",
+    message: messages.expected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { ignore: ["after-comment"] } ],
 
   accept: [ {
@@ -295,6 +312,36 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
     message: messages.expected,
   } ],
 }))
+
+testRule(rule, {
+  ruleName,
+  config: [ "never", { ignore: ["blockless-group"] } ],
+
+  accept: [ {
+    code: `
+      @media {};
+
+      @import 'x.css';
+    `,
+  }, {
+    code: `
+      @import 'x.css';
+
+      @import 'y.css';
+    `,
+  } ],
+
+  reject: [{
+    code: `
+      @import 'x.css';
+
+      @media {};
+    `,
+    message: messages.rejected,
+    line: 4,
+    column: 7,
+  }],
+})
 
 testRule(rule, {
   ruleName,

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -23,7 +23,7 @@ export default function (expectation, options) {
       actual: options,
       possible: {
         except: [ "blockless-group", "first-nested", "all-nested" ],
-        ignore: [ "after-comment", "all-nested" ],
+        ignore: [ "blockless-group", "after-comment", "all-nested" ],
       },
       optional: true,
     })
@@ -34,6 +34,10 @@ export default function (expectation, options) {
       // Ignore the first node
       if (atRule === root.first) { return }
 
+      // Optionally ignore the expectation if the node is blockless
+      if (optionsHaveIgnored(options, "blockless-group") && !hasBlock(atRule)) { return }
+
+      // Optionally ignore the expectation if the node is nested
       const isNested = atRule.parent !== root
       if (optionsHaveIgnored(options, "all-nested") && isNested) { return }
 


### PR DESCRIPTION
Closes #1413

(Cleaned follow-up PR for #1415)