### PR TITLE
Simplify NPM test scripts now that Tape has been removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ matrix:
       script: npm run pretest
       env: CI=pretest
     - node_js: '7'
-      script: npm run test:jest -- --runInBand
+      script: npm run jest -- --runInBand
       env: CI=tests 7
     - node_js: '6'
-      script: npm run test:jest -- --runInBand --testPathPattern .*lib/.*
+      script: npm run jest -- --runInBand --testPathPattern .*lib/.*
       env: CI=tests 6
     - node_js: '4'
-      script: npm run test:jest -- --runInBand --testPathPattern .*lib/.*
+      script: npm run jest -- --runInBand --testPathPattern .*lib/.*
       env: CI=tests 4
 before_install:
   - npm prune

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,4 +19,4 @@ install:
 test_script:
   - node --version
   - npm --version
-  - cmd: "npm run test:jest -- --runInBand --testPathPattern \\lib"
+  - cmd: "npm run jest -- --runInBand --testPathPattern \\lib"

--- a/package.json
+++ b/package.json
@@ -91,14 +91,14 @@
   "scripts": {
     "benchmark-rule": "node scripts/benchmark-rule.js",
     "flow": "flow",
+    "jest": "jest",
     "lint:js": "eslint .",
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",
     "pretest": "npm-run-all --serial lint flow",
     "release": "npmpub",
-    "test:jest": "jest",
-    "test": "npm-run-all --serial test:*",
-    "watch": "npm run test:jest -- --watch"
+    "test": "jest",
+    "watch": "npm run jest -- --watch"
   },
   "jest": {
     "setupFiles": [

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "pretest": "npm-run-all --serial lint flow",
     "release": "npmpub",
     "test": "jest",
-    "watch": "npm run jest -- --watch"
+    "watch": "jest --watch"
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
Now that Tape was removed in #2158 there's no need for multiple `tape:*` scripts.