### PR TITLE
Allow `configFile` and `configBasedir` to be used together

### DIFF
--- a/src/__tests__/buildConfig-test.js
+++ b/src/__tests__/buildConfig-test.js
@@ -107,6 +107,32 @@ test(
   t.plan(planned)
 })
 
+test(
+  "buildConfig finds config (via options.configFile), resolves plugin names into absolute paths, " +
+  "interpreting relative paths relative to configBasedir", t => {
+  let planned = 0
+
+  const optionsA = {
+    configFile: path.join(__dirname, "./fixtures/config-relative-plugin-nested.json"),
+    configBasedir: path.join(__dirname, "./fixtures/nested-plugin"),
+  }
+  buildConfig(optionsA).then(({ config, configDir }) => {
+    t.deepEqual(config, {
+      plugins: [
+        path.join(__dirname, "./fixtures/nested-plugin/plugin-nested-warn-about-foo.js"),
+      ],
+      rules: {
+        "plugin/warn-about-foo": "always",
+      },
+    }, "returns config")
+    t.equal(configDir, path.join(__dirname, "./fixtures/nested-plugin"
+    ), "uses configBasedir as configDir")
+  }).catch(logError)
+  planned += 2
+
+  t.plan(planned)
+})
+
 test("buildConfig extends", t => {
   let planned = 0
 

--- a/src/__tests__/fixtures/config-relative-plugin-nested.json
+++ b/src/__tests__/fixtures/config-relative-plugin-nested.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "./plugin-nested-warn-about-foo"
+  ],
+  "rules": {
+    "plugin/warn-about-foo": "always"
+  }
+}

--- a/src/__tests__/fixtures/nested-plugin/plugin-nested-warn-about-foo.js
+++ b/src/__tests__/fixtures/nested-plugin/plugin-nested-warn-about-foo.js
@@ -1,0 +1,24 @@
+import stylelint from "../../../"
+
+const ruleName = "plugin/warn-about-foo"
+
+const warnAboutFooMessages = stylelint.utils.ruleMessages("plugin/warn-about-foo", {
+  found: "found .foo",
+})
+
+export default stylelint.createPlugin(ruleName, function (expectation) {
+  return (root, result) => {
+    root.walkRules(rule => {
+      if (rule.selector === ".foo") {
+        if (expectation === "always") {
+          stylelint.utils.report({
+            result,
+            ruleName,
+            message: warnAboutFooMessages.found,
+            node: rule,
+          })
+        }
+      }
+    })
+  }
+})

--- a/src/buildConfig.js
+++ b/src/buildConfig.js
@@ -41,16 +41,17 @@ export default function (options) {
     if (options.rules) return options
     return null
   })()
-  const configBasedir = options.configBasedir || process.cwd()
+  const configBasedir = options.configBasedir || false
 
   if (rawConfig) {
-    return augmentConfig(rawConfig, configBasedir, {
+    const configDir = configBasedir || process.cwd()
+    return augmentConfig(rawConfig, configDir, {
       addIgnorePatterns: true,
       ignorePath: options.ignorePath,
     }).then(augmentedConfig => {
       return {
         config: merge(augmentedConfig, options.configOverrides),
-        configDir: configBasedir,
+        configDir,
       }
     })
   }
@@ -72,7 +73,7 @@ export default function (options) {
 
   return cosmiconfig("stylelint", cosmiconfigOptions).then(result => {
     if (!result) throw configurationError("No configuration found")
-    rootConfigDir = path.dirname(result.filepath)
+    rootConfigDir = configBasedir || path.dirname(result.filepath)
     return augmentConfig(result.config, rootConfigDir, {
       addIgnorePatterns: true,
       ignorePath: options.ignorePath,


### PR DESCRIPTION
Initial work on issue #1801

I'm not confident that these two tests are comprehensive. I wonder if splitting `augmentConfig` (and associated functions) out into a separate util would make this easier to test?

Refs #1801