### PR TITLE
Add except: ["after-same-name"] option to at-rule-empty-line-before

### DIFF
--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -64,7 +64,38 @@ a {}
 
 ## Optional secondary options
 
-### `except: ["all-nested", "blockless-after-same-name-blockless", "blockless-group", "first-nested"]`
+### `except: ["after-same-name", "all-nested", "blockless-after-same-name-blockless", "blockless-group", "first-nested"]`
+
+#### `"after-same-name"`
+
+Reverse the primary option for at-rules that follow another at-rule with the same name.
+
+This means that you can group your at-rules by name.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered warnings:
+
+```css
+@charset "UTF-8";
+
+@import url(x.css);
+@import url(y.css);
+
+@media (min-width: 100px) {}
+@media (min-width: 200px) {}
+```
+
+```css
+a {
+
+  @extends .foo;
+  @extends .bar;
+
+  @include x;
+  @include y {}
+}
+```
 
 ### `"all-nested"`
 

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -660,7 +660,7 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
     code: stripIndent`
       @charset "UTF-8";
       @import url(x.css);
-      
+
       @import url(y.css);`,
   }, {
     code: stripIndent`
@@ -688,6 +688,98 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
         @extends .bar;
         @include loop;
         @include doo;
+      }`,
+    message: messages.expected,
+    line: 4,
+    column: 3,
+  } ],
+}))
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", {
+    except: ["after-same-name"],
+  } ],
+
+  accept: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+
+      @include x;
+      @include y {}`,
+  }, {
+    code: stripIndent`
+      a {
+
+        @extends .foo;
+        @extends .bar;
+
+        @include y {}
+        @include x;
+      }`,
+  } ],
+
+  reject: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+      @include x;
+      @include y {}`,
+    message: messages.expected,
+    line: 2,
+    column: 1,
+  }, {
+    code: stripIndent`
+      a {
+
+        @extends .foo;
+        @extends .bar;
+        @include y {}
+        @include x;
+      }`,
+    message: messages.expected,
+    line: 5,
+    column: 3,
+  } ],
+})
+
+testRule(rule, mergeTestDescriptions(sharedNeverTests, {
+  ruleName,
+  config: [ "never", {
+    except: ["after-same-name"],
+  } ],
+
+  accept: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+      @include x;
+
+      @include y {}`,
+  }, {
+    code: stripIndent`
+      a {
+        @extends .foo;
+
+        @extends .bar;
+        @include y {}
+
+        @include x;
+      }`,
+  } ],
+
+  reject: [ {
+    code: stripIndent`
+      @charset "UTF-8";
+      @include x;
+      @include y {}`,
+    message: messages.expected,
+    line: 3,
+    column: 1,
+  }, {
+    code: stripIndent`
+      a {
+        @extends .bar;
+        @include x;
+        @include y {}
       }`,
     message: messages.expected,
     line: 4,

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -27,6 +27,7 @@ const rule = function (expectation, options) {
       actual: options,
       possible: {
         except: [
+          "after-same-name",
           "all-nested",
           "blockless-after-same-name-blockless",
           "blockless-group",
@@ -100,7 +101,9 @@ const rule = function (expectation, options) {
 
       // Optionally reverse the expectation if any exceptions apply
       if (
-        optionsMatches(options, "except", "all-nested")
+        optionsMatches(options, "except", "after-same-name")
+        && isAfterSameName()
+        || optionsMatches(options, "except", "all-nested")
         && isNested
         || optionsMatches(options, "except", "first-nested")
         && isFirstNested()
@@ -141,6 +144,12 @@ const rule = function (expectation, options) {
           && !hasBlock(previousNode)
           && previousNode.type === "atrule"
           && previousNode.name == atRule.name
+      }
+
+      function isAfterSameName() {
+        return previousNode
+          && previousNode.type === "atrule"
+          && previousNode.name === atRule.name
       }
 
       function isFirstNested() {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

 #2211

> Is there anything in the PR that needs further explanation?

Maybe `"after-same-name"` should be placed before `"blockless-after-same-name-blockless"` in docs, because of its broader nature?

Should I add `ignore: ["after-same-name"]` also?
