### PR TITLE
[chore] Update cosmiconfig to 2.1.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "babel-tape-runner": "^2.0.0",
     "benchmark": "^2.1.0",
     "common-tags": "^1.3.0",
+    "cosmiconfig": "^2.1.0",
     "coveralls": "^2.11.9",
     "eslint": "~3.8.0",
     "eslint-config-stylelint": "^5.0.0",


### PR DESCRIPTION
When having stylelint as a dependency and installing with Yarn and Yarn have locked cosmiconfig to `2.0.0`, installation will fail on Node >= 4  because of https://github.com/davidtheclark/cosmiconfig/issues/32.

This PR should fix it.