### PR TITLE
selector-max-specificity rule incorrectly reporting specificity

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "postcss-selector-parser": "^2.0.0",
     "postcss-value-parser": "^3.1.1",
     "resolve-from": "^2.0.0",
-    "specificity": "^0.1.5",
+    "specificity": "^0.2.1",
     "string-width": "^1.0.1",
     "stylehacks": "^2.3.0",
     "sugarss": "^0.1.2",

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -6,6 +6,35 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
+  config: ["0,1,0"],
+
+  accept: [ {
+    code: ".ab {}",
+  }, {
+    code: "span a {}",
+  }, {
+    code: "div div div div div div div div div div div {}",
+    message: "a selector with 11 elements has a lower specificity than a selector with one classname",
+  }, {
+    code: "z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z {}",
+    message: "a selector with 101 elements has a lower specificity than a selector with one classname",
+  } ],
+
+  reject: [ {
+    code: ".ab .ab {}",
+    message: messages.expected(".ab .ab", "0,1,0"),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".ab span {}",
+    message: messages.expected(".ab span", "0,1,0"),
+    line: 1,
+    column: 1,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: ["0,3,0"],
 
   accept: [ {

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -27,7 +27,7 @@ export default function (max) {
     })
     if (!validOptions) { return }
 
-    const maxSpecificityArray = ("0," + max).split(",").map(parseFloat);
+    const maxSpecificityArray = ("0," + max).split(",").map(parseFloat)
     root.walkRules(rule => {
       if (!isStandardSyntaxRule(rule)) { return }
       if (!isStandardSyntaxSelector(rule.selector)) { return }

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -1,4 +1,4 @@
-import { calculate } from "specificity"
+import { compare } from "specificity"
 import resolvedNestedSelector from "postcss-resolve-nested-selector"
 
 import {
@@ -27,16 +27,15 @@ export default function (max) {
     })
     if (!validOptions) { return }
 
+    const maxSpecificityArray = ("0," + max).split(",").map(parseFloat);
     root.walkRules(rule => {
       if (!isStandardSyntaxRule(rule)) { return }
       if (!isStandardSyntaxSelector(rule.selector)) { return }
       // Using rule.selectors gets us each selector in the eventuality we have a comma separated set
       rule.selectors.forEach(selector => {
         resolvedNestedSelector(selector, rule).forEach(resolvedSelector => {
-          // calculate() returns a four section string — we only need 3 so strip the first two characters
-          const computedSpecificity = calculate(resolvedSelector)[0].specificity.substring(2)
           // Check if the selector specificity exceeds the allowed maximum
-          if (parseFloat(computedSpecificity.replace(/,/g, "")) > parseFloat(max.replace(/,/g, ""))) {
+          if (compare(resolvedSelector, maxSpecificityArray) === 1) {
             report({
               ruleName,
               result,


### PR DESCRIPTION
The `selector-max-specificity` rule is incorrectly reporting that a selector with 11 elements has a higher specificity than a selector with a single classname. This is not an issue with the [specificity calculator](https://www.npmjs.com/package/specificity) module but in the way that this rule compares specificity as a base 10 number.

I have updated the unit tests and added a fix for this issue.

I recently updated the specificity calculator module to include a "compare" function, so I have used that function in this rule.

It doesn't appear to have had any negative performance impact.

Before:

```
MacBook:stylelint keegan$ npm run benchmark-rule -- selector-max-specificity "0,2,0"

> stylelint@6.6.0 benchmark-rule /Users/keegan/Projects/Tools/stylelint
> babel-node scripts/benchmark-rule.js "selector-max-specificity" "0,2,0"

Warnings: 900
Mean: 225.90502433333327 ms
Deviation: 67.87000886072683 ms
```

After:

```
MacBook:stylelint keegan$ npm run benchmark-rule -- selector-max-specificity "0,2,0"

> stylelint@6.6.0 benchmark-rule /Users/keegan/Projects/Tools/stylelint
> babel-node scripts/benchmark-rule.js "selector-max-specificity" "0,2,0"

Warnings: 900
Mean: 215.66833793103447 ms
Deviation: 84.2738416992734 ms
```