### PR TITLE
Ensure absolute paths to processors

### DIFF
--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -59,6 +59,8 @@ The difference between the `configOverrides` and `config` options is this: If an
 
 A file glob, or array of file globs. Ultimately passed to [node-glob](https://github.com/isaacs/node-glob) to figure out what files you want to lint.
 
+Relative globs are considered relative to `process.cwd()`.
+
 `node_modules` and `bower_components` are always ignored.
 
 ### `formatter`

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -296,7 +296,9 @@ function addProcessorFunctions(config/*: stylelint$config*/)/*: stylelint$config
   if (!config.processors) return config
 
   const codeProcessors = []
-  const resultProcessors = [];[].concat(config.processors).forEach(processorConfig => {
+  const resultProcessors = []
+
+  ;[].concat(config.processors).forEach(processorConfig => {
     const processorKey = JSON.stringify(processorConfig)
 
     let initializedProcessor

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -3,25 +3,36 @@
 const _ = require("lodash")
 const assignDisabledRanges = require("./assignDisabledRanges")
 const configurationError = require("./utils/configurationError")
+const path = require("path")
 const ruleDefinitions = require("./rules")
 
 // Run stylelint on a PostCSS Result, either one that is provided
 // or one that we create
-module.exports = function (stylelint/*: stylelint$internalApi*/)/*: Promise<Object>*/ {
-  const options/*: {
+module.exports = function (
+  stylelint/*: stylelint$internalApi*/,
+  options/*: {
     code?: string,
-    codeFilename?: string,
-    filePath?: string,
+    codeFilename?: string, // Must be an absolute file path
+    filePath?: string, // Must be an absolute file path
     existingPostcssResult?: Object,
-  }*/ = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {}
+  }*/
+)/*: Promise<Object>*/ {
+  options = options || {}
 
   if (!options.filePath && options.code === undefined && !options.existingPostcssResult) {
-    return Promise.reject("You must provide filePath, code, or existingPostcssResult")
+    return Promise.reject(new Error("You must provide filePath, code, or existingPostcssResult"))
   }
 
   const isCodeNotFile = options.code !== undefined
 
   const inputFilePath = isCodeNotFile ? options.codeFilename : options.filePath
+  if (inputFilePath !== undefined && !path.isAbsolute(inputFilePath)) {
+    if (isCodeNotFile) {
+      return Promise.reject(new Error("codeFilename must be an absolute path"))
+    } else {
+      return Promise.reject(new Error("filePath must be an absolute path"))
+    }
+  }
 
   const getIsIgnored = stylelint.isPathIgnored(inputFilePath).catch(err => {
     if (isCodeNotFile && err.code === "ENOENT") return false

--- a/lib/postcssPlugin.js
+++ b/lib/postcssPlugin.js
@@ -3,16 +3,24 @@
 const _ = require("lodash")
 const createStylelint = require("./createStylelint")
 const postcss = require("postcss")
+const path = require("path")
 
-module.exports = postcss.plugin("stylelint", function () {
-  const options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {}
+module.exports = postcss.plugin("stylelint", function (options) {
+  options = options || {}
 
-  const tailoredOptions/*: Object*/ = options.rules ? { config: options } : options
-
+  const tailoredOptions/*: Object*/ = options.rules
+    ? { config: options }
+    : options
   const stylelint = createStylelint(tailoredOptions)
+
   return (root, result) => {
+    let filePath = options.from || _.get(root, "source.input.file")
+    if (filePath !== undefined && !path.isAbsolute(filePath)) {
+      filePath = path.join(process.cwd(), filePath)
+    }
+
     return stylelint._lintSource({
-      filePath: options.from || _.get(root, "source.input.file"),
+      filePath,
       existingPostcssResult: result,
     })
   }

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -1,5 +1,6 @@
 /* @flow */
 "use strict"
+const path = require("path")
 const formatters = require("./formatters")
 const createStylelint = require("./createStylelint")
 const globby = require("globby")
@@ -51,7 +52,13 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
   })
 
   if (!files) {
-    return stylelint._lintSource({ code, codeFilename }).then(postcssResult => {
+    const absoluteCodeFilename = (codeFilename !== undefined && !path.isAbsolute(codeFilename))
+      ? path.join(process.cwd(), codeFilename)
+      : codeFilename
+    return stylelint._lintSource({
+      code,
+      codeFilename: absoluteCodeFilename,
+    }).then(postcssResult => {
       return stylelint._createStylelintResult(postcssResult)
     }).catch(handleError).then(stylelintResult => {
       return prepareReturnValue([stylelintResult])
@@ -70,7 +77,12 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
     }
 
     const getStylelintResults = filePaths.map(filePath => {
-      return stylelint._lintSource({ filePath }).then(postcssResult => {
+      const absoluteFilepath = (!path.isAbsolute(filePath))
+        ? path.join(process.cwd(), filePath)
+        : filePath
+      return stylelint._lintSource({
+        filePath: absoluteFilepath,
+      }).then(postcssResult => {
         return stylelint._createStylelintResult(postcssResult, filePath)
       }).catch(handleError)
     })


### PR DESCRIPTION
Closes #2194, closes #2195.

Although this does not add more tests, it does add some errors that break things (causing tests to fail) if absolute paths are for some reason not coming through. More focused unit tests looked like more trouble to figure out than they were worth, so I think this does the trick.

I'd like to cut a release for this as soon as possible, so processors stop failing. How about finishing up this and #2197 and then releasing?