### PR TITLE
Add ignore: ["comments"] option to max-empty-lines

### DIFF
--- a/lib/rules/max-empty-lines/README.md
+++ b/lib/rules/max-empty-lines/README.md
@@ -58,3 +58,45 @@ a {}
 
 b {}
 ```
+
+## Optional secondary options
+
+### `ignore: ["comments"]`
+
+Only enforce the adjacent empty lines limit for lines that are not comments.
+
+For example, with `2` adjacent empty lines:
+
+The following patterns are considered warnings:
+
+```css
+/* horse */
+a {}
+
+
+
+b {}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+/**
+ * Call me Ishmael.
+ *
+ *
+ *
+ * Some years ago -- never mind how log precisely -- ...
+ */
+```
+
+```css
+/**
+ * Call me Ishmael.
+ *
+ *
+ *
+ * Some years ago -- never mind how log precisely -- ...
+ */
+a { color: pink; }
+```

--- a/lib/rules/max-empty-lines/README.md
+++ b/lib/rules/max-empty-lines/README.md
@@ -91,12 +91,14 @@ The following patterns are *not* considered warnings:
 ```
 
 ```css
-/**
- * Call me Ishmael.
- *
- *
- *
- * Some years ago -- never mind how log precisely -- ...
- */
-a { color: pink; }
+a { 
+    /**
+    * Comment 
+    *
+    *
+    *
+    * inside the declaration with a lot of empty lines...
+    */
+     color: pink; 
+}
 ```

--- a/lib/rules/max-empty-lines/__tests__/index.js
+++ b/lib/rules/max-empty-lines/__tests__/index.js
@@ -129,3 +129,28 @@ testRule(rule, {
     column: 1,
   }],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [ 2, { ignore: "comments" } ],
+
+  accept: [ {
+    code: "a{}\r\n\r\n/*\n\n\n\nhorse */\r\n\r\nb{}",
+  }, {
+    code: "a{}\r\n\r\n/** \r\n\r\n\r\n\nhor\r\n\r\n\r\nse */\r\n\r\nb{}",
+  }, {
+    code: "a{\r\n display: block;\r\n /* \r\n\r\n\r\nsome long comments */}\r\n\r\n",
+  }, {
+    code: "a{\r\n display: block\r\n /* \r\n\r\n\r\nsome long comments */;}\r\n\r\n",
+  }, {
+    code: "a{\r\n display: \r\n /* some long comments \r\n\r\n\r\n*/block;}\r\n\r\n",
+  } ],
+
+  reject: [{
+    code: "a {}\r\n\r\n\n\n/**\n\n\nhorse */\r\n\r\n\r\n\r\nb{}",
+    message: messages.expected(2),
+    line: 12,
+    column: 1,
+  }],
+
+})

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -1,6 +1,7 @@
 "use strict"
 
 const _ = require("lodash")
+const optionsMatches = require("../../utils/optionsMatches")
 const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
@@ -12,13 +13,21 @@ const messages = ruleMessages(ruleName, {
   expected: max => `Expected no more than ${max} empty line(s)`,
 })
 
-const rule = function (max) {
+const rule = function (max, options) {
   const maxAdjacentNewlines = max + 1
 
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: max,
       possible: _.isNumber,
+    }, {
+      actual: options,
+      possible: {
+        ignore: [
+          "comments",
+        ],
+      },
+      optional: true,
     })
     if (!validOptions) {
       return
@@ -27,6 +36,7 @@ const rule = function (max) {
     const rootString = root.toString()
     const repeatLFNewLines = _.repeat("\n", maxAdjacentNewlines)
     const repeatCRLFNewLines = _.repeat("\r\n", maxAdjacentNewlines)
+    const ignoreComments = optionsMatches(options, "ignore", "comments")
 
     styleSearch({ source: rootString, target: "\n" }, match => {
       checkMatch(rootString, match.endIndex, root)
@@ -36,12 +46,14 @@ const rule = function (max) {
     // `//`-comments from SCSS, which postcss-scss converts to `/* ... */`,
     // which adds to extra characters at the end, which messes up our
     // warning position
-    root.walkComments(comment => {
-      const source = (comment.raws.left || "") + comment.text + (comment.raws.right || "")
-      styleSearch({ source, target: "\n" }, match => {
-        checkMatch(source, match.endIndex, comment, 2)
+    if (!ignoreComments) {
+      root.walkComments(comment => {
+        const source = (comment.raws.left || "") + comment.text + (comment.raws.right || "")
+        styleSearch({ source, target: "\n" }, match => {
+          checkMatch(source, match.endIndex, comment, 2)
+        })
       })
-    })
+    }
 
     function checkMatch(source, matchEndIndex, node) {
       const offset = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 0


### PR DESCRIPTION
Add ignore: ["comments"] option to max-empty-lines


<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

fixes #2356 

> Is there anything in the PR that needs further explanation?

Adds ignore comments option to max-empty-lines
