### PR TITLE
Ignore non-standard constructs in selector-combinator-space-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added: `custom-property-empty-line-before` rule.
 - Fixed: `no-descending-specificity` message to correctly show which selector should come first.
+- Fixed: `selector-combinator-space-after` and `selector-combinator-space-before` now ignore operators within parenthetical non-standard constructs.
 
 # 7.0.3
 

--- a/src/rules/selector-combinator-space-after/__tests__/index.js
+++ b/src/rules/selector-combinator-space-after/__tests__/index.js
@@ -217,3 +217,20 @@ testRule(rule, {
     column: 16,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: ["always"],
+
+  accept:[{
+    code: ".a when (@size>=60) and (@size<102) {}",
+    description: "ignore constructs",
+  }],
+
+  reject: [{
+    code: "a+  a {}",
+    description: "two spaces after + combinator",
+    message: messages.expectedAfter("+"),
+  }],
+})

--- a/src/rules/selector-combinator-space-after/index.js
+++ b/src/rules/selector-combinator-space-after/index.js
@@ -44,7 +44,7 @@ export function selectorCombinatorSpaceChecker({ locationChecker, root, result, 
       styleSearch({
         source: selector,
         target: _.toArray(nonSpaceCombinators),
-        functionArguments: "skip",
+        parentheticals: "skip",
       }, match => {
 
         const { endIndex, startIndex, target } = match

--- a/src/rules/selector-combinator-space-before/__tests__/index.js
+++ b/src/rules/selector-combinator-space-before/__tests__/index.js
@@ -222,3 +222,20 @@ testRule(rule, {
     column: 16,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: ["always"],
+
+  accept:[{
+    code: ".a when (@size>=60) and (@size<102) {}",
+    description: "ignore constructs",
+  }],
+
+  reject: [{
+    code: "a  +a {}",
+    description: "two spaces before + combinator",
+    message: messages.expectedBefore("+"),
+  }],
+})


### PR DESCRIPTION
Closes #1681

By switching to `style-search`’s broader [`parentheticals`](https://github.com/davidtheclark/style-search#parentheticals).

As an aside, I’m glad we have `style-search` and our `isStandardSyntax*` utils :)