### PR TITLE
Add declaration-block-no-redundant-longhand-properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Added: `ignore: ["consecutive-duplicates-with-different-values"]` option to `declaration-block-no-duplicate-properties`.
 -   Added: `--report-needless-disables` and `reportNeedlessDisables` option.
 -   Added: `--ignore-disables` and `ignoreDisables` option.
+-   Added: `declaration-block-no-redundant-longhand-properties` rule.
 -   Added: `value-list-max-empty-lines` rule.
 -   Added: `media-feature-name-no-unknown` rule.
 -   Added: `ignore: ["comments"]` option to `max-line-length`.

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -44,6 +44,7 @@ You might want to learn a little about [how rules are named and how they work to
     "declaration-bang-space-before": "always"|"never",
     "declaration-block-no-duplicate-properties": true,
     "declaration-block-no-ignored-properties": true,
+    "declaration-block-no-redundant-longhand-properties": true,
     "declaration-block-no-shorthand-property-overrides": true,
     "declaration-block-properties-order": "alphabetical"|[],
     "declaration-block-semicolon-newline-after": "always"|"always-multi-line"|"never-multi-line",

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -123,6 +123,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 -   [`declaration-block-no-duplicate-properties`](../../src/rules/declaration-block-no-duplicate-properties/README.md): Disallow duplicate properties within declaration blocks.
 -   [`declaration-block-no-ignored-properties`](../../src/rules/declaration-block-no-ignored-properties/README.md): Disallow property values that are ignored due to another property value in the same rule.
+-   [`declaration-block-no-redundant-longhand-properties`](../../src/rules/declaration-block-no-redundant-longhand-properties/README.md): Disallow longhand properties that can be combined into one shorthand property.
 -   [`declaration-block-no-shorthand-property-overrides`](../../src/rules/declaration-block-no-shorthand-property-overrides/README.md): Disallow shorthand properties that override related longhand properties within declaration blocks.
 -   [`declaration-block-properties-order`](../../src/rules/declaration-block-properties-order/README.md): Specify the order of properties within declaration blocks.
 -   [`declaration-block-semicolon-newline-after`](../../src/rules/declaration-block-semicolon-newline-after/README.md): Require a newline or disallow whitespace after the semicolons of declaration blocks.

--- a/src/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/src/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -24,20 +24,20 @@ This rule will only warn if you've used the longhand equivalent of *all* the pro
 
 This rule warns when the following shorthand properties can be used:
 
-- `padding`
-- `margin`
-- `background`
-- `font`
-- `border`
-- `border-top`
-- `border-bottom`
-- `border-left`
-- `border-right`
-- `border-width`
-- `border-style`
-- `border-color`
-- `border-radius`
-- `transition`
+-   `padding`
+-   `margin`
+-   `background`
+-   `font`
+-   `border`
+-   `border-top`
+-   `border-bottom`
+-   `border-left`
+-   `border-right`
+-   `border-width`
+-   `border-style`
+-   `border-color`
+-   `border-radius`
+-   `transition`
 
 ## Options
 

--- a/src/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/src/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -1,0 +1,158 @@
+# declaration-block-no-redundant-longhand-properties
+
+Disallow longhand properties that can be combined into one shorthand property.
+
+```css
+  a {
+    padding-top: 1px;
+    padding-right: 2px;
+    padding-bottom: 3px;
+    padding-left: 4px; }
+/** ↑
+ *  These longhand properties */
+```
+
+The longhand properties in the example above can be more concisely written as:
+
+```css
+a {
+  padding: 1px 2px 3px 4px;
+}
+```
+
+This rule will only warn if you've used the longhand equivalent of *all* the properties that the shorthand will set.
+
+This rule warns when the following shorthand properties can be used:
+
+- `padding`
+- `margin`
+- `background`
+- `font`
+- `border`
+- `border-top`
+- `border-bottom`
+- `border-left`
+- `border-right`
+- `border-width`
+- `border-style`
+- `border-color`
+- `border-radius`
+- `transition`
+
+## Options
+
+### `true`
+
+The following patterns are considered warnings:
+
+```css
+a {
+  margin-top: 1px;
+  margin-right: 2px;
+  margin-bottom: 3px;
+  margin-left: 4px;
+}
+```
+
+```css
+a {
+  font-style: italic;
+  font-variant: normal;
+  font-weight: bold;
+  font-stretch: normal;
+  font-size: 14px;
+  line-height: 1.2;
+  font-family: serif;
+}
+```
+
+```css
+a {
+  -webkit-transition-property: top;
+  -webkit-transition-duration: 2s;  
+  -webkit-transition-timing-function: ease;
+  -webkit-transition-delay: 0.5s;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  margin: 1px 2px 3px 4px;
+}
+```
+
+```css
+a {
+  font: italic normal bold normal 14px/1.2 serif;
+}
+```
+
+```css
+a {
+  -webkit-transition: top 2s ease 0.5s;
+}
+```
+
+```css
+a {
+  margin-top: 1px;
+  margin-right: 2px;
+}
+```
+
+```css
+a {
+  margin-top: 1px;
+  margin-right: 2px;
+  margin-bottom: 3px;
+}
+```
+
+## Optional secondary options
+
+### `ignoreShorthands: ["/regex/", "string"]`
+
+Given:
+
+```js
+["padding", "/border/"]
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  padding-top: 20px;
+  padding-right: 10px;
+  padding-bottom: 30px;
+  padding-left: 10px;
+}
+```
+
+```css
+a {
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  border-right-width: 1px;
+}
+```
+
+```css
+a {
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  border-right-width: 1px;
+}
+```
+
+```css
+a {
+  border-top-color: green;
+  border-top-style: double;
+  border-top-width: 7px;
+}
+```

--- a/src/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -1,0 +1,65 @@
+import {
+  messages,
+  ruleName,
+} from ".."
+import rules from "../../../rules"
+import { testRule } from "../../../testUtils"
+
+const rule = rules[ruleName]
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+
+  accept: [ {
+    code: "a { margin-right: 10px; margin-top: 20px; }",
+  }, {
+    code: "a { margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }",
+  }, {
+    code: "a { padding-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }",
+  }, {
+    code: "a { padding-top: 1px; padding-bottom: 1px; } b { padding-left: 1px; padding-right: 1px; }",
+  } ],
+
+  reject: [ {
+    code: "a { margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }",
+    message: messages.expected("margin"),
+  }, {
+    code: "a { MARGIN-LEFT: 10px; MARGIN-RIGHT: 10px; margin-top: 20px; margin-bottom: 30px; }",
+    message: messages.expected("margin"),
+  }, {
+    code: "a { MARGIN-LEFT: 10px; MARGIN-RIGHT: 10px; MARGIN-TOP: 20px; MARGIN-BOTTOM: 30px; }",
+    message: messages.expected("margin"),
+  }, {
+    code: "a { padding-left: 10px; padding-right: 10px; padding-top: 20px; padding-bottom: 30px; }",
+    message: messages.expected("padding"),
+  }, {
+    code: "a { font-style: italic; font-variant: normal; font-weight: bold; font-size: .8em; font-family: Arial; line-height: 1.2; font-stretch: normal; }",
+    message: messages.expected("font"),
+  }, {
+    code: "a { border-top-width: 7px; border-top-style: double; border-top-color: green; }",
+    message: messages.expected("border-top"),
+  }, {
+    code: "a { -webkit-transition-delay: 0.5s; -webkit-transition-duration: 2s; -webkit-transition-property: top; -webkit-transition-timing-function: ease; }",
+    message: messages.expected("-webkit-transition"),
+  }, {
+    code: "a { border-top-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-right-width: 1px; }",
+    message: messages.expected("border-width"),
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignoreShorthands: [ "/border/", "padding" ] } ],
+
+  accept: [ {
+    code: "a { border-top-width: 7px; border-top-style: double; border-top-color: green; }",
+  }, {
+    code: "a { padding-left: 10px; padding-right: 10px; padding-top: 20px; padding-bottom: 30px; }",
+  } ],
+
+  reject: [{
+    code: "a { margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }",
+    message: messages.expected("margin"),
+  }],
+})

