### PR TITLE
Rename "at-rules-without-declaration-blocks" to "blockless-at-rules" in max-nesting-depth

### DIFF
--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -98,7 +98,7 @@ a .foo__foo .bar .baz {}
 
 ### `ignore: ["blockless-at-rules"]`
 
-***Note: This option was previously called `at-rules-without-declaration-blocks`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
+***Note: This option was previously called `at-rules-without-declaration-blocks`.***
 
 Ignore at-rules that only wrap other rules, and do not themselves have declaration blocks.
 

--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -96,7 +96,9 @@ a .foo__foo .bar .baz {}
 
 ## Optional secondary options
 
-### `ignore: ["at-rules-without-declaration-blocks"]`
+### `ignore: ["blockless-at-rules"]`
+
+***Note: This option was previously called `at-rules-without-declaration-blocks`. See [the release planning docs](http://stylelint.io/user-guide/release-planning/) for details.***
 
 Ignore at-rules that only wrap other rules, and do not themselves have declaration blocks.
 
@@ -109,7 +111,7 @@ As the at-rules have a declarations blocks.
 ```css
 a {
   &:hover { /* 1 */
-    @media (min-width: 500px) { color: pink; } /* 2 */      
+    @media (min-width: 500px) { color: pink; } /* 2 */
   }
 }
 ```
@@ -117,7 +119,7 @@ a {
 ```css
 a {
   @nest > b { /* 1 */
-    .foo { color: pink; } /* 2 */      
+    .foo { color: pink; } /* 2 */
   }
 }
 ```

--- a/lib/rules/max-nesting-depth/__tests__/deprecate-at-rules-without-declaration-blocks.js
+++ b/lib/rules/max-nesting-depth/__tests__/deprecate-at-rules-without-declaration-blocks.js
@@ -1,0 +1,22 @@
+"use strict"
+
+const stylelint = require("../../..")
+
+const deprecationResult = [{
+  text: "'max-nesting-depth\'s' \"at-rules-without-declaration-blocks\" option has been deprecated and in 8.0 will be removed. Instead use the \"blockless-at-rules\" option.",
+  reference: "http://stylelint.io/user-guide/rules/max-nesting-depth/",
+}]
+
+it("deprecation result from '1, ignore at-rules-without-declaration-blocks' config", () => {
+  const code = ""
+  const config = {
+    rules: {
+      "max-nesting-depth": [ 1, { ignore: ["at-rules-without-declaration-blocks"] } ],
+    },
+  }
+
+  return stylelint.lint({ code, config }).then(data => {
+    expect(data.results[0].deprecations.length).toEqual(1)
+    expect(data.results[0].deprecations).toEqual(deprecationResult)
+  })
+})

--- a/lib/rules/max-nesting-depth/__tests__/index.js
+++ b/lib/rules/max-nesting-depth/__tests__/index.js
@@ -88,6 +88,30 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ 1, { ignore: ["blockless-at-rules"] } ],
+
+  accept: [ {
+    code: "a { b { top: 0; }}",
+  }, {
+    code: "a { @media print { b { top: 0; }}}",
+  }, {
+    code: "a { @nest b { c { top: 0; }}}",
+  } ],
+
+  reject: [ {
+    code: "a { b { c { top: 0; }}}",
+    message: messages.expected(1),
+  }, {
+    code: "a { @media print { b { c { top: 0; }}}}",
+    message: messages.expected(1),
+  }, {
+    code: "a { @nest b { @nest c { top: 0; @nest d { bottom: 0; }}}}",
+    message: messages.expected(1),
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ 1, { ignoreAtRules: [ "media", "/^my-/" ] } ],
 
   accept: [ {

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 })
 
 const rule = function (max, options) {
-  const ignoreAtRulesWithoutDeclarationBlocks = optionsMatches(options, "ignore", "at-rules-without-declaration-blocks")
+  const ignoreAtRulesWithoutDeclarationBlocks = optionsMatches(options, "ignore", "at-rules-without-declaration-blocks") || optionsMatches(options, "ignore", "blockless-at-rules")
   const isIgnoreAtRule = node => node.type === "atrule" && optionsMatches(options, "ignoreAtRules", node.name)
 
   return (root, result) => {
@@ -25,10 +25,22 @@ const rule = function (max, options) {
       optional: true,
       actual: options,
       possible: {
-        ignore: ["at-rules-without-declaration-blocks"],
+        ignore: [
+          "at-rules-without-declaration-blocks",
+          "blockless-at-rules",
+        ],
         ignoreAtRules: [_.isString],
       },
     })
+
+    if (optionsMatches(options, "ignore", "at-rules-without-declaration-blocks")) {
+      result.warn((
+        "'max-nesting-depth\'s' \"at-rules-without-declaration-blocks\" option has been deprecated and in 8.0 will be removed. Instead use the \"blockless-at-rules\" option."
+      ), {
+        stylelintType: "deprecation",
+        stylelintReference: "http://stylelint.io/user-guide/rules/max-nesting-depth/",
+      })
+    }
 
     root.walkRules(checkStatement)
     root.walkAtRules(checkStatement)

--- a/system-tests/deprecations/002/__snapshots__/002.test.js.snap
+++ b/system-tests/deprecations/002/__snapshots__/002.test.js.snap
@@ -35,6 +35,10 @@ Array [
         "text": "\'declaration-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
       },
       Object {
+        "reference": "http://stylelint.io/user-guide/rules/max-nesting-depth/",
+        "text": "\'max-nesting-depth\'s\' \"at-rules-without-declaration-blocks\" option has been deprecated and in 8.0 will be removed. Instead use the \"blockless-at-rules\" option.",
+      },
+      Object {
         "reference": "http://stylelint.io/user-guide/rules/rule-nested-empty-line-before/",
         "text": "\'rule-nested-empty-line-before\'s\' \"first-nested\" option has been deprecated and in 8.0 will be removed. Instead use the \"after-opening-brace\" option.",
       },

--- a/system-tests/deprecations/002/config.json
+++ b/system-tests/deprecations/002/config.json
@@ -32,6 +32,12 @@
         "except": ["first-nested"]
       }
     ],
+    "max-nesting-depth": [
+      1,
+      {
+        "ignore": ["at-rules-without-declaration-blocks"]
+      }
+    ],
     "rule-nested-empty-line-before": [
       "never",
       {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #2231.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
