### PR TITLE
Changes `selector-no-type` to automatically resolve nested selectors when `ignore: ["descendant"]` option is enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed: bug causing rules in extended configs to be merged with, rather than replaced by, the extending config.
 - Fixed: bug where fractional keyframes yielded false positives in `selector-class-pattern`
+- Fixed: `selector-no-type` with secondary option `ignore: ["descendant"]` will now resolve nested selectors.
 
 # 7.0.2
 

--- a/src/rules/selector-no-type/README.md
+++ b/src/rules/selector-no-type/README.md
@@ -50,10 +50,6 @@ The following patterns are *not* considered warnings:
 
 ## Optional options
 
-### `resolveNestedSelectors: true | false` (default: `false`)
-
-This option will resolve nested selectors before checking any rules.
-
 ### `ignore: ["compounded", "descendant"]`
 
 #### `"compounded"`

--- a/src/rules/selector-no-type/README.md
+++ b/src/rules/selector-no-type/README.md
@@ -50,6 +50,10 @@ The following patterns are *not* considered warnings:
 
 ## Optional options
 
+### `resolveNestedSelectors: true | false` (default: `false`)
+
+This option will resolve nested selectors before checking any rules.
+
 ### `ignore: ["compounded", "descendant"]`
 
 #### `"compounded"`

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -79,6 +79,12 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 13,
+  }, {
+    code: ".foo { div {} }",
+    description: "nested descendant",
+    message: messages.rejected,
+    line: 1,
+    column: 8,
   } ],
 })
 
@@ -96,6 +102,9 @@ testRule(rule, {
   }, {
     code: "#bar div.foo {}",
     description: "compounded and descendant",
+  }, {
+    code: ".foo { div {} }",
+    description: "nested descendant",
   } ],
 
   reject: [ {
@@ -160,9 +169,10 @@ testRule(rule, {
   ],
 
   reject: [{
-    code: ".foo { div {} }",
-    description: "nested descendant",
-    message: messages.rejected,
+    code: "@for $n from 1 through 5 { .foo-#{$n} { div { content: \"#{$n}\"; } } }",
+    description: "ignore sass interpolation inside @for for nested descendant",
+    line: 1,
+    column: 41,
   }],
 })
 
@@ -173,8 +183,8 @@ testRule(rule, {
   syntax: "scss",
 
   accept: [{
-    code: ".foo { div {} }",
-    description: "nested descendant",
+    code: "@for $n from 1 through 5 { .foo-#{$n} { div { content: \"#{$n}\"; } } }",
+    description: "ignore sass interpolation inside @for for nested descendant",
   }],
 })
 
@@ -189,9 +199,10 @@ testRule(rule, {
   ],
 
   reject: [{
-    code: ".foo { div {} }",
-    description: "nested descendant",
-    message: messages.rejected,
+    code: ".for(@n: 1) when (@n <= 5) { .foo-@{n} { div { content: \"@{n}\"; } } .for (@n + 1); }",
+    description: "ignore less interpolation inside @for for nested descendant",
+    line: 1,
+    column: 42,
   }],
 })
 
@@ -202,7 +213,7 @@ testRule(rule, {
   syntax: "less",
 
   accept: [{
-    code: ".foo { div {} }",
-    description: "nested descendant",
+    code: ".for(@n: 1) when (@n <= 5) { .foo-@{n} { div { content: \"@{n}\"; } } .for (@n + 1); }",
+    description: "ignore less interpolation inside @for for nested descendant",
   }],
 })

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -107,7 +107,20 @@ testRule(rule, {
   }, {
     code: "div.foo {}",
     message: messages.rejected,
+  }, {
+    code: ".foo { div { } }",
+    message: messages.rejected,
   } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignore: ["descendant"], resolveNestedSelectors: true } ],
