### PR TITLE
Avoid truncated stdout

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -134,7 +134,7 @@ Promise.resolve().then(() => {
 }).then(({ output, errored }) => {
   if (!output) { return }
   process.stdout.write(output)
-  if (errored) { process.exit(2) }
+  if (errored) { process.exitCode = 2 }
 }).catch(err => {
   console.log(err.stack) // eslint-disable-line no-console
   process.exit(err.code || 1)


### PR DESCRIPTION
I found a fairly nasty bug when testing out stylelint with a large project:  `process.exit` aborts any pending `process.stdout.write` calls, causing output to be truncated.  Therefore any code that parses the reported output will generate invalid results.

The existing code is almost identical to the "what not to do" example in the [`process.exit` docs](https://nodejs.org/api/process.html#process_process_exit_code):

```js
if (someConditionNotMet()) {
  printUsageToStdout();
  process.exit(1);
}
```

> The reason this is problematic is because writes to `process.stdout` in Node.js are usually *non-blocking* and may occur over multiple ticks of the Node.js event loop.  Calling `process.exit()`, however, forces the process to exit *before* those additional writes to `stdout` can be performed.

> Rather than calling `process.exit()` directly, the code *should* set the `process.exitCode` and allow the process to exit naturally by avoiding scheduling any additional work for the event loop.

The suggested fix seems to work fine here.