### PR TITLE
Remove src folder from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "files": [
     "CONTRIBUTING.md",
     "dist",
-    "src",
     "docs",
     "!**/__tests__"
   ],


### PR DESCRIPTION
It appears to be unneeded and removing it halves the npm package size.

Ref: https://github.com/mxstbr/react-boilerplate/issues/893