### PR TITLE
`declaration-block-no-ignored-properties` now ignore `display: inline-block` with `float` property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Changed: `time-no-imperceptible` now checks vendor prefixed properties.
 - Changed: `selector-attribute-quotes` now checks attribute selectors with whitespace around the operator or inside the brackets.
 - Changed: plugin arrays in extended configs are now concatenated with the main config's plugin array, instead of being overwritten by it. So plugins from the main config and from extended configs will all be loaded.
+- Changed: `declaration-block-no-ignored-properties` now ignores the combination of `float` and `display: inline-block | inline`.
 - Added: non-standard syntaxes are automatically inferred from file extensions `.scss`, `.less`, and `.sss`.
 - Added: [processors](/docs/user-guide/configuration#processors.md).
 - Added: `media-feature-parentheses-space-inside` rule.

--- a/src/rules/declaration-block-no-ignored-properties/README.md
+++ b/src/rules/declaration-block-no-ignored-properties/README.md
@@ -12,8 +12,7 @@ Certain property value pairs rule out other property value pairs, causing them t
 
 The rule warns when it finds:
 
-- `display: inline` used with `width`, `height`, `margin`, `margin-top`, `margin-bottom`, `float`, `overflow` (and all variants).
-- `display: inline-block` used with `float`.
+- `display: inline` used with `width`, `height`, `margin`, `margin-top`, `margin-bottom`, `overflow` (and all variants).
 - `display: list-item` used with `vertical-align`.
 - `display: block` used with `vertical-align`.
 - `display: flex` used with `vertical-align`.
@@ -50,12 +49,6 @@ a { display: inline; margin: 10px; }
 ```
 
 `display: inline` causes `margin` to be ignored.
-
-```css
-a { display: inline-block; float: left; }
-```
-
-`display: inline-block` causes `float` to be ignored.
 
 ```css
 a { display: block; vertical-align: baseline; }
@@ -100,12 +93,6 @@ a { display: inline-block; width: 100px; }
 ```
 
 Although `display: inline` causes `width` to be ignored, `inline-block` works with `width`.
-
-```css
-a { display: block; float: left; }
-```
-
-Although `display: inline-block` causes `float` to be ignored, `block` works with `float`.
 
 ```css
 a { display: table-cell; vertical-align: baseline; }

--- a/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
@@ -161,12 +161,6 @@ testRule(rule, {
     column: 22,
     description: "display: inline rules out width, height, margin-top and margin-bottom, and float",
   }, {
-    code: "a { display: inline; float: left; }",
-    message: messages.rejected("float", "display: inline"),
-    line: 1,
-    column: 22,
-    description: "display: inline rules out width, height, margin-top and margin-bottom, and float",
-  }, {
     code: "a { display: inline; overflow: scroll; }",
     message: messages.rejected("overflow", "display: inline"),
     line: 1,
@@ -184,12 +178,6 @@ testRule(rule, {
     line: 1,
     column: 22,
     description: "display: inline rules out overflow-x",
-  }, {
-    code: "a { display: inline-block; float: left; }",
-    message: messages.rejected("float", "display: inline-block"),
-    line: 1,
-    column: 28,
-    description: "display: inline-block rules out float",
   }, {
     code: "a { display: block; vertical-align: baseline; }",
     message: messages.rejected("vertical-align", "display: block"),

--- a/src/rules/declaration-block-no-ignored-properties/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/index.js
@@ -25,16 +25,9 @@ const ignored = [ {
     "margin",
     "margin-top",
     "margin-bottom",
-    "float",
     "overflow",
     "overflow-x",
     "overflow-y",
-  ],
-}, {
-  property: "display",
-  value: "inline-block",
-  ignoredProperties: [
-    "float",
   ],
 }, {
   property: "display",


### PR DESCRIPTION
Close https://github.com/stylelint/stylelint/issues/1238
/cc @davidtheclark @jeddy3 