### PR TITLE
Chore: use `raws` instead `raw()`.

### DIFF
--- a/src/rules/at-rule-empty-line-before/index.js
+++ b/src/rules/at-rule-empty-line-before/index.js
@@ -68,7 +68,7 @@ export default function (expectation, options) {
       if (optionsMatches(options, "ignore", "after-comment")
         && isAfterComment()) { return }
 
-      const hasEmptyLineBefore = hasEmptyLine(atRule.raw("before"))
+      const hasEmptyLineBefore = hasEmptyLine(atRule.raws.before)
       let expectEmptyLineBefore = (expectation === "always") ? true : false
 
       // Optionally reverse the expectation if any exceptions apply

--- a/src/rules/block-closing-brace-empty-line-before/index.js
+++ b/src/rules/block-closing-brace-empty-line-before/index.js
@@ -36,7 +36,7 @@ export default function (expectation) {
       if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
 
       // Get whitespace after ""}", ignoring extra semicolon
-      const before = statement.raw("after").replace(/;+/, "")
+      const before = statement.raws.after.replace(/;+/, "")
       if (before === undefined) { return }
 
       // Calculate index

--- a/src/rules/block-closing-brace-newline-after/index.js
+++ b/src/rules/block-closing-brace-newline-after/index.js
@@ -55,7 +55,7 @@ export default function (expectation, options) {
       // Allow an end-of-line comment x spaces after the brace
       const nextNodeIsSingleLineComment = (
         nextNode.type === "comment"
-        && !/[^ ]/.test(nextNode.raw("before"))
+        && !/[^ ]/.test(nextNode.raws.before)
         && nextNode.toString().indexOf("\n") === -1
       )
 

--- a/src/rules/block-closing-brace-newline-before/index.js
+++ b/src/rules/block-closing-brace-newline-before/index.js
@@ -38,7 +38,7 @@ export default function (expectation) {
       if (!hasBlock(statement) || hasEmptyBlock(statement)) { return }
 
       // Ignore extra semicolon
-      const after = statement.raw("after").replace(/;+/, "")
+      const after = statement.raws.after.replace(/;+/, "")
       if (after === undefined) { return }
 
       const blockIsMultiLine = !isSingleLineString(blockString(statement))

--- a/src/rules/comment-empty-line-before/index.js
+++ b/src/rules/comment-empty-line-before/index.js
@@ -55,7 +55,7 @@ export default function (expectation, options) {
 
       if (comment.raws.inline || comment.inline) { return }
 
-      const before = comment.raw("before")
+      const before = comment.raws.before
 
       // Ignore shared-line comments
       if (before.indexOf("\n") === -1) { return }

--- a/src/rules/declaration-block-properties-order/index.js
+++ b/src/rules/declaration-block-properties-order/index.js
@@ -69,7 +69,7 @@ function rule(expectation, options) {
           name: prop,
           unprefixedName: unprefixedPropName,
           orderData: (alphabetical) ? null : getOrderData(expectedOrder, unprefixedPropName),
-          before: child.raw("before"),
+          before: child.raws.before,
           index: allPropData.length,
           node: child,
         }

--- a/src/rules/declaration-block-semicolon-newline-after/index.js
+++ b/src/rules/declaration-block-semicolon-newline-after/index.js
@@ -33,7 +33,7 @@ export default function (expectation) {
     root.walkDecls(decl => {
       // Ignore last declaration if there's no trailing semicolon
       const parentRule = decl.parent
-      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
+      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
 
       const nextNode = decl.next()
       if (!nextNode) { return }

--- a/src/rules/declaration-block-semicolon-newline-before/index.js
+++ b/src/rules/declaration-block-semicolon-newline-before/index.js
@@ -30,7 +30,7 @@ export default function (expectation) {
 
     root.walkDecls(function (decl) {
       const parentRule = decl.parent
-      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
+      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
 
       const declString = decl.toString()
 

--- a/src/rules/declaration-block-semicolon-space-after/index.js
+++ b/src/rules/declaration-block-semicolon-space-after/index.js
@@ -34,7 +34,7 @@ export default function (expectation) {
     root.walkDecls(function (decl) {
       // Ignore last declaration if there's no trailing semicolon
       const parentRule = decl.parent
-      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
+      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
 
       const nextDecl = decl.next()
       if (!nextDecl) { return }

--- a/src/rules/declaration-block-semicolon-space-before/index.js
+++ b/src/rules/declaration-block-semicolon-space-before/index.js
@@ -33,7 +33,7 @@ export default function (expectation) {
     root.walkDecls(decl => {
       // Ignore last declaration if there's no trailing semicolon
       const parentRule = decl.parent
-      if (!parentRule.raw("semicolon") && parentRule.last === decl) { return }
+      if (!parentRule.raws.semicolon && parentRule.last === decl) { return }
 
       const declString = decl.toString()
 

--- a/src/rules/declaration-colon-newline-after/index.js
+++ b/src/rules/declaration-colon-newline-after/index.js
@@ -30,7 +30,7 @@ export default function (expectation) {
       if (!isStandardSyntaxDeclaration(decl)) { return }
 
       // Get the raw prop, and only the prop
-      const endOfPropIndex = declarationValueIndex(decl) + decl.raw("between").length - 1
+      const endOfPropIndex = declarationValueIndex(decl) + decl.raws.between.length - 1
 
       // The extra characters tacked onto the end ensure that there is a character to check
       // after the colon. Otherwise, with `background:pink` the character after the

--- a/src/rules/declaration-colon-space-after/index.js
+++ b/src/rules/declaration-colon-space-after/index.js
@@ -42,7 +42,7 @@ export function declarationColonSpaceChecker({ locationChecker, root, result, ch
     if (!isStandardSyntaxDeclaration(decl)) { return }
 
     // Get the raw prop, and only the prop
-    const endOfPropIndex = declarationValueIndex(decl) + decl.raw("between").length - 1
+    const endOfPropIndex = declarationValueIndex(decl) + decl.raws.between.length - 1
 
     // The extra characters tacked onto the end ensure that there is a character to check
     // after the colon. Otherwise, with `background:pink` the character after the

--- a/src/rules/indentation/index.js
+++ b/src/rules/indentation/index.js
@@ -49,8 +49,8 @@ export default function (space, options = {}) {
       const nodeLevel = indentationLevel(node)
       const expectedWhitespace = repeat(indentChar, nodeLevel)
 
-      let before = node.raw("before")
-      const after = node.raw("after")
+      let before = node.raws.before
+      const after = node.raws.after
 
       // Only inspect the spaces before the node
       // if this is the first node in root

--- a/src/rules/max-empty-lines/index.js
+++ b/src/rules/max-empty-lines/index.js
@@ -38,7 +38,7 @@ export default function (max) {
     // which adds to extra characters at the end, which messes up our
     // warning position
     root.walkComments(comment => {
-      const source = comment.raw("left") + comment.text + comment.raw("right")
+      const source = comment.raws.left + comment.text + comment.raws.right
       styleSearch({ source, target: "\n" }, match => {
         checkMatch(source, match.endIndex, comment, 2)
       })

--- a/src/rules/rule-non-nested-empty-line-before/index.js
+++ b/src/rules/rule-non-nested-empty-line-before/index.js
@@ -76,7 +76,7 @@ export function checkRuleEmptyLineBefore({ rule, expectation, options, result, m
     expectEmptyLineBefore = !expectEmptyLineBefore
   }
 
-  const hasEmptyLineBefore = hasEmptyLine(rule.raw("before"))
+  const hasEmptyLineBefore = hasEmptyLine(rule.raws.before)
 
   // Return if the expectation is met
   if (expectEmptyLineBefore === hasEmptyLineBefore) { return }

--- a/src/utils/atRuleParamIndex.js
+++ b/src/utils/atRuleParamIndex.js
@@ -7,8 +7,8 @@
 export default function (atRule) {
   // Initial 1 is for the `@`
   let index = 1 + atRule.name.length
-  if (atRule.raw("afterName")) {
-    index += atRule.raw("afterName").length
+  if (atRule.raws.afterName) {
+    index += atRule.raws.afterName.length
   }
   return index
 }

--- a/src/utils/rawNodeString.js
+++ b/src/utils/rawNodeString.js
@@ -6,8 +6,8 @@
  */
 export default function (node) {
   let result = ""
-  if (node.raw("before")) {
-    result += node.raw("before")
+  if (node.raws.before) {
+    result += node.raws.before
   }
   result += node.toString()
   return result


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

no

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

We don't use `raw()` because it is call `stringify` and return `stringifier` value, it is potential error in all non-standard syntax, special `sugarss`. Related commit: https://github.com/stylelint/stylelint/commit/f4bd57a0c4aaa0faae36eb71a88a956102497d19 .

/cc @davidtheclark @jeddy3 
I think we should add note about this in docs.
