### PR TITLE
Issue 1330

### DIFF
--- a/src/rules/selector-no-attribute/__tests__/index.js
+++ b/src/rules/selector-no-attribute/__tests__/index.js
@@ -6,7 +6,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
 
   accept: [ {
     code: "foo {}",
@@ -43,5 +43,71 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 2,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "less",
+
+  reject: [ {
+    code: "[@{attribute}] {}",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "@{selector} [foo] {}",
+    message: messages.rejected,
+    line: 1,
+    column: 13,
+  }, {
+    code: "[foo] @{selector} {}",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "@{selector}[title] {}",
+    message: messages.rejected,
+    line: 1,
+    column: 12,
+  }, {
+    code: "[title]@{selector} {}",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  reject: [ {
+    code: "[#{$attribute}] {}",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "#{$selector} [foo] {}",
+    message: messages.rejected,
+    line: 1,
+    column: 14,
+  }, {
+    code: "[foo] #{$selector} {}",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "%placeholder[title] {}",
+    message: messages.rejected,
+    line: 1,
+    column: 13,
+  }, {
+    code: "[title]%placeholder {}",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
   } ],
 })

--- a/src/rules/selector-no-attribute/index.js
+++ b/src/rules/selector-no-attribute/index.js
@@ -1,6 +1,5 @@
 import {
   isStandardSyntaxRule,
-  isStandardSyntaxSelector,
   parseSelector,
   report,
   ruleMessages,
@@ -21,7 +20,6 @@ export default function (actual) {
     root.walkRules(rule => {
       if (!isStandardSyntaxRule(rule)) { return }
       const { selector } = rule
-      if (!isStandardSyntaxSelector(selector)) { return }
       parseSelector(selector, result, rule, selectorAST => {
         selectorAST.walkAttributes(attribute => {
           report({


### PR DESCRIPTION
Why in some rules we check selector on `isStandardSyntaxRule`? Example `selector-no-attribute`?
We are in fact no difference whether there is a non-standard syntax or not. See tests.
/cc @davidtheclark @jeddy3 