### PR TITLE
Add except: blockless-after-same-name-blockless option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed: `selector-combinator-space-after` and `selector-combinator-space-before` now ignore operators within parenthetical non-standard constructs.
 - Added: `comment-no-empty` rule.
 - Added `ignore: ["blockless-after-same-name-blockless"]` option to `at-rule-empty-line-before`.
+- Added `except: ["blockless-after-same-name-blockless"]` option to `at-rule-empty-line-before`.
 - Fixed: `font-family-name-quotes` now ignores if font-weight in font short hand is a number
 - Added: `ignoreTypes` support to `selector-no-type` to whitelist allowed types for selectors.
 - Fixed: `color-named` now ignores declarations that accept *custom idents*.

--- a/src/rules/at-rule-empty-line-before/README.md
+++ b/src/rules/at-rule-empty-line-before/README.md
@@ -64,7 +64,7 @@ a {}
 
 ## Optional options
 
-### `except: ["all-nested", "blockless-group", "first-nested"]`
+### `except: ["all-nested", "blockless-after-same-name-blockless", "blockless-group", "first-nested"]`
 
 ### `"all-nested"`
 
@@ -99,6 +99,34 @@ a {
 b {
   color: pink;
   @extend foo;
+}
+```
+
+#### `"blockless-after-same-name-blockless"`
+
+Reverse the primary option for blockless at-rules that follow another blockless at-rule with the same name.
+
+This means that you can group your blockless at-rules by name.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```css
+@charset "UTF-8";
+
+@import url(x.css);
+@import url(y.css);
+```
+
+```css
+a {
+
+  @extends .foo;
+  @extends .bar;
+
+  @include loop;
+  @include doo;
 }
 ```
 
@@ -163,7 +191,7 @@ b {
 }
 ```
 
-### `ignore: ["after-comment", "blockless-group", "all-nested", "blockless-after-same-name-blockless"]`
+### `ignore: ["after-comment", "all-nested", "blockless-after-same-name-blockless", "blockless-group",]`
 
 #### `"after-comment"`
 
@@ -214,29 +242,6 @@ b {
 }
 ```
 
-#### `"blockless-group"`
-
-Ignore at-rules within a blockless group.
-
-For example, with `"always"`:
-
-The following patterns are *not* considered warnings:
-
-```css
-@import url(x.css);
-
-@import url(y.css);
-
-@media print {}
-```
-
-```css
-@import url(x.css);
-@import url(y.css);
-
-@media print {}
-```
-
 #### `"blockless-after-same-name-blockless"`
 
 Ignore blockless at-rules that follow another blockless at-rule with the same name.
@@ -264,6 +269,29 @@ a {
   @include loop;
   @include doo;
 }
+```
+
+#### `"blockless-group"`
+
+Ignore at-rules within a blockless group.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```css
+@import url(x.css);
+
+@import url(y.css);
+
+@media print {}
+```
+
+```css
+@import url(x.css);
+@import url(y.css);
+
+@media print {}
 ```
 
 ### `ignoreAtRules: ["array", "of", "at-rules"]`

--- a/src/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/src/rules/at-rule-empty-line-before/__tests__/index.js
@@ -604,3 +604,95 @@ testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
     column: 3,
   } ],
 }))
+
+testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
+  ruleName,
+  config: [ "always", {
+    except: ["blockless-after-same-name-blockless"],
+  } ],
+
+  accept: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+
+      @import url(x.css);
+      @import url(y.css);`,
+  }, {
+    code: stripIndent`
+      a {
+
+        @extends .foo;
+        @extends .bar;
+
+        @include loop;
+        @include doo;
+      }`,
+  } ],
+
+  reject: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+      @import url(x.css);
+      @import url(y.css);`,
+    message: messages.expected,
+    line: 2,
+    column: 1,
+  }, {
+    code: stripIndent`
+      a {
+
+        @extends .foo;
+        @extends .bar;
+        @include loop;
+        @include doo;
+      }`,
+    message: messages.expected,
+    line: 5,
+    column: 3,
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedNeverTests, {
+  ruleName,
+  config: [ "never", {
+    except: ["blockless-after-same-name-blockless"],
+  } ],
+
+  accept: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+      @import url(x.css);
+      
+      @import url(y.css);`,
+  }, {
+    code: stripIndent`
+      a {
+        @extends .foo;
+
+        @extends .bar;
+        @include loop;
+
+        @include doo;
+      }`,
+  } ],
+
+  reject: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+      @import url(x.css);
+      @import url(y.css);`,
+    message: messages.expected,
+    line: 3,
+    column: 1,
+  }, {
+    code: stripIndent`
+      a {
+        @extends .bar;
+        @include loop;
+        @include doo;
+      }`,
+    message: messages.expected,
+    line: 4,
+    column: 3,
+  } ],
+}))

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -76,14 +76,14 @@ export default function (expectation, options) {
 
       // Optionally reverse the expectation if any exceptions apply
       if (
-        (optionsHaveException(options, "all-nested")
-          && isNested)
-        || optionsHaveException(options, "first-nested")
-          && isFirstNested()
-        || optionsHaveException(options, "blockless-group")
-          && isBlocklessAfterBlockless()
-        || optionsHaveException(options, "blockless-after-same-name-blockless")
-          && isBlocklessAfterSameNameBlockless()
+        ((optionsHaveException(options, "all-nested")
+          && isNested))
+        || (optionsHaveException(options, "first-nested")
+          && isFirstNested())
+        || (optionsHaveException(options, "blockless-group")
+          && isBlocklessAfterBlockless())
+        || (optionsHaveException(options, "blockless-after-same-name-blockless")
+          && isBlocklessAfterSameNameBlockless())
       ) {
         expectEmptyLineBefore = !expectEmptyLineBefore
       }

--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -26,10 +26,10 @@ export default function (expectation, options) {
       actual: options,
       possible: {
         except: [
+          "all-nested",
           "blockless-after-same-name-blockless",
           "blockless-group",
           "first-nested",
-          "all-nested",
         ],
         ignore: [
           "after-comment",


### PR DESCRIPTION
Closes #1366

The diff changes for the ignore option of the README is just because I ordered the options alphabetically to be consistent with the `except` options (and in other rule READMEs).