### PR TITLE
Fix custom properties sets followed by comments in no-extra-semicolons

### DIFF
--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -40,6 +40,8 @@ testRule(rule, {
     code: ":root { --foo: red; --bar: blue; }",
   }, {
     code: ":root { --foo: { color: red }; --bar: { color: blue }; --foo-bar: { color: blue }; --bar-foo: { color: red }; }",
+  }, {
+    code: ":root { --foo: { color: red }; /* comment */ --bar: { color: blue };/* comment */ --foo-bar: { color: blue }; --bar-foo: { color: red }; }",
   } ],
 
   reject: [ {
@@ -498,10 +500,20 @@ testRule(rule, {
     line: 1,
     column: 31,
   }, {
+    code: ":root { --foo: { color: red };/* comment */; --bar: { color: blue }; --bar-foo: { color: red }; }",
+    message: messages.rejected,
+    line: 1,
+    column: 44,
+  }, {
     code: ":root { --foo: { color: red }; --bar: { color: blue };; --bar-foo: { color: red }; }",
     message: messages.rejected,
     line: 1,
     column: 55,
+  }, {
+    code: ":root { --foo: { color: red }; --bar: { color: blue };/* comment 1 */ /* comment 2 */; --bar-foo: { color: red }; }",
+    message: messages.rejected,
+    line: 1,
+    column: 86,
   }, {
     code: ":root { --foo: { color: red }; --bar: { color: blue }; --bar-foo: { color: red };; }",
     message: messages.rejected,

--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -500,17 +500,27 @@ testRule(rule, {
     line: 1,
     column: 31,
   }, {
-    code: ":root { --foo: { color: red };/* comment */; --bar: { color: blue }; --bar-foo: { color: red }; }",
-    message: messages.rejected,
-    line: 1,
-    column: 44,
-  }, {
     code: ":root { --foo: { color: red }; --bar: { color: blue };; --bar-foo: { color: red }; }",
     message: messages.rejected,
     line: 1,
     column: 55,
   }, {
+    code: ":root { --foo: { color: red };/* comment */;}",
+    message: messages.rejected,
+    line: 1,
+    column: 44,
+  }, {
+    code: ":root { --foo: { color: red };/* comment */; --bar: { color: blue }; --bar-foo: { color: red }; }",
+    message: messages.rejected,
+    line: 1,
+    column: 44,
+  }, {
     code: ":root { --foo: { color: red }; --bar: { color: blue };/* comment 1 */ /* comment 2 */; --bar-foo: { color: red }; }",
+    message: messages.rejected,
+    line: 1,
+    column: 86,
+  }, {
+    code: ":root { --foo: { color: red }; --bar: { color: blue }/* comment 1 */; /* comment 2 */; --bar-foo: { color: red }; }",
     message: messages.rejected,
     line: 1,
     column: 86,

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 })
 
 function getOffsetByNode(node) {
-  const string = node.root().toString()
+  const string = node.root().source.input.css
   const nodeColumn = node.source.start.column
   const nodeLine = node.source.start.line
   let line = 1
@@ -54,14 +54,31 @@ const rule = function (actual) {
     }
 
     root.walk(node => {
-      const rawBeforeNode = node.raws.before
+      let rawBeforeNode = node.raws.before
 
       if (rawBeforeNode && rawBeforeNode.trim().length !== 0) {
         let allowedSemi = 0
 
         // Forbid semicolon before first custom properties sets
-        if (isCustomPropertySet(node) && node.parent.index(node) > 0) {
+        if ((isCustomPropertySet(node) && node.parent.index(node) > 0)) {
           allowedSemi = 1
+        }
+
+        const next = node.next()
+
+        // Ignore semicolon before comment if next node is custom properties sets or comment
+        if (node.type === "comment" && next
+          && (isCustomPropertySet(next) && node.parent.index(next) > 0 || next.type === "comment")
+        ) {
+          allowedSemi = 1
+        }
+
+        const prev = node.prev()
+
+        // Adding previous node string to custom properties set if previous node is comment
+        if (isCustomPropertySet(node) && node.parent.index(node) > 0 && prev && prev.type === "comment") {
+          rawBeforeNode = prev.toString() + rawBeforeNode
+          allowedSemi = 0
         }
 
         styleSearch({ source: rawBeforeNode, target: ";" }, (match, count) => {

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -60,7 +60,7 @@ const rule = function (actual) {
         let allowedSemi = 0
 
         // Forbid semicolon before first custom properties sets
-        if ((isCustomPropertySet(node) && node.parent.index(node) > 0)) {
+        if (isCustomPropertySet(node) && node.parent.index(node) > 0) {
           allowedSemi = 1
         }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2395

> Is there anything in the PR that needs further explanation?

Just failing tests. Have no time to look into the problem yet.