### PR TITLE
newline-after without never option - increased test coverage

### DIFF
--- a/src/rules/at-rule-name-newline-after/index.js
+++ b/src/rules/at-rule-name-newline-after/index.js
@@ -9,7 +9,6 @@ export const ruleName = "at-rule-name-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: (name) => `Expected newline after at-rule name \"${name}\"`,
-  rejectedAfter: (name) => `Unexpected newline after at-rule name \"${name}\"`,
 })
 
 export default function (expectation) {

--- a/src/rules/declaration-colon-newline-after/index.js
+++ b/src/rules/declaration-colon-newline-after/index.js
@@ -11,7 +11,6 @@ export const ruleName = "declaration-colon-newline-after"
 
 export const messages = ruleMessages(ruleName, {
   expectedAfter: () => "Expected newline after \":\"",
-  rejectedAfter: () => "Unexpected whitespace after \":\"",
   expectedAfterMultiLine: () => "Expected newline after \":\" with a multi-line declaration",
 })
 


### PR DESCRIPTION
@jeddy3 @ntwb 

This two are not having `never` in their possible values. So there is no need of `rejectionAfter()` message. 

When we remove those two, the test coverage is increased to `100%`

