### PR TITLE
Use tilde for eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "benchmark": "^2.1.0",
     "common-tags": "^1.3.0",
     "coveralls": "^2.11.9",
-    "eslint": "~3.1.0",
+    "eslint": "~3.2.0",
     "eslint-config-stylelint": "^3.0.0",
     "htmlparser2": "^3.9.0",
     "npm-run-all": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "benchmark": "^2.1.0",
     "common-tags": "^1.3.0",
     "coveralls": "^2.11.9",
-    "eslint": "^3.0.0",
+    "eslint": "~3.1.0",
     "eslint-config-stylelint": "^3.0.0",
     "htmlparser2": "^3.9.0",
     "npm-run-all": "^2.1.0",

--- a/src/__tests__/standalone-test.js
+++ b/src/__tests__/standalone-test.js
@@ -158,9 +158,9 @@ test("unknown syntax option", t => {
     code: "",
     config: { rules: { "block-no-empty": "wahoo" } },
   }).then()
-  .catch(err => {
-    t.equal(err.message, "You must use a valid syntax option, either: scss, less or sugarss")
-  })
+    .catch(err => {
+      t.equal(err.message, "You must use a valid syntax option, either: scss, less or sugarss")
+    })
 
   t.plan(1)
 })
@@ -171,9 +171,9 @@ test("unknown formatter option", t => {
     code: "",
     config: { rules: { "block-no-empty": "wahoo" } },
   }).then()
-  .catch(err => {
-    t.equal(err.message, "You must use a valid formatter option, either: json, string or verbose")
-  })
+    .catch(err => {
+      t.equal(err.message, "You must use a valid formatter option, either: json, string or verbose")
+    })
 
   t.plan(1)
 })


### PR DESCRIPTION
See: https://github.com/eslint/eslint/blob/master/README.md#semantic-versioning-policy

And: https://github.com/eslint/eslint/issues/6795