### PR TITLE
Added: new rule `media-feature-name-no-unknown`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added: `--report-needless-disables` and `reportNeedlessDisables` option.
 - Added: `--ignore-disables` and `ignoreDisables` option.
 - Added: `value-list-max-empty-lines` rule.
+- Added: `media-feature-name-no-unknown` rule.
 - Fixed: `no-unknown-animations` and `unit-blacklist` now handle numbers without leading zeros.
 
 # 7.1.0

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -88,6 +88,7 @@ You might want to learn a little about [how rules are named and how they work to
     "media-feature-colon-space-after": "always"|"never",
     "media-feature-colon-space-before": "always"|"never",
     "media-feature-name-case": "lower"|"upper",
+    "media-feature-name-no-unknown": true,
     "media-feature-name-no-vendor-prefix": true,
     "media-feature-no-missing-punctuation": true,
     "media-feature-parentheses-space-inside": "always"|"never",

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -201,6 +201,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 - [`media-feature-colon-space-after`](../../src/rules/media-feature-colon-space-after/README.md): Require a single space or disallow whitespace after the colon in media features.
 - [`media-feature-colon-space-before`](../../src/rules/media-feature-colon-space-before/README.md): Require a single space or disallow whitespace before the colon in media features.
 - [`media-feature-name-case`](../../src/rules/media-feature-name-case/README.md): Specify lowercase or uppercase for media feature names.
+- [`media-feature-name-no-unknown`](../../src/rules/media-feature-name-no-unknown/README.md): Disallow unknown media feature names.
 - [`media-feature-name-no-vendor-prefix`](../../src/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names.
 - [`media-feature-no-missing-punctuation`](../../src/rules/media-feature-no-missing-punctuation/README.md): Disallow missing punctuation for non-boolean media features.
 - [`media-feature-parentheses-space-inside`](../../src/rules/media-feature-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within media features.

--- a/src/reference/keywordSets.js
+++ b/src/reference/keywordSets.js
@@ -499,6 +499,56 @@ export const atRules = new Set([
   "viewport",
 ])
 
+// https://drafts.csswg.org/mediaqueries/#descdef-media-update
+export const deprecatedMediaFeatureNames = new Set([
+  "device-aspect-ratio",
+  "device-height",
+  "device-width",
+  "max-device-aspect-ratio",
+  "max-device-height",
+  "max-device-width",
+  "min-device-aspect-ratio",
+  "min-device-height",
+  "min-device-width",
+])
+
+// https://drafts.csswg.org/mediaqueries/#descdef-media-update
+export const mediaFeatureNames = uniteSets(deprecatedMediaFeatureNames, [
+  "any-hover",
+  "any-pointer",
+  "aspect-ratio",
+  "color",
+  "color-gamut",
+  "color-index",
+  "grid",
+  "height",
+  "hover",
+  "max-aspect-ratio",
+  "max-color",
+  "max-color-index",
+  "max-height",
+  "max-monochrome",
+  "max-resolution",
+  "max-width",
+  "min-aspect-ratio",
+  "min-color",
+  "min-color-index",
+  "min-height",
+  "min-monochrome",
+  "min-resolution",
+  "min-width",
+  "monochrome",
+  "orientation",
+  "overflow-block",
+  "overflow-inline",
+  "pointer",
+  "resolution",
+  "scan",
+  "scripting",
+  "update",
+  "width",
+])
+
 function uniteSets(...sets) {
   return new Set(sets.reduce((result, set) => {
     return result.concat(_.toArray(set))

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -79,6 +79,7 @@ import maxNestingDepth from "./max-nesting-depth"
 import mediaFeatureColonSpaceAfter from "./media-feature-colon-space-after"
 import mediaFeatureColonSpaceBefore from "./media-feature-colon-space-before"
 import mediaFeatureNameCase from "./media-feature-name-case"
+import mediaFeatureNameNoUnknown from "./media-feature-name-no-unknown"
 import mediaFeatureNameNoVendorPrefix from "./media-feature-name-no-vendor-prefix"
 import mediaFeatureNoMissingPunctuation from "./media-feature-no-missing-punctuation"
 import mediaFeatureParenthesesSpaceInside from "./media-feature-parentheses-space-inside"
@@ -245,6 +246,7 @@ export default {
   "media-feature-colon-space-after": mediaFeatureColonSpaceAfter,
   "media-feature-colon-space-before": mediaFeatureColonSpaceBefore,
   "media-feature-name-case": mediaFeatureNameCase,
+  "media-feature-name-no-unknown": mediaFeatureNameNoUnknown,
   "media-feature-name-no-vendor-prefix": mediaFeatureNameNoVendorPrefix,
   "media-feature-no-missing-punctuation": mediaFeatureNoMissingPunctuation,
   "media-feature-parentheses-space-inside": mediaFeatureParenthesesSpaceInside,

--- a/src/rules/media-feature-name-no-unknown/README.md
+++ b/src/rules/media-feature-name-no-unknown/README.md
@@ -1,0 +1,79 @@
+# media-feature-name-no-unknown
+
+Disallow unknown media feature names.
+
+```css
+@media (min-width: 700px) { }
+/**     ↑
+ * These media feature names */
+```
+
+This rule considers media feature names defined in the CSS Specifications, up to and including Editor's Drafts, to be known.
+
+All vendor-prefixed media feature names are ignored.
+
+Caveat: Media feature names within a [range context](https://www.w3.org/TR/mediaqueries-4/#mq-ranges) are currently ignored.
+
+## Options
+
+### `true`
+
+The following patterns are considered warnings:
+
+```css
+@media screen and (unknown) { }
+```
+
+```css
+@media screen and (unknown: 10px) { }
+```
+
+The following patterns are *not* considered warnings:
+
+```css  
+@media all and (monochrome) { }
+```
+
+```css  
+@media (min-width: 700px) { }
+```
+
+```css
+@media (MIN-WIDTH: 700px) { }
+```
+
+```css
+@media (min-width: 700px) and (orientation: landscape) { }
+```
+
+```css
+@media (-webkit-min-device-pixel-ratio: 2) { }
+```
+
+## Optional options
+
+### `ignoreMediaFeatureNames: ["/regex/", "string"]`
+
+Given:
+
+```js
+["/^my-/", "custom"]
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+@media screen and (my-media-feature-name) { }
+```
+
+```css
+@media screen and (MY-MEDIA-FEATURE-NAME) { }
+```
+
+```css
+@media screen and (custom: 10px) { }
+```
+
+```css
+@media (min-width: 700px) and (custom: 10px) { }
+```

--- a/src/rules/media-feature-name-no-unknown/__tests__/index.js
+++ b/src/rules/media-feature-name-no-unknown/__tests__/index.js
@@ -1,0 +1,155 @@
+import {
+  messages,
+  ruleName,
+} from ".."
+import rules from "../../../rules"
+import { testRule } from "../../../testUtils"
+
+const rule = rules[ruleName]
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+
+  accept: [ {
+    code: "@media all and (monochrome) { }",
+  }, {
+    code: "@media all and (MONOCHROME) { }",
+  }, {
+    code: "@media (min-width: 700px) { }",
+  }, {
+    code: "@media (MIN-WIDTH: 700px) { }",
+  }, {
+    code: "@media (min-width: 700px) and (orientation: landscape) { }",
+  }, {
+    code: "@media (MIN-WIDTH: 700px) and (ORIENTATION: landscape) { }",
+  }, {
+    code: "@media (-webkit-min-device-pixel-ratio: 2) { }",
+  }, {
+    code: "@media (--viewport-medium) { }",
+    description: "ignore css variables",
+  }, {
+    code: "@media (width < 100px) { }",
+    description: "ignore range context",
+  }, {
+    code: "@media (width = 100px) { }",
+    description: "ignore range context",
+  }, {
+    code: "@media (width <= 100px) { }",
+    description: "ignore range context",
+  }, {
+    code: "@media (10px >= width <= 100px) { }",
+    description: "ignore complex range context",
+  } ],
+
+  reject: [ {
+    code: "@media screen and (unknown) { }",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 20,
+  }, {
+    code: "@media screen and (UNKNOWN) { }",
+    message: messages.rejected("UNKNOWN"),
+    line: 1,
+    column: 20,
+  }, {
+    code: "@media screen and (unknown: 2) { }",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 20,
+  }, {
+    code: "@media screen and (UNKNOWN: 2) { }",
+    message: messages.rejected("UNKNOWN"),
+    line: 1,
+    column: 20,
+  }, {
+    code: "@media (min-width: 700px) and (unknown: landscape) { }",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 32,
+  }, {
+    code: "@media (min-width: 700px) and (UNKNOWN: landscape) { }",
+    message: messages.rejected("UNKNOWN"),
+    line: 1,
+    column: 32,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "less",
+
+  accept: [ {
+    code: "@media (min-width: @tablet) { }",
+  }, {
+    code: "@media @smartphones and (orientation: landscape) { }",
+  }, {
+    code: "@media @smartphones { }",
+  } ],
+
+  reject: [{
+    code: "@media (unknown: @tablet) { }",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 9,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  accept: [ {
+    code: "@media not all and ($monochrome) { }",
+  }, {
+    code: "@media not all and (#{$monochrome}) { }",
+  }, {
+    code: "@media (min-width: $var) { }",
+  }, {
+    code: "@media ($feature-name: $value) { }",
+  }, {
+    code: "@media (#{$feature-name}: $value) { }",
+  }, {
+    code: "@media (#{$width}: $value) { }",
+  }, {
+    code: "@media (#{$WIDTH}: $value) { }",
+  }, {
+    code: "@media #{$feature-name} { }",
+  } ],
+
+  reject: [{
+    code: "@media (unknown: $var) { }",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 9,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignoreMediaFeatureNames: [ "/^my-/", "custom" ] } ],
+
+  accept: [ {
+    code: "@media screen and (my-media-feature-name) { }",
+  }, {
+    code: "@media screen and (MY-MEDIA-FEATURE-NAME) { }",
+  }, {
+    code: "@media screen and (custom: 10px) { }",
+  }, {
+    code: "@media screen and (CUSTOM: 10px) { }",
+  } ],
+
+  reject: [ {
+    code: "@media screen and (unknown) { }",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 20,
+  }, {
+    code: "@media screen and (UNKNOWN) { }",
+    message: messages.rejected("UNKNOWN"),
+    line: 1,
+    column: 20,
+  } ],
+})

--- a/src/rules/media-feature-name-no-unknown/index.js
+++ b/src/rules/media-feature-name-no-unknown/index.js
@@ -1,0 +1,54 @@
+import {
+  atRuleParamIndex,
+  isRangeContextMediaFeature,
+  isStandardSyntaxMediaFeatureName,
+  optionsMatches,
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+import { isString } from "lodash"
+import { mediaFeatureNames } from "../../reference/keywordSets"
+import mediaParser from "postcss-media-query-parser"
+import { vendor } from "postcss"
+
+export const ruleName = "media-feature-name-no-unknown"
+
+export const messages = ruleMessages(ruleName, {
+  rejected: (mediaFeatureName) => `Unexpected unknown media feature name "${mediaFeatureName}"`,
+})
+
+export default function (actual, options) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, { actual }, {
+      actual: options,
+      possible: {
+        ignoreMediaFeatureNames: [isString],
+      },
+      optional: true,
+    })
+
+    if (!validOptions) { return }
+
+    root.walkAtRules(/^media$/i, atRule => {
+      mediaParser(atRule.params).walk(/^media-feature$/i, mediaFeatureNode => {
+        const { parent, sourceIndex, value } = mediaFeatureNode
+
+        if (isRangeContextMediaFeature(parent.value)) { return }
+        if (!isStandardSyntaxMediaFeatureName(value)) { return }
+
+        if (optionsMatches(options, "ignoreMediaFeatureNames", value)) { return }
+
+        if (vendor.prefix(value) || mediaFeatureNames.has(value.toLowerCase())) { return }
+
+        report({
+          index: atRuleParamIndex(atRule) + sourceIndex,
+          message: messages.rejected(value),
+          node: atRule,
+          ruleName,
+          result,
+        })
+      })
+    })
+  }
+}


### PR DESCRIPTION
Close https://github.com/stylelint/stylelint/issues/1698
/cc @davidtheclark @jeddy3 
Two question:
1. Should we test `scss` and `less` in this rule? (maybe be remove all non standard syntax tests and have tests only in `isStandard*`, it is decrease tests and do this more readable and supported, we can do this in future major release).
2. In all `*-no-unknown` rules, excluding `property-no-unknown`, we ignore all vendor specific construction, we have to deal with the matter - we ignore or not vendor specific construction in `*-no-unknown` rules. I vote for check vendor specific everywhere and add options `ignoreVendor: true|false`(maybe other name) to disable check. In future major release we can change behavior this rules. Often code have vendor prefixes, which can't handle autoprefixer and we should check this on errors.