### PR TITLE
Fixed: `report-needless-disables` argument is now exit with non-zero code.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -207,10 +207,19 @@ Promise.resolve().then(() => {
   return standalone(options)
 }).then((linted) => {
   if (reportNeedlessDisables) {
-    process.stdout.write(needlessDisablesStringFormatter(linted.needlessDisables))
-    if (reportNeedlessDisables === "error") {
+    const hasReportNeedlessDisable = !!linted.needlessDisables && linted.needlessDisables.some((sourceReport) => {
+      if (!sourceReport.ranges || sourceReport.ranges.length === 0) {
+        return false
+      }
+
+      return true
+    })
+
+    if (hasReportNeedlessDisable) {
+      process.stdout.write(needlessDisablesStringFormatter(linted.needlessDisables))
       process.exitCode = 2
     }
+
     return
   }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2325 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

It is very strange :smile:  `reportNeedlessDisables` can be only `true` or `false`.

/cc @jeddy3 @davidtheclark 