### PR TITLE
Add ignore:["custom-element"] option to selector-type-no-unknown

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -609,6 +609,32 @@ keywordSets.systemColors = new Set([
   "windowtext",
 ])
 
+// htmlTags includes only "standard" tags. So we augment it with older tags etc.
+keywordSets.nonStandardHtmlTags = new Set([
+  "acronym",
+  "applet",
+  "basefont",
+  "big",
+  "blink",
+  "center",
+  "content",
+  "dir",
+  "font",
+  "frame",
+  "frameset",
+  "hgroup",
+  "isindex",
+  "keygen",
+  "listing",
+  "marquee",
+  "noembed",
+  "plaintext",
+  "spacer",
+  "strike",
+  "tt",
+  "xmp",
+])
+
 function uniteSets() {
   const sets = Array.from(arguments)
 

--- a/lib/rules/selector-type-no-unknown/README.md
+++ b/lib/rules/selector-type-no-unknown/README.md
@@ -40,7 +40,27 @@ li > a {}
 
 ## Optional secondary options
 
-### `ignore: ["default-namespace"]`
+### `ignore: ["custom-elements", "default-namespace"]`
+
+#### `"custom-elements"`
+
+Allow custom elements.
+
+The following patterns are considered warnings:
+
+```css
+unknown {}
+```
+
+```css
+x-Foo {}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+x-foo {}
+```
 
 #### `"default-namespace"`
 

--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -119,6 +119,24 @@ testRule(rule, {
     message: messages.rejected("unknown"),
     line: 1,
     column: 11,
+  }, {
+    code: "x-Foo {}",
+    description: "invalid custom element",
+    message: messages.rejected("x-Foo"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "X-foo {}",
+    description: "invalid custom element",
+    message: messages.rejected("X-foo"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "X-FOO {}",
+    description: "invalid custom element",
+    message: messages.rejected("X-FOO"),
+    line: 1,
+    column: 1,
   } ],
 })
 
@@ -173,8 +191,8 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "not-my-type {}",
-    message: messages.rejected("not-my-type"),
+    code: "notmytype {}",
+    message: messages.rejected("notmytype"),
     line: 1,
     column: 1,
   } ],
@@ -225,4 +243,29 @@ testRule(rule, {
     line: 1,
     column: 11,
   }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ true, { ignore: ["custom-elements"] } ],
+
+  accept: [ {
+    code: "a {}",
+  }, {
+    code: "x-foo {}",
+    description: "custom element",
+  } ],
+
+  reject: [ {
+    code: "unknown {}",
+    message: messages.rejected("unknown"),
+    line: 1,
+    column: 1,
+  }, {
+    code: "x-Foo {}",
+    description: "invalid custom element",
+    message: messages.rejected("x-Foo"),
+    line: 1,
+    column: 1,
+  } ],
 })

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -4,12 +4,14 @@ const isKeyframeSelector = require("../../utils/isKeyframeSelector")
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
 const isStandardSyntaxTypeSelector = require("../../utils/isStandardSyntaxTypeSelector")
+const isCustomElement = require("../../utils/isCustomElement")
 const optionsMatches = require("../../utils/optionsMatches")
 const parseSelector = require("../../utils/parseSelector")
 const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
 const htmlTags = require("html-tags")
+const keywordSets = require("../../reference/keywordSets")
 const _ = require("lodash")
 const svgTags = require("svg-tags")
 const mathMLTags = require("mathml-tag-names")
@@ -20,38 +22,13 @@ const messages = ruleMessages(ruleName, {
   rejected: selector => `Unexpected unknown type selector "${selector}"`,
 })
 
