### PR TITLE
Fix error when no args in url-prefix() brackets

### DIFF
--- a/src/rules/function-url-quotes/README.md
+++ b/src/rules/function-url-quotes/README.md
@@ -30,6 +30,11 @@ The following patterns are considered warnings:
 @font-face { font-family: 'foo'; src: url(foo.ttf); }
 ```
 
+```css
+@-moz-document url-prefix() {
+}
+```
+
 The following patterns are *not* considered warnings:
 
 ```css
@@ -46,6 +51,11 @@ a { background: url('x.jpg'); }
 
 ```css
 @font-face { font-family: "foo"; src: url("foo.ttf"); }
+```
+
+```css
+@-moz-document url-prefix('') {
+}
 ```
 
 ### `"never"`
@@ -78,4 +88,16 @@ a { background: url(x.jpg); }
 
 ```css
 @font-face { font-family: 'foo'; src: url(foo.ttf); }
+```
+
+## Optional secondary options
+
+### `except: ["empty"]`
+Do not require quotes if argument is empty
+
+The following pattern is *not* considered warnings:
+
+```css
+@-moz-document url-prefix() {
+}
 ```

--- a/src/rules/function-url-quotes/README.md
+++ b/src/rules/function-url-quotes/README.md
@@ -31,8 +31,7 @@ The following patterns are considered warnings:
 ```
 
 ```css
-@-moz-document url-prefix() {
-}
+@-moz-document url-prefix() {}
 ```
 
 The following patterns are *not* considered warnings:
@@ -54,8 +53,7 @@ a { background: url('x.jpg'); }
 ```
 
 ```css
-@-moz-document url-prefix('') {
-}
+@-moz-document url-prefix('') {}
 ```
 
 ### `"never"`
@@ -93,11 +91,13 @@ a { background: url(x.jpg); }
 ## Optional secondary options
 
 ### `except: ["empty"]`
-Do not require quotes if argument is empty
+
+Reverse the primary option if the function has no arguments.
+
+For example, with `"always"`.
 
 The following pattern is *not* considered warnings:
 
 ```css
-@-moz-document url-prefix() {
-}
+@-moz-document url-prefix() {}
 ```

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -146,10 +146,6 @@ testRule(rule, {
   }, {
     code: "a { background: url(\"/images/my_image@2x.png\") }",
   }, {
-    code: "@-moz-document url-prefix() {}",
-  }, {
-    code: "a { background: url() }",
-  }, {
     code: "a { background: url(\"\") }",
   } ],
 
@@ -430,5 +426,16 @@ testRule(rule, {
     message: messages.rejected(),
     line: 1,
     column: 21,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", { except: ["empty"] } ],
+
+  accept: [ {
+    code: "@-moz-document url-prefix() {}",
+  }, {
+    code: "a { background: url() }",
   } ],
 })

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -439,12 +439,22 @@ testRule(rule, {
     code: "a { background: url() }",
   } ],
 
