### PR TITLE
Fix max-line-length example for url in Documentation

### DIFF
--- a/src/rules/max-line-length/README.md
+++ b/src/rules/max-line-length/README.md
@@ -26,7 +26,7 @@ a { color: 0; top: 0; }
 
 ```css
 a {
-  background: url(a-url-that-is-over-20-characters-long);
+  background: linear-gradient(red, blue);
 }
 ```
 


### PR DESCRIPTION
It seems to me that this is a better example, since the original one is listed below as generating no warning.