### PR TITLE
Standardise no-* rules test options

### DIFF
--- a/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "@keyframes { 0% { top: 0; } }",

--- a/src/rules/block-no-empty/__tests__/index.js
+++ b/src/rules/block-no-empty/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
 
   accept: [ {

--- a/src/rules/block-no-single-line/__tests__/index.js
+++ b/src/rules/block-no-single-line/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
 
   accept: [ {

--- a/src/rules/color-no-hex/__tests__/index.js
+++ b/src/rules/color-no-hex/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/src/rules/color-no-invalid-hex/__tests__/index.js
+++ b/src/rules/color-no-invalid-hex/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/src/rules/custom-property-no-outside-root/__tests__/index.js
+++ b/src/rules/custom-property-no-outside-root/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: ":root { --foo-bar: 1px; }",

--- a/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { display: inline; }",

--- a/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/src/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { padding: 10px; }",

--- a/src/rules/declaration-no-important/__tests__/index.js
+++ b/src/rules/declaration-no-important/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [{
     code: "a { color: pink; }",

--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { padding: 0 /* calc(1px+2px) */ 0; }",

--- a/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/src/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: ".foo { background: linear-gradient(to top, #fff, #000; )}",

--- a/src/rules/length-zero-no-unit/__tests__/index.js
+++ b/src/rules/length-zero-no-unit/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { top: 0; }",

--- a/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [{
     code: "@media (min-resolution: 96dpi) {}",

--- a/src/rules/no-duplicate-selectors/__tests__/index.js
+++ b/src/rules/no-duplicate-selectors/__tests__/index.js
@@ -10,7 +10,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [null],
+  config: [true],
 
   accept: [ {
     code: "a {} b {} c {} d, e, f {}",

--- a/src/rules/no-eol-whitespace/__tests__/index.js
+++ b/src/rules/no-eol-whitespace/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
 
   accept: [ {

--- a/src/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/src/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { /* color: pink; */ }",
@@ -48,7 +48,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "scss",
 
@@ -60,7 +60,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "scss",
 
@@ -72,7 +72,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "less",
 
@@ -84,7 +84,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "less",
 

--- a/src/rules/no-missing-eof-newline/__tests__/index.js
+++ b/src/rules/no-missing-eof-newline/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
 
   accept: [ {

--- a/src/rules/no-unknown-animations/__tests__/index.js
+++ b/src/rules/no-unknown-animations/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "@keyframes foo {} a { animation-name: foo; }",

--- a/src/rules/number-no-trailing-zeros/__tests__/index.js
+++ b/src/rules/number-no-trailing-zeros/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { padding: 1px; }",

--- a/src/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/property-no-vendor-prefix/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: ":root { --foo-bar: 1px; }",

--- a/src/rules/root-no-standard-properties/__tests__/index.js
+++ b/src/rules/root-no-standard-properties/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: ":root { --foo: 0; }",

--- a/src/rules/selector-no-attribute/__tests__/index.js
+++ b/src/rules/selector-no-attribute/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "foo {}",

--- a/src/rules/selector-no-combinator/__tests__/index.js
+++ b/src/rules/selector-no-combinator/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a {}",
@@ -66,7 +66,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "scss",
 
@@ -95,7 +95,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "less",
 

--- a/src/rules/selector-no-id/__tests__/index.js
+++ b/src/rules/selector-no-id/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "foo {}",
@@ -43,7 +43,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "scss",
 
@@ -75,7 +75,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "less",
 

--- a/src/rules/selector-no-universal/__tests__/index.js
+++ b/src/rules/selector-no-universal/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "foo {}",

--- a/src/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: ":fullscreen a {}",

--- a/src/rules/selector-root-no-composition/__tests__/index.js
+++ b/src/rules/selector-root-no-composition/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: ":root {}",

--- a/src/rules/string-no-newline/__tests__/index.js
+++ b/src/rules/string-no-newline/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a::before { content: 'one'; }",

--- a/src/rules/time-no-imperceptible/__tests__/index.js
+++ b/src/rules/time-no-imperceptible/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "a { transition-delay: 0.2s; }",


### PR DESCRIPTION
We were using `undefined`, `null` and `true`. This PR standardises them all to `true`.