### PR TITLE
Handle non-integer error codes as code 1 (#2115)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -203,5 +203,5 @@ Promise.resolve().then(() => {
   if (errored) { process.exitCode = 2 }
 }).catch(err => {
   console.log(err.stack) // eslint-disable-line no-console
-  process.exit(err.code || 1)
+  process.exit(parseInt(err.code) || 1)
 })


### PR DESCRIPTION
Fixes #2115 

When there is an error in require() in configuration file, cli gets an error code which is not actually integer, so passing it to process.exit is not a good idea.

Obvious soultion here is just ensure that code that we got is integer, and we can do that with just covering it with parseInt, which will give the integer back if it's actually an integer, and will return NaN if it's a string, so exit code will default to `1`, exactly what we need.

PS. Since I created PR from github UI, I have this weird `patch-1` branch name, if it's an issue, just tell me and I'll re-create PR with proper branch name.