### PR TITLE
Add checkAgainstRule util

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -38,13 +38,61 @@ In order for your plugin rule to work with the [standard configuration format](.
 
 ## `stylelint.utils`
 
-Three of stylelint's internal utilities are exposed publicly in `stylelint.utils` and should be used:
+stylelint exposes some utilities that are useful. *For details about the APIs of these functions, please look at comments in the source code and examples in the standard rules.*
 
--   `report`: Report your linting warnings. *Do not use `node.warn()` directly.* If you use `report`, your plugin will respect disabled ranges and other possible future features of stylelint, so it will fit in better with the standard rules.
--   `ruleMessages`: Tailor your messages to look like the messages of other stylelint rules.
--   `validateOptions`: Help your user's out by checking that the options they've submitted are valid.
+### `stylelint.utils.report`
 
-For details about the APIs of these functions, please look at comments in the source code and examples in the standard rules.
+Adds warnings from your plugin to the list of warnings that stylelint will report to the user.
+
+*Do not use PostCSS's `node.warn()` method directly.* When you use `stylelint.utils.report`, your plugin will respect disabled ranges and other possible future features of stylelint, providing a better user-experience, one that better fits the standard rules.
+
+### `stylelint.utils.ruleMessages`
+
+Tailors your messages to the format of standard stylelint rules.
+
+### `stylelint.utils.validateOptions`
+
+Validates the options for your rule.
+
+### `stylelint.utils.checkAgainstRule`
+
+Checks CSS against a standard stylelint rule *within your own rule*. This function provides power and flexibility for plugins authors who wish to modify, constrain, or extend the functionality of existing stylelint rules.
+
+Accepts an options object and a callback that is invoked with warnings from the specified rule. The options are:
+- `ruleName`: The name of the rule you are invoking.
+- `ruleSettings`: Settings for the rule you are invoking, formatting in the same way they would be in a `.stylelintrc` configuration object.
+- `root`: The root node to run this rule against.
+
+Use the warning to create a *new* warning *from your plugin rule* that you report with `stylelint.utils.report`.
+
+For example, imagine you want to create a plugin that runs `at-rule-no-unknown` with a built-in list of exceptions for at-rules provided by your preprocessor-of-choice:
+
+```js
+const allowableAtRules = [..]
+
+function myPluginRule(primaryOption, secondaryOptions) {
+  return (root, result) => {
+    const defaultedOptions = Object.assign({}, secondaryOptions, {
+      ignoreAtRules: allowableAtRules.concat(options.ignoreAtRules || []),
+    })
+
+    stylelint.utils.checkAgainstRule({
+      ruleName: 'at-rule-no-unknown',
+      ruleSettings: [primaryOption, defaultedOptions],
+      root: root
+    }, (warning) => {
+      stylelint.utils.report({
+        message: myMessage,   
+        ruleName: myRuleName,     
+        result: result,        
+        node: warning.node,
+        line: warning.line,
+        column: warning.column,
+      })
+    })
+  }
+}
+```
 
 ## `stylelint.rules`
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -59,9 +59,9 @@ Validates the options for your rule.
 Checks CSS against a standard stylelint rule *within your own rule*. This function provides power and flexibility for plugins authors who wish to modify, constrain, or extend the functionality of existing stylelint rules.
 
 Accepts an options object and a callback that is invoked with warnings from the specified rule. The options are:
-- `ruleName`: The name of the rule you are invoking.
-- `ruleSettings`: Settings for the rule you are invoking, formatting in the same way they would be in a `.stylelintrc` configuration object.
-- `root`: The root node to run this rule against.
+-   `ruleName`: The name of the rule you are invoking.
+-   `ruleSettings`: Settings for the rule you are invoking, formatting in the same way they would be in a `.stylelintrc` configuration object.
+-   `root`: The root node to run this rule against.
 
 Use the warning to create a *new* warning *from your plugin rule* that you report with `stylelint.utils.report`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const report = require("./utils/report")
 const ruleMessages = require("./utils/ruleMessages")
 const validateOptions = require("./utils/validateOptions")
+const checkAgainstRule = require("./utils/checkAgainstRule")
 const createPlugin = require("./createPlugin")
 const createRuleTester = require("./testUtils/createRuleTester")
 const createStylelint = require("./createStylelint")
@@ -17,6 +18,7 @@ api.utils = {
   report,
   ruleMessages,
   validateOptions,
+  checkAgainstRule,
 }
 
 api.lint = standalone

--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -1,6 +1,7 @@
 /* @flow */
 "use strict"
 const _ = require("lodash")
+const rules = require("./rules")
 
 // Rule settings can take a number of forms, e.g.
 // a. "rule-name": null
@@ -17,6 +18,8 @@ const _ = require("lodash")
 module.exports = function (
   rawSettings/*: stylelint$configRuleSettings*/,
   ruleName/*: string*/,
+  // If primaryOptionArray is not provided, we try to get it from the
+  // rules themselves, which will not work for plugins
   primaryOptionArray/*:: ?: boolean*/
 )/*: ?Array<any | [any, Object]>*/ {
   if (rawSettings === null) {
@@ -40,6 +43,11 @@ module.exports = function (
     if (typeof rawSettings[0] === "string") {
       return [rawSettings]
     }
+  }
+
+  if (primaryOptionArray === undefined) {
+    const rule = rules[ruleName]
+    primaryOptionArray = _.get(rule, "primaryOptionArray")
   }
 
   if (!primaryOptionArray) {

--- a/lib/testUtils/createRuleTester.js
+++ b/lib/testUtils/createRuleTester.js
@@ -123,7 +123,7 @@ module.exports = function (equalityCheck) {
 function processGroup(rule, schema, equalityCheck) {
   const ruleName = schema.ruleName
 
-  const ruleOptions = normalizeRuleSettings(schema.config)
+  const ruleOptions = normalizeRuleSettings(schema.config, ruleName)
   const rulePrimaryOptions = ruleOptions[0]
   const ruleSecondaryOptions = ruleOptions[1]
 

--- a/lib/utils/__tests__/checkAgainstRule.test.js
+++ b/lib/utils/__tests__/checkAgainstRule.test.js
@@ -1,0 +1,52 @@
+/* @flow */
+"use strict"
+
+const postcss = require("postcss")
+const checkAgainstRule = require("../checkAgainstRule")
+
+describe("checkAgainstRule", () => {
+  it("does nothing with no errors", () => {
+    const root = postcss.parse("a {} @media {}")
+
+    const warnings = []
+    checkAgainstRule({
+      ruleName: "at-rule-name-case",
+      ruleSettings: "lower",
+      root,
+    }, (warning) => warnings.push(warning))
+
+    expect(warnings.length).toBe(0)
+  })
+
+  it("handles non-array rule settings", () => {
+    const root = postcss.parse("a {} @media {}")
+
+    const warnings = []
+    checkAgainstRule({
+      ruleName: "at-rule-name-case",
+      ruleSettings: "upper",
+      root,
+    }, (warning) => warnings.push(warning))
+
+    expect(warnings.length).toBe(1)
+    expect(warnings[0].rule).toBe("at-rule-name-case")
+    expect(warnings[0].line).toBe(1)
+    expect(warnings[0].column).toBe(6)
+  })
+
+  it("handles array rule settings", () => {
+    const root = postcss.parse("@import horse.css\n@media {}\n@import dog.css;")
+
+    const warnings = []
+    checkAgainstRule({
+      ruleName: "at-rule-empty-line-before",
+      ruleSettings: [ "always", { ignoreAtRules: ["media"] } ],
+      root,
+    }, (warning) => warnings.push(warning))
+
+    expect(warnings.length).toBe(1)
+    expect(warnings[0].rule).toBe("at-rule-empty-line-before")
+    expect(warnings[0].line).toBe(3)
+    expect(warnings[0].column).toBe(1)
+  })
+})

--- a/lib/utils/checkAgainstRule.js
+++ b/lib/utils/checkAgainstRule.js
@@ -1,0 +1,30 @@
+/* @flow */
+"use strict"
+
+const Result = require("postcss/lib/result")
+const normalizeRuleSettings = require("../normalizeRuleSettings")
+const rules = require("../rules")
+
+// Useful for third-party code (e.g. plugins) to run a PostCSS Root
+// against a specific rule and do something with the warnings
+module.exports = function (
+  options/*: {
+    ruleName: string,
+    ruleSettings: any,
+    root: Object,
+  }*/,
+  callback/*: Function*/
+) {
+  if (!options) throw new Error("checkAgainstRule requires an options object with 'ruleName', 'ruleSettings', and 'root' properties")
+  if (!callback) throw new Error("checkAgainstRule requires a callback")
+  if (!options.ruleName) throw new Error("checkAgainstRule requires a 'ruleName' option")
+  if (!rules[options.ruleName]) throw new Error(`Rule '${options.ruleName}' does not exist`)
+  if (!options.ruleSettings) throw new Error("checkAgainstRule requires a 'ruleSettings' option")
+  if (!options.root) throw new Error("checkAgainstRule requires a 'root' option")
+
+  const settings = normalizeRuleSettings(options.ruleSettings)
+
+  const tmpPostcssResult = new Result()
+  rules[options.ruleName](settings[0], settings[1])(options.root, tmpPostcssResult)
+  tmpPostcssResult.warnings().forEach(callback)
+}

--- a/lib/utils/checkAgainstRule.js
+++ b/lib/utils/checkAgainstRule.js
@@ -10,7 +10,7 @@ const rules = require("../rules")
 module.exports = function (
   options/*: {
     ruleName: string,
-    ruleSettings: any,
+    ruleSettings: stylelint$configRuleSettings,
     root: Object,
   }*/,
   callback/*: Function*/
@@ -22,7 +22,8 @@ module.exports = function (
   if (!options.ruleSettings) throw new Error("checkAgainstRule requires a 'ruleSettings' option")
   if (!options.root) throw new Error("checkAgainstRule requires a 'root' option")
 
-  const settings = normalizeRuleSettings(options.ruleSettings)
+  const settings = normalizeRuleSettings(options.ruleSettings, options.ruleName)
+  if (!settings) { return }
 
   const tmpPostcssResult = new Result()
   rules[options.ruleName](settings[0], settings[1])(options.root, tmpPostcssResult)


### PR DESCRIPTION
Here's an idea to solve #2139.

It exposes another function `stylelint.checkAgainstRule`, which you can use to run a PostCSS `Root` object through a rule, and invoke a callback with every warning that is created.

What I'd like to see in a situation liked #2139 is that the plugin rule that uses a core rule is the only one that calls `report()`. *It* is the reporting rule, and its severity should be used.

I have not yet added documentation, but did add some tests.

@hudochenkov would you please try this branch out and see if it works for your use-case?

@stylelint/core any input on this?