### PR TITLE
Implement caching

### DIFF
--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -100,6 +100,8 @@ export type stylelint$standaloneReturnValue = {
 
 export type stylelint$standaloneOptions = {
   files?: string | Array<string>,
+  cache?: bool,
+  cacheLocation?: string,
   code?: string,
   codeFilename?: string,
   config?: stylelint$config,

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -40,6 +40,12 @@ Using `bar/mySpecialConfig.json` as config, with quiet mode on, to lint all `.cs
 stylelint "foo/**/*.css bar/*.css" -q -f json --config bar/mySpecialConfig.json > myJsonReport.json
 ```
 
+Caching processed `.scss` files in order to operate only on changed ones in the `foo` directory, using the `cache` and `cache-location` options:
+
+```
+stylelint "foo/**/*.scss" --cache --cache-location "/Users/user/.stylelintcache/"
+```
+
 Linting all the `.scss` files in the `foo` directory, using the `syntax` option:
 
 ```shell

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -77,6 +77,22 @@ If `true`, all disable comments (e.g. `/* stylelint-disable block-no-empty */`) 
 
 You can use this option to see what your linting results would be like without those exceptions.
 
+## `cache`
+
+Store the info about processed files in order to only operate on the changed ones the next time you run stylelint. Enabling this option can dramatically improve stylelint's speed, because only changed files will be linted.
+
+By default, the cache is stored in `.stylelintcache` in `process.cwd()`. To change this, use the `cacheLocation` option.
+
+**Note:** If you run stylelint with `cache` and then run stylelint without `cache`, the `.stylelintcache` file will be deleted. This is necessary because we have to assume that `.stylelintcache` was invalidated by that second command.
+
+## `cacheLocation`
+
+A path to a file or directory to be used for `cache`. Only meaningful alongside `cache`. If no location is specified, `.stylelintcache` will be created in `process.cwd()`.
+
+If a directory is specified, a cache file will be created inside the specified folder. The name of the file will be based on the hash of `process.cwd()` (e.g. `.cache_hashOfCWD`). This allows stylelint to reuse a single location for a variety of caches from different projects.
+
+**Note:** If the directory of `cacheLocation` does not exist, make sure you add a trailing `/` on \*nix systems or `\` on Windows. Otherwise, the path will be assumed to be a file.
+
 ### `reportNeedlessDisables`
 
 If `true`, `ignoreDisables` will also be set to `true` and the returned data will contain a `needlessDisables` property, whose value is an array of objects, one for each source, with tells you which stylelint-disable comments are not blocking a lint warning.

--- a/lib/__tests__/fixtures/cache/valid.css
+++ b/lib/__tests__/fixtures/cache/valid.css
@@ -1,0 +1,1 @@
+/* This file will not cause a linting error */

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -1,0 +1,188 @@
+"use strict"
+
+const path = require("path")
+const standalone = require("../standalone")
+const hash = require("../utils/hash")
+const fixturesPath = path.join(__dirname, "fixtures")
+const pify = require("pify")
+const fs = require("fs")
+const readFile = pify(fs.readFile)
+const unlink = pify(fs.unlink)
+const cpFile = require("cp-file")
+const fileExists = require("file-exists-promise")
+
+const cwd = process.cwd()
+const invalidFile = path.join(fixturesPath, "empty-block.css")
+const validFile = path.join(fixturesPath, "cache", "valid.css")
+const newFileDest = path.join(fixturesPath, "cache", "newFile.css")
+
+// Config object is getting mutated internally.
+// Return new object of the same structure to
+// make sure config doesn't change between runs.
+function getConfig() {
+  return {
+    files: path.join(fixturesPath, "cache", "*.css"),
+    config: {
+      rules: { "block-no-empty": true, "color-no-invalid-hex": true },
+    },
+    cache: true,
+  }
+}
+
+describe("standalone cache", () => {
+  const expectedCacheFilePath = path.join(cwd, ".stylelintcache")
+
+  beforeEach(() => {
+    // Initial run to warm up the cache
+    return standalone(getConfig())
+  })
+
+  afterEach(() => {
+    // Clean up after each test case
+    return Promise.all([
+      unlink(expectedCacheFilePath).catch(() => {
+        // fs.unlink() throws an error if file doesn't exist and it's ok. We just
+        // want to make sure it's not there for next test.
+      }),
+      unlink(newFileDest).catch(() => {
+        // fs.unlink() throws an error if file doesn't exist and it's ok. We just
+        // want to make sure it's not there for next test.
+      }),
+    ])
+  })
+
+  it("cache file is created at $CWD/.stylelintcache", () => {
+    // Ensure cache file exists
+    return fileExists(expectedCacheFilePath).then(isFileExist => {
+      expect(!!isFileExist).toBe(true)
+      return readFile(expectedCacheFilePath, "utf8")
+    }).then(fileContents => {
+      return JSON.parse(fileContents)
+    }).then(cacheFile => {
+      // Ensure cache file contains only linted css file
+      expect(typeof cacheFile[validFile] === "object").toBe(true)
+      expect(typeof cacheFile[newFileDest] === "undefined").toBe(true)
+    })
+  })
+
+  it("only changed files are linted", () => {
+    // Add "changed" file
+    return cpFile(validFile, newFileDest).then(() => {
+      // Next run should lint only changed files
+      return standalone(getConfig())
+    }).then(output => {
+      // Ensure only changed files are linted
+      const isValidFileLinted = !!output.results.find(file => file.source === validFile)
+      const isNewFileLinted = !!output.results.find(file => file.source === newFileDest)
+      expect(isValidFileLinted).toBe(false)
+      expect(isNewFileLinted).toBe(true)
+      // Ensure cache file contains linted css files
+      return readFile(expectedCacheFilePath, "utf8")
+    }).then(fileContents => {
+      return JSON.parse(fileContents)
+    }).then(cachedFiles => {
+      expect(typeof cachedFiles[validFile] === "object").toBe(true)
+      expect(typeof cachedFiles[newFileDest] === "object").toBe(true)
+    })
+  })
+
+  it("all files are linted on config change", () => {
+    const changedConfig = getConfig()
+    changedConfig.config.rules["block-no-empty"] = false
+    return cpFile(validFile, newFileDest).then(() => {
+      // All file should be re-linted as config has changed
+      return standalone(changedConfig)
+    }).then(output => {
+      // Ensure all files are re-linted
+      const isValidFileLinted = !!output.results.find(file => file.source === validFile)
+      const isNewFileLinted = !!output.results.find(file => file.source === newFileDest)
+      expect(isValidFileLinted).toBe(true)
+      expect(isNewFileLinted).toBe(true)
+    })
+  })
+
+  it("invalid files are not cached", () => {
+    return cpFile(invalidFile, newFileDest).then(() => {
+      // Should lint only changed files
+      return standalone(getConfig())
+    }).then((output) => {
+      expect(output.errored).toBe(true)
+      // Ensure only changed files are linted
+      const isValidFileLinted = !!output.results.find(file => file.source === validFile)
+      const isInvalidFileLinted = !!output.results.find(file => file.source === newFileDest)
+      expect(isValidFileLinted).toBe(false)
+      expect(isInvalidFileLinted).toBe(true)
+      // Ensure cache file doesn't contain invalid file
+      return readFile(expectedCacheFilePath, "utf8")
+    }).then(fileContents => {
+      return JSON.parse(fileContents)
+    }).then(cachedFiles => {
+      expect(typeof cachedFiles[validFile] === "object").toBe(true)
+      expect(typeof cachedFiles[newFileDest] === "undefined").toBe(true)
+    })
+  })
+  it("cache file is removed when cache is disabled", () => {
+    const noCacheConfig = getConfig()
+
+    noCacheConfig.cache = false
+    let cacheFileExists = true
+    return standalone(noCacheConfig).then(() => {
+      return fileExists(expectedCacheFilePath).then(() => {
+        throw new Error(`Cache file is supposed to be removed, ${expectedCacheFilePath} is found instead`)
+      }).catch(() => {
+        cacheFileExists = false
+        expect(cacheFileExists).toBe(false)
+      })
+    })
+  })
+})
+describe("standalone cache uses cacheLocation", () => {
+  const cacheLocationFile = path.join(fixturesPath, "cache", ".cachefile")
+  const cacheLocationDir = path.join(fixturesPath, "cache")
+  const expectedCacheFilePath = path.join(cacheLocationDir, `.stylelintcache_${hash(cwd)}`)
+  afterEach(() => {
+    // clean up after each test
+    return Promise.all([
+      unlink(expectedCacheFilePath).catch(() => {
+        // fs.unlink() throws an error if file doesn't exist and it's ok. We just
+        // want to make sure it's not there for next test.
+      }),
+      unlink(cacheLocationFile).catch(() => {
+        // fs.unlink() throws an error if file doesn't exist and it's ok. We just
+        // want to make sure it's not there for next test.
+      }),
+    ])
+  })
+  it("cacheLocation is a file", () => {
+    const config = getConfig()
+    config.cacheLocation = cacheLocationFile
+    return standalone(config).then(() => {
+      // Ensure cache file is created
+      return fileExists(cacheLocationFile)
+    }).then(fileStats => {
+      expect(!!fileStats).toBe(true)
+      // Ensure cache file contains cached entity
+      return readFile(cacheLocationFile, "utf8")
+    }).then(fileContents => {
+      return JSON.parse(fileContents)
+    }).then(cacheFile => {
+      expect(typeof cacheFile[validFile] === "object").toBe(true)
+    })
+  })
+  it("cacheLocation is a directory", () => {
+    const config = getConfig()
+    config.cacheLocation = cacheLocationDir
+    return standalone(config).then(() => {
+      return fileExists(expectedCacheFilePath)
+    }).then(cacheFileStats => {
+      // Ensure cache file is created
+      expect(!!cacheFileStats).toBe(true)
+      // Ensure cache file contains cached entity
+      return readFile(expectedCacheFilePath, "utf8")
+    }).then(fileContents => {
+      return JSON.parse(fileContents)
+    }).then(cacheFile => {
+      expect(typeof cacheFile[validFile] === "object").toBe(true)
+    })
+  })
+})

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -93,6 +93,23 @@ const meowOptions = {
       --ignore-disables, --id
 
         Ignore styleline-disable comments.
+        
+      --cache                       [default: false]
+
+        Store the info about processed files in order to only operate on the 
+        changed ones the next time you run stylelint. By default, the cache 
+        is stored in "./.stylelintcache". To adjust this, use --cache-location.
+
+      --cache-location              [default: '.stylelintcache']
+
+        Path to a file or directory to be used for the cache location.
+        Default is "./.stylelintcache". If a directory is specified, a cache 
+        file will be created inside the specified folder, with a name derived
+        from a hash of the current working directory.
+
+        If the directory for the cache does not exist, make sure you add a trailing "/" 
+        on \*nix systems or "\" on Windows. Otherwise the path will be assumed to be a file.
+         
 
       --formatter, -f               [default: "string"]
 
@@ -182,6 +199,14 @@ if (cli.flags.ignoreDisables) {
 
 if (cli.flags.allowEmptyInput) {
   optionsBase.allowEmptyInput = cli.flags.allowEmptyInput
+}
+
+if (cli.flags.cache) {
+  optionsBase.cache = true
+}
+
+if (cli.flags.cacheLocation) {
+  optionsBase.cacheLocation = cli.flags.cacheLocation
 }
 
 const reportNeedlessDisables = cli.flags.reportNeedlessDisables

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -6,6 +6,10 @@ const createStylelint = require("./createStylelint")
 const globby/*: Function*/ = require("globby")
 const needlessDisables/*: Function*/ = require("./needlessDisables")
 const alwaysIgnoredGlobs = require("./alwaysIgnoredGlobs")
+const FileCache = require("./utils/FileCache")
+const debug = require("debug")("stylelint:standalone")
+const pkg = require("../package.json")
+const hash = require("./utils/hash")
 
 /*::type CssSyntaxErrorT = {
   column: number;
@@ -38,6 +42,11 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
   const syntax = options.syntax
   const customSyntax = options.customSyntax
   const allowEmptyInput = options.allowEmptyInput
+  const cacheLocation = options.cacheLocation
+  const useCache = options.cache || false
+  let fileCache
+
+  const startTime = Date.now()
 
   const isValidCode = typeof code === "string"
   if (!files && !isValidCode || files && (code || isValidCode)) {
@@ -90,6 +99,17 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
     alwaysIgnoredGlobs.map(file => "!" + file)
   )
 
+  if (useCache) {
+    const stylelintVersion = pkg.version
+    const hashOfConfig = hash(`${stylelintVersion}_${JSON.stringify(config)}`)
+    fileCache = new FileCache(cacheLocation, hashOfConfig)
+  } else {
+    // No need to calculate hash here, we just want to delete cache file.
+    fileCache = new FileCache(cacheLocation)
+    // Remove cache file if cache option is disabled
+    fileCache.destroy()
+  }
+
   return globby(fileList).then(filePaths => {
     if (!filePaths.length) {
       if (allowEmptyInput === undefined || !allowEmptyInput) {
@@ -113,14 +133,27 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
       }
     }
 
-    const getStylelintResults = filePaths.map(filePath => {
+    let absoluteFilePaths = filePaths.map(filePath => {
       const absoluteFilepath = (!path.isAbsolute(filePath))
         ? path.join(process.cwd(), filePath)
-        : filePath
+        : path.normalize(filePath)
+      return absoluteFilepath
+    })
+
+    if (useCache) {
+      absoluteFilePaths = absoluteFilePaths.filter(fileCache.hasFileChanged.bind(fileCache))
+    }
+
+    const getStylelintResults = absoluteFilePaths.map(absoluteFilepath => {
+      debug(`Processing ${absoluteFilepath}`)
       return stylelint._lintSource({
         filePath: absoluteFilepath,
       }).then(postcssResult => {
-        return stylelint._createStylelintResult(postcssResult, filePath)
+        if (postcssResult.stylelint.stylelintError && useCache) {
+          debug(`${absoluteFilepath} contains linting errors and will not be cached.`)
+          fileCache.removeEntry(absoluteFilepath)
+        }
+        return stylelint._createStylelintResult(postcssResult, absoluteFilepath)
       }).catch(handleError)
     })
 
@@ -137,6 +170,10 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
     if (reportNeedlessDisables) {
       returnValue.needlessDisables = needlessDisables(stylelintResults)
     }
+    if (useCache) {
+      fileCache.reconcile()
+    }
+    debug(`Linting complete in ${Date.now() - startTime}ms`)
     return returnValue
   }
 }

--- a/lib/utils/FileCache.js
+++ b/lib/utils/FileCache.js
@@ -1,0 +1,48 @@
+/* @flow */
+"use strict"
+
+const fileEntryCache = require("file-entry-cache")
+const path = require("path")
+const debug = require("debug")("stylelint:file-cache")
+const getCacheFile = require("./getCacheFile")
+
+const DEFAULT_CACHE_LOCATION = "./.stylelintcache"
+const DEFAULT_HASH = ""
+
+function FileCache(cacheLocation/*: ?string */, hashOfConfig/*: ?string */) {
+  const cacheFile = path.resolve(getCacheFile(cacheLocation || DEFAULT_CACHE_LOCATION, process.cwd()))
+  debug(`Cache file is created at ${cacheFile}`)
+  this._fileCache = fileEntryCache.create(cacheFile)
+  this._hashOfConfig = hashOfConfig || DEFAULT_HASH
+}
+
+FileCache.prototype.hasFileChanged = function (absoluteFilepath) {
+  // Get file descriptor compares current metadata against cached
+  // one and stores the result to "changed" prop.w
+  const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath)
+  const meta = descriptor.meta || {}
+  const changed = descriptor.changed || meta.hashOfConfig !== this._hashOfConfig
+  if (!changed) {
+    debug(`Skip linting ${absoluteFilepath}. File hasn't changed.`)
+  }
+  // Mutate file descriptor object and store config hash to each file.
+  // Running lint with different config should invalidate the cache.
+  if (meta.hashOfConfig !== this._hashOfConfig) {
+    meta.hashOfConfig = this._hashOfConfig
+  }
+  return changed
+}
+
+FileCache.prototype.reconcile = function () {
+  this._fileCache.reconcile()
+}
+
+FileCache.prototype.destroy = function () {
+  this._fileCache.destroy()
+}
+
+FileCache.prototype.removeEntry = function (absoluteFilepath) {
+  this._fileCache.removeEntry(absoluteFilepath)
+}
+
+module.exports = FileCache

