### PR TITLE
Fixed: typo in `selector-max-compound-selectors` docs.

### DIFF
--- a/src/rules/selector-max-compound-selectors/README.md
+++ b/src/rules/selector-max-compound-selectors/README.md
@@ -6,7 +6,7 @@ Limit the number of compound selectors in a selector.
    div .bar[data-val] > a.baz + .boom > #lorem {}
 /* ↑   ↑                ↑       ↑       ↑
    |   |                |       |       |
-  Lv1  v2               Lv3     Lv4     Lv5  -- these are compound selectors */
+  Lv1 Lv2              Lv3     Lv4     Lv5  -- these are compound selectors */
 ```
 
 A [compound selector](https://www.w3.org/TR/selectors4/#compound) is a chain of one or more simple (tag, class, id, universal, attribute) selectors. If there is more than one compound selector in a complete selector, they will be separated by combinators (e.g. ` `, `+`, `>`). One reason why you might want to limit the number of compound selectors is described in the [SMACSS book](http://smacss.com/book/applicability).


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

