### PR TITLE
Restore Travis CI NPM Cache & Coveralls setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 cache:
   directories:
     - node_modules
-notifications:
-  webhooks:
-    - https://webhooks.gitter.im/e/d763493612da45967361
 matrix:
   include:
     - node_js: '6'
@@ -18,3 +15,11 @@ matrix:
       script: npm run test
     - node_js: '4'
       script: npm run test
+before_install:
+  - npm prune
+  - npm update
+after_success: npm run coveralls
+notifications:
+  webhooks:
+    - https://webhooks.gitter.im/e/d763493612da45967361
+    


### PR DESCRIPTION
In https://github.com/stylelint/stylelint/commit/d4e461552324b37067b6e8582914bbafbf4f23a1 Travis CI _cache maintainence_ `npm prune`, and `npm update` along with Coveralls support via `npm run coveralls` was removed, this PR restores this functionality.