### PR TITLE
Use consistent options for white/blacklist rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added: `at-rule-name-newline-after` rule.
 - Added: `at-rule-blacklist` rule.
 - Added: `at-rule-whitelist` rule.
+- Added: `function-blacklist` now accepts regular expressions.
+- Added: `function-whitelist` now accepts regular expressions.
 - Added: `ignore: "blockless-group"` option for `at-rule-empty-line-before`.
 - Added: `ignoreAtRules: []` option for `at-rule-empty-line-before`.
 - Fixed: `selector-combinator-space-*` rules now ignore escaped combinator-like characters.

--- a/src/rules/at-rule-blacklist/README.md
+++ b/src/rules/at-rule-blacklist/README.md
@@ -10,7 +10,7 @@ Specify a blacklist of disallowed at-rules.
 
 ## Options
 
-`array`: `"["array", "of", "unprefixed", "at-rules"]`
+`array|string`: `"["array", "of", "unprefixed", "at-rules"]|"at-rule"`
 
 Given:
 

--- a/src/rules/at-rule-whitelist/README.md
+++ b/src/rules/at-rule-whitelist/README.md
@@ -10,7 +10,7 @@ Specify a whitelist of allowed at-rules.
 
 ## Options
 
-`array`: `"["array", "of", "unprefixed", "at-rules"]`
+`array|string`: `"["array", "of", "unprefixed", "at-rules"]|"at-rule"`
 
 Given:
 

--- a/src/rules/comment-word-blacklist/README.md
+++ b/src/rules/comment-word-blacklist/README.md
@@ -10,7 +10,9 @@ Specify a blacklist of disallowed words within comments.
 
 ## Options
 
-`array`: `["array", "of", "words", "or", "/regex/" ]`
+`array|string`: `["array", "of", "words", "or", "/regex/"]|"word"|"/regex/"`
+
+If a string is surrounded with `"/"` (e.g. `"/^TODO:/"`), it is interpreted as a regular expression.
 
 Given:
 

