### PR TITLE
Add primary option to -no- rule READMEs

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -118,9 +118,9 @@ Each rule must be accompanied by a README, fitting the following format:
 
 1. Rule name.
 2. Single line description.
-3. Prototypical code example (if necessary).
+3. Prototypical code example.
 4. Expanded description (if necessary).
-5. Options (if applicable).
+5. Options.
 6. Example patterns that are considered warnings (for each option value).
 7. Example patterns that are *not* considered warnings (for each option value).
 8. Optional options (if applicable).

--- a/src/rules/at-rule-no-vendor-prefix/README.md
+++ b/src/rules/at-rule-no-vendor-prefix/README.md
@@ -8,6 +8,10 @@ Disallow vendor prefixes for at-rules.
  * These prefixes */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/block-no-empty/README.md
+++ b/src/rules/block-no-empty/README.md
@@ -8,6 +8,10 @@ Disallow empty blocks.
  * Blocks like this */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/block-no-single-line/README.md
+++ b/src/rules/block-no-single-line/README.md
@@ -8,6 +8,10 @@ Disallow single-line blocks.
  * Declaration blocks like this */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/color-no-hex/README.md
+++ b/src/rules/color-no-hex/README.md
@@ -8,6 +8,10 @@ a { color: #333 }
  * These hex colors */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/color-no-invalid-hex/README.md
+++ b/src/rules/color-no-invalid-hex/README.md
@@ -10,6 +10,10 @@ a { color: #y3 }
 
 Longhand hex colors can be either 6 or 8 (with alpha channel) hexadecimal characters. And their shorthand variants are 3 and 4 characters respectively.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/custom-property-no-outside-root/README.md
+++ b/src/rules/custom-property-no-outside-root/README.md
@@ -8,6 +8,10 @@ Disallow custom properties outside of `:root` rules.
  * These selectors and these types of custom properties */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/declaration-block-no-duplicate-properties/README.md
+++ b/src/rules/declaration-block-no-duplicate-properties/README.md
@@ -10,6 +10,10 @@ a { color: pink; color: orange; }
 
 This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/declaration-block-no-ignored-properties/README.md
+++ b/src/rules/declaration-block-no-ignored-properties/README.md
@@ -27,6 +27,10 @@ The rule warns when it finds:
 - `position: absolute` used with `float`, `clear` or `vertical-align`.
 - `position: fixed` used with `float`, `clear` or `vertical-align`.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/declaration-block-no-shorthand-property-overrides/README.md
+++ b/src/rules/declaration-block-no-shorthand-property-overrides/README.md
@@ -10,6 +10,10 @@ a { background-repeat: repeat; background: green; }
 
 In almost every case, this is just an authorial oversight. For more about this behavior, see [MDN's documentation of shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties).
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/declaration-no-important/README.md
+++ b/src/rules/declaration-no-important/README.md
@@ -10,6 +10,10 @@ a { color: pink !important; }
 
 If you always want `!important` in your declarations, e.g. if you're writing [user styles](https://userstyles.org/), you can *safely* add them using [`postcss-safe-important`](https://github.com/crimx/postcss-safe-important).
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/function-calc-no-unspaced-operator/README.md
+++ b/src/rules/function-calc-no-unspaced-operator/README.md
@@ -10,6 +10,10 @@ a { top: calc(1px + 2px); }
 
 Before the operator, there must be a single whitespace or a newline plus indentation. After the operator, there must be a single whitespace or a newline.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/keyframe-declaration-no-important/README.md
+++ b/src/rules/keyframe-declaration-no-important/README.md
@@ -11,6 +11,10 @@ Disallow `!important` within keyframe declarations.
 *     This !important */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/src/rules/media-feature-name-no-vendor-prefix/README.md
@@ -10,6 +10,10 @@ Disallow vendor prefixes for media feature names.
 
 Right now this rule simply checks for prefixed *resolutions*.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/media-feature-no-missing-punctuation/README.md
+++ b/src/rules/media-feature-no-missing-punctuation/README.md
@@ -10,6 +10,10 @@ Disallow missing punctuation for non-boolean media features.
 
 This rule ensures that there is either a colon or a range operator in non-boolean media features.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/no-browser-hacks/README.md
+++ b/src/rules/no-browser-hacks/README.md
@@ -16,11 +16,9 @@ This rule uses [stylehacks](https://github.com/ben-eb/stylehacks) to detect the 
 
 Bugs and feature requests should be reported on the [stylehacks issue tracker](https://github.com/ben-eb/stylehacks/issues).
 
-## Optional Options
+## Options
 
-### `browsers: "browserslist string"`
-
-A string interpreted by [browserslist](https://github.com/ai/browserslist) that designates precisely which browsers you wish to support. Something like `"> 1%, last 2 versions, ie >= 8"`. For details about the syntax (which is the same as when using Autoprefixer, by the way), please read [the browserslist documentation](https://github.com/ai/browserslist).
+### `true`
 
 Defaults to the browserslist default, which targets modern browsers.
 
@@ -30,4 +28,10 @@ For example, with the default settings, the following, which targets IE7-8, is c
 .foo { color/*\**/: pink\9; }
 ```
 
-But if you set `browsers: [ "last 2 versions", "ie >=7" ]` the hack above is allowed.
+## Optional Options
+
+### `browsers: "browserslist string"`
+
+A string interpreted by [browserslist](https://github.com/ai/browserslist) that designates precisely which browsers you wish to support. Something like `"> 1%, last 2 versions, ie >= 8"`. For details about the syntax (which is the same as when using Autoprefixer, by the way), please read [the browserslist documentation](https://github.com/ai/browserslist).
+
+If you set `browsers: [ "last 2 versions", "ie >=7" ]` the hack above is allowed.

--- a/src/rules/no-descending-specificity/README.md
+++ b/src/rules/no-descending-specificity/README.md
@@ -24,6 +24,10 @@ This rule only compares rules that are within the same media context. So `a {} @
 
 This rule resolves nested selectors before calculating the specificity of the selectors.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/no-duplicate-selectors/README.md
+++ b/src/rules/no-duplicate-selectors/README.md
@@ -21,6 +21,10 @@ The same selector *is* allowed to repeat in the following circumstances:
 
 This rule resolves nested selectors. So `a b {} a { & b {} }` counts as a warning, because the resolved selectors end up with a duplicate.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/no-eol-whitespace/README.md
+++ b/src/rules/no-eol-whitespace/README.md
@@ -8,6 +8,10 @@ a { color: pink; }···
  *  This whitespace */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/no-extra-semicolons/README.md
+++ b/src/rules/no-extra-semicolons/README.md
@@ -8,6 +8,10 @@ a { color: pink;; }
  *  This semicolons */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css
@@ -21,19 +25,19 @@ The following patterns are considered warnings:
 
 ```css
 .foo {
-  color: pink;; 
+  color: pink;;
 }
 ```
 
 ```css
 .foo {
-  ;color: pink; 
+  ;color: pink;
 }
 ```
 
 ```css
 .foo {
-  color: pink; 
+  color: pink;
   ;
 }
 ```

--- a/src/rules/no-indistinguishable-colors/README.md
+++ b/src/rules/no-indistinguishable-colors/README.md
@@ -16,9 +16,27 @@ For more details about how css-colorguard works, please read [that module's docu
 
 Bugs and feature requests should be reported on the [css-colorguard issue tracker](https://github.com/SlexAxton/css-colorguard/issues).
 
-The options below directly correspond to the css-colorguard options.
+## Options
+
+### `true`
+
+Defaults to css-colorguard's default threshold of `3`.
+
+The following patterns are considered warnings:
+
+```css
+a { color: black; background: #010101; }
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a { color: black; background: #FFF; }
+```
 
 ## Optional Options
+
+The options below directly correspond to the css-colorguard options.
 
 ### `threshold: number`
 

--- a/src/rules/no-invalid-double-slash-comments/README.md
+++ b/src/rules/no-invalid-double-slash-comments/README.md
@@ -10,6 +10,10 @@ a { // color: pink; }
 
 If you are using a preprocessor that allows `//` single-line comments (e.g. Sass, Less, Stylus), this rule will not complain about those. They are compiled into standard CSS comments by your preprocessor, so stylelint will consider them valid. This rule only complains about the lesser-known method of using `//` to "comment out" a single line of code in regular CSS. (If you didn't know this was possible, have a look at ["Single Line Comments (//) in CSS"](http://www.xanthir.com/b4U10)).
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/no-missing-eof-newline/README.md
+++ b/src/rules/no-missing-eof-newline/README.md
@@ -9,6 +9,10 @@ Disallow missing end-of-file newlines in non-empty files.
  * This newline */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/no-unknown-animations/README.md
+++ b/src/rules/no-unknown-animations/README.md
@@ -12,6 +12,10 @@ Disallow animation names that do not correspond to a `@keyframes` declaration.
  *           And this one */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/no-unsupported-browser-features/README.md
+++ b/src/rules/no-unsupported-browser-features/README.md
@@ -14,13 +14,9 @@ This rule uses [doiuse](https://github.com/anandthakker/doiuse) to detect browse
 
 Bugs and feature requests should be reported on the [doiuse issue tracker](https://github.com/anandthakker/doiuse/issues).
 
-## Optional Options
+## Options
 
-These options are passed directly to doiuse.
-
-### `browsers: "browserslist string"`
-
-A string interpreted by [browserslist](https://github.com/ai/browserslist) that designates precisely which browsers you wish to support. Something like `"> 1%, last 2 versions, ie >= 8"`. For details about the syntax (which is the same as when using Autoprefixer, by the way), please read [the browserslist documentation](https://github.com/ai/browserslist).
+### `true`
 
 Defaults to the doiuse default, which is `"> 1%, last 2 versions, Firefox ESR, Opera 12.1"`.
 
@@ -30,7 +26,15 @@ For example, with the default settings, the following is considered a warning, b
 .foo { opacity: 0.5; }
 ```
 
-But if you set `browsers: "last 2 versions, ie >=9"` the declaration above is allowed.
+## Optional Options
+
+These options are passed directly to doiuse.
+
+### `browsers: "browserslist string"`
+
+A string interpreted by [browserslist](https://github.com/ai/browserslist) that designates precisely which browsers you wish to support. Something like `"> 1%, last 2 versions, ie >= 8"`. For details about the syntax (which is the same as when using Autoprefixer, by the way), please read [the browserslist documentation](https://github.com/ai/browserslist).
+
+If you set `browsers: "last 2 versions, ie >=9"` the declaration above is allowed.
 
 ### `ignore: [ "array", "of", "features", "to", "ignore" ]`
 

--- a/src/rules/number-no-trailing-zeros/README.md
+++ b/src/rules/number-no-trailing-zeros/README.md
@@ -8,6 +8,10 @@ a { top: 0.5000px; bottom: 1.0px; }
  *        These trailing zeros */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/number-zero-length-no-unit/README.md
+++ b/src/rules/number-zero-length-no-unit/README.md
@@ -10,6 +10,10 @@ a { top: 0px; }
 
 *Lengths* refer to distance measurements. A length is a *dimension*, which is a *number* immediately followed by a *unit identifier*. However, for zero lengths the unit identifier is optional. The length units are: `em`, `ex`, `ch`, `vw`, `vh`, `cm`, `mm`, `in`, `pt`, `pc`, `px`, `rem`, `vmin`, and `vmax`.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/property-no-vendor-prefix/README.md
+++ b/src/rules/property-no-vendor-prefix/README.md
@@ -10,6 +10,10 @@ a { -webkit-transform: scale(1); }
 
 This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a warning or not. *If you've included a vendor prefixed property that has a standard alternative, one that Autoprefixer could take care of for you, this rule will warn about it*. If, however, you use a non-standard vendor-prefixed property, one that Autoprefixer would ignore and could not provide (such as `-webkit-touch-callout`), this rule will ignore it.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/root-no-standard-properties/README.md
+++ b/src/rules/root-no-standard-properties/README.md
@@ -10,6 +10,10 @@ Disallow standard properties inside `:root` rules.
 
 This rule ignores `$sass` and `@less` variables.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-no-attribute/README.md
+++ b/src/rules/selector-no-attribute/README.md
@@ -8,6 +8,10 @@ Disallow attribute selectors.
  * This type of selector */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-no-combinator/README.md
+++ b/src/rules/selector-no-combinator/README.md
@@ -10,6 +10,10 @@ Disallow combinators in selectors.
 
 Combinators are used to combine several different selectors into new and more specific ones. There are several types of combinators, including: child (`>`), adjacent sibling (`+`), general sibling (`~`), and descendant (which is represented by a blank space between two selectors).
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-no-id/README.md
+++ b/src/rules/selector-no-id/README.md
@@ -8,6 +8,10 @@ Disallow id selectors.
  * This type of selector */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-no-qualifying-type/README.md
+++ b/src/rules/selector-no-qualifying-type/README.md
@@ -10,6 +10,10 @@ Disallow qualifying a selector by type.
 
 A type selector is "qualifying" when it is compounded with (chained to) another selector (e.g. a.foo, a#foo). This rule does not regulate type selectors that are combined with other selectors via a combinator (e.g. a > .foo, a #foo).
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-no-type/README.md
+++ b/src/rules/selector-no-type/README.md
@@ -8,6 +8,10 @@ Disallow type selectors.
  * This type of selector */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-no-universal/README.md
+++ b/src/rules/selector-no-universal/README.md
@@ -8,6 +8,10 @@ Disallow the universal selector.
  * This selector */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-no-vendor-prefix/README.md
+++ b/src/rules/selector-no-vendor-prefix/README.md
@@ -10,6 +10,10 @@ input::-moz-placeholder {}
 
 This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a warning or not. *If you've included a vendor prefixed selector that has a standard alternative, one that Autoprefixer could take care of for you, this rule will warn about it*. If, however, you use a non-standard vendor-prefixed selector, one that Autoprefixer would ignore and could not provide, this rule will ignore it.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-pseudo-class-no-unknown/README.md
+++ b/src/rules/selector-pseudo-class-no-unknown/README.md
@@ -10,6 +10,10 @@ Disallow unknown pseudo-class selectors.
 
 All vendor-prefixes pseudo-class selectors are ignored.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-pseudo-element-no-unknown/README.md
+++ b/src/rules/selector-pseudo-element-no-unknown/README.md
@@ -10,6 +10,10 @@ Disallow unknown pseudo-element selectors.
 
 All vendor-prefixes pseudo-element selectors are ignored.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-root-no-composition/README.md
+++ b/src/rules/selector-root-no-composition/README.md
@@ -8,6 +8,10 @@ Disallow the composition of `:root` in selectors.
  * This type of composite selector */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/selector-type-no-unknown/README.md
+++ b/src/rules/selector-type-no-unknown/README.md
@@ -8,6 +8,10 @@ Disallow unknown type selectors.
  * This type selector */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/shorthand-property-no-redundant-values/README.md
+++ b/src/rules/shorthand-property-no-redundant-values/README.md
@@ -17,6 +17,10 @@ This rule warns you when you use redundant values in the following shorthand pro
 - `border-style`
 - `border-width`
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/string-no-newline/README.md
+++ b/src/rules/string-no-newline/README.md
@@ -13,6 +13,10 @@ a {
 
 [The spec](https://www.w3.org/TR/CSS2/syndata.html#strings) says this: "A string cannot directly contain a newline. To include a newline in a string, use an escape representing the line feed character in ISO-10646 (U+000A), such as \"\A\" or \"\00000a\"." And also: "It is possible to break strings over several lines, for aesthetic or other reasons, but in such a case the newline itself has to be escaped with a backslash (\)."
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/time-no-imperceptible/README.md
+++ b/src/rules/time-no-imperceptible/README.md
@@ -10,6 +10,10 @@ Disallow `animation` and `transition` less than or equal to 100ms.
 
 This rule checks `transition-duration`, `transition-delay`, `animation-duration`, `animation-delay`, and those times as they manifest in the `transition` and `animation` shorthands.
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/unit-no-unknown/README.md
+++ b/src/rules/unit-no-unknown/README.md
@@ -8,6 +8,10 @@ a { width: 100pixels; }
  *  These units */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css

--- a/src/rules/value-no-vendor-prefix/README.md
+++ b/src/rules/value-no-vendor-prefix/README.md
@@ -8,6 +8,10 @@ Disallow vendor prefixes for values.
  *  These prefixes */
 ```
 
+## Options
+
+### `true`
+
 The following patterns are considered warnings:
 
 ```css


### PR DESCRIPTION
Closes #1380

I think this was worth doing as it clarifies that, unlike `eslint`, *all* rules require a primary option. And that primary option might be `true` or `false`.

I think it also helps make the options for the wrapping-rules (e.g. `no-browser-hacks` etc) clearer.