--- a/lib/utils/getCacheFile.js
+++ b/lib/utils/getCacheFile.js
@@ -1,0 +1,51 @@
+"use strict"
+
+const hash = require("./hash")
+const path = require("path")
+const fs = require("fs")
+/**
+ * Return the cacheFile to be used by stylelint, based on whether the provided parameter is
+ * a directory or looks like a directory (ends in `path.sep`), in which case the file
+ * name will be `cacheFile/.cache_hashOfCWD`.
+ *
+ * If cacheFile points to a file or looks like a file, then it will just use that file.
+ *
+ * @param {string} cacheFile - The name of file to be used to store the cache
+ * @param {string} cwd - Current working directory. Used for tests
+ * @returns {string} Resolved path to the cache file
+ */
+module.exports = function getCacheFile(cacheFile, cwd) {
+  /*
+   * Make sure path separators are normalized for environment/os.
+   * Also, keep trailing path separator if present.
+   */
+  cacheFile = path.normalize(cacheFile)
+
+  const resolvedCacheFile = path.resolve(cwd, cacheFile)
+  // If the last character passed is a path separator, we assume is a directory.
+  const looksLikeADirectory = cacheFile[cacheFile.length - 1] === path.sep
+
+  /**
+   * Return the default cache file name when provided parameter is a directory.
+   * @returns {string} - Resolved path to the cacheFile
+   */
+  function getCacheFileForDirectory() {
+    return path.join(resolvedCacheFile, `.stylelintcache_${hash(cwd)}`)
+  }
+
+  let fileStats
+
+  try {
+    fileStats = fs.lstatSync(resolvedCacheFile)
+  } catch (ex) {
+    fileStats = null
+  }
+
+  if (looksLikeADirectory || (fileStats && fileStats.isDirectory())) {
+    // Return path to provided directory with generated file name.
+    return getCacheFileForDirectory()
+  }
+
+  // Return normalized path to cache file.
+  return resolvedCacheFile
+}

