### PR TITLE
Docs: fixed typos `descendent` to `descendant`.

### DIFF
--- a/src/rules/selector-combinator-space-after/README.md
+++ b/src/rules/selector-combinator-space-after/README.md
@@ -10,7 +10,7 @@ Require a single space or disallow whitespace after the combinators of selectors
 
 Combinators are used to combine several different selectors into new and more specific ones. There are several types of combinators, including: child (`>`), adjacent sibling (`+`), general sibling (`~`), and descendant (which is represented by a blank space between two selectors).
 
-The descendent combinator is *not* checked by this rule.
+The descendant combinator is *not* checked by this rule.
 
 Also, `+` and `-` signs within `:nth-*()` arguments are not checked (e.g. `a:nth-child(2n+1)`).
 

--- a/src/rules/selector-combinator-space-before/README.md
+++ b/src/rules/selector-combinator-space-before/README.md
@@ -10,7 +10,7 @@ Require a single space or disallow whitespace before the combinators of selector
 
 Combinators are used to combine several different selectors into new and more specific ones. There are several types of combinators, including: child (`>`), adjacent sibling (`+`), general sibling (`~`), and descendant (which is represented by a blank space between two selectors).
 
-The descendent combinator is *not* checked by this rule.
+The descendant combinator is *not* checked by this rule.
 
 Also, `+` and `-` signs within `:nth-*()` arguments are not checked (e.g. `a:nth-child(2n+1)`).
 


### PR DESCRIPTION
/cc @davidtheclark @jeddy3 