### PR TITLE
Add ignore: ["after-comment"] option to *-empty-line-before

### DIFF
--- a/src/rules/custom-property-empty-line-before/README.md
+++ b/src/rules/custom-property-empty-line-before/README.md
@@ -167,7 +167,22 @@ a {
 }
 ```
 
-### `ignore: ["inside-single-line-block"]`
+### `ignore: ["after-comment", "inside-single-line-block"]`
+
+#### `"after-comment"`
+
+Ignore custom properties that are preceded by comments.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  /* comment */
+  --custom-prop: value;
+}
+```
 
 #### `"inside-single-line-block"`
 

--- a/src/rules/custom-property-empty-line-before/__tests__/index.js
+++ b/src/rules/custom-property-empty-line-before/__tests__/index.js
@@ -69,6 +69,24 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { ignore: ["after-comment"] } ],
+
+  accept: [ {
+    code: "a {\n/* comment */ --custom-prop: value;\n}",
+  }, {
+    code: "a {\n/* comment */\n--custom-prop: value;\n}",
+  } ],
+
+  reject: [{
+    code: "a {\n --custom-prop: value;\n}",
+    message: messages.expected,
+    line: 2,
+    column: 2,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { ignore: ["inside-single-line-block"] } ],
 
   accept: [ {

--- a/src/rules/custom-property-empty-line-before/__tests__/index.js
+++ b/src/rules/custom-property-empty-line-before/__tests__/index.js
@@ -75,6 +75,8 @@ testRule(rule, {
     code: "a {\n/* comment */ --custom-prop: value;\n}",
   }, {
     code: "a {\n/* comment */\n--custom-prop: value;\n}",
+  }, {
+    code: "a {\r\n/* comment */\r\nn--custom-prop: value;\r\n}",
   } ],
 
   reject: [{

--- a/src/rules/custom-property-empty-line-before/index.js
+++ b/src/rules/custom-property-empty-line-before/index.js
@@ -35,6 +35,7 @@ export default function (expectation, options) {
           "after-custom-property",
         ],
         ignore: [
+          "after-comment",
           "inside-single-line-block",
         ],
       },
@@ -47,6 +48,15 @@ export default function (expectation, options) {
 
       if (!isStandardSyntaxDeclaration(decl)) { return }
       if (!isCustomProperty(prop)) { return }
+
+      // Optionally ignore the node if a comment precedes it
+      if (
+        optionsHaveIgnored(options, "after-comment")
+        && decl.prev()
+        && decl.prev().type === "comment"
+      ) {
+        return
+      }
 
       // Optionally ignore nodes inside single-line blocks
       if (

--- a/src/rules/declaration-empty-line-before/README.md
+++ b/src/rules/declaration-empty-line-before/README.md
@@ -174,7 +174,22 @@ a {
 }
 ```
 
-### `ignore: ["inside-single-line-block"]`
+### `ignore: ["after-comment", "inside-single-line-block"]`
+
+#### `"after-comment"`
+
+Ignore declarations that are preceded by comments.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  /* comment */
+  bottom: 15px;
+}
+```
 
 #### `"inside-single-line-block"`
 

--- a/src/rules/declaration-empty-line-before/__tests__/index.js
+++ b/src/rules/declaration-empty-line-before/__tests__/index.js
@@ -171,6 +171,24 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { ignore: ["after-comment"] } ],
+
+  accept: [ {
+    code: "a {\n/* comment */ top: 15px;\n}",
+  }, {
+    code: "a {\n/* comment */\ntop: 15px;\n}",
+  } ],
+
+  reject: [{
+    code: "a {\n top: 15px;\n}",
+    message: messages.expected,
+    line: 2,
+    column: 2,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { except: ["first-nested"] } ],
 
   accept: [ {

--- a/src/rules/declaration-empty-line-before/__tests__/index.js
+++ b/src/rules/declaration-empty-line-before/__tests__/index.js
@@ -177,6 +177,8 @@ testRule(rule, {
     code: "a {\n/* comment */ top: 15px;\n}",
   }, {
     code: "a {\n/* comment */\ntop: 15px;\n}",
+  }, {
+    code: "a {\r\n/* comment */\r\nntop: 15px;\r\n}",
   } ],
 
   reject: [{

--- a/src/rules/declaration-empty-line-before/index.js
+++ b/src/rules/declaration-empty-line-before/index.js
@@ -35,6 +35,7 @@ export default function (expectation, options) {
           "after-declaration",
         ],
         ignore: [
+          "after-comment",
           "inside-single-line-block",
         ],
       },
@@ -47,6 +48,15 @@ export default function (expectation, options) {
 
       if (!isStandardSyntaxDeclaration(decl)) { return }
       if (isCustomProperty(prop)) { return }
+
+      // Optionally ignore the node if a comment precedes it
+      if (
+        optionsHaveIgnored(options, "after-comment")
+        && decl.prev()
+        && decl.prev().type === "comment"
+      ) {
+        return
+      }
 
       // Optionally ignore nodes inside single-line blocks
       if (


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint-config-standard/pull/32#issuecomment-235297574

Using these options in `config-standard`, rather than `except`, will be a little less restrictive and inline with how we handle preceding comments for other `*-empty-line-before` rules.