### PR TITLE
Some rules now accept array as first option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
-- Fixed: rules `unit-*` correctly handles browser hacks.
+- Fixed: `at-rule-blacklist`, `at-rule-whitelist`, `comment-word-blacklist`, `selector-attribute-operator-blacklist`, `selector-attribute-operator-whitelist` now accept array as first option.
+- Fixed: `unit-*` rules now ignore CSS hacks.
 
 # 7.0.1
 

--- a/src/rules/at-rule-blacklist/index.js
+++ b/src/rules/at-rule-blacklist/index.js
@@ -12,7 +12,7 @@ export const messages = ruleMessages(ruleName, {
   rejected: (name) => `Unexpected at-rule "${name}"`,
 })
 
-export default function (blacklistInput) {
+function rule(blacklistInput) {
   // To allow for just a string as a parameter (not only arrays of strings)
   const blacklist = [].concat(blacklistInput)
   return (root, result) => {
@@ -35,3 +35,7 @@ export default function (blacklistInput) {
     })
   }
 }
+
+rule.primaryOptionArray = true
+
+export default rule

--- a/src/rules/at-rule-whitelist/index.js
+++ b/src/rules/at-rule-whitelist/index.js
@@ -12,7 +12,7 @@ export const messages = ruleMessages(ruleName, {
   rejected: (name) => `Unexpected at-rule "${name}"`,
 })
 
-export default function (whitelistInput) {
+function rule(whitelistInput) {
   // To allow for just a string as a parameter (not only arrays of strings)
   const whitelist = [].concat(whitelistInput)
   return (root, result) => {
@@ -35,3 +35,7 @@ export default function (whitelistInput) {
     })
   }
 }
+
+rule.primaryOptionArray = true
+
+export default rule

--- a/src/rules/comment-word-blacklist/index.js
+++ b/src/rules/comment-word-blacklist/index.js
@@ -13,7 +13,7 @@ export const messages = ruleMessages(ruleName, {
   rejected: (pattern) => `Unexpected word matching pattern "${pattern}"`,
 })
 
-export default function (blacklist) {
+function rule(blacklist) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: blacklist,
@@ -42,3 +42,7 @@ export default function (blacklist) {
     })
   }
 }
+
+rule.primaryOptionArray = true
+
+export default rule

--- a/src/rules/selector-attribute-operator-blacklist/index.js
+++ b/src/rules/selector-attribute-operator-blacklist/index.js
@@ -13,7 +13,7 @@ export const messages = ruleMessages(ruleName, {
   rejected: (operator) => `Unexpected operator "${operator}"`,
 })
 
-export default function (blacklistInput) {
+function rule(blacklistInput) {
   const blacklist = [].concat(blacklistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -32,8 +32,6 @@ export default function (blacklistInput) {
         selectorTree.walkAttributes(attributeNode => {
           const operator = attributeNode.operator
 
-          if (!operator) { return }
-
           if (!operator || (operator && blacklist.indexOf(operator) === -1)) { return }
 
           report({
@@ -48,3 +46,7 @@ export default function (blacklistInput) {
     })
   }
 }
+
+rule.primaryOptionArray = true
+
+export default rule

--- a/src/rules/selector-attribute-operator-whitelist/index.js
+++ b/src/rules/selector-attribute-operator-whitelist/index.js
@@ -13,7 +13,7 @@ export const messages = ruleMessages(ruleName, {
   rejected: (operator) => `Unexpected operator "${operator}"`,
 })
 
-export default function (whitelistInput) {
+function rule(whitelistInput) {
   const whitelist = [].concat(whitelistInput)
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -46,3 +46,7 @@ export default function (whitelistInput) {
     })
   }
 }
+
+rule.primaryOptionArray = true
+
+export default rule


### PR DESCRIPTION
Rules `at-rule-blacklist`, `at-rule-whitelist`, `comment-word-blacklist`, `selector-attribute-operator-blacklist`, `selctor-attribute-operator-whitelist` now accept array as first option.

Close https://github.com/stylelint/stylelint/issues/1644
/cc @davidtheclark @jeddy3 