### PR TITLE
Correctly calculate column positions in max-line-length when windows line endings are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Head
 
-- Added: `ignore: ["consecutive-duplicates-with-different-values"]` option to `declaration-block-no-duplicate-properties`.
+- Fixed: `max-line-length` now correctly handles Windows line endings.
 - Added: `--report-needless-disables` and `reportNeedlessDisables` option.
 - Added: `--ignore-disables` and `ignoreDisables` option.
 - Added: `value-list-max-empty-lines` rule.
 - Added: `media-feature-name-no-unknown` rule.
-- Added: `ignore: ["comments"]` option to `max-line-length`.
-- Added: `ignoreAtRules` option to `max-nesting-depth`.
-- Added: `function-url-scheme-whitelist` rule.
-- Fixed: no longer parsing ignored files before ignoring them.
 - Fixed: `no-unknown-animations` and `unit-blacklist` now handle numbers without leading zeros.
-- Fixed: `root-no-standard-properties` now handles custom property sets.
 
 # 7.1.0
 

--- a/src/rules/max-line-length/__tests__/index.js
+++ b/src/rules/max-line-length/__tests__/index.js
@@ -31,6 +31,10 @@ testRule(rule, {
     code: "a {\n  background: uRl(\n  somethingsomethingsomethingsomething\n  );\n}",
   }, {
     code: "a {\n  background: URL(\n  somethingsomethingsomethingsomething\n  );\n}",
+  }, {
+    code: "a { margin: 0 2px; }\r\n",
+  }, {
+    code: "a { margin: 0 2px; }\r\na { margin: 4px 0; }\n",
   } ],
 
   reject: [ {
@@ -63,6 +67,11 @@ testRule(rule, {
     message: messages.expected(20),
     line: 1,
     column: 38,
+  }, {
+    code: "a { margin: 0 2rem; }\r\n",
+    message: messages.expected(20),
+    line: 1,
+    column: 21,
   } ],
 })
 

--- a/src/rules/max-line-length/index.js
+++ b/src/rules/max-line-length/index.js
@@ -51,7 +51,8 @@ export default function (maxLength, options) {
     }
 
     function checkNewline(match) {
-      let nextNewlineIndex = rootString.indexOf("\n", match.endIndex)
+      const endOfLineIndicator = (rootString.indexOf("\r\n", match.endIndex) !== -1) ? "\r\n" : "\n"
+      let nextNewlineIndex = rootString.indexOf(endOfLineIndicator, match.endIndex)
 
       // Accommodate last line
       if (nextNewlineIndex === -1) {


### PR DESCRIPTION
**Issue:** In operating systems, such as Windows, where the end of the line is "\r\n" (instead of "\n") the line length is being reported incorrectly (+1 to length).
 
The rule max-line-length is only looking for \n, which leaves \r in the string and causes the line count to be off by 1. 

I noticed this issue at work today with one of the devs who is on a Windows machine and was reporting style warnings for a line where none should exist. The line was 100 characters in length and our max-line-length is 100. On a Mac, the line was reporting as 100 length. On a Windows machine, it was reporting as 101.

**Replication:** Create a CSS style line that is exactly the length of max-line-length and use stylelint on that file in Windows. You will end up with a lint warning for the line length.

**Solution:** My fix adds a check for "\r\n" and if it exists, it uses that instead of "\n" for end of line.

**Testing:** I tested this on a Windows machine and Macbook Pro and the line length is now being reported correctly in each instance.
