### PR TITLE
Initial pass adding `except: ["after-single-line-comment"]` option to`rule-non-nested-empty-line-before` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Head
 
 - Deprecated: `-e` and `--extract` CLI flags, and the `extractStyleTagsFromHtml` node API option. If you use these flags or option, please consider creating a processor for the community. See the [release planning](/docs/user-guide/release-planning.md) document for more details.
-- Added: `ignoreProperties: []` option for `declaration-block-no-duplicate-properties`.
-- Added: `no-empty-source` rule.
 - Added: `at-rule-no-unknown` rule.
+- Added: `no-empty-source` rule.
+- Added: `except: ["after-single-line-comment"]` option for `rule-non-nested-empty-line-before`.
+- Added: `ignoreProperties: []` option for `declaration-block-no-duplicate-properties`.
 - Fixed: accuracy of warning positions for empty blocks when using SugarSS parser.
 
 # 6.7.1

--- a/src/rules/rule-non-nested-empty-line-before/README.md
+++ b/src/rules/rule-non-nested-empty-line-before/README.md
@@ -132,3 +132,26 @@ a
 b
 {}
 ```
+
+## Optional options
+
+### `except: ["after-single-line-comment"]`
+
+For example, with `"always"`:
+
+The following patterns are considered warnings:
+
+```css
+/* comment */
+
+a
+{}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+/* comment */
+a
+{}
+```

--- a/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
@@ -49,6 +49,26 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { except: ["after-single-line-comment"] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "/**\n * comment\n*/\n\na {}",
+  }, {
+    code: "/* comment */\na {}",
+  } ],
+
+  reject: [ {
+    code: "/**\n * comment\n*/\na {}",
+    message: messages.expected,
+  }, {
+    code: "/* comment */\n\na {}",
+    message: messages.rejected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { ignore: ["after-comment"] } ],
   skipBasicChecks: true,
 
@@ -104,6 +124,26 @@ testRule(rule, {
   }, {
     code: "b {}\n\n/* comment here*/\n\na {}",
     message: messages.rejected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "never", { except: ["after-single-line-comment"] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "/**\n * comment\n*/\na {}",
+  }, {
+    code: "/* comment */\n\na {}",
+  } ],
+
+  reject: [ {
+    code: "/**\n * comment\n*/\n\na {}",
+    message: messages.rejected,
+  }, {
+    code: "/* comment */\na {}",
+    message: messages.expected,
   } ],
 })
 

--- a/src/rules/rule-non-nested-empty-line-before/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/index.js
@@ -29,6 +29,7 @@ export default function (expectation, options) {
       actual: options,
       possible: {
         ignore: ["after-comment"],
+        except: ["after-single-line-comment"],
       },
       optional: true,
     })
@@ -64,6 +65,16 @@ export function checkRuleEmptyLineBefore({ rule, expectation, options, result, m
   // Optionally reverse the expectation for the first nested node
   if (optionsHaveException(options, "first-nested")
     && rule === rule.parent.first) {
+    expectEmptyLineBefore = !expectEmptyLineBefore
+  }
+
+  // Optionally reverse the expectation for single line comments
+  if (
+    optionsHaveException(options, "after-single-line-comment")
+    && rule.prev()
+    && rule.prev().type === "comment"
+    && isSingleLineString(rule.prev().toString())
+  ) {
     expectEmptyLineBefore = !expectEmptyLineBefore
   }
 


### PR DESCRIPTION
Ref #1351 Initial pass, got one remaining issue to fix, make the rule option actually work 😏 