### PR TITLE
Improve indentation's understanding of parentheticals, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
-- Fixed: `no-unsupported-browser-features` message now clearly states that only *fully* supported features are allowed. 
+- Fixed: `indentation` better understands nested parentheticals that aren't just Sass maps and lists.
+- Fixed: `no-unsupported-browser-features` message now clearly states that only *fully* supported features are allowed.
 
 # 6.6.0
 

--- a/src/rules/indentation/__tests__/functions.js
+++ b/src/rules/indentation/__tests__/functions.js
@@ -95,6 +95,14 @@ testRule(rule, {
     "  )\n" +
     ");",
     description: "nested Sass map",
+  }, {
+    code: "background:\n" +
+    "  linear-gradient(\n" +
+    "    to bottom,\n" +
+    "    transparentize($gray-dark, 1) 0%,\n" +
+    "    transparentize($gray-dark, 0.1) 100%\n" +
+    "  );",
+    description: "nested parenthetical inside multiline value",
   } ],
 
   reject: [ {
@@ -345,4 +353,22 @@ testRule(rule, {
     line: 5,
     column: 1,
   } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ 2, { indentInsideParens: "once" } ],
+  syntax: "less",
+  skipBasicChecks: true,
+
+  accept: [{
+    code: ".foo {\n" +
+    "  .mixin(\n" +
+    "    @foo,\n" +
+    "    @bar,\n" +
+    "    @baz\n" +
+    "  );\n" +
+    "}",
+    description: "Less mixin with multi-line arguments",
+  }],
 })


### PR DESCRIPTION
Took a lot of tinkering but I seem to have a solution here that solves the problematic use-cases provided in #1149 and #1451.