### PR TITLE
Add documentation on turning rules off and setting secondary options

### DIFF
--- a/docs/user-guide/about-rules.md
+++ b/docs/user-guide/about-rules.md
@@ -116,6 +116,20 @@ a { transform: translate( 1, 1 ); }
  * The space inside these two parentheses */
 ```
 
+## About rule options
+
+A complete list of primary rule options can be found in the [example configuration.](example-config.md)
+
+To turn a rule off (when extending a configuration) you can set the value of the rule to `null`.
+
+Many rules have secondary options which provide further customization. To set secondary options, a two-member array replaces the primary option primitive. For example:
+
+```js
+"selector-type-no-unknown": [true, {
+  "ignoreTypes": ["date-input-polyfill"]
+}]
+```
+
 ## Rules work together
 
 The rules can be used together to enforce strict conventions.


### PR DESCRIPTION
DOCUMENTATION CHANGE ONLY

Although secondary options are documented under each rule, I found there was no general explanation of how to set them. (If I just missed this, feel free to close).

Adds a section to "About rules" explaining that the "value" for each rule can either be the primary rule itself, `null` or a two-part array.