### PR TITLE
Add `env` values to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,16 @@ matrix:
   include:
     - node_js: '6'
       script: npm run lint && npm run flow
+      env: CI=lint+flow
     - node_js: '6'
       script: npm run jest
+      env: CI=jest
     - node_js: '7'
       script: npm run test
+      env: CI=test
     - node_js: '6'
       script: npm run test
+      env: CI=test
     - node_js: '4'
       script: npm run test
+      env: CI=test


### PR DESCRIPTION
I've added some Travis CI environment variables to the build matrix.

I've added these as "hacky docs labels"  as when investigating Travis CI builds there is are no "labels" per se describing what each of the 5 jobs are, at the moment differentiating between which of the 3 NodeJS jobs are running what task (lint+flow, jest, or test) is guess work:

![no-envs](https://cloud.githubusercontent.com/assets/1016458/20509416/b82d91ce-b0bc-11e6-80b7-c04d313a6876.png)

By adding these "hacky environment labels" we can now identify which npm task is ran by each job a little quicker:

![envs](https://cloud.githubusercontent.com/assets/1016458/20509473/1be994c4-b0bd-11e6-9c1c-e22934d3efec.png)

p.s. These have no effect on the actual Travis CI jobs