### PR TITLE
Clarify proprietary browser and user-defined properties configuration

### DIFF
--- a/src/rules/declaration-block-properties-order/README.md
+++ b/src/rules/declaration-block-properties-order/README.md
@@ -183,6 +183,70 @@ a {
 Given:
 
 ```js
+["my", "font-smoothing", "color"]
+```
+
+Where `font-smoothing` is the unprefixed version of proprietary browser property `-webkit-font-smoothing` and `my` is a user-defined shorthand property.
+
+The following patterns are considered warnings:
+
+```css
+a {
+  color: pink;
+  -webkit-font-smoothing: antialiased;
+}
+```
+
+```css
+a {
+  -webkit-font-smoothing: antialiased;
+  my-property: 2em;
+}
+```
+
+```css
+a {
+  my-property: 2em;
+  color: pink;
+  my-other-property: 1em;
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+a {
+  -webkit-font-smoothing: antialiased;
+  color: pink;
+}
+```
+
+```css
+a {
+  my-property: 2em;
+  -webkit-font-smoothing: antialiased;
+}
+```
+
+```css
+a {
+  my-property: 2em;
+  my-other-property: 1em;
+  color: pink;
+}
+```
+
+```css
+a {
+  my-other-property: 1em;
+  my-property: 2em;
+  color: pink;
+}
+```
+
+Given:
+
+```js
 ["padding", "padding-top", "padding-right", "padding-bottom", "padding-left", "color"]
 ```
 

--- a/src/rules/declaration-block-properties-order/__tests__/flat.js
+++ b/src/rules/declaration-block-properties-order/__tests__/flat.js
@@ -11,6 +11,7 @@ testRule(rule, {
   ruleName,
 
   config: [[
+    "my",
     "transform",
     "font-smoothing",
     "top",
@@ -29,6 +30,8 @@ testRule(rule, {
     code: "a { -moz-transform: scale(1); -webkit-transform: scale(1); transform: scale(1); }",
   }, {
     code: "a { -webkit-font-smoothing: antialiased; top: 0; color: pink; }",
+  }, {
+    code: "a { my-property: 2em; -webkit-font-smoothing: antialiased; }",
   }, {
     code: "a { top: 0; color: pink; width: 0; }",
   }, {
@@ -73,6 +76,9 @@ testRule(rule, {
   }, {
     code: "a { color: pink; -webkit-font-smoothing: antialiased; }",
     message: messages.expected("-webkit-font-smoothing", "color"),
+  }, {
+    code: "a { my-property: 2em; -webkit-font-smoothing: antialiased; my-other-property: 1em; }",
+    message: messages.expected("my-other-property", "-webkit-font-smoothing"),
   }, {
     code: "a { color: pink; border: 1px solid; }",
     message: messages.expected("border", "color"),


### PR DESCRIPTION
Closes #1751

I think how we handle proprietary browser and user-defined properties within `declaration-block-properties-order` is fine. 

This PR adds tests for a user-defined shorthand property, and adds an example to the README that shows this and how all properties, regardless of whether they are proprietary or standard, should be unprefixed in the config.