### PR TITLE
AppVeyor: Only test `master` branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,10 @@ version: "{build}"
 build: off
 deploy: off
 
+branches:
+    only:
+      - master
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install


### PR DESCRIPTION
This change has AppVeyor only run one build per pull request rather than previously two builds were ran per pull request, one against `master` and one against the pull request `branch-name`.

See http://www.appveyor.com/docs/branches#white-and-blacklisting