### PR TITLE
CLI: Mark some parameters as booleans explicitly

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -26,6 +26,15 @@ const minimistOptions = {
     v: "version",
     aei: "allow-empty-input",
   },
+  boolean: [
+    "allow-empty-input",
+    "color",
+    "help",
+    "ignore-disables",
+    "no-color",
+    "quiet",
+    "version",
+  ],
 }
 
 const meowOptions = {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2184

> Is there anything in the PR that needs further explanation?

No.

Fixes #2184

This change states that --allow-empty-input, --color, --help,
--ignore-disables, --no-color, --quiet, --version has no arguments