--- a/src/rules/comment-word-blacklist/__tests__/index.js
+++ b/src/rules/comment-word-blacklist/__tests__/index.js
@@ -6,6 +6,30 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
+  config: ["bad-word"],
+
+  accept: [ {
+    code: "/* comment */",
+  }, {
+    code: "/*! bad-word */",
+  }, {
+    code: "/*# bad-word */",
+  }, {
+    code: "/** bad-word **/",
+  }, {
+    code: "/*** bad-word ***/",
+  } ],
+
+  reject: [{
+    code: "/* bad-word */",
+    message: messages.rejected("bad-word"),
+    line: 1,
+    column: 1,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
   config: [[
     "/^TODO:/",
     "bad-word",

--- a/src/rules/function-blacklist/README.md
+++ b/src/rules/function-blacklist/README.md
@@ -10,7 +10,9 @@ a { transform: scale(1); }
 
 ## Options
 
-`array`: `"["array", "of", "unprefixed", "functions"]`
+`array|string`: `["array", "of", "unprefixed", "functions" or "regex"]|"function"|"/regex/"`
+
+If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
 
 Given:
 

--- a/src/rules/function-blacklist/__tests__/index.js
+++ b/src/rules/function-blacklist/__tests__/index.js
@@ -89,3 +89,25 @@ testRule(rule, {
     column: 45,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+
+  config: ["/rgb/"],
+
+  accept: [{
+    code: "a { color: hsl(208, 100%, 97%); }",
+  }],
+
+  reject: [ {
+    code: "a { color: rgb(0, 0, 0); }",
+    message: messages.rejected("rgb"),
+    line: 1,
+    column: 12,
+  }, {
+    code: "a { color: rgba(0, 0, 0); }",
+    message: messages.rejected("rgba"),
+    line: 1,
+    column: 12,
+  } ],
+})

--- a/src/rules/function-blacklist/index.js
+++ b/src/rules/function-blacklist/index.js
@@ -5,6 +5,7 @@ import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   isStandardSyntaxFunction,
+  matchesStringOrRegExp,
   report,
   ruleMessages,
   validateOptions,
@@ -28,7 +29,7 @@ export default function (blacklist) {
       valueParser(value).walk(function (node) {
         if (node.type !== "function") { return }
         if (!isStandardSyntaxFunction(node)) { return }
-        if (blacklist.indexOf(vendor.unprefixed(node.value).toLowerCase()) === -1) { return }
+        if (!matchesStringOrRegExp(vendor.unprefixed(node.value).toLowerCase(), blacklist)) { return }
 
         report({
           message: messages.rejected(node.value),

--- a/src/rules/function-whitelist/README.md
+++ b/src/rules/function-whitelist/README.md
@@ -10,7 +10,9 @@ a { transform: scale(1); }
 
 ## Options
 
-`array`: `["array", "of", "unprefixed", "functions"]`
+`array|string`: `["array", "of", "unprefixed", "functions" or "regex"]|"function"|"/regex/"`
+
+If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
 
 Given:
 

--- a/src/rules/function-whitelist/__tests__/index.js
+++ b/src/rules/function-whitelist/__tests__/index.js
@@ -108,3 +108,22 @@ testRule(rule, {
     column: 16,
   }],
 })
+
+testRule(rule, {
+  ruleName,
+
+  config: ["/rgb/"],
+
+  accept: [ {
+    code: "a { color: rgb(0, 0, 0); }",
+  }, {
+    code: "a { color: rgba(0, 0, 0, 0); }",
+  } ],
+
+  reject: [{
+    code: "a { color: hsl(208, 100%, 97%); }",
+    message: messages.rejected("hsl"),
+    line: 1,
+    column: 12,
+  }],
+})

--- a/src/rules/function-whitelist/index.js
+++ b/src/rules/function-whitelist/index.js
@@ -5,6 +5,7 @@ import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   isStandardSyntaxFunction,
+  matchesStringOrRegExp,
   report,
   ruleMessages,
   validateOptions,
@@ -29,7 +30,7 @@ export default function (whitelistInput) {
       valueParser(value).walk(function (node) {
         if (node.type !== "function") { return }
         if (!isStandardSyntaxFunction(node)) { return }
-        if (whitelist.indexOf(vendor.unprefixed(node.value).toLowerCase()) !== -1) { return }
+        if (matchesStringOrRegExp(vendor.unprefixed(node.value).toLowerCase(), whitelist)) { return }
         report({
           message: messages.rejected(node.value),
           node: decl,

--- a/src/rules/property-blacklist/README.md
+++ b/src/rules/property-blacklist/README.md
@@ -10,13 +10,9 @@ a { text-rendering: optimizeLegibility; }
 
 ## Options
 
-`array`: `"["array", "of", "unprefixed", "properties"]`
+`array|string`: `["array", "of", "unprefixed", "properties" or "regex"]|"property"|"/regex/"`
 
-### `["array", "of", "unprefixed", properties"]`
-
-Blacklisted properties *must never* be used.
-
-If a string in the array is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
+If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 
 Given:
 

--- a/src/rules/property-blacklist/__tests__/index.js
+++ b/src/rules/property-blacklist/__tests__/index.js
@@ -84,9 +84,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
 
-  config: [[
-    "/margin/",
-  ]],
+  config: ["/margin/"],
 
   accept: [ {
     code: "a { $margin: 0; }",

--- a/src/rules/property-blacklist/index.js
+++ b/src/rules/property-blacklist/index.js
@@ -15,8 +15,7 @@ export const messages = ruleMessages(ruleName, {
   rejected: (property) => `Unexpected property "${property}"`,
 })
 
-export default function (blacklistInput) {
-  const blacklist = [].concat(blacklistInput)
+export default function (blacklist) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: blacklist,

--- a/src/rules/property-whitelist/README.md
+++ b/src/rules/property-whitelist/README.md
@@ -12,16 +12,9 @@ This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
 ## Options
 
-`array`: `"["array", "of", "unprefixed", "properties"]`
+`array|string`: `["array", "of", "unprefixed", "properties" or "regex"]|"property"|"/regex/"`
 
-### `["array", "of", "unprefixed", properties"]`
-
-Whitelisted properties are the only *allowed* properties.
-
-If a string in the array is surrounded with `"/"` (e.g. `"/^background/"`),
-it is interpreted as a regular expression. This allows, for example,
-easy targeting of shorthands: `/^background/` will match `background`,
-`background-size`, `background-color`, etc.
+If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 
 Given:
 

--- a/src/rules/property-whitelist/__tests__/index.js
+++ b/src/rules/property-whitelist/__tests__/index.js
@@ -85,9 +85,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
 
-  config: [[
-    "/margin/",
-  ]],
+  config: ["/margin/"],
 
   accept: [ {
     code: "a { $padding: 0; }",

--- a/src/rules/property-whitelist/index.js
+++ b/src/rules/property-whitelist/index.js
@@ -15,8 +15,7 @@ export const messages = ruleMessages(ruleName, {
   rejected: (property) => `Unexpected property "${property}"`,
 })
 
-export default function (whitelistInput) {
-  const whitelist = [].concat(whitelistInput)
+export default function (whitelist) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: whitelist,

--- a/src/rules/selector-attribute-operator-blacklist/README.md
+++ b/src/rules/selector-attribute-operator-blacklist/README.md
@@ -10,11 +10,7 @@ a[target="_blank"] { }
 
 ## Options
 
-`array`: `"["array", "of", "operators"]`
-
-### `["array", "of", "operators"]`
-
-Blacklisted attribute operators *must never* be used.
+`array|string`: `"["array", "of", "operators"]|"operator"`
 
 Given:
 

--- a/src/rules/selector-attribute-operator-whitelist/README.md
+++ b/src/rules/selector-attribute-operator-whitelist/README.md
@@ -10,11 +10,7 @@ a[target="_blank"] { }
 
 ## Options
 
-`array`: `"["array", "of", "operators"]`
-
-### `["array", "of", "operators"]`
-
-Whitelisted attribute operators are the only *allowed* attribute operators.
+`array|string`: `"["array", "of", "operators"]|"operator"`
 
 Given:
 


### PR DESCRIPTION
- Added regex support to `function-whitelist` and `function-blacklist`. 
- Updated the all the black/whitelist READMEs to show that they all accept single strings.
- Clearly show if a rule supports regex.
- Tweak few other tests to show the single string options work.