### PR TITLE
Fixed: false positives for hyphenated function names in `function-calc-no-unspaced-operator`.

### DIFF
--- a/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -77,6 +77,12 @@ testRule(rule, {
     code: "a { top: calc(2rem + @fh+d*sf-as); }",
     description: "Less variable with symbols",
   }, {
+    code: "a { top: calc(100% - #{$foo}); }",
+    description: "Scss interpolation",
+  }, {
+    code: "a { top: calc(100% - #{map-get($container-max-widths, xl)}); }",
+    description: "Scss interpolation with function",
+  }, {
     code: "a { top: rem-calc(10px+ 10px); }",
     description: "ignore function have calc in name",
   }, {
@@ -282,5 +288,28 @@ testRule(rule, {
     message: messages.expectedOperatorBeforeSign("-"),
     line: 1,
     column: 28,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  reject: [ {
+    code: "a { top: calc(100%- #{$foo}); }",
+    message: messages.expectedBefore("-"),
+    line: 1,
+    column: 19,
+  }, {
+    code: "a { top: calc(100% *#{$foo}); }",
+    message: messages.expectedAfter("*"),
+    line: 1,
+    column: 20,
+  }, {
+    code: "a { top: calc(100% -#{$foo}); }",
+    message: messages.expectedOperatorBeforeSign("-"),
+    line: 1,
+    column: 20,
   } ],
 })

--- a/src/rules/function-calc-no-unspaced-operator/index.js
+++ b/src/rules/function-calc-no-unspaced-operator/index.js
@@ -98,7 +98,7 @@ export default function (actual) {
 }
 
 function blurVariables(source) {
-  return source.replace(/[\$@][^\)\s]+/g, "0")
+  return source.replace(/[\$@][^\)\s]+|#{.+?}/g, "0")
 }
 
 function newlineBefore(str, startIndex) {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#1878 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.