--- a/lib/utils/hash.js
+++ b/lib/utils/hash.js
@@ -1,0 +1,11 @@
+"use strict"
+const murmur = require("imurmurhash")
+
+/**
+ * hash the given string
+ * @param  {string} str the string to hash
+ * @returns {string}    the hash
+ */
+module.exports = function hash(str) {
+  return murmur(str).result().toString(36)
+}

--- a/package.json
+++ b/package.json
@@ -41,13 +41,16 @@
     "chalk": "^1.1.1",
     "colorguard": "^1.2.0",
     "cosmiconfig": "^2.1.1",
+    "debug": "^2.6.0",
     "doiuse": "^2.4.1",
     "execall": "^1.0.0",
+    "file-entry-cache": "^2.0.0",
     "get-stdin": "^5.0.0",
     "globby": "^6.0.0",
     "globjoin": "^0.1.4",
     "html-tags": "^1.1.1",
     "ignore": "^3.2.0",
+    "imurmurhash": "^0.1.4",
     "known-css-properties": "^0.0.7",
     "lodash": "^4.17.4",
     "log-symbols": "^1.0.2",
@@ -75,13 +78,17 @@
     "benchmark": "^2.1.0",
     "common-tags": "^1.3.0",
     "coveralls": "^2.11.16",
