### PR TITLE
Handle non-integer error codes as exit code 1 (#2115)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -214,5 +214,6 @@ Promise.resolve().then(() => {
   }
 }).catch(err => {
   console.log(err.stack) // eslint-disable-line no-console
-  process.exit(err.code || 1)
+  const exitCode = typeof err.code === "number" ? err.code : 1
+  process.exit(exitCode)
 })

--- a/system-tests/004/004.test.js
+++ b/system-tests/004/004.test.js
@@ -1,0 +1,28 @@
+/* @flow */
+"use strict"
+const path = require("path")
+const spawn = require("child_process").spawn
+
+// this test ensures that CLI returns exit code which is not 0
+// when there is a runtime error in configuration javascript file
+// https://github.com/stylelint/stylelint/issues/2115
+
+it("004", (done) => {
+  const localPath = path.resolve(__dirname)
+  const cliPath = path.join(localPath, "../../lib/cli.js")
+
+  const cliProcess = spawn("node", [ cliPath, `${localPath}/*.css` ], { cwd: localPath })
+
+  cliProcess.on("error", function (error) {
+    console.log("error running cli:", error) // eslint-disable-line no-console
+  })
+
+  let stdout = ""
+  cliProcess.stdout.on("data", (data) => stdout += data)
+
+  cliProcess.on("close", function (code) {
+    expect(stdout.includes("Cannot find module")).toBeTruthy()
+    expect(code).not.toEqual(0)
+    done()
+  })
+})

--- a/system-tests/004/stylelint.config.js
+++ b/system-tests/004/stylelint.config.js
@@ -1,0 +1,2 @@
+"use strict"
+module.exports = require("./someUnknownFile.js")


### PR DESCRIPTION
Fixes #2115 

When there is an error in require() in configuration file, cli gets an error code which is not actually integer, so passing it to process.exit is not a good idea.

Now value is getting checked if it's a number or not, and if it's not a number, it's replaced with plain `1`.

System test added that runs cli in ensures that exit code != 0