### PR TITLE
New rule `no-empty-source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Deprecated: `-e` and `--extract` CLI flags, and the `extractStyleTagsFromHtml` node API option. If you use these flags or option, please consider creating a processor for the community. See the [release planning](/docs/user-guide/release-planning.md) document for more details.
 - Added: `ignoreProperties: []` option for `declaration-block-no-duplicate-properties`.
+- Added: `no-empty-source` rule.
 
 # 6.7.1
 

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -93,6 +93,7 @@ You might want to learn a little about [how rules are named and how they work to
     "no-browser-hacks": true,
     "no-descending-specificity": true,
     "no-duplicate-selectors": true,
+    "no-empty-source": true,
     "no-eol-whitespace": true,
     "no-extra-semicolons": true,
     "no-indistinguishable-colors": true,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -240,6 +240,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 - [`no-browser-hacks`](../../src/rules/no-browser-hacks/README.md): Disallow browser hacks that are irrelevant to the browsers you are targeting.
 - [`no-descending-specificity`](../../src/rules/no-descending-specificity/README.md): Disallow selectors of lower specificity from coming after overriding selectors of higher specificity.
 - [`no-duplicate-selectors`](../../src/rules/no-duplicate-selectors/README.md): Disallow duplicate selectors.
+- [`no-empty-source`](../../src/rules/no-empty-source/README.md): Disallow empty sources.
 - [`no-eol-whitespace`](../../src/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
 - [`no-extra-semicolons`](../../src/rules/no-extra-semicolons/README.md): Disallow extra semicolons.
 - [`no-indistinguishable-colors`](../../src/rules/no-indistinguishable-colors/README.md): Disallow colors that are suspiciously close to being identical.

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -30,6 +30,7 @@ import customPropertyPattern from "./custom-property-pattern"
 import declarationBangSpaceAfter from "./declaration-bang-space-after"
 import declarationBangSpaceBefore from "./declaration-bang-space-before"
 import declarationBlockNoDuplicateProperties from "./declaration-block-no-duplicate-properties"
+import noEmptySource from "./no-empty-source"
 import declarationBlockNoIgnoredProperties from "./declaration-block-no-ignored-properties"
 import declarationBlockNoShorthandPropertyOverrides from "./declaration-block-no-shorthand-property-overrides"
 import declarationBlockPropertiesOrder from "./declaration-block-properties-order"
@@ -241,6 +242,7 @@ export default {
   "no-browser-hacks": noBrowserHacks,
   "no-descending-specificity": noDescendingSpecificity,
   "no-duplicate-selectors": noDuplicateSelectors,
+  "no-empty-source": noEmptySource,
   "no-eol-whitespace": noEolWhitespace,
   "no-extra-semicolons": noExtraSemicolons,
   "no-indistinguishable-colors": noIndistinguishableColors,

--- a/src/rules/no-empty-source/README.md
+++ b/src/rules/no-empty-source/README.md
@@ -1,0 +1,35 @@
+# no-empty-source
+
+Disallow empty sources.
+
+```css
+  ···\n\t
+/**     ↑
+ *  This empty source */
+```
+
+A source containing only whitespace is considered empty.
+
+The following patterns are considered warnings:
+
+```css
+
+```
+
+```css
+\t\t
+```
+
+```css
+\n
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+.class { }
+```
+
+```css
+/* Only comments */
+```

--- a/src/rules/no-empty-source/__tests__/index.js
+++ b/src/rules/no-empty-source/__tests__/index.js
@@ -1,0 +1,82 @@
+import {
+  messages,
+  ruleName,
+} from ".."
+import rules from "../../../rules"
+import { testRule } from "../../../testUtils"
+
+const rule = rules[ruleName]
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: ".class { }",
+  }, {
+    code: "   .class { }   ",
+  }, {
+    code: "/* comment */",
+  }, {
+    code: "\n.class {}",
+  }, {
+    code: "\r\n.class {}",
+  } ],
+
+  reject: [ {
+    code: "",
+    description: "empty source",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "   ",
+    description: "source with spaces",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "\t",
+    description: "source with tab",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "\n",
+    description: "source with newline",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  },  {
+    code: "\r\n",
+    description: "source with newline",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "\n\n\n",
+    description: "source with multiple newline",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "\r\n\r\n\r\n",
+    description: "source with multiple newline",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "  \n  ",
+    description: "source with spaces and newline",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "  \r\n  ",
+    description: "source with spaces and newline",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  } ],
+})

--- a/src/rules/no-empty-source/index.js
+++ b/src/rules/no-empty-source/index.js
@@ -1,0 +1,27 @@
+import {
+  ruleMessages,
+  report,
+  validateOptions,
+} from "../../utils"
+
+export const ruleName = "no-empty-source"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: "Unexpected empty source",
+})
+
+export default function (actual) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, { actual })
+    if (!validOptions) { return }
+
+    if (!(/^\s*$/).test(root.toString())) { return }
+
+    report({
+      message: messages.rejected,
+      node: root,
+      result,
+      ruleName,
+    })
+  }
+}


### PR DESCRIPTION
I think we should change name for this rule, because this rule work too on 
```html
<style></style>
``` 

and it is no file, maybe rename `no-empty-stylesheet`. Also i think be good add option `ignoreComment`, maybe something check only empty files, another check empty files with comments.
/cc @davidtheclark @jeddy3 