### PR TITLE
Allow empty input for --allow-empty-input argument in CLI

### DIFF
--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -112,4 +112,5 @@ export type stylelint$standaloneOptions = {
   syntax?: stylelint$syntaxes,
   customSyntax?: string,
   formatter?: "json" | "string" | "verbose" | Function,
+  allowEmptyInput?: boolean,
 }

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -103,6 +103,10 @@ An absolute path to a custom [PostCSS-compatible syntax](https://github.com/post
 
 Note, however, that stylelint can provide no guarantee that core rules will work with syntaxes other than the defaults listed for the `syntax` option above.
 
+### `allowEmptyInput`
+
+If `true`, will prevent a non-zero exit code when there is no input.
+
 
 ## The returned promise
 

--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -90,6 +90,28 @@ it("standalone with non-existent-file should throw error with code 80", () => {
   })
 })
 
+describe("standalone with non-existent-file and allow-empty-input", () => {
+  it("should not throw error", () => {
+    expect(() => standalone({
+      files: `${fixturesPath}/non-existent-file.css`,
+      allowEmptyInput: true,
+    })).not.toThrow()
+  })
+
+  it("should resolve empty results", () => {
+    return standalone({
+      files: `${fixturesPath}/non-existent-file.css`,
+      allowEmptyInput: true,
+    }).then(data => {
+      expect(data).toEqual({
+        errored: false,
+        output: "[]",
+        results: [],
+      })
+    })
+  })
+})
+
 describe("standalone passing code with syntax error", () => {
   let results
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -107,6 +107,10 @@ const meowOptions = {
         If you provide the argument "error", the process will exit with code 2
         if needless disables are found.
 
+      --allow-empty-input
+
+        Prevent a non-zero exit code when there is no input.
+
       --version, -v
 
         Show the currently installed version of stylelint.
@@ -170,7 +174,12 @@ if (cli.flags.ignoreDisables) {
   optionsBase.ignoreDisables = cli.flags.ignoreDisables
 }
 
-const { reportNeedlessDisables } = cli.flags
+const { allowEmptyInput, reportNeedlessDisables } = cli.flags
+
+if (allowEmptyInput) {
+  optionsBase.allowEmptyInput = allowEmptyInput
+}
+
 if (reportNeedlessDisables) {
   optionsBase.reportNeedlessDisables = reportNeedlessDisables
 }

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -23,6 +23,7 @@ export default function ({
   formatter,
   syntax,
   customSyntax,
+  allowEmptyInput,
 }: stylelint$standaloneOptions = {}): Promise<stylelint$standaloneReturnValue> {
   const isValidCode = typeof code === "string"
   if (!files && !isValidCode || files && (code || isValidCode)) {
@@ -67,6 +68,10 @@ export default function ({
   return globby([].concat(files, alwaysIgnoredGlobs))
     .then((filePaths) => {
       if (!filePaths.length) {
+        if (allowEmptyInput) {
+          return Promise.resolve([])
+        }
+
         const err: Object = new Error("Files glob patterns specified did not match any files")
         err.code = 80
         throw err


### PR DESCRIPTION
Issue: #2048 Add --allow-empty-input CLI option

With `--allow-empty-input` option when there is no input will prevent exit code 80


