### PR TITLE
Add more tests for `declaration-block-properties-order` options

### DIFF
--- a/src/rules/declaration-block-properties-order/__tests__/validate-options.js
+++ b/src/rules/declaration-block-properties-order/__tests__/validate-options.js
@@ -66,6 +66,108 @@ test("valid 'flexible' order", t => {
   t.plan(1)
 })
 
+test.skip("valid order with a group and one outside property before the group", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [
+        "height",
+        {
+          properties: [
+            "color",
+          ],
+        },
+      ],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 0)
+  })
+
+  t.plan(1)
+})
+
+test("valid order with a group and one outside property after the group", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [
+        {
+          properties: [
+            "color",
+          ],
+        },
+        "height",
+      ],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 0)
+  })
+
+  t.plan(1)
+})
+
+test("valid order with a group and two outside properties before the group", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [
+        "height",
+        "width",
+        {
+          properties: [
+            "color",
+          ],
+        },
+      ],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 0)
+  })
+
+  t.plan(1)
+})
+
+test("valid order with groups and one outside property before groups", t => {
+  const config = {
+    rules: {
+      "declaration-block-properties-order": [
+        "height",
+        {
+          properties: [
+            "color",
+          ],
+        },
+        {
+          properties: [
+            "width",
+          ],
+        },
+      ],
+    },
+  }
+  stylelint.lint({
+    code: "",
+    config,
+  }).then(function (data) {
+    const invalidOptionWarnings = data.results[0].invalidOptionWarnings
+    t.equal(invalidOptionWarnings.length, 0)
+  })
+
+  t.plan(1)
+})
+
 test("invalid option order option", t => {
   const config = {
     rules: {


### PR DESCRIPTION
Failing test for `declaration-block-properties-order`. It skipped in order not to break CI. It's for issue https://github.com/stylelint/stylelint/issues/1948