### PR TITLE
Update configuration.md

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -36,7 +36,7 @@ The `rules` property is *an object whose keys are rule names and values are rule
     "block-no-empty": null,
     "color-no-invalid-hex": true,
     "comment-empty-line-before": [ "always", {
-      "ignore": ["stylelint-commands", "between-comments"],
+      "ignore": ["stylelint-commands", "between-comments"]
     } ],
     "declaration-colon-space-after": "always",
     "indentation": ["tab", {
@@ -45,7 +45,7 @@ The `rules` property is *an object whose keys are rule names and values are rule
     "max-empty-lines": 2,
     "rule-nested-empty-line-before": [ "always", {
       "except": ["first-nested"],
-      "ignore": ["after-comment"],
+      "ignore": ["after-comment"]
     } ],
     "unit-whitelist": ["em", "rem", "%", "s"]
   }

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -207,7 +207,7 @@ Once the plugin is declared, within your `"rules"` object *you'll need to add op
   ],
   "rules": {
     "plugin/special-rule": "everything"
-  },
+  }
 }
 ```
 
@@ -222,7 +222,7 @@ A "plugin" can provide a single rule or a set of rules. If the plugin you use pr
     "some-rule-set/first-rule": "everything",
     "some-rule-set/second-rule": "nothing",
     "some-rule-set/third-rule": "everything"
-  },
+  }
 }
 ```
 
@@ -239,7 +239,7 @@ To use one, add a `"processors"` array to your config, containing "locaters" ide
 ```json
 {
   "processors": ["stylelint-html-processor"],
-  "rules": {..},
+  "rules": {..}
 }
 ```
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Remove invalid commas as per JSONLint and thus removing error when running gulp lint-css
Change >>

```json
{
	"rules": {
		"block-no-empty": null,
		"color-no-invalid-hex": true,
		"comment-empty-line-before": ["always", {
			"ignore": ["stylelint-commands", "between-comments"],
		}],
		"declaration-colon-space-after": "always",
		"indentation": ["tab", {
			"except": ["value"]
		}],
		"max-empty-lines": 2,
		"rule-nested-empty-line-before": ["always", {
			"except": ["first-nested"],
			"ignore": ["after-comment"],
		}],
		"unit-whitelist": ["em", "rem", "%", "s"]
	}
}  
```

to >>

```json
{
  "rules": {
    "block-no-empty": null,
    "color-no-invalid-hex": true,
    "comment-empty-line-before": [ "always", {
      "ignore": ["stylelint-commands", "between-comments"]
    } ],
    "declaration-colon-space-after": "always",
    "indentation": ["tab", {
      "except": ["value"]
    }],
    "max-empty-lines": 2,
    "rule-nested-empty-line-before": [ "always", {
      "except": ["first-nested"],
      "ignore": ["after-comment"]
    } ],
    "unit-whitelist": ["em", "rem", "%", "s"]
  }
}
```