### PR TITLE
Fixed: `color-hex-case` rule is now respect SVG reference interaction.

### DIFF
--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -15,6 +15,9 @@ const sharedTests = {
   }, {
     code: "a { box-sizing: #$type-box; }",
     description: "ignore sass-like interpolation",
+  }, {
+    code: "a { stroke: url(#gradiantA) }",
+    description: "SVG reference interaction",
   } ],
 }
 

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -1,5 +1,6 @@
 "use strict"
 
+const blurFunctionArguments = require("../../utils/blurFunctionArguments")
 const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const styleSearch = require("style-search")
@@ -25,7 +26,7 @@ const rule = function (expectation) {
     }
 
     root.walkDecls(decl => {
-      const declString = decl.toString()
+      const declString = blurFunctionArguments(decl.toString(), "url")
       styleSearch({ source: declString, target: "#" }, match => {
         const hexMatch = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))
         if (!hexMatch) {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2332

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
