### PR TITLE
Fixed: `no-unknown-animations` no longer delivers false positives for multiple animation names

### DIFF
--- a/src/rules/no-unknown-animations/__tests__/index.js
+++ b/src/rules/no-unknown-animations/__tests__/index.js
@@ -107,6 +107,12 @@ testRule(rule, {
   }, {
     code: "@keyframes foo {} a { animation: foo .1s ease .2s 1 both; }",
     description: "animation shorthand",
+  }, {
+    code: "@keyframes foo {} @keyframes bar {} a { animation-name: foo, bar; }",
+    description: "multiple animation names",
+  }, {
+    code: "@keyframes foo {} a { animation-name: none, foo; }",
+    description: "multiple animation names and keyword none",
   } ],
 
   reject: [ {
@@ -169,5 +175,17 @@ testRule(rule, {
     message: messages.rejected("BAZ"),
     line: 1,
     column: 16,
+  }, {
+    code: "@keyframes foo {} a { animation-name: foo, bar; }",
+    description: "multiple animation names",
+    message: messages.rejected("bar"),
+    line: 1,
+    column: 44,
+  }, {
+    code: "@keyframes foo {} a { animation-name: none, bar; }",
+    description: "multiple animation names",
+    message: messages.rejected("bar"),
+    line: 1,
+    column: 45,
   } ],
 })

--- a/src/rules/no-unknown-animations/index.js
+++ b/src/rules/no-unknown-animations/index.js
@@ -1,14 +1,11 @@
 import {
-  animationNameKeywords,
-  basicKeywords,
-} from "../../reference/keywordSets"
-import {
   declarationValueIndex,
   findAnimationName,
   report,
   ruleMessages,
   validateOptions,
 } from "../../utils"
+import { animationNameKeywords } from "../../reference/keywordSets"
 
 export const ruleName = "no-unknown-animations"
 
@@ -27,33 +24,24 @@ export default function (actual) {
     })
 
     root.walkDecls(decl => {
-      if (decl.prop.toLowerCase() === "animation-name"
-        && !animationNameKeywords.has(decl.value.toLowerCase())
-      ) {
-        checkAnimationName(decl.value, decl)
-      }
-
-      if (decl.prop.toLowerCase() === "animation") {
+      if (decl.prop.toLowerCase() === "animation" || decl.prop.toLowerCase() === "animation-name") {
         const animationNames = findAnimationName(decl.value)
+
         if (animationNames.length === 0) { return }
 
         animationNames.forEach((animationNameNode) => {
-          if (basicKeywords.has(animationNameNode.value.toLowerCase())) { return }
+          if (animationNameKeywords.has(animationNameNode.value.toLowerCase())) { return }
+          if (declaredAnimations.has(animationNameNode.value)) { return }
 
-          checkAnimationName(animationNameNode.value, decl, animationNameNode.sourceIndex)
+          report({
+            result,
+            ruleName,
+            message: messages.rejected(animationNameNode.value),
+            node: decl,
+            index: declarationValueIndex(decl) + animationNameNode.sourceIndex,
+          })
         })
       }
     })
-
-    function checkAnimationName(animationName, decl, offset = 0) {
-      if (declaredAnimations.has(animationName)) { return }
-      report({
-        result,
-        ruleName,
-        message: messages.rejected(animationName),
-        node: decl,
-        index: declarationValueIndex(decl) + offset,
-      })
-    }
   }
 }


### PR DESCRIPTION
<!--- Please read the following. Pull requests that do not adhere to these guidelines will be closed. -->

<!--- Each pull request must, with the exception of minor documentation fixes, be associated with an open issue.  -->
<!--- If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first. -->

<!--- If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide: -->
- [ ] Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule
- [ ] Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules
- [x] Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

<!--- If you've done that, then please continue and create this pull request. Thank you for contributing. -->

Close https://github.com/stylelint/stylelint/issues/1902