### PR TITLE
Ignore complex keyframe selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed: `indentation` better understands nested parentheticals that aren't just Sass maps and lists.
 - Fixed: `no-unsupported-browser-features` message now clearly states that only *fully* supported features are allowed.
 - Fixed: `selector-max-specificity` no longer reports that a selector with 11 elements or more has a higher specificity than a selector with a single classname.
+- Fixed: Fixed: `selector-type-no-unknown` no longer warns for complex keyframe selectors.
 
 # 6.6.0
 

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -54,6 +54,9 @@ testRule(rule, {
     code: "@media keyframes { 0% {} 100% {} }",
     description: "standard usage of keyframe selectors",
   }, {
+    code: "@media keyframes { 0%, 100% {} }",
+    description: "standard usage of complex keyframe selectors",
+  }, {
     code: "@include keyframes(identifier) { 0% {} 100% {} }",
     description: "non-standard usage of keyframe selectors",
   } ],

--- a/src/rules/selector-type-no-unknown/index.js
+++ b/src/rules/selector-type-no-unknown/index.js
@@ -59,7 +59,6 @@ export default function (actual, options) {
       if (!isStandardSyntaxRule(rule)) { return }
       const { selector } = rule
       if (!isStandardSyntaxSelector(selector)) { return }
-      if (isKeyframeSelector(selector)) { return }
 
       parseSelector(selector, result, rule, selectorTree => {
         selectorTree.walkTags(tagNode => {
@@ -67,6 +66,7 @@ export default function (actual, options) {
 
           const tagName = tagNode.value
           const tagNameLowerCase = tagName.toLowerCase()
+          if (isKeyframeSelector(tagName)) { return }
 
           if (htmlTags.indexOf(tagNameLowerCase) !== -1
             || svgTags.indexOf(tagNameLowerCase) !== -1


### PR DESCRIPTION
https://github.com/stylelint/stylelint/pull/1496

@davidtheclark If you’re ok to quickly give this the once over I’ll get out `6.7` - we’ve merged in the `ignoreFunction:[]` option so this will be a minor, rather than patch, release.