### PR TITLE
Add defaultIgnores: false option

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -286,7 +286,7 @@ If the globs are absolute paths, they are used as is. If they are relative, they
 -   the config's filepath, if the config is a file that stylelint found a loaded;
 -   or `process.cwd()`.
 
-`node_modules` and `bower_components` are always ignored.
+By default, all `node_modules` and `bower_components` are ignored. Default values will be overridden if `ignoreFiles` is set.
 
 The `ignoreFiles` property is stripped from extended configs: only the root-level config can ignore files.
 
@@ -307,4 +307,4 @@ The patterns in your `.stylelintignore` file must match [`.gitignore` syntax](ht
 
 stylelint will look for a `.stylelintignore` file in `process.cwd()`. You can also specify a path to your ignore patterns file (absolute or relative to `process.cwd()`) using the `--ignore-path` (in the CLI) and `ignorePath` (in JS) options.
 
-`node_modules` and `bower_components` are always ignored.
+By default, all `node_modules` and `bower_components` are ignored. Default values will be overridden by `.stylelintignore`.

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -61,7 +61,7 @@ A file glob, or array of file globs. Ultimately passed to [node-glob](https://gi
 
 Relative globs are considered relative to `process.cwd()`.
 
-`node_modules` and `bower_components` are always ignored.
+By default, all `node_modules` and `bower_components` are ignored.
 
 ### `formatter`
 

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -403,3 +403,43 @@ describe("file in bower_components", () => {
     })
   })
 })
+
+describe("file in node_modules, ignore is overridden by user", () => {
+  const lint = () => standalone({
+    code: "a {}",
+    codeFilename: "/something/node_modules/path/to/something.css",
+    config: {
+      ignoreFiles: ["foo.css"],
+      rules: {
+        "block-no-empty": true,
+      },
+    },
+  })
+
+  it("is not ignored", () => {
+    return lint().then((output) => {
+      expect(output.results[0].warnings.length).toBe(1)
+      expect(output.results[0].ignored).toBeFalsy()
+    })
+  })
+})
+
+describe("file in bower_components, ignore is overridden by user", () => {
+  const lint = () => standalone({
+    code: "a {}",
+    codeFilename: "/something/bower_components/path/to/something.css",
+    config: {
+      ignoreFiles: ["foo.css"],
+      rules: {
+        "block-no-empty": true,
+      },
+    },
+  })
+
+  it("is not ignored", () => {
+    return lint().then((output) => {
+      expect(output.results[0].warnings.length).toBe(1)
+      expect(output.results[0].ignored).toBeFalsy()
+    })
+  })
+})

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -25,7 +25,12 @@ module.exports = function (
 
     const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath)
 
-    const ignoreFiles = alwaysIgnoredGlobs.concat(config.ignoreFiles || [])
+    let ignoreFiles = alwaysIgnoredGlobs
+
+    if (config.ignoreFiles && config.ignoreFiles.length) {
+      ignoreFiles = [].concat(config.ignoreFiles) // it should always be an array
+    }
+
     if (micromatch(absoluteFilePath, ignoreFiles).length) {
       return true
     }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2236

> Is there anything in the PR that needs further explanation?

Changing default behaviour for `ignoreFiles`. User's config will override default values.

Should we somewhere in docs write default pattern? Users might want to add some patterns additionally to default patterns.

Also, what to do to [this code](https://github.com/stylelint/stylelint/blob/c6c5a79cea760e65a6e8a3fb651c84f8d79afc15/lib/standalone.js#L69-L75) which was added recently (https://github.com/stylelint/stylelint/commit/9578c4871fba233905e9bc66e803bddb6996362f).
