### PR TITLE
`number-max-precision` now better handle case insensitive `@import` at-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed: `selector-max-specificity` no longer crashes on selectors containing `:not()` pseudo-classes.
 - Fixed: `time-no-imperceptible` correctly handles negative time.
 - Fixed: `function-calc-no-unspaced-operator` correctly interprets negative fractional numbers without leading zeros and those wrapped in parentheses.
+- Fixed: `number-max-precision` now ignores uppercase and mixed case `@import` at-rules.
 
 # 6.8.0
 

--- a/src/rules/number-max-precision/__tests__/index.js
+++ b/src/rules/number-max-precision/__tests__/index.js
@@ -29,6 +29,8 @@ testRule(rule, {
   }, {
     code: "@import '1.123.css'",
   }, {
+    code: "@IMPORT '1.123.css'",
+  }, {
     code: "a { background: url(1.123.jpg) }",
   } ],
 

--- a/src/rules/number-max-precision/index.js
+++ b/src/rules/number-max-precision/index.js
@@ -32,7 +32,7 @@ export default function (precision) {
 
     root.walkAtRules(atRule => {
       // Ignore @imports
-      if (atRule.name === "import") { return }
+      if (atRule.name.toLowerCase() === "import") { return }
 
       const source = (hasBlock(atRule))
         ? beforeBlockString(atRule, { noRawBefore: true })


### PR DESCRIPTION
/cc @davidtheclark @jeddy3 