### PR TITLE
Remove redundant details from message

### DIFF
--- a/src/rules/font-family-name-quotes/index.js
+++ b/src/rules/font-family-name-quotes/index.js
@@ -11,8 +11,8 @@ import { fontFamilyKeywords } from "../../reference/keywordSets"
 export const ruleName = "font-family-name-quotes"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (family) => `Expected quotes around font-family name "${family}"`,
-  rejected: (family) => `Unexpected quotes around font-family name "${family}"`,
+  expected: (family) => `Expected quotes around "${family}"`,
+  rejected: (family) => `Unexpected quotes around "${family}"`,
 })
 
 function isSystemFontKeyword(font) {


### PR DESCRIPTION
I missed this one in the `v7` branch when doing https://github.com/stylelint/stylelint/pull/1422