### PR TITLE
Fix ignore blockless-group behavior in at-rule-empty-line-before

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -21,13 +21,15 @@ global.testRule = (rule, schema) => {
       describe("accept", () => {
         passingTestCases.forEach((testCase) => {
           const spec = (testCase.only) ? it.only : it
-          spec(testCase.description || "no description", () => {
-            return stylelint({
-              code: testCase.code,
-              config: stylelintConfig,
-              syntax: schema.syntax,
-            }).then((output) => {
-              expect(output.results[0].warnings).toEqual([])
+          describe(JSON.stringify(testCase.code), () => {
+            spec(testCase.description || "no description", () => {
+              return stylelint({
+                code: testCase.code,
+                config: stylelintConfig,
+                syntax: schema.syntax,
+              }).then((output) => {
+                expect(output.results[0].warnings).toEqual([])
+              })
             })
           })
         })
@@ -38,22 +40,24 @@ global.testRule = (rule, schema) => {
       describe("reject", () => {
         schema.reject.forEach((testCase) => {
           const spec = (testCase.only) ? it.only : it
-          spec(testCase.description || "no description", () => {
-            return stylelint({
-              code: testCase.code,
-              config: stylelintConfig,
-              syntax: schema.syntax,
-            }).then((output) => {
-              const warning = output.results[0].warnings[0]
-              if (testCase.message) {
-                expect(_.get(warning, "text")).toBe(testCase.message)
-              }
-              if (testCase.line) {
-                expect(_.get(warning, "line")).toBe(testCase.line)
-              }
-              if (testCase.column) {
-                expect(_.get(warning, "column")).toBe(testCase.column)
-              }
+          describe(JSON.stringify(testCase.code), () => {
+            spec(testCase.description || "no description", () => {
+              return stylelint({
+                code: testCase.code,
+                config: stylelintConfig,
+                syntax: schema.syntax,
+              }).then((output) => {
+                const warning = output.results[0].warnings[0]
+                if (testCase.message) {
+                  expect(_.get(warning, "text")).toBe(testCase.message)
+                }
+                if (testCase.line) {
+                  expect(_.get(warning, "line")).toBe(testCase.line)
+                }
+                if (testCase.column) {
+                  expect(_.get(warning, "column")).toBe(testCase.column)
+                }
+              })
             })
           })
         })

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -139,12 +139,19 @@ testRule(rule, {
   config: [ "always", { ignore: ["blockless-group"] } ],
 
   accept: [{
-    code: "@media {}; @import 'x.css';",
+    code: "@import 'y.css'; @import 'x.css';",
   }],
 
   reject: [ {
     code: "@import 'x.css'; @media {};",
     message: messages.expected,
+    line: 1,
+    column: 18,
+  }, {
+    code: "@media {}; @import 'x.css';",
+    message: messages.expected,
+    line: 1,
+    column: 12,
   }, {
     code: "@import 'test'; @include mixin(1) { @content; };",
     message: messages.expected,
@@ -332,21 +339,15 @@ testRule(rule, {
   ruleName,
   config: [ "never", { ignore: ["blockless-group"] } ],
 
-  accept: [ {
-    code: `
-      @media {};
-
-      @import 'x.css';
-    `,
-  }, {
+  accept: [{
     code: `
       @import 'x.css';
 
       @import 'y.css';
     `,
-  } ],
+  }],
 
-  reject: [{
+  reject: [ {
     code: `
       @import 'x.css';
 
@@ -355,7 +356,16 @@ testRule(rule, {
     message: messages.rejected,
     line: 4,
     column: 7,
-  }],
+  }, {
+    code: `
+      @media {};
+
+      @import 'x.css';
+    `,
+    message: messages.rejected,
+    line: 4,
+    column: 7,
+  } ],
 })
 
 testRule(rule, {
@@ -660,7 +670,7 @@ testRule(rule, mergeTestDescriptions(sharedNeverTests, {
     code: stripIndent`
       @charset "UTF-8";
       @import url(x.css);
-      
+
       @import url(y.css);`,
   }, {
     code: stripIndent`

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -47,6 +47,9 @@ const rule = function (expectation, options) {
     }
 
     root.walkAtRules(atRule => {
+      const isNested = atRule.parent !== root
+      const previousNode = atRule.prev()
+
       // Ignore the first node
       if (atRule === root.first) {
         return
@@ -60,13 +63,10 @@ const rule = function (expectation, options) {
       // Optionally ignore the expectation if the node is blockless
       if (
         optionsMatches(options, "ignore", "blockless-group")
-        && !hasBlock(atRule)
+        && isBlocklessAfterBlockless(atRule)
       ) {
         return
       }
-
-      const isNested = atRule.parent !== root
-      const previousNode = atRule.prev()
 
       // Optionally ignore the expection if the node is blockless
       // and following another blockless at-rule with the same name


### PR DESCRIPTION
Fixes #2240.

This also adds test case CSS code to the test description, which helps us locate the failing test. (Unfortunately, Jest's stacks traces don't help here.)