### PR TITLE
Allow no unicode characters as flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -25,6 +25,7 @@ const minimistOptions = {
     rd: "report-needless-disables",
     s: "syntax",
     v: "version",
+    nu: "no-unicode",
   },
 }
 
@@ -98,6 +99,11 @@ const meowOptions = {
         If you provide the argument "error", the process will exit with code 2
         if needless disables are found.
 
+      --no-unicode, ---nu
+
+        Disables Unicode characters when linting with "string" formatter. Replaces
+        Unicode warning/error characters with words "warning" and "error".
+
       --version, -v
 
         Show the currently installed version of stylelint.
@@ -151,6 +157,10 @@ if (cli.flags.ignoreDisables) {
 const { reportNeedlessDisables } = cli.flags
 if (reportNeedlessDisables) {
   optionsBase.reportNeedlessDisables = reportNeedlessDisables
+}
+
+if (cli.flags.noUnicode) {
+  optionsBase.noUnicode = cli.flags.noUnicode
 }
 
 Promise.resolve().then(() => {

--- a/src/formatters/__tests__/stringFormatter-test.js
+++ b/src/formatters/__tests__/stringFormatter-test.js
@@ -25,6 +25,37 @@ test("no warnings", t => {
   t.end()
 })
 
+test("returning no unicode", t => {
+  const results = [{
+    "source":  "path/to/file.css",
+    "errored": true,
+    "warnings":[ {
+      "line": 1,
+      "column": 2,
+      "rule": "bar",
+      "severity": "error",
+      "text": "Unexpected foo",
+    }, {
+      "line": 3,
+      "column": 3,
+      "rule": "foo",
+      "severity": "warning",
+      "text": "Missing unit for foobar",
+    } ],
+    "deprecations": [],
+    "invalidOptionWarnings":[],
+  }]
+
+  const output = prepareFormatterOutput(results, stringFormatter, { noUnicode: true })
+
+  t.equal(output, stripIndent`
+    path/to/file.css
+     1:2  error    Unexpected foo           bar
+     3:3  warning  Missing unit for foobar  foo
+  `)
+  t.end()
+})
+
 test("condensing of deprecations and invalid option warnings", t => {
 
   const results = [ {
@@ -77,9 +108,9 @@ test("one ignored file", t => {
   t.end()
 })
 
-export function prepareFormatterOutput(results, formatter) {
+export function prepareFormatterOutput(results, formatter, opts = {}) {
 
-  let output = chalk.stripColor(formatter(results)).trim()
+  let output = chalk.stripColor(formatter(results, opts)).trim()
 
   for (const [ nix, win ] of symbolConversions.entries()) {
     output = output.replace(new RegExp(nix, "g"), win)

--- a/src/formatters/stringFormatter.js
+++ b/src/formatters/stringFormatter.js
@@ -63,7 +63,7 @@ function getMessageWidth(columnWidths) {
   return availableWidth - (fullWidth - columnWidths[3] + MARGIN_WIDTHS)
 }
 
-function formatter(messages, source) {
+function formatter(messages, source, opts = {}) {
   if (!messages.length) return ""
 
   const orderedMessages = _.sortBy(
@@ -93,6 +93,8 @@ function formatter(messages, source) {
     output += chalk.underline(logFrom(source)) + "\n"
   }
 
+  const tokens = opts.noUnicode ? { warning: "warning", error: "error" } : symbols
+
   const cleanedMessages = orderedMessages.map(
     (message) => {
       const location = utils.getLocation(message)
@@ -100,7 +102,7 @@ function formatter(messages, source) {
       const row = [
         location.line || "",
         location.column || "",
-        symbols[severity] ? chalk[levelColors[severity]](symbols[severity]) : severity,
+        tokens[severity] ? chalk[levelColors[severity]](tokens[severity]) : severity,
         message
           .text
           // Remove all control characters (newline, tab and etc)
@@ -122,7 +124,7 @@ function formatter(messages, source) {
       columns: {
         0: { alignment: "right", width: columnWidths[0], paddingRight: 0 },
         1: { alignment: "left", width: columnWidths[1] },
-        2: { alignment: "center", width: columnWidths[2] },
+        2: { alignment: "left", width: columnWidths[2] },
         3: { alignment: "left", width: getMessageWidth(columnWidths), wrapWord: true },
         4: { alignment: "left", width: columnWidths[4], paddingRight: 0 },
       },
@@ -136,12 +138,12 @@ function formatter(messages, source) {
   return output
 }
 
-export default function (results) {
+export default function (results, opts) {
   let output = invalidOptionsFormatter(results)
   output += deprecationsFormatter(results)
 
   output = results.reduce((output, result) => {
-    output += formatter(result.warnings, result.source)
+    output += formatter(result.warnings, result.source, opts)
     return output
   }, output)
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -27,6 +27,7 @@ export default function ({
   configOverrides,
   ignoreDisables,
   ignorePath,
+  noUnicode,
   reportNeedlessDisables,
   syntax,
   formatter = "json",
@@ -42,6 +43,7 @@ export default function ({
     configBasedir,
     configOverrides,
     ignorePath,
+    noUnicode,
   }).then(({ config, configDir }) => {
 
     // Prepare processors
@@ -71,11 +73,11 @@ export default function ({
 
     let initialisedPostcss
 
-    function prepareReturnValue(results) {
+    function prepareReturnValue(results, opts) {
       const returnValue = {
         results,
         errored,
-        output: chosenFormatter(results),
+        output: chosenFormatter(results, opts),
       }
       if (reportNeedlessDisables) {
         returnValue.needlessDisables = needlessDisables(results)
@@ -86,7 +88,11 @@ export default function ({
     if (!files) {
       return lintString(code, codeFilename).then(result => {
         const results = [result]
-        return prepareReturnValue(results)
+        const opts = {
+          noUnicode,
+        }
+
+        return prepareReturnValue(results, opts)
       })
     }
 
@@ -98,7 +104,11 @@ export default function ({
       }
       const promises = input.map(filepath => lintFile(filepath))
       return Promise.all(promises).then(results => {
-        return prepareReturnValue(results)
+        const opts = {
+          noUnicode,
+        }
+
+        return prepareReturnValue(results, opts)
       })
     })
 


### PR DESCRIPTION
See https://github.com/jo-sm/SublimeLinter-contrib-stylelint_d/issues/3

To detect errors vs warnings in e.g. a editor plugin with the String formatter, you have to make a regex that contains Unicode characters, and because `log-symbols` uses different symbols for Windows and Unix, it makes it difficult to immediately tell why the regex contains those Unicode characters. For example, the regex currently would look something like this: `r'^\s*(?P<line>\d+)\:(?P<col>\d+)\s*(?:(?P<error>\u00D7|\u2716)|(?P<warning>\u203C|\u26A0))\s*(?P<message>.+)'`

This PR adds a `--no-unicode` flag that allows a user to pass in the `--no-unicode` flag via CLI, or the `noUnicode` option via `stylelint.lint`, and it will output "error" or "warning" instead of "✖" and "⚠" respectively. 