+  skipBasicChecks: true,
+
+  accept: [{
+    code: ".foo { div { } }",
+  }],
 })
 
 testRule(rule, {

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -159,11 +159,11 @@ testRule(rule, {
     { code: "// Comment\n.c {}" },
   ],
 
-  reject: [ {
+  reject: [{
     code: ".foo { div {} }",
     description: "nested descendant",
     message: messages.rejected,
-  } ],
+  }],
 })
 
 testRule(rule, {
@@ -188,11 +188,11 @@ testRule(rule, {
     { code: "// Comment\n.c {}" },
   ],
 
-  reject: [ {
+  reject: [{
     code: ".foo { div {} }",
     description: "nested descendant",
     message: messages.rejected,
-  } ],
+  }],
 })
 
 testRule(rule, {

--- a/src/rules/selector-no-type/__tests__/index.js
+++ b/src/rules/selector-no-type/__tests__/index.js
@@ -107,20 +107,7 @@ testRule(rule, {
   }, {
     code: "div.foo {}",
     message: messages.rejected,
-  }, {
-    code: ".foo { div { } }",
-    message: messages.rejected,
   } ],
-})
-
-testRule(rule, {
-  ruleName,
-  config: [ true, { ignore: ["descendant"], resolveNestedSelectors: true } ],
-  skipBasicChecks: true,
-
-  accept: [{
-    code: ".foo { div { } }",
-  }],
 })
 
 testRule(rule, {
@@ -171,6 +158,24 @@ testRule(rule, {
   accept: [
     { code: "// Comment\n.c {}" },
   ],
+
+  reject: [ {
+    code: ".foo { div {} }",
+    description: "nested descendant",
+    message: messages.rejected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignore: ["descendant"] } ],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [{
+    code: ".foo { div {} }",
+    description: "nested descendant",
+  }],
 })
 
 testRule(rule, {
@@ -182,4 +187,22 @@ testRule(rule, {
   accept: [
     { code: "// Comment\n.c {}" },
   ],
+
+  reject: [ {
+    code: ".foo { div {} }",
+    description: "nested descendant",
+    message: messages.rejected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignore: ["descendant"] } ],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [{
+    code: ".foo { div {} }",
+    description: "nested descendant",
+  }],
 })

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -27,13 +27,11 @@ export default function (on, options) {
       actual: options,
       possible: {
         ignore: [ "descendant", "compounded" ],
-        resolveNestedSelectors: isBoolean,
       },
       optional: true,
     })
     if (!validOptions) { return }
 
-    const shouldResolveNestedSelectors = get(options, "resolveNestedSelectors")
     const ignoreDescendant = optionsHaveIgnored(options, "descendant")
     const ignoreCompounded = optionsHaveIgnored(options, "compounded")
 
@@ -45,7 +43,7 @@ export default function (on, options) {
       if (!isStandardSyntaxSelector(selector)) { return }
       if (selectors.some(s => isKeyframeSelector(s))) { return }
 
-      if (shouldResolveNestedSelectors) {
+      if (ignoreDescendant) {
         resolveNestedSelector(selector, rule).forEach(selector => {
           checkSelector(selector, rule)
         })

--- a/src/rules/selector-no-type/index.js
+++ b/src/rules/selector-no-type/index.js
@@ -1,8 +1,4 @@
 import {
-    get,
-    isBoolean,
-} from "lodash"
-import {
   isKeyframeSelector,
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
@@ -13,6 +9,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { get } from "lodash"
 import resolveNestedSelector from "postcss-resolve-nested-selector"
 
 export const ruleName = "selector-no-type"


### PR DESCRIPTION
### Description

This PR addresses #1654.

These changes will automatically resolve nested selectors automatically if the `ignore: ["descendant"]` option is enabled. 

And since this is my first PR on this project, please let me know if there's anything else I may have missed or of there is any other pertinent information I should add to the PR.

### Benchmarks

#### Before

```
❯ npm run benchmark-rule -- selector-no-type "[true, {\"ignore\": [\"descendant\"]}]"

Warnings: 406
Mean: 171.1881831515151 ms
Deviation: 38.763392889220015 ms
```

#### After

```
❯ npm run benchmark-rule -- selector-no-type "[true, {\"ignore\": [\"descendant\"]}]"

Warnings: 406
Mean: 156.6367916 ms
Deviation: 25.370745159382917 ms
```