### PR TITLE
Allow non-existent codeFilenames

### DIFF
--- a/src/__tests__/standalone.test.js
+++ b/src/__tests__/standalone.test.js
@@ -311,3 +311,32 @@ it("Setting `plugins` inside `configOverrides` object should overrides the ones 
     expect(results[0].warnings[0].text).toBe("found .bar (plugin/warn-about-bar)")
   })
 })
+
+describe("nonexistent codeFilename with loaded config", () => {
+  let actualCwd
+
+  beforeAll(() => {
+    actualCwd = process.cwd()
+    process.chdir(path.join(__dirname, "./fixtures/getConfigForFile/a/b"))
+  })
+
+  afterAll(() => {
+    process.chdir(actualCwd)
+  })
+
+  it("does not cause error", () => {
+    return standalone({
+      code: "a {}",
+      codeFilename: "does-not-exist.css",
+    })
+  })
+
+  it("does load config from process.cwd", () => {
+    return standalone({
+      code: "a {}",
+      codeFilename: "does-not-exist.css",
+    }).then(({ results }) => {
+      expect(results[0].warnings.length).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
Closes #2064.

This was a little tricky to track down and fix without breaking other tests, but I think I got it.

The key is that we need to anticipate non-existent files in `lintSource` if `code` and `codeFilename` are being used.

