### PR TITLE
Consistent options

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -72,7 +72,7 @@ A rule's secondary option can be anything if you're not ignoring or making excep
 
 ##### Keyword `"ignore"` and `"except"`
 
-`"ignore"` and `"except"` accept an array of predefined keyword options e.g. `["relative", "first-nested", "descendant"]`.
+`"ignore"` and `"except"` accept an array of predefined keyword options e.g. `["relative", "after-opening-brace", "descendant"]`.
 
 -   Use `"ignore"` when you want the rule to simply skip-over a particular pattern.
 -   Use `"except"` when you want to invert the primary option for a particular pattern.

--- a/docs/user-guide/about-rules.md
+++ b/docs/user-guide/about-rules.md
@@ -272,25 +272,25 @@ You can do that with:
 
 ```js
 "at-rule-empty-line-before": ["always", {
-  "except": ["first-nested"]
+  "except": ["after-opening-brace"]
 }],
 "custom-property-empty-line-before": [ "always", {
   "except": [
     "after-custom-property",
-    "first-nested"
+    "after-opening-brace"
   ]
 }],
 "declaration-empty-line-before": ["always", {
   "except": [
     "after-declaration",
-    "first-nested"
+    "after-opening-brace"
   ]
 }],
 "block-closing-brace-empty-line-before": "never",
 "rule-non-nested-empty-line-before": ["always-multi-line"]
 ```
 
-We recommend that you set your primary option (e.g. `"always"` or `"never"`) to whatever is your most common occurrence and define your exceptions with the `except` optional secondary options. There are many values for the `except` option e.g. `first-nested`, `after-comment` etc.
+We recommend that you set your primary option (e.g. `"always"` or `"never"`) to whatever is your most common occurrence and define your exceptions with the `except` optional secondary options. There are many values for the `except` option e.g. `after-opening-brace`, `after-comment` etc.
 
 The `*-empty-line-before` rules control whether there must never be an empty line or whether there must be *one or more* empty lines before a *thing*. The `*-max-empty-lines` rules complement this by controlling *the number* of empty lines within *things*. The `max-empty-lines` rule is used to set a limit across the entire source. A *stricter* limit can then be set within *things* using the likes of `function-max-empty-lines`, `selector-max-empty-lines` and `value-list-max-empty-lines`.
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -36,7 +36,7 @@ The `rules` property is *an object whose keys are rule names and values are rule
     "block-no-empty": null,
     "color-no-invalid-hex": true,
     "comment-empty-line-before": [ "always", {
-      "ignore": ["stylelint-commands", "between-comments"]
+      "ignore": ["stylelint-command", "after-comment"]
     } ],
     "declaration-colon-space-after": "always",
     "indentation": ["tab", {
@@ -44,7 +44,7 @@ The `rules` property is *an object whose keys are rule names and values are rule
     }],
     "max-empty-lines": 2,
     "rule-nested-empty-line-before": [ "always", {
-      "except": ["first-nested"],
+      "except": ["after-opening-brace"],
       "ignore": ["after-comment"]
     } ],
     "unit-whitelist": ["em", "rem", "%", "s"]

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -64,7 +64,7 @@ a {}
 
 ## Optional secondary options
 
-### `except: ["inside-block", "blockless-after-same-name-blockless", "blockless-after-blockless", "first-nested"]`
+### `except: ["inside-block", "blockless-after-same-name-blockless", "blockless-after-blockless", "after-opening-brace"]`
 
 ### `"inside-block"`
 
@@ -159,7 +159,9 @@ The following patterns are *not* considered warnings:
 @media print {}
 ```
 
-#### `"first-nested"`
+#### `"after-opening-brace"`
+
+***Note: This option was previously called `first-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Reverse the primary option for at-rules that are nested and the first child of their parent node.
 

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -64,9 +64,11 @@ a {}
 
 ## Optional secondary options
 
-### `except: ["all-nested", "blockless-after-same-name-blockless", "blockless-group", "first-nested"]`
+### `except: ["inside-block", "blockless-after-same-name-blockless", "blockless-group", "first-nested"]`
 
-### `"all-nested"`
+### `"inside-block"`
+
+***Note: This option was previously called `all-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Reverse the primary option for at-rules that are nested.
 
@@ -191,7 +193,7 @@ b {
 }
 ```
 
-### `ignore: ["after-comment", "all-nested", "blockless-after-same-name-blockless", "blockless-group",]`
+### `ignore: ["after-comment", "inside-block", "blockless-after-same-name-blockless", "blockless-group",]`
 
 #### `"after-comment"`
 
@@ -210,7 +212,9 @@ The following patterns are *not* considered warnings:
 @media {}
 ```
 
-#### `"all-nested"`
+#### `"inside-block"`
+
+***Note: This option was previously called `all-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Ignore at-rules that are nested.
 

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -64,7 +64,7 @@ a {}
 
 ## Optional secondary options
 
-### `except: ["inside-block", "blockless-after-same-name-blockless", "blockless-group", "first-nested"]`
+### `except: ["inside-block", "blockless-after-same-name-blockless", "blockless-after-blockless", "first-nested"]`
 
 ### `"inside-block"`
 
@@ -132,7 +132,9 @@ a {
 }
 ```
 
-#### `"blockless-group"`
+#### `"blockless-after-blockless"`
+
+***Note: This option was previously called `blockless-group`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Reverse the primary option for at-rules within a blockless group.
 
@@ -193,7 +195,7 @@ b {
 }
 ```
 
-### `ignore: ["after-comment", "inside-block", "blockless-after-same-name-blockless", "blockless-group",]`
+### `ignore: ["after-comment", "inside-block", "blockless-after-same-name-blockless", "blockless-after-blockless",]`
 
 #### `"after-comment"`
 
@@ -275,7 +277,9 @@ a {
 }
 ```
 
-#### `"blockless-group"`
+#### `"blockless-after-blockless"`
+
+***Note: This option was previously called `blockless-group`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Ignore at-rules within a blockless group.
 

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -220,7 +220,7 @@ The following patterns are *not* considered warnings:
 
 ***Note: This option was previously called `all-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
-Ignore at-rules that are nested.
+Ignore at-rules that are inside a declaration block.
 
 For example, with `"always"`:
 
@@ -283,7 +283,7 @@ a {
 
 ***Note: This option was previously called `blockless-group`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
-Ignore at-rules within a blockless group.
+Ignore blockless at-rules that follow another blockless at-rule.
 
 For example, with `"always"`:
 

--- a/lib/rules/at-rule-empty-line-before/__tests__/deprecate-all-nested.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/deprecate-all-nested.js
@@ -1,0 +1,58 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'at-rule-empty-line-before\'s' \"all-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"inside-block\" option.",
+  reference: "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, except all-nested' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "always", { except: ["all-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never, except all-nested' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "never", { except: ["all-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'always, ignore all-nested' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "always", { ignore: ["all-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never, ignore all-nested' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "never", { ignore: ["all-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/at-rule-empty-line-before/__tests__/deprecate-blockless-group.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/deprecate-blockless-group.js
@@ -1,0 +1,58 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'at-rule-empty-line-before\'s' \"blockless-group\" option has been deprecated and in 8.0 will be removed. Instead use the \"blockless-after-blockless\" option.",
+  reference: "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, except blockless-group' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "always", { except: ["blockless-group"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never, except blockless-group' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "never", { except: ["blockless-group"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'always, ignore blockless-group' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "always", { ignore: ["blockless-group"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never, ignore blockless-group' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "never", { ignore: ["blockless-group"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/at-rule-empty-line-before/__tests__/deprecate-first-nested.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/deprecate-first-nested.js
@@ -1,0 +1,34 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'at-rule-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+  reference: "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "always", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'always, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "at-rule-empty-line-before": [ "never", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -134,9 +134,52 @@ testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
   } ],
 }))
 
+testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
+  ruleName,
+  config: [ "always", { except: ["blockless-after-blockless"] } ],
+
+  accept: [ {
+    code: "a {\n\n  @mixin foo;\n}",
+  }, {
+    code: "@keyframes foo {}\n\n@import 'x.css'",
+    description: "empty line not blockless pair",
+  }, {
+    code: "@import 'x.css';\n@import 'y.css'",
+    description: "no empty line blockless pair",
+  }, {
+    code: "@import 'x.css';",
+    description: "single blockless rule",
+  } ],
+
+  reject: [ {
+    code: "@keyframes foo {}\n@import 'x.css'",
+    message: messages.expected,
+  }, {
+    code: "@import 'x.css';\n\n@import 'y.css'",
+    message: messages.rejected,
+  } ],
+}))
+
 testRule(rule, {
   ruleName,
   config: [ "always", { ignore: ["blockless-group"] } ],
+
+  accept: [{
+    code: "@media {}; @import 'x.css';",
+  }],
+
+  reject: [ {
+    code: "@import 'x.css'; @media {};",
+    message: messages.expected,
+  }, {
+    code: "@import 'test'; @include mixin(1) { @content; };",
+    message: messages.expected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", { ignore: ["blockless-after-blockless"] } ],
 
   accept: [{
     code: "@media {}; @import 'x.css';",
@@ -293,7 +336,7 @@ testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
 
 testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
   ruleName,
-  config: [ "always", { except: [ "blockless-group", "inside-block" ] } ],
+  config: [ "always", { except: [ "blockless-after-blockless", "inside-block" ] } ],
 
   accept: [ {
     code: "a {\n  @mixin foo;\n  color: pink;\n}",
@@ -339,6 +382,32 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
 testRule(rule, mergeTestDescriptions(sharedNeverTests, {
   ruleName,
   config: [ "never", { except: ["blockless-group"] } ],
+
+  accept: [ {
+    code: "a {\n  @mixin foo;\n}",
+  }, {
+    code: "@keyframes foo {}\n@import 'x.css'",
+    description: "no empty line not blockless pair",
+  }, {
+    code: "@import 'x.css';\n\n@import 'y.css'",
+    description: "empty line blockless pair",
+  }, {
+    code: "@import 'x.css';",
+    description: "single blockless rule",
+  } ],
+
+  reject: [ {
+    code: "@keyframes foo {}\n\n@import 'x.css'",
+    message: messages.rejected,
+  }, {
+    code: "@import 'x.css';\n@import 'y.css'",
+    message: messages.expected,
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedNeverTests, {
+  ruleName,
+  config: [ "never", { except: ["blockless-after-blockless"] } ],
 
   accept: [ {
     code: "a {\n  @mixin foo;\n}",
@@ -420,6 +489,36 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
 testRule(rule, {
   ruleName,
   config: [ "never", { ignore: ["blockless-group"] } ],
+
+  accept: [ {
+    code: `
+      @media {};
+
+      @import 'x.css';
+    `,
+  }, {
+    code: `
+      @import 'x.css';
+
+      @import 'y.css';
+    `,
+  } ],
+
+  reject: [{
+    code: `
+      @import 'x.css';
+
+      @media {};
+    `,
+    message: messages.rejected,
+    line: 4,
+    column: 7,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "never", { ignore: ["blockless-after-blockless"] } ],
 
   accept: [ {
     code: `

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -270,6 +270,23 @@ testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
 
 testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
   ruleName,
+  config: [ "always", { except: ["after-opening-brace"] } ],
+
+  accept: [{
+    code: "a {\n  @mixin foo;\n  color: pink;\n}",
+  }],
+
+  reject: [ {
+    code: "a {\n  color: pink;\n  @mixin foo;\n}",
+    message: messages.expected,
+  }, {
+    code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
+    message: messages.rejected,
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
+  ruleName,
   config: [ "always", { ignore: ["all-nested"] } ],
 
   accept: [ {
@@ -472,6 +489,23 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
 testRule(rule, mergeTestDescriptions(sharedNeverTests, {
   ruleName,
   config: [ "never", { except: ["first-nested"] } ],
+
+  accept: [{
+    code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
+  }],
+
+  reject: [ {
+    code: "a {\n  color: pink;\n\n  @mixin foo;\n}",
+    message: messages.rejected,
+  }, {
+    code: "a {\n  @mixin foo;\n  color: pink;\n}",
+    message: messages.expected,
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedNeverTests, {
+  ruleName,
+  config: [ "never", { except: ["after-opening-brace"] } ],
 
   accept: [{
     code: "a {\n\n  @mixin foo;\n  color: pink;\n}",

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -191,6 +191,25 @@ testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
 
 testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
   ruleName,
+  config: [ "always", { except: ["inside-block"] } ],
+
+  accept: [ {
+    code: "a {\n  @mixin foo;\n  color: pink;\n}",
+  }, {
+    code: "a {\n  color: pink;\n  @mixin foo;\n}",
+  } ],
+
+  reject: [ {
+    code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
+    message: messages.rejected,
+  }, {
+    code: "a {\n\n  color: pink;\n\n  @mixin foo;\n}",
+    message: messages.rejected,
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
+  ruleName,
   config: [ "always", { except: ["first-nested"] } ],
 
   accept: [{
@@ -223,7 +242,58 @@ testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
 
 testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
   ruleName,
+  config: [ "always", { ignore: ["inside-block"] } ],
+
+  accept: [ {
+    code: "a {\n  @mixin foo;\n  color: pink;\n}",
+  }, {
+    code: "a {\n  color: pink;\n  @mixin foo;\n}",
+  }, {
+    code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
+  }, {
+    code: "a {\n\n  color: pink;\n\n  @mixin foo;\n}",
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
+  ruleName,
   config: [ "always", { except: [ "blockless-group", "all-nested" ] } ],
+
+  accept: [ {
+    code: "a {\n  @mixin foo;\n  color: pink;\n}",
+  }, {
+    code: "a {\n  color: pink;\n  @mixin foo;\n}",
+  }, {
+    code: "@keyframes foo {}\n\n@import 'x.css'",
+    description: "empty line not blockless pair",
+  }, {
+    code: "@import 'x.css';\n@import 'y.css'",
+    description: "no empty line blockless pair",
+  }, {
+    code: "@import 'x.css';",
+    description: "single blockless rule",
+  }, {
+    code: "a {\n  @mixin foo;\n  @mixin bar;\n}",
+  } ],
+
+  reject: [ {
+    code: "@keyframes foo {}\n@import 'x.css'",
+    message: messages.expected,
+  }, {
+    code: "@import 'x.css';\n\n@import 'y.css'",
+    message: messages.rejected,
+  }, {
+    code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
+    message: messages.rejected,
+  }, {
+    code: "a {\n\n  color: pink;\n\n  @mixin foo;\n}",
+    message: messages.rejected,
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedAlwaysTests, {
+  ruleName,
+  config: [ "always", { except: [ "blockless-group", "inside-block" ] } ],
 
   accept: [ {
     code: "a {\n  @mixin foo;\n  color: pink;\n}",
@@ -313,6 +383,25 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
 
 testRule(rule, mergeTestDescriptions(sharedNeverTests, {
   ruleName,
+  config: [ "never", { except: ["inside-block"] } ],
+
+  accept: [ {
+    code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
+  }, {
+    code: "a {\n  color: pink;\n\n  @mixin foo;\n}",
+  } ],
+
+  reject: [ {
+    code: "a {\n  @mixin foo;\n  color: pink;\n}",
+    message: messages.expected,
+  }, {
+    code: "a {\n\n  color: pink;\n  @mixin foo;\n}",
+    message: messages.expected,
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedNeverTests, {
+  ruleName,
   config: [ "never", { except: ["first-nested"] } ],
 
   accept: [{
@@ -384,6 +473,21 @@ testRule(rule, {
 testRule(rule, mergeTestDescriptions(sharedNeverTests, {
   ruleName,
   config: [ "never", { ignore: ["all-nested"] } ],
+
+  accept: [ {
+    code: "a {\n  @mixin foo;\n  color: pink;\n}",
+  }, {
+    code: "a {\n  color: pink;\n  @mixin foo;\n}",
+  }, {
+    code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
+  }, {
+    code: "a {\n\n  color: pink;\n\n  @mixin foo;\n}",
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(sharedNeverTests, {
+  ruleName,
+  config: [ "never", { ignore: ["inside-block"] } ],
 
   accept: [ {
     code: "a {\n  @mixin foo;\n  color: pink;\n}",
@@ -660,7 +764,7 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
     code: stripIndent`
       @charset "UTF-8";
       @import url(x.css);
-      
+
       @import url(y.css);`,
   }, {
     code: stripIndent`

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -33,6 +33,7 @@ const rule = function (expectation, options) {
           "blockless-group",
           "blockless-after-blockless",
           "first-nested",
+          "after-opening-brace",
         ],
         ignore: [
           "after-comment",
@@ -48,6 +49,16 @@ const rule = function (expectation, options) {
     })
     if (!validOptions) {
       return
+    }
+
+    if (optionsMatches(options, "except", "first-nested")) {
+      result.warn((
+        "'at-rule-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"after-opening-brace\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+      })
     }
 
     if (
@@ -139,6 +150,8 @@ const rule = function (expectation, options) {
         || optionsMatches(options, "except", "inside-block")
         && isNested
         || optionsMatches(options, "except", "first-nested")
+        && isFirstNested()
+        || optionsMatches(options, "except", "after-opening-brace")
         && isFirstNested()
         || optionsMatches(options, "except", "blockless-group")
         && isBlocklessAfterBlockless()

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -28,6 +28,7 @@ const rule = function (expectation, options) {
       possible: {
         except: [
           "all-nested",
+          "inside-block",
           "blockless-after-same-name-blockless",
           "blockless-group",
           "first-nested",
@@ -35,6 +36,7 @@ const rule = function (expectation, options) {
         ignore: [
           "after-comment",
           "all-nested",
+          "inside-block",
           "blockless-after-same-name-blockless",
           "blockless-group",
         ],
@@ -44,6 +46,19 @@ const rule = function (expectation, options) {
     })
     if (!validOptions) {
       return
+    }
+
+    if (
+      optionsMatches(options, "ignore", "all-nested")
+      || optionsMatches(options, "except", "all-nested")
+    ) {
+      result.warn((
+        "'at-rule-empty-line-before\'s' \"all-nested\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"inside-block\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+      })
     }
 
     root.walkAtRules(atRule => {
@@ -77,9 +92,11 @@ const rule = function (expectation, options) {
         return
       }
 
-      // Optionally ignore the expectation if the node is nested
+      // Optionally ignore the expectation if the node is inside a block
       if (
         optionsMatches(options, "ignore", "all-nested")
+        && isNested
+        || optionsMatches(options, "ignore", "inside-block")
         && isNested
       ) {
         return
@@ -101,6 +118,8 @@ const rule = function (expectation, options) {
       // Optionally reverse the expectation if any exceptions apply
       if (
         optionsMatches(options, "except", "all-nested")
+        && isNested
+        || optionsMatches(options, "except", "inside-block")
         && isNested
         || optionsMatches(options, "except", "first-nested")
         && isFirstNested()

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -31,6 +31,7 @@ const rule = function (expectation, options) {
           "inside-block",
           "blockless-after-same-name-blockless",
           "blockless-group",
+          "blockless-after-blockless",
           "first-nested",
         ],
         ignore: [
@@ -39,6 +40,7 @@ const rule = function (expectation, options) {
           "inside-block",
           "blockless-after-same-name-blockless",
           "blockless-group",
+          "blockless-after-blockless",
         ],
         ignoreAtRules: [_.isString],
       },
@@ -61,6 +63,19 @@ const rule = function (expectation, options) {
       })
     }
 
+    if (
+      optionsMatches(options, "ignore", "blockless-group")
+      || optionsMatches(options, "except", "blockless-group")
+    ) {
+      result.warn((
+        "'at-rule-empty-line-before\'s' \"blockless-group\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"blockless-after-blockless\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+      })
+    }
+
     root.walkAtRules(atRule => {
       // Ignore the first node
       if (atRule === root.first) {
@@ -75,6 +90,8 @@ const rule = function (expectation, options) {
       // Optionally ignore the expectation if the node is blockless
       if (
         optionsMatches(options, "ignore", "blockless-group")
+        && !hasBlock(atRule)
+        || optionsMatches(options, "ignore", "blockless-after-blockless")
         && !hasBlock(atRule)
       ) {
         return
@@ -124,6 +141,8 @@ const rule = function (expectation, options) {
         || optionsMatches(options, "except", "first-nested")
         && isFirstNested()
         || optionsMatches(options, "except", "blockless-group")
+        && isBlocklessAfterBlockless()
+        || optionsMatches(options, "except", "blockless-after-blockless")
         && isBlocklessAfterBlockless()
         || optionsMatches(options, "except", "blockless-after-same-name-blockless")
         && isBlocklessAfterSameNameBlockless()

--- a/lib/rules/checkRuleEmptyLineBefore.js
+++ b/lib/rules/checkRuleEmptyLineBefore.js
@@ -23,6 +23,11 @@ module.exports = function (opts) {
     expectEmptyLineBefore = !expectEmptyLineBefore
   }
 
+  // Optionally reverse the expectation for the first nested node
+  if (optionsMatches(opts.options, "except", "after-opening-brace") && opts.rule === opts.rule.parent.first) {
+    expectEmptyLineBefore = !expectEmptyLineBefore
+  }
+
   // Optionally reverse the expectation if a rule precedes this node
   if (optionsMatches(opts.options, "except", "after-rule") && opts.rule.prev() && opts.rule.prev().type === "rule") {
     expectEmptyLineBefore = !expectEmptyLineBefore

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -93,9 +93,11 @@ a {
 }
 ```
 
-### `ignore: ["between-comments", "stylelint-commands"]`
+### `ignore: ["after-comment", "stylelint-commands"]`
 
-#### `"between-comments"`
+#### `"after-comment"`
+
+***Note: This option was previously called `between-comments`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Don't require an empty line between comments.
 

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -68,7 +68,9 @@ a {} /* comment */
 
 ## Optional secondary options
 
-### `except: ["first-nested"]`
+### `except: ["after-opening-brace"]`
+
+***Note: This option was previously called `first-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Reverse the primary option for comments that are nested and the first child of their parent node.
 

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -101,7 +101,7 @@ a {
 
 ***Note: This option was previously called `between-comments`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
-Don't require an empty line between comments.
+Don't require an empty line after a comment.
 
 For example, with `"always"`:
 
@@ -131,7 +131,6 @@ a {
 #### `"stylelint-command"`
 
 ***Note: This option was previously called `stylelint-commands`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
-
 
 Ignore comments that deliver commands to stylelint, e.g. `/* stylelint-disable color-no-hex */`.
 

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -93,7 +93,7 @@ a {
 }
 ```
 
-### `ignore: ["after-comment", "stylelint-commands"]`
+### `ignore: ["after-comment", "stylelint-command"]`
 
 #### `"after-comment"`
 
@@ -126,7 +126,10 @@ a {
 }
 ```
 
-#### `"stylelint-commands"`
+#### `"stylelint-command"`
+
+***Note: This option was previously called `stylelint-commands`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
+
 
 Ignore comments that deliver commands to stylelint, e.g. `/* stylelint-disable color-no-hex */`.
 

--- a/lib/rules/comment-empty-line-before/__tests__/deprecate-between-comments.js
+++ b/lib/rules/comment-empty-line-before/__tests__/deprecate-between-comments.js
@@ -1,0 +1,22 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'comment-empty-line-before\'s' \"between-comments\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-comment\" option.",
+  reference: "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, ignore between-comments' config", () => {
+  const config = {
+    rules: {
+      "comment-empty-line-before": [ "always", { ignore: ["between-comments"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/comment-empty-line-before/__tests__/deprecate-first-nested.js
+++ b/lib/rules/comment-empty-line-before/__tests__/deprecate-first-nested.js
@@ -1,0 +1,22 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'comment-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+  reference: "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "comment-empty-line-before": [ "always", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/comment-empty-line-before/__tests__/deprecate-stylelint-commands.js
+++ b/lib/rules/comment-empty-line-before/__tests__/deprecate-stylelint-commands.js
@@ -1,0 +1,22 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'comment-empty-line-before\'s' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
+  reference: "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, ignore stylelint-commands' config", () => {
+  const config = {
+    rules: {
+      "comment-empty-line-before": [ "always", { ignore: ["stylelint-commands"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -113,6 +113,24 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { ignore: ["after-comment"] } ],
+
+  accept: [ {
+    code: "/* a */\n/* b */\n/* c */\nbody {\n}",
+    description: "no newline between comments",
+  }, {
+    code: "a { color: pink;\n\n/** comment */\n/** comment */\ntop: 0; }",
+    description: "no newline between comments",
+  } ],
+
+  reject: [{
+    code: "a { color: pink;\n/** comment */\n/** comment */\ntop: 0; }",
+    message: messages.expected,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
   config: ["never"],
 
   accept: [ {

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -85,6 +85,24 @@ testRule(rule, mergeTestDescriptions(alwaysTests, {
 
 testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
+  config: [ "always", { except: ["after-opening-brace"] } ],
+
+  accept: [{
+    code: "a {\n  /* comment */\n  color: pink;\n}",
+    description: "after-opening-brace without empty line before",
+  }],
+
+  reject: [{
+    code: "a {\n\n  /* comment */\n  color: pink;\n}",
+    description: "after-opening-brace with empty line before",
+    message: messages.rejected,
+    line: 3,
+    column: 3,
+  }],
+}))
+
+testRule(rule, mergeTestDescriptions(alwaysTests, {
+  ruleName,
   config: [ "always", { ignore: ["stylelint-commands"] } ],
 
   accept: [{

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -93,6 +93,16 @@ testRule(rule, mergeTestDescriptions(alwaysTests, {
   }],
 }))
 
+testRule(rule, mergeTestDescriptions(alwaysTests, {
+  ruleName,
+  config: [ "always", { ignore: ["stylelint-command"] } ],
+
+  accept: [{
+    code: "a {\ncolor: pink;\n/* stylelint-disable something */\ntop: 0;\n}",
+    description: "no newline before a stylelint command comment",
+  }],
+}))
+
 testRule(rule, {
   ruleName,
   config: [ "always", { ignore: ["between-comments"] } ],

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -29,6 +29,7 @@ const rule = function (expectation, options) {
         except: ["first-nested"],
         ignore: [
           "stylelint-commands",
+          "stylelint-command",
           "between-comments",
           "after-comment",
         ],
@@ -51,6 +52,18 @@ const rule = function (expectation, options) {
       })
     }
 
+    if (
+      optionsMatches(options, "ignore", "stylelint-commands")
+    ) {
+      result.warn((
+        "'comment-empty-line-before\'s' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"stylelint-command\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+      })
+    }
+
     root.walkComments(comment => {
       // Ignore the first node
       if (comment === root.first) {
@@ -61,6 +74,8 @@ const rule = function (expectation, options) {
       if (
         comment.text.indexOf(stylelintCommandPrefix) === 0
         && optionsMatches(options, "ignore", "stylelint-commands")
+        || comment.text.indexOf(stylelintCommandPrefix) === 0
+        && optionsMatches(options, "ignore", "stylelint-command")
       ) {
         return
       }

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -30,12 +30,25 @@ const rule = function (expectation, options) {
         ignore: [
           "stylelint-commands",
           "between-comments",
+          "after-comment",
         ],
       },
       optional: true,
     })
     if (!validOptions) {
       return
+    }
+
+    if (
+      optionsMatches(options, "ignore", "between-comments")
+    ) {
+      result.warn((
+        "'comment-empty-line-before\'s' \"between-comments\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"after-comment\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+      })
     }
 
     root.walkComments(comment => {
@@ -58,6 +71,14 @@ const rule = function (expectation, options) {
         prev
         && prev.type === "comment"
         && optionsMatches(options, "ignore", "between-comments")
+      ) {
+        return
+      }
+
+      if (
+        prev
+        && prev.type === "comment"
+        && optionsMatches(options, "ignore", "after-comment")
       ) {
         return
       }

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -26,7 +26,10 @@ const rule = function (expectation, options) {
     }, {
       actual: options,
       possible: {
-        except: ["first-nested"],
+        except: [
+          "first-nested",
+          "after-opening-brace",
+        ],
         ignore: [
           "stylelint-commands",
           "stylelint-command",
@@ -38,6 +41,16 @@ const rule = function (expectation, options) {
     })
     if (!validOptions) {
       return
+    }
+
+    if (optionsMatches(options, "except", "first-nested")) {
+      result.warn((
+        "'comment-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"after-opening-brace\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+      })
     }
 
     if (
@@ -115,6 +128,13 @@ const rule = function (expectation, options) {
       const expectEmptyLineBefore = (() => {
         if (
           optionsMatches(options, "except", "first-nested")
+          && comment.parent !== root
+          && comment === comment.parent.first
+        ) {
+          return false
+        }
+        if (
+          optionsMatches(options, "except", "after-opening-brace")
           && comment.parent !== root
           && comment === comment.parent.first
         ) {

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -81,7 +81,7 @@ a {
 
 ## Optional secondary options
 
-### `except: ["after-comment", "after-custom-property", "first-nested"]`
+### `except: ["after-comment", "after-custom-property", "after-opening-brace"]`
 
 #### `"after-comment"`
 
@@ -140,7 +140,9 @@ a {
 }
 ```
 
-#### `"first-nested"`
+#### `"after-opening-brace"`
+
+***Note: This option was previously called `first-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Reverse the primary option for custom properties that are nested and the first child of their parent node.
 

--- a/lib/rules/custom-property-empty-line-before/__tests__/deprecate-first-nested.js
+++ b/lib/rules/custom-property-empty-line-before/__tests__/deprecate-first-nested.js
@@ -1,0 +1,34 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'custom-property-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+  reference: "http://stylelint.io/user-guide/rules/custom-property-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "custom-property-empty-line-before": [ "always", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "custom-property-empty-line-before": [ "never", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/custom-property-empty-line-before/__tests__/index.js
+++ b/lib/rules/custom-property-empty-line-before/__tests__/index.js
@@ -131,6 +131,31 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { except: ["after-opening-brace"] } ],
+
+  accept: [ {
+    code: "a { --custom-prop: value;\n}",
+  }, {
+    code: "a {\n --custom-prop: value;\n}",
+  }, {
+    code: "a {\r\n --custom-prop: value;\r\n}",
+  } ],
+
+  reject: [ {
+    code: "a {\n\n --custom-prop: value;\n}",
+    message: messages.rejected,
+    line: 3,
+    column: 2,
+  }, {
+    code: "a {\r\n\r\n --custom-prop: value;\r\n}",
+    message: messages.rejected,
+    line: 3,
+    column: 2,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { except: ["after-comment"] } ],
 
   accept: [ {
@@ -183,6 +208,15 @@ testRule(rule, {
   ruleName,
   config: [ "always", {
     except: [ "first-nested", "after-comment", "after-custom-property" ] } ],
+
+  accept: [{ code: "a {\n --custom-prop: value; \n --custom-prop2: value; \n /* comment */ \n --custom-prop3: value;\n\n @extends 'x';\n\n --custom-prop4: value; \n & b {\n prop: value;\n } \n\n --custom-prop5: value; \n }" }],
+
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", {
+    except: [ "after-opening-brace", "after-comment", "after-custom-property" ] } ],
 
   accept: [{ code: "a {\n --custom-prop: value; \n --custom-prop2: value; \n /* comment */ \n --custom-prop3: value;\n\n @extends 'x';\n\n --custom-prop4: value; \n & b {\n prop: value;\n } \n\n --custom-prop5: value; \n }" }],
 
@@ -261,6 +295,31 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "never", { except: ["after-opening-brace"] } ],
+
+  accept: [ {
+    code: "a {\n\n --custom-prop: value;\n}",
+  }, {
+    code: "a {\n\n --custom-prop: value;\n}",
+  }, {
+    code: "a {\r\n\r\n --custom-prop: value;\r\n}",
+  } ],
+
+  reject: [ {
+    code: "a {\n --custom-prop: value;\n}",
+    message: messages.expected,
+    line: 2,
+    column: 2,
+  }, {
+    code: "a {\r\n --custom-prop: value;\r\n}",
+    message: messages.expected,
+    line: 2,
+    column: 2,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "never", { except: ["after-comment"] } ],
 
   accept: [ {
@@ -315,5 +374,12 @@ testRule(rule, {
     except: [ "first-nested", "after-comment", "after-custom-property" ] } ],
 
   accept: [{ code: "a {\n\n --custom-prop: value; \n\n --custom-prop2: value; \n /* comment */ \n\n --custom-prop3: value;\n\n @extends 'x';\n --custom-prop4: value; \n & b {\n prop: value;\n } \n --custom-prop5: value; \n }" }],
+})
 
+testRule(rule, {
+  ruleName,
+  config: [ "never", {
+    except: [ "after-opening-brace", "after-comment", "after-custom-property" ] } ],
+
+  accept: [{ code: "a {\n\n --custom-prop: value; \n\n --custom-prop2: value; \n /* comment */ \n\n --custom-prop3: value;\n\n @extends 'x';\n --custom-prop4: value; \n & b {\n prop: value;\n } \n --custom-prop5: value; \n }" }],
 })

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -30,6 +30,7 @@ const rule = function (expectation, options) {
       possible: {
         except: [
           "first-nested",
+          "after-opening-brace",
           "after-comment",
           "after-custom-property",
         ],
@@ -42,6 +43,16 @@ const rule = function (expectation, options) {
     })
     if (!validOptions) {
       return
+    }
+
+    if (optionsMatches(options, "except", "first-nested")) {
+      result.warn((
+        "'custom-property-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"after-opening-brace\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/custom-property-empty-line-before/",
+      })
     }
 
     root.walkDecls(decl => {
@@ -77,6 +88,8 @@ const rule = function (expectation, options) {
       // Optionally reverse the expectation for the first nested node
       if (
         optionsMatches(options, "except", "first-nested")
+        && decl === parent.first
+        || optionsMatches(options, "except", "after-opening-brace")
         && decl === parent.first
       ) {
         expectEmptyLineBefore = !expectEmptyLineBefore

--- a/lib/rules/declaration-empty-line-before/README.md
+++ b/lib/rules/declaration-empty-line-before/README.md
@@ -6,7 +6,7 @@ Require or disallow an empty line before declarations.
 a {
   --foo: pink;
              /* ← */
-  top: 15px; /* ↑ */   
+  top: 15px; /* ↑ */
 }            /* ↑ */
 /**             ↑
  *      This line */
@@ -92,7 +92,7 @@ a {
 
 ## Optional secondary options
 
-### `except: ["after-comment", "after-declaration", "first-nested"]`
+### `except: ["after-comment", "after-declaration", "after-opening-brace"]`
 
 #### `"after-comment"`
 
@@ -147,7 +147,9 @@ a {
 }
 ```
 
-#### `"first-nested"`
+#### `"after-opening-brace"`
+
+***Note: This option was previously called `first-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Reverse the primary option for declarations that are nested and the first child of their parent node.
 

--- a/lib/rules/declaration-empty-line-before/__tests__/deprecate-first-nested.js
+++ b/lib/rules/declaration-empty-line-before/__tests__/deprecate-first-nested.js
@@ -1,0 +1,34 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'declaration-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+  reference: "http://stylelint.io/user-guide/rules/declaration-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "declaration-empty-line-before": [ "always", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "declaration-empty-line-before": [ "never", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/declaration-empty-line-before/__tests__/index.js
+++ b/lib/rules/declaration-empty-line-before/__tests__/index.js
@@ -266,6 +266,31 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { except: ["after-opening-brace"] } ],
+
+  accept: [ {
+    code: "a { top: 15px;\n}",
+  }, {
+    code: "a {\n top: 15px;\n}",
+  }, {
+    code: "a {\r\n top: 15px;\r\n}",
+  } ],
+
+  reject: [ {
+    code: "a {\n\n top: 15px;\n}",
+    message: messages.rejected,
+    line: 3,
+    column: 2,
+  }, {
+    code: "a {\r\n\r\n top: 15px;\r\n}",
+    message: messages.rejected,
+    line: 3,
+    column: 2,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { except: ["after-comment"] } ],
 
   accept: [ {
@@ -372,6 +397,14 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", {
+    except: [ "after-opening-brace", "after-comment", "after-declaration" ] } ],
+
+  accept: [{ code: "a {\n top: 15px; \n bottom: 5px; \n /* comment */ \n prop: 15px;\n\n @extends 'x';\n\n prop: 15px; \n & b {\n prop: 15px;\n } \n\n prop: 15px; \n }" }],
+})
+
+testRule(rule, {
+  ruleName,
   config: ["never"],
 
   accept: [ {
@@ -430,6 +463,36 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [ "never", { except: ["first-nested"] } ],
+
+  accept: [ {
+    code: "a {\n\n top: 15px;\n}",
+  }, {
+    code: "a {\n\n top: 15px;\n bottom: 5px;}",
+  }, {
+    code: "a {\r\n\r\n top: 15px;\r\n}",
+  } ],
+
+  reject: [ {
+    code: "a {\n\n top: 15px;\n\nbottom:5px; }",
+    message: messages.rejected,
+    line: 5,
+    column: 1,
+  }, {
+    code: "a {\n top: 15px;\n}",
+    message: messages.expected,
+    line: 2,
+    column: 2,
+  }, {
+    code: "a {\r\n top: 15px;\r\n}",
+    message: messages.expected,
+    line: 2,
+    column: 2,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "never", { except: ["after-opening-brace"] } ],
 
   accept: [ {
     code: "a {\n\n top: 15px;\n}",
@@ -523,5 +586,12 @@ testRule(rule, {
     except: [ "first-nested", "after-comment", "after-declaration" ] } ],
 
   accept: [{ code: "a {\n\n top: 15px; \n\n bottom: 5px; \n /* comment */ \n\n prop: 15px;\n\n @extends 'x';\n prop: 15px; \n & b {\n\n prop: 15px;\n } \n prop: 15px; \n }" }],
+})
 
+testRule(rule, {
+  ruleName,
+  config: [ "never", {
+    except: [ "after-opening-brace", "after-comment", "after-declaration" ] } ],
+
+  accept: [{ code: "a {\n\n top: 15px; \n\n bottom: 5px; \n /* comment */ \n\n prop: 15px;\n\n @extends 'x';\n prop: 15px; \n & b {\n\n prop: 15px;\n } \n prop: 15px; \n }" }],
 })

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -30,6 +30,7 @@ const rule = function (expectation, options) {
       possible: {
         except: [
           "first-nested",
+          "after-opening-brace",
           "after-comment",
           "after-declaration",
         ],
@@ -43,6 +44,16 @@ const rule = function (expectation, options) {
     })
     if (!validOptions) {
       return
+    }
+
+    if (optionsMatches(options, "except", "first-nested")) {
+      result.warn((
+        "'declaration-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"after-opening-brace\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/declaration-empty-line-before/",
+      })
     }
 
     root.walkDecls(decl => {
@@ -89,6 +100,8 @@ const rule = function (expectation, options) {
       // Optionally reverse the expectation for the first nested node
       if (
         optionsMatches(options, "except", "first-nested")
+        && decl === parent.first
+        || optionsMatches(options, "except", "after-opening-brace")
         && decl === parent.first
       ) {
         expectEmptyLineBefore = !expectEmptyLineBefore

--- a/lib/rules/rule-nested-empty-line-before/README.md
+++ b/lib/rules/rule-nested-empty-line-before/README.md
@@ -121,7 +121,9 @@ The following patterns are *not* considered warnings:
 
 ## Optional secondary options
 
-### `except: ["first-nested"]`
+### `except: ["after-opening-brace"]`
+
+***Note: This option was previously called `first-nested`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Reverse the primary option if the rule is the first in a block.
 

--- a/lib/rules/rule-nested-empty-line-before/__tests__/deprecate-first-nested.js
+++ b/lib/rules/rule-nested-empty-line-before/__tests__/deprecate-first-nested.js
@@ -1,0 +1,59 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'rule-nested-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+  reference: "http://stylelint.io/user-guide/rules/rule-nested-empty-line-before/",
+}]
+
+const code = ""
+
+it("deprecation result from 'always, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "rule-nested-empty-line-before": [ "always", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "rule-nested-empty-line-before": [ "never", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'always-multi-line, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "rule-nested-empty-line-before": [ "always-multi-line", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+
+it("deprecation result from 'never-multi-line, except first-nested' config", () => {
+  const config = {
+    rules: {
+      "rule-nested-empty-line-before": [ "never-multi-line", { except: ["first-nested"] } ],
+    },
+  }
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})
+

--- a/lib/rules/rule-nested-empty-line-before/__tests__/index.js
+++ b/lib/rules/rule-nested-empty-line-before/__tests__/index.js
@@ -122,6 +122,60 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ "always", { except: ["after-opening-brace"] } ],
+
+  accept: [ {
+    code: "a {} b {}",
+    description: "non-nested node ignored",
+  }, {
+    code: "a {}\nb {}",
+    description: "non-nested node ignored",
+  }, {
+    code: "@media {\n  a {}\n\n}",
+  }, {
+    code: "@media {\r\n  a {}\r\n\r\n}",
+    description: "CRLF",
+  }, {
+    code: "@media {\n  a {}\n\n  b{}\n\n}",
+  }, {
+    code: "@media {\n\ta {}\n\n\tb{}\n}",
+  }, {
+    code: "@media {\n\ta {}}",
+  }, {
+    code: "@media {\r\n\ta {}}",
+    description: "CRLF",
+  }, {
+    code: "@media {\na {}\n/* comment */\n\nb {}}",
+  }, {
+    code: "@media {\r\na {}\r\n/* comment */\r\n\r\nb {}}",
+    description: "CRLF",
+  } ],
+
+  reject: [ {
+    code: "@media {\n\n  a {}\n}",
+    message: messages.rejected,
+  }, {
+    code: "@media {\n\n  a {}\n\n  b{}\n}",
+    message: messages.rejected,
+  }, {
+    code: "@media {\r\n\r\n  a {}\r\n\r\n  b{}\r\n}",
+    description: "CRLF",
+    message: messages.rejected,
+  }, {
+    code: "@media {\n  b {} a {} }",
+    message: messages.expected,
+  }, {
+    code: "@media {\r\n  b {} a {} }",
+    description: "CRLF",
+    message: messages.expected,
+  }, {
+    code: "@media {\n  b {}\n  a {}\n\n}",
+    message: messages.expected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ "always", { except: ["after-rule"] } ],
 
   accept: [ {
@@ -374,6 +428,51 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [ "always-multi-line", { except: ["first-nested"] } ],
+
+  accept: [ {
+    code: "@media { a { color:pink; } b { top: 0; } }",
+    description: "single-line ignored",
+  }, {
+    code: "a {} b {}",
+    description: "non-nested node ignored",
+  }, {
+    code: "a {}\nb {}",
+    description: "non-nested node ignored",
+  }, {
+    code: "a {}\r\nb {}",
+    description: "non-nested node ignored and CRLF",
+  }, {
+    code: "@media {\n  a {\n    color: pink;\n}\n\n}",
+  }, {
+    code: "@media {\n  a {\n    color: pink;\n}\n\n  b {\n    top: 0;\n}\n\n}",
+  }, {
+    code: "@media {\n\ta {\n\t\tcolor: pink; }\n\n\tb{\n\t\ttop: 0; }\n}",
+  }, {
+    code: "@media {\na {\n\t\tcolor: pink; }\n/* comment */\n\nb {\n\t\ttop: 0; }}",
+  }, {
+    code: "@media {\r\na {\r\n\t\tcolor: pink; }\r\n/* comment */\r\n\r\nb {\r\n\t\ttop: 0; }}",
+    description: "CRLF",
+  } ],
+
+  reject: [ {
+    code: "@media {\n\n  a {\n    color: pink;\n}\n\n}",
+    message: messages.rejected,
+  }, {
+    code: "@media {\n  a {\n    color: pink;\n}\n  b {\n    top: 0;\n}\n\n}",
+    message: messages.expected,
+  }, {
+    code: "@media {\r\n  a {\r\n    color: pink;\r\n}\r\n  b {\r\n    top: 0;\r\n}\r\n\r\n}",
+    description: "CRLF",
+    message: messages.expected,
+  }, {
+    code: "@media {\na {\n\t\tcolor: pink; }\n/* comment */\nb {\n\t\ttop: 0; }}",
+    message: messages.expected,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ "always-multi-line", { except: ["after-opening-brace"] } ],
 
   accept: [ {
     code: "@media { a { color:pink; } b { top: 0; } }",

--- a/lib/rules/rule-nested-empty-line-before/index.js
+++ b/lib/rules/rule-nested-empty-line-before/index.js
@@ -3,6 +3,7 @@
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
+const optionsMatches = require("../../utils/optionsMatches")
 const checkRuleEmptyLineBefore = require("../checkRuleEmptyLineBefore")
 
 const ruleName = "rule-nested-empty-line-before"
@@ -28,6 +29,7 @@ const rule = function (expectation, options) {
         ignore: ["after-comment"],
         except: [
           "first-nested",
+          "after-opening-brace",
           "after-comment",
           "after-rule",
         ],
@@ -36,6 +38,16 @@ const rule = function (expectation, options) {
     })
     if (!validOptions) {
       return
+    }
+
+    if (optionsMatches(options, "except", "first-nested")) {
+      result.warn((
+        "'rule-nested-empty-line-before\'s' \"first-nested\" option has been deprecated and in 8.0 will be removed. " +
+        "Instead use the \"after-opening-brace\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/rule-nested-empty-line-before/",
+      })
     }
 
     root.walkRules(rule => {

--- a/system-tests/001/__snapshots__/001.test.js.snap
+++ b/system-tests/001/__snapshots__/001.test.js.snap
@@ -15,6 +15,10 @@ Array [
         "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
       },
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/custom-property-empty-line-before/",
+        "text": "\'custom-property-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/declaration-block-no-ignored-properties/",
         "text": "\'declaration-block-no-ignored-properties\' has been deprecated and in 8.0 will be removed.",
       },

--- a/system-tests/001/__snapshots__/001.test.js.snap
+++ b/system-tests/001/__snapshots__/001.test.js.snap
@@ -8,6 +8,10 @@ Array [
       },
       Object {
         "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+        "text": "\'comment-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
         "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
       },
       Object {

--- a/system-tests/001/__snapshots__/001.test.js.snap
+++ b/system-tests/001/__snapshots__/001.test.js.snap
@@ -3,6 +3,10 @@ Array [
   Object {
     "deprecations": Array [
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+        "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/declaration-block-no-ignored-properties/",
         "text": "\'declaration-block-no-ignored-properties\' has been deprecated and in 8.0 will be removed.",
       },

--- a/system-tests/001/__snapshots__/001.test.js.snap
+++ b/system-tests/001/__snapshots__/001.test.js.snap
@@ -31,6 +31,10 @@ Array [
         "text": "\'media-feature-no-missing-punctuation\' has been deprecated and in 8.0 will be removed.",
       },
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/rule-nested-empty-line-before/",
+        "text": "\'rule-nested-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/selector-no-empty/",
         "text": "\'selector-no-empty\' has been deprecated and in 8.0 will be removed.",
       },

--- a/system-tests/001/__snapshots__/001.test.js.snap
+++ b/system-tests/001/__snapshots__/001.test.js.snap
@@ -23,6 +23,10 @@ Array [
         "text": "\'declaration-block-no-ignored-properties\' has been deprecated and in 8.0 will be removed.",
       },
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/declaration-empty-line-before/",
+        "text": "\'declaration-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/media-feature-no-missing-punctuation/",
         "text": "\'media-feature-no-missing-punctuation\' has been deprecated and in 8.0 will be removed.",
       },

--- a/system-tests/001/__snapshots__/001.test.js.snap
+++ b/system-tests/001/__snapshots__/001.test.js.snap
@@ -3,6 +3,10 @@ Array [
   Object {
     "deprecations": Array [
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+        "text": "\'at-rule-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
         "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
       },

--- a/system-tests/002/__snapshots__/002.test.js.snap
+++ b/system-tests/002/__snapshots__/002.test.js.snap
@@ -15,6 +15,10 @@ Array [
         "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
       },
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/custom-property-empty-line-before/",
+        "text": "\'custom-property-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/declaration-block-no-ignored-properties/",
         "text": "\'declaration-block-no-ignored-properties\' has been deprecated and in 8.0 will be removed.",
       },

--- a/system-tests/002/__snapshots__/002.test.js.snap
+++ b/system-tests/002/__snapshots__/002.test.js.snap
@@ -30,6 +30,10 @@ Array [
         "reference": "http://stylelint.io/user-guide/rules/media-feature-no-missing-punctuation/",
         "text": "\'media-feature-no-missing-punctuation\' has been deprecated and in 8.0 will be removed.",
       },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/rule-nested-empty-line-before/",
+        "text": "\'rule-nested-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
     ],
     "errored": undefined,
     "ignored": undefined,

--- a/system-tests/002/__snapshots__/002.test.js.snap
+++ b/system-tests/002/__snapshots__/002.test.js.snap
@@ -8,6 +8,10 @@ Array [
       },
       Object {
         "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+        "text": "\'comment-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
         "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
       },
       Object {

--- a/system-tests/002/__snapshots__/002.test.js.snap
+++ b/system-tests/002/__snapshots__/002.test.js.snap
@@ -3,6 +3,10 @@ Array [
   Object {
     "deprecations": Array [
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+        "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/declaration-block-no-ignored-properties/",
         "text": "\'declaration-block-no-ignored-properties\' has been deprecated and in 8.0 will be removed.",
       },

--- a/system-tests/002/__snapshots__/002.test.js.snap
+++ b/system-tests/002/__snapshots__/002.test.js.snap
@@ -23,6 +23,10 @@ Array [
         "text": "\'declaration-block-no-ignored-properties\' has been deprecated and in 8.0 will be removed.",
       },
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/declaration-empty-line-before/",
+        "text": "\'declaration-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/media-feature-no-missing-punctuation/",
         "text": "\'media-feature-no-missing-punctuation\' has been deprecated and in 8.0 will be removed.",
       },

--- a/system-tests/002/__snapshots__/002.test.js.snap
+++ b/system-tests/002/__snapshots__/002.test.js.snap
@@ -3,6 +3,10 @@ Array [
   Object {
     "deprecations": Array [
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+        "text": "\'at-rule-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
         "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
       },

--- a/system-tests/003/__snapshots__/003.test.js.snap
+++ b/system-tests/003/__snapshots__/003.test.js.snap
@@ -6,6 +6,10 @@ Array [
         "reference": "http://stylelint.io/user-guide/rules/declaration-block-properties-order/",
         "text": "\'declaration-block-properties-order\'has been deprecated and in 8.0 will be removed. Instead use the community \'stylelint-order\' plugin pack.",
       },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/rule-nested-empty-line-before/",
+        "text": "\'rule-nested-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
     ],
     "errored": undefined,
     "ignored": undefined,

--- a/system-tests/deprecations/002/002.test.js
+++ b/system-tests/deprecations/002/002.test.js
@@ -1,0 +1,14 @@
+/* @flow */
+"use strict"
+
+const systemTestUtils = require("../../systemTestUtils")
+const stylelint = require("../../../lib")
+
+it("deprecations/002", () => {
+  return stylelint.lint({
+    files: [systemTestUtils.caseStylesheetGlob("deprecations/002")],
+    configFile: systemTestUtils.caseConfig("deprecations/002"),
+  }).then((output) => {
+    expect(systemTestUtils.prepResults(output.results)).toMatchSnapshot()
+  })
+})

--- a/system-tests/deprecations/002/__snapshots__/002.test.js.snap
+++ b/system-tests/deprecations/002/__snapshots__/002.test.js.snap
@@ -1,0 +1,99 @@
+exports[`test deprecations/002 1`] = `
+Array [
+  Object {
+    "deprecations": Array [
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+        "text": "\'at-rule-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+        "text": "\'at-rule-empty-line-before\'s\' \"all-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"inside-block\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/at-rule-empty-line-before/",
+        "text": "\'at-rule-empty-line-before\'s\' \"blockless-group\" option has been deprecated and in 8.0 will be removed. Instead use the \"blockless-after-blockless\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+        "text": "\'comment-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+        "text": "\'comment-empty-line-before\'s\' \"between-comments\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-comment\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/comment-empty-line-before/",
+        "text": "\'comment-empty-line-before\'s\' \"stylelint-commands\" option has been deprecated and in 8.0 will be removed. Instead use the \"stylelint-command\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/custom-property-empty-line-before/",
+        "text": "\'custom-property-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/declaration-empty-line-before/",
+        "text": "\'declaration-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+      Object {
+        "reference": "http://stylelint.io/user-guide/rules/rule-nested-empty-line-before/",
+        "text": "\'rule-nested-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
+      },
+    ],
+    "errored": true,
+    "ignored": undefined,
+    "invalidOptionWarnings": Array [],
+    "source": "deprecations/002/stylesheet.css",
+    "warnings": Array [
+      Object {
+        "column": 3,
+        "line": 2,
+        "rule": "at-rule-empty-line-before",
+        "severity": "error",
+        "text": "Expected empty line before at-rule (at-rule-empty-line-before)",
+      },
+      Object {
+        "column": 3,
+        "line": 4,
+        "rule": "at-rule-empty-line-before",
+        "severity": "error",
+        "text": "Expected empty line before at-rule (at-rule-empty-line-before)",
+      },
+      Object {
+        "column": 1,
+        "line": 7,
+        "rule": "at-rule-empty-line-before",
+        "severity": "error",
+        "text": "Unexpected empty line before at-rule (at-rule-empty-line-before)",
+      },
+      Object {
+        "column": 3,
+        "line": 11,
+        "rule": "comment-empty-line-before",
+        "severity": "error",
+        "text": "Unexpected empty line before comment (comment-empty-line-before)",
+      },
+      Object {
+        "column": 3,
+        "line": 24,
+        "rule": "custom-property-empty-line-before",
+        "severity": "error",
+        "text": "Unexpected empty line before custom property (custom-property-empty-line-before)",
+      },
+      Object {
+        "column": 3,
+        "line": 31,
+        "rule": "declaration-empty-line-before",
+        "severity": "error",
+        "text": "Unexpected empty line before declaration (declaration-empty-line-before)",
+      },
+      Object {
+        "column": 3,
+        "line": 37,
+        "rule": "rule-nested-empty-line-before",
+        "severity": "error",
+        "text": "Unexpected empty line before nested rule (rule-nested-empty-line-before)",
+      },
+    ],
+  },
+]
+`;

--- a/system-tests/deprecations/002/config.json
+++ b/system-tests/deprecations/002/config.json
@@ -1,0 +1,42 @@
+{
+  "rules": {
+    "at-rule-empty-line-before": [
+      "never",
+      {
+        "except": [
+          "all-nested",
+          "blockless-group",
+          "first-nested"
+        ]
+      }
+    ],
+    "comment-empty-line-before": [
+      "never",
+      {
+        "except": ["first-nested"],
+        "ignore": [
+          "between-comments",
+          "stylelint-commands"
+        ]
+      }
+    ],
+    "custom-property-empty-line-before": [
+      "never",
+      {
+        "except": ["first-nested"]
+      }
+    ],
+    "declaration-empty-line-before": [
+      "never",
+      {
+        "except": ["first-nested"]
+      }
+    ],
+    "rule-nested-empty-line-before": [
+      "never",
+      {
+        "except": ["first-nested"]
+      }
+    ]
+  }
+}

--- a/system-tests/deprecations/002/stylesheet.css
+++ b/system-tests/deprecations/002/stylesheet.css
@@ -1,0 +1,38 @@
+a {
+  @extend foo;
+  color: pink;
+  @extend bar;
+}
+
+@import url(x.css);
+
+a {
+
+  /* not a stylelint command */
+
+  /* not a stylelint command */
+
+  /* stylelint-disable color-no-hex */
+  color: #eee;
+  /* stylelint-disable color-named */
+}
+
+a {
+
+  --foo: pink;
+
+  --bar: red;
+}
+
+a {
+
+  bottom: 15px;
+
+  top: 5px;
+}
+@media {
+
+  a {}
+
+  b {}
+}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#1663 

> Is there anything in the PR that needs further explanation?

This deprecates the [options listed in the related issue](https://github.com/stylelint/stylelint/issues/1663#issuecomment-267795609). 

The changes required for each deprecation are listed below.

In the rule:
- trigger a deprecation warning when the old option name is used
- duplicate all code blocks that reference the old option name and modify them to reference the new option name

In the rule's readme:
- rename the option
- add a note to each option describing the previous name of the option

In the rule's tests:
- duplicate all unit tests that reference the old option name and modify them to reference the new option name
- add one or more deprecation unit tests in a new file

Then:
- update system test snapshots affected by previous changes

