### PR TITLE
Fix custom property sets in root-no-standard-properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added: `ignoreAtRules` option to `max-nesting-depth`.
 - Fixed: no longer parsing ignored files before ignoring them.
 - Fixed: `no-unknown-animations` and `unit-blacklist` now handle numbers without leading zeros.
+- Fixed: `root-no-standard-properties` now handles custom property sets.
 
 # 7.1.0
 

--- a/src/rules/root-no-standard-properties/__tests__/index.js
+++ b/src/rules/root-no-standard-properties/__tests__/index.js
@@ -52,6 +52,12 @@ testRule(rule, {
   }, {
     code: "div, a:not(div a:root) { --foo: pink; }",
     description: "negation pseudo-class",
+  }, {
+    code: ":root { --foo: { color: pink; }; }",
+    description: "custom property set",
+  }, {
+    code: ":root { a { color: pink; } }",
+    description: "nested rule",
   } ],
 
   reject: [ {

--- a/src/rules/root-no-standard-properties/index.js
+++ b/src/rules/root-no-standard-properties/index.js
@@ -25,15 +25,17 @@ export default function (actual) {
       function checkSelector(selectorAST) {
         if (ignoreRule(selectorAST)) { return }
 
-        rule.walkDecls(function (decl) {
+        rule.each(function (node) {
 
-          const { prop } = decl
+          if (node.type !== "decl") { return }
+
+          const { prop } = node
           if (!isStandardSyntaxProperty(prop)) { return }
           if (isCustomProperty(prop)) { return }
 
           report({
             message: messages.rejected(prop),
-            node: decl,
+            node,
             result,
             ruleName,
           })


### PR DESCRIPTION
Closes #1789

Replaces https://github.com/stylelint/stylelint/pull/1794

The new tests were failing even with the correct syntax i.e. colon and semicolon. So, patch was needed.