### PR TITLE
Updates docs for testing set of rules

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -144,11 +144,11 @@ npm test
 
 However, this runs all 25,000+ unit tests and also linting.
 
-The `npm run test:tape` command accepts an optional list of rules. You can use this to run tests for just a chosen set of rules (which you'll want to do during development). For examples, to run the tests for just the `color-hex-case` and `color-hex-length` rules:
+You can use the interactive testing prompt to run tests for just a chosen set of rules (which you'll want to do during development). For example, to run the tests for just the `color-hex-case` and `color-hex-length` rules:
 
-```console
-npm run test:tape color-hex-case color-hex-length
-```
+1.  Use `npm run watch` to start the prompt.
+2.  Press `p` to filter by a filename regex pattern.
+3.  Enter `color-hex-case|color-hex-length` i.e. each rule name separated by the pipe symbol (`|`).
 
 ### Write the README
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.0",
-    "cli-cursor": "^1.0.2",
     "common-tags": "^1.3.0",
     "coveralls": "^2.11.9",
     "d3-queue": "^3.0.3",


### PR DESCRIPTION
As an aside, by default I think the `--watch` is only suppose to run the tests on _changed_ files. However, it currently triggers a complete run on my machine. Perhaps I'm missing something?