### PR TITLE
Chore: add tests to check units with and without leading zero to `unit-*` rules

### DIFF
--- a/src/rules/unit-blacklist/__tests__/index.js
+++ b/src/rules/unit-blacklist/__tests__/index.js
@@ -30,6 +30,10 @@ testRule(rule, {
   }, {
     code: "a { line-height: 1.2REM; }",
   }, {
+    code: "a { font-size: .5rem; }",
+  }, {
+    code: "a { font-size: 0.5rem; }",
+  }, {
     code: "a { margin: 0 10em 5rem 2in; }",
   }, {
     code: "a { background-position: top right, 1em 5vh; }",
@@ -112,6 +116,11 @@ testRule(rule, {
     column: 12,
   }, {
     code: "a { line-height: .1px; }",
+    message: messages.rejected("px"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { line-height: 0.1px; }",
     message: messages.rejected("px"),
     line: 1,
     column: 18,

--- a/src/rules/unit-case/__tests__/index.js
+++ b/src/rules/unit-case/__tests__/index.js
@@ -18,6 +18,10 @@ testRule(rule, {
   }, {
     code: "a { font-size: 100%; }",
   }, {
+    code: "a { font-size: .5rem; }",
+  }, {
+    code: "a { font-size: 0.5rem; }",
+  }, {
     code: "a { width: 10px; }",
   }, {
     code: "a { margin: 0 10em 5rem 2in; }",
@@ -114,6 +118,16 @@ testRule(rule, {
     message: messages.expected("PX", "px"),
     line: 1,
     column: 18,
+  }, {
+    code: "a { font-size: .5REM; }",
+    message: messages.expected("REM", "rem"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { font-size: 0.5REM; }",
+    message: messages.expected("REM", "rem"),
+    line: 1,
+    column: 16,
   }, {
     code: "a { margin: calc(10px + 10PX); }",
     message: messages.expected("PX", "px"),
@@ -282,6 +296,10 @@ testRule(rule, {
   }, {
     code: "a { font-size: 100%; }",
   }, {
+    code: "a { font-size: .5REM; }",
+  }, {
+    code: "a { font-size: 0.5REM; }",
+  }, {
     code: "a { width: 10PX; }",
   }, {
     code: "a { margin: 0 10EM 5REM 2IN; }",
@@ -358,6 +376,16 @@ testRule(rule, {
     message: messages.expected("px", "PX"),
     line: 1,
     column: 12,
+  }, {
+    code: "a { font-size: .5rem; }",
+    message: messages.expected("rem", "REM"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { font-size: 0.5rem; }",
+    message: messages.expected("rem", "REM"),
+    line: 1,
+    column: 16,
   }, {
     code: "a { margin: 10PX 10px; }",
     message: messages.expected("px", "PX"),

--- a/src/rules/unit-no-unknown/__tests__/index.js
+++ b/src/rules/unit-no-unknown/__tests__/index.js
@@ -52,6 +52,10 @@ testRule(rule, {
   }, {
     code: "a { margin: 1vmax; }",
   }, {
+    code: "a { font-size: .5rem; }",
+  }, {
+    code: "a { font-size: 0.5rem; }",
+  }, {
     code: "a { margin: 1vmin 1vmax; }",
   }, {
     code: "a { margin: 0 10em 5rem 2in; }",
@@ -148,6 +152,16 @@ testRule(rule, {
     message: messages.rejected("xpx"),
     line: 1,
     column: 13,
+  }, {
+    code: "a { font-size: .5remm; }",
+    message: messages.rejected("remm"),
+    line: 1,
+    column: 16,
+  }, {
+    code: "a { font-size: 0.5remm; }",
+    message: messages.rejected("remm"),
+    line: 1,
+    column: 16,
   }, {
     code: "a { color: rgb(255pix, 0, 51); }",
     message: messages.rejected("pix"),

--- a/src/rules/unit-whitelist/__tests__/index.js
+++ b/src/rules/unit-whitelist/__tests__/index.js
@@ -28,6 +28,10 @@ testRule(rule, {
   }, {
     code: "a { font-size: 1.2em; }",
   }, {
+    code: "a { font-size: .5em; }",
+  }, {
+    code: "a { font-size: 0.5em; }",
+  }, {
     code: "a { margin: 0 10em 5em 2px; }",
   }, {
     code: "a { background-position: top right, 10px 20px; }",
@@ -108,6 +112,16 @@ testRule(rule, {
     message: messages.rejected("VMIN"),
     line: 1,
     column: 12,
+  }, {
+    code: "a { line-height: .1rem; }",
+    message: messages.rejected("rem"),
+    line: 1,
+    column: 18,
+  }, {
+    code: "a { line-height: 0.1rem; }",
+    message: messages.rejected("rem"),
+    line: 1,
+    column: 18,
   }, {
     code: "a { border-left: 1rem solid #ccc; }",
     message: messages.rejected("rem"),


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/issues/1773 https://github.com/stylelint/stylelint/issues/1771
/cc @davidtheclark @jeddy3 