### PR TITLE
Document selector and value list comment limitation

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -95,6 +95,8 @@ Complex, overlapping disabling & enabling patterns are supported:
 /* stylelint-enable foo */
 ```
 
+**Caveat:** Comments within *selector and value lists* are currently ignored.
+
 #### Severities: error & warning
 
 By default, all rules have an `"error"`-level severity. You can change this default by adding a `defaultSeverity` property to your configuration (see below).

--- a/src/rules/comment-empty-line-before/README.md
+++ b/src/rules/comment-empty-line-before/README.md
@@ -14,6 +14,8 @@ If the comment is the very first node in a stylesheet then it is ignored. Shared
 
 If you're using a custom syntax which support single-line comments with `//`, those are ignored as well.
 
+**Caveat:** Comments within *selector and value lists* are currently ignored.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/src/rules/comment-no-empty/README.md
+++ b/src/rules/comment-no-empty/README.md
@@ -8,6 +8,8 @@ Disallow empty comments.
  * Comments like this */
 ```
 
+**Caveat:** Comments within *selector and value lists* are currently ignored.
+
 ## Options
 
 ### `true`

--- a/src/rules/comment-whitespace-inside/README.md
+++ b/src/rules/comment-whitespace-inside/README.md
@@ -10,6 +10,8 @@ Require or disallow whitespace on the inside of comment markers.
 
 Any number of asterisks are allowed at the beginning or end of the comment. So `/** comment **/` is treated the same way as `/* comment */`.
 
+**Caveat:** Comments within *selector and value lists* are currently ignored.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/src/rules/comment-word-blacklist/README.md
+++ b/src/rules/comment-word-blacklist/README.md
@@ -8,6 +8,8 @@ Specify a blacklist of disallowed words within comments.
  * These three words */
 ```
 
+**Caveat:** Comments within *selector and value lists* are currently ignored.
+
 ## Options
 
 `array|string`: `["array", "of", "words", "or", "/regex/"]|"word"|"/regex/"`


### PR DESCRIPTION
Closes #1700. Closes #1628.

I went with “Caveat: xyz” as we’ve used it [before](https://github.com/stylelint/stylelint/blob/master/src/rules/font-family-name-quotes/README.md) to highlight a current limitation.