### PR TITLE
Maybe update invalid rule options in system test 005?

### DIFF
--- a/system-tests/005/__snapshots__/005.test.js.snap
+++ b/system-tests/005/__snapshots__/005.test.js.snap
@@ -4,14 +4,7 @@ Array [
     "deprecations": Array [],
     "errored": true,
     "ignored": undefined,
-    "invalidOptionWarnings": Array [
-      Object {
-        "text": "Unexpected option value \"always\" for rule \"selector-pseudo-element-no-unknown\"",
-      },
-      Object {
-        "text": "Unexpected option value \"always\" for rule \"value-no-vendor-prefix\"",
-      },
-    ],
+    "invalidOptionWarnings": Array [],
     "source": "005/stylesheet.css",
     "warnings": Array [
       Object {
@@ -18536,6 +18529,13 @@ Array [
         "text": "Expected single colon pseudo-element notation (selector-pseudo-element-colon-notation)",
       },
       Object {
+        "column": 2,
+        "line": 214,
+        "rule": "selector-pseudo-element-no-unknown",
+        "severity": "error",
+        "text": "Unexpected unknown pseudo-element selector \"::pseudo\" (selector-pseudo-element-no-unknown)",
+      },
+      Object {
         "column": 1,
         "line": 215,
         "rule": "selector-root-no-composition",
@@ -19182,6 +19182,13 @@ Array [
         "rule": "value-list-max-empty-lines",
         "severity": "error",
         "text": "Expected no more than 0 empty line(s) (value-list-max-empty-lines)",
+      },
+      Object {
+        "column": 14,
+        "line": 252,
+        "rule": "value-no-vendor-prefix",
+        "severity": "error",
+        "text": "Unexpected vendor-prefix \"-webkit-flex\" (value-no-vendor-prefix)",
       },
     ],
   },

--- a/system-tests/005/config.json
+++ b/system-tests/005/config.json
@@ -187,6 +187,6 @@
     "value-list-comma-space-after": "always",
     "value-list-comma-space-before": "always",
     "value-list-max-empty-lines": 0,
-    "value-no-vendor-prefix": "always"
+    "value-no-vendor-prefix": true
   }
 }

--- a/system-tests/005/config.json
+++ b/system-tests/005/config.json
@@ -168,7 +168,7 @@
     "selector-pseudo-class-whitelist": ["hover", "/^nth-/"],
     "selector-pseudo-element-case": "lower",
     "selector-pseudo-element-colon-notation": "single",
-    "selector-pseudo-element-no-unknown": "always",
+    "selector-pseudo-element-no-unknown": true,
     "selector-root-no-composition": true,
     "selector-type-case": "lower",
     "selector-type-no-unknown": true,


### PR DESCRIPTION
Regarding the system test 005 added in #2192

The rule `value-no-vendor-prefix` was added with the incorrect option `always` rather than `true`

@m-allanson Do you remember if you explicitly added the invalid option to explicitly test the _invalid option_ syntax? 

Here's the [snapshot message](https://github.com/stylelint/stylelint/blob/master/system-tests/005/__snapshots__/005.test.js.snap#L11-L13):
```
"text": "Unexpected option value \"always\" for rule \"value-no-vendor-prefix\"",
```

Similarly, the same case for the `selector-pseudo-element-no-unknown` rule, [snapshot message](https://github.com/stylelint/stylelint/blob/master/system-tests/005/__snapshots__/005.test.js.snap#L9):
```
"text": "Unexpected option value \"always\" for rule \"selector-pseudo-element-no-unknown\"",
```

If these were in fact done on purpose please close this PR and delete the branch, if they were not I'll update the pull request with the correct options and update the snapshots 😄 