### PR TITLE
Setup ESLint for local caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 .nyc_output
+.eslintcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 cache:
   directories:
     - node_modules
-    - .eslintcache
 matrix:
   include:
     - node_js: '7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 cache:
   directories:
     - node_modules
+    - .eslintcache
 matrix:
   include:
     - node_js: '7'

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "benchmark-rule": "node scripts/benchmark-rule.js",
     "flow": "flow",
     "jest": "jest",
-    "lint:js": "eslint .",
+    "lint:js": "eslint . --cache",
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",
     "pretest": "npm-run-all --serial lint flow",


### PR DESCRIPTION
I heard ESLint can do caching via #2270

```shell
> eslint . --cache

        5.16 real         5.34 user         0.25 sys
```

Subsequent runs are approx 3 times faster

2nd run
```
> eslint . --cache

        1.78 real         1.69 user         0.16 sys
```

3rd run
```
> eslint . --cache

        1.78 real         1.69 user         0.17 sys
```

cc @sergesemashko