### PR TITLE
Fixed: false positives for resolved and interpolated selectors in `selector-class-pattern`.

### DIFF
--- a/lib/rules/selector-class-pattern/__tests__/index.js
+++ b/lib/rules/selector-class-pattern/__tests__/index.js
@@ -130,6 +130,10 @@ testRule(rule, {
   }, {
     code: ".#{$a} {}",
     description: "ignore sass var interpolation",
+  },
+  {
+    code: ".A#{$B} { &C {} &D, &E {} }",
+    description: "ignore sass var interpolation for parents of nested selectors",
   } ],
 })
 

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -55,6 +55,10 @@ const rule = function (pattern, options) {
       // Only bother resolving selectors that have an interpolating &
       if (shouldResolveNestedSelectors && hasInterpolatingAmpersand(selector)) {
         resolveNestedSelector(selector, rule).forEach(selector => {
+          if (!isStandardSyntaxSelector(selector)) {
+            return
+          }
+
           parseSelector(selector, result, rule, s => checkSelector(s, rule))
         })
       } else {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2334

For `selector-class-pattern`.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
