### PR TITLE
Fix rule extension; closes #1646

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+- Fixed: bug causing rules in extended configs to be merged with, rather than replaced by, the extending config.
+
 # 7.0.2
 
 - Fixed: `at-rule-blacklist`, `at-rule-whitelist`, `comment-word-blacklist`, `selector-attribute-operator-blacklist`, `selector-attribute-operator-whitelist` now accept array as first option.

--- a/src/__tests__/buildConfig-test.js
+++ b/src/__tests__/buildConfig-test.js
@@ -124,7 +124,7 @@ test("buildConfig extends", t => {
         "color-no-invalid-hex": true,
       },
     }, "extends deeply, merging rules and plugins")
-  })
+  }).catch(logError)
   planned += 1
 
   t.plan(planned)
@@ -147,7 +147,7 @@ test("buildConfig config with plugins extends with plugins", t => {
         "plugin/warn-about-bar": "always",
       },
     }, "extends, and merges plugins")
-  })
+  }).catch(logError)
   planned += 1
 
   t.plan(planned)
@@ -180,6 +180,26 @@ test("buildConfig throws as needed", t => {
   planned += 1
 
   t.plan(planned)
+})
+
+test("buildConfig extends rules by replacing the prior rule config completely, not merging", t => {
+  buildConfig({
+    extends: [path.join(__dirname, "./fixtures/config-at-rule-empty-line-before")],
+    rules: {
+      "at-rule-empty-line-before": [ "always", {
+        expect: ["blockless-group"],
+      } ],
+    },
+  }).then(({ config }) => {
+    t.deepEqual(config, {
+      rules: {
+        "at-rule-empty-line-before": [ "always", {
+          expect: ["blockless-group"],
+        } ],
+      },
+    })
+    t.end()
+  }).catch(logError)
 })
 
 function logError(err) { console.log(err.stack) } // eslint-disable-line

--- a/src/__tests__/extends-test.js
+++ b/src/__tests__/extends-test.js
@@ -8,44 +8,46 @@ import test from "tape"
 const fixturesPath = path.join(__dirname, "fixtures")
 
 test("standalone with extending configuration and configBasedir", t => {
-  let planned = 0
+  t.test("basic extending", st => {
+    standalone({
+      code: "a {}",
+      config: configExtendingOne,
+      configBasedir: path.join(__dirname, "fixtures"),
+    }).then(({ output, results }) => {
+      st.equal(typeof output, "string")
+      st.equal(results.length, 1)
+      st.equal(results[0].warnings.length, 1)
+      st.equal(results[0].warnings[0].rule, "block-no-empty")
+    }).catch(logError)
+    st.end()
+  })
 
-  standalone({
-    code: "a {}",
-    config: configExtendingOne,
-    configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ output, results }) => {
-    t.equal(typeof output, "string")
-    t.equal(results.length, 1)
-    t.equal(results[0].warnings.length, 1)
-    t.equal(results[0].warnings[0].rule, "block-no-empty")
-  }).catch(logError)
-  planned += 4
+  t.test("recursive extending", st => {
+    standalone({
+      code: "a {}",
+      config: configExtendingAnotherExtend,
+      configBasedir: path.join(__dirname, "fixtures"),
+    }).then(({ output, results }) => {
+      st.equal(typeof output, "string")
+      st.equal(results.length, 1)
+      st.equal(results[0].warnings.length, 1)
+      st.equal(results[0].warnings[0].rule, "block-no-empty")
+    }).catch(logError)
+    st.end()
+  })
 
-  // Recursive extending
-  standalone({
-    code: "a {}",
-    config: configExtendingAnotherExtend,
-    configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ output, results }) => {
-    t.equal(typeof output, "string")
-    t.equal(results.length, 1)
-    t.equal(results[0].warnings.length, 1)
-    t.equal(results[0].warnings[0].rule, "block-no-empty")
-  }).catch(logError)
-  planned += 4
+  t.test("extending with overrides", st => {
+    standalone({
+      code: "a {}",
+      config: configExtendingThreeWithOverride,
+      configBasedir: path.join(__dirname, "fixtures"),
+    }).then(({ results }) => {
+      st.equal(results[0].warnings.length, 0)
+    }).catch(logError)
+    st.end()
+  })
 
-  // Extending with overrides
-  standalone({
-    code: "a {}",
-    config: configExtendingThreeWithOverride,
-    configBasedir: path.join(__dirname, "fixtures"),
-  }).then(({ results }) => {
-    t.equal(results[0].warnings.length, 0)
-  }).catch(logError)
-  planned += 1
-
-  t.plan(planned)
+  t.end()
 })
 
 test("standalone with extending configuration and no configBasedir", t => {
@@ -73,8 +75,8 @@ test("standalone extending a config that is overridden", t => {
     },
   }).then(({ results }) => {
     t.equal(results[0].warnings.length, 0)
+    t.end()
   }).catch(logError)
-  t.plan(1)
 })
 
 function logError(err) { console.log(err.stack) } // eslint-disable-line no-console

--- a/src/__tests__/fixtures/config-at-rule-empty-line-before.json
+++ b/src/__tests__/fixtures/config-at-rule-empty-line-before.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "at-rule-empty-line-before": ["always", {
+      "except": ["blockless-group", "all-nested"]
+    }]
+  }
+}


### PR DESCRIPTION
Ref #1646.

Looks to me like this has probably been a longstanding bug that nobody's run into (and reported) yet.

In the diff here, most of the changes to test files are just minor refactoring I did while debugging some failing tests. The key here is the new test and the logic changes in `src/buildConfig.js`.