### PR TITLE
Align custom-prop-empty-line-before with declaration variety

### DIFF
--- a/src/rules/custom-property-empty-line-before/README.md
+++ b/src/rules/custom-property-empty-line-before/README.md
@@ -166,3 +166,17 @@ a {
   --custom-prop2: value;
 }
 ```
+
+### `ignore: ["inside-single-line-block"]`
+
+#### `"inside-single-line-block"`
+
+Ignore custom properties that are inside single-line blocks.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```css
+a { --custom-prop: value; --custom-prop2: value; }
+```

--- a/src/rules/custom-property-empty-line-before/__tests__/index.js
+++ b/src/rules/custom-property-empty-line-before/__tests__/index.js
@@ -69,6 +69,24 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { ignore: ["inside-single-line-block"] } ],
+
+  accept: [ {
+    code: "a { --custom-prop: value; }",
+  }, {
+    code: "a {\n\n --custom-prop: value;\n}",
+  } ],
+
+  reject: [{
+    code: "a {\n --custom-prop: value;\n}",
+    message: messages.expected,
+    line: 2,
+    column: 2,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { except: ["first-nested"] } ],
 
   accept: [ {


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/pull/1694#issue-166875781

Last PR to go into `7.1`.