### PR TITLE
Fixed: `block-no-single-line` now ignores empty blocks (#1828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+-   Fixed: `block-no-single-line` now ignores empty blocks.
 -   Fixed: `--ignore-path` and `--report-needless-disables` no longer fails when used together.
 -   Fixed: the `indentation` rule now correctly handles `_` hacks on property names.
 

--- a/src/rules/block-no-single-line/__tests__/index.js
+++ b/src/rules/block-no-single-line/__tests__/index.js
@@ -10,12 +10,9 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
   config: [true],
-  skipBasicChecks: true,
 
   accept: [ {
-    code: "",
-  }, {
-    code: "@import \"foo.css\";",
+    code: "a { }",
   }, {
     code: "a {\ncolor: pink; }",
     description: "multi-line declaration block with newline at start",

--- a/src/rules/block-no-single-line/index.js
+++ b/src/rules/block-no-single-line/index.js
@@ -2,6 +2,7 @@ import {
   beforeBlockString,
   blockString,
   hasBlock,
+  hasEmptyBlock,
   isSingleLineString,
   report,
   ruleMessages,
@@ -24,7 +25,7 @@ export default function (actual) {
     root.walkAtRules(check)
 
     function check(statement) {
-      if (!hasBlock(statement)) { return }
+      if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
       if (!isSingleLineString(blockString(statement))) { return }
 
       report({


### PR DESCRIPTION
Closes #1828 