### PR TITLE
Refactoring `selector-no-qualifying-type` - remove unnecessary `getLeftNodes` function.

### DIFF
--- a/src/rules/selector-no-qualifying-type/index.js
+++ b/src/rules/selector-no-qualifying-type/index.js
@@ -24,23 +24,6 @@ function isSelectorCharacters(value) {
   return selectorCharacters.some(char => value.indexOf(char) !== -1)
 }
 
-function getLeftNodes(node) {
-  const result = []
-  let leftNode = node
-
-  while ((leftNode = leftNode.prev())) {
-    if (leftNode.type === "combinator") { break }
-    if (leftNode.type !== "id"
-      && leftNode.type !== "class"
-      && leftNode.type !== "attribute"
-    ) { continue }
-
-    result.push(leftNode)
-  }
-
-  return result
-}
-
 function getRightNodes(node) {
   const result = []
   let rightNode = node
@@ -86,12 +69,10 @@ export default (enabled, options) => {
             return
           }
 
-          const leftNodes = getLeftNodes(selector)
-          const rightNodes = getRightNodes(selector)
-          const concatNodes = [].concat(leftNodes, rightNodes)
+          const selectorNodes = getRightNodes(selector)
           const index = selector.sourceIndex
 
-          concatNodes.forEach((selectorNode) => {
+          selectorNodes.forEach((selectorNode) => {
             if (selectorNode.type === "id" && !optionsHaveIgnored(options, "id")) {
               complain(index)
             }


### PR DESCRIPTION
/cc @davidtheclark @jeddy3 
Close https://github.com/stylelint/stylelint/issues/1545
Why i remove this line? Because `getLeftNodes` get left nodes (until combinator selector) relatively type selector (`div`, `a` and etc), e. g.
```css
[attribute]div {}
#iddiv
.classdiv
```
But first selector is not valid, second and third is interpreted as `id` and `class` selector. Honestly I do not know why it did, perhaps suggested the possibility the first variant.