### PR TITLE
Fixed: `selector-no-qualifying-type` rule now ignore SCSS placeholder selectors.

### DIFF
--- a/src/rules/selector-no-qualifying-type/__tests__/index.js
+++ b/src/rules/selector-no-qualifying-type/__tests__/index.js
@@ -1613,6 +1613,8 @@ testRule(rule, {
     code: "#{$selector}.class { }",
   }, {
     code: "a.class#{$selector}.class { }",
+  }, {
+    code: "%foo { &.bar { } }",
   } ],
 
   reject: [ {

--- a/src/rules/selector-no-qualifying-type/index.js
+++ b/src/rules/selector-no-qualifying-type/index.js
@@ -58,6 +58,7 @@ export default (enabled, options) => {
     root.walkRules(rule => {
       if (!isStandardSyntaxRule(rule)) { return }
       if (isKeyframeRule(rule)) { return }
+      // Increasing performance
       if (!isStandardSyntaxSelector(rule.selector)) { return }
       if (!isSelectorCharacters(rule.selector)) { return }
 
@@ -89,6 +90,8 @@ export default (enabled, options) => {
       }
 
       resolvedNestedSelector(rule.selector, rule).forEach(resolvedSelector => {
+        if (!isStandardSyntaxSelector(resolvedSelector)) { return }
+
         parseSelector(resolvedSelector, result, rule, checkSelector)
       })
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2041

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

/cc @davidtheclark @jeddy3 