### PR TITLE
Ensure one or more newlines are accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Fixed: `no-extra-semicolons` reports errors on the correct line.
 - Fixed: crash when tty columns is reported as zero, which happened when running stylelint on Travis CI in OSX.
 - Fixed: `indentation` better understands nested parentheticals, like nested Sass maps.
+- Fixed: `at-rule-name-newline-after` now correctly accepts one *or more* newlines.
+- Fixed: `declaration-block-semicolon-newline-before` now correctly accepts one *or more* newlines.
 
 # 6.5.1
 

--- a/src/rules/at-rule-name-newline-after/__tests__/index.js
+++ b/src/rules/at-rule-name-newline-after/__tests__/index.js
@@ -65,6 +65,12 @@ testRule(rule, {
     code: "@unknown\nident { };",
   }, {
     code: "a { color: pink; @crazy-custom-at-rule; }",
+  }, {
+    code: "@charset\n\n\"UTF-8\";",
+  }, {
+    code: "@charset\r\n\r\n\"UTF-8\";",
+  }, {
+    code: "@media\n\n(width <= 100px) { }",
   } ],
 
   reject: [ {
@@ -82,21 +88,6 @@ testRule(rule, {
     message: messages.expectedAfter("@charset"),
     line: 1,
     column: 8,
-  }, {
-    code: "@charset\n\n\"UTF-8\";",
-    message: messages.expectedAfter("@charset"),
-    line: 1,
-    column: 8,
-  }, {
-    code: "@charset\r\n\r\n\"UTF-8\";",
-    message: messages.expectedAfter("@charset"),
-    line: 1,
-    column: 8,
-  }, {
-    code: "@media\n\n(width <= 100px) { }",
-    message: messages.expectedAfter("@media"),
-    line: 1,
-    column: 6,
   }, {
     code: "@media (width <= 100px) { }",
     message: messages.expectedAfter("@media"),
@@ -253,19 +244,15 @@ testRule(rule, {
     code: "@unknown\"ident\";",
   }, {
     code: "@unknown ident { };",
+  }, {
+    code: "@charset\n\n\"UTF-8\";",
+  }, {
+    code: "@charset\r\n\r\n\"UTF-8\";",
+  }, {
+    code: "@media\n\n(min-width: 700px) and (orientation: landscape) { }",
   } ],
 
   reject: [ {
-    code: "@charset\n\n\"UTF-8\";",
-    message: messages.expectedAfter("@charset"),
-    line: 1,
-    column: 8,
-  }, {
-    code: "@charset\r\n\r\n\"UTF-8\";",
-    message: messages.expectedAfter("@charset"),
-    line: 1,
-    column: 8,
-  }, {
     code: "@import url(\"x.css\")\nscreen and (orientation:landscape);",
     message: messages.expectedAfter("@import"),
     line: 1,
@@ -275,11 +262,6 @@ testRule(rule, {
     message: messages.expectedAfter("@import"),
     line: 1,
     column: 7,
-  }, {
-    code: "@media\n\n(min-width: 700px) and (orientation: landscape) { }",
-    message: messages.expectedAfter("@media"),
-    line: 1,
-    column: 6,
   }, {
     code: "@media (\nmin-width: 700px) and (orientation: landscape) { }",
     message: messages.expectedAfter("@media"),

--- a/src/rules/at-rule-name-newline-after/index.js
+++ b/src/rules/at-rule-name-newline-after/index.js
@@ -27,7 +27,7 @@ export default function (expectation) {
     atRuleNameSpaceChecker({
       root,
       result,
-      locationChecker: checker.after,
+      locationChecker: checker.afterOneOnly,
       checkedRuleName: ruleName,
     })
   }

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -16,6 +16,11 @@ testRule(rule, {
     code: "a { color: pink; }\r\nb { color: red; }",
     description: "CRLF",
   }, {
+    code: "a { color: pink; }\n\nb { color: red; }",
+  }, {
+    code: "a { color: pink; }\r\n\r\nb { color: red; }",
+    description: "CRLF",
+  }, {
     code: "a { color: pink;}\n\t\tb { color: red;}",
   }, {
     code: "a { color: pink;}\r\n\t\tb { color: red;}",

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -18,6 +18,11 @@ testRule(rule, {
     code: "a { color: pink;\r\n}",
     description: "CRLF",
   }, {
+    code: "a { color: pink;\n\n}",
+  }, {
+    code: "a { color: pink;\r\n\r\n}",
+    description: "CRLF",
+  }, {
     code: "a { color: pink;\n\t\t}",
   }, {
     code: "a { color: pink;\n} b { color: red;\n}",

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -16,6 +16,11 @@ testRule(rule, {
     code: "a {\r\ncolor: pink; }",
     description: "CRLF",
   }, {
+    code: "a {\n\ncolor: pink; }",
+  }, {
+    code: "a {\r\n\r\ncolor: pink; }",
+    description: "CRLF",
+  }, {
     code: "a{\ncolor: pink; }",
   }, {
     code: "a{\n\tcolor: pink; }",

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -17,6 +17,11 @@ testRule(rule, {
     code: "a\r\n{ color: pink; }",
     description: "CRLF",
   }, {
+    code: "a\n\n{ color: pink; }",
+  }, {
+    code: "a\r\n\r\n{ color: pink; }",
+    description: "CRLF",
+  }, {
     code: "a\n{color: pink; }",
   }, {
     code: "@media print\n{ a\n{ color: pink; } }",

--- a/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
@@ -14,6 +14,11 @@ testRule(rule, {
     code: "a { color: pink;\r\n}",
     description: "CRLF",
   }, {
+    code: "a { color: pink;\n\n}",
+  }, {
+    code: "a { color: pink;\r\n\r\n}",
+    description: "CRLF",
+  }, {
     code: "a::before { content: \";a\";\n}",
   }, {
     code: "a {\ncolor: pink;\n top:0;\n}",

--- a/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
@@ -14,6 +14,8 @@ testRule(rule, {
   }, {
     code: "a { color: pink\n; }",
   }, {
+    code: "a { color: pink\n\n; }",
+  }, {
     code: "a::before { content: \";a\"\n; }",
   }, {
     code: "a { color: pink\n;top: 0 }",
@@ -21,6 +23,9 @@ testRule(rule, {
     code: "a { color: pink\n;top: 0}",
   }, {
     code: "a { color: pink\r\n;top: 0}",
+    description: "CRLF",
+  }, {
+    code: "a { color: pink\r\n\r\n;top: 0}",
     description: "CRLF",
   }, {
     code: "a,\nb { color: pink\n;top: 0}",

--- a/src/rules/declaration-block-semicolon-newline-before/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/index.js
@@ -35,7 +35,7 @@ export default function (expectation) {
 
       const declString = decl.toString()
 
-      checker.before({
+      checker.beforeAllowingIndentation({
         source: declString,
         index: declString.length,
         lineCheckStr: blockString(parentRule),

--- a/src/rules/declaration-colon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-colon-newline-after/__tests__/index.js
@@ -25,6 +25,12 @@ testRule(rule, {
     code: "a { color\r\n:\r\npink }",
     description: "CRLF before and after",
   }, {
+    code: "a { color\n\n:\n\npink }",
+    description: "double newline before after",
+  }, {
+    code: "a { color\r\n\r\n:\r\n\r\npink }",
+    description: "double CRLF before and after",
+  }, {
     code: "$map: (key: value)",
     description: "SCSS map with no newlines",
   }, {

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -14,12 +14,17 @@ testRule(rule, {
     code: "a::before { background: url('func(foo,bar,baz)'); }",
   }, {
     code: "a { background-size: 0,\n  0,\n  0; }",
-  }, {
+  },  {
     code: "a { transform: translate(1 ,\n1); }",
+  }, {
+    code: "a { transform: translate(1 ,\n\n1); }",
   }, {
     code: "a { transform: translate(\n  1,\n  1\n); }",
   }, {
     code: "a { transform: translate(1,\r\n1); }",
+    description: "CRLF",
+  }, {
+    code: "a { transform: translate(1,\r\n\r\n1); }",
     description: "CRLF",
   }, {
     code: "a { transform: color(rgb(0 ,\n\t0,\n\t0) lightness(50%)); }",

--- a/src/rules/function-comma-newline-before/__tests__/index.js
+++ b/src/rules/function-comma-newline-before/__tests__/index.js
@@ -20,6 +20,11 @@ testRule(rule, {
     code: "a { transform: translate(1\r\n, 1); }",
     description: "CRLF",
   }, {
+    code: "a { transform: translate(1\n\n,1); }",
+  }, {
+    code: "a { transform: translate(1\r\n\r\n, 1); }",
+    description: "CRLF",
+  }, {
     code: "a { transform: color(rgb(0\n\t, 0\n\t,0) lightness(50%)); }",
   }, {
     code: "a { transform: color(rgb(0\n  , 0\n  ,0) lightness(50%)); }",

--- a/src/rules/function-parentheses-newline-inside/__tests__/index.js
+++ b/src/rules/function-parentheses-newline-inside/__tests__/index.js
@@ -15,7 +15,12 @@ testRule(rule, {
   }, {
     code: "a { transform: translate(\n1, 1\n); }",
   }, {
+    code: "a { transform: translate(\n\n1, 1\n\n); }",
+  }, {
     code: "a { transform: translate(\r\n1, 1\r\n); }",
+    description: "CRLF",
+  }, {
+    code: "a { transform: translate(\r\n\r\n1, 1\r\n\r\n); }",
     description: "CRLF",
   }, {
     code: "a { color: color(\nrgb(\n0, 0, 0\n) lightness(\n50%\n)\n); }",

--- a/src/rules/media-query-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-after/__tests__/index.js
@@ -19,9 +19,14 @@ testRule(rule, {
   }, {
     code: "@media screen and (color),\nprojection and (color) {}",
   }, {
+    code: "@media screen and (color),\n\nprojection and (color) {}",
+  }, {
     code: "@media screen and (color) ,\n  projection and (color) {}",
   }, {
     code: "@media screen and (color) ,\r\n  projection and (color) {}",
+    description: "CRLF",
+  }, {
+    code: "@media screen and (color) ,\r\n\r\n  projection and (color) {}",
     description: "CRLF",
   }, {
     code: "@media screen and (color)\n,\n\t\t\tprojection and (color) {}",

--- a/src/rules/media-query-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-before/__tests__/index.js
@@ -19,7 +19,12 @@ testRule(rule, {
   }, {
     code: "@media screen and (color)\n, projection and (color) {}",
   }, {
+    code: "@media screen and (color)\n\n, projection and (color) {}",
+  }, {
     code: "@media screen and (color)\r\n, projection and (color) {}",
+    description: "CRLF",
+  }, {
+    code: "@media screen and (color)\r\n\r\n, projection and (color) {}",
     description: "CRLF",
   }, {
     code: "@media screen and (color)\n     ,  projection and (color) {}",

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -11,8 +11,13 @@ testRule(rule, {
   accept: [ {
     code: "a,\nb {}",
   }, {
+    code: "a,\n\nb {}",
+  }, {
     code: "a,\r\nb {}",
     description: "CRLF",
+  }, {
+    code: "a,\r\n\r\nb {}",
+    description: "Double CRLF",
   }, {
     code: "a,\nb,\nc {}",
   }, {

--- a/src/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -11,10 +11,15 @@ testRule(rule, {
   accept: [ {
     code: "a\n,b {}",
   }, {
+    code: "a\n\n,b {}",
+  }, {
     code: "a\n,b\n,c {}",
   }, {
     code: "a\r\n,b\r\n,c {}",
     description: "CRLF",
+  }, {
+    code: "a\r\n\r\n,b\r\n,c {}",
+    description: "Double CRLF",
   }, {
     code: "a\n, b {}",
   }, {

--- a/src/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-after/__tests__/index.js
@@ -11,10 +11,15 @@ testRule(rule, {
   accept: [ {
     code: "a { background-size: 0,\n0; }",
   }, {
+    code: "a { background-size: 0,\n\n0; }",
+  }, {
     code: "a { background-size: 0 ,\n  0; }",
   }, {
     code: "a { background-size: 0 ,\r\n  0; }",
     description: "CRLF",
+  }, {
+    code: "a { background-size: 0 ,\r\n\r\n  0; }",
+    description: "Double CRLF",
   }, {
     code: "a::before { content: \"foo,bar,baz\"; }",
     description: "string",

--- a/src/rules/value-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-before/__tests__/index.js
@@ -11,10 +11,15 @@ testRule(rule, {
   accept: [ {
     code: "a { background-size: 0\n,0\n,0; }",
   }, {
+    code: "a { background-size: 0\n\n,0\n\n,0; }",
+  }, {
     code: "a { background-size: 0\n,  0\n,\t0; }",
   }, {
     code: "a { background-size: 0\r\n,  0\r\n,\t0; }",
     description: "CRLF",
+  }, {
+    code: "a { background-size: 0\r\n\r\n,  0\r\n,\t0; }",
+    description: "Double CRLF",
   }, {
     code: "a { background-size: 0\n    ,0\n,0; }",
     description: "indentation after the newline before the comma",


### PR DESCRIPTION
Closes #1374

@davidtheclark Good news. It was just the `at-rule-name-newline-after` and `declaration-block-semicolon-newline-before` rules that weren’t behaving as expected.

As these fixes make both those rule more permissive, then this can be released as a fix in `6.6`.

I also checked through the docs. We correctly use “single space” when one *and only one* space is allowed, and we use “a newline” to indicate that one or more newlines are allowed.
