### PR TITLE
Print out filenames/globs when files do not exist

### DIFF
--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -79,7 +79,7 @@ it("standalone without input css and file(s) should throw error", () => {
 })
 
 it("standalone with non-existent-file should throw error with code 80", () => {
-  const expectedError = new Error("Files glob patterns specified did not match any files")
+  const expectedError = new Error(`${fixturesPath}/non-existent-file.css does not match any files`)
   expectedError.code = 80
 
   return standalone({

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -92,12 +92,42 @@ it("standalone with non-existent-file should throw error with code 80", () => {
   })
 })
 
-it("standalone with non-existent-file and allowEmptyInput false should throw error with code 80", () => {
-  const expectedError = new Error("Files glob patterns specified did not match any files")
+it("standalone with a single non-existent-file and allowEmptyInput false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/non-existent-file.css does not match any files`)
   expectedError.code = 80
 
   return standalone({
     files: `${fixturesPath}/non-existent-file.css`,
+    config: configBlockNoEmpty,
+    allowEmptyInput: false,
+  }).then(() => {
+    throw new Error("should not have succeeded")
+  }).catch(actualError => {
+    expect(actualError).toEqual(expectedError)
+  })
+})
+
+it("standalone with two non-existent-files and allowEmptyInput false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/non-existent-file.css and ${fixturesPath}/another-non-existent-file.css does not match any files`)
+  expectedError.code = 80
+
+  return standalone({
+    files: [ `${fixturesPath}/non-existent-file.css`, `${fixturesPath}/another-non-existent-file.css` ],
+    config: configBlockNoEmpty,
+    allowEmptyInput: false,
+  }).then(() => {
+    throw new Error("should not have succeeded")
+  }).catch(actualError => {
+    expect(actualError).toEqual(expectedError)
+  })
+})
+
+it("standalone with three or more non-existent-files and allowEmptyInput false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/non-existent-file.css, ${fixturesPath}/another-non-existent-file.css and ${fixturesPath}/third-non-existent-file.css does not match any files`)
+  expectedError.code = 80
+
+  return standalone({
+    files: [ `${fixturesPath}/non-existent-file.css`, `${fixturesPath}/another-non-existent-file.css`, `${fixturesPath}/third-non-existent-file.css` ],
     config: configBlockNoEmpty,
     allowEmptyInput: false,
   }).then(() => {

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -137,6 +137,51 @@ it("standalone with three or more non-existent-files and allowEmptyInput false s
   })
 })
 
+it("standalone with a glob that doesn't match anything and allowEmptyInput false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/nodir/**/*.css does not match any files`)
+  expectedError.code = 80
+
+  return standalone({
+    files: [`${fixturesPath}/nodir/**/*.css`],
+    config: configBlockNoEmpty,
+    allowEmptyInput: false,
+  }).then(() => {
+    throw new Error("should not have succeeded")
+  }).catch(actualError => {
+    expect(actualError).toEqual(expectedError)
+  })
+})
+
+it("standalone with two globs that don't match anything and allowEmptyInput false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/nodir/**/*.css and ${fixturesPath}/anotherdir/**/*.css does not match any files`)
+  expectedError.code = 80
+
+  return standalone({
+    files: [ `${fixturesPath}/nodir/**/*.css`, `${fixturesPath}/anotherdir/**/*.css` ],
+    config: configBlockNoEmpty,
+    allowEmptyInput: false,
+  }).then(() => {
+    throw new Error("should not have succeeded")
+  }).catch(actualError => {
+    expect(actualError).toEqual(expectedError)
+  })
+})
+
+it("standalone with three globs that don't match anything and allowEmptyInput false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/nodir/**/*.css, ${fixturesPath}/anotherdir/**/*.css and ${fixturesPath}/athird/**/*.css does not match any files`)
+  expectedError.code = 80
+
+  return standalone({
+    files: [ `${fixturesPath}/nodir/**/*.css`, `${fixturesPath}/anotherdir/**/*.css`, `${fixturesPath}/athird/**/*.css` ],
+    config: configBlockNoEmpty,
+    allowEmptyInput: false,
+  }).then(() => {
+    throw new Error("should not have succeeded")
+  }).catch(actualError => {
+    expect(actualError).toEqual(expectedError)
+  })
+})
+
 it("standalone with non-existent-file and allowEmptyInput true", () => {
   return standalone({
     files: `${fixturesPath}/non-existent-file.css`,

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -87,12 +87,12 @@ it("standalone with non-existent-file should throw error with code 80", () => {
     config: configBlockNoEmpty,
   }).then(() => {
     throw new Error("should not have succeeded")
-  }).catch(actualError => {
+  }, actualError => {
     expect(actualError).toEqual(expectedError)
   })
 })
 
-it("standalone with a single non-existent-file and allowEmptyInput false should throw error with code 80", () => {
+it("standalone with non-existent-file and allowEmptyInput false should throw error with code 80", () => {
   const expectedError = new Error(`${fixturesPath}/non-existent-file.css does not match any files`)
   expectedError.code = 80
 
@@ -102,82 +102,77 @@ it("standalone with a single non-existent-file and allowEmptyInput false should 
     allowEmptyInput: false,
   }).then(() => {
     throw new Error("should not have succeeded")
-  }).catch(actualError => {
+  }, actualError => {
     expect(actualError).toEqual(expectedError)
   })
 })
 
-it("standalone with two non-existent-files and allowEmptyInput false should throw error with code 80", () => {
-  const expectedError = new Error(`${fixturesPath}/non-existent-file.css and ${fixturesPath}/another-non-existent-file.css does not match any files`)
+it("standalone with two non-existent-files false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/non-existent-file.css and ${fixturesPath}/another-non-existent-file.css do not match any files`)
   expectedError.code = 80
 
   return standalone({
     files: [ `${fixturesPath}/non-existent-file.css`, `${fixturesPath}/another-non-existent-file.css` ],
     config: configBlockNoEmpty,
-    allowEmptyInput: false,
   }).then(() => {
     throw new Error("should not have succeeded")
-  }).catch(actualError => {
+  }, actualError => {
     expect(actualError).toEqual(expectedError)
   })
 })
 
-it("standalone with three or more non-existent-files and allowEmptyInput false should throw error with code 80", () => {
-  const expectedError = new Error(`${fixturesPath}/non-existent-file.css, ${fixturesPath}/another-non-existent-file.css and ${fixturesPath}/third-non-existent-file.css does not match any files`)
+it("standalone with three or more non-existent-files false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/non-existent-file.css, ${fixturesPath}/another-non-existent-file.css and ${fixturesPath}/third-non-existent-file.css do not match any files`)
   expectedError.code = 80
 
   return standalone({
     files: [ `${fixturesPath}/non-existent-file.css`, `${fixturesPath}/another-non-existent-file.css`, `${fixturesPath}/third-non-existent-file.css` ],
     config: configBlockNoEmpty,
-    allowEmptyInput: false,
   }).then(() => {
     throw new Error("should not have succeeded")
-  }).catch(actualError => {
+  }, actualError => {
     expect(actualError).toEqual(expectedError)
   })
 })
 
-it("standalone with a glob that doesn't match anything and allowEmptyInput false should throw error with code 80", () => {
+it("standalone with a glob that doesn't match anything false should throw error with code 80", () => {
   const expectedError = new Error(`${fixturesPath}/nodir/**/*.css does not match any files`)
   expectedError.code = 80
 
   return standalone({
     files: [`${fixturesPath}/nodir/**/*.css`],
     config: configBlockNoEmpty,
-    allowEmptyInput: false,
   }).then(() => {
     throw new Error("should not have succeeded")
-  }).catch(actualError => {
+  }, actualError => {
     expect(actualError).toEqual(expectedError)
   })
 })
 
-it("standalone with two globs that don't match anything and allowEmptyInput false should throw error with code 80", () => {
-  const expectedError = new Error(`${fixturesPath}/nodir/**/*.css and ${fixturesPath}/anotherdir/**/*.css does not match any files`)
+it("standalone with two globs that don't match anything should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/nodir/**/*.css and ${fixturesPath}/anotherdir/**/*.css do not match any files`)
   expectedError.code = 80
 
   return standalone({
     files: [ `${fixturesPath}/nodir/**/*.css`, `${fixturesPath}/anotherdir/**/*.css` ],
     config: configBlockNoEmpty,
-    allowEmptyInput: false,
   }).then(() => {
     throw new Error("should not have succeeded")
-  }).catch(actualError => {
+  }, actualError => {
     expect(actualError).toEqual(expectedError)
   })
 })
 
-it("standalone with three globs that don't match anything and allowEmptyInput false should throw error with code 80", () => {
-  const expectedError = new Error(`${fixturesPath}/nodir/**/*.css, ${fixturesPath}/anotherdir/**/*.css and ${fixturesPath}/athird/**/*.css does not match any files`)
+it("standalone with three globs that don't match anything false should throw error with code 80", () => {
+  const expectedError = new Error(`${fixturesPath}/nodir/**/*.css, ${fixturesPath}/anotherdir/**/*.css and ${fixturesPath}/athird/**/*.css do not match any files`)
   expectedError.code = 80
 
   return standalone({
     files: [ `${fixturesPath}/nodir/**/*.css`, `${fixturesPath}/anotherdir/**/*.css`, `${fixturesPath}/athird/**/*.css` ],
     config: configBlockNoEmpty,
-    allowEmptyInput: false,
   }).then(() => {
     throw new Error("should not have succeeded")
-  }).catch(actualError => {
+  }, actualError => {
     expect(actualError).toEqual(expectedError)
   })
 })

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -69,7 +69,6 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
     if (!filePaths.length) {
       if (allowEmptyInput === undefined || !allowEmptyInput) {
         const message = (files => {
-<<<<<<< HEAD
           if (typeof files === "string") {
             return files
           } else {
@@ -80,12 +79,6 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
           }
         })(files) + " does not match any files"
 
-=======
-          const [ last, ...initial ] = files.slice(0).reverse()
-          const finalSeparator = (files.length > 1 ? " and" : "")
-          return `${initial.join(", ")} ${finalSeparator} ${last}`
-        })(files)
->>>>>>> c11fbd1f273d670916c85e3ad1ec209c0e305415
         const err/*: Object*/ = new Error(message)
         err.code = 80
         throw err

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -68,7 +68,12 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
   return globby(files).then(filePaths => {
     if (!filePaths.length) {
       if (allowEmptyInput === undefined || !allowEmptyInput) {
-        const err/*: Object*/ = new Error("Files glob patterns specified did not match any files")
+        const message = (files => {
+          const [ last, ...initial ] = files.slice(0).reverse()
+          const finalSeparator = (files.length > 1 ? " and" : "")
+          return `${initial.join(", ")} ${finalSeparator} ${last}`
+        })(files)
+        const err/*: Object*/ = new Error(message)
         err.code = 80
         throw err
       } else {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -70,15 +70,15 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
       if (allowEmptyInput === undefined || !allowEmptyInput) {
         const message = (files => {
           if (typeof files === "string") {
-            return files
+            return `${files} does`
           }
           // seperate files into last (last file) and initial) all the others
           const initial = files.slice(0)
           const last = initial.pop()
           // join into a comma seperated string of file names
-          const finalSeparator = (files.length > 1 ? " and" : "")
-          return `${initial.join(", ")}${finalSeparator} ${last}`.trim()
-        })(files) + " does not match any files"
+          const ending = (files.length > 1 ? `and ${last} do` : `${last} does`)
+          return `${initial.join(", ")} ${ending}`.trim()
+        })(files) + " not match any files"
 
         const err/*: Object*/ = new Error(message)
         err.code = 80

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -71,12 +71,13 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
         const message = (files => {
           if (typeof files === "string") {
             return files
-          } else {
-            const initial = files.slice(0)
-            const last = initial.pop()
-            const finalSeparator = (files.length > 1 ? " and" : "")
-            return `${initial.join(", ")}${finalSeparator} ${last}`
           }
+          // seperate files into last (last file) and initial) all the others
+          const initial = files.slice(0)
+          const last = initial.pop()
+          // join into a comma seperated string of file names
+          const finalSeparator = (files.length > 1 ? " and" : "")
+          return `${initial.join(", ")}${finalSeparator} ${last}`
         })(files) + " does not match any files"
 
         const err/*: Object*/ = new Error(message)

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -69,10 +69,16 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
     if (!filePaths.length) {
       if (allowEmptyInput === undefined || !allowEmptyInput) {
         const message = (files => {
-          const [ last, ...initial ] = files.slice(0).reverse()
-          const finalSeparator = (files.length > 1 ? " and" : "")
-          return `${initial.join(", ")} ${finalSeparator} ${last}`
-        })(files)
+          if (typeof files === "string") {
+            return files
+          } else {
+            const initial = files.slice(0)
+            const last = initial.pop()
+            const finalSeparator = (files.length > 1 ? " and" : "")
+            return `${initial.join(", ")}${finalSeparator} ${last}`
+          }
+        })(files) + " does not match any files"
+
         const err/*: Object*/ = new Error(message)
         err.code = 80
         throw err

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -77,7 +77,7 @@ module.exports = function (options/*: Object */)/*: Promise<stylelint$standalone
           const last = initial.pop()
           // join into a comma seperated string of file names
           const finalSeparator = (files.length > 1 ? " and" : "")
-          return `${initial.join(", ")}${finalSeparator} ${last}`
+          return `${initial.join(", ")}${finalSeparator} ${last}`.trim()
         })(files) + " does not match any files"
 
         const err/*: Object*/ = new Error(message)


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Issue #2251 

> Is there anything in the PR that needs further explanation?

The formatting of multiple filenames/globs into a string is non-trivial. I addressed this with an immediately-executing anonymous function in the globby promise handler, because I wasn't sure if there's a standard place pure helper functions like this. Let me know if it could be improved.
