### PR TITLE
Fix ignoreUnits option being listed as ignoreTypes

### DIFF
--- a/src/rules/unit-no-unknown/README.md
+++ b/src/rules/unit-no-unknown/README.md
@@ -56,7 +56,7 @@ a {
 
 ## Optional options
 
-### `ignoreTypes: ["/regex/", "string"]`
+### `ignoreUnits: ["/regex/", "string"]`
 
 Given:
 


### PR DESCRIPTION
Just a little doc fix, looks like the option is really ignoreUnits: https://github.com/stylelint/stylelint/blob/master/src/rules/unit-no-unknown/index.js#L25