### PR TITLE
Add string and verbose formatter tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-preset-es2015": "^6.1.18",
     "babel-tape-runner": "^2.0.0",
     "benchmark": "^2.1.0",
+    "common-tags": "^1.3.0",
     "coveralls": "^2.11.9",
     "eslint": "^2.4.0",
     "eslint-config-stylelint": "^2.0.0",

--- a/src/formatters/__tests__/stringFormatter-test.js
+++ b/src/formatters/__tests__/stringFormatter-test.js
@@ -1,0 +1,95 @@
+import { stripIndent } from "common-tags"
+import chalk from "chalk"
+import test from "tape"
+import stringFormatter from "../stringFormatter"
+
+const symbolConversions = new Map()
+symbolConversions.set("ℹ", "i")
+symbolConversions.set("✔", "√")
+symbolConversions.set("⚠", "‼")
+symbolConversions.set("✖", "×")
+
+test("no warnings", t => {
+
+  const results = [{
+    "source":  "path/to/file.css",
+    "errored": false,
+    "warnings": [],
+    "deprecations": [],
+    "invalidOptionWarnings":[],
+  }]
+
+  const output = stringFormatter(results)
+
+  t.equal(output, "")
+  t.end()
+})
+
+test("condensing of deprecations and invalid option warnings", t => {
+
+  const results = [ {
+    "source": "file.css",
+    "deprecations": [{
+      "text": "Deprecated foo",
+      "reference": "bar",
+    }],
+    "invalidOptionWarnings": [{
+      "text": "Unexpected option for baz",
+    }],
+    "errored": true,
+    "warnings": [],
+  }, {
+    "source": "file2.css",
+    "deprecations": [{
+      "text": "Deprecated foo",
+      "reference": "bar",
+    }],
+    "invalidOptionWarnings": [{
+      "text": "Unexpected option for baz",
+    }],
+    "errored": true,
+    "warnings": [],
+  } ]
+
+  const output = prepareFormatterOutput(results, stringFormatter)
+
+  t.equal(output, stripIndent`
+    Invalid Option: Unexpected option for baz
+
+    Deprecation Warning: Deprecated foo See: bar
+  `)
+  t.end()
+})
+
+test("one ignored file", t => {
+
+  const results = [{
+    "source": "file.css",
+    "warnings":[{
+      "column": null,
+      "severity": "info",
+      "text": "This file is ignored",
+    }],
+    "deprecations": [],
+    "invalidOptionWarnings": [],
+  }]
+
+  const output = prepareFormatterOutput(results, stringFormatter)
+
+  t.equal(output, stripIndent`
+    file.css
+          i  This file is ignored
+    `)
+  t.end()
+})
+
+export function prepareFormatterOutput(results, formatter) {
+
+  let output = chalk.stripColor(formatter(results)).trim()
+
+  for (const [ nix, win ] of symbolConversions.entries()) {
+    output = output.replace(new RegExp(nix, "g"), win)
+  }
+
+  return output
+}

--- a/src/formatters/__tests__/verboseFormatter-test.js
+++ b/src/formatters/__tests__/verboseFormatter-test.js
@@ -1,0 +1,174 @@
+import { stripIndent } from "common-tags"
+import test from "tape"
+import verboseFormatter from "../verboseFormatter"
+
+import { prepareFormatterOutput } from "./stringFormatter-test"
+
+test("no warnings", t => {
+
+  const results = [{
+    "source":  "path/to/file.css",
+    "errored": false,
+    "warnings": [],
+    "deprecations": [],
+    "invalidOptionWarnings":[],
+  }]
+
+  const output = prepareFormatterOutput(results, verboseFormatter)
+
+  t.equal(output, stripIndent`
+    1 source checked
+     path/to/file.css
+
+    0 problems found
+  `)
+  t.end()
+})
+
+test("one warnings (of severity 'error')", t => {
+
+  const results = [{
+    "source":  "path/to/file.css",
+    "errored": true,
+    "warnings":[{
+      "line": 1,
+      "column": 2,
+      "rule": "bar",
+      "severity": "error",
+      "text": "Unexpected foo",
+    }],
+    "deprecations": [],
+    "invalidOptionWarnings":[],
+  }]
+
+  const output = prepareFormatterOutput(results, verboseFormatter)
+
+  t.equal(output, stripIndent`
+    path/to/file.css
+     1:2  ×  Unexpected foo  bar
+
+    1 source checked
+     path/to/file.css
+
+    1 problem found
+     severity level "error": 1
+      bar: 1
+    `)
+  t.end()
+})
+
+test("two of the same warnings of 'error' and one of 'warning' across two files", t => {
+
+  const results = [ {
+    "source":  "path/to/file.css",
+    "errored": true,
+    "warnings":[ {
+      "line": 1,
+      "column": 2,
+      "rule": "bar",
+      "severity": "error",
+      "text": "Unexpected foo",
+    }, {
+      "line": 2,
+      "column": 3,
+      "rule": "bar",
+      "severity": "error",
+      "text": "Unexpected foo",
+    } ],
+    "deprecations": [],
+    "invalidOptionWarnings":[],
+  }, {
+    "source":  "file2.css",
+    "errored": true,
+    "warnings":[{
+      "line": 3,
+      "column": 1,
+      "rule": "baz",
+      "severity": "warning",
+      "text": "Expected cat",
+    }],
+    "deprecations": [],
+    "invalidOptionWarnings":[],
+  } ]
+
+  const output = prepareFormatterOutput(results, verboseFormatter)
+
+  t.equal(output, stripIndent`
+    path/to/file.css
+     1:2  ×  Unexpected foo  bar
+     2:3  ×  Unexpected foo  bar
+
+    file2.css
+     3:1  ‼  Expected cat  baz
+
+    2 sources checked
+     path/to/file.css
+     file2.css
+
+    3 problems found
+     severity level "error": 2
+      bar: 2
+     severity level "warning": 1
+      baz: 1
+  `)
+  t.end()
+})
+
+test("lineless syntax error", t => {
+
+  const results = [{
+    "source":  "path/to/file.css",
+    "errored": false,
+    "warnings":[{
+      "rule": "SyntaxError",
+      "severity": "error",
+      "text": "Unexpected foo",
+    }],
+    "deprecations": [],
+    "invalidOptionWarnings":[],
+  }]
+
+  const output = prepareFormatterOutput(results, verboseFormatter)
+
+  t.equal(output, stripIndent`
+    path/to/file.css
+          ×  Unexpected foo  SyntaxError
+
+    1 source checked
+     path/to/file.css
+
+    1 problem found
+     severity level "error": 1
+      SyntaxError: 1
+    `)
+  t.end()
+})
+
+test("one ignored file", t => {
+
+  const results = [{
+    "source": "file.css",
+    "warnings":[{
+      "column": null,
+      "severity": "info",
+      "text": "This file is ignored",
+    }],
+    "deprecations": [],
+    "invalidOptionWarnings": [],
+  }]
+
+  const output = prepareFormatterOutput(results, verboseFormatter)
+
+  t.equal(output, stripIndent`
+    file.css
+          i  This file is ignored
+
+    1 source checked
+     file.css
+
+    1 problem found
+     severity level "info": 1
+      undefined: 1
+    `)
+  t.end()
+})


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/issues/1359

As the verbose formatter uses the string one, I’ve used the former to test most things.

If we’re happy with this, and once it’s merged I’ll rebase `v7` and update the ignore tests because we treat ignored files differently there.