### PR TITLE
Fixed: typo in `block-opening-brace-newline-after` docs.

### DIFF
--- a/src/rules/block-opening-brace-newline-after/README.md
+++ b/src/rules/block-opening-brace-newline-after/README.md
@@ -19,7 +19,7 @@ a { /* end-of-line comment */
 
 ## Options
 
-`string`: `"always"|"always-multi-line"|"never-multi-line`
+`string`: `"always"|"always-multi-line"|"never-multi-line"`
 
 ### `"always"`
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

