### PR TITLE
Add `node_modules` caching support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ node_js:
   - '6'
   - '4'
   - '0.12'
-
+cache:
+  directories:
+    - node_modules
+before_install:
+- npm update
+- npm prune
 after_success: npm run coveralls
-
 notifications:
   webhooks:
     - https://webhooks.gitter.im/e/d763493612da45967361


### PR DESCRIPTION
Currently installing NodeJS modules in Travis CI takes anywhere between ~120 and ~180 seconds, this PR should eliminate most of that time