### PR TITLE
Consistent readme examples

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -172,6 +172,12 @@ Take the form of:
 
 - Use complete CSS patterns i.e. avoid ellipses (`...`)
 - Use standard CSS syntax (and use `css` code fences) by default.
+- Use the minimum amount of code possible to communicate the patten e.g. if the rule targets selectors then use an empty rule e.g. `{}`.
+- Use `{}`, rather than `{ }` for empty rules.
+- Use the `a` type selector by default.
+- Use the `@media` at-rules by default.
+- Use the `color` property by default.
+- Use *foo*, *bar* and *baz* for names e.g. `.foo`, `#bar` `--baz`
 
 ### Wire up the rule
 

--- a/src/rules/at-rule-name-newline-after/README.md
+++ b/src/rules/at-rule-name-newline-after/README.md
@@ -25,7 +25,7 @@ The following patterns are considered warnings:
 
 ```css
 @media (min-width: 700px) and
-  (orientation: landscape) { }
+  (orientation: landscape) {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -43,13 +43,13 @@ The following patterns are *not* considered warnings:
 
 ```css
 @media
-  (min-width: 700px) and (orientation: landscape) { }
+  (min-width: 700px) and (orientation: landscape) {}
 ```
 
 ```css
 @media
   (min-width: 700px) and
-  (orientation: landscape) { }
+  (orientation: landscape) {}
 ```
 
 ### `"always-multi-line"`
@@ -65,7 +65,7 @@ The following patterns are considered warnings:
 
 ```css
 @media (min-width: 700px) and
