### PR TITLE
Remove redundant whitespaceChecker code

### DIFF
--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -153,18 +153,6 @@ export default function (targetWhitespace, expectation, messages) {
 
     if (!isValue(oneCharBefore)) { return }
 
-    if (targetWhitespace === "newline") {
-      // If index is preceeded by a Windows CR-LF ...
-      if (oneCharBefore === "\n" && twoCharsBefore === "\r") {
-        if (activeArgs.onlyOneChar || !isWhitespace(source[index - 3])) { return }
-      }
-
-      // If index is followed by a Unix LF ...
-      if (oneCharBefore === "\n" && twoCharsBefore !== "\r") {
-        if (activeArgs.onlyOneChar || !isWhitespace(twoCharsBefore)) { return }
-      }
-    }
-
     if (targetWhitespace === "space" && oneCharBefore === " ") {
       if (activeArgs.onlyOneChar || !isWhitespace(twoCharsBefore)) { return }
     }
@@ -176,7 +164,6 @@ export default function (targetWhitespace, expectation, messages) {
     const { source, index, err } = activeArgs
     const expectedChar = (function () {
       if (targetWhitespace === "newline") { return "\n" }
-      if (targetWhitespace === "space") { return " " }
     }())
     let i = index - 1
     while (source[i] !== expectedChar) {


### PR DESCRIPTION
I’ve been poking around for a while in the whitespaceChecker as three lines there were being flagged as uncovered. I've been scratching my head trying to work out how to test the lines, but I now think they are redundant as I can’t think of a situation where’d you either:

- disallow indentation if targeting before a newline.
- allow indentation if targeting before a space.

This PR removes those conditionals and brings coverage up to 100% across the board in `v7`.

