### PR TITLE
Ignore fractional keyframes in selector-class-pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 - Fixed: bug causing rules in extended configs to be merged with, rather than replaced by, the extending config.
+- Fixed: bug where fractional keyframes yielded false positives in `selector-class-pattern`
 
 # 7.0.2
 

--- a/src/rules/selector-class-pattern/__tests__/index.js
+++ b/src/rules/selector-class-pattern/__tests__/index.js
@@ -25,6 +25,9 @@ const basicAZTests = {
     code: "a /* .foo */ {}",
   }, {
     code: ":root { --custom-property-set: {} }",
+  }, {
+    code: "@keyframes a { 0%, 48.59% {} }",
+    message: "Keyframes with decimal percentages",
   } ],
 
   reject: [ {

--- a/src/rules/selector-class-pattern/index.js
+++ b/src/rules/selector-class-pattern/index.js
@@ -1,4 +1,5 @@
 import {
+  isKeyframeSelector,
   isStandardSyntaxRule,
   isStandardSyntaxSelector,
   parseSelector,
@@ -35,10 +36,11 @@ export default function (pattern, options) {
       : pattern
 
     root.walkRules(rule => {
-      if (!isStandardSyntaxRule(rule)) { return }
+      const { selector, selectors } = rule
 
-      const { selector } = rule
+      if (!isStandardSyntaxRule(rule)) { return }
       if (!isStandardSyntaxSelector(selector)) { return }
+      if (selectors.some(s => isKeyframeSelector(s))) { return }
 
       // Only bother resolving selectors that have an interpolating &
       if (shouldResolveNestedSelectors && hasInterpolatingAmpersand(selector)) {


### PR DESCRIPTION
Relates to #1583, #1513. `selector-class-pattern` was yielding false positive
for fractional keyframes. This commit fixes this issue, essentially copying
the work done in PR #1514.