### PR TITLE
Rules `unit-*` correctly handles browser hacks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: rules `unit-*` correctly handles browser hacks.
+
 # 7.0.1
 
 - Fixed: missing `known-css-properties` dependency.

--- a/src/rules/unit-no-unknown/__tests__/index.js
+++ b/src/rules/unit-no-unknown/__tests__/index.js
@@ -133,6 +133,9 @@ testRule(rule, {
   }, {
     code: "@media (min-width: 10px)\n  and (max-width: 20px) {}",
     description: "complex @media",
+  }, {
+    code: "@media screen and (min-width:0\\0) {}",
+    description: "ignore media query hack",
   } ],
 
   reject: [ {

--- a/src/utils/__tests__/getUnitFromValueNode-test.js
+++ b/src/utils/__tests__/getUnitFromValueNode-test.js
@@ -10,6 +10,8 @@ test("getUnitFromValueNode", t => {
   t.equal(getUnitFromValueNode(valueParser("1PX").nodes[0]), "PX")
   t.equal(getUnitFromValueNode(valueParser("100%").nodes[0]), "%")
   t.equal(getUnitFromValueNode(valueParser("100").nodes[0]), "")
+  t.equal(getUnitFromValueNode(valueParser("0\\0").nodes[0]), "")
+  t.equal(getUnitFromValueNode(valueParser("10px\\9").nodes[0]), "px")
   t.equal(getUnitFromValueNode(valueParser("#fff").nodes[0]), null)
   t.equal(getUnitFromValueNode(valueParser("#000").nodes[0]), null)
   t.equal(getUnitFromValueNode(valueParser("\"100\"").nodes[0]), null)

--- a/src/utils/getUnitFromValueNode.js
+++ b/src/utils/getUnitFromValueNode.js
@@ -15,6 +15,9 @@ export default function (node) {
   if (!node || (node && !node.value)) { return null }
 
   const value = blurInterpolation(node.value, "")
+    // ignore hack unit
+    .replace("\\0", "")
+    .replace("\\9", "")
 
   if (node.type !== "word"
     || !isStandardSyntaxValue(value)


### PR DESCRIPTION
Close https://github.com/stylelint/stylelint/issues/1645
/cc @davidtheclark @jeddy3 