### PR TITLE
Add ignoreDisableComments and reportNeedlessDisables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Head
 
+- Added: `--report-needless-disables` and `reportNeedlessDisables` option.
+- Added: `--ignore-disables` and `ignoreDisables` option.
 - Added: `value-list-max-empty-lines` rule.
 
 # 7.1.0

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -69,6 +69,20 @@ Specify the formatter that you would like to use to format your results.
 
 If you pass a function, it must fit the signature described in the [Developer Guide](/docs/developer-guide/formatters.md).
 
+### `ignoreDisables`
+
+If `true`, all disable comments (e.g. `/* stylelint-disable block-no-empty */`) will be ignored.
+
+You can use this option to see what your linting results would be like without those exceptions.
+
+### `reportNeedlessDisables`
+
+If `true`, `ignoreDisables` will also be set to `true` and the returned data will contain a `needlessDisables` property, whose value is an array of objects, one for each source, with tells you which stylelint-disable comments are not blocking a lint warning.
+
+Use this report to clean up your codebase, keeping only the stylelint-disable comments that serve a purpose.
+
+*The recommended way to use this option is through the CLI.* It will output a clean report to the console.
+
 ### `ignorePath`
 
 A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, stylelint looks for `.stylelintignore` in `process.cwd()`. See [Configuration](/docs/user-guide/configuration.md#stylelintignore).

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -43,6 +43,12 @@ A partial stylelint configuration object whose properties will override the exis
 
 The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to *both* load a `.stylelintrc` file *and* override specific parts of it, `configOverrides` does just that.
 
+### `ignoreDisables`
+
+If `true`, all disable comments (e.g. `/* stylelint-disable block-no-empty */`) will be ignored.
+
+You can use this option to see what your linting results would be like without those exceptions.
+
 ### `ignorePath`
 
 A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, stylelint looks for `.stylelintignore` in `process.cwd()`. See [Configuration](/docs/user-guide/configuration.md#stylelintignore).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stylelint",
   "version": "7.1.0",
-  "description": "Modern CSS linter",
+  "description": "A mighty, modern CSS linter.",
   "keywords": [
     "css",
     "csslint",

--- a/src/__tests__/fixtures/needlessDisables/disabled-ranges-1.css
+++ b/src/__tests__/fixtures/needlessDisables/disabled-ranges-1.css
@@ -1,0 +1,14 @@
+/* stylelint-disable color-named */
+a {}
+/* stylelint-enable */
+
+/* stylelint-disable block-no-empty */
+a { color: red; }
+/* stylelint-enable */
+
+a {} /* stylelint-disable-line */
+a { color: red; } /* stylelint-disable-line */
+
+/* stylelint-disable */
+a {}
+/* stylelint-enable */

--- a/src/__tests__/fixtures/needlessDisables/disabled-ranges-2.css
+++ b/src/__tests__/fixtures/needlessDisables/disabled-ranges-2.css
@@ -1,0 +1,10 @@
+/* stylelint-disable block-no-empty */
+a {}
+/* stylelint-enable */
+
+a {} /* stylelint-disable-line color-named */
+a { color: red; } /* stylelint-disable-line block-no-empty */
+
+/* stylelint-disable block-no-empty */
+a { color: red; } /* stylelint-disable-line */
+/* stylelint-enable */

--- a/src/__tests__/ignoreDisables-test.js
+++ b/src/__tests__/ignoreDisables-test.js
@@ -1,0 +1,43 @@
+import postcssPlugin from "../postcssPlugin"
+import standalone from "../standalone"
+import { stripIndent } from "common-tags"
+import test from "tape"
+
+const config = {
+  rules: { "block-no-empty": true },
+}
+
+const css = stripIndent`
+  /* stylelint-disable */
+  a {}
+  /* stylelint-enable */
+  a {
+    b {} /* stylelint-disable-line block-no-empty */
+  }`
+
+test("ignoreDisables with postcssPlugins", t => {
+  postcssPlugin.process(css, {
+    config,
+    ignoreDisables: true,
+  }).then(result => {
+    const warnings = result.warnings()
+    t.equal(warnings.length, 2)
+    t.ok(warnings[0].text.indexOf("block-no-empty") !== 1)
+    t.ok(warnings[1].text.indexOf("block-no-empty") !== 1)
+    t.end()
+  }).catch(t.threw)
+})
+
+test("ignoreDisables with standalone", t => {
+  standalone({
+    config,
+    code: css,
+    ignoreDisables: true,
+  }).then(({ results }) => {
+    const warnings = results[0].warnings
+    t.equal(warnings.length, 2)
+    t.ok(warnings[0].text.indexOf("block-no-empty") !== 1)
+    t.ok(warnings[1].text.indexOf("block-no-empty") !== 1)
+    t.end()
+  })
+})

--- a/src/__tests__/needlessDisables-test.js
+++ b/src/__tests__/needlessDisables-test.js
@@ -1,0 +1,82 @@
+import needlessDisables from "../needlessDisables"
+import path from "path"
+import standalone from "../standalone"
+import { stripIndent } from "common-tags"
+import test from "tape"
+
+function fixture(name) {
+  return path.join(__dirname, "./fixtures/needlessDisables", name)
+}
+
+test("needlessDisables simple case", t => {
+  const config = {
+    rules: { "block-no-empty": true },
+  }
+
+  const css = stripIndent`
+    /* stylelint-disable */
+    a {}
+    /* stylelint-enable */
+    a {
+      b {} /* stylelint-disable-line block-no-empty */
+    }
+    /* stylelint-disable */
+    a { color: pink; }
+    /* stylelint-enable */
+    a {
+      b { color: pink; } /* stylelint-disable-line block-no-empty */
+    }
+    `
+
+  standalone({
+    config,
+    code: css,
+    ignoreDisables: true,
+  }).then(({ results }) => {
+    const report = needlessDisables(results)
+    t.equal(report.length, 1)
+    t.deepEqual(report[0].ranges, [
+      { start: 7, end: 9 },
+      { start: 11, end: 11 },
+    ])
+    t.end()
+  }).catch(t.end)
+})
+
+test("needlessDisables complex case", t => {
+  const config = {
+    rules: {
+      "block-no-empty": true,
+      "color-named": "never",
+    },
+  }
+
+  standalone({
+    config,
+    files: [
+      fixture("disabled-ranges-1.css"),
+      fixture("disabled-ranges-2.css"),
+    ],
+    ignoreDisables: true,
+  }).then(({ results }) => {
+    t.deepEqual(needlessDisables(results), [
+      {
+        source: fixture("disabled-ranges-1.css"),
+        ranges: [
+          { start: 1, end: 3 },
+          { start: 5, end: 7 },
+          { start: 10, end: 10 },
+        ],
+      },
+      {
+        source: fixture("disabled-ranges-2.css"),
+        ranges: [
+          { start: 5, end: 5 },
+          { start: 6, end: 6 },
+          { start: 8 },
+        ],
+      },
+    ])
+    t.end()
+  }).catch(t.end)
+})

--- a/src/cli.js
+++ b/src/cli.js
@@ -95,6 +95,8 @@ const meowOptions = {
       --report-needless-disables, --rd
 
         Report stylelint-disable comments that are not blocking a lint warning.
+        If you provide the argument "error", the process will exit with code 2
+        if needless disables are found.
 
       --version, -v
 
@@ -170,6 +172,7 @@ Promise.resolve().then(() => {
 }).then(({ output, errored, needlessDisables }) => {
   if (reportNeedlessDisables) {
     process.stdout.write(needlessDisablesStringFormatter(needlessDisables))
+    if (reportNeedlessDisables === "error") { process.exitCode = 2 }
     return
   }
 

--- a/src/formatters/__tests__/needlessDisablesStringFormatter-test.js
+++ b/src/formatters/__tests__/needlessDisablesStringFormatter-test.js
@@ -1,0 +1,36 @@
+import chalk from "chalk"
+import needlessDisablesStringFormatter from "../needlessDisablesStringFormatter"
+import { stripIndent } from "common-tags"
+import test from "tape"
+
+test("needlessDisables formatter stringified", t => {
+  const actual = chalk.stripColor(needlessDisablesStringFormatter([
+    {
+      source: "foo",
+      ranges: [
+        { start: 1, end: 3 },
+        { start: 7 },
+      ],
+    },
+    {
+      source: "bar",
+      ranges: [
+        { start: 19, end: 33 },
+        { start: 99, end: 102 },
+      ],
+    },
+  ]))
+
+  let expected = stripIndent`
+    foo
+    start: 1, end: 3
+    start: 7
+
+    bar
+    start: 19, end: 33
+    start: 99, end: 102`
+  expected = `\n${expected}\n`
+
+  t.equal(actual, expected)
+  t.end()
+})

--- a/src/formatters/__tests__/needlessDisablesStringFormatter-test.js
+++ b/src/formatters/__tests__/needlessDisablesStringFormatter-test.js
@@ -19,6 +19,10 @@ test("needlessDisables formatter stringified", t => {
         { start: 99, end: 102 },
       ],
     },
+    {
+      sourc: "baz",
+      ranges: [],
+    },
   ]))
 
   let expected = stripIndent`

--- a/src/formatters/needlessDisablesStringFormatter.js
+++ b/src/formatters/needlessDisablesStringFormatter.js
@@ -1,0 +1,25 @@
+import chalk from "chalk"
+import path from "path"
+
+function logFrom(fromValue) {
+  if (fromValue.charAt(0) === "<") return fromValue
+  return path.relative(process.cwd(), fromValue).split(path.sep).join("/")
+}
+
+export default function (report) {
+  let output = ""
+
+  report.forEach(sourceReport => {
+    output += "\n"
+    output += chalk.underline(logFrom(sourceReport.source)) + "\n"
+    sourceReport.ranges.forEach(range => {
+      output += `start: ${range.start}`
+      if (range.end !== undefined) {
+        output += `, end: ${range.end}`
+      }
+      output += "\n"
+    })
+  })
+
+  return output
+}

--- a/src/formatters/needlessDisablesStringFormatter.js
+++ b/src/formatters/needlessDisablesStringFormatter.js
@@ -10,6 +10,7 @@ export default function (report) {
   let output = ""
 
   report.forEach(sourceReport => {
+    if (!sourceReport.ranges || sourceReport.ranges.length === 0) { return }
     output += "\n"
     output += chalk.underline(logFrom(sourceReport.source)) + "\n"
     sourceReport.ranges.forEach(range => {

--- a/src/needlessDisables.js
+++ b/src/needlessDisables.js
@@ -1,0 +1,67 @@
+import _ from "lodash"
+
+export default function (results) {
+  const report = []
+
+  results.forEach(result => {
+    const unused = { source: result.source, ranges: [] }
+    const rangeData = _.cloneDeep(result._postcssResult.stylelint.disabledRanges)
+
+    result.warnings.forEach(warning => {
+      const { rule } = warning
+
+      const ruleRanges = rangeData[rule]
+      if (ruleRanges) {
+        // Back to front so we get the *last* range that applies to the warning
+        for (const range of ruleRanges.reverse()) {
+          if (isWarningInRange(warning, range)) {
+            range.used = true
+            return
+          }
+        }
+      }
+
+      for (const range of rangeData.all.reverse()) {
+        if (isWarningInRange(warning, range)) {
+          range.used = true
+          return
+        }
+      }
+    })
+
+    Object.keys(rangeData).forEach(rule => {
+      rangeData[rule].forEach(range => {
+        // Is an equivalent range already marked as unused?
+        const alreadyMarkedUnused = unused.ranges.find(unusedRange => {
+          return unusedRange.start === range.start && unusedRange.end === range.end
+        })
+
+        // If this range is unused and no equivalent is marked,
+        // mark this range as unused
+        if (!range.used && !alreadyMarkedUnused) {
+          unused.ranges.push(range)
+        }
+
+        // If this range is used but an equivalent has been marked as unused,
+        // remove that equivalent. This can happen because of the duplication
+        // of ranges in rule-specific range sets and the "all" range set
+        if (range.used && alreadyMarkedUnused) {
+          _.remove(unused.ranges, alreadyMarkedUnused)
+        }
+      })
+    })
+
+    unused.ranges = _.sortBy(unused.ranges, [ "start", "end" ])
+
+    report.push(unused)
+  })
+
+  return report
+}
+
+function isWarningInRange(warning, range) {
+  const { rule, line } = warning
+  return range.start <= line
+    && (range.end >= line || range.end === undefined)
+    && (!range.rules || range.rules.indexOf(rule) !== -1)
+}

--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -83,6 +83,9 @@ export default postcss.plugin("stylelint", (options = {}) => {
 
       // First check for disabled ranges, adding them to the result object
       disableRanges(root, result)
+      if (options.ignoreDisables) {
+        result.stylelint.ignoreDisables = true
+      }
 
       Object.keys(config.rules).forEach(ruleName => {
         if (!ruleDefinitions[ruleName]) {

--- a/src/utils/report.js
+++ b/src/utils/report.js
@@ -41,7 +41,7 @@ export default function ({
   // line number that the complaint pertains to
   const startLine = line || node.positionBy({ index }).line
 
-  if (result.stylelint.disabledRanges) {
+  if (result.stylelint.disabledRanges && !result.stylelint.ignoreDisables) {
     const ranges = result.stylelint.disabledRanges[ruleName] || result.stylelint.disabledRanges.all
     for (const range of ranges) {
       if (


### PR DESCRIPTION
Ref #1184. cc @jonrohan

I've done several things here, all pointing towards the goal of #1184:

- Added an `ignoreDisables / --ignore-disables` option which you can use to ignore your `stylelint-disable` comments and see what lint results would be like without them.
- Added a `reportNeedlessDisables / --report-needless-disables` option to CLI and Node API (not the PostCSS plugin) which you can use to get a report of which `stylelint-disable` comments are not actually protecting you from any lint warnings.
- Added a little string formatter for the needless disables so that from the CLI you get nice legible output. Looks like this:

```
src/__tests__/fixtures/needlessDisables/disabled-ranges-1.css
start: 1, end: 3
start: 5, end: 7
start: 10, end: 10

src/__tests__/fixtures/needlessDisables/disabled-ranges-2.css
start: 5, end: 5
start: 6, end: 6
start: 8
start: 9, end: 9
```

- Adjusted the format of the CLI help to better accommodate our longish explanations of options.

This is quite an experiment so I'm wide open to feedback! And please try it out and see if it works for you!