### PR TITLE
Updated `no-unsupported-browser-features` test message for doiuse 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chalk": "^1.1.1",
     "colorguard": "^1.2.0",
     "cosmiconfig": "^1.1.0",
-    "doiuse": "^2.4.0",
+    "doiuse": "^2.4.1",
     "execall": "^1.0.0",
     "get-stdin": "^5.0.0",
     "globby": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "chalk": "^1.1.1",
     "colorguard": "^1.2.0",
     "cosmiconfig": "^1.1.0",
-    "doiuse": "^2.3.0",
+    "doiuse": "^2.4.0",
     "execall": "^1.0.0",
     "get-stdin": "^5.0.0",
     "globby": "^5.0.0",

--- a/src/rules/no-unsupported-browser-features/README.md
+++ b/src/rules/no-unsupported-browser-features/README.md
@@ -10,8 +10,6 @@ Disallow features that are unsupported by the browsers that you are targeting.
 
 This rule uses [doiuse](https://github.com/anandthakker/doiuse) to detect browser support. doiuse itself checks your code against the ["Can I use"](http://caniuse.com/) database.
 
-doiuse only checks if a browser *fully* supports a feature. As such, *partially* supported features will be flagged by this rule.
-
 **This is a good rule to use with "warning"-level severity**, because its primary purpose is to warn you that you are using features not all browsers fully support *and therefore ought to provide fallbacks*. But the warning will continue even if you have a fallback in place (it doesn't know); so you probably do not want this rule to break your build. Instead, consider it a friendly reminder to double-check certain spots for fallbacks.
 
 Bugs and feature requests should be reported on the [doiuse issue tracker](https://github.com/anandthakker/doiuse/issues).

--- a/src/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/src/rules/no-unsupported-browser-features/__tests__/index.js
@@ -71,7 +71,7 @@ testRule(rule, {
   reject: [{
     code: "a { background: linear-gradient(black, white); }",
     description: "gradient",
-    message: messages.rejected("\"css-gradients\" is not fully supported by IE 9 and  only partially supported by: Chrome 4,5,6,7,8,9"),
+    message: messages.rejected("\"css-gradients\" is not fully supported by IE 9 and only partially supported by: Chrome 4,5,6,7,8,9"),
     line: 1,
     column: 5,
   }],

--- a/src/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/src/rules/no-unsupported-browser-features/__tests__/index.js
@@ -29,13 +29,13 @@ testRule(rule, {
   reject: [ {
     code: "a { opacity: 1; }",
     description: "opacity",
-    message: messages.rejected("\"css-opacity\" is not fully supported by IE 7,8"),
+    message: messages.rejected("\"css-opacity\" is only partially supported by IE 7,8"),
     line: 1,
     column: 5,
   }, {
     code: "a { outline: none; }",
     description: "outline",
-    message: messages.rejected("\"outline\" is not fully supported by IE 7"),
+    message: messages.rejected("\"outline\" is not supported by IE 7"),
     line: 1,
     column: 5,
   } ],
@@ -52,7 +52,7 @@ testRule(rule, {
   reject: [{
     code: "a { opacity: 1; }",
     description: "opacity",
-    message: messages.rejected("\"css-opacity\" is not fully supported by IE 7,8"),
+    message: messages.rejected("\"css-opacity\" is only partially supported by IE 7,8"),
     line: 1,
     column: 5,
   }],
@@ -71,7 +71,7 @@ testRule(rule, {
   reject: [{
     code: "a { background: linear-gradient(black, white); }",
     description: "gradient",
-    message: messages.rejected("\"css-gradients\" is not fully supported by IE 9 and only partially supported by: Chrome 4,5,6,7,8,9"),
+    message: messages.rejected("\"css-gradients\" is not supported by IE 9 and only partially supported by Chrome 4,5,6,7,8,9"),
     line: 1,
     column: 5,
   }],

--- a/src/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/src/rules/no-unsupported-browser-features/__tests__/index.js
@@ -71,7 +71,7 @@ testRule(rule, {
   reject: [{
     code: "a { background: linear-gradient(black, white); }",
     description: "gradient",
-    message: messages.rejected("\"css-gradients\" is not fully supported by IE 9, Chrome 4,5,6,7,8,9"),
+    message: messages.rejected("\"css-gradients\" is not fully supported by IE 9 and  only partially supported by: Chrome 4,5,6,7,8,9"),
     line: 1,
     column: 5,
   }],

--- a/src/rules/no-unsupported-browser-features/index.js
+++ b/src/rules/no-unsupported-browser-features/index.js
@@ -58,8 +58,11 @@ function cleanDoiuseWarningText(warningText) {
   // Get feature Id, then replace brackets with quotes
   const featureId = warningText.slice(featureIdIndex, warningText.length).replace(/\(|\)/g, "\"")
 
-  // Get list of browsers, then strip brackets.
-  const browsers = warningText.slice(warningText.indexOf(":") + 2, featureIdIndex - 1).replace(/\(|\)/g, "")
+  // Get start of support text i.e. "x not supported by...", or "y only partially supported by..."
+  const browserSupportStartIndex = warningText.indexOf("not") !== -1 ? warningText.indexOf("not") : warningText.indexOf("only")
 
-  return `${featureId} is not fully supported by ${browsers}`
+  // Get browser support text, then strip brackets.
+  const browserSupport = warningText.slice(browserSupportStartIndex, featureIdIndex - 1).replace(/\(|\)|:/g, "")
+
+  return `${featureId} is ${browserSupport}`
 }


### PR DESCRIPTION
doiuse 2.4.0 updated the message format returned, this PR updates the one test message in our `no-unsupported-browser-features` tests that is affected.

https://github.com/anandthakker/doiuse/compare/v2.3.0...v2.4.0

Note: There are two spaces between `and` and `only` in the test, see https://github.com/anandthakker/doiuse/issues/48