### PR TITLE
Do not show help when only bool flags are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: a regression within the CLI where all flags required a parameter.
+
 # 6.9.0
 
 - Added: `defaultSeverity` configuration option.

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,7 @@
 
 import meow from "meow"
 import path from "path"
-import { assign, includes } from "lodash"
+import { assign, cloneDeep, isEqual, includes } from "lodash"
 import getStdin from "get-stdin"
 import resolveFrom from "resolve-from"
 import standalone from "./standalone"
@@ -79,10 +79,12 @@ if (cli.flags.customFormatter) {
   )
 }
 
-const optionsBase = {
+const optionsBaseDefault = {
   formatter,
   configOverrides: {},
 }
+
+const optionsBase = cloneDeep(optionsBaseDefault)
 
 if (cli.flags.quiet) {
   optionsBase.configOverrides.quiet =  cli.flags.quiet
@@ -126,7 +128,11 @@ Promise.resolve().then(() => {
     code: stdin,
   }))
 }).then(options => {
-  if (!options.files && !options.code) {
+  if (
+    !options.files
+    && !options.code
+    && isEqual(optionsBaseDefault, optionsBase)
+  ) {
     cli.showHelp()
   }
 


### PR DESCRIPTION
Closes #1605

Anyone know of a more eloquent way to do this? This seemed like the safest way to do it i.e. accounting for future bool flags.