### PR TITLE
chore(package): update eslint to version 3.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "common-tags": "^1.3.0",
     "coveralls": "^2.11.9",
     "d3-queue": "^3.0.3",
-    "eslint": "~3.13.0",
+    "eslint": "~3.14.0",
     "eslint-config-stylelint": "^6.0.0",
     "flow-bin": "^0.37.0",
     "jest": "^18.0.0",


### PR DESCRIPTION
For some reason @greenkeeperio failed to create a pull request, it created the branch though /shrug