### PR TITLE
Fix warning positioning of `block-no-empty` when using sugarss syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Deprecated: `-e` and `--extract` CLI flags, and the `extractStyleTagsFromHtml` node API option. If you use these flags or option, please consider creating a processor for the community. See the [release planning](/docs/user-guide/release-planning.md) document for more details.
 - Added: `ignoreProperties: []` option for `declaration-block-no-duplicate-properties`.
 - Added: `no-empty-source` rule.
+- Fixed: accuracy of warning positions for empty blocks when using SugarSS parser.
 
 # 6.7.1
 

--- a/src/rules/block-no-empty/__tests__/index.js
+++ b/src/rules/block-no-empty/__tests__/index.js
@@ -48,3 +48,17 @@ testRule(rule, {
     column: 18,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [undefined],
+  skipBasicChecks: true,
+  syntax: "sugarss",
+
+  reject: [{
+    code: ".a",
+    message: messages.rejected,
+    line: 1,
+    column: 2,
+  }],
+})

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -24,10 +24,17 @@ export default function (actual) {
     function check(statement) {
       if (!hasEmptyBlock(statement)) { return }
 
+      let index = beforeBlockString(statement, { noRawBefore: true }).length
+
+      // For empty blocks when using SugarSS parser
+      if (statement.raw("between") === undefined) {
+        index--
+      }
+
       report({
         message: messages.rejected,
         node: statement,
-        index: beforeBlockString(statement, { noRawBefore: true }).length,
+        index,
         result,
         ruleName,
       })

--- a/src/utils/__tests__/beforeBlockString-test.js
+++ b/src/utils/__tests__/beforeBlockString-test.js
@@ -1,5 +1,6 @@
 import test from "tape"
 import postcss from "postcss"
+import sugarss from "sugarss"
 import beforeBlockString from "../beforeBlockString"
 
 test("beforeBlockString rules", t => {
@@ -41,10 +42,15 @@ test("beforeBlockString with comment after selector", t => {
   t.end()
 })
 
-function postcssCheck(options = {}, cssString) {
+test("beforeBlockString without brackets using SugarSS parser", t => {
+  t.equal(postcssCheck({ noRawBefore: true }, ".a", sugarss), ".a")
+  t.end()
+})
+
+function postcssCheck(options = {}, cssString, parser = postcss) {
   if (typeof options === "string") {
     cssString = options
   }
-  const root = postcss.parse(cssString)
+  const root = parser.parse(cssString)
   return beforeBlockString(root.first, options)
 }

--- a/src/utils/beforeBlockString.js
+++ b/src/utils/beforeBlockString.js
@@ -22,6 +22,12 @@ export default function (statement, { noRawBefore } = {}) {
   } else {
     result += "@" + statement.name + statement.raw("afterName") + statement.params
   }
-  result += statement.raw("between")
+
+  const between = statement.raw("between")
+
+  if (between !== undefined) {
+    result += between
+  }
+
   return result
 }


### PR DESCRIPTION
Add a failing test for #1544 