### PR TITLE
Tests: `shorthand-property-no-redundant-values` rule produces normal message (#2330).

### DIFF
--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -230,6 +230,11 @@ testRule(rule, {
     message: messages.rejected("thin thin thin thin", "thin"),
     line: 1,
     column: 5,
+  }, {
+    code: "a { margin: 1em 0 2em 0; }",
+    message: messages.rejected("1em 0 2em 0", "1em 0 2em"),
+    line: 1,
+    column: 5,
   } ],
 })
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2330

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
