### PR TITLE
Add colon to trigger valid-pattern style in docs.

### DIFF
--- a/src/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/src/rules/media-feature-name-no-vendor-prefix/README.md
@@ -28,7 +28,7 @@ The following patterns are considered warnings:
 @media (-o-max-device-pixel-ratio: 1/1) {}
 ```
 
-The following patterns are *not* considered warnings
+The following patterns are *not* considered warnings:
 
 ```css
 @media (min-resolution: 96dpi) {}


### PR DESCRIPTION
`media-feature-name-no-vendor-prefix` was styling both set of examples invalid as it looks for the exact phrase (https://github.com/stylelint/stylelint.io/blob/f38a22e9a234f1a314982d56926ae6f5d172a0ce/web_modules/layouts/Page/index.js#L10).