- (orientation: landscape) { }
+ (orientation: landscape) {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -84,11 +84,11 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-@media (min-width: 700px) and (orientation: landscape) { }
+@media (min-width: 700px) and (orientation: landscape) {}
 ```
 
 ```css
 @media
   (min-width: 700px) and
-  (orientation: landscape) { }
+  (orientation: landscape) {}
 ```

--- a/src/rules/at-rule-name-space-after/README.md
+++ b/src/rules/at-rule-name-space-after/README.md
@@ -23,16 +23,16 @@ The following patterns are considered warnings:
 ```
 
 ```css
-@media(min-width: 700px) { }
+@media(min-width: 700px) {}
 ```
 
 ```css
-@media  (min-width: 700px) { }
+@media  (min-width: 700px) {}
 ```
 
 ```css
 @media 
-(min-width: 700px) { }
+(min-width: 700px) {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -46,7 +46,7 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-@media (min-width: 700px) { }
+@media (min-width: 700px) {}
 ```
 
 ### `"always-single-line"`
@@ -60,11 +60,11 @@ The following patterns are considered warnings:
 ```
 
 ```css
-@media(min-width: 700px) { }
+@media(min-width: 700px) {}
 ```
 
 ```css
-@media  (min-width: 700px) { }
+@media  (min-width: 700px) {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -78,21 +78,21 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-@media (min-width: 700px) { }
+@media (min-width: 700px) {}
 ```
 
 ```css
 @media 
-(min-width: 700px) { }
+(min-width: 700px) {}
 ```
 
 ```css
 @media(min-width: 700px) and
-  (orientation: portrait) { }
+  (orientation: portrait) {}
 ```
 
 ```css
 @media
   (min-width: 700px) and
-  (orientation: portrait) { }
+  (orientation: portrait) {}
 ```

--- a/src/rules/at-rule-whitelist/README.md
+++ b/src/rules/at-rule-whitelist/README.md
@@ -26,7 +26,7 @@ The following patterns are considered warnings:
 
 ```css
 @media screen and (max-width: 1024px) {
-  .a { display: none; }
+  a { display: none; }
 }
 ```
 

--- a/src/rules/block-closing-brace-newline-after/README.md
+++ b/src/rules/block-closing-brace-newline-after/README.md
@@ -148,9 +148,9 @@ Given:
 The following patterns are *not* considered warnings:
 
 ```css
-@if ... {
+@if ($var) {
   color: pink;
-} @else if ... {
+} @else if ($var2) {
   color: red;
 } @else {
   color: blue;
@@ -158,5 +158,5 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-@if ... { color: pink; } @else { color: blue; }
+@if ($var) { color: pink; } @else { color: blue; }
 ```

--- a/src/rules/color-named/README.md
+++ b/src/rules/color-named/README.md
@@ -95,7 +95,7 @@ a { color: rgb(0, 0, 0); }
 ```
 
 ```css
-a { color: var(--foo-color-white); }
+a { color: var(--white); }
 ```
 
 ```scss

--- a/src/rules/custom-media-pattern/README.md
+++ b/src/rules/custom-media-pattern/README.md
@@ -3,7 +3,7 @@
 Specify a pattern for custom media query names.
 
 ```css
-@custom-media --narrow-window (max-width: 30em);
+@custom-media --foo (max-width: 30em);
 /**             ↑
  * The pattern of this */
 ```
@@ -23,11 +23,11 @@ Given the string:
 The following patterns are considered warnings:
 
 ```css
-@custom-media --big-dog (min-width: 30em);
+@custom-media --bar (min-width: 30em);
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-@custom-media --foo-big-dog (min-width: 30em);
+@custom-media --foo-bar (min-width: 30em);
 ```

--- a/src/rules/custom-property-empty-line-before/README.md
+++ b/src/rules/custom-property-empty-line-before/README.md
@@ -6,7 +6,7 @@ Require or disallow an empty line before custom properties.
 a {
   top: 10px;
                           /* ← */
-  --custom-prop2: value;  /* ↑ */   
+  --foo: pink;  /* ↑ */   
 }                         /* ↑ */
 /**                          ↑
  *                   This line */
@@ -23,8 +23,8 @@ The following patterns are considered warnings:
 ```css
 a {
   top: 10px;
-  --custom-prop: value;
-  --custom-prop2: value;
+  --foo: pink;
+  --bar: red;
 }
 ```
 
@@ -34,9 +34,9 @@ The following patterns are *not* considered warnings:
 a {
   top: 10px;
 
-  --custom-prop: value;
+  --foo: pink;
 
-  --custom-prop2: value;
+  --bar: red;
 }
 ```
 
@@ -48,17 +48,17 @@ The following patterns are considered warnings:
 a {
   top: 10px;
 
-  --custom-prop: value;
+  --foo: pink;
 
-  --custom-prop2: value;
+  --bar: red;
 }
 ```
 
 ```css
 a {
 
-  --custom-prop: value;
-  --custom-prop2: value;
+  --foo: pink;
+  --bar: red;
 }
 ```
 
@@ -67,15 +67,15 @@ The following patterns are *not* considered warnings:
 ```css
 a {
   top: 10px;
-  --custom-prop: value;
-  --custom-prop2: value;
+  --foo: pink;
+  --bar: red;
 }
 ```
 
 ```css
 a {
-  --custom-prop: value;
-  --custom-prop2: value;
+  --foo: pink;
+  --bar: red;
 }
 ```
 
@@ -94,10 +94,10 @@ The following patterns are considered warnings:
 ```css
 a {
 
-  --custom-prop: value;
+  --foo: pink;
   /* comment */
 
-  --custom-prop2: value;
+  --bar: red;
 }
 ```
 
@@ -106,9 +106,9 @@ The following patterns are *not* considered warnings:
 ```css
 a {
 
-  --custom-prop: value;
+  --foo: pink;
   /* comment */
-  --custom-prop2: value;
+  --bar: red;
 }
 
 ```
@@ -124,9 +124,9 @@ The following patterns are considered warnings:
 ```css
 a {
 
-  --custom-prop: value;
+  --foo: pink;
 
-  --custom-prop2: value;
+  --bar: red;
 }
 ```
 
@@ -135,8 +135,8 @@ The following patterns are *not* considered warnings:
 ```css
 a {
 
-  --custom-prop: value;
-  --custom-prop2: value;
+  --foo: pink;
+  --bar: red;
 }
 ```
 
@@ -151,9 +151,9 @@ The following patterns are considered warnings:
 ```css
 a {
 
-  --custom-prop: value;
+  --foo: pink;
 
-  --custom-prop2: value;
+  --bar: red;
 }
 ```
 
@@ -161,9 +161,9 @@ The following patterns are *not* considered warnings:
 
 ```css
 a {
-  --custom-prop: value;
+  --foo: pink;
 
-  --custom-prop2: value;
+  --bar: red;
 }
 ```
 
@@ -180,7 +180,7 @@ The following patterns are *not* considered warnings:
 ```css
 a {
   /* comment */
-  --custom-prop: value;
+  --foo: pink;
 }
 ```
 
@@ -193,5 +193,5 @@ For example, with `"always"`:
 The following patterns are *not* considered warnings:
 
 ```css
-a { --custom-prop: value; --custom-prop2: value; }
+a { --foo: pink; --bar: red; }
 ```

--- a/src/rules/custom-property-no-outside-root/README.md
+++ b/src/rules/custom-property-no-outside-root/README.md
@@ -3,7 +3,7 @@
 Disallow custom properties outside of `:root` rules.
 
 ```css
-    a { --foo-bar: 1px; }
+    a { --foo: 1px; }
 /** ↑   ↑
  * These selectors and these types of custom properties */
 ```
@@ -15,15 +15,15 @@ Disallow custom properties outside of `:root` rules.
 The following patterns are considered warnings:
 
 ```css
-a { --foo-bar: 1px; }
+a { --foo: 1px; }
 ```
 
 ```css
-:root, a { --foo-bar: 1px; }
+:root, a { --foo: 1px; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-:root { --foo-bar: 1px; }
+:root { --foo: 1px; }
 ```

--- a/src/rules/custom-property-pattern/README.md
+++ b/src/rules/custom-property-pattern/README.md
@@ -3,7 +3,7 @@
 Specify a pattern for custom properties.
 
 ```css
-a { --foo-bar: 1px; }
+a { --foo-: 1px; }
 /**   ↑
  * The pattern of this */
 ```

--- a/src/rules/declaration-empty-line-before/README.md
+++ b/src/rules/declaration-empty-line-before/README.md
@@ -4,7 +4,7 @@ Require or disallow an empty line before declarations.
 
 ```css
 a {
-  --custom-prop: value;
+  --foo: pink;
              /* ← */
   top: 15px; /* ↑ */   
 }            /* ↑ */
@@ -22,7 +22,7 @@ The following patterns are considered warnings:
 
 ```css
 a {
-  --custom-prop: value;
+  --foo: pink;
   top: 5px;
 }
 ```
@@ -38,7 +38,7 @@ The following patterns are *not* considered warnings:
 
 ```css
 a {
-  --custom-prop: value;
+  --foo: pink;
 
   top: 5px;
 }
@@ -59,7 +59,7 @@ The following patterns are considered warnings:
 
 ```css
 a {
-  --custom-prop: value;
+  --foo: pink;
 
   bottom: 15px;
 }
@@ -78,7 +78,7 @@ The following patterns are *not* considered warnings:
 
 ```css
 a {
-  --custom-prop: value;
+  --foo: pink;
   bottom: 15px;
 }
 ```

--- a/src/rules/declaration-property-value-blacklist/README.md
+++ b/src/rules/declaration-property-value-blacklist/README.md
@@ -35,7 +35,7 @@ Given:
 The following patterns are considered warnings:
 
 ```css
-div { position: fixed; }
+a { position: fixed; }
 ```
 
 ```css
@@ -65,7 +65,7 @@ a { -webkit-animation-timing-function: ease-in-out; }
 The following patterns are *not* considered warnings:
 
 ```css
-div { position: relative; }
+a { position: relative; }
 ```
 
 ```css

--- a/src/rules/declaration-property-value-whitelist/README.md
+++ b/src/rules/declaration-property-value-whitelist/README.md
@@ -36,7 +36,7 @@ Given:
 The following patterns are considered warnings:
 
 ```css
-div { whitespace: pre; }
+a { whitespace: pre; }
 ```
 
 ```css
@@ -62,7 +62,7 @@ a { color: pink; }
 ```
 
 ```css
-div { whitespace: nowrap; }
+a { whitespace: nowrap; }
 ```
 
 ```css

--- a/src/rules/function-calc-no-unspaced-operator/README.md
+++ b/src/rules/function-calc-no-unspaced-operator/README.md
@@ -36,14 +36,14 @@ a { top: calc(calc(1em * 2) / 3); }
 
 ```css
 a {
-  top: calc(var(--some-variable) +
-    var(--some-other-variable));
+  top: calc(var(--foo) +
+    var(--bar));
 }
 ```
 
 ```css
 a {
-  top: calc(var(--some-variable)
-    + var(--some-other-variable));
+  top: calc(var(--foo)
+    + var(--bar));
 }
 ```

--- a/src/rules/function-calc-no-unspaced-operator/README.md
+++ b/src/rules/function-calc-no-unspaced-operator/README.md
@@ -35,11 +35,15 @@ a { top: calc(calc(1em * 2) / 3); }
 ```
 
 ```css
-margin-top: calc(var(--some-variable) +
-  var(--some-other-variable));
+a {
+  top: calc(var(--some-variable) +
+    var(--some-other-variable));
+}
 ```
 
 ```css
-margin-top: calc(var(--some-variable)
-  + var(--some-other-variable));
+a {
+  top: calc(var(--some-variable)
+    + var(--some-other-variable));
+}
 ```

--- a/src/rules/function-whitespace-after/README.md
+++ b/src/rules/function-whitespace-after/README.md
@@ -54,14 +54,14 @@ a { padding: calc(1 * 2px), calc(2 * 5px); }
 
 ```scss
 /* notice the )}, with no space after the closing parenthesis */
-h1 {
+a {
   max-height: #{($line-height) * ($lines-to-show)}em;
 }
 ```
 
 ```less
 /* notice the )}, with no space after the closing parenthesis */
-h1 {
+a {
   max-height: ((@line-height) * (@lines-to-show))em;
 }
 ```

--- a/src/rules/max-nesting-depth/README.md
+++ b/src/rules/max-nesting-depth/README.md
@@ -161,7 +161,7 @@ For example, with `1` and given:
 The following patterns are *not* considered warnings:
 
 ```css
-a { 
+a {
   @media print {      /* 1 */
     b {               /* 2 */
       c { top: 0; }   /* 3 */
@@ -171,7 +171,7 @@ a {
 ```
 
 ```css
-a { 
+a {
   b {                 /* 1 */
     @media print {    /* 2 */
       c { top: 0; }   /* 3 */
@@ -181,7 +181,7 @@ a {
 ```
 
 ```css
-a { 
+a {
   @my-at-rule print {  /* 1 */
     b {                /* 2 */
       c { top: 0; }    /* 3 */
@@ -191,7 +191,7 @@ a {
 ```
 
 ```css
-a { 
+a {
   @my-other-at-rule print {  /* 1 */
     b {                      /* 2 */
       c { top: 0; }          /* 3 */
@@ -203,7 +203,7 @@ a {
 The following patterns are considered warnings:
 
 ```css
-a { 
+a {
   @import print {       /* 1 */
     b { top: 0; }       /* 2 */
   }
@@ -211,8 +211,8 @@ a {
 ```
 
 ```css
-a { 
-  @my_at_rule print {   /* 1 */
+a {
+  @not-my-at-rule print {   /* 1 */
     b { top: 0; }       /* 2 */
   }
 }

--- a/src/rules/media-feature-name-case/README.md
+++ b/src/rules/media-feature-name-case/README.md
@@ -3,7 +3,7 @@
 Specify lowercase or uppercase for media feature names.
 
 ```css
-@media (min-width: 700px) { }
+@media (min-width: 700px) {}
 /**     ↑
  * These media feature names */
 ```
@@ -19,11 +19,11 @@ Specify lowercase or uppercase for media feature names.
 The following patterns are considered warnings:
 
 ```css
-@media (MIN-WIDTH: 700px) { }
+@media (MIN-WIDTH: 700px) {}
 ```
 
 ```css
-@media not all and (MONOCHROME) { }
+@media not all and (MONOCHROME) {}
 ```
 
 ```css
@@ -33,11 +33,11 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-@media (min-width: 700px) { }
+@media (min-width: 700px) {}
 ```
 
 ```css
-@media not all and (monochrome) { }
+@media not all and (monochrome) {}
 ```
 
 ```css
@@ -49,11 +49,11 @@ The following patterns are *not* considered warnings:
 The following patterns are considered warnings:
 
 ```css
-@media (min-width: 700px) { }
+@media (min-width: 700px) {}
 ```
 
 ```css
-@media not all and (monochrome) { }
+@media not all and (monochrome) {}
 ```
 
 ```css
@@ -63,11 +63,11 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-@media (MIN-WIDTH: 700px) { }
+@media (MIN-WIDTH: 700px) {}
 ```
 
 ```css
-@media not all and (MONOCHROME) { }
+@media not all and (MONOCHROME) {}
 ```
 
 ```css

--- a/src/rules/media-feature-name-case/README.md
+++ b/src/rules/media-feature-name-case/README.md
@@ -27,7 +27,7 @@ The following patterns are considered warnings:
 ```
 
 ```css
-@media (min-width: 700px) and (ORIENTATION: landscape) { ... }
+@media (min-width: 700px) and (ORIENTATION: landscape) {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -41,7 +41,7 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-@media (min-width: 700px) and (orientation: landscape) { ... }
+@media (min-width: 700px) and (orientation: landscape) {}
 ```
 
 ### `"upper"`
@@ -57,7 +57,7 @@ The following patterns are considered warnings:
 ```
 
 ```css
-@media (MIN-WIDTH: 700px) and (orientation: landscape) { ... }
+@media (MIN-WIDTH: 700px) and (orientation: landscape) {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -71,5 +71,5 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-@media (MIN-WIDTH: 700px) and (ORIENTATION: landscape) { ... }
+@media (MIN-WIDTH: 700px) and (ORIENTATION: landscape) {}
 ```

--- a/src/rules/media-feature-name-no-unknown/README.md
+++ b/src/rules/media-feature-name-no-unknown/README.md
@@ -3,7 +3,7 @@
 Disallow unknown media feature names.
 
 ```css
-@media (min-width: 700px) { }
+@media (min-width: 700px) {}
 /**     ↑
  * These media feature names */
 ```
@@ -21,33 +21,33 @@ Caveat: Media feature names within a [range context](https://www.w3.org/TR/media
 The following patterns are considered warnings:
 
 ```css
-@media screen and (unknown) { }
+@media screen and (unknown) {}
 ```
 
 ```css
-@media screen and (unknown: 10px) { }
+@media screen and (unknown: 10px) {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css  
-@media all and (monochrome) { }
+@media all and (monochrome) {}
 ```
 
 ```css  
-@media (min-width: 700px) { }
+@media (min-width: 700px) {}
 ```
 
 ```css
-@media (MIN-WIDTH: 700px) { }
+@media (MIN-WIDTH: 700px) {}
 ```
 
 ```css
-@media (min-width: 700px) and (orientation: landscape) { }
+@media (min-width: 700px) and (orientation: landscape) {}
 ```
 
 ```css
-@media (-webkit-min-device-pixel-ratio: 2) { }
+@media (-webkit-min-device-pixel-ratio: 2) {}
 ```
 
 ## Optional options
@@ -63,17 +63,17 @@ Given:
 The following patterns are *not* considered warnings:
 
 ```css
-@media screen and (my-media-feature-name) { }
+@media screen and (my-media-feature-name) {}
 ```
 
 ```css
-@media screen and (MY-MEDIA-FEATURE-NAME) { }
+@media screen and (MY-MEDIA-FEATURE-NAME) {}
 ```
 
 ```css
-@media screen and (custom: 10px) { }
+@media screen and (custom: 10px) {}
 ```
 
 ```css
-@media (min-width: 700px) and (custom: 10px) { }
+@media (min-width: 700px) and (custom: 10px) {}
 ```

--- a/src/rules/no-browser-hacks/README.md
+++ b/src/rules/no-browser-hacks/README.md
@@ -25,7 +25,7 @@ Defaults to the browserslist default, which targets modern browsers.
 The following patterns are considered warnings:
 
 ```css
-.foo { color/*\**/: pink\9; }
+a { color/*\**/: pink\9; }
 ```
 
 As this hack targets IE7-8.

--- a/src/rules/no-duplicate-selectors/README.md
+++ b/src/rules/no-duplicate-selectors/README.md
@@ -3,7 +3,7 @@
 Disallow duplicate selectors within a stylesheet.
 
 ```css
-    .foo {} .ba {} .foo {}
+    .foo {} .bar {} .foo {}
 /** ↑              ↑
  * These duplicates */
 ```

--- a/src/rules/no-empty-source/README.md
+++ b/src/rules/no-empty-source/README.md
@@ -31,7 +31,7 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-.class { }
+a { }
 ```
 
 ```css

--- a/src/rules/no-empty-source/README.md
+++ b/src/rules/no-empty-source/README.md
@@ -31,7 +31,7 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-a { }
+a {}
 ```
 
 ```css

--- a/src/rules/no-extra-semicolons/README.md
+++ b/src/rules/no-extra-semicolons/README.md
@@ -26,30 +26,30 @@ The following patterns are considered warnings:
 ```
 
 ```css
-.foo {
+a {
   color: pink;;
 }
 ```
 
 ```css
-.foo {
+a {
   ;color: pink;
 }
 ```
 
 ```css
-.foo {
+a {
   color: pink;
   ;
 }
 ```
 
 ```css
-.foo {
+a {
   color: red;
 }
 ;
-.bar {
+b {
   color: white;
 }
 ```
@@ -61,7 +61,7 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-.foo {
+a {
   color: pink;
 }
 ```

--- a/src/rules/no-unknown-animations/README.md
+++ b/src/rules/no-unknown-animations/README.md
@@ -3,11 +3,11 @@
 Disallow animation names that do not correspond to a `@keyframes` declaration.
 
 ```css
-.foo { animation-name: fancy-slide; }
+a { animation-name: fancy-slide; }
 /**                    ↑
  *   This animation name */
 
-.foo { animation: fancy-slide 2s linear; }
+a { animation: fancy-slide 2s linear; }
 /**                    ↑
  *           And this one */
 ```
@@ -19,46 +19,46 @@ Disallow animation names that do not correspond to a `@keyframes` declaration.
 The following patterns are considered warnings:
 
 ```css
-.foo { animation-name: fancy-slide; }
+a { animation-name: fancy-slide; }
 ```
 
 ```css
-.foo { animation: fancy-slide 2s linear; }
+a { animation: fancy-slide 2s linear; }
 ```
 
 ```css
-.foo { animation-name: fancccy-slide; }
+a { animation-name: fancccy-slide; }
 @keyframes fancy-slide { ... }
 ```
 
 ```css
-.foo { animation: linear 100ms fancccy-slide; }
+a { animation: linear 100ms fancccy-slide; }
 @keyframes fancy-slide { ... }
 ```
 
 ```css
-.foo { animation-name: jump; }
+a { animation-name: jump; }
 @keyframes fancy-slide { ... }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-.foo { animation-name: fancy-slide; }
+a { animation-name: fancy-slide; }
 @keyframes fancy-slide { ... }
 ```
 
 ```css
 @keyframes fancy-slide { ... }
-.foo { animation-name: fancy-slide; }
+a { animation-name: fancy-slide; }
 ```
 
 ```css
 @keyframes fancy-slide { ... }
-.foo { animation: fancy-slide 2s linear; }
+a { animation: fancy-slide 2s linear; }
 ```
 
 ```css
-.foo { animation: 100ms steps(12, end) fancy-slide; }
+a { animation: 100ms steps(12, end) fancy-slide; }
 @keyframes fancy-slide { ... }
 ```

--- a/src/rules/no-unknown-animations/README.md
+++ b/src/rules/no-unknown-animations/README.md
@@ -28,37 +28,37 @@ a { animation: fancy-slide 2s linear; }
 
 ```css
 a { animation-name: fancccy-slide; }
-@keyframes fancy-slide { ... }
+@keyframes fancy-slide {}
 ```
 
 ```css
 a { animation: linear 100ms fancccy-slide; }
-@keyframes fancy-slide { ... }
+@keyframes fancy-slide {}
 ```
 
 ```css
 a { animation-name: jump; }
-@keyframes fancy-slide { ... }
+@keyframes fancy-slide {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
 a { animation-name: fancy-slide; }
-@keyframes fancy-slide { ... }
+@keyframes fancy-slide {}
 ```
 
 ```css
-@keyframes fancy-slide { ... }
+@keyframes fancy-slide {}
 a { animation-name: fancy-slide; }
 ```
 
 ```css
-@keyframes fancy-slide { ... }
+@keyframes fancy-slide {}
 a { animation: fancy-slide 2s linear; }
 ```
 
 ```css
 a { animation: 100ms steps(12, end) fancy-slide; }
-@keyframes fancy-slide { ... }
+@keyframes fancy-slide {}
 ```

--- a/src/rules/no-unsupported-browser-features/README.md
+++ b/src/rules/no-unsupported-browser-features/README.md
@@ -23,7 +23,7 @@ Defaults to the doiuse default, which is `"> 1%, last 2 versions, Firefox ESR, O
 The following patterns are considered warnings:
 
 ```css
-.foo { opacity: 0.5; }
+a { opacity: 0.5; }
 ```
 
 As IE8 (which as of this writing had *just over* 1% global usage) does not support `opacity`:

--- a/src/rules/number-max-precision/README.md
+++ b/src/rules/number-max-precision/README.md
@@ -25,7 +25,7 @@ a { top: 3.245634px; }
 ```
 
 ```css
-@media (min-width: 3.234em) { ... }
+@media (min-width: 3.234em) {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -35,5 +35,5 @@ a { top: 3.24px; }
 ```
 
 ```css
-@media (min-width: 3.23em) { ... }
+@media (min-width: 3.23em) {}
 ```

--- a/src/rules/number-max-precision/README.md
+++ b/src/rules/number-max-precision/README.md
@@ -3,7 +3,7 @@
 Limit the number of decimal places allowed in numbers.
 
 ```css
-.foo { top: 3.245634px; }
+a { top: 3.245634px; }
 /**           ↑
  * These decimal places */
 ```
@@ -17,11 +17,11 @@ For example, with `2`:
 The following patterns are considered warnings:
 
 ```css
-.foo { top: 3.245px; }
+a { top: 3.245px; }
 ```
 
 ```css
-.foo { top: 3.245634px; }
+a { top: 3.245634px; }
 ```
 
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-.foo { top: 3.24px; }
+a { top: 3.24px; }
 ```
 
 ```css

--- a/src/rules/property-no-unknown/README.md
+++ b/src/rules/property-no-unknown/README.md
@@ -3,8 +3,8 @@
 Disallow unknown properties.
 
 ```css
-.foo { heigth: 100%; }
-/**    ↑
+a { heigth: 100%; }
+/** ↑
  * These properties */
 ```
 
@@ -22,13 +22,13 @@ Use option `checkPrefixed` described below to turn on checking of vendor-prefixe
 The following patterns are considered warnings:
 
 ```css
-.foo {
+a {
   colr: blue;
 }
 ```
 
 ```css
-.foo {
+a {
   my-property: 1;
 }
 ```
@@ -36,31 +36,31 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-.foo {
+a {
   color: green;
 }
 ```
 
 ```css
-.foo {
+a {
   fill: black;
 }
 ```
 
 ```css
-.foo {
+a {
   -moz-align-self: center;
 }
 ```
 
 ```css
-.foo {
+a {
   -webkit-align-self: center;
 }
 ```
 
 ```css
-.foo {
+a {
   align-self: center;
 }
 ```
@@ -78,19 +78,19 @@ Given:
 The following patterns are *not* considered warnings:
 
 ```css
-.foo {
+a {
   my-property: 10px;
 }
 ```
 
 ```css
-.foo {
+a {
   my-other-property: 10px;
 }
 ```
 
 ```css
-.foo {
+a {
   custom: 10px;
 }
 ```
@@ -103,13 +103,13 @@ For example with `true`:
 The following patterns are *not* considered warnings:
 
 ```css
-.foo {
+a {
   -webkit-overflow-scrolling: auto;
 }
 ```
 
 ```css
-.foo {
+a {
   -moz-box-flex: 0;
 }
 ```
@@ -117,13 +117,13 @@ The following patterns are *not* considered warnings:
 The following patterns are considered  warnings:
 
 ```css
-.foo {
+a {
   -moz-align-self: center;
 }
 ```
 
 ```css
-.foo {
+a {
   -moz-overflow-scrolling: center;
 }
 ```

--- a/src/rules/selector-attribute-brackets-space-inside/README.md
+++ b/src/rules/selector-attribute-brackets-space-inside/README.md
@@ -3,7 +3,7 @@
 Require a single space or disallow whitespace on the inside of the brackets within attribute selectors.
 
 ```css
-.foo[ target=_blank ]
+    [ target=_blank ]
 /** ↑               ↑
  * The space inside these two brackets */
 ```

--- a/src/rules/selector-attribute-operator-blacklist/README.md
+++ b/src/rules/selector-attribute-operator-blacklist/README.md
@@ -3,8 +3,8 @@
 Specify a blacklist of disallowed attribute operators.
 
 ```css
-a[target="_blank"] { }
-/**     ↑
+[target="_blank"] { }
+/**    ↑
  * These operators */
 ```
 
@@ -27,11 +27,11 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-a[target] { }
+[target] { }
 ```
 
 ```css
-a[target="_blank"] { }
+[target="_blank"] { }
 ```
 
 ```css

--- a/src/rules/selector-attribute-operator-blacklist/README.md
+++ b/src/rules/selector-attribute-operator-blacklist/README.md
@@ -3,7 +3,7 @@
 Specify a blacklist of disallowed attribute operators.
 
 ```css
-[target="_blank"] { }
+[target="_blank"] {}
 /**    ↑
  * These operators */
 ```
@@ -21,19 +21,19 @@ Given:
 The following patterns are considered warnings:
 
 ```css
-[class*="test"] { }
+[class*="test"] {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-[target] { }
+[target] {}
 ```
 
 ```css
-[target="_blank"] { }
+[target="_blank"] {}
 ```
 
 ```css
-[class|="top"] { }
+[class|="top"] {}
 ```

--- a/src/rules/selector-attribute-operator-space-after/README.md
+++ b/src/rules/selector-attribute-operator-space-after/README.md
@@ -3,8 +3,8 @@
 Require a single space or disallow whitespace after operators within attribute selectors.
 
 ```css
-.foo[target= _blank]
-/**         ↑    
+[target= _blank]
+/**    ↑    
  * The space after operator */
 ```
 

--- a/src/rules/selector-attribute-operator-space-before/README.md
+++ b/src/rules/selector-attribute-operator-space-before/README.md
@@ -3,8 +3,8 @@
 Require a single space or disallow whitespace before operators within attribute selectors.
 
 ```css
-.foo[target =_blank]
-/**        ↑    
+[target =_blank]
+/**     ↑    
  * The space before operator */
 ```
 

--- a/src/rules/selector-attribute-operator-whitelist/README.md
+++ b/src/rules/selector-attribute-operator-whitelist/README.md
@@ -3,7 +3,7 @@
 Specify a whitelist of allowed attribute operators.
 
 ```css
-[target="_blank"] { }
+[target="_blank"] {}
 /**    ↑
  * These operators */
 ```
@@ -21,27 +21,27 @@ Given:
 The following patterns are considered warnings:
 
 ```css
-[class*="test"] { }
+[class*="test"] {}
 ```
 
 ```css
-[title~="flower"] { }
+[title~="flower"] {}
 ```
 
 ```css
-[class^="top"] { }
+[class^="top"] {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-[target] { }
+[target] {}
 ```
 
 ```css
-[target="_blank"] { }
+[target="_blank"] {}
 ```
 
 ```css
-[class|="top"] { }
+[class|="top"] {}
 ```

--- a/src/rules/selector-attribute-operator-whitelist/README.md
+++ b/src/rules/selector-attribute-operator-whitelist/README.md
@@ -3,8 +3,8 @@
 Specify a whitelist of allowed attribute operators.
 
 ```css
-a[target="_blank"] { }
-/**     ↑
+[target="_blank"] { }
+/**    ↑
  * These operators */
 ```
 
@@ -35,11 +35,11 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-a[target] { }
+[target] { }
 ```
 
 ```css
-a[target="_blank"] { }
+[target="_blank"] { }
 ```
 
 ```css

--- a/src/rules/selector-attribute-quotes/README.md
+++ b/src/rules/selector-attribute-quotes/README.md
@@ -3,7 +3,7 @@
 Require or disallow quotes for attribute values.
 
 ```css
-[target="_blank"] { }
+[target="_blank"] {}
 /**     ↑      ↑
  * These quotes */
 ```
@@ -19,33 +19,33 @@ Attribute values *must always* be quoted.
 The following patterns are considered warnings:
 
 ```css
-[title=flower] { }
+[title=flower] {}
 ```
 
 ```css
-[class^=top] { }
+[class^=top] {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-[title] { }
+[title] {}
 ```
 
 ```css
-[target="_blank"] { }
+[target="_blank"] {}
 ```
 
 ```css
-[class|="top"] { }
+[class|="top"] {}
 ```
 
 ```css
-[title~='text'] { }
+[title~='text'] {}
 ```
 
 ```css
-[data-attribute='component'] { }
+[data-attribute='component'] {}
 ```
 
 ### `"never"`
@@ -55,31 +55,31 @@ Attribute values *must never* be quoted.
 The following patterns are considered warnings:
 
 ```css
-[target="_blank"] { }
+[target="_blank"] {}
 ```
 
 ```css
-[class|="top"] { }
+[class|="top"] {}
 ```
 
 ```css
-[title~='text'] { }
+[title~='text'] {}
 ```
 
 ```css
-[data-attribute='component'] { }
+[data-attribute='component'] {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-[title] { }
+[title] {}
 ```
 
 ```css
-[title=flower] { }
+[title=flower] {}
 ```
 
 ```css
-[class^=top] { }
+[class^=top] {}
 ```

--- a/src/rules/selector-attribute-quotes/README.md
+++ b/src/rules/selector-attribute-quotes/README.md
@@ -3,8 +3,8 @@
 Require or disallow quotes for attribute values.
 
 ```css
-a[target="_blank"] { }
-/**      ↑      ↑
+[target="_blank"] { }
+/**     ↑      ↑
  * These quotes */
 ```
 
@@ -19,7 +19,7 @@ Attribute values *must always* be quoted.
 The following patterns are considered warnings:
 
 ```css
-a[title=flower] { }
+[title=flower] { }
 ```
 
 ```css
@@ -33,7 +33,7 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-a[target="_blank"] { }
+[target="_blank"] { }
 ```
 
 ```css
@@ -55,7 +55,7 @@ Attribute values *must never* be quoted.
 The following patterns are considered warnings:
 
 ```css
-a[target="_blank"] { }
+[target="_blank"] { }
 ```
 
 ```css

--- a/src/rules/selector-max-empty-lines/README.md
+++ b/src/rules/selector-max-empty-lines/README.md
@@ -3,9 +3,9 @@
 Limit the number of adjacent empty lines within selectors.
 
 ```css
-.foo,
+a,
               /* ← */
-.bar {        /* ↑ */
+b {        /* ↑ */
   color: red; /* ↑ */
 }             /* ↑ */
 /**              ↑
@@ -21,35 +21,35 @@ For example, with `0`:
 The following patterns are considered warnings:
 
 ```css
-.foo
+a
 
-.bar {
+b {
   color: red;
 }
 ```
 
 ```css
-.foo,
+a,
 
-.bar {
+b {
   color: red;
 }
 ```
 
 ```css
-.foo
+a
 
 >
-.bar {
+b {
   color: red;
 }
 ```
 
 ```css
-.foo
+a
 >
 
-.bar {
+b {
   color: red;
 }
 ```
@@ -57,35 +57,35 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-.foo .bar {
+a b {
   color: red;
 }
 ```
 
 ```css
-.foo
-.bar {
+a
+b {
   color: red;
 }
 ```
 
 ```css
-.foo,
-.bar {
+a,
+b {
   color: red;
 }
 ```
 
 ```css
-.foo > .bar {
+a > b {
   color: red;
 }
 ```
 
 ```css
-.foo 
-> 
-.bar {
+a
+>
+b {
   color: red;
 }
 ```

--- a/src/rules/selector-max-specificity/README.md
+++ b/src/rules/selector-max-specificity/README.md
@@ -27,7 +27,7 @@ For example, with `"0,2,0"`:
 The following patterns are considered warnings:
 
 ```css
-#id {}
+#foo {}
 ```
 
 ```css

--- a/src/rules/selector-nested-pattern/README.md
+++ b/src/rules/selector-nested-pattern/README.md
@@ -3,7 +3,7 @@
 Specify a pattern for the selectors of rules nested within rules.
 
 ```css
-    .foo {
+    a {
       color: orange;
       &:hover { color: pink; }
     } ↑
@@ -30,19 +30,19 @@ Given the string:
 The following patterns are considered warnings:
 
 ```css
-.foo {
+a {
   .bar {}
 }
 ```
 
 ```css
-.foo {
+a {
   .bar:hover {}
 }
 ```
 
 ```css
-.foo {
+a {
   &:hover,
   &:focus {}
 }
@@ -51,19 +51,19 @@ The following patterns are considered warnings:
 The following patterns are *not* considered warnings:
 
 ```css
-.foo {
+a {
   &:hover {}
 }
 ```
 
 ```css
-.foo {
+a {
   &:focus {}
 }
 ```
 
 ```css
-.foo {
+a {
   &:hover {}
   &:focus {}
 }

--- a/src/rules/selector-no-attribute/README.md
+++ b/src/rules/selector-no-attribute/README.md
@@ -3,7 +3,7 @@
 Disallow attribute selectors.
 
 ```css
-   a[rel="external"] {}
+    [rel="external"] {}
 /** ↑
  * This type of selector */
 ```
@@ -19,12 +19,12 @@ The following patterns are considered warnings:
 ```
 
 ```css
-a[rel="external"] {}
+[rel="external"] {}
 ```
 
 ```css
 a,
-.foo[type="text"] {}
+[type="text"] {}
 ```
 
 ```css
@@ -34,17 +34,13 @@ a > [foo] {}
 The following patterns are *not* considered warnings:
 
 ```css
+a {}
+```
+
+```css
 .foo {}
 ```
 
 ```css
-#foo {}
-```
-
-```css
-.bar > #foo {}
-```
-
-```css
-#foo.bar {}
+#bar {}
 ```

--- a/src/rules/selector-no-combinator/README.md
+++ b/src/rules/selector-no-combinator/README.md
@@ -31,7 +31,7 @@ a { color: pink; }
 ```
 
 ```css
-.foo, #bar { color: pink; }
+a, b { color: pink; }
 ```
 
 ```css

--- a/src/rules/selector-no-qualifying-type/README.md
+++ b/src/rules/selector-no-qualifying-type/README.md
@@ -3,7 +3,7 @@
 Disallow qualifying a selector by type.
 
 ```css
-    a.class {}
+    a.foo {}
 /** ↑
  * This type selector is qualifying the class */
 ```
@@ -17,13 +17,13 @@ A type selector is "qualifying" when it is compounded with (chained to) another 
 The following patterns are considered warnings:
 
 ```css
-div.class {
+a.foo {
   margin: 0
 }
 ```
 
 ```css
-div#id {
+a#foo {
   margin: 0
 }
 ```
@@ -37,13 +37,13 @@ input[type='button'] {
 The following patterns are *not* considered warnings:
 
 ```css
-.class {
+.foo {
   margin: 0
 }
 ```
 
 ```css
-#id {
+#foo {
   margin: 0
 }
 ```
@@ -77,7 +77,7 @@ Allow class selectors qualified by type.
 The following patterns are *not* considered warnings:
 
 ```css
-div.class {
+a.foo {
   margin: 0
 }
 ```
@@ -89,7 +89,7 @@ Allow id selectors qualified by type.
 The following patterns are *not* considered warnings:
 
 ```css
-div#id {
+a#foo {
   margin: 0
 }
 ```

--- a/src/rules/selector-no-type/README.md
+++ b/src/rules/selector-no-type/README.md
@@ -91,13 +91,13 @@ Given:
 The following patterns are *not* considered warnings:
 
 ```css
-custom { }
+custom {}
 ```
 
 ```css
-my-type { }
+my-type {}
 ```
 
 ```css
-my-other-type { }
+my-other-type {}
 ```

--- a/src/rules/selector-no-type/README.md
+++ b/src/rules/selector-no-type/README.md
@@ -59,11 +59,11 @@ Allow compounded type selectors -- i.e. type selectors chained with other select
 The following patterns are *not* considered warnings:
 
 ```css
-ul.foo {}
+a.foo {}
 ```
 
 ```css
-ul#bar {}
+a#bar {}
 ```
 
 #### `"descendant"`
@@ -73,11 +73,11 @@ Allow descendant type selectors.
 The following patterns are *not* considered warnings:
 
 ```css
-.foo ul {}
+.foo a {}
 ```
 
 ```css
-#bar ul.foo {}
+#bar a.foo {}
 ```
 
 ### `ignoreTypes: ["/regex/", "string"]`
@@ -85,13 +85,13 @@ The following patterns are *not* considered warnings:
 Given:
 
 ```js
-["/^my-/", "fieldset"]
+["/^my-/", "custom"]
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-fieldset { }
+custom { }
 ```
 
 ```css

--- a/src/rules/selector-pseudo-class-no-unknown/README.md
+++ b/src/rules/selector-pseudo-class-no-unknown/README.md
@@ -19,33 +19,33 @@ All vendor-prefixes pseudo-class selectors are ignored.
 The following patterns are considered warnings:
 
 ```css
-a:unknown { }
+a:unknown {}
 ```
 
 ```css
-a:UNKNOWN { }
+a:UNKNOWN {}
 ```
 
 ```css
-a:hoverr { }
+a:hoverr {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a:hover { }
+a:hover {}
 ```
 
 ```css
-a:focus { }
+a:focus {}
 ```
 
 ```css
-:not(p) { }
+:not(p) {}
 ```
 
 ```css
-input:-moz-placeholder { }
+input:-moz-placeholder {}
 ```
 
 ## Optional options
@@ -61,13 +61,13 @@ Given:
 The following patterns are *not* considered warnings:
 
 ```css
-a:pseudo-class { }
+a:pseudo-class {}
 ```
 
 ```css
-a:my-pseudo { }
+a:my-pseudo {}
 ```
 
 ```css
-a:my-other-pseudo { }
+a:my-other-pseudo {}
 ```

--- a/src/rules/selector-pseudo-element-no-unknown/README.md
+++ b/src/rules/selector-pseudo-element-no-unknown/README.md
@@ -19,33 +19,33 @@ All vendor-prefixes pseudo-element selectors are ignored.
 The following patterns are considered warnings:
 
 ```css
-a::pseudo { }
+a::pseudo {}
 ```
 
 ```css
-a::PSEUDO { }
+a::PSEUDO {}
 ```
 
 ```css
-a::element { }
+a::element {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-a:before { }
+a:before {}
 ```
 
 ```css
-a::before { }
+a::before {}
 ```
 
 ```css
-::selection { }
+::selection {}
 ```
 
 ```css
-input::-moz-placeholder { }
+input::-moz-placeholder {}
 ```
 
 ## Optional options
@@ -61,13 +61,13 @@ Given:
 The following patterns are *not* considered warnings:
 
 ```css
-a::pseudo-element { }
+a::pseudo-element {}
 ```
 
 ```css
-a::my-pseudo { }
+a::my-pseudo {}
 ```
 
 ```css
-a::my-other-pseudo { }
+a::my-other-pseudo {}
 ```

--- a/src/rules/selector-type-no-unknown/README.md
+++ b/src/rules/selector-type-no-unknown/README.md
@@ -17,25 +17,25 @@ This rule considers tags defined in the HTML and SVG Specifications to be known.
 The following patterns are considered warnings:
 
 ```css
-unknown { }
+unknown {}
 ```
 
 ```css
-tag { }
+tag {}
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-input { }
+input {}
 ```
 
 ```css
-ul li { }
+ul li {}
 ```
 
 ```css
-li > a { }
+li > a {}
 ```
 
 ## Optional options
@@ -51,13 +51,13 @@ Given:
 The following patterns are *not* considered warnings:
 
 ```css
-custom-type { }
+custom-type {}
 ```
 
 ```css
-my-type { }
+my-type {}
 ```
 
 ```css
-my-other-type { }
+my-other-type {}
 ```

--- a/src/rules/shorthand-property-no-redundant-values/README.md
+++ b/src/rules/shorthand-property-no-redundant-values/README.md
@@ -3,9 +3,9 @@
 Disallow redundant values in shorthand properties.
 
 ```css
-.foo { margin: 1px 1px 1px 1px; }
-/**                ↑   ↑   ↑
- *              These values */
+a { margin: 1px 1px 1px 1px; }
+/**             ↑   ↑   ↑
+ *           These values */
 ```
 
 This rule warns you when you use redundant values in the following shorthand properties:
@@ -24,39 +24,39 @@ This rule warns you when you use redundant values in the following shorthand pro
 The following patterns are considered warnings:
 
 ```css
-.foo { margin: 1px 1px; }
+a { margin: 1px 1px; }
 ```
 
 ```css
-.foo { margin: 1px 1px 1px 1px; }
+a { margin: 1px 1px 1px 1px; }
 ```
 
 ```css
-.foo { padding: 1px 2px 1px; }
+a { padding: 1px 2px 1px; }
 ```
 
 ```css
-.foo { border-radius: 1px 2px 1px 2px; }
+a { border-radius: 1px 2px 1px 2px; }
 ```
 
 ```css
-.foo { -webkit-border-radius: 1px 1px 1px 1px; }
+a { -webkit-border-radius: 1px 1px 1px 1px; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-.foo { margin: 1px; }
+a { margin: 1px; }
 ```
 
 ```css
-.foo { margin: 1px 1px 1px 2px; }
+a { margin: 1px 1px 1px 2px; }
 ```
 
 ```css
-.foo { padding: 1px 1em 1pt 1pc; }
+a { padding: 1px 1em 1pt 1pc; }
 ```
 
 ```css
-.foo { border-radius: 10px / 5px; }
+a { border-radius: 10px / 5px; }
 ```

--- a/src/rules/string-no-newline/README.md
+++ b/src/rules/string-no-newline/README.md
@@ -27,12 +27,12 @@ a {
 ```
 
 ```css
-a[title="something
+[title="something
 is probably wrong"] {}  
 ```
 
 ```css
-.foo {
+a {
   font-family: "Times
     New
     Roman";
@@ -54,12 +54,12 @@ a {
 ```
 
 ```css
-a[title="nothing\
+[title="nothing\
   is wrong"] {}  
 ```
 
 ```css
-.foo {
+a {
   font-family: "Times New Roman";
 }  
 ```

--- a/src/rules/time-no-imperceptible/README.md
+++ b/src/rules/time-no-imperceptible/README.md
@@ -3,9 +3,9 @@
 Disallow `animation` and `transition` less than or equal to 100ms.
 
 ```css
-.foo { animation: slip-n-slide 150ms linear; }
-/**                            ↑
- *                     This time */
+a { animation: slip-n-slide 150ms linear; }
+/**                         ↑
+ *                  This time */
 ```
 
 This rule checks `transition-duration`, `transition-delay`, `animation-duration`, `animation-delay`, and those times as they manifest in the `transition` and `animation` shorthands.
@@ -17,35 +17,35 @@ This rule checks `transition-duration`, `transition-delay`, `animation-duration`
 The following patterns are considered warnings:
 
 ```css
-.foo { animation: 80ms; }
+a { animation: 80ms; }
 ```
 
 ```css
-.foo { transition-duration: 0.08s; }
+a { transition-duration: 0.08s; }
 ```
 
 ```css
-.foo { transition: background-color 6ms linear; }
+a { transition: background-color 6ms linear; }
 ```
 
 ```css
-.foo { animation: horse-dance 1s linear 0.01s; }
+a { animation: horse-dance 1s linear 0.01s; }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-.foo { animation: 8s; }
+a { animation: 8s; }
 ```
 
 ```css
-.foo { transition-duration: 0.8s; }
+a { transition-duration: 0.8s; }
 ```
 
 ```css
-.foo { transition: background-color 600ms linear; }
+a { transition: background-color 600ms linear; }
 ```
 
 ```css
-.foo { animation: horse-dance 1s linear 1.3s; }
+a { animation: horse-dance 1s linear 1.3s; }
 ```

--- a/src/rules/value-no-vendor-prefix/README.md
+++ b/src/rules/value-no-vendor-prefix/README.md
@@ -3,8 +3,8 @@
 Disallow vendor prefixes for values.
 
 ```css
-.foo { display: -webkit-flex; }
-/**              ↑
+a { display: -webkit-flex; }
+/**          ↑
  *  These prefixes */
 ```
 
@@ -15,27 +15,27 @@ Disallow vendor prefixes for values.
 The following patterns are considered warnings:
 
 ```css
-.foo { display: -webkit-flex; }
+a { display: -webkit-flex; }
 ```
 
 ```css
-.foo { max-width: -moz-max-content; }
+a { max-width: -moz-max-content; }
 ```
 
 ```css
-.foo { background: -webkit-linear-gradient(bottom, #000, #fff); }
+a { background: -webkit-linear-gradient(bottom, #000, #fff); }
 ```
 
 The following patterns are *not* considered warnings:
 
 ```css
-.foo { display: flex; }
+a { display: flex; }
 ```
 
 ```css
-.foo { max-width: max-content; }
+a { max-width: max-content; }
 ```
 
 ```css
-.foo { background: linear-gradient(bottom, #000, #fff); }
+a { background: linear-gradient(bottom, #000, #fff); }
 ```


### PR DESCRIPTION
There’s quite a few inconsistencies to what code is used in our example patterns e.g. in most places we use the `a` type selector when the rule isn't concerned the selector itself, but in some cases we use `.foo`. This PR standardise everything to `a`, leaving `.foo` reserved for when the selector itself is being checked.

I’m finding these consistencies quite distracting when trying to quickly parse issues. Sometimes it takes a while to deconstruct what an example is trying to communicate. Hopefully keeping everything but the key thing consistent will help with this.

It also has the benefit of consistency for users looking through all the docs.