### PR TITLE
Remove redundant ignore code from selector-type-no-unknown

### DIFF
--- a/src/rules/selector-type-no-unknown/index.js
+++ b/src/rules/selector-type-no-unknown/index.js
@@ -77,10 +77,6 @@ export default function (actual, options) {
             || nonStandardHtmlTags.has(tagNameLowerCase)
           ) { return }
 
-          const ignoreTypes = options && options.ignoreTypes || []
-
-          if (ignoreTypes.indexOf(tagNameLowerCase) !== -1) { return }
-
           report({
             message: messages.rejected(tagName),
             node: rule,


### PR DESCRIPTION
Closes #1733.

I checked the other `*-no-unknown` rules. This was the only one where I forgot to remove old ignore code.