### PR TITLE
Fixed: False positives when triggering property is overriden in declaration-block-no-ignored-properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Head
 
 -   Added: `ignore: ["inside-function"]` option to `color-named`.
+-   Fixed: `declaration-block-no-ignored-properties` now uses the value of the last occurrence of a triggering property.
 -   Fixed: `block-no-single-line` now ignores empty blocks.
 -   Fixed: `--ignore-path` and `--report-needless-disables` no longer fails when used together.
 -   Fixed: the `indentation` rule now correctly handles `_` hacks on property names.

--- a/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/__tests__/index.js
@@ -91,6 +91,10 @@ testRule(rule, {
     code: "a { display: inline; &:hover { width: 100px; } }",
   }, {
     code: "a { display: inline; &::before { width: 100px; } }",
+  }, {
+    code: "a { display: inline; display: inline-block; width: 100px; }",
+  }, {
+    code: "a { display: inline; width: 100px; display: inline-block; }",
   } ],
 
   reject: [ {

--- a/src/rules/declaration-block-no-ignored-properties/index.js
+++ b/src/rules/declaration-block-no-ignored-properties/index.js
@@ -130,10 +130,15 @@ export default function (actual) {
 
     if (!validOptions) { return }
 
-    root.walkDecls((decl, index) => {
-      const { prop, value } = decl
+    const uniqueDecls = {}
+    root.walkDecls((decl) => {
+      uniqueDecls[decl.prop] = decl
+    })
+
+    Object.keys(uniqueDecls).forEach((prop, index) => {
+      const decl = uniqueDecls[prop]
       const unprefixedProp = vendor.unprefixed(prop)
-      const unprefixedValue = vendor.unprefixed(value)
+      const unprefixedValue = vendor.unprefixed(decl.value)
 
       ignored.forEach(ignore => {
         const matchProperty = matchesStringOrRegExp(unprefixedProp.toLowerCase(), ignore.property)


### PR DESCRIPTION
Follow up of #1880. Sorry, I somehow messed up the rebase, and had to create a new branch.