### PR TITLE
Make except and ignore option docs clearer

### DIFF
--- a/src/rules/at-rule-empty-line-before/README.md
+++ b/src/rules/at-rule-empty-line-before/README.md
@@ -64,32 +64,9 @@ a {}
 
 ## Optional options
 
-### `except: ["blockless-group"]`
+### `except: ["all-nested", "blockless-group", "first-nested"]`
 
-Reverse the primary option for at-rules within a blockless group.
-
-For example, with `"always"`:
-
-The following patterns are considered warnings:
-
-```css
-@import url(x.css);
-
-@import url(y.css);
-
-@media print {}
-```
-
-The following patterns are *not* considered warnings:
-
-```css
-@import url(x.css);
-@import url(y.css);
-
-@media print {}
-```
-
-### `except: ["all-nested"]`
+### `"all-nested"`
 
 Reverse the primary option for at-rules that are nested.
 
@@ -125,7 +102,32 @@ b {
 }
 ```
 
-### `except: ["first-nested"]`
+#### `"blockless-group"`
+
+Reverse the primary option for at-rules within a blockless group.
+
+For example, with `"always"`:
+
+The following patterns are considered warnings:
+
+```css
+@import url(x.css);
+
+@import url(y.css);
+
+@media print {}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+@import url(x.css);
+@import url(y.css);
+
+@media print {}
+```
+
+#### `"first-nested"`
 
 Reverse the primary option for at-rules that are nested and the first child of their parent node.
 
@@ -161,7 +163,9 @@ b {
 }
 ```
 
-### `ignore: ["after-comment"]`
+### `ignore: ["after-comment", "blockless-group", "all-nested"]`
+
+#### `"after-comment"`
 
 Ignore rules that come after a comment.
 
@@ -178,7 +182,7 @@ The following patterns are *not* considered warnings:
 @media {}
 ```
 
-### `ignore: ["all-nested"]`
+#### `"all-nested"`
 
 Ignore at-rules that are nested.
 
@@ -210,7 +214,7 @@ b {
 }
 ```
 
-### `ignore: ["blockless-group"]`
+#### `"blockless-group"`
 
 Ignore at-rules within a blockless group.
 

--- a/src/rules/comment-empty-line-before/README.md
+++ b/src/rules/comment-empty-line-before/README.md
@@ -91,33 +91,9 @@ a {
 }
 ```
 
-### `ignore: ["stylelint-commands"]`
+### `ignore: ["between-comments", "stylelint-commands"]`
 
-Ignore comments that deliver commands to stylelint, e.g. `/* stylelint-disable color-no-hex */`.
-
-For example, with `"always"`:
-
-The following patterns are considered warnings:
-
-```css
-a {
-  background: pink;
-  /* not a stylelint command */
-  color: #eee;
-}
-```
-
-The following patterns are *not* considered warnings:
-
-```css
-a {
-  background: pink;
-  /* stylelint-disable color-no-hex */
-  color: pink;
-}
-```
-
-### `ignore: ["between-comments"]`
+#### `"between-comments"`
 
 Don't require an empty line between comments.
 
@@ -143,5 +119,31 @@ a {
 
   /* comment */
   color: #eee;
+}
+```
+
+#### `"stylelint-commands"`
+
+Ignore comments that deliver commands to stylelint, e.g. `/* stylelint-disable color-no-hex */`.
+
+For example, with `"always"`:
+
+The following patterns are considered warnings:
+
+```css
+a {
+  background: pink;
+  /* not a stylelint command */
+  color: #eee;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  background: pink;
+  /* stylelint-disable color-no-hex */
+  color: pink;
 }
 ```

--- a/src/rules/indentation/README.md
+++ b/src/rules/indentation/README.md
@@ -15,7 +15,7 @@ Specify indentation.
 
 ## Options
 
-`int|"tab"` - int = number of spaces
+`int|"tab"`, where `int` is the number of spaces
 
 ### `2`
 
