### PR TITLE
Report every selector resolved selector in selector-max-compound-selectors

### DIFF
--- a/lib/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/lib/rules/selector-max-compound-selectors/__tests__/index.js
@@ -149,13 +149,32 @@ testRule(rule, {
     code: ".cd { .de { .fg > & {} } }",
     message: messages.expected(".fg > .cd .de", 2),
   }, {
+    code: "a { b { c {} } }",
+    description: "standard nesting",
+  }, {
+    code: "a b { c { top: 10px; } }",
+    description: "standard nesting with declaration",
+    message: messages.expected("a b c", 2),
+  }, {
+    code: "a b { c { d {} } }",
+    description: "standard nesting with declaration and more nested rule",
+    message: messages.expected("a b c", 2),
+  }, {
+    code: "a b { c { top: 10px; @media print {} } }",
+    description: "standard nesting with declaration and more nested rule",
+    message: messages.expected("a b c", 2),
+  }, {
+    code: "a b { c { @media print { top: 10px; } } }",
+    description: "standard nesting with declaration and more nested rule",
+    message: messages.expected("a b c", 2),
+  }, {
     code: "a { @media print { b > c { d {} } } }",
     description: "The rule fails, but nesting even deeper with more compound selectors,",
-    message: messages.expected("a b > c d", 2),
+    message: messages.expected("a b > c", 2),
   }, {
     code: ".a { @media print { & .b > .c { & + .d {} } } }",
     description: "The rule fails, but nesting even deeper with more compound selectors, parent ref.,",
-    message: messages.expected(".a .b > .c + .d", 2),
+    message: messages.expected(".a .b > .c", 2),
   }, {
     code: "@media print { li { & + .ab { .cd { top: 10px; } } } }",
     description: "The rule fails, but nesting even deeper with more compound selectors, has declarations",

--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -63,12 +63,6 @@ const rule = function (max) {
         return
       }
 
-      // Nested selectors are processed in steps, as nesting levels are resolved.
-      // Here we skip processing the intermediate parts of selectors (to process only fully resolved selectors)
-      if (rule.nodes.some(node => node.type === "rule" || node.type === "atrule")) {
-        return
-      }
-
       // Using `rule.selectors` gets us each selector if there is a comma separated set
       rule.selectors.forEach(selector => {
         resolvedNestedSelector(selector, rule).forEach(resolvedSelector => {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2136

> Is there anything in the PR that needs further explanation?

The only way I see to avoid incorrectly resolved selector in custom syntaxes is report every resolved selector rather the deeper one. Because variation of nesting may be very different.

I have a question about testing new behaviour. The rule now produced more than one warning and we should test for more than one warning. E. g. [this test](https://github.com/stylelint/stylelint/blob/db2098115a3b53fbc1a2c218328159701057b649/lib/rules/selector-max-compound-selectors/__tests__/index.js#L177) produce two warnings, but we can test only the first one.