### PR TITLE
Properties warned about by declaration-block-no-ignored-properties are not always ignored

### DIFF
--- a/src/rules/declaration-block-no-ignored-properties/README.md
+++ b/src/rules/declaration-block-no-ignored-properties/README.md
@@ -10,6 +10,8 @@ a { display: inline; width: 100px; }
 
 Certain property value pairs rule out other property value pairs, causing them to be ignored by the browser. For example, when an element has display: inline, any further declarations about width, height and margin-top properties will be ignored. Sometimes this is confusing: maybe you forgot that your margin-top will have no effect because the element has display: inline, so you spend a while struggling to figure out what you've done wrong. This rule protects against that confusion by ensuring that within a single rule you don't use property values that are ruled out by other property values in that same rule.
 
+Note that these properties are not ignored on all elements with display: inline set, especially they __do__ have effect on img elements.
+
 The rule warns when it finds:
 
 -   `display: inline` used with `width`, `height`, `margin`, `margin-top`, `margin-bottom`, `overflow` (and all variants).


### PR DESCRIPTION
This PR simply adds a note to rule’s README file. Something more sophisticated may be done, e.g. disabling the rule, when selector targets `img` elements.

declaration-block-no-ignored-properties rule warns about properties ignored with certain display values. They are not always ignored — e.g. `img` and `object` elements with `display: inline` set _do_ respect `width` and such.

# Test case

(also [on codepen](http://codepen.io/marek-saji/pen/BLzzXJ?editors=1100))

## Code

```html
<p>p</p>

<i>i</i>

<img src alt=img>

<object>object</object>

empty object: <object></object>
```

```css
body { padding: 1em; font-size: 3em; }

body > *
{
  outline: red solid;
  background: green;
  display: inline;
  vertical-align: top;
  
  max-height: 2em;
  width: 5em;
  margin-top: 1em;
}
```

## Result

![image](https://cloud.githubusercontent.com/assets/192323/18584890/e9172648-7c13-11e6-8d13-f57669d37fc7.png)