### PR TITLE
Document and test `string` options for rules that accept `array`|`string`

### DIFF
--- a/src/rules/selector-attribute-operator-blacklist/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-blacklist/__tests__/index.js
@@ -49,3 +49,20 @@ testRule(rule, {
     column: 7,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+
+  config: ["*="],
+
+  accept: [{
+    code: "a[target=\"_blank\"] { }",
+  }],
+
+  reject: [{
+    code: "[title*=\"foo\"] { }",
+    message: messages.rejected("*="),
+    line: 1,
+    column: 7,
+  }],
+})

--- a/src/rules/selector-attribute-operator-whitelist/__tests__/index.js
+++ b/src/rules/selector-attribute-operator-whitelist/__tests__/index.js
@@ -55,3 +55,20 @@ testRule(rule, {
     column: 7,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+
+  config: ["="],
+
+  accept: [{
+    code: "a[target=\"_blank\"] { }",
+  }],
+
+  reject: [{
+    code: "[title~=\"flower\"] { }",
+    message: messages.rejected("~="),
+    line: 1,
+    column: 7,
+  }],
+})

--- a/src/rules/unit-blacklist/README.md
+++ b/src/rules/unit-blacklist/README.md
@@ -10,7 +10,7 @@ a { width: 100px; }
 
 ## Options
 
-`array`: `"["array", "of", "units"]"`
+`array|string`: `["array", "of", "units"]|"unit"`
 
 Given:
 

--- a/src/rules/unit-blacklist/__tests__/index.js
+++ b/src/rules/unit-blacklist/__tests__/index.js
@@ -179,3 +179,20 @@ testRule(rule, {
     column: 17,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+
+  config: ["px"],
+
+  accept: [{
+    code: "a { line-height: 1em; }",
+  }],
+
+  reject: [{
+    code: "a { line-height: 1px; }",
+    message: messages.rejected("px"),
+    line: 1,
+    column: 18,
+  }],
+})

--- a/src/rules/unit-whitelist/README.md
+++ b/src/rules/unit-whitelist/README.md
@@ -10,7 +10,7 @@ a { width: 100px; }
 
 ## Options
 
-`array`: `"["array", "of", "units"]"`
+`array|string`: `["array", "of", "units"]|"unit"`
 
 Given:
 

--- a/src/rules/unit-whitelist/__tests__/index.js
+++ b/src/rules/unit-whitelist/__tests__/index.js
@@ -177,3 +177,20 @@ testRule(rule, {
     column: 17,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+
+  config: ["px"],
+
+  accept: [{
+    code: "a { line-height: 1px; }",
+  }],
+
+  reject: [{
+    code: "a { line-height: 1em; }",
+    message: messages.rejected("em"),
+    line: 1,
+    column: 18,
+  }],
+})


### PR DESCRIPTION
I noticed a couple of docs inconsistencies while working on #1807. This updates the docs and adds a few basic tests to ensure that rules that accept `array` or `string` will work as expected when passed a `string`.