### PR TITLE
Fixed: the `indentation` rule now correctly handles `_` hacks on property names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 -   Fixed: `--ignore-path` and `--report-needless-disables` no longer fails when used together.
+-   Fixed: the `indentation` rule now correctly handles `_` hacks on property names.
 
 # 7.2.0
 

--- a/src/rules/indentation/__tests__/rules.js
+++ b/src/rules/indentation/__tests__/rules.js
@@ -83,6 +83,10 @@ testRule(rule, {
     "  *top: 1px;\n" +
     "}",
   }, {
+    code: "a {\n" +
+    "  _top: 1px;\n" +
+    "}",
+  }, {
     code: "* { top: 0; }",
   }, {
     code: "@media print {\n" +
@@ -156,6 +160,10 @@ testRule(rule, {
   }, {
     code: "a {\r\n" +
     "  *top: 1px;\r\n" +
+    "}",
+  }, {
+    code: "a {\r\n" +
+    "  _top: 1px;\r\n" +
     "}",
   }, {
     code: "* { top: 0; }",

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -61,7 +61,7 @@ export default function (space, options = {}) {
       const inspectBefore = (root.first === node) || before.indexOf("\n") !== -1
 
       // Cut out any * hacks from `before`
-      before = (before[before.length - 1] === "*")
+      before = (before[before.length - 1] === "*" || before[before.length - 1] === "_")
         ? before.slice(0, before.length - 1)
         : before
 


### PR DESCRIPTION
Close https://github.com/stylelint/stylelint/issues/1787.
/cc @davidtheclark @jeddy3 