### PR TITLE
Fix CRLF warning positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: `block-*-brace-*-before` CRLF (`\r\n`) warning positioning.
+
 # 6.7.0
 
 - Added: `ignoreFunctions: []` option for `function-name-case`.

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -61,7 +61,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.expectedBefore,
     line: 1,
-    column: 19,
+    column: 18,
   }, {
     code: "a { color: pink;  }",
     message: messages.expectedBefore,

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -38,11 +38,15 @@ export default function (expectation) {
       // Return early if blockless or has empty block
       if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
 
-      const blockIsMultiLine = !isSingleLineString(blockString(statement))
       // Ignore extra semicolon
       const after = statement.raw("after").replace(/;+/, "")
-
       if (after === undefined) { return }
+
+      const blockIsMultiLine = !isSingleLineString(blockString(statement))
+      const statementString = statement.toString()
+
+      let index = statementString.length - 2
+      if (statementString[index - 1] === "\r") { index -= 1 }
 
       // We're really just checking whether a
       // newline *starts* the block's final space -- between
@@ -66,7 +70,7 @@ export default function (expectation) {
           result,
           ruleName,
           node: statement,
-          index: statement.toString().length - 2,
+          index,
         })
       }
     }

--- a/src/rules/block-closing-brace-space-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-before/__tests__/index.js
@@ -36,7 +36,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.expectedBefore(),
     line: 1,
-    column: 18,
+    column: 17,
   }, {
     code: "a { color: pink;\t}",
     message: messages.expectedBefore(),
@@ -82,7 +82,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.rejectedBefore(),
     line: 1,
-    column: 18,
+    column: 17,
   }, {
     code: "a { color: pink;\t}",
     message: messages.rejectedBefore(),

--- a/src/rules/block-closing-brace-space-before/index.js
+++ b/src/rules/block-closing-brace-space-before/index.js
@@ -47,6 +47,10 @@ export default function (expectation) {
       if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
 
       const source = blockString(statement)
+      const statementString = statement.toString()
+
+      let index = statementString.length - 2
+      if (statementString[index - 1] === "\r") { index -= 1 }
 
       checker.before({
         source,
@@ -55,7 +59,7 @@ export default function (expectation) {
           report({
             message: msg,
             node: statement,
-            index: statement.toString().length - 2,
+            index,
             result,
             ruleName,
           })

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -219,7 +219,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.rejectedBeforeSingleLine(),
     line: 1,
-    column: 3,
+    column: 2,
   }, {
     code: "a { color: pink; }",
     message: messages.rejectedBeforeSingleLine(),
@@ -245,7 +245,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.rejectedBeforeSingleLine(),
     line: 2,
-    column: 5,
+    column: 4,
   }, {
     code: "@media print { a\n{ color: pink; } }",
     message: messages.rejectedBeforeSingleLine(),
@@ -387,6 +387,6 @@ testRule(rule, {
     code: "@media print{ a\r\n{ color: pink;\r\nbackground: orange; } }",
     message: messages.rejectedBeforeMultiLine(),
     line: 1,
-    column: 17,
+    column: 16,
   } ],
 })

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -44,17 +44,21 @@ export default function (expectation) {
       // Return early if blockless or has an empty block
       if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
 
-      const beforeBrace = beforeBlockString(statement)
+      const source = beforeBlockString(statement)
+      const beforeBraceNoRaw = beforeBlockString(statement, { noRawBefore: true })
+
+      let index = beforeBraceNoRaw.length - 1
+      if (beforeBraceNoRaw[index - 1] === "\r") { index -= 1 }
 
       checker.beforeAllowingIndentation({
         lineCheckStr: blockString(statement),
-        source: beforeBrace,
-        index: beforeBrace.length,
+        source,
+        index: source.length,
         err: m => {
           report({
             message: m,
             node: statement,
-            index: beforeBlockString(statement, { noRawBefore: true }).length - 1,
+            index,
             result,
             ruleName,
           })

--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -45,7 +45,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.expectedBefore(),
     line: 1,
-    column: 3,
+    column: 2,
   }, {
     code: "@media print\n{ a { color: pink; } }",
     message: messages.expectedBefore(),
@@ -134,7 +134,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.rejectedBefore(),
     line: 1,
-    column: 3,
+    column: 2,
   }, {
     code: "@media print { a{ color: pink; } }",
     message: messages.rejectedBefore(),
@@ -191,7 +191,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.expectedBeforeSingleLine(),
     line: 1,
-    column: 3,
+    column: 2,
   }, {
     code: "@media print\n{ a { color: pink; } }",
     message: messages.expectedBeforeSingleLine(),
@@ -256,7 +256,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.rejectedBeforeSingleLine(),
     line: 1,
-    column: 3,
+    column: 2,
   }, {
     code: "@media print { a{ color: pink; } }",
     message: messages.rejectedBeforeSingleLine(),
@@ -318,7 +318,7 @@ testRule(rule, {
     description: "CRLF",
     message: messages.expectedBeforeMultiLine(),
     line: 1,
-    column: 3,
+    column: 2,
   }, {
     code: "@media print\n{\na { color: pink;\nbackground: orange; } }",
     message: messages.expectedBeforeMultiLine(),
@@ -390,6 +390,6 @@ testRule(rule, {
     description: "CRLF",
     message: messages.rejectedBeforeMultiLine(),
     line: 1,
-    column: 17,
+    column: 16,
   } ],
 })

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -57,6 +57,10 @@ export default function (expectation, options) {
       if (optionsHaveIgnoredAtRule(options, statement)) { return }
 
       const source = beforeBlockString(statement)
+      const beforeBraceNoRaw = beforeBlockString(statement, { noRawBefore: true })
+
+      let index = beforeBraceNoRaw.length - 1
+      if (beforeBraceNoRaw[index - 1] === "\r") { index -= 1 }
 
       checker.before({
         source,
@@ -66,7 +70,7 @@ export default function (expectation, options) {
           report({
             message: m,
             node: statement,
-            index: beforeBlockString(statement, { noRawBefore: true }).length - 1,
+            index,
             result,
             ruleName,
           })


### PR DESCRIPTION
Closes #1502

It feels like a while since I actually squished a bug.

Anyhow, turns out this issue effect all four of the `block-*-brace-*-before` rules.