### PR TITLE
Update the greenkeeper label

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,9 @@
       "template-curly-spacing": 2
     }
   },
+  "greenkeeper": {
+    "label": "PR: review needed"
+  },
   "remarkConfig": {
     "presets": [
       "lint-recommended",


### PR DESCRIPTION
To our standard “PR: review needed” one.

It’ll save us click or two each time :)