### PR TITLE
Update ignoreFiles formatter tests

### DIFF
--- a/src/formatters/__tests__/stringFormatter-test.js
+++ b/src/formatters/__tests__/stringFormatter-test.js
@@ -65,21 +65,15 @@ test("one ignored file", t => {
 
   const results = [{
     "source": "file.css",
-    "warnings":[{
-      "column": null,
-      "severity": "info",
-      "text": "This file is ignored",
-    }],
+    "warnings":[],
     "deprecations": [],
     "invalidOptionWarnings": [],
+    "ignored": true,
   }]
 
   const output = prepareFormatterOutput(results, stringFormatter)
 
-  t.equal(output, stripIndent`
-    file.css
-          i  This file is ignored
-    `)
+  t.equal(output, "")
   t.end()
 })
 

--- a/src/formatters/__tests__/verboseFormatter-test.js
+++ b/src/formatters/__tests__/verboseFormatter-test.js
@@ -18,7 +18,7 @@ test("no warnings", t => {
 
   t.equal(output, stripIndent`
     1 source checked
-      path/to/file.css
+     path/to/file.css
 
     0 problems found
   `)
@@ -48,7 +48,7 @@ test("one warnings (of severity 'error')", t => {
      1:2  ×  Unexpected foo  bar
 
     1 source checked
-      path/to/file.css
+     path/to/file.css
 
     1 problem found
      severity level "error": 1
@@ -102,8 +102,8 @@ test("two of the same warnings of 'error' and one of 'warning' across two files"
      3:1  ‼  Expected cat  baz
 
     2 sources checked
-      path/to/file.css
-      file2.css
+     path/to/file.css
+     file2.css
 
     3 problems found
      severity level "error": 2
@@ -135,7 +135,7 @@ test("lineless syntax error", t => {
           ×  Unexpected foo  SyntaxError
 
     1 source checked
-      path/to/file.css
+     path/to/file.css
 
     1 problem found
      severity level "error": 1

--- a/src/formatters/__tests__/verboseFormatter-test.js
+++ b/src/formatters/__tests__/verboseFormatter-test.js
@@ -148,27 +148,19 @@ test("one ignored file", t => {
 
   const results = [{
     "source": "file.css",
-    "warnings":[{
-      "column": null,
-      "severity": "info",
-      "text": "This file is ignored",
-    }],
+    "warnings":[],
     "deprecations": [],
     "invalidOptionWarnings": [],
+    "ignored": true,
   }]
 
   const output = prepareFormatterOutput(results, verboseFormatter)
 
   t.equal(output, stripIndent`
-    file.css
-          i  This file is ignored
+    0 of 1 source checked
+     file.css (ignored)
 
-    1 source checked
-      file.css
-
-    1 problem found
-     severity level "info": 1
-      undefined: 1
+    0 problems found
     `)
   t.end()
 })

--- a/src/formatters/verboseFormatter.js
+++ b/src/formatters/verboseFormatter.js
@@ -22,7 +22,7 @@ export default function (results) {
     } else if (result.ignored) {
       formatting = "gray"
     }
-    let sourceText = ` ${result.source}`
+    let sourceText = `${result.source}`
     if (result.ignored) { sourceText += " (ignored)" }
     output += _.get(chalk, formatting)(` ${sourceText}\n`)
   })


### PR DESCRIPTION
@davidtheclark After the rebase from master there are couple of failing `indentation` tests around parens. 

I took a quick look, but figured you might be able to spot the gaff quicker than I. Would you mind taking a look?