### PR TITLE
Fixed: false positives for some properties in `value-keyword-case`.

### DIFF
--- a/src/reference/keywordSets.js
+++ b/src/reference/keywordSets.js
@@ -280,9 +280,16 @@ export const timeProperties = uniteSets(
 
 export const camelCaseKeywords = new Set([
   "optimizeSpeed",
+  "optimizeQuality",
   "optimizeLegibility",
   "geometricPrecision",
   "currentColor",
+  "crispEdges",
+  "visiblePainted",
+  "visibleFill",
+  "visibleStroke",
+  "sRGB",
+  "linearRGB",
 ])
 
 // https://developer.mozilla.org/docs/Web/CSS/counter-increment


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/1997

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Ref to properties and their values:
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-rendering
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/image-rendering
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointer-events

