### PR TITLE
Ignore factional keyframes and non-standard usage in selector-type-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Head
 
 - Fixed: `block-*-brace-*-before` CRLF (`\r\n`) warning positioning.
+- Fixed: `selector-no-type` and `selector-type-case` now ignore non-standard keyframe selectors (e.g. within an SCSS mixin).
+- Fixed: `selector-type-no-unknown` no longer reports factional keyframe selectors.
 
 # 6.7.0
 

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -50,6 +50,9 @@ testRule(rule, {
   }, {
     code: "@keyframes spin { to {} from {} }",
   }, {
+    code: "@include keyframes(identifier) { to, 50.0% {} 50.01% {} 100% {} }",
+    description: "non-standard usage of keyframe selectors",
+  }, {
     code: ":root { --custom-property-set: {} }",
   } ],
 

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -1,6 +1,6 @@
 import { get } from "lodash"
 import {
-  isKeyframeRule,
+  isKeyframeSelector,
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
   isStandardSyntaxTypeSelector,
@@ -33,10 +33,11 @@ export default function (on, options) {
 
     root.walkRules(rule => {
 
+      const { selector, selectors } = rule
+
       if (!isStandardSyntaxRule(rule)) { return }
-      if (isKeyframeRule(rule)) { return }
-      const { selector } = rule
       if (!isStandardSyntaxSelector(selector)) { return }
+      if (selectors.some(s => isKeyframeSelector(s))) { return }
 
       parseSelector(selector, result, rule, selectorAST => {
         selectorAST.walkTags(tag => {

--- a/src/rules/selector-type-case/__tests__/index.js
+++ b/src/rules/selector-type-case/__tests__/index.js
@@ -47,6 +47,9 @@ testRule(rule, {
   }, {
     code: "@keyframes spin { to {} from {} }",
   }, {
+    code: "@include keyframes(identifier) { TO, 50.0% {} 50.01% {} 100% {} }",
+    description: "non-standard usage of keyframe selectors",
+  }, {
     code: ":root { --custom-property-set: {} }",
   } ],
 

--- a/src/rules/selector-type-case/index.js
+++ b/src/rules/selector-type-case/index.js
@@ -1,5 +1,5 @@
 import {
-  isKeyframeRule,
+  isKeyframeSelector,
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
   isStandardSyntaxTypeSelector,
@@ -28,10 +28,11 @@ export default function (expectation) {
 
     root.walkRules(rule => {
 
+      const { selector, selectors } = rule
+
       if (!isStandardSyntaxRule(rule)) { return }
-      if (isKeyframeRule(rule)) { return }
-      const { selector } = rule
       if (!isStandardSyntaxSelector(selector)) { return }
+      if (selectors.some(s => isKeyframeSelector(s))) { return }
 
       parseSelector(selector, result, rule, selectorAST => {
         selectorAST.walkTags(tag => {

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -51,10 +51,10 @@ testRule(rule, {
     code: "circle {}",
     description: "svg tags",
   }, {
-    code: "@media keyframes { 0% {} 100% {} }",
+    code: "@media keyframes { 0.0% {} 49.1% {} 100% {} }",
     description: "standard usage of keyframe selectors",
   }, {
-    code: "@media keyframes { 0%, 100% {} }",
+    code: "@media keyframes { 0%, 50.001%, 100% {} }",
     description: "standard usage of complex keyframe selectors",
   }, {
     code: "@include keyframes(identifier) { 0% {} 100% {} }",

--- a/src/rules/selector-type-no-unknown/index.js
+++ b/src/rules/selector-type-no-unknown/index.js
@@ -56,9 +56,11 @@ export default function (actual, options) {
     if (!validOptions) { return }
 
     root.walkRules(rule => {
+      const { selector, selectors } = rule
+
       if (!isStandardSyntaxRule(rule)) { return }
-      const { selector } = rule
       if (!isStandardSyntaxSelector(selector)) { return }
+      if (selectors.some(s => isKeyframeSelector(s))) { return }
 
       parseSelector(selector, result, rule, selectorTree => {
         selectorTree.walkTags(tagNode => {
@@ -66,7 +68,6 @@ export default function (actual, options) {
 
           const tagName = tagNode.value
           const tagNameLowerCase = tagName.toLowerCase()
-          if (isKeyframeSelector(tagName)) { return }
 
           if (htmlTags.indexOf(tagNameLowerCase) !== -1
             || svgTags.indexOf(tagNameLowerCase) !== -1


### PR DESCRIPTION
https://github.com/stylelint/stylelint/issues/1513 - we were testing if a selector was a keyframe *after* running it through the selector parser, which correctly treats something like `50.0%` as a tag and class compound selector. I’ve moved the conditional to before the parser.

The `.every()` is needed for complex keyframe selectors like `0%, 50% {}`

At the same time I updated `selector-no-type` and `selector-type-case` to use the same approach as the https://github.com/stylelint/stylelint/issues/1383 bug was present in them.

@davidtheclark Shall I put out a patch release (`6.7.1`) once this is in?