-// htmlTags includes only "standard" tags. So we augment it with older tags etc.
-const nonStandardHtmlTags = new Set([
-  "acronym",
-  "applet",
-  "basefont",
-  "big",
-  "blink",
-  "center",
-  "content",
-  "dir",
-  "font",
-  "frame",
-  "frameset",
-  "hgroup",
-  "isindex",
-  "keygen",
-  "listing",
-  "marquee",
-  "noembed",
-  "plaintext",
-  "spacer",
-  "strike",
-  "tt",
-  "xmp",
-])
-
 const rule = function (actual, options) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, { actual }, {
       actual: options,
       possible: {
         ignore: [
+          "custom-elements",
           "default-namespace",
         ],
         ignoreNamespaces: [_.isString],
@@ -84,6 +61,13 @@ const rule = function (actual, options) {
           }
 
           if (
+            optionsMatches(options, "ignore", "custom-elements")
+            && isCustomElement(tagNode.value)
+          ) {
+            return
+          }
+
+          if (
             optionsMatches(options, "ignore", "default-namespace")
             && !tagNode.hasOwnProperty("namespace")
           ) {
@@ -103,7 +87,7 @@ const rule = function (actual, options) {
 
           if (htmlTags.indexOf(tagNameLowerCase) !== -1
             || svgTags.indexOf(tagNameLowerCase) !== -1
-            || nonStandardHtmlTags.has(tagNameLowerCase)
+            || keywordSets.nonStandardHtmlTags.has(tagNameLowerCase)
             || mathMLTags.indexOf(tagNameLowerCase) !== -1
           ) {
             return

--- a/lib/utils/__tests__/isCustomElement.test.js
+++ b/lib/utils/__tests__/isCustomElement.test.js
@@ -1,0 +1,36 @@
+"use strict"
+
+const isCustomElement = require("../isCustomElement")
+
+it("isCustomElement", () => {
+  expect(isCustomElement("x-foo")).toBeTruthy()
+  expect(isCustomElement("math-α")).toBeTruthy()
+  expect(isCustomElement("emotion-😍")).toBeTruthy()
+
+  expect(isCustomElement("X-foo")).toBeFalsy()
+  expect(isCustomElement("x-Foo")).toBeFalsy()
+  expect(isCustomElement("X-FOO")).toBeFalsy()
+
+  // Html tags
+  expect(isCustomElement("div")).toBeFalsy()
+  expect(isCustomElement("dIv")).toBeFalsy()
+  expect(isCustomElement("DiV")).toBeFalsy()
+  expect(isCustomElement("DIV")).toBeFalsy()
+  expect(isCustomElement("foo")).toBeFalsy()
+  expect(isCustomElement("acronym")).toBeFalsy()
+  // Svg tags
+  expect(isCustomElement("font-face")).toBeFalsy()
+  expect(isCustomElement("clipPath")).toBeFalsy()
+  // Mathml tags
+  expect(isCustomElement("abs")).toBeFalsy()
+  expect(isCustomElement("annotation-xml")).toBeFalsy()
+
+  expect(isCustomElement(".foo")).toBeFalsy()
+  expect(isCustomElement(".foo-bar")).toBeFalsy()
+  expect(isCustomElement("#foo")).toBeFalsy()
+  expect(isCustomElement("#foo-bar")).toBeFalsy()
+  expect(isCustomElement(":foo")).toBeFalsy()
+  expect(isCustomElement(":foo-bar")).toBeFalsy()
+  expect(isCustomElement("::foo")).toBeFalsy()
+  expect(isCustomElement("::foo-bar")).toBeFalsy()
+})

--- a/lib/utils/isCustomElement.js
+++ b/lib/utils/isCustomElement.js
@@ -1,0 +1,40 @@
+/* @flow */
+"use strict"
+
+const svgTags = require("svg-tags")
+const htmlTags = require("html-tags")
+const keywordSets = require("../reference/keywordSets")
+const mathMLTags = require("mathml-tag-names")
+
+/**
+ * Check whether a type selector is a custom element
+ */
+module.exports = function (selector/*: string*/)/*: boolean*/ {
+  if (!(/^[a-z]/).test(selector)) {
+    return false
+  }
+
+  if (selector.indexOf("-") === -1) {
+    return false
+  }
+
+  const selectorLowerCase = selector.toLowerCase()
+
+  if (selectorLowerCase !== selector) {
+    return false
+  }
+  if (svgTags.indexOf(selectorLowerCase) !== -1) {
+    return false
+  }
+  if (htmlTags.indexOf(selectorLowerCase) !== -1) {
+    return false
+  }
+  if (keywordSets.nonStandardHtmlTags.has(selectorLowerCase)) {
+    return false
+  }
+  if (mathMLTags.indexOf(selectorLowerCase) !== -1) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2348

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Btw, i think be good add option `resolve: ['custom-element']` (maybe best name). Because `not-my-type` is valid as custom element but invalid as known type selector :sob: 
