### PR TITLE
Added link to stylelint-config-amp

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -19,3 +19,4 @@ Plugins are rules and sets of rules built by the community that support methodol
 ## Validators
 
 -   [`stylelint-csstree-validator`](https://github.com/csstree/stylelint-validator): Validate CSS values to match W3C specs and browsers extensions.
+-   [`stylelint-config-amp`](https://github.com/tinovyatkin/stylelint-config-amp): Enforces CSS restrictions of Accelerated Mobile Pages.


### PR DESCRIPTION
Documentation fix, added link to my [stylelint-config-amp](https://github.com/tinovyatkin/stylelint-config-amp) config that enforces rules for [Accelerated Mobile Pages](https://ampproject.org) requirements.