@@ -111,7 +111,7 @@ a {
 
 ## Optional options
 
-### `indentInsideParens: ["once", "twice", "once-at-root-twice-in-block"]`
+### `indentInsideParens: "once"|"twice"|"once-at-root-twice-in-block"`
 
 By default, indentation within function arguments and other parentheses are ignored. If you would like to enforce indentation inside parentheses, use this option.
 
@@ -159,70 +159,6 @@ a {
 }
 ```
 
-### `except: ["block", "value", "param"]`
-
-Do *not* indent for these things.
-
-For example, with `2`:
-
-The following patterns are considered warnings:
-
-```css
-@media print,
-  (-webkit-min-device-pixel-ratio: 1.25),
-  (min-resolution: 120dpi) {
-  a {
-    background-position: top left,
-      top right;
-  }
-}
-```
-
-The following patterns are *not* considered warnings:
-
-```css
-@media print,
-(-webkit-min-device-pixel-ratio: 1.25),
-(min-resolution: 120dpi) {
-a {
-background-position: top left,
-top right;
-}
-}
-```
-
-### `ignore: ["value"]`
-
-Ignore the indentation of values.
-
-For example, with `2`:
-
-The following patterns are *not* considered warnings:
-
-```css
-a {
-  background-position: top left,
-top right,
-  bottom left,
-    bottom right;
-}
-```
-
-### `ignore: ["param"]`
-
-Ignore the indentation of at-rule params.
-
-For example, with `2`:
-
-The following patterns are *not* considered warnings:
-
-```css
-@media print,
-  (-webkit-min-device-pixel-ratio: 1.25),
-    (min-resolution: 120dpi) {
-}
-```
-
 ### `indentClosingBrace: true|false`
 
 If `true`, the closing brace of a block (rule or at-rule) will be expected at the same indentation level as the block's inner nodes.
@@ -257,4 +193,70 @@ a {
     color: pink;
     }  
   }
+```
+
+### `except: ["block", "value", "param"]`
+
+Do *not* indent for these things.
+
+For example, with `2`:
+
+The following patterns are considered warnings:
+
+```css
+@media print,
+  (-webkit-min-device-pixel-ratio: 1.25),
+  (min-resolution: 120dpi) {
+  a {
+    background-position: top left,
+      top right;
+  }
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+@media print,
+(-webkit-min-device-pixel-ratio: 1.25),
+(min-resolution: 120dpi) {
+a {
+background-position: top left,
+top right;
+}
+}
+```
+
+### `ignore: ["value", "param"]`
+
+#### `"value"`
+
+Ignore the indentation of values.
+
+For example, with `2`:
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  background-position: top left,
+top right,
+  bottom left,
+    bottom right;
+}
+```
+
+#### `"param"`
+
+Ignore the indentation of at-rule params.
+
+For example, with `2`:
+
+The following patterns are *not* considered warnings:
+
+```css
+@media print,
+  (-webkit-min-device-pixel-ratio: 1.25),
+    (min-resolution: 120dpi) {
+}
 ```

--- a/src/rules/selector-no-qualifying-type/README.md
+++ b/src/rules/selector-no-qualifying-type/README.md
@@ -56,11 +56,25 @@ input {
 
 ## Optional options
 
-### `ignore: ["class"]`
+### `ignore: ["attribute", "class", "id"]`
+
+#### `"attribute"`
+
+Allow attribute selectors qualified by type.
+
+The following patterns are *not* considered warnings:
+
+```css
+input[type='button'] {
+  margin: 0
+}
+```
+
+#### `"class"`
 
 Allow class selectors qualified by type.
 
-For example, the following would *not* be considered warnings:
+The following patterns are *not* considered warnings:
 
 ```css
 div.class {
@@ -68,26 +82,14 @@ div.class {
 }
 ```
 
-### `ignore: ["id"]`
+#### `"id"`
 
 Allow id selectors qualified by type.
 
-For example, the following would *not* be considered warnings:
+The following patterns are *not* considered warnings:
 
 ```css
 div#id {
-  margin: 0
-}
-```
-
-### `ignore: ["attribute"]`
-
-Allow attribute selectors qualified by type.
-
-For example, the following would *not* be considered warnings:
-
-```css
-input[type='button'] {
   margin: 0
 }
 ```

--- a/src/rules/selector-no-type/README.md
+++ b/src/rules/selector-no-type/README.md
@@ -50,25 +50,13 @@ The following patterns are *not* considered warnings:
 
 ## Optional options
 
-### `ignore: [ "descendant" ]`
+### `ignore: ["compounded", "descendant"]`
 
-Allow descendant type selectors.
-
-For example, the following would *not* be considered warnings:
-
-```css
-.foo ul {}
-```
-
-```css
-#bar ul.foo {}
-```
-
-### `ignore: [ "compounded" ]`
+#### `"compounded"`
 
 Allow compounded type selectors -- i.e. type selectors chained with other selectors.
 
-For example, the following would *not* be considered warnings:
+The following patterns are *not* considered warnings:
 
 ```css
 ul.foo {}
@@ -76,4 +64,18 @@ ul.foo {}
 
 ```css
 ul#bar {}
+```
+
+#### `"descendant"`
+
+Allow descendant type selectors.
+
+The following patterns are *not* considered warnings:
+
+```css
+.foo ul {}
+```
+
+```css
+#bar ul.foo {}
 ```


### PR DESCRIPTION
Can you guys view these two markdown files and check that this approach is clearer (i.e. using a subheading for each `ignore` and `except` keyword)? If it is, I’ll roll it out for the other rules.

Ref: #1467

