### PR TITLE
Make the issue and pr templates consistent

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -61,8 +61,6 @@ test.css
 Here are the best ways to help resolve your issue:
 1. Figure out what needs to be done, propose it, and then write the code and submit a PR.
 2. If your issue is a bug, consider at least submitting a PR with failing tests.
--->
 
-<!--
 Note: GitHub issues are for stylelint bugs and enhancements, if you're looking for help or support with stylelint then stackoverflow is our preferred question and answer forum - http://stackoverflow.com/questions/tagged/stylelint
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,22 @@
-<!--- Please read the following. Pull requests that do not adhere to these guidelines will be closed. -->
+<!---
+Please read the following. Pull requests that do not adhere to these guidelines will be closed.
 
-<!--- Each pull request must, with the exception of minor documentation fixes, be associated with an open issue.  -->
-<!--- If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first. -->
+Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.
 
-<!--- If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide: -->
-- [ ] Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule
-- [ ] Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules
-- [ ] Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs
+If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:
 
-<!--- If you've done that, then please continue and create this pull request. Thank you for contributing. -->
+- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule
+
+- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules
+
+- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs
+
+Once you've done that, then please continue by answering these two questions:  -->
+
+> Which issue, if any, is this issue related to?
+
+e.g. "#000" or "None, as it's a documentation fix."
+
+> Is there anything in the PR that needs further explanation?
+
+e.g. "No, it's self explanatory."


### PR DESCRIPTION
Single comment block.

Q&A format.

Remove the checklist as confusing i.e. it looks like their are two remaining tasks when one of the items is checked.