### PR TITLE
Fixed: false positives Scss selector with nested properties.

### DIFF
--- a/src/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/src/rules/selector-max-compound-selectors/__tests__/index.js
@@ -170,10 +170,13 @@ testRule(rule, {
   config: [1],
   syntax: "scss",
 
-  accept: [{
+  accept: [ {
     code: "#hello #{$test} {}",
     description: "ignore rules with variable interpolation",
-  }],
+  }, {
+    code: ".foo { margin: { left: 5px; top: 10px; }; }",
+    description: "nested properties",
+  } ],
 })
 
 testRule(rule, {

--- a/src/rules/selector-max-compound-selectors/index.js
+++ b/src/rules/selector-max-compound-selectors/index.js
@@ -34,7 +34,7 @@ export default function (max) {
           checkSelector(childNode, rule)
         }
 
-        // Compund selectors are separated by combinators, so increase count when meeting one
+        // Compound selectors are separated by combinators, so increase count when meeting one
         if (childNode.type === "combinator") { compoundCount++ }
       })
 

--- a/src/utils/isStandardSyntaxRule.js
+++ b/src/utils/isStandardSyntaxRule.js
@@ -27,5 +27,8 @@ export default function (rule) {
   // Non-outputting Less mixin definition (e.g. .mixin() {})
   if (_.endsWith(selector, ")") && !_.includes(selector, ":")) { return false }
 
+  // Ignore Scss nested properties
+  if (selector.slice(-1) === ":") { return false }
+
   return true
 }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2093

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

I believe that the rule does not work correctly and we should fix this in `8.0.0`.

Example:
```scss
.foo .bar > .foobar { & .test { @media screen { color: red; } } }
```

We this line use for check on nested

```if (rule.nodes.some(node => node.type === "rule" || node.type === "atrule")) { return }```

And we get:
1. We use `walkRules`.
2. Here we have 2 selector `.foo .bar > .foobar` and `& .test`
    First selector have `nodes` and return.
    Second selector have `nodes` and return.
But we should get error here.

Also rule don't work with nested properties.

/cc @davidtheclark @jeddy3 