### PR TITLE
Chore: use `isStandardSyntaxRule` instead pure check.

### DIFF
--- a/src/utils/isStandardSyntaxRule.js
+++ b/src/utils/isStandardSyntaxRule.js
@@ -1,4 +1,5 @@
 import _ from "lodash"
+import { isCustomPropertySet } from "../utils"
 
 /**
  * Check whether a rule is standard
@@ -11,7 +12,7 @@ export default function (rule) {
   const selector = _.get(rule, "raws.selector.raw", rule.selector)
 
   // Custom property set (e.g. --custom-property-set: {})
-  if (_.endsWith(selector, ":")) { return false }
+  if (isCustomPropertySet(rule)) { return false }
 
   // Called Less mixin (e.g. a { .mixin() })
   if (rule.ruleWithoutBody) { return false }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

no

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

/cc @davidtheclark 

