### PR TITLE
Allow ruleset var declarations in :root (mixins)

### DIFF
--- a/src/rules/root-no-standard-properties/__tests__/index.js
+++ b/src/rules/root-no-standard-properties/__tests__/index.js
@@ -11,7 +11,9 @@ testRule(rule, {
   ruleName,
   config: [true],
 
-  accept: [ {
+  accept: [  {
+    code: ":root { --foo { color: pink; } }",
+  }, {
     code: ":root { --foo: 0; }",
   }, {
     code: ":rOoT { --foo: 0; }",

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -25,7 +25,7 @@ export default function (actual) {
       function checkSelector(selectorAST) {
         if (ignoreRule(selectorAST)) { return }
 
-        rule.walkDecls(function (decl) {
+        rule.each(function (decl) {
 
           const { prop } = decl
           if (!isStandardSyntaxProperty(prop)) { return }


### PR DESCRIPTION
Addresses: https://github.com/stylelint/stylelint/issues/1789

The tests for rule `root-no-standard-properties` pass, but some other things didn't. 
`¯\_(ツ)_/¯`