### PR TITLE
Fixed: `--ignore-path` and `--report-needless-disables` no longer fails when used together.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Head
+
+-   Fixed: `--ignore-path` and `--report-needless-disables` no longer fails when used together.
+
 # 7.2.0
 
 -   Added: `--report-needless-disables` and `reportNeedlessDisables` option.

--- a/src/__tests__/fixtures/needlessDisables/.stylelintignore
+++ b/src/__tests__/fixtures/needlessDisables/.stylelintignore
@@ -1,0 +1,3 @@
+# Ignore file patterns are always relative to process.cwd()
+
+**/ignored-file.css

--- a/src/__tests__/fixtures/needlessDisables/ignored-file.css
+++ b/src/__tests__/fixtures/needlessDisables/ignored-file.css
@@ -1,0 +1,3 @@
+/* stylelint-disable color-named */
+a {}
+/* stylelint-enable */

--- a/src/__tests__/needlessDisables-test.js
+++ b/src/__tests__/needlessDisables-test.js
@@ -80,3 +80,33 @@ test("needlessDisables complex case", t => {
     t.end()
   }).catch(t.end)
 })
+
+test("needlessDisables ignored case", t => {
+  const config = {
+    rules: {
+      "block-no-empty": true,
+    },
+  }
+
+  standalone({
+    config,
+    files: [
+      fixture("disabled-ranges-1.css"),
+      fixture("ignored-file.css"),
+    ],
+    ignoreDisables: true,
+    ignorePath: fixture(".stylelintignore"),
+  }).then(({ results }) => {
+    t.deepEqual(needlessDisables(results), [
+      {
+        source: fixture("disabled-ranges-1.css"),
+        ranges: [
+          { start: 1, end: 3 },
+          { start: 5, end: 7 },
+          { start: 10, end: 10 },
+        ],
+      },
+    ])
+    t.end()
+  }).catch(t.end)
+})

--- a/src/needlessDisables.js
+++ b/src/needlessDisables.js
@@ -7,6 +7,8 @@ export default function (results) {
     const unused = { source: result.source, ranges: [] }
     const rangeData = _.cloneDeep(result._postcssResult.stylelint.disabledRanges)
 
+    if (!rangeData) { return }
+
     result.warnings.forEach(warning => {
       const { rule } = warning
 


### PR DESCRIPTION
Close https://github.com/stylelint/stylelint/issues/1867.
/cc @davidtheclark @jeddy3 