### PR TITLE
Fix "too many files open" error

### DIFF
--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -5,6 +5,8 @@ const formatters = require("./formatters")
 const createStylelint = require("./createStylelint")
 const globby = require("globby")
 const needlessDisables = require("./needlessDisables")
+const createThrottle = require("async-throttle")
+const os = require("os")
 
 module.exports = function (options/*: Object */)/*: Promise<stylelint$standaloneReturnValue>*/ {
   const files = options.files
@@ -65,6 +67,8 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
     })
   }
 
+  const throttle = createThrottle(os.cpus().length)
+
   return globby(files).then(filePaths => {
     if (!filePaths.length) {
       if (allowEmptyInput === undefined || !allowEmptyInput) {
@@ -76,7 +80,7 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
       }
     }
 
-    const getStylelintResults = filePaths.map(filePath => {
+    const getStylelintResults = filePaths.map(filePath => throttle(() => {
       const absoluteFilepath = (!path.isAbsolute(filePath))
         ? path.join(process.cwd(), filePath)
         : filePath
@@ -85,7 +89,7 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
       }).then(postcssResult => {
         return stylelint._createStylelintResult(postcssResult, filePath)
       }).catch(handleError)
-    })
+    }))
 
     return Promise.all(getStylelintResults)
   }).then(prepareReturnValue)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "node": ">=4.2.1"
   },
   "dependencies": {
+    "async-throttle": "^1.0.0",
     "autoprefixer": "^6.0.0",
     "balanced-match": "^0.4.0",
     "chalk": "^1.1.1",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

PoC of parallelism. Why?

1. Speedup linting on multiprocessor system
2. No error: "Too many files..." and etc, each file open, parse and create result in a separate process.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
