### PR TITLE
Allow a trailing semicolon in block-closing-brace-*-after (#1806)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+-   Fixed: `block-closing-brace-newline-after` and `block-closing-brace-space-after` now allow a trailing semicolon after the closing brace of a block.
 -   Added: `processors` can accept options objects.
 -   Added: `ignore: ["inside-function"]` option to `color-named`.
 -   Fixed: `declaration-block-no-ignored-properties` now uses the value of the last occurrence of a triggering property.

--- a/src/rules/block-closing-brace-newline-after/README.md
+++ b/src/rules/block-closing-brace-newline-after/README.md
@@ -17,6 +17,18 @@ a {
 } /* end-of-line comment */
 ```
 
+This rule allows a trailing semicolon after the closing brace of a block. For example,
+
+```css
+:root {
+  --toolbar-theme: {
+    background-color: hsl(120, 70%, 95%);
+  };
+/* ↑
+ * This semicolon */  
+}
+```
+
 ## Options
 
 `string`: `"always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

--- a/src/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -40,6 +40,12 @@ testRule(rule, {
     code: ".a {} /* stylelint-disable-line block-no-empty */",
   }, {
     code: ".a {} /* stylelint-disable-line block-no-empty */\n b {}",
+  }, {
+    code: ":root {\n --x { color: pink; };\n --y { color: red; };\n }",
+    description: "Allow a trailing semicolon after the closing brace of a block",
+  }, {
+    code: ".foo {\n --my-theme: { color: red; };\n --toolbar-theme: { color: green; };\n }",
+    description: "Make sure trailing semicolon works well for blocks outside :root",
   } ],
 
   reject: [ {
@@ -77,6 +83,22 @@ testRule(rule, {
     message: messages.expectedAfter(),
     line: 1,
     column: 6,
+  }, {
+    code: ":root {\n --x { color: pink; } ;\n --y { color: red; };\n }",
+    message: messages.expectedAfter(),
+    line: 2,
+    column: 22,
+  }, {
+    code: ":root {\n --x { color: pink; }; \n --y { color: red; };\n }",
+    message: messages.expectedAfter(),
+    line: 2,
+    column: 23,
+  }, {
+    code: ".foo {\n --my-theme: { color: red; }; \n --toolbar-theme: { color: green; };\n }",
+    description: "Make sure trailing semicolon works well for blocks outside :root",
+    message: messages.expectedAfter(),
+    line: 2,
+    column: 30,
   } ],
 })
 

--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -62,17 +62,26 @@ export default function (expectation, options) {
       const nodeToCheck = (nextNodeIsSingleLineComment) ? nextNode.next() : nextNode
       if (!nodeToCheck) { return }
 
+      let reportIndex = statement.toString().length
+      let source = rawNodeString(nodeToCheck)
+
+      // Skip a semicolon at the beginning, if any
+      if (source && source[0] === ";") {
+        source = source.slice(1)
+        reportIndex++
+      }
+
       // Only check one after, because there might be other
       // spaces handled by the indentation rule
       checker.afterOneOnly({
-        source: rawNodeString(nodeToCheck),
+        source,
         index: -1,
         lineCheckStr: blockString(statement),
         err: msg => {
           report({
             message: msg,
             node: statement,
-            index: statement.toString().length,
+            index: reportIndex,
             result,
             ruleName,
           })

--- a/src/rules/block-closing-brace-space-after/README.md
+++ b/src/rules/block-closing-brace-space-after/README.md
@@ -8,6 +8,18 @@ a { color: pink; }
  * The space after this brace */
 ```
 
+This rule allows a trailing semicolon after the closing brace of a block. For example,
+
+```css
+:root {
+  --toolbar-theme: {
+    background-color: hsl(120, 70%, 95%);
+  };
+/* ↑
+ * This semicolon */
+}
+```
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

--- a/src/rules/block-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/block-closing-brace-space-after/__tests__/index.js
@@ -30,6 +30,12 @@ testRule(rule, {
     code: "@media print { a { color: pink; }} @media screen { b { color: red; }}",
   }, {
     code: ".a {} /* stylelint-disable-line block-no-empty */",
+  }, {
+    code: ":root { --x { color: pink; }; --y { color: red; }; }",
+    description: "Allow a trailing semicolon after the closing brace of a block",
+  }, {
+    code: ".foo { --my-theme: { color: red; }; --toolbar-theme: { color: green; }; }",
+    description: "Make sure trailing semicolon works well for blocks outside :root",
   } ],
 
   reject: [ {
@@ -68,6 +74,17 @@ testRule(rule, {
     message: messages.expectedAfter(),
     line: 1,
     column: 35,
+  }, {
+    code: ":root { --x { color: pink; };--y { color: red; }; }",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 30,
+  }, {
+    code: ".foo { --my-theme: { color: red; };--toolbar-theme: { color: green; }; }",
+    description: "Make sure trailing semicolon works well for blocks outside :root",
+    message: messages.expectedAfter(),
+    line: 1,
+    column: 36,
   } ],
 })
 

--- a/src/rules/block-closing-brace-space-after/index.js
+++ b/src/rules/block-closing-brace-space-after/index.js
@@ -46,15 +46,24 @@ export default function (expectation) {
       if (!nextNode) { return }
       if (!hasBlock(statement)) { return }
 
+      let reportIndex = statement.toString().length
+      let source = rawNodeString(nextNode)
+
+      // Skip a semicolon at the beginning, if any
+      if (source && source[0] === ";") {
+        source = source.slice(1)
+        reportIndex++
+      }
+
       checker.after({
-        source: rawNodeString(nextNode),
+        source,
         index: -1,
         lineCheckStr: blockString(statement),
         err: msg => {
           report({
             message: msg,
             node: statement,
-            index: statement.toString().length,
+            index: reportIndex,
             result,
             ruleName,
           })


### PR DESCRIPTION
Closes #1806 