### PR TITLE
Fixes typo in selector-max-specificity documentation.

### DIFF
--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -18,7 +18,7 @@ This rule resolves nested selectors before calculating the specificity of a sele
 
 `string`: Maximum specificity allowed.
 
-Format is `"id,foo,type"`, as laid out in the [W3C selector spec](https://drafts.csswg.org/selectors/#specificity-rules).
+Format is `"id,class,type"`, as laid out in the [W3C selector spec](https://drafts.csswg.org/selectors/#specificity-rules).
 
 For example, with `"0,2,0"`:
 


### PR DESCRIPTION
I could be wrong here, but I am guessing that the format example should use `class` instead of `foo`.

This PR changes the format to match what is outlined in the W3C spec documentation. 