### PR TITLE
Fix minor formatting problem in documentation

### DIFF
--- a/src/rules/custom-property-empty-line-before/README.md
+++ b/src/rules/custom-property-empty-line-before/README.md
@@ -6,7 +6,7 @@ Require or disallow an empty line before custom properties.
 a {
   top: 10px;
                           /* ← */
-  --foo: pink;  /* ↑ */   
+  --foo: pink;            /* ↑ */
 }                         /* ↑ */
 /**                          ↑
  *                   This line */


### PR DESCRIPTION
Just a small formatting fix in the README.md of `custom-property-empty-line-before`

[Visible on the corresponding stylelint.io page](http://stylelint.io/user-guide/rules/custom-property-empty-line-before/)

