### PR TITLE
Use eslint sort-imports rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
       "no-var": 2,
       "object-shorthand": 2,
       "prefer-const": 2,
+      "sort-imports": 2,
       "template-curly-spacing": 2
     }
   },

--- a/scripts/benchmark-rule.js
+++ b/scripts/benchmark-rule.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-console */
 import Benchmark from "benchmark"
-import request from "request"
-import postcss from "postcss"
 import chalk from "chalk"
-import rules from "../src/rules"
 import normalizeRuleSettings from "../src/normalizeRuleSettings"
+import postcss from "postcss"
+import request from "request"
+import rules from "../src/rules"
 
 const ruleName = process.argv[2]
 const ruleOptions = process.argv[3]

--- a/src/__tests__/buildConfig-test.js
+++ b/src/__tests__/buildConfig-test.js
@@ -1,6 +1,6 @@
-import test from "tape"
-import path from "path"
 import buildConfig from "../buildConfig"
+import path from "path"
+import test from "tape"
 
 test("buildConfig with config as argument object", t => {
   let planned = 0

--- a/src/__tests__/disableRanges-integration-test.js
+++ b/src/__tests__/disableRanges-integration-test.js
@@ -1,20 +1,20 @@
-import testRule from "../testUtils/testRule.js"
 import blockNoEmpty, {
-  ruleName as blockNoEmptyName,
   messages as blockNoEmptyMessages,
+  ruleName as blockNoEmptyName,
 } from "../rules/block-no-empty"
-import selectorCombinatorSpaceBefore, {
-  ruleName as selectorCombinatorSpaceBeforeName,
-  messages as selectorCombinatorSpaceBeforeMessages,
-} from "../rules/selector-combinator-space-before"
 import maxLineLength, {
-  ruleName as maxLineLengthName,
   messages as maxLineLengthMessages,
+  ruleName as maxLineLengthName,
 } from "../rules/max-line-length"
+import selectorCombinatorSpaceBefore, {
+  messages as selectorCombinatorSpaceBeforeMessages,
+  ruleName as selectorCombinatorSpaceBeforeName,
+} from "../rules/selector-combinator-space-before"
 import stringQuotes, {
-  ruleName as stringQuotesName,
   messages as stringQuotesMessages,
+  ruleName as stringQuotesName,
 } from "../rules/string-quotes"
+import testRule from "../testUtils/testRule.js"
 
 // disabling all rules
 testRule(blockNoEmpty, {

--- a/src/__tests__/disableRanges-test.js
+++ b/src/__tests__/disableRanges-test.js
@@ -1,9 +1,9 @@
-import test from "tape"
+import disableRanges from "../disableRanges"
+import less from "postcss-less"
 import { noop } from "lodash"
 import postcss from "postcss"
 import scss from "postcss-scss"
-import less from "postcss-less"
-import disableRanges from "../disableRanges"
+import test from "tape"
 
 test("disableRanges registers disable/enable commands without rules", t => {
   let planCount = 0

--- a/src/__tests__/ignore-test.js
+++ b/src/__tests__/ignore-test.js
@@ -1,6 +1,6 @@
+import path from "path"
 import standalone from "../standalone"
 import test from "tape"
-import path from "path"
 
 const fixturesPath = path.join(__dirname, "fixtures")
 

--- a/src/__tests__/integration.js
+++ b/src/__tests__/integration.js
@@ -1,8 +1,8 @@
-import test from "tape"
+import lessSyntax from "postcss-less"
 import postcss from "postcss"
 import scssSyntax from "postcss-scss"
-import lessSyntax from "postcss-less"
 import stylelint from "../"
+import test from "tape"
 
 const config = {
   rules: {

--- a/src/__tests__/plugins-test.js
+++ b/src/__tests__/plugins-test.js
@@ -1,7 +1,7 @@
-import postcss from "postcss"
-import test from "tape"
 import path from "path"
+import postcss from "postcss"
 import stylelint from ".."
+import test from "tape"
 
 const cssWithFoo = (
 ".foo {}"

--- a/src/__tests__/postcssPlugin-test.js
+++ b/src/__tests__/postcssPlugin-test.js
@@ -1,6 +1,6 @@
-import test from "tape"
 import path from "path"
 import postcssPlugin from "../postcssPlugin"
+import test from "tape"
 
 test("`configFile` option with absolute path", t => {
   const config = {

--- a/src/__tests__/processors-test.js
+++ b/src/__tests__/processors-test.js
@@ -1,7 +1,7 @@
+import configHtmlProcessor from "./fixtures/config-html-processor"
+import path from "path"
 import standalone from "../standalone"
 import test from "tape"
-import path from "path"
-import configHtmlProcessor from "./fixtures/config-html-processor"
 
 const fixturesPath = path.join(__dirname, "./fixtures")
 

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -1,13 +1,13 @@
-import path from "path"
-import fs from "fs"
-import cosmiconfig from "cosmiconfig"
-import resolveFrom from "resolve-from"
 import {
   assign,
   merge,
   omit,
 } from "lodash"
 import { configurationError } from "./utils"
+import cosmiconfig from "cosmiconfig"
+import fs from "fs"
+import path from "path"
+import resolveFrom from "resolve-from"
 
 const IGNORE_FILENAME = ".stylelintignore"
 const FILE_NOT_FOUND_ERROR_CODE = "ENOENT"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
+import {
+  assign,
+  includes,
+} from "lodash"
+import getStdin from "get-stdin"
 import meow from "meow"
 import path from "path"
-import { assign, includes } from "lodash"
-import getStdin from "get-stdin"
 import resolveFrom from "resolve-from"
 import standalone from "./standalone"
 

--- a/src/formatters/__tests__/jsonFormatter-test.js
+++ b/src/formatters/__tests__/jsonFormatter-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import jsonFormatter from "../jsonFormatter"
+import test from "tape"
 
 test("json formatter", t => {
 

--- a/src/formatters/__tests__/stringFormatter-test.js
+++ b/src/formatters/__tests__/stringFormatter-test.js
@@ -1,7 +1,7 @@
-import { stripIndent } from "common-tags"
 import chalk from "chalk"
-import test from "tape"
 import stringFormatter from "../stringFormatter"
+import { stripIndent } from "common-tags"
+import test from "tape"
 
 const symbolConversions = new Map()
 symbolConversions.set("ℹ", "i")

--- a/src/formatters/__tests__/verboseFormatter-test.js
+++ b/src/formatters/__tests__/verboseFormatter-test.js
@@ -1,8 +1,7 @@
+import { prepareFormatterOutput } from "./stringFormatter-test"
 import { stripIndent } from "common-tags"
 import test from "tape"
 import verboseFormatter from "../verboseFormatter"
-
-import { prepareFormatterOutput } from "./stringFormatter-test"
 
 test("no warnings", t => {
 

--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -1,9 +1,9 @@
+import table, { getBorderCharacters } from "table"
+import _ from "lodash"
 import chalk from "chalk"
 import path from "path"
-import _ from "lodash"
-import symbols from "log-symbols"
 import stringWidth from "string-width"
-import table, { getBorderCharacters } from "table"
+import symbols from "log-symbols"
 import utils from "postcss-reporter/lib/util"
 
 const MARGIN_WIDTHS = 9

--- a/src/formatters/verboseFormatter.js
+++ b/src/formatters/verboseFormatter.js
@@ -1,6 +1,6 @@
 import _ from "lodash"
-import stringFormatter from "./stringFormatter"
 import chalk from "chalk"
+import stringFormatter from "./stringFormatter"
 
 export default function (results) {
   let output = stringFormatter(results)

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-import postcssPlugin from "./postcssPlugin"
-import standalone from "./standalone"
-import createPlugin from "./createPlugin"
-import rules from "./rules"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "./utils"
+import createPlugin from "./createPlugin"
 import createRuleTester from "./testUtils/createRuleTester"
+import postcssPlugin from "./postcssPlugin"
+import rules from "./rules"
+import standalone from "./standalone"
 
 const stylelint = postcssPlugin
 

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -1,13 +1,13 @@
-import postcss from "postcss"
-import multimatch from "multimatch"
-import globjoin from "globjoin"
 import _ from "lodash"
-import path from "path"
-import { configurationError } from "./utils"
-import ruleDefinitions from "./rules"
-import disableRanges from "./disableRanges"
 import buildConfig from "./buildConfig"
+import { configurationError } from "./utils"
+import disableRanges from "./disableRanges"
+import globjoin from "globjoin"
+import multimatch from "multimatch"
 import normalizeRuleSettings from "./normalizeRuleSettings"
+import path from "path"
+import postcss from "postcss"
+import ruleDefinitions from "./rules"
 
 export default postcss.plugin("stylelint", (options = {}) => {
   // The Node API (standalone.js) will pass in its own _configPromise

--- a/src/rules/at-rule-blacklist/__tests__/index.js
+++ b/src/rules/at-rule-blacklist/__tests__/index.js
@@ -1,5 +1,11 @@
+import {
+  messages,
+  ruleName,
+} from ".."
+import rules from "../../../rules"
 import { testRule } from "../../../testUtils"
-import rule, { ruleName, messages } from ".."
+
+const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,

--- a/src/rules/at-rule-blacklist/index.js
+++ b/src/rules/at-rule-blacklist/index.js
@@ -1,11 +1,10 @@
-import { isString } from "lodash"
-import { vendor } from "postcss"
-
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import { vendor } from "postcss"
 
 export const ruleName = "at-rule-blacklist"
 

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -1,6 +1,12 @@
-import { mergeTestDescriptions, testRule } from "../../../testUtils"
+import {
+  mergeTestDescriptions,
+  testRule,
+} from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
 
 const rule = rules[ruleName]
 

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -1,5 +1,3 @@
-import { isString } from "lodash"
-
 import {
   hasBlock,
   optionsHaveException,
@@ -9,6 +7,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
 
 export const ruleName = "at-rule-empty-line-before"
 

--- a/src/rules/at-rule-name-case/__tests__/index.js
+++ b/src/rules/at-rule-name-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/at-rule-name-newline-after/__tests__/index.js
+++ b/src/rules/at-rule-name-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/at-rule-name-space-after/__tests__/index.js
+++ b/src/rules/at-rule-name-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/at-rule-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/at-rule-semicolon-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/at-rule-whitelist/__tests__/index.js
+++ b/src/rules/at-rule-whitelist/__tests__/index.js
@@ -1,5 +1,11 @@
+import {
+  messages,
+  ruleName,
+} from ".."
+import rules from "../../../rules"
 import { testRule } from "../../../testUtils"
-import rule, { ruleName, messages } from ".."
+
+const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,

--- a/src/rules/at-rule-whitelist/index.js
+++ b/src/rules/at-rule-whitelist/index.js
@@ -1,11 +1,10 @@
-import { isString } from "lodash"
-import { vendor } from "postcss"
-
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import { vendor } from "postcss"
 
 export const ruleName = "at-rule-whitelist"
 

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -1,5 +1,3 @@
-import { isString } from "lodash"
-
 import {
   blockString,
   hasBlock,
@@ -10,6 +8,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import { isString } from "lodash"
 
 export const ruleName = "block-closing-brace-newline-after"
 

--- a/src/rules/block-closing-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -1,4 +1,3 @@
-import { startsWith } from "lodash"
 import {
   blockString,
   hasBlock,
@@ -8,6 +7,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { startsWith } from "lodash"
 
 export const ruleName = "block-closing-brace-newline-before"
 

--- a/src/rules/block-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -1,8 +1,8 @@
 import {
   blockString,
   hasBlock,
-  report,
   rawNodeString,
+  report,
   ruleMessages,
   validateOptions,
   whitespaceChecker,

--- a/src/rules/block-closing-brace-space-before/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-no-empty/__tests__/index.js
+++ b/src/rules/block-no-empty/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -1,6 +1,6 @@
 import {
-  hasEmptyBlock,
   beforeBlockString,
+  hasEmptyBlock,
   report,
   ruleMessages,
   validateOptions,

--- a/src/rules/block-no-single-line/__tests__/index.js
+++ b/src/rules/block-no-single-line/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-no-single-line/index.js
+++ b/src/rules/block-no-single-line/index.js
@@ -1,7 +1,7 @@
 import {
+  beforeBlockString,
   blockString,
   hasBlock,
-  beforeBlockString,
   isSingleLineString,
   report,
   ruleMessages,

--- a/src/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-opening-brace-newline-after/index.js
+++ b/src/rules/block-opening-brace-newline-after/index.js
@@ -1,8 +1,8 @@
 import {
+  beforeBlockString,
   blockString,
   hasBlock,
   hasEmptyBlock,
-  beforeBlockString,
   nextNonCommentNode,
   rawNodeString,
   report,

--- a/src/rules/block-opening-brace-newline-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-newline-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-opening-brace-newline-before/index.js
+++ b/src/rules/block-opening-brace-newline-before/index.js
@@ -1,8 +1,8 @@
 import {
+  beforeBlockString,
+  blockString,
   hasBlock,
   hasEmptyBlock,
-  blockString,
-  beforeBlockString,
   report,
   ruleMessages,
   validateOptions,

--- a/src/rules/block-opening-brace-space-after/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-opening-brace-space-after/index.js
+++ b/src/rules/block-opening-brace-space-after/index.js
@@ -1,8 +1,8 @@
 import {
+  beforeBlockString,
   blockString,
   hasBlock,
   hasEmptyBlock,
-  beforeBlockString,
   report,
   ruleMessages,
   validateOptions,

--- a/src/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/src/rules/block-opening-brace-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/block-opening-brace-space-before/index.js
+++ b/src/rules/block-opening-brace-space-before/index.js
@@ -1,16 +1,15 @@
-import { isString } from "lodash"
-
 import {
+  beforeBlockString,
   blockString,
   hasBlock,
   hasEmptyBlock,
-  beforeBlockString,
   optionsHaveIgnoredAtRule,
   report,
   ruleMessages,
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import { isString } from "lodash"
 
 export const ruleName = "block-opening-brace-space-before"
 

--- a/src/rules/color-hex-case/__tests__/index.js
+++ b/src/rules/color-hex-case/__tests__/index.js
@@ -1,6 +1,12 @@
-import { mergeTestDescriptions, testRule } from "../../../testUtils"
+import {
+  mergeTestDescriptions,
+  testRule,
+} from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
 
 const rule = rules[ruleName]
 

--- a/src/rules/color-hex-case/index.js
+++ b/src/rules/color-hex-case/index.js
@@ -1,9 +1,9 @@
-import styleSearch from "style-search"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "color-hex-case"
 

--- a/src/rules/color-hex-length/__tests__/index.js
+++ b/src/rules/color-hex-length/__tests__/index.js
@@ -1,6 +1,12 @@
-import { mergeTestDescriptions, testRule } from "../../../testUtils"
+import {
+  mergeTestDescriptions,
+  testRule,
+} from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
 
 const rule = rules[ruleName]
 

--- a/src/rules/color-hex-length/index.js
+++ b/src/rules/color-hex-length/index.js
@@ -1,9 +1,9 @@
-import styleSearch from "style-search"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "color-hex-length"
 

--- a/src/rules/color-named/__tests__/index.js
+++ b/src/rules/color-named/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/color-named/index.js
+++ b/src/rules/color-named/index.js
@@ -1,4 +1,3 @@
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   isStandardSyntaxValue,
@@ -8,6 +7,7 @@ import {
 } from "../../utils"
 import { colorFunctionNames } from "../../reference/keywordSets"
 import namedColorData from "../../reference/namedColorData"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "color-named"
 

--- a/src/rules/color-no-hex/__tests__/index.js
+++ b/src/rules/color-no-hex/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/color-no-hex/index.js
+++ b/src/rules/color-no-hex/index.js
@@ -1,9 +1,9 @@
-import styleSearch from "style-search"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "color-no-hex"
 

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/color-no-invalid-hex/index.js
+++ b/src/rules/color-no-invalid-hex/index.js
@@ -1,10 +1,10 @@
-import styleSearch from "style-search"
 import {
   isValidHex,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "color-no-invalid-hex"
 

--- a/src/rules/comment-empty-line-before/__tests__/index.js
+++ b/src/rules/comment-empty-line-before/__tests__/index.js
@@ -1,6 +1,12 @@
-import { mergeTestDescriptions, testRule } from "../../../testUtils"
+import {
+  mergeTestDescriptions,
+  testRule,
+} from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
 
 const rule = rules[ruleName]
 

--- a/src/rules/comment-whitespace-inside/__tests__/index.js
+++ b/src/rules/comment-whitespace-inside/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/comment-word-blacklist/__tests__/index.js
+++ b/src/rules/comment-word-blacklist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/comment-word-blacklist/index.js
+++ b/src/rules/comment-word-blacklist/index.js
@@ -1,11 +1,11 @@
-import { isString } from "lodash"
 import {
+  containsString,
+  matchesStringOrRegExp,
   report,
   ruleMessages,
   validateOptions,
-  matchesStringOrRegExp,
-  containsString,
 } from "../../utils"
+import { isString } from "lodash"
 
 export const ruleName = "comment-word-blacklist"
 

--- a/src/rules/custom-media-pattern/__tests__/index.js
+++ b/src/rules/custom-media-pattern/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/custom-media-pattern/index.js
+++ b/src/rules/custom-media-pattern/index.js
@@ -1,10 +1,13 @@
-import { isRegExp, isString } from "lodash"
 import {
   atRuleParamIndex,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import {
+  isRegExp,
+  isString,
+} from "lodash"
 
 export const ruleName = "custom-media-pattern"
 

--- a/src/rules/custom-property-no-outside-root/__tests__/index.js
+++ b/src/rules/custom-property-no-outside-root/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/custom-property-pattern/__tests__/index.js
+++ b/src/rules/custom-property-pattern/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-bang-space-after/__tests__/index.js
+++ b/src/rules/declaration-bang-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-bang-space-after/index.js
+++ b/src/rules/declaration-bang-space-after/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   declarationValueIndex,
   report,
@@ -6,6 +5,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "declaration-bang-space-after"
 

--- a/src/rules/declaration-bang-space-before/__tests__/index.js
+++ b/src/rules/declaration-bang-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-no-ignored-properties/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/index.js
@@ -1,10 +1,10 @@
-import { vendor } from "postcss"
 import {
+  matchesStringOrRegExp,
   report,
   ruleMessages,
   validateOptions,
-  matchesStringOrRegExp,
 } from "../../utils"
+import { vendor } from "postcss"
 
 export const ruleName = "declaration-block-no-ignored-properties"
 

--- a/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-properties-order/__tests__/alphabetical.js
+++ b/src/rules/declaration-block-properties-order/__tests__/alphabetical.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-properties-order/__tests__/flat.js
+++ b/src/rules/declaration-block-properties-order/__tests__/flat.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-properties-order/__tests__/grouped-flexible.js
+++ b/src/rules/declaration-block-properties-order/__tests__/grouped-flexible.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-properties-order/__tests__/grouped-strict.js
+++ b/src/rules/declaration-block-properties-order/__tests__/grouped-strict.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-properties-order/__tests__/validate-options.js
+++ b/src/rules/declaration-block-properties-order/__tests__/validate-options.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import stylelint from "../../.."
+import test from "tape"
 
 test("valid default order", t => {
   const config = {

--- a/src/rules/declaration-block-properties-order/index.js
+++ b/src/rules/declaration-block-properties-order/index.js
@@ -1,5 +1,3 @@
-import _ from "lodash"
-import { vendor } from "postcss"
 import {
   isCustomProperty,
   isStandardSyntaxProperty,
@@ -7,6 +5,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
+import { vendor } from "postcss"
 
 export const ruleName = "declaration-block-properties-order"
 

--- a/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-semicolon-newline-after/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/index.js
@@ -1,8 +1,8 @@
 import {
   blockString,
-  report,
   nextNonCommentNode,
   rawNodeString,
+  report,
   ruleMessages,
   validateOptions,
   whitespaceChecker,

--- a/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-semicolon-space-before/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-single-line-max-declarations/__tests__/index.js
+++ b/src/rules/declaration-block-single-line-max-declarations/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-single-line-max-declarations/index.js
+++ b/src/rules/declaration-block-single-line-max-declarations/index.js
@@ -1,12 +1,12 @@
-import { isNumber } from "lodash"
 import {
-  blockString,
   beforeBlockString,
+  blockString,
   isSingleLineString,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isNumber } from "lodash"
 
 export const ruleName = "declaration-block-single-line-max-declarations"
 

--- a/src/rules/declaration-block-trailing-semicolon/__tests__/index.js
+++ b/src/rules/declaration-block-trailing-semicolon/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-block-trailing-semicolon/index.js
+++ b/src/rules/declaration-block-trailing-semicolon/index.js
@@ -1,7 +1,7 @@
 import {
+  hasBlock,
   report,
   ruleMessages,
-  hasBlock,
   validateOptions,
 } from "../../utils"
 

--- a/src/rules/declaration-colon-newline-after/__tests__/index.js
+++ b/src/rules/declaration-colon-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-colon-newline-after/index.js
+++ b/src/rules/declaration-colon-newline-after/index.js
@@ -1,6 +1,6 @@
 import {
-  isStandardSyntaxDeclaration,
   declarationValueIndex,
+  isStandardSyntaxDeclaration,
   report,
   ruleMessages,
   validateOptions,

--- a/src/rules/declaration-colon-space-after/__tests__/index.js
+++ b/src/rules/declaration-colon-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-colon-space-after/index.js
+++ b/src/rules/declaration-colon-space-after/index.js
@@ -1,6 +1,6 @@
 import {
-  isStandardSyntaxDeclaration,
   declarationValueIndex,
+  isStandardSyntaxDeclaration,
   report,
   ruleMessages,
   validateOptions,

--- a/src/rules/declaration-colon-space-before/__tests__/index.js
+++ b/src/rules/declaration-colon-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-no-important/__tests__/index.js
+++ b/src/rules/declaration-no-important/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-property-unit-blacklist/__tests__/index.js
+++ b/src/rules/declaration-property-unit-blacklist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-property-unit-blacklist/index.js
+++ b/src/rules/declaration-property-unit-blacklist/index.js
@@ -1,6 +1,3 @@
-import { vendor } from "postcss"
-import { isObject, find } from "lodash"
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -9,6 +6,12 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import {
+  find,
+  isObject,
+} from "lodash"
+import valueParser from "postcss-value-parser"
+import { vendor } from "postcss"
 
 export const ruleName = "declaration-property-unit-blacklist"
 

--- a/src/rules/declaration-property-unit-whitelist/__tests__/index.js
+++ b/src/rules/declaration-property-unit-whitelist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-property-unit-whitelist/index.js
+++ b/src/rules/declaration-property-unit-whitelist/index.js
@@ -1,14 +1,17 @@
-import { vendor } from "postcss"
-import { isObject, find } from "lodash"
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   getUnitFromValueNode,
+  matchesStringOrRegExp,
   report,
   ruleMessages,
   validateOptions,
-  matchesStringOrRegExp,
 } from "../../utils"
+import {
+  find,
+  isObject,
+} from "lodash"
+import valueParser from "postcss-value-parser"
+import { vendor } from "postcss"
 
 export const ruleName = "declaration-property-unit-whitelist"
 

--- a/src/rules/declaration-property-value-blacklist/__tests__/index.js
+++ b/src/rules/declaration-property-value-blacklist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-property-value-blacklist/index.js
+++ b/src/rules/declaration-property-value-blacklist/index.js
@@ -1,11 +1,15 @@
-import { vendor } from "postcss"
-import { isObject, isEmpty, find } from "lodash"
 import {
+  find,
+  isEmpty,
+  isObject,
+} from "lodash"
+import {
+  matchesStringOrRegExp,
   report,
   ruleMessages,
   validateOptions,
-  matchesStringOrRegExp,
 } from "../../utils"
+import { vendor } from "postcss"
 
 export const ruleName = "declaration-property-value-blacklist"
 

--- a/src/rules/declaration-property-value-whitelist/__tests__/index.js
+++ b/src/rules/declaration-property-value-whitelist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/declaration-property-value-whitelist/index.js
+++ b/src/rules/declaration-property-value-whitelist/index.js
@@ -1,11 +1,15 @@
-import { vendor } from "postcss"
-import { isObject, isEmpty, find } from "lodash"
 import {
+  find,
+  isEmpty,
+  isObject,
+} from "lodash"
+import {
+  matchesStringOrRegExp,
   report,
   ruleMessages,
   validateOptions,
-  matchesStringOrRegExp,
 } from "../../utils"
+import { vendor } from "postcss"
 
 export const ruleName = "declaration-property-value-whitelist"
 

--- a/src/rules/font-family-name-quotes/__tests__/index.js
+++ b/src/rules/font-family-name-quotes/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/font-family-name-quotes/index.js
+++ b/src/rules/font-family-name-quotes/index.js
@@ -1,7 +1,7 @@
 import {
+  findFontFamily,
   isStandardSyntaxValue,
   isVariable,
-  findFontFamily,
   report,
   ruleMessages,
   validateOptions,

--- a/src/rules/font-weight-notation/__tests__/index.js
+++ b/src/rules/font-weight-notation/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/font-weight-notation/index.js
+++ b/src/rules/font-weight-notation/index.js
@@ -1,9 +1,7 @@
-import postcss from "postcss"
-import { includes } from "lodash"
 import {
+  declarationValueIndex,
   isStandardSyntaxValue,
   isVariable,
-  declarationValueIndex,
   optionsHaveIgnored,
   report,
   ruleMessages,
@@ -13,6 +11,8 @@ import {
   fontWeightKeywords,
   fontWeightRelativeKeywords,
 } from "../../reference/keywordSets"
+import { includes } from "lodash"
+import postcss from "postcss"
 
 export const ruleName = "font-weight-notation"
 

--- a/src/rules/function-blacklist/__tests__/index.js
+++ b/src/rules/function-blacklist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-blacklist/index.js
+++ b/src/rules/function-blacklist/index.js
@@ -1,7 +1,3 @@
-import { isString } from "lodash"
-import { vendor } from "postcss"
-import valueParser from "postcss-value-parser"
-
 import {
   declarationValueIndex,
   isStandardSyntaxFunction,
@@ -10,6 +6,9 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import valueParser from "postcss-value-parser"
+import { vendor } from "postcss"
 
 export const ruleName = "function-blacklist"
 

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -1,12 +1,12 @@
-import styleSearch from "style-search"
 import {
   isWhitespace,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
-import valueParser from "postcss-value-parser"
 import balancedMatch from "balanced-match"
+import styleSearch from "style-search"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "function-calc-no-unspaced-operator"
 

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-comma-newline-before/__tests__/index.js
+++ b/src/rules/function-comma-newline-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-comma-space-after/__tests__/index.js
+++ b/src/rules/function-comma-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-comma-space-after/index.js
+++ b/src/rules/function-comma-space-after/index.js
@@ -1,6 +1,3 @@
-import styleSearch from "style-search"
-import _ from "lodash"
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   isStandardSyntaxFunction,
@@ -9,6 +6,9 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import _ from "lodash"
+import styleSearch from "style-search"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "function-comma-space-after"
 

--- a/src/rules/function-comma-space-before/__tests__/index.js
+++ b/src/rules/function-comma-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-max-empty-lines/__tests__/index.js
+++ b/src/rules/function-max-empty-lines/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-max-empty-lines/index.js
+++ b/src/rules/function-max-empty-lines/index.js
@@ -1,10 +1,13 @@
-import styleSearch from "style-search"
-import { isNumber, repeat } from "lodash"
+import {
+  isNumber,
+  repeat,
+} from "lodash"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "function-max-empty-lines"
 

--- a/src/rules/function-name-case/__tests__/index.js
+++ b/src/rules/function-name-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-name-case/index.js
+++ b/src/rules/function-name-case/index.js
@@ -1,5 +1,3 @@
-import valueParser from "postcss-value-parser"
-import { isString } from "lodash"
 import {
   declarationValueIndex,
   isStandardSyntaxFunction,
@@ -9,6 +7,8 @@ import {
   validateOptions,
 } from "../../utils"
 import { camelCaseFunctionNames } from "../../reference/keywordSets"
+import { isString } from "lodash"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "function-name-case"
 

--- a/src/rules/function-parentheses-newline-inside/__tests__/index.js
+++ b/src/rules/function-parentheses-newline-inside/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-parentheses-newline-inside/index.js
+++ b/src/rules/function-parentheses-newline-inside/index.js
@@ -1,4 +1,3 @@
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   isSingleLineString,
@@ -7,6 +6,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "function-parentheses-newline-inside"
 

--- a/src/rules/function-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/function-parentheses-space-inside/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-parentheses-space-inside/index.js
+++ b/src/rules/function-parentheses-space-inside/index.js
@@ -1,4 +1,3 @@
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   isSingleLineString,
@@ -7,6 +6,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "function-parentheses-space-inside"
 

--- a/src/rules/function-url-data-uris/__tests__/index.js
+++ b/src/rules/function-url-data-uris/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-url-data-uris/index.js
+++ b/src/rules/function-url-data-uris/index.js
@@ -1,4 +1,3 @@
-import valueParser from "postcss-value-parser"
 import {
   isStandardSyntaxValue,
   isVariable,
@@ -6,6 +5,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "function-url-data-uris"
 

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -1,7 +1,7 @@
 import {
-  isStandardSyntaxUrl,
-  functionArgumentsSearch,
   atRuleParamIndex,
+  functionArgumentsSearch,
+  isStandardSyntaxUrl,
   report,
   ruleMessages,
   validateOptions,

--- a/src/rules/function-whitelist/__tests__/index.js
+++ b/src/rules/function-whitelist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-whitelist/index.js
+++ b/src/rules/function-whitelist/index.js
@@ -1,7 +1,3 @@
-import { isString } from "lodash"
-import { vendor } from "postcss"
-import valueParser from "postcss-value-parser"
-
 import {
   declarationValueIndex,
   isStandardSyntaxFunction,
@@ -10,6 +6,9 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import valueParser from "postcss-value-parser"
+import { vendor } from "postcss"
 
 export const ruleName = "function-whitelist"
 

--- a/src/rules/function-whitespace-after/__tests__/index.js
+++ b/src/rules/function-whitespace-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/function-whitespace-after/index.js
+++ b/src/rules/function-whitespace-after/index.js
@@ -1,10 +1,10 @@
-import styleSearch from "style-search"
 import {
   isWhitespace,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "function-whitespace-after"
 

--- a/src/rules/indentation/__tests__/at-rules.js
+++ b/src/rules/indentation/__tests__/at-rules.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/indentation/__tests__/comments.js
+++ b/src/rules/indentation/__tests__/comments.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/indentation/__tests__/functions.js
+++ b/src/rules/indentation/__tests__/functions.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/indentation/__tests__/selectors.js
+++ b/src/rules/indentation/__tests__/selectors.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -1,14 +1,18 @@
-import styleSearch from "style-search"
-import { repeat, isNumber, isBoolean } from "lodash"
 import {
+  beforeBlockString,
+  hasBlock,
   optionsHaveException,
   optionsHaveIgnored,
   report,
   ruleMessages,
-  hasBlock,
-  beforeBlockString,
   validateOptions,
 } from "../../utils"
+import {
+  isBoolean,
+  isNumber,
+  repeat,
+} from "lodash"
+import styleSearch from "style-search"
 
 export const ruleName = "indentation"
 export const messages = ruleMessages(ruleName, {

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -114,8 +114,8 @@ import selectorListCommaNewlineAfter from "./selector-list-comma-newline-after"
 import selectorListCommaNewlineBefore from "./selector-list-comma-newline-before"
 import selectorListCommaSpaceAfter from "./selector-list-comma-space-after"
 import selectorListCommaSpaceBefore from "./selector-list-comma-space-before"
-import selectorMaxEmptyLines from "./selector-max-empty-lines"
 import selectorMaxCompoundSelectors from "./selector-max-compound-selectors"
+import selectorMaxEmptyLines from "./selector-max-empty-lines"
 import selectorMaxSpecificity from "./selector-max-specificity"
 import selectorNoAttribute from "./selector-no-attribute"
 import selectorNoCombinator from "./selector-no-combinator"
@@ -266,8 +266,8 @@ export default {
   "selector-list-comma-newline-before": selectorListCommaNewlineBefore,
   "selector-list-comma-space-after": selectorListCommaSpaceAfter,
   "selector-list-comma-space-before": selectorListCommaSpaceBefore,
-  "selector-max-empty-lines": selectorMaxEmptyLines,
   "selector-max-compound-selectors": selectorMaxCompoundSelectors,
+  "selector-max-empty-lines": selectorMaxEmptyLines,
   "selector-max-specificity": selectorMaxSpecificity,
   "selector-no-attribute": selectorNoAttribute,
   "selector-no-combinator": selectorNoCombinator,

--- a/src/rules/keyframe-declaration-no-important/__tests__/index.js
+++ b/src/rules/keyframe-declaration-no-important/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/length-zero-no-unit/__tests__/index.js
+++ b/src/rules/length-zero-no-unit/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/length-zero-no-unit/index.js
+++ b/src/rules/length-zero-no-unit/index.js
@@ -1,19 +1,19 @@
-import styleSearch from "style-search"
+import {
+  beforeBlockString,
+  blurComments,
+  hasBlock,
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
 import {
   findIndex,
   findLastIndex,
   range,
 } from "lodash"
-import valueParser from "postcss-value-parser"
-import {
-  blurComments,
-  hasBlock,
-  beforeBlockString,
-  report,
-  ruleMessages,
-  validateOptions,
-} from "../../utils"
 import { lengthUnits } from "../../reference/keywordSets"
+import styleSearch from "style-search"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "length-zero-no-unit"
 

--- a/src/rules/max-empty-lines/__tests__/index.js
+++ b/src/rules/max-empty-lines/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/max-empty-lines/index.js
+++ b/src/rules/max-empty-lines/index.js
@@ -1,10 +1,13 @@
-import styleSearch from "style-search"
-import { isNumber, repeat } from "lodash"
+import {
+  isNumber,
+  repeat,
+} from "lodash"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "max-empty-lines"
 

--- a/src/rules/max-line-length/__tests__/index.js
+++ b/src/rules/max-line-length/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/max-line-length/index.js
+++ b/src/rules/max-line-length/index.js
@@ -1,11 +1,11 @@
-import styleSearch from "style-search"
-import { isNumber } from "lodash"
 import {
   optionsHaveIgnored,
-  ruleMessages,
   report,
+  ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isNumber } from "lodash"
+import styleSearch from "style-search"
 
 export const ruleName = "max-line-length"
 

--- a/src/rules/max-nesting-depth/__tests__/index.js
+++ b/src/rules/max-nesting-depth/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/max-nesting-depth/index.js
+++ b/src/rules/max-nesting-depth/index.js
@@ -1,11 +1,11 @@
-import _ from "lodash"
 import {
   hasBlock,
   optionsHaveIgnored,
-  ruleMessages,
   report,
+  ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
 
 export const ruleName = "max-nesting-depth"
 

--- a/src/rules/media-feature-colon-space-after/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-feature-colon-space-after/index.js
+++ b/src/rules/media-feature-colon-space-after/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   atRuleParamIndex,
   report,
@@ -6,6 +5,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "media-feature-colon-space-after"
 

--- a/src/rules/media-feature-colon-space-before/__tests__/index.js
+++ b/src/rules/media-feature-colon-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
+++ b/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-feature-no-missing-punctuation/index.js
+++ b/src/rules/media-feature-no-missing-punctuation/index.js
@@ -1,10 +1,10 @@
-import execall from "execall"
 import {
   atRuleParamIndex,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import execall from "execall"
 import { mediaFeaturePunctuation } from "../../reference/punctuationSets"
 
 export const ruleName = "media-feature-no-missing-punctuation"

--- a/src/rules/media-feature-range-operator-space-after/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-feature-range-operator-space-before/__tests__/index.js
+++ b/src/rules/media-feature-range-operator-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-query-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-query-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-newline-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-query-list-comma-space-after/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-query-list-comma-space-after/index.js
+++ b/src/rules/media-query-list-comma-space-after/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   atRuleParamIndex,
   report,
@@ -6,6 +5,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "media-query-list-comma-space-after"
 

--- a/src/rules/media-query-list-comma-space-before/__tests__/index.js
+++ b/src/rules/media-query-list-comma-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-query-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/media-query-parentheses-space-inside/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/media-query-parentheses-space-inside/index.js
+++ b/src/rules/media-query-parentheses-space-inside/index.js
@@ -1,10 +1,10 @@
-import styleSearch from "style-search"
 import {
   atRuleParamIndex,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "media-query-parentheses-space-inside"
 

--- a/src/rules/no-browser-hacks/__tests__/index.js
+++ b/src/rules/no-browser-hacks/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-browser-hacks/index.js
+++ b/src/rules/no-browser-hacks/index.js
@@ -1,11 +1,11 @@
-import stylehacks from "stylehacks"
-import Result from "postcss/lib/result"
-import { isString } from "lodash"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import Result from "postcss/lib/result"
+import { isString } from "lodash"
+import stylehacks from "stylehacks"
 
 export const ruleName = "no-browser-hacks"
 

--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -1,15 +1,17 @@
-import { calculate, compare } from "specificity"
-import _ from "lodash"
-import resolvedNestedSelector from "postcss-resolve-nested-selector"
-
 import {
-  nodeContextLookup,
+  calculate,
+  compare,
+} from "specificity"
+import {
   findAtRuleContext,
+  nodeContextLookup,
   parseSelector,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
+import resolvedNestedSelector from "postcss-resolve-nested-selector"
 
 export const ruleName = "no-descending-specificity"
 

--- a/src/rules/no-duplicate-selectors/__tests__/index.js
+++ b/src/rules/no-duplicate-selectors/__tests__/index.js
@@ -1,10 +1,13 @@
-import { testRule } from "../../../testUtils"
-import rules from "../../../rules"
+import {
+  messages,
+  ruleName,
+} from ".."
+import path from "path"
 import postcss from "postcss"
 import postcssImport from "postcss-import"
-import path from "path"
+import rules from "../../../rules"
 import test from "tape"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-duplicate-selectors/index.js
+++ b/src/rules/no-duplicate-selectors/index.js
@@ -1,14 +1,17 @@
-import { includes, union } from "lodash"
-import resolvedNestedSelector from "postcss-resolve-nested-selector"
-import normalizeSelector from "normalize-selector"
 import {
-  nodeContextLookup,
-  isKeyframeRule,
   findAtRuleContext,
-  ruleMessages,
+  isKeyframeRule,
+  nodeContextLookup,
   report,
+  ruleMessages,
   validateOptions,
 } from "../../utils"
+import {
+  includes,
+  union,
+} from "lodash"
+import normalizeSelector from "normalize-selector"
+import resolvedNestedSelector from "postcss-resolve-nested-selector"
 
 export const ruleName = "no-duplicate-selectors"
 

--- a/src/rules/no-eol-whitespace/__tests__/index.js
+++ b/src/rules/no-eol-whitespace/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-eol-whitespace/index.js
+++ b/src/rules/no-eol-whitespace/index.js
@@ -1,9 +1,9 @@
-import styleSearch from "style-search"
 import {
-  ruleMessages,
   report,
+  ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "no-eol-whitespace"
 

--- a/src/rules/no-extra-semicolons/__tests__/index.js
+++ b/src/rules/no-extra-semicolons/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-extra-semicolons/index.js
+++ b/src/rules/no-extra-semicolons/index.js
@@ -1,9 +1,9 @@
-import styleSearch from "style-search"
 import {
-  ruleMessages,
   report,
+  ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "no-extra-semicolons"
 

--- a/src/rules/no-indistinguishable-colors/__tests__/index.js
+++ b/src/rules/no-indistinguishable-colors/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-indistinguishable-colors/index.js
+++ b/src/rules/no-indistinguishable-colors/index.js
@@ -1,12 +1,15 @@
-import colorguard from "colorguard"
-import { isArray, isNumber } from "lodash"
-import Result from "postcss/lib/result"
+import {
+  isArray,
+  isNumber,
+} from "lodash"
 import {
   isValidHex,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import Result from "postcss/lib/result"
+import colorguard from "colorguard"
 
 export const ruleName = "no-indistinguishable-colors"
 

--- a/src/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/src/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-missing-eof-newline/__tests__/index.js
+++ b/src/rules/no-missing-eof-newline/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-unknown-animations/__tests__/index.js
+++ b/src/rules/no-unknown-animations/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-unknown-animations/index.js
+++ b/src/rules/no-unknown-animations/index.js
@@ -1,14 +1,14 @@
 import {
+  animationNameKeywords,
+  basicKeywords,
+} from "../../reference/keywordSets"
+import {
   declarationValueIndex,
   findAnimationName,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
-import {
-  animationNameKeywords,
-  basicKeywords,
-} from "../../reference/keywordSets"
 
 export const ruleName = "no-unknown-animations"
 

--- a/src/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/src/rules/no-unsupported-browser-features/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/no-unsupported-browser-features/index.js
+++ b/src/rules/no-unsupported-browser-features/index.js
@@ -1,11 +1,11 @@
 const doiuse = require("doiuse")
-import Result from "postcss/lib/result"
-import { isString } from "lodash"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import Result from "postcss/lib/result"
+import { isString } from "lodash"
 
 export const ruleName = "no-unsupported-browser-features"
 

--- a/src/rules/number-leading-zero/__tests__/index.js
+++ b/src/rules/number-leading-zero/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/number-leading-zero/index.js
+++ b/src/rules/number-leading-zero/index.js
@@ -1,13 +1,13 @@
-import execall from "execall"
-import _ from "lodash"
 import {
+  beforeBlockString,
   blurFunctionArguments,
   hasBlock,
-  beforeBlockString,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
+import execall from "execall"
 
 export const ruleName = "number-leading-zero"
 

--- a/src/rules/number-max-precision/__tests__/index.js
+++ b/src/rules/number-max-precision/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/number-max-precision/index.js
+++ b/src/rules/number-max-precision/index.js
@@ -1,5 +1,3 @@
-import { isNumber } from "lodash"
-import execall from "execall"
 import {
   beforeBlockString,
   blurComments,
@@ -9,6 +7,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import execall from "execall"
+import { isNumber } from "lodash"
 
 export const ruleName = "number-max-precision"
 

--- a/src/rules/number-no-trailing-zeros/__tests__/index.js
+++ b/src/rules/number-no-trailing-zeros/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/number-no-trailing-zeros/index.js
+++ b/src/rules/number-no-trailing-zeros/index.js
@@ -1,13 +1,13 @@
-import execall from "execall"
 import {
+  beforeBlockString,
   blurComments,
   blurFunctionArguments,
   hasBlock,
-  beforeBlockString,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import execall from "execall"
 
 export const ruleName = "number-no-trailing-zeros"
 

--- a/src/rules/property-blacklist/__tests__/index.js
+++ b/src/rules/property-blacklist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/property-blacklist/index.js
+++ b/src/rules/property-blacklist/index.js
@@ -1,5 +1,3 @@
-import { vendor } from "postcss"
-import { isString } from "lodash"
 import {
   isCustomProperty,
   isStandardSyntaxProperty,
@@ -8,6 +6,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import { vendor } from "postcss"
 
 export const ruleName = "property-blacklist"
 

--- a/src/rules/property-case/__tests__/index.js
+++ b/src/rules/property-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/property-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/property-whitelist/__tests__/index.js
+++ b/src/rules/property-whitelist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/property-whitelist/index.js
+++ b/src/rules/property-whitelist/index.js
@@ -1,5 +1,3 @@
-import { vendor } from "postcss"
-import { isString } from "lodash"
 import {
   isCustomProperty,
   isStandardSyntaxProperty,
@@ -8,6 +6,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import { vendor } from "postcss"
 
 export const ruleName = "property-whitelist"
 

--- a/src/rules/root-no-standard-properties/__tests__/index.js
+++ b/src/rules/root-no-standard-properties/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -1,6 +1,6 @@
 import {
-  isStandardSyntaxProperty,
   isCustomProperty,
+  isStandardSyntaxProperty,
   parseSelector,
   report,
   ruleMessages,

--- a/src/rules/rule-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-nested-empty-line-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-attribute-brackets-space-inside/__tests__/index.js
+++ b/src/rules/selector-attribute-brackets-space-inside/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-attribute-brackets-space-inside/index.js
+++ b/src/rules/selector-attribute-brackets-space-inside/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   isStandardSyntaxRule,
   parseSelector,
@@ -6,6 +5,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-attribute-brackets-space-inside"
 

--- a/src/rules/selector-attribute-operator-blacklist/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-blacklist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-attribute-operator-blacklist/index.js
+++ b/src/rules/selector-attribute-operator-blacklist/index.js
@@ -1,4 +1,3 @@
-import { isString } from "lodash"
 import {
   isStandardSyntaxRule,
   parseSelector,
@@ -6,6 +5,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
 
 export const ruleName = "selector-attribute-operator-blacklist"
 

--- a/src/rules/selector-attribute-operator-space-after/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-attribute-operator-space-after/index.js
+++ b/src/rules/selector-attribute-operator-space-after/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   isStandardSyntaxRule,
   parseSelector,
@@ -7,6 +6,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-attribute-operator-space-after"
 

--- a/src/rules/selector-attribute-operator-space-before/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-attribute-operator-whitelist/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-whitelist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-attribute-operator-whitelist/index.js
+++ b/src/rules/selector-attribute-operator-whitelist/index.js
@@ -1,4 +1,3 @@
-import { isString } from "lodash"
 import {
   isStandardSyntaxRule,
   parseSelector,
@@ -6,6 +5,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
 
 export const ruleName = "selector-attribute-operator-whitelist"
 

--- a/src/rules/selector-class-pattern/__tests__/index.js
+++ b/src/rules/selector-class-pattern/__tests__/index.js
@@ -1,6 +1,12 @@
-import { mergeTestDescriptions, testRule } from "../../../testUtils"
+import {
+  mergeTestDescriptions,
+  testRule,
+} from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-class-pattern/index.js
+++ b/src/rules/selector-class-pattern/index.js
@@ -1,5 +1,3 @@
-import resolveNestedSelector from "postcss-resolve-nested-selector"
-import _ from "lodash"
 import {
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
@@ -8,6 +6,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
+import resolveNestedSelector from "postcss-resolve-nested-selector"
 
 export const ruleName = "selector-class-pattern"
 

--- a/src/rules/selector-combinator-space-after/__tests__/index.js
+++ b/src/rules/selector-combinator-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -1,12 +1,12 @@
-import styleSearch from "style-search"
-import _ from "lodash"
 import {
   report,
   ruleMessages,
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import _ from "lodash"
 import { nonSpaceCombinators } from "../../reference/punctuationSets"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-combinator-space-after"
 

--- a/src/rules/selector-combinator-space-before/__tests__/index.js
+++ b/src/rules/selector-combinator-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-id-pattern/__tests__/index.js
+++ b/src/rules/selector-id-pattern/__tests__/index.js
@@ -1,6 +1,12 @@
-import { mergeTestDescriptions, testRule } from "../../../testUtils"
+import {
+  mergeTestDescriptions,
+  testRule,
+} from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-id-pattern/index.js
+++ b/src/rules/selector-id-pattern/index.js
@@ -1,4 +1,7 @@
-import { isRegExp, isString } from "lodash"
+import {
+  isRegExp,
+  isString,
+} from "lodash"
 import {
   isStandardSyntaxRule,
   isStandardSyntaxSelector,

--- a/src/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-list-comma-newline-after/index.js
+++ b/src/rules/selector-list-comma-newline-after/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   isStandardSyntaxRule,
   report,
@@ -6,6 +5,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-list-comma-newline-after"
 

--- a/src/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-list-comma-space-after/index.js
+++ b/src/rules/selector-list-comma-space-after/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   isStandardSyntaxRule,
   report,
@@ -6,6 +5,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-list-comma-space-after"
 

--- a/src/rules/selector-list-comma-space-before/__tests__/index.js
+++ b/src/rules/selector-list-comma-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/src/rules/selector-max-compound-selectors/__tests__/index.js
@@ -1,6 +1,11 @@
+import {
+  messages,
+  ruleName,
+} from ".."
+import rules from "../../../rules"
 import { testRule } from "../../../testUtils"
 
-import rule, { ruleName, messages } from ".."
+const rule = rules[ruleName]
 
 // Testing plain selectors, different combinators
 testRule(rule, {

--- a/src/rules/selector-max-compound-selectors/index.js
+++ b/src/rules/selector-max-compound-selectors/index.js
@@ -1,6 +1,3 @@
-import resolvedNestedSelector from "postcss-resolve-nested-selector"
-import selectorParser from "postcss-selector-parser"
-
 import {
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
@@ -8,6 +5,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import resolvedNestedSelector from "postcss-resolve-nested-selector"
+import selectorParser from "postcss-selector-parser"
 
 export const ruleName = "selector-max-compound-selectors"
 

--- a/src/rules/selector-max-empty-lines/__tests__/index.js
+++ b/src/rules/selector-max-empty-lines/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-max-empty-lines/index.js
+++ b/src/rules/selector-max-empty-lines/index.js
@@ -1,10 +1,13 @@
-import styleSearch from "style-search"
-import { isNumber, repeat } from "lodash"
+import {
+  isNumber,
+  repeat,
+} from "lodash"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-max-empty-lines"
 

--- a/src/rules/selector-max-specificity/__tests__/index.js
+++ b/src/rules/selector-max-specificity/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-max-specificity/index.js
+++ b/src/rules/selector-max-specificity/index.js
@@ -1,6 +1,3 @@
-import { compare } from "specificity"
-import resolvedNestedSelector from "postcss-resolve-nested-selector"
-
 import {
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
@@ -8,6 +5,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { compare } from "specificity"
+import resolvedNestedSelector from "postcss-resolve-nested-selector"
 
 export const ruleName = "selector-max-specificity"
 

--- a/src/rules/selector-no-attribute/__tests__/index.js
+++ b/src/rules/selector-no-attribute/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-no-combinator/__tests__/index.js
+++ b/src/rules/selector-no-combinator/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-no-qualifying-type/__tests__/index.js
+++ b/src/rules/selector-no-qualifying-type/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-no-qualifying-type/index.js
+++ b/src/rules/selector-no-qualifying-type/index.js
@@ -1,4 +1,3 @@
-import resolvedNestedSelector from "postcss-resolve-nested-selector"
 import {
   isKeyframeRule,
   isStandardSyntaxRule,
@@ -9,6 +8,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import resolvedNestedSelector from "postcss-resolve-nested-selector"
 
 export const ruleName = "selector-no-qualifying-type"
 

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -1,4 +1,3 @@
-import { get } from "lodash"
 import {
   isKeyframeSelector,
   isStandardSyntaxRule,
@@ -10,6 +9,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { get } from "lodash"
 
 export const ruleName = "selector-no-type"
 

--- a/src/rules/selector-no-universal/__tests__/index.js
+++ b/src/rules/selector-no-universal/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-no-vendor-prefix/index.js
+++ b/src/rules/selector-no-vendor-prefix/index.js
@@ -1,10 +1,10 @@
 import {
+  isAutoprefixable,
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
   parseSelector,
   report,
   ruleMessages,
-  isAutoprefixable,
   validateOptions,
 } from "../../utils"
 

--- a/src/rules/selector-pseudo-class-case/__tests__/index.js
+++ b/src/rules/selector-pseudo-class-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/src/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-pseudo-class-no-unknown/index.js
+++ b/src/rules/selector-pseudo-class-no-unknown/index.js
@@ -1,5 +1,3 @@
-import { isString } from "lodash"
-import { vendor } from "postcss"
 import {
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
@@ -12,6 +10,8 @@ import {
   pseudoClasses,
   pseudoElements,
 } from "../../reference/keywordSets"
+import { isString } from "lodash"
+import { vendor } from "postcss"
 
 export const ruleName = "selector-pseudo-class-no-unknown"
 

--- a/src/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/src/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -1,5 +1,3 @@
-import styleSearch from "style-search"
-import _ from "lodash"
 import {
   isStandardSyntaxRule,
   parseSelector,
@@ -7,6 +5,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-pseudo-class-parentheses-space-inside"
 

--- a/src/rules/selector-pseudo-element-case/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-pseudo-element-colon-notation/index.js
+++ b/src/rules/selector-pseudo-element-colon-notation/index.js
@@ -1,12 +1,12 @@
-import styleSearch from "style-search"
-import _ from "lodash"
 import {
   isStandardSyntaxRule,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
 import { levelOneAndTwoPseudoElements } from "../../reference/keywordSets"
+import styleSearch from "style-search"
 
 export const ruleName = "selector-pseudo-element-colon-notation"
 

--- a/src/rules/selector-pseudo-element-no-unknown/__tests__/index.js
+++ b/src/rules/selector-pseudo-element-no-unknown/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-pseudo-element-no-unknown/index.js
+++ b/src/rules/selector-pseudo-element-no-unknown/index.js
@@ -1,5 +1,3 @@
-import { isString } from "lodash"
-import { vendor } from "postcss"
 import {
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
@@ -8,7 +6,9 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
 import { pseudoElements } from "../../reference/keywordSets"
+import { vendor } from "postcss"
 
 export const ruleName = "selector-pseudo-element-no-unknown"
 

--- a/src/rules/selector-root-no-composition/__tests__/index.js
+++ b/src/rules/selector-root-no-composition/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-type-case/__tests__/index.js
+++ b/src/rules/selector-type-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/selector-type-no-unknown/index.js
+++ b/src/rules/selector-type-no-unknown/index.js
@@ -1,6 +1,3 @@
-import { isString } from "lodash"
-import htmlTags from "html-tags"
-import svgTags from "svg-tags"
 import {
   isKeyframeSelector,
   isStandardSyntaxRule,
@@ -11,6 +8,9 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import htmlTags from "html-tags"
+import { isString } from "lodash"
+import svgTags from "svg-tags"
 
 export const ruleName = "selector-type-no-unknown"
 

--- a/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/shorthand-property-no-redundant-values/index.js
+++ b/src/rules/shorthand-property-no-redundant-values/index.js
@@ -1,5 +1,3 @@
-import valueParser from "postcss-value-parser"
-import { vendor } from "postcss"
 import {
   isStandardSyntaxDeclaration,
   isStandardSyntaxProperty,
@@ -8,6 +6,8 @@ import {
   validateOptions,
 } from "../../utils"
 import shorthandData from "../../reference/shorthandData"
+import valueParser from "postcss-value-parser"
+import { vendor } from "postcss"
 
 export const ruleName = "shorthand-property-no-redundant-values"
 

--- a/src/rules/string-no-newline/__tests__/index.js
+++ b/src/rules/string-no-newline/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/string-no-newline/index.js
+++ b/src/rules/string-no-newline/index.js
@@ -1,9 +1,9 @@
-import styleSearch from "style-search"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "string-no-newline"
 

--- a/src/rules/string-quotes/__tests__/index.js
+++ b/src/rules/string-quotes/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/string-quotes/index.js
+++ b/src/rules/string-quotes/index.js
@@ -1,9 +1,9 @@
-import styleSearch from "style-search"
 import {
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "string-quotes"
 

--- a/src/rules/stylelint-disable-reason/__tests__/index.js
+++ b/src/rules/stylelint-disable-reason/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/time-no-imperceptible/__tests__/index.js
+++ b/src/rules/time-no-imperceptible/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/time-no-imperceptible/index.js
+++ b/src/rules/time-no-imperceptible/index.js
@@ -1,5 +1,3 @@
-import postcss from "postcss"
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   report,
@@ -10,6 +8,8 @@ import {
   longhandTimeProperties,
   shorthandTimeProperties,
 } from "../../reference/keywordSets"
+import postcss from "postcss"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "time-no-imperceptible"
 

--- a/src/rules/unit-blacklist/__tests__/index.js
+++ b/src/rules/unit-blacklist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/unit-blacklist/index.js
+++ b/src/rules/unit-blacklist/index.js
@@ -1,5 +1,3 @@
-import { isString } from "lodash"
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -7,6 +5,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "unit-blacklist"
 

--- a/src/rules/unit-case/__tests__/index.js
+++ b/src/rules/unit-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/unit-case/index.js
+++ b/src/rules/unit-case/index.js
@@ -1,4 +1,3 @@
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -6,6 +5,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "unit-case"
 

--- a/src/rules/unit-no-unknown/__tests__/index.js
+++ b/src/rules/unit-no-unknown/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/unit-no-unknown/index.js
+++ b/src/rules/unit-no-unknown/index.js
@@ -1,5 +1,3 @@
-import { isString } from "lodash"
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -7,7 +5,9 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
 import { units } from "../../reference/keywordSets"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "unit-no-unknown"
 

--- a/src/rules/unit-whitelist/__tests__/index.js
+++ b/src/rules/unit-whitelist/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/unit-whitelist/index.js
+++ b/src/rules/unit-whitelist/index.js
@@ -1,5 +1,3 @@
-import { isString } from "lodash"
-import valueParser from "postcss-value-parser"
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -7,6 +5,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { isString } from "lodash"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "unit-whitelist"
 

--- a/src/rules/value-keyword-case/__tests__/index.js
+++ b/src/rules/value-keyword-case/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/value-keyword-case/index.js
+++ b/src/rules/value-keyword-case/index.js
@@ -1,5 +1,15 @@
-import valueParser from "postcss-value-parser"
-import { isString } from "lodash"
+import {
+  animationNameKeywords,
+  animationShorthandKeywords,
+  camelCaseKeywords,
+  fontFamilyKeywords,
+  fontShorthandKeywords,
+  gridAreaKeywords,
+  gridColumnKeywords,
+  gridRowKeywords,
+  listStyleShorthandKeywords,
+  listStyleTypeKeywords,
+} from "../../reference/keywordSets"
 import {
   declarationValueIndex,
   getUnitFromValueNode,
@@ -10,18 +20,8 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
-import {
-  animationShorthandKeywords,
-  animationNameKeywords,
-  camelCaseKeywords,
-  fontFamilyKeywords,
-  fontShorthandKeywords,
-  gridRowKeywords,
-  gridColumnKeywords,
-  gridAreaKeywords,
-  listStyleTypeKeywords,
-  listStyleShorthandKeywords,
-} from "../../reference/keywordSets"
+import { isString } from "lodash"
+import valueParser from "postcss-value-parser"
 
 export const ruleName = "value-keyword-case"
 

--- a/src/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/value-list-comma-newline-before/__tests__/index.js
+++ b/src/rules/value-list-comma-newline-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/value-list-comma-space-after/__tests__/index.js
+++ b/src/rules/value-list-comma-space-after/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/value-list-comma-space-after/index.js
+++ b/src/rules/value-list-comma-space-after/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   isStandardSyntaxDeclaration,
   isStandardSyntaxProperty,
@@ -7,6 +6,7 @@ import {
   validateOptions,
   whitespaceChecker,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "value-list-comma-space-after"
 

--- a/src/rules/value-list-comma-space-before/__tests__/index.js
+++ b/src/rules/value-list-comma-space-before/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/value-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/value-no-vendor-prefix/__tests__/index.js
@@ -1,6 +1,9 @@
-import { testRule } from "../../../testUtils"
+import {
+  messages,
+  ruleName,
+} from ".."
 import rules from "../../../rules"
-import { ruleName, messages } from ".."
+import { testRule } from "../../../testUtils"
 
 const rule = rules[ruleName]
 

--- a/src/rules/value-no-vendor-prefix/index.js
+++ b/src/rules/value-no-vendor-prefix/index.js
@@ -1,4 +1,3 @@
-import styleSearch from "style-search"
 import {
   isAutoprefixable,
   isStandardSyntaxDeclaration,
@@ -7,6 +6,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import styleSearch from "style-search"
 
 export const ruleName = "value-no-vendor-prefix"
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1,14 +1,14 @@
+import * as formatters from "./formatters"
+import _ from "lodash"
+import buildConfig from "./buildConfig"
+import globby from "globby"
+import lessSyntax from "postcss-less"
 import path from "path"
 import postcss from "postcss"
-import globby from "globby"
-import _ from "lodash"
 import { readFile } from "fs"
 import scssSyntax from "postcss-scss"
-import lessSyntax from "postcss-less"
-import sugarss from "sugarss"
-import buildConfig from "./buildConfig"
 import stylelintPostcssPlugin from "./postcssPlugin"
-import * as formatters from "./formatters"
+import sugarss from "sugarss"
 
 const ignoredGlobs = [
   "!**/node_modules/**",

--- a/src/testUtils/createRuleTester.js
+++ b/src/testUtils/createRuleTester.js
@@ -1,11 +1,11 @@
+import _ from "lodash"
+import basicChecks from "./basicChecks"
+import disableRanges from "../disableRanges"
+import lessSyntax from "postcss-less"
+import normalizeRuleSettings from "../normalizeRuleSettings"
 import postcss from "postcss"
 import scssSyntax from "postcss-scss"
-import lessSyntax from "postcss-less"
 import sugarss from "sugarss"
-import _ from "lodash"
-import normalizeRuleSettings from "../normalizeRuleSettings"
-import disableRanges from "../disableRanges"
-import basicChecks from "./basicChecks"
 
 /**
  * Create a stylelint rule testing function.

--- a/src/utils/__tests__/beforeBlockString-test.js
+++ b/src/utils/__tests__/beforeBlockString-test.js
@@ -1,6 +1,6 @@
-import test from "tape"
-import postcss from "postcss"
 import beforeBlockString from "../beforeBlockString"
+import postcss from "postcss"
+import test from "tape"
 
 test("beforeBlockString rules", t => {
   t.equal(postcssCheck("a {}"), "a ")

--- a/src/utils/__tests__/blockString-test.js
+++ b/src/utils/__tests__/blockString-test.js
@@ -1,6 +1,6 @@
-import test from "tape"
-import postcss from "postcss"
 import blockString from "../blockString"
+import postcss from "postcss"
+import test from "tape"
 
 test("blockString rules", t => {
   t.equal(postcssCheck("a { color: pink; }"), "{ color: pink; }")

--- a/src/utils/__tests__/blurComments-test.js
+++ b/src/utils/__tests__/blurComments-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import blurComments from "../blurComments"
+import test from "tape"
 
 test("blurComments", t => {
   t.equal(blurComments("abc"), "abc")

--- a/src/utils/__tests__/blurFunctionArguments-test.js
+++ b/src/utils/__tests__/blurFunctionArguments-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import blurFunctionArguments from "../blurFunctionArguments"
+import test from "tape"
 
 test("blurFunctionArguments", t => {
   t.equal(blurFunctionArguments("abc abc", "url"), "abc abc")

--- a/src/utils/__tests__/blurInterpolation-test.js
+++ b/src/utils/__tests__/blurInterpolation-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import blurInterpolation from "../blurInterpolation"
+import test from "tape"
 
 test("blurInterpolation", t => {
   t.equal(blurInterpolation("#{$selector}"), " $selector ")

--- a/src/utils/__tests__/containsString-test.js
+++ b/src/utils/__tests__/containsString-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import containsString from "../containsString"
+import test from "tape"
 
 test("containsString comparing with string comparison values", t => {
   t.deepEqual(containsString("bar", "bar"),

--- a/src/utils/__tests__/findAnimationName-test.js
+++ b/src/utils/__tests__/findAnimationName-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import findAnimationName from "../findAnimationName"
+import test from "tape"
 
 test("findAnimationName", t => {
   t.deepEqual(

--- a/src/utils/__tests__/findAtRuleContext-test.js
+++ b/src/utils/__tests__/findAtRuleContext-test.js
@@ -1,6 +1,6 @@
-import test from "tape"
-import postcss from "postcss"
 import findAtRuleContext from "../findAtRuleContext"
+import postcss from "postcss"
+import test from "tape"
 
 test("findAtRuleContext", t => {
   const css = `

--- a/src/utils/__tests__/findFontFamily-test.js
+++ b/src/utils/__tests__/findFontFamily-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import findFontFamily from "../findFontFamily"
+import test from "tape"
 
 test("findFontFamily", t => {
   t.deepEqual(

--- a/src/utils/__tests__/findListStyleType-test.js
+++ b/src/utils/__tests__/findListStyleType-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import findListStyleType from "../findListStyleType"
+import test from "tape"
 
 test("findListStyleType", t => {
   t.deepEqual(

--- a/src/utils/__tests__/functionArgumentsSearch-test.js
+++ b/src/utils/__tests__/functionArgumentsSearch-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import functionArgumentsSearch from "../functionArgumentsSearch"
+import test from "tape"
 
 test("passes function arguments to callback", t => {
   functionArgumentsSearch("calc(1 + 3)", "calc", (expression, expressionIndex) => {

--- a/src/utils/__tests__/getUnitFromValueNode-test.js
+++ b/src/utils/__tests__/getUnitFromValueNode-test.js
@@ -1,6 +1,6 @@
+import getUnitFromValueNode from "../getUnitFromValueNode"
 import test from "tape"
 import valueParser from "postcss-value-parser"
-import getUnitFromValueNode from "../getUnitFromValueNode"
 
 test("getUnitFromValueNode", t => {
   t.equal(getUnitFromValueNode(), null)

--- a/src/utils/__tests__/isCustomIdentPropertyCounterIncrement-test.js
+++ b/src/utils/__tests__/isCustomIdentPropertyCounterIncrement-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isCustomIdentPropertyCounterIncrement from "../isCustomIdentPropertyCounterIncrement"
+import test from "tape"
 
 test("isCustomIdents", t => {
   t.ok(isCustomIdentPropertyCounterIncrement("counter"))

--- a/src/utils/__tests__/isCustomProperty-test.js
+++ b/src/utils/__tests__/isCustomProperty-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isCustomProperty from "../isCustomProperty"
+import test from "tape"
 
 test("isCustomProperty", t => {
   t.ok(isCustomProperty("--custom-property"))

--- a/src/utils/__tests__/isKeyframeSelector-test.js
+++ b/src/utils/__tests__/isKeyframeSelector-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isKeyframeSelector from "../isKeyframeSelector"
+import test from "tape"
 
 test("isKeyframeSelector", t => {
   t.ok(isKeyframeSelector("to"), "to keyword")

--- a/src/utils/__tests__/isSingleLineString-test.js
+++ b/src/utils/__tests__/isSingleLineString-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isSingleLineString from "../isSingleLineString"
+import test from "tape"
 
 const multiLineTemplate = (
 `foo

--- a/src/utils/__tests__/isStandardSyntax-test.js
+++ b/src/utils/__tests__/isStandardSyntax-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isStandardSyntaxUrl from "../isStandardSyntaxUrl"
+import test from "tape"
 
 test("isStandardSyntaxValue", t => {
   t.ok(

--- a/src/utils/__tests__/isStandardSyntaxAtRule-test.js
+++ b/src/utils/__tests__/isStandardSyntaxAtRule-test.js
@@ -1,7 +1,7 @@
 import isStandardSyntaxAtRule from "../isStandardSyntaxAtRule"
-import scss from "postcss-scss"
 import less from "postcss-less"
 import postcss from "postcss"
+import scss from "postcss-scss"
 import test from "tape"
 
 test("isStandardSyntaxAtRule", t => {

--- a/src/utils/__tests__/isStandardSyntaxProperty-test.js
+++ b/src/utils/__tests__/isStandardSyntaxProperty-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isStandardSyntaxProperty from "../isStandardSyntaxProperty"
+import test from "tape"
 
 test("isStandardSyntaxProperty", t => {
   t.ok(isStandardSyntaxProperty("top"), "single word")

--- a/src/utils/__tests__/isStandardSyntaxSelector-test.js
+++ b/src/utils/__tests__/isStandardSyntaxSelector-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isStandardSyntaxSelector from "../isStandardSyntaxSelector"
+import test from "tape"
 
 test("isStandardSyntaxSelector", t => {
   t.ok(isStandardSyntaxSelector("a"), "type")

--- a/src/utils/__tests__/isStandardSyntaxTypeSelector-test.js
+++ b/src/utils/__tests__/isStandardSyntaxTypeSelector-test.js
@@ -1,7 +1,7 @@
 import isStandardSyntaxTypeSelector from "../isStandardSyntaxTypeSelector"
 import postcss from "postcss"
-import test from "tape"
 import selectorParser from "postcss-selector-parser"
+import test from "tape"
 
 test("isStandardSyntaxTypeSelector", t => {
   t.plan(8)

--- a/src/utils/__tests__/isStandardSyntaxValue-test.js
+++ b/src/utils/__tests__/isStandardSyntaxValue-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isStandardSyntaxValue from "../isStandardSyntaxValue"
+import test from "tape"
 
 test("isStandardSyntaxValue", t => {
   t.ok(isStandardSyntaxValue("initial"), "keyword")

--- a/src/utils/__tests__/isValidFontSize-test.js
+++ b/src/utils/__tests__/isValidFontSize-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isValidFontSize from "../isValidFontSize"
+import test from "tape"
 
 test("isValidFontSize", t => {
   t.ok(isValidFontSize("10px"))

--- a/src/utils/__tests__/isValidHex-test.js
+++ b/src/utils/__tests__/isValidHex-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isValidHex from "../isValidHex"
+import test from "tape"
 
 test("isValidHex", t => {
   t.ok(isValidHex("#333"))

--- a/src/utils/__tests__/isVariable-test.js
+++ b/src/utils/__tests__/isVariable-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import isVariable from "../isVariable"
+import test from "tape"
 
 test("isVariable", t => {
   t.ok(isVariable("var(--something)"))

--- a/src/utils/__tests__/matchesStringOrRegExp-test.js
+++ b/src/utils/__tests__/matchesStringOrRegExp-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import matchesStringOrRegExp from "../matchesStringOrRegExp"
+import test from "tape"
 
 test("matchesStringOrRegExp comparing with string comparisonValues", t => {
   t.deepEqual(matchesStringOrRegExp("bar", "bar"),

--- a/src/utils/__tests__/nextNonCommentNode-test.js
+++ b/src/utils/__tests__/nextNonCommentNode-test.js
@@ -1,6 +1,6 @@
-import test from "tape"
-import postcss from "postcss"
 import nextNonCommentNode from "../nextNonCommentNode"
+import postcss from "postcss"
+import test from "tape"
 
 test("nextNonCommentNode", t => {
   let planned = 0

--- a/src/utils/__tests__/nodeContextLookup-test.js
+++ b/src/utils/__tests__/nodeContextLookup-test.js
@@ -1,8 +1,8 @@
-import test from "tape"
+import nodeContextLookup from "../nodeContextLookup"
+import path from "path"
 import postcss from "postcss"
 import postcssImport from "postcss-import"
-import path from "path"
-import nodeContextLookup from "../nodeContextLookup"
+import test from "tape"
 
 test("nodeContextLookup checking media context", t => {
   const testLookup = nodeContextLookup()

--- a/src/utils/__tests__/report-test.js
+++ b/src/utils/__tests__/report-test.js
@@ -1,6 +1,6 @@
-import test from "tape"
-import sinon from "sinon"
 import report from "../report"
+import sinon from "sinon"
+import test from "tape"
 
 test("without disabledRanges", t => {
   const v = {

--- a/src/utils/__tests__/ruleMessages-test.js
+++ b/src/utils/__tests__/ruleMessages-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import ruleMessages from "../ruleMessages"
+import test from "tape"
 
 test("ruleMessages with simple messages", t => {
   t.deepEqual(

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -1,5 +1,5 @@
-import test from "tape"
 import sinon from "sinon"
+import test from "tape"
 import validateOptions from "../validateOptions"
 
 function mockResult() {

--- a/src/utils/blockString.js
+++ b/src/utils/blockString.js
@@ -1,6 +1,6 @@
-import rawNodeString from "./rawNodeString"
-import hasBlock from "./hasBlock"
 import beforeBlockString from "./beforeBlockString"
+import hasBlock from "./hasBlock"
+import rawNodeString from "./rawNodeString"
 
 /**
  * Return a CSS statement's block -- the string that starts and `{` and ends with `}`.

--- a/src/utils/findAnimationName.js
+++ b/src/utils/findAnimationName.js
@@ -1,13 +1,13 @@
-import postcssValueParser from "postcss-value-parser"
+import {
+  animationShorthandKeywords,
+  basicKeywords,
+} from "../reference/keywordSets"
 import {
   getUnitFromValueNode,
   isStandardSyntaxValue,
   isVariable,
 } from "./"
-import {
-  basicKeywords,
-  animationShorthandKeywords,
-} from "../reference/keywordSets"
+import postcssValueParser from "postcss-value-parser"
 
 /**
  * Get the font-families within a `font` shorthand property value.

--- a/src/utils/findFontFamily.js
+++ b/src/utils/findFontFamily.js
@@ -1,14 +1,14 @@
-import postcssValueParser from "postcss-value-parser"
-import {
-  isStandardSyntaxValue,
-  isVariable,
-  isValidFontSize,
-} from "./"
 import {
   basicKeywords,
   fontFamilyKeywords,
   fontShorthandKeywords,
 } from "../reference/keywordSets"
+import {
+  isStandardSyntaxValue,
+  isValidFontSize,
+  isVariable,
+} from "./"
+import postcssValueParser from "postcss-value-parser"
 
 const nodeTypesToCheck = new Set([
   "word",

--- a/src/utils/findListStyleType.js
+++ b/src/utils/findListStyleType.js
@@ -1,13 +1,13 @@
-import postcssValueParser from "postcss-value-parser"
 import {
   isStandardSyntaxValue,
   isVariable,
 } from "./"
 import {
-  listStyleTypeKeywords,
-  listStylePositionKeywords,
   listStyleImageKeywords,
+  listStylePositionKeywords,
+  listStyleTypeKeywords,
 } from "../reference/keywordSets"
+import postcssValueParser from "postcss-value-parser"
 
 /**
  * Get the list-style-type within a `list-style` shorthand property value.
@@ -45,4 +45,3 @@ export default function findListStyleType(value) {
 
   return listStyleTypes
 }
-

--- a/src/utils/functionArgumentsSearch.js
+++ b/src/utils/functionArgumentsSearch.js
@@ -1,5 +1,5 @@
-import styleSearch from "style-search"
 import balancedMatch from "balanced-match"
+import styleSearch from "style-search"
 
 /**
  * Search a CSS string for functions by name.

--- a/src/utils/getUnitFromValueNode.js
+++ b/src/utils/getUnitFromValueNode.js
@@ -1,7 +1,7 @@
 import blurInterpolation from "./blurInterpolation"
+import { isFinite } from "lodash"
 import isStandardSyntaxValue from "./isStandardSyntaxValue"
 import valueParser from "postcss-value-parser"
-import { isFinite } from "lodash"
 
 /**
  * Get unit from value node

--- a/src/utils/isAutoprefixable.js
+++ b/src/utils/isAutoprefixable.js
@@ -1,6 +1,6 @@
-import autoprefixer from "autoprefixer"
-import Prefixes from "autoprefixer/lib/prefixes"
 import Browsers from "autoprefixer/lib/browsers"
+import Prefixes from "autoprefixer/lib/prefixes"
+import autoprefixer from "autoprefixer"
 
 /**
  * Use Autoprefixer's secret powers to determine whether or

--- a/src/utils/isCustomIdentPropertyCounterIncrement.js
+++ b/src/utils/isCustomIdentPropertyCounterIncrement.js
@@ -1,5 +1,5 @@
-import { isFinite } from "lodash"
 import { counterIncrementKeywords } from "../reference/keywordSets"
+import { isFinite } from "lodash"
 
 /**
  * Check value is a custom ident

--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -1,7 +1,7 @@
 import { assign } from "lodash"
-import isWhitespace from "./isWhitespace"
-import isSingleLineString from "./isSingleLineString"
 import configurationError from "./configurationError"
+import isSingleLineString from "./isSingleLineString"
+import isWhitespace from "./isWhitespace"
 
 /**
  * Create a whitespaceChecker, which exposes the following functions:


### PR DESCRIPTION
This makes is easier to scan what utils are being used in a new rule PR.

As a bonus, going through this process highlighted a few rules that weren’t using the `const rule = rules[ruleName]` approach in their test file.