### PR TITLE
Deprecate verbose flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Deprecated: `number-zero-length-no-unit`. Use `length-zero-no-unit` instead.
 - Deprecated: `property-*-blacklist` and `property-*-whitelist`. Use `declaration-property-*-blacklist` and `declaration-property-*-whitelist` instead.
+- Deprecated: `-v` and `--verbose` CLI flags. Use `-f verbose` or `--formatter verbose` instead.
 - Deprecated: `stylelint.util.styleSearch()`. Use the external module [style-search](https://github.com/davidtheclark/style-search) instead.
 - Added: option `ignorePath` (for JS) and `--ignore-path` (for CLI).
 - Added: `at-rule-blacklist` rule.

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,7 +51,7 @@ const meowOptions = {
     "  --version           Get the currently installed version of stylelint.",
     "  --custom-formatter  Path to a JS file exporting a custom formatting function",
     "  --stdin-filename    Specify a filename to assign stdin input",
-    "  -f, --formatter     Specify a formatter: \"json\" or \"string\". Default is \"string\".",
+    "  -f, --formatter     Specify a formatter: \"json\", \"string\" or \"verbose\". Default is \"string\".",
     "  -i, --ignore-path   Specify a to a file containing patterns describing files",
     "                      to ignore. The path can be absolute or relative to `cwd`.",
     "                      By default, stylelint looks for `.stylelintignore` in the",
@@ -61,7 +61,6 @@ const meowOptions = {
     "  -s, --syntax        Specify a non-standard syntax that should be used to ",
     "                      parse source stylesheets. Options: \"scss\", \"less\", \"sugarss\"",
     "  -e, --extract       Extract and lint CSS from style tags in HTML structures",
-    "  -v, --verbose       Get more stats",
   ],
   pkg: "../package.json",
 }
@@ -73,6 +72,10 @@ if (cli.flags.customFormatter) {
   formatter = require(path.join(process.cwd(), cli.flags.customFormatter))
 } else if (cli.flags.verbose) {
   formatter = "verbose"
+  console.log( // eslint-disable-line no-console
+    "The '-v' and '--verbose' flags have been deprecated, and will be removed in '7.0'. " +
+    "Use '-f verbose' or '--formatter verbose' instead."
+  )
 }
 
 const optionsBase = {


### PR DESCRIPTION
@davidtheclark `-f verbose` already worked, so it was just a case of updating the CLI help docs and adding the deprecation warning.

Ref: https://github.com/stylelint/stylelint/issues/1439