### PR TITLE
Typo Correction

### DIFF
--- a/lib/rules/selector-attribute-operator-space-before/README.md
+++ b/lib/rules/selector-attribute-operator-space-before/README.md
@@ -74,7 +74,7 @@ The following patterns are *not* considered warnings:
 
 ### `"never"`
 
-There *must never* be a single before after the operator.
+There *must never* be a single space before the operator.
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
Just a typo fix 👍 

"... single before after the operator." –> "... single space before the operator."
