### PR TITLE
Ignore node_modules effectively

### DIFF
--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -365,3 +365,41 @@ describe("using codeFilename and ignoreFiles with configBasedir", () => {
     expect(_.get(results[0], [ "_postcssResult", "standaloneIgnored" ])).toBeTruthy()
   })
 })
+
+describe("file in node_modules", () => {
+  const lint = () => standalone({
+    code: "a {}",
+    codeFilename: "/something/node_modules/path/to/something.css",
+    config: {
+      rules: {
+        "block-no-empty": true,
+      },
+    },
+  })
+
+  it("is ignored", () => {
+    return lint().then((output) => {
+      expect(output.results[0].warnings.length).toBe(0)
+      expect(output.results[0].ignored).toBeTruthy()
+    })
+  })
+})
+
+describe("file in bower_components", () => {
+  const lint = () => standalone({
+    code: "a {}",
+    codeFilename: "/something/bower_components/path/to/something.css",
+    config: {
+      rules: {
+        "block-no-empty": true,
+      },
+    },
+  })
+
+  it("is ignored", () => {
+    return lint().then((output) => {
+      expect(output.results[0].warnings.length).toBe(0)
+      expect(output.results[0].ignored).toBeTruthy()
+    })
+  })
+})

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -4,6 +4,8 @@ const ignore = require("ignore")
 const multimatch = require("multimatch")
 const path = require("path")
 
+const alwaysIgnoredGlobs = [ "**/node_modules/**", "**/bower_components/**" ]
+
 // To find out if a path is ignored, we need to load the config,
 // which may have an ignoreFiles property,
 // and will have incorporated any .stylelintignore file that was found
@@ -23,7 +25,8 @@ module.exports = function (
 
     const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath)
 
-    if (config.ignoreFiles && multimatch(absoluteFilePath, config.ignoreFiles).length) {
+    const ignoreFiles = alwaysIgnoredGlobs.concat(config.ignoreFiles || [])
+    if (multimatch(absoluteFilePath, ignoreFiles).length) {
       return true
     }
 

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -5,8 +5,6 @@ const createStylelint = require("./createStylelint")
 const globby = require("globby")
 const needlessDisables = require("./needlessDisables")
 
-const alwaysIgnoredGlobs = [ "!**/node_modules/**", "!**/bower_components/**" ]
-
 module.exports = function (options/*: Object */)/*: Promise<stylelint$standaloneReturnValue>*/ {
   const files = options.files
   const code = options.code
@@ -60,7 +58,7 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
     })
   }
 
-  return globby([].concat(files, alwaysIgnoredGlobs)).then(filePaths => {
+  return globby(files).then(filePaths => {
     if (!filePaths.length) {
       if (allowEmptyInput === undefined || !allowEmptyInput) {
         const err/*: Object*/ = new Error("Files glob patterns specified did not match any files")


### PR DESCRIPTION
Closes #2149.

Managed to reproduce that problem in a test case, and made it pass. I'm not sure if this feature ever worked *before* in the PostCSS plugin; but we always intended it to, assumed it did, so I'd consider this a bug fix.

cc @simonsmith