### PR TITLE
Fixed: `no-missing-end-of-source-newline` warning positioning when using SugarSS parser.

### DIFF
--- a/src/rules/no-missing-end-of-source-newline/__tests__/index.js
+++ b/src/rules/no-missing-end-of-source-newline/__tests__/index.js
@@ -34,3 +34,26 @@ testRule(rule, {
     column: 19,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  skipBasicChecks: true,
+  syntax: "sugarss",
+
+  accept: [{
+    code: "a\n",
+  }],
+
+  reject: [ {
+    code: "a",
+    message: messages.rejected,
+    line: 1,
+    column: 1,
+  }, {
+    code: "body\n  padding: 5% 2% 5%",
+    message: messages.rejected,
+    line: 2,
+    column: 17,
+  } ],
+})

--- a/src/rules/no-missing-end-of-source-newline/index.js
+++ b/src/rules/no-missing-end-of-source-newline/index.js
@@ -15,16 +15,15 @@ export default function (actual) {
     const validOptions = validateOptions(result, ruleName, { actual })
     if (!validOptions) { return }
 
-    const sourceCss = root.toString()
-    if (sourceCss === "") { return }
-    if (sourceCss.slice(-1) !== "\n") {
-      report({
-        message: messages.rejected,
-        node: root,
-        index: root.toString().length - 1,
-        result,
-        ruleName,
-      })
-    }
+    const sourceCss = root.source.input.css
+    if (sourceCss === "" || sourceCss.slice(-1) === "\n") { return }
+
+    report({
+      message: messages.rejected,
+      node: root,
+      index: sourceCss.length - 1,
+      result,
+      ruleName,
+    })
   }
 }


### PR DESCRIPTION
<!--- Please read the following. Pull requests that do not adhere to these guidelines will be closed. -->

<!--- Each pull request must, with the exception of minor documentation fixes, be associated with an open issue.  -->
<!--- If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first. -->

<!--- If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide: -->
- [ ] Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule
- [ ] Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules
- [x] Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

<!--- If you've done that, then please continue and create this pull request. Thank you for contributing. -->
Ref https://github.com/stylelint/stylelint/issues/1892