### PR TITLE
Fixed: regression of 7.3.0 which caused a "Cannot read property 'length' of undefined" error on certain selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+-   Fixed: regression of 7.3.0 which caused a "Cannot read property 'length' of undefined" error on certain selector.
+
 # 7.3.0
 
 -   Added: `processors` can accept options objects.

--- a/src/utils/__tests__/isStandardSyntaxDeclaration-test.js
+++ b/src/utils/__tests__/isStandardSyntaxDeclaration-test.js
@@ -6,7 +6,7 @@ import test from "tape"
 
 test("isStandardSyntaxDeclaration", t => {
 
-  t.plan(21)
+  t.plan(22)
 
   rules("a { a: b }", decl => {
     t.ok(isStandardSyntaxDeclaration(decl), "standard prop and value")
@@ -19,6 +19,9 @@ test("isStandardSyntaxDeclaration", t => {
   })
   rules("a { a : calc(b + c) }", decl => {
     t.ok(isStandardSyntaxDeclaration(decl), "standard prop and calc value")
+  })
+  rules("@page { size: A4 }", decl => {
+    t.ok(isStandardSyntaxDeclaration(decl), "does not break @selector")
   })
   scssRules("a { #{$var}: 10px; }", decl => {
     t.ok(isStandardSyntaxDeclaration(decl), "property with scss variable interpolation (only)")

--- a/src/utils/isStandardSyntaxDeclaration.js
+++ b/src/utils/isStandardSyntaxDeclaration.js
@@ -18,7 +18,7 @@ export default function (decl) {
   if (prop[0] === "@" && prop[1] !== "{") { return false }
 
   // SCSS nested properties (e.g. border: { style: solid; color: red; })
-  if (parent.selector[parent.selector.length - 1] === ":" && parent.selector.substring(0, 2) !== "--") { return false }
+  if (parent.selector && parent.selector[parent.selector.length - 1] === ":" && parent.selector.substring(0, 2) !== "--") { return false }
 
   return true
 }


### PR DESCRIPTION
Should closes #1914

Not sure why but until I update t.plan I got no failure by doing `babel-tape-runner src/utils/__tests__/isStandardSyntaxDeclaration-test.js`: the test was just not in the result, this was a weird experience :)