### PR TITLE
Fix decl-block-prop-order options validation

### DIFF
--- a/src/rules/declaration-block-properties-order/__tests__/validate-options.js
+++ b/src/rules/declaration-block-properties-order/__tests__/validate-options.js
@@ -1,0 +1,162 @@
+import test from "tape"
+import stylelint from "../../.."
+
+test("valid default order", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [{
+        properties: [
+          "color",
+        ],
+      }],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 0)
+  })
+
+  t.plan(1)
+})
+
+test("valid 'strict' order", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [{
+        order: "strict",
+        properties: [
+          "color",
+        ],
+      }],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 0)
+  })
+
+  t.plan(1)
+})
+
+test("valid 'flexible' order", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [{
+        order: "flexible",
+        properties: [
+          "color",
+        ],
+      }],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 0)
+  })
+
+  t.plan(1)
+})
+
+test("invalid option order option", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [{
+        order: "unknown-keyword",
+        properties: [
+          "color",
+        ],
+      }],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 1)
+    t.equal(
+      invalidOptionWarnings[0].text,
+      "Invalid option \"[{\"order\":\"unknown-keyword\",\"properties\":[\"color\"]}]\" for rule declaration-block-properties-order"
+    )
+  })
+
+  t.plan(2)
+})
+
+test("invalid object lacks 'properties' property", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [{
+        order: "flexible",
+      }],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 1)
+    t.equal(
+      invalidOptionWarnings[0].text,
+      "Invalid option \"[{\"order\":\"flexible\"}]\" for rule declaration-block-properties-order"
+    )
+  })
+
+  t.plan(2)
+})
+
+test("invalid nested array", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [["nested-array"]],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 1)
+    t.equal(
+      invalidOptionWarnings[0].text,
+      "Invalid option \"[[\"nested-array\"]]\" for rule declaration-block-properties-order"
+    )
+  })
+
+  t.plan(2)
+})
+
+test("invalid object outside of array", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": {
+        properties: [
+          "color",
+        ],
+      },
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 1)
+    t.equal(
+      invalidOptionWarnings[0].text,
+      "Invalid option \"{\"properties\":[\"color\"]}\" for rule declaration-block-properties-order"
+    )
+  })
+
+  t.plan(2)
+})

--- a/src/rules/declaration-block-properties-order/index.js
+++ b/src/rules/declaration-block-properties-order/index.js
@@ -215,30 +215,26 @@ function checkAlpabeticalOrder(firstPropData, secondPropData) {
 
 function validatePrimaryOption(actualOptions) {
 
+  // Return true early if alphabetical
   if (actualOptions === "alphabetical") { return true }
 
+  // Otherwise, begin checking array options
   if (!Array.isArray(actualOptions)) { return false }
 
   // Every item in the array must be a string or an object
   // with a "properties" property
-  if (actualOptions.every(item => {
+  if (!actualOptions.every(item => {
     if (_.isString(item)) { return true }
     return _.isPlainObject(item) && !_.isUndefined(item.properties)
-  })) { return true }
+  })) { return false }
 
   const objectItems = actualOptions.filter(_.isPlainObject)
 
-  // Every object-item's "emptyLineBefore" must be "always" or "never"
-  if (objectItems.every(item => {
-    if (_.isUndefined(item.emptyLineBefore)) { return true }
-    return _.includes([ "always", "never" ], item.emptyLineBefore)
-  })) { return true }
+  // Every object-item's "order" property must be "strict" or "flexible"
+  if (!objectItems.every(item => {
+    if (_.isUndefined(item.order)) { return true }
+    return _.includes([ "strict", "flexible" ], item.order)
+  })) { return false }
 
-  // Every object-item's "type" property must be "strict" or "flexible"
-  if (objectItems.every(item => {
-    if (_.isUndefined(item.type)) { return true }
-    return _.includes([ "string", "flexible" ], item.type)
-  })) { return true }
-
-  return false
+  return true
 }


### PR DESCRIPTION
It looks like the additional options validation in this rule would let anything that looks like an array pass. I’ve patched it up.

This PR brings coverage up to 100% for this rule.

And overall to 99.8% on this branch.

(the failing tests are the `indentation` ones mentioned in the other PR).