--- a/src/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/src/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -1,0 +1,74 @@
+import {
+  isEqual,
+  isString,
+  transform,
+} from "lodash"
+import {
+  optionsMatches,
+  report,
+  ruleMessages,
+  validateOptions,
+} from "../../utils"
+import shorthandData from "../../reference/shorthandData"
+
+export const ruleName = "declaration-block-no-redundant-longhand-properties"
+
+export const messages = ruleMessages(ruleName, {
+  expected: (props) => (
+    `Expected shorthand property "${props}"`
+  ),
+})
+
+export default function (actual, options) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, { actual }, {
+      actual: options,
+      possible: {
+        ignoreShorthands: [isString],
+      },
+      optional: true,
+    })
+    if (!validOptions) { return }
+
+    const longhandProperties = transform(shorthandData, (result, values, key) => {
+      if (optionsMatches(options, "ignoreShorthands", key)) { return }
+
+      values.forEach((value) => {
+        (result[value] || (result[value] = [])).push(key)
+      })
+    })
+
+    root.walkRules(check)
+    root.walkAtRules(check)
+
+    function check(statement) {
+      const longhandDeclarations = {}
+      // Shallow iteration so nesting doesn't produce
+      // false positives
+      statement.each(node => {
+        if (node.type !== "decl") { return }
+
+        const prop = node.prop.toLowerCase()
+
+        const shorthandProperties = longhandProperties[prop]
+
+        if (!shorthandProperties) { return }
+
+        shorthandProperties.forEach((shorthandProperty) => {
+          (longhandDeclarations[shorthandProperty] || (longhandDeclarations[shorthandProperty] = [])).push(prop)
+
+          if (!isEqual(shorthandData[shorthandProperty].sort(), longhandDeclarations[shorthandProperty].sort())) {
+            return
+          }
+
+          report({
+            ruleName,
+            result,
+            node,
+            message: messages.expected(shorthandProperty),
+          })
+        })
+      })
+    }
+  }
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -35,6 +35,7 @@ import declarationBangSpaceAfter from "./declaration-bang-space-after"
 import declarationBangSpaceBefore from "./declaration-bang-space-before"
 import declarationBlockNoDuplicateProperties from "./declaration-block-no-duplicate-properties"
 import declarationBlockNoIgnoredProperties from "./declaration-block-no-ignored-properties"
