### PR TITLE
`no-descending-specificity` - added exception for custom property sets

### DIFF
--- a/src/rules/no-descending-specificity/__tests__/index.js
+++ b/src/rules/no-descending-specificity/__tests__/index.js
@@ -56,6 +56,8 @@ testRule(rule, {
     code: ".selector, { }",
   }, {
     code: ".a:not(.b) .c:matches(.d, .e) .f:unknown(.g, .h) {} .a {}",
+  }, {
+    code: ":root { --foo: {}; }",
   } ],
 
   reject: [ {

--- a/src/rules/no-descending-specificity/index.js
+++ b/src/rules/no-descending-specificity/index.js
@@ -4,6 +4,7 @@ import {
 } from "specificity"
 import {
   findAtRuleContext,
+  isCustomPropertySet,
   nodeContextLookup,
   parseSelector,
   report,
@@ -28,6 +29,9 @@ export default function (actual) {
     const selectorContextLookup = nodeContextLookup()
 
     root.walkRules(rule => {
+      // Ignore custom property set `--foo: {};`
+      if (isCustomPropertySet(rule)) { return }
+
       const comparisonContext = selectorContextLookup.getContext(rule, findAtRuleContext(rule))
 
       rule.selectors.forEach(selector => {


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#1999 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.