### PR TITLE
Add support for negative time values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: `time-no-imperceptible` correctly handles negative time.
+
 # 6.8.0
 
 - Deprecated: `-e` and `--extract` CLI flags, and the `extractStyleTagsFromHtml` node API option. If you use these flags or option, please consider creating a processor for the community. See the [release planning](/docs/user-guide/release-planning.md) document for more details.

--- a/src/rules/time-no-imperceptible/__tests__/index.js
+++ b/src/rules/time-no-imperceptible/__tests__/index.js
@@ -56,6 +56,10 @@ testRule(rule, {
     code: "a { animation: foo 0.8s linear; }",
   }, {
     code: "a { animation: foo 0.8s 200ms ease-in-out; }",
+  }, {
+    code: "a { animation-delay: -2.5s; }",
+  }, {
+    code: "a { animation-delay: -150ms; }",
   } ],
 
   reject: [ {
@@ -146,6 +150,11 @@ testRule(rule, {
   }, {
     code: "a { animation: foo 0.8s 20ms ease-in-out; }",
     message: messages.rejected("20ms"),
+    line: 1,
+    column: 25,
+  }, {
+    code: "a { animation: foo 0.8s -20ms ease-in-out; }",
+    message: messages.rejected("-20ms"),
     line: 1,
     column: 25,
   } ],

--- a/src/rules/time-no-imperceptible/index.js
+++ b/src/rules/time-no-imperceptible/index.js
@@ -44,8 +44,9 @@ export default function (actual) {
     function isImperceptibleTime(time) {
       const parsedTime = valueParser.unit(time)
       if (!parsedTime) return false
-      if (parsedTime.unit.toLowerCase() === "ms" && parsedTime.number <= MINIMUM_MILLISECONDS) { return true }
-      if (parsedTime.unit.toLowerCase() === "s" && parsedTime.number * 1000 <= MINIMUM_MILLISECONDS) { return true }
+      const absoluteTime = Math.abs(parsedTime.number)
+      if (parsedTime.unit.toLowerCase() === "ms" && absoluteTime <= MINIMUM_MILLISECONDS) { return true }
+      if (parsedTime.unit.toLowerCase() === "s" && absoluteTime * 1000 <= MINIMUM_MILLISECONDS) { return true }
       return false
     }
 


### PR DESCRIPTION
Some properties supports negative time values. [`animation-delay`, for example](https://drafts.csswg.org/css-animations/#valdef-animation-delay-time).