### PR TITLE
Clarify *-pattern rule options in docs

### DIFF
--- a/src/rules/custom-media-pattern/README.md
+++ b/src/rules/custom-media-pattern/README.md
@@ -14,7 +14,7 @@ Specify a pattern for custom media query names.
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-Given:
+Given the string:
 
 ```js
 "foo-.+"

--- a/src/rules/custom-media-pattern/README.md
+++ b/src/rules/custom-media-pattern/README.md
@@ -10,11 +10,15 @@ Specify a pattern for custom media query names.
 
 ## Options
 
-`regex` or `string`
+`regex|string`
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-### E.g. `/foo-.+/`
+Given:
+
+```js
+"foo-.+"
+```
 
 The following patterns are considered warnings:
 

--- a/src/rules/custom-property-pattern/README.md
+++ b/src/rules/custom-property-pattern/README.md
@@ -10,11 +10,15 @@ a { --foo-bar: 1px; }
 
 ## Options
 
-`regex` or `string`
+`regex|string`
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-### E.g. `/foo-.+/`
+Given:
+
+```js
+"foo-.+"
+```
 
 The following patterns are considered warnings:
 

--- a/src/rules/custom-property-pattern/README.md
+++ b/src/rules/custom-property-pattern/README.md
@@ -14,7 +14,7 @@ a { --foo-bar: 1px; }
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-Given:
+Given the string:
 
 ```js
 "foo-.+"

--- a/src/rules/selector-class-pattern/README.md
+++ b/src/rules/selector-class-pattern/README.md
@@ -74,7 +74,7 @@ This option will resolve nested selectors with `&` interpolation.
 
 For example, with `true`.
 
-Given:
+Given the string:
 
 ```js
 "^[A-Z]+$"

--- a/src/rules/selector-class-pattern/README.md
+++ b/src/rules/selector-class-pattern/README.md
@@ -12,13 +12,17 @@ This rule ignores non-ouputting Less mixin definitions and called Less mixins.
 
 ## Options
 
-`regex` or `string`
+`regex|string`
 
 A string will be translated into a RegExp — `new RegExp(yourString)` — so *be sure to escape properly*.
 
 The selector value *after `.`* will be checked. No need to include `.` in your pattern.
 
-### E.g. `/foo-[a-z]+/`
+Given:
+
+```js
+"foo-[a-z]+"
+```
 
 The following patterns are considered warnings:
 
@@ -68,7 +72,13 @@ div > #zing + .foo-bar {}
 
 This option will resolve nested selectors with `&` interpolation.
 
-### E.g. `/^[A-Z]+$/`
+For example, with `true`.
+
+Given:
+
+```js
+"^[A-Z]+$"
+```
 
 The following patterns are considered warnings:
 

--- a/src/rules/selector-class-pattern/README.md
+++ b/src/rules/selector-class-pattern/README.md
@@ -18,7 +18,7 @@ A string will be translated into a RegExp — `new RegExp(yourString)` — so *
 
 The selector value *after `.`* will be checked. No need to include `.` in your pattern.
 
-Given:
+Given the string:
 
 ```js
 "foo-[a-z]+"

--- a/src/rules/selector-id-pattern/README.md
+++ b/src/rules/selector-id-pattern/README.md
@@ -16,7 +16,7 @@ A string will be translated into a RegExp — `new RegExp(yourString)` — so *
 
 The selector value *after `#`* will be checked. No need to include `#` in your pattern.
 
-Given:
+Given the string:
 
 ```js
 "foo-[a-z]+"

--- a/src/rules/selector-id-pattern/README.md
+++ b/src/rules/selector-id-pattern/README.md
@@ -10,13 +10,17 @@ Specify a pattern for id selectors.
 
 ## Options
 
-`regex` or `string`
+`regex|string`
 
 A string will be translated into a RegExp — `new RegExp(yourString)` — so *be sure to escape properly*.
 
 The selector value *after `#`* will be checked. No need to include `#` in your pattern.
 
-### E.g. `/foo-[a-z]+/`
+Given:
+
+```js
+"foo-[a-z]+"
+```
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
Closes #1650

I standardised on string options as JSON configs seem most popular.