+import declarationBlockNoRedundantLonghandProperties from "./declaration-block-no-redundant-longhand-properties"
 import declarationBlockNoShorthandPropertyOverrides from "./declaration-block-no-shorthand-property-overrides"
 import declarationBlockPropertiesOrder from "./declaration-block-properties-order"
 import declarationBlockSemicolonNewlineAfter from "./declaration-block-semicolon-newline-after"
@@ -203,6 +204,7 @@ export default {
   "declaration-bang-space-before": declarationBangSpaceBefore,
   "declaration-block-no-duplicate-properties": declarationBlockNoDuplicateProperties,
   "declaration-block-no-ignored-properties": declarationBlockNoIgnoredProperties,
+  "declaration-block-no-redundant-longhand-properties": declarationBlockNoRedundantLonghandProperties,
   "declaration-block-no-shorthand-property-overrides": declarationBlockNoShorthandPropertyOverrides,
   "declaration-block-properties-order": declarationBlockPropertiesOrder,
   "declaration-block-semicolon-newline-after": declarationBlockSemicolonNewlineAfter,


### PR DESCRIPTION
Close https://github.com/stylelint/stylelint/issues/1735.
/cc @davidtheclark @jeddy3 @ntwb 
Maybe add tests to check on non standard syntax? or it is overly?