### PR TITLE
Fixed: `block-no-empty` warning positioning when using SugarSS parser.

### DIFF
--- a/src/rules/block-no-empty/__tests__/index.js
+++ b/src/rules/block-no-empty/__tests__/index.js
@@ -89,14 +89,19 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
   syntax: "sugarss",
 
-  reject: [{
+  reject: [ {
     code: ".a",
     message: messages.rejected,
     line: 1,
     column: 2,
-  }],
+  }, {
+    code: ".a\n  padding: 25px\n  .a\n",
+    message: messages.rejected,
+    line: 3,
+    column: 4,
+  } ],
 })

--- a/src/rules/block-no-empty/index.js
+++ b/src/rules/block-no-empty/index.js
@@ -27,7 +27,7 @@ export default function (actual) {
       let index = beforeBlockString(statement, { noRawBefore: true }).length
 
       // For empty blocks when using SugarSS parser
-      if (statement.raw("between") === undefined) {
+      if (statement.raws.between === undefined) {
         index--
       }
 

--- a/src/utils/beforeBlockString.js
+++ b/src/utils/beforeBlockString.js
@@ -15,15 +15,15 @@ export default function (statement, { noRawBefore } = {}) {
   if (statement.type !== "rule" && statement.type !== "atrule") { return result }
 
   if (!noRawBefore) {
-    result += statement.raw("before")
+    result += statement.raws.before
   }
   if (statement.type === "rule") {
     result += statement.selector
   } else {
-    result += "@" + statement.name + statement.raw("afterName") + statement.params
+    result += "@" + statement.name + statement.raws.afterName + statement.params
   }
 
-  const between = statement.raw("between")
+  const between = statement.raws.between
 
   if (between !== undefined) {
     result += between


### PR DESCRIPTION
<!--- Please read the following. Pull requests that do not adhere to these guidelines will be closed. -->

<!--- Each pull request must, with the exception of minor documentation fixes, be associated with an open issue.  -->
<!--- If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first. -->

<!--- If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide: -->
- [ ] Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule
- [ ] Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules
- [x] Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

<!--- If you've done that, then please continue and create this pull request. Thank you for contributing. -->

Ref https://github.com/stylelint/stylelint/issues/1889
We don't use `raw()`, because it is call `stringify` (https://github.com/postcss/postcss/blob/979409b215bc70f5b69efe49a09dbc703642babe/lib/node.es6#L378) and return wrong node (`.a` -> `.a{}`)