+    "cp-file": "^4.1.1",
     "d3-queue": "^3.0.3",
     "eslint": "~3.18.0",
     "eslint-config-stylelint": "^6.0.0",
+    "file-exists-promise": "^1.0.2",
     "flow-bin": "^0.42.0",
+    "fs-promise": "^2.0.0",
     "jest": "^19.0.1",
     "npm-run-all": "^4.0.0",
     "npmpub": "^3.0.1",
+    "pify": "^2.3.0",
     "postcss-import": "^9.0.0",
     "postcss-safe-parser": "^2.0.0",
     "remark-cli": "^3.0.0",
@@ -147,7 +154,12 @@
     "plugins": [
       "preset-lint-recommended",
       "preset-lint-consistent",
-      ["validate-links", {"repository": "stylelint/stylelint"}]
+      [
+        "validate-links",
+        {
+          "repository": "stylelint/stylelint"
+        }
+      ]
     ]
   }
 }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2270

> Is there anything in the PR that needs further explanation?

UPDATED:
Tests are ~~in progress~~ **done**.
~~I decided to submit a PR for initial feedback before going too deep into woods with tests.~~

New dependencies:
- [debug](https://www.npmjs.com/package/debug) - for easy debugging/execution time profiling. To profile lint time just prefix you stylelint command with `DEBUG=stylelint:standalone stylelint "*.scss"`
- [imurmurhash](https://www.npmjs.com/package/imurmurhash) - see [eslint requires nodejs built with ssl support #5522](https://github.com/eslint/eslint/issues/5522)
- [file-entry-cache](https://www.npmjs.com/package/file-entry-cache) - required to get and cache file metadata
- [fs-promise](https://www.npmjs.com/package/fs-promise) - a promisified `fs-extra` version to read, copy, remove files using promises in tests.

Accounted for issues ESlint had with implementing cache:

- [Fix: invalidate cache when config changes. (fixes #3770)](https://github.com/eslint/eslint/pull/3818)
- [Update: --cache-file can take a directory where to store the cache. Fixes #4241](https://github.com/eslint/eslint/pull/4255)
- [Fix: `cacheLocation` handles paths in windows style. (fixes #4285)](https://github.com/eslint/eslint/pull/4287)
- [New: do not remove non visited files from cache. (Fixes #6780)](https://github.com/eslint/eslint/pull/6921)
- [eslint requires nodejs built with ssl support #5522](https://github.com/eslint/eslint/issues/5522)

@jeddy3, @davidtheclark, please, take a look