### PR TITLE
Allow comma separated list of values for keyframe selector

### DIFF
--- a/src/utils/__tests__/isKeyframeSelector-test.js
+++ b/src/utils/__tests__/isKeyframeSelector-test.js
@@ -13,6 +13,7 @@ test("isKeyframeSelector", t => {
   t.ok(isKeyframeSelector(".5%"))
   t.ok(isKeyframeSelector("000.5%"))
   t.ok(isKeyframeSelector("209%"))
+  t.ok(isKeyframeSelector("0%, 50%"))
 
   t.notOk(isKeyframeSelector("a"))
   t.notOk(isKeyframeSelector(".foo"))

--- a/src/utils/isKeyframeSelector.js
+++ b/src/utils/isKeyframeSelector.js
@@ -7,10 +7,13 @@ import { keyframeSelectorKeywords } from "../reference/keywordSets"
  * @return {boolean} If `true`, the selector is a keyframe selector
  */
 export default function (selector) {
-  if (keyframeSelectorKeywords.has(selector)) { return true }
+  const simpleSelectors = selector.split(",")
+  for (const simpleSelector of simpleSelectors) {
+    if (keyframeSelectorKeywords.has(simpleSelector)) { return true }
 
-  // Percentages
-  if (/^(?:\d+\.?\d*|\d*\.?\d+)%$/.test(selector)) { return true }
+    // Percentages
+    if (/^(?:\d+\.?\d*|\d*\.?\d+)%$/.test(simpleSelector)) { return true }
+  }
 
   return false
 }


### PR DESCRIPTION
I get `selector-type-no-unknown` when using multiple values for the keyframe selector like this:

```css
@keyframes identifier {
  0%, 100% { top: 0; }
}
```

According to https://www.w3.org/TR/css3-animations/#keyframes it should be allowed. 

In my pull request I'm simply splitting the string at each comma and iterate over it. Please let me know if there is a more appropriate method for this already.