### PR TITLE
Remove superfluous quote from various rule options docs

### DIFF
--- a/src/rules/at-rule-blacklist/README.md
+++ b/src/rules/at-rule-blacklist/README.md
@@ -10,7 +10,7 @@ Specify a blacklist of disallowed at-rules.
 
 ## Options
 
-`array|string`: `"["array", "of", "unprefixed", "at-rules"]|"at-rule"`
+`array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`
 
 Given:
 

--- a/src/rules/at-rule-whitelist/README.md
+++ b/src/rules/at-rule-whitelist/README.md
@@ -10,7 +10,7 @@ Specify a whitelist of allowed at-rules.
 
 ## Options
 
-`array|string`: `"["array", "of", "unprefixed", "at-rules"]|"at-rule"`
+`array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`
 
 Given:
 

--- a/src/rules/selector-attribute-operator-blacklist/README.md
+++ b/src/rules/selector-attribute-operator-blacklist/README.md
@@ -10,7 +10,7 @@ a[target="_blank"] { }
 
 ## Options
 
-`array|string`: `"["array", "of", "operators"]|"operator"`
+`array|string`: `["array", "of", "operators"]|"operator"`
 
 Given:
 

--- a/src/rules/selector-attribute-operator-whitelist/README.md
+++ b/src/rules/selector-attribute-operator-whitelist/README.md
@@ -10,7 +10,7 @@ a[target="_blank"] { }
 
 ## Options
 
-`array|string`: `"["array", "of", "operators"]|"operator"`
+`array|string`: `["array", "of", "operators"]|"operator"`
 
 Given:
 


### PR DESCRIPTION
There was an extra double quote in these 4 rule option docs:
https://github.com/stylelint/stylelint/tree/master/src/rules/at-rule-blacklist/README.md
https://github.com/stylelint/stylelint/tree/master/src/rules/at-rule-whitelist/README.md
https://github.com/stylelint/stylelint/tree/master/src/rules/selector-attribute-operator-blacklist/README.md
https://github.com/stylelint/stylelint/tree/master/src/rules/selector-attribute-operator-whitelist/README.md

This change brings the above files in line with the following rule option docs for consistency:
https://github.com/stylelint/stylelint/tree/master/src/rules/comment-word-blacklist/README.md
https://github.com/stylelint/stylelint/tree/master/src/rules/function-blacklist/README.md
https://github.com/stylelint/stylelint/tree/master/src/rules/function-whitelist/README.md
https://github.com/stylelint/stylelint/tree/master/src/rules/property-blacklist/README.md
https://github.com/stylelint/stylelint/tree/master/src/rules/property-whitelist/README.md