### PR TITLE
Expand plugin docs

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -68,9 +68,11 @@ export default stylelint.createPlugin(ruleName, function (expectation) {
 
 In addition to the standard parsers mentioned in the ["Working on rules"](/docs/developer-guide/rules.md) doc, there are other external modules used within stylelint that we recommend using. These include:
 
+- [normalize-selector](https://github.com/getify/normalize-selector) - Normalize CSS selectors.
+- [postcss-resolve-nested-selector](https://github.com/davidtheclark/postcss-resolve-nested-selector) - Given a (nested) selector in a PostCSS AST, return an array of resolved selectors.
 - [style-search](https://github.com/davidtheclark/style-search) - Search CSS (and CSS-like) strings, with sensitivity to whether matches occur inside strings, comments, and functions.
 
-Have a look through the [stylelint's internal utils](https://github.com/stylelint/stylelint/tree/master/src/utils) and if you come across one that you need in your plugin, then please consider helping us extract it out into a external module.
+Have a look through [stylelint's internal utils](https://github.com/stylelint/stylelint/tree/master/src/utils) and if you come across one that you need in your plugin, then please consider helping us extract it out into a external module.
 
 ## Testing plugins
 


### PR DESCRIPTION
Closes #1365

As well as starting the list of external modules and adding a call-to-help extracting utils out, this PR:

- emphases adhering to the “working on rules” conventions.
- expands the plugin example to include the exposed utils.
- remove redundancy between this doc and the “working on rules” one.