### PR TITLE
Fixed: `max-line-length` rule is now reported correct column for `SASS` comments.

### DIFF
--- a/lib/rules/max-line-length/__tests__/index.js
+++ b/lib/rules/max-line-length/__tests__/index.js
@@ -97,7 +97,25 @@ testRule(rule, {
     message: messages.expected(20),
     line: 1,
     column: 48,
+  }, {
+    code: "a {\n    /* Lorem ipsum dolor sit amet. The comment Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium officia fugiat unde deserunt sit, tenetur! Incidunt similique blanditiis placeat ad quia possimus libero, reiciendis excepturi non esse deserunt a odit. */\n}",
+    message: messages.expected(20),
+    line: 2,
+    column: 272,
   } ],
+})
+
+testRule(rule, {
+  ruleName,
+  syntax: "scss",
+  config: [20],
+
+  reject: [{
+    code: "a {\n    // Lorem ipsum dolor sit amet. The comment Lorem ipsum dolor sit amet, consectetur adipisicing elit. Praesentium officia fugiat unde deserunt sit, tenetur! Incidunt similique blanditiis placeat ad quia possimus libero, reiciendis excepturi non esse deserunt a odit.\n}",
+    message: messages.expected(20),
+    line: 2,
+    column: 269,
+  }],
 })
 
 testRule(rule, {

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -33,7 +33,7 @@ const rule = function (maxLength, options) {
       return
     }
 
-    const rootString = root.toString()
+    const rootString = root.source.input.css
 
     const ignoreNonComments = optionsMatches(options, "ignore", "non-comments")
     const ignoreComments = optionsMatches(options, "ignore", "comments")


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2266

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
