### PR TITLE
Fix option validation of null

### DIFF
--- a/src/__tests__/fixtures/config-no-pixels.json
+++ b/src/__tests__/fixtures/config-no-pixels.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "unit-blacklist": ["px"]
+  }
+}

--- a/src/__tests__/integration.js
+++ b/src/__tests__/integration.js
@@ -1,4 +1,5 @@
 import lessSyntax from "postcss-less"
+import path from "path"
 import postcss from "postcss"
 import scssSyntax from "postcss-scss"
 import stylelint from "../"
@@ -131,4 +132,19 @@ test("Scss integration test", t => {
     t.equal(result.messages.length, 0)
     t.end()
   }
+})
+
+test("integration test null option", t => {
+  stylelint.lint({
+    config: {
+      extends: [path.join(__dirname, "fixtures/config-no-pixels")],
+      rules: {
+        "unit-blacklist": null,
+      },
+    },
+    code: "a { top: 10px; }",
+  }).then(({ results }) => {
+    t.equal(results[0].invalidOptionWarnings.length, 0, "no invalid option warnings")
+    t.end()
+  }).catch(t.end)
 })

--- a/src/__tests__/normalizeRuleSettings-integration-test.js
+++ b/src/__tests__/normalizeRuleSettings-integration-test.js
@@ -1,7 +1,8 @@
+import path from "path"
 import standalone from "../standalone"
 import test from "tape"
 
-test("[normalized rule settings] primary options array", t => {
+test("[normalized rule settings] primary option array", t => {
   standalone({
     code: "a:focus {}",
     config: {
@@ -15,7 +16,7 @@ test("[normalized rule settings] primary options array", t => {
   }).catch(t.end)
 })
 
-test("[normalized rule settings] primary options array in array", t => {
+test("[normalized rule settings] primary option array in array", t => {
   standalone({
     code: "a:focus {}",
     config: {
@@ -25,6 +26,66 @@ test("[normalized rule settings] primary options array in array", t => {
     },
   }).then(({ results }) => {
     t.equal(results[0].warnings[0].rule, "selector-pseudo-class-blacklist")
+    t.end()
+  }).catch(t.end)
+})
+
+test("[normalized rule settings] no-array primary, primary option null", t => {
+  standalone({
+    code: "a:focus {}",
+    config: {
+      extends: [path.join(__dirname, "fixtures/config-block-no-empty.json")],
+      rules: {
+        "block-no-empty": null,
+      },
+    },
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 0)
+    t.end()
+  }).catch(t.end)
+})
+
+test("[normalized rule settings] no-array primary, primary option null in array", t => {
+  standalone({
+    code: "a:focus {}",
+    config: {
+      extends: [path.join(__dirname, "fixtures/config-block-no-empty.json")],
+      rules: {
+        "block-no-empty": [null],
+      },
+    },
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 0)
+    t.end()
+  }).catch(t.end)
+})
+
+test("[normalized rule settings] array primary, primary option null", t => {
+  standalone({
+    code: "a { top: 10px; }",
+    config: {
+      extends: [path.join(__dirname, "fixtures/config-no-pixels.json")],
+      rules: {
+        "unit-blacklist": null,
+      },
+    },
+  }).then(({ results }) => {
+    t.equal(results[0].warnings.length, 0)
+    t.end()
+  }).catch(t.end)
+})
+
+test("[normalized rule settings] array primary, primary option null in array", t => {
+  standalone({
+    code: "a { top: 10px; }",
+    config: {
+      extends: [path.join(__dirname, "fixtures/config-no-pixels.json")],
+      rules: {
+        "unit-blacklist": [null],
+      },
+    },
+  }).then(({ results }) => {
+    t.equal(results[0].invalidOptionWarnings.length, 0)
     t.end()
   }).catch(t.end)
 })

--- a/src/__tests__/normalizeRuleSettings-test.js
+++ b/src/__tests__/normalizeRuleSettings-test.js
@@ -4,6 +4,8 @@ import test from "tape"
 test("rules whose primary option IS NOT an array", t => {
   t.deepEqual(normalizeRuleSettings(null, "foo"), [null],
     "solo null returns arrayed null")
+  t.deepEqual(normalizeRuleSettings([null], "foo"), [null],
+    "arrayed null returns arrayed null")
   t.deepEqual(normalizeRuleSettings(2, "foo"), [2],
     "solo number returns arrayed number")
   t.deepEqual(normalizeRuleSettings([2], "foo"), [2],
@@ -35,6 +37,10 @@ test("rules whose primary option IS NOT an array", t => {
 })
 
 test("rules whose primary option CAN BE an array", t => {
+  t.deepEqual(normalizeRuleSettings(null, "foo"), [null],
+    "solo null returns arrayed null")
+  t.deepEqual(normalizeRuleSettings([null], "foo"), [null],
+    "arrayed null returns arrayed null")
   t.deepEqual(
     normalizeRuleSettings([ "calc", "rgba" ], "function-whitelist", true),
     [[ "calc", "rgba" ]],

--- a/src/utils/__tests__/validateOptions-test.js
+++ b/src/utils/__tests__/validateOptions-test.js
@@ -269,3 +269,23 @@ test("validateOptions with a function for 'possible'", t => {
 
   t.end()
 })
+
+test("validateOptions for null instead of array", t => {
+  const result = mockResult()
+  validateOptions(result, "no-dancing", {
+    actual: null,
+    possible: [(v) => typeof v === "string"],
+  })
+  t.notOk(result.warn.called)
+  t.end()
+})
+
+test("validateOptions for arrayed null instead of array", t => {
+  const result = mockResult()
+  validateOptions(result, "no-dancing", {
+    actual: [null],
+    possible: [(v) => typeof v === "string"],
+  })
+  t.notOk(result.warn.called)
+  t.end()
+})


### PR DESCRIPTION
Fixes #1964 and adds several tests to prevent future regressions.

Most of the diff in `validateOptions.js` is the result of pulling an unnecessarily nested function to the top level. The key difference is that I added this line (47):

```js
if (actual === null || _.isEqual(actual, [null])) { return }
```

@jeddy3: If you think this looks good let's release the patch right away.