### PR TITLE
Add tests for less mixin semicolons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed: `function-calc-no-unspaced-operator` correctly interprets negative fractional numbers without leading zeros and those wrapped in parentheses.
 - Fixed: `number-max-precision` now ignores uppercase and mixed case `@import` at-rules.
 - Fixed:  Use `process.exitCode` with `stdOut` CLI to allow the process to exit naturally and avoid truncating output.
+- Fixed: `no-extra-semicolons` now ignores semicolons after Less mixins.
 
 # 6.8.0
 

--- a/src/rules/no-extra-semicolons/README.md
+++ b/src/rules/no-extra-semicolons/README.md
@@ -8,6 +8,8 @@ a { color: pink;; }
  *  This semicolons */
 ```
 
+This rule ignores semicolons after Less mixins.
+
 ## Options
 
 ### `true`

--- a/src/rules/no-extra-semicolons/__tests__/index.js
+++ b/src/rules/no-extra-semicolons/__tests__/index.js
@@ -473,3 +473,25 @@ testRule(rule, {
     column: 1,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "less",
+
+  accept: [ {
+    code: "@import 'x.css';",
+  }, {
+    code: "a { .mixin(); .mixin2; }",
+  }, {
+    code: "a { .mixin();; .mixin2;; }",
+    description: "ignore less mixins",
+  } ],
+
+  reject: [{
+    code: "a { .mixin();\ncolor: red;; }",
+    message: messages.rejected,
+    line: 2,
+    column: 10,
+  }],
+})


### PR DESCRIPTION
Closes #1409 and closes #1389

Smoked tested locally using the CSS provided in those two configs. Looks good to me.