### PR TITLE
Add custom-property-set test to selector-type-no-unknown

### DIFF
--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -63,7 +63,7 @@ testRule(rule, {
     code: "@include keyframes(identifier) { 0% {} 100% {} }",
     description: "non-standard usage of keyframe selectors",
   }, {
-    code: "a { --custom-property-set: {} }",
+    code: "a { --custom-property-set: {}; }",
     description: "custom property set",
   } ],
 

--- a/src/rules/selector-type-no-unknown/__tests__/index.js
+++ b/src/rules/selector-type-no-unknown/__tests__/index.js
@@ -62,6 +62,9 @@ testRule(rule, {
   }, {
     code: "@include keyframes(identifier) { 0% {} 100% {} }",
     description: "non-standard usage of keyframe selectors",
+  }, {
+    code: "a { --custom-property-set: {} }",
+    description: "custom property set",
   } ],
 
   reject: [ {


### PR DESCRIPTION
Closes #1791

My bad, I totally didn’t see the missing semicolon in code.