### PR TITLE
Chore: correction stylistic errors.

### DIFF
--- a/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
+++ b/src/rules/at-rule-no-vendor-prefix/__tests__/index.js
@@ -23,7 +23,7 @@ testRule(rule, {
   }, {
     code: "@-wEbKiT-kEyFrAmEs { 0% { top: 0; } }",
     message: messages.rejected("-wEbKiT-kEyFrAmEs"),
-  },  {
+  }, {
     code: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
     message: messages.rejected("-WEBKIT-KEYFRAMES"),
   }, {

--- a/src/rules/comment-word-blacklist/__tests__/index.js
+++ b/src/rules/comment-word-blacklist/__tests__/index.js
@@ -92,7 +92,7 @@ testRule(rule, {
     code: "/* tOdO: comment */",
   }, {
     code: "/* Todo: comment */",
-  },  {
+  }, {
     code: "/*! Todo: comment */",
   }, {
     code: "/*# Todo: comment */",

--- a/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/__tests__/index.js
@@ -73,7 +73,7 @@ testRule(rule, {
     message: messages.rejectedAfter(),
     line: 1,
     column: 17,
-  },  {
+  }, {
     code: "a { color: pink; top: 0; }",
     message: messages.rejectedAfter(),
     line: 1,

--- a/src/rules/function-comma-newline-after/__tests__/index.js
+++ b/src/rules/function-comma-newline-after/__tests__/index.js
@@ -17,7 +17,7 @@ testRule(rule, {
     code: "a::before { background: url('func(foo,bar,baz)'); }",
   }, {
     code: "a { background-size: 0,\n  0,\n  0; }",
-  },  {
+  }, {
     code: "a { transform: translate(1 ,\n1); }",
   }, {
     code: "a { transform: translate(1 ,\n\n1); }",

--- a/src/rules/function-max-empty-lines/__tests__/index.js
+++ b/src/rules/function-max-empty-lines/__tests__/index.js
@@ -21,7 +21,7 @@ testRule(rule, {
     code: "a { transform: translate\n\n(1, 1); }",
   }, {
     code: "a { transform: translate\r\n\r\n(1, 1); }",
-  },  {
+  }, {
     code: "a { transform: translate(1, 1)\n\n; }",
   }, {
     code: "a { transform: translate(1, 1)\r\n\r\n; }",

--- a/src/rules/function-url-data-uris/__tests__/index.js
+++ b/src/rules/function-url-data-uris/__tests__/index.js
@@ -229,7 +229,7 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 34,
-  },  {
+  }, {
     code: "@font-face { font-family: 'foo'; src: url( 'data:font/ttf;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=' ); }",
     message: messages.rejected,
     line: 1,

--- a/src/rules/function-url-no-scheme-relative/__tests__/index.js
+++ b/src/rules/function-url-no-scheme-relative/__tests__/index.js
@@ -60,7 +60,7 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 21,
-  },  {
+  }, {
     code: "a { background: url(//www.google.com/file.jpg); }",
     message: messages.rejected,
     line: 1,

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -45,7 +45,7 @@ testRule(rule, {
     },
   }, {
     code: "@document url(\"http://www.w3.org/\");",
-  },  {
+  }, {
     code: "@document url( \"http://www.w3.org/\" );",
   }, {
     code: "@document url-prefix(\"http://www.w3.org/\");",

--- a/src/rules/keyframe-declaration-no-important/__tests__/index.js
+++ b/src/rules/keyframe-declaration-no-important/__tests__/index.js
@@ -17,7 +17,7 @@ testRule(rule, {
     code: "@keyframes important { from { margin: 1px; } }",
   }, {
     code: "@-webkit-keyframes important { from { margin: 1px; } }",
-  },  {
+  }, {
     code: "@-WEBKIT-KEYFRAMES important { from { margin: 1px; } }",
   }, {
     code: "@non-keyframes important { from { margin: 1px !important; } }",

--- a/src/rules/no-empty-source/__tests__/index.js
+++ b/src/rules/no-empty-source/__tests__/index.js
@@ -48,7 +48,7 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 1,
-  },  {
+  }, {
     code: "\r\n",
     description: "source with newline",
     message: messages.rejected,

--- a/src/rules/selector-attribute-operator-space-after/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-space-after/__tests__/index.js
@@ -317,7 +317,7 @@ testRule(rule, {
     message: messages.expectedAfter("="),
     line: 1,
     column: 9,
-  },  {
+  }, {
     code: "[target=\" _blank \"] { }",
     message: messages.expectedAfter("="),
     line: 1,
@@ -327,7 +327,7 @@ testRule(rule, {
     message: messages.expectedAfter("="),
     line: 1,
     column: 9,
-  },  {
+  }, {
     code: "[ target =\"_blank\"] { }",
     message: messages.expectedAfter("="),
     line: 1,
@@ -472,7 +472,7 @@ testRule(rule, {
     message: messages.expectedAfter("="),
     line: 1,
     column: 8,
-  },  {
+  }, {
     code: "[target =_blank] .foo { }",
     message: messages.expectedAfter("="),
     line: 1,
@@ -492,7 +492,7 @@ testRule(rule, {
     message: messages.expectedAfter("="),
     line: 1,
     column: 15,
-  },  {
+  }, {
     code: "li[aria-hidden=false]:nth-child( 1 ) { }",
     message: messages.expectedAfter("="),
     line: 1,
@@ -517,7 +517,7 @@ testRule(rule, {
     message: messages.expectedAfter("="),
     line: 1,
     column: 16,
-  },  {
+  }, {
     code: "ul li[aria-hidden=false] + li[aria-hidden= false] a { }",
     message: messages.expectedAfter("="),
     line: 1,

--- a/src/rules/selector-attribute-operator-space-before/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-space-before/__tests__/index.js
@@ -317,7 +317,7 @@ testRule(rule, {
     message: messages.expectedBefore("="),
     line: 1,
     column: 8,
-  },  {
+  }, {
     code: "[target=\" _blank \"] { }",
     message: messages.expectedBefore("="),
     line: 1,
@@ -327,7 +327,7 @@ testRule(rule, {
     message: messages.expectedBefore("="),
     line: 1,
     column: 9,
-  },  {
+  }, {
     code: "[ target= \"_blank\"] { }",
     message: messages.expectedBefore("="),
     line: 1,
@@ -472,7 +472,7 @@ testRule(rule, {
     message: messages.expectedBefore("="),
     line: 1,
     column: 8,
-  },  {
+  }, {
     code: "[target= _blank] .foo { }",
     message: messages.expectedBefore("="),
     line: 1,
@@ -492,7 +492,7 @@ testRule(rule, {
     message: messages.expectedBefore("="),
     line: 1,
     column: 15,
-  },  {
+  }, {
     code: "li[aria-hidden=false]:nth-child( 1 ) { }",
     message: messages.expectedBefore("="),
     line: 1,

--- a/src/rules/selector-max-empty-lines/__tests__/index.js
+++ b/src/rules/selector-max-empty-lines/__tests__/index.js
@@ -255,7 +255,7 @@ testRule(rule, {
     code: "a\r\n[itemprop=url] { }",
   }, {
     code: "a[\nitemprop=url] { }",
-  },  {
+  }, {
     code: "a[\r\nitemprop=url] { }",
   }, {
     code: "a[itemprop\n=url] { }",
@@ -602,7 +602,7 @@ testRule(rule, {
     message: messages.expected(0),
     line: 2,
     column: 5,
-  },  {
+  }, {
     code: ".foo\r\n.bar\r\n\r\n> .other\r\n\r\n{ }",
     message: messages.expected(0),
     line: 2,
@@ -998,11 +998,11 @@ testRule(rule, {
     code: "a\r\n\r\n[itemprop=url] { }",
   }, {
     code: "a[\nitemprop=url] { }",
-  },  {
+  }, {
     code: "a[\r\nitemprop=url] { }",
   }, {
     code: "a[\n\nitemprop=url] { }",
-  },  {
+  }, {
     code: "a[\r\n\r\nitemprop=url] { }",
   }, {
     code: "a[itemprop\n=url] { }",
@@ -1507,7 +1507,7 @@ testRule(rule, {
     message: messages.expected(1),
     line: 2,
     column: 5,
-  },  {
+  }, {
     code: ".foo\r\n.bar\r\n\r\n\r\n> .other\r\n\r\n{ }",
     message: messages.expected(1),
     line: 2,
@@ -1517,7 +1517,7 @@ testRule(rule, {
     message: messages.expected(1),
     line: 3,
     column: 5,
-  },  {
+  }, {
     code: ".foo\r\n\r\n.bar\r\n\r\n\r\n> .other\r\n\r\n\r\n{ }",
     message: messages.expected(1),
     line: 3,

--- a/src/rules/selector-no-qualifying-type/__tests__/index.js
+++ b/src/rules/selector-no-qualifying-type/__tests__/index.js
@@ -33,7 +33,7 @@ testRule(rule, {
     code: "p { }",
   }, {
     code: "div, p { }",
-  },  {
+  }, {
     code: ".class, p { }",
   }, {
     code: "div, .class { }",
@@ -436,7 +436,7 @@ testRule(rule, {
     code: "p { }",
   }, {
     code: "div, p { }",
-  },  {
+  }, {
     code: ".class, p { }",
   }, {
     code: "div, .class { }",
@@ -791,7 +791,7 @@ testRule(rule, {
     code: "p { }",
   }, {
     code: "div, p { }",
-  },  {
+  }, {
     code: ".class, p { }",
   }, {
     code: "div, .class { }",
@@ -1158,7 +1158,7 @@ testRule(rule, {
     code: "p { }",
   }, {
     code: "div, p { }",
-  },  {
+  }, {
     code: ".class, p { }",
   }, {
     code: "div, .class { }",

--- a/src/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
+++ b/src/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
@@ -67,7 +67,7 @@ testRule(rule, {
     message: messages.expectedOpening,
     line: 1,
     column: 19,
-  },  {
+  }, {
     code: "section:not( :has( h1, h2) ) { }",
     message: messages.expectedClosing,
     line: 1,

--- a/src/rules/time-no-imperceptible/__tests__/index.js
+++ b/src/rules/time-no-imperceptible/__tests__/index.js
@@ -57,7 +57,7 @@ testRule(rule, {
     code: "a { animation-delay: 5000ms; }",
   }, {
     code: "a { animation-duration: 0.15s; }",
-  },  {
+  }, {
     code: "a { -webkitanimation-duration: 0.15s; }",
   }, {
     code: "a { animation-duration: 2.8s; }",
@@ -67,7 +67,7 @@ testRule(rule, {
     code: "a { animation-duration: 4700ms; }",
   }, {
     code: "a { animation: foo 0.8s linear; }",
-  },  {
+  }, {
     code: "a { -webkit-animation: foo 0.8s linear; }",
   }, {
     code: "a { animation: foo 0.8s 200ms ease-in-out; }",
@@ -187,7 +187,7 @@ testRule(rule, {
     message: messages.rejected("0.008s"),
     line: 1,
     column: 20,
-  },  {
+  }, {
     code: "a { -webkit-animation: foo 0.008s linear; }",
     message: messages.rejected("0.008s"),
     line: 1,

--- a/src/rules/value-keyword-case/__tests__/index.js
+++ b/src/rules/value-keyword-case/__tests__/index.js
@@ -666,10 +666,10 @@ testRule(rule, {
   }, {
     code: "a { font-size: var(--some-fs-block); }",
     description: "ignore css variable includes value keyword",
-  },  {
+  }, {
     code: "a { font-size: vAr(--some-fs-block); }",
     description: "ignore css variable includes value keyword",
-  },  {
+  }, {
     code: "a { font-size: VAR(--some-fs-block); }",
     description: "ignore css variable includes value keyword",
   }, {

--- a/src/rules/value-list-max-empty-lines/__tests__/index.js
+++ b/src/rules/value-list-max-empty-lines/__tests__/index.js
@@ -19,7 +19,7 @@ testRule(rule, {
     code: "a { padding:\n\n10px 10px 10px 10px }",
   }, {
     code: "a { padding:\r\n10px 10px 10px 10px }",
-  },  {
+  }, {
     code: "a { padding:\r\n\r\n10px 10px 10px 10px }",
   }, {
     code: "a { padding: 10px 10px 10px 10px\n }",


### PR DESCRIPTION
It would be good to add `no-multi-spaces` in `eslint-config-stylelint`.