### PR TITLE
Tweak Stack Overflow support info

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -64,5 +64,5 @@ Here are the best ways to help resolve your issue:
 -->
 
 <!--
-Note: stackoverflow is our preferred QA forum - http://stackoverflow.com/questions/tagged/stylelint
+Note: GitHub issues are for stylelint bugs and enhancements, if you're looking for help or support with stylelint then stackoverflow is our preferred question and answer forum - http://stackoverflow.com/questions/tagged/stylelint
 -->


### PR DESCRIPTION
Via Gitter: `I didn’t thoroughly understand what stackoverflow is our preferred QA forum meant.`
• https://gitter.im/stylelint/stylelint?at=576d7b4f165412787f1ac447