### PR TITLE
Fixed: `media-feature-no-missing-punctuation` no longer delivers false positives for scss operators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Fixed: `--ignore-path` and `--report-needless-disables` no longer fails when used together.
 -   Fixed: the `indentation` rule now correctly handles `_` hacks on property names.
+-   Fixed: `media-feature-no-missing-punctuation` no longer delivers false positives for SCSS operators.
 
 # 7.2.0
 

--- a/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
+++ b/src/rules/media-feature-no-missing-punctuation/__tests__/index.js
@@ -61,6 +61,9 @@ testRule(rule, {
   }, {
     code: "@media screen and (max-width:($var - 42px)) {}",
     description: "ignore non-standard complex SCSS values",
+  }, {
+    code: "@media (max-width: $content-size + $side * 2) {}",
+    description: "ignore non-standard complex SCSS values",
   } ],
 
   reject: [ {

--- a/src/utils/__tests__/isStandardSyntaxMediaFeature-test.js
+++ b/src/utils/__tests__/isStandardSyntaxMediaFeature-test.js
@@ -8,6 +8,7 @@ test("isStandardSyntaxMediaFeature", t => {
   t.ok(isStandardSyntaxMediaFeature("(color)"), "boolean context")
   t.notOk(isStandardSyntaxMediaFeature("(min-width: calc(100% - 20px))"), "complex value")
   t.notOk(isStandardSyntaxMediaFeature("(min-width: ($var - 10px))"), "complex SCSS value")
+  t.notOk(isStandardSyntaxMediaFeature("(max-width: $content-size + $side * 2)"), "complex SCSS value")
   t.notOk(isStandardSyntaxMediaFeature("(min-width#{$value}: 10px)"), "scss interpolation")
   t.notOk(isStandardSyntaxMediaFeature("(@{value}min-width : 10px)"), "Less interpolation")
   t.end()

--- a/src/utils/isStandardSyntaxMediaFeature.js
+++ b/src/utils/isStandardSyntaxMediaFeature.js
@@ -16,5 +16,8 @@ export default function (mediaFeature) {
   // SCSS or Less interpolation
   if (hasInterpolation(mediaFeature)) { return false }
 
+  // SCSS variables
+  if (/\$.+?/.test(mediaFeature)) { return false }
+
   return true
 }


### PR DESCRIPTION
Close https://github.com/stylelint/stylelint/issues/1754
/cc @davidtheclark @jeddy3 