-  reject: [{
+  reject: [ {
     code: "@import url(foo.css);",
     message: messages.expected(),
     line: 1,
     column: 13,
-  }],
+  }, {
+    code: "@import url('');",
+    message: messages.rejected(),
+    line: 1,
+    column: 13,
+  }, {
+    code: "@import url(\"\");",
+    message: messages.rejected(),
+    line: 1,
+    column: 13,
+  } ],
 })
 
 testRule(rule, {
@@ -456,6 +466,8 @@ testRule(rule, {
   }, {
     code: "a { background: url(\"\") }",
   }, {
+    code: "a { background: url('') }",
+  }, {
     code: "@import url(foo.css);",
   } ],
 
@@ -465,6 +477,11 @@ testRule(rule, {
     code: "a { background: url() }",
   }, {
     code: "@import url(\"foo.css\");",
+    message: messages.rejected(),
+    line: 1,
+    column: 13,
+  }, {
+    code: "@import url('foo.css');",
     message: messages.rejected(),
     line: 1,
     column: 13,

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -438,4 +438,35 @@ testRule(rule, {
   }, {
     code: "a { background: url() }",
   } ],
+
+  reject: [{
+    code: "@import url(foo.css);",
+    message: messages.expected(),
+    line: 1,
+    column: 13,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "never", { except: ["empty"] } ],
+
+  accept: [ {
+    code: "@-moz-document url-prefix(\"\") {}",
+  }, {
+    code: "a { background: url(\"\") }",
+  }, {
+    code: "@import url(foo.css);",
+  } ],
+
+  reject: [ {
+    code: "@-moz-document url-prefix() {}",
+  }, {
+    code: "a { background: url() }",
+  }, {
+    code: "@import url(\"foo.css\");",
+    message: messages.rejected(),
+    line: 1,
+    column: 13,
+  } ],
 })

--- a/src/rules/function-url-quotes/__tests__/index.js
+++ b/src/rules/function-url-quotes/__tests__/index.js
@@ -145,6 +145,12 @@ testRule(rule, {
     code: "@font-face { font-family: 'foo'; src: url($variable + \"foo.ttf\" + $variable); }",
   }, {
     code: "a { background: url(\"/images/my_image@2x.png\") }",
+  }, {
+    code: "@-moz-document url-prefix() {}",
+  }, {
+    code: "a { background: url() }",
+  }, {
+    code: "a { background: url(\"\") }",
   } ],
 
   reject: [ {

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -69,7 +69,7 @@ export default function (expectation, options) {
       const hasQuotes = leftTrimmedArgs[0] === "'" || leftTrimmedArgs[0] === "\""
 
       const trimmedArg = args.trim()
-      const isEmptyArgument = [ "", "'", "\"\"" ].includes(trimmedArg)
+      const isEmptyArgument = [ "", "''", "\"\"" ].includes(trimmedArg)
       if (optionsMatches(options, "except", "empty") && isEmptyArgument) {
         shouldHasQuotes = !shouldHasQuotes
       }

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -54,6 +54,9 @@ export default function (expectation) {
     }
 
     function checkArgs(args, node, index, functionName) {
+      // skip empty brackets
+      if (args === "") { return }
+
       const leftTrimmedArgs = args.trimLeft()
       if (!isStandardSyntaxUrl(leftTrimmedArgs)) { return }
       const complaintIndex = index + args.length - leftTrimmedArgs.length

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -10,11 +10,15 @@ import {
 export const ruleName = "function-url-quotes"
 
 export const messages = ruleMessages(ruleName, {
-  expected: (f = "url") => `Expected quotes around ${f} argument`,
-  rejected: (f = "url") => `Unexpected quotes around ${f} argument`,
+  expected: () => "Expected quotes",
+  rejected: () => "Unexpected quotes",
 })
 
-export default function (expectation) {
+const defaultOptions = {
+  except: [],
+}
+
+export default function (expectation, options = defaultOptions) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -22,6 +26,11 @@ export default function (expectation) {
         "always",
         "never",
       ],
+    }, {
+      actual: options,
+      possible: {
+        except: ["empty"],
+      },
     })
     if (!validOptions) { return }
 
@@ -54,8 +63,8 @@ export default function (expectation) {
     }
 
     function checkArgs(args, node, index, functionName) {
-      // skip empty brackets
-      if (args === "") { return }
+      const argumentIsEmpty = args === ""
+      if (argumentIsEmpty && options.except.includes("empty")) { return }
 
       const leftTrimmedArgs = args.trimLeft()
       if (!isStandardSyntaxUrl(leftTrimmedArgs)) { return }

--- a/src/rules/function-url-quotes/index.js
+++ b/src/rules/function-url-quotes/index.js
@@ -7,6 +7,7 @@ import {
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import _ from "lodash"
 
 export const ruleName = "function-url-quotes"
 
@@ -69,7 +70,7 @@ export default function (expectation, options) {
       const hasQuotes = leftTrimmedArgs[0] === "'" || leftTrimmedArgs[0] === "\""
 
       const trimmedArg = args.trim()
-      const isEmptyArgument = [ "", "''", "\"\"" ].includes(trimmedArg)
+      const isEmptyArgument = _.includes([ "", "''", "\"\"" ], trimmedArg)
       if (optionsMatches(options, "except", "empty") && isEmptyArgument) {
         shouldHasQuotes = !shouldHasQuotes
       }


### PR DESCRIPTION
`function-url-quotes` rule throw error `Expected quotes around url-prefix argument` when no arguments in brackets.

Example:
```css
@-moz-document url-prefix() { // Error: Expected quotes around url-prefix argument
  /* styles for Firefox */
}
```
