### PR TITLE
WiP - @deprecated support

### DIFF
--- a/lib/rules/deprecated-variable-comments/index.js
+++ b/lib/rules/deprecated-variable-comments/index.js
@@ -35,9 +35,9 @@ const rule = function(isActivated) {
     root.walkDecls(decl => {
       const prop = decl.prop;
 
-      if (prop.startsWith('@')) { // currently this rules only match for Less @variables properties, why not generalize this?
+      if (prop.startsWith("@")) { // currently this rules only match for Less @variables properties, why not generalize this?
           const parentNode = decl.parent.nodes[decl.parent.nodes.indexOf(decl) - 1]
-          if (_.get(parentNode, 'text', '').startsWith('@deprecated')) {
+          if (_.get(parentNode, "text", ").startsWith("@deprecated")) {
             deprecatedVariables[prop] = {
               comment: parentNode.text
             }

--- a/lib/rules/deprecated-variable-comments/index.js
+++ b/lib/rules/deprecated-variable-comments/index.js
@@ -28,12 +28,12 @@ const rule = function(isActivated) {
     }
 
     if(!isActivated){
-      return;
+      return
     }
 
     // @todo maybe use ``walkComments` instead and lookup @deprecated comments first
     root.walkDecls(decl => {
-      const prop = decl.prop;
+      const prop = decl.prop
 
       if (prop.startsWith("@")) { // currently this rules only match for Less @variables properties, why not generalize this?
           const parentNode = decl.parent.nodes[decl.parent.nodes.indexOf(decl) - 1]

--- a/lib/rules/deprecated-variable-comments/index.js
+++ b/lib/rules/deprecated-variable-comments/index.js
@@ -37,7 +37,7 @@ const rule = function(isActivated) {
 
       if (prop.startsWith("@")) { // currently this rules only match for Less @variables properties, why not generalize this?
           const parentNode = decl.parent.nodes[decl.parent.nodes.indexOf(decl) - 1]
-          if (_.get(parentNode, "text", ").startsWith("@deprecated")) {
+          if (_.get(parentNode, "text", "").startsWith("@deprecated")) {
             deprecatedVariables[prop] = {
               comment: parentNode.text
             }

--- a/lib/rules/deprecated-variable-comments/index.js
+++ b/lib/rules/deprecated-variable-comments/index.js
@@ -1,0 +1,65 @@
+"use strict"
+
+const report = require("../../utils/report")
+const ruleMessages = require("../../utils/ruleMessages")
+const validateOptions = require("../../utils/validateOptions")
+const _ = require("lodash")
+const postcss = require("postcss")
+
+const ruleName = "deprecated-variables-rule"
+
+const messages = ruleMessages(ruleName, {
+  deprecated: (variable, comment) => `Deprecated usage of variable "${variable}" (${comment})`
+})
+
+// keep it outside every files
+// still, _variables.less
+const deprecatedVariables = {}
+
+const rule = function(isActivated) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: isActivated,
+      possible: _.isBoolean
+    })
+
+    if (!validOptions) {
+      return
+    }
+
+    if(!isActivated){
+      return;
+    }
+
+    // @todo maybe use ``walkComments` instead and lookup @deprecated comments first
+    root.walkDecls(decl => {
+      const prop = decl.prop;
+
+      if (prop.startsWith('@')) { // currently this rules only match for Less @variables properties, why not generalize this?
+          const parentNode = decl.parent.nodes[decl.parent.nodes.indexOf(decl) - 1]
+          if (_.get(parentNode, 'text', '').startsWith('@deprecated')) {
+            deprecatedVariables[prop] = {
+              comment: parentNode.text
+            }
+          }
+      }
+    });
+
+    root.walkDecls(decl => {
+      const value = decl.value
+      if (_.has(deprecatedVariables, value)) {
+        report({
+          message: messages.deprecated(value, deprecatedVariables[value].comment),
+          node: decl,
+          result,
+          ruleName,
+        })
+      }
+    });
+
+  }
+}
+
+rule.ruleName = ruleName
+rule.messages = messages
+module.exports = rule


### PR DESCRIPTION
### Usage

In `_variables.less`:

```less
// @deprecated use @grayTrout instead
@grayLight:             #555B64;
```

In another file:

```less
.a{
  color: @grayLight;
}
```

Output:

![capture d ecran 2017-03-01 10 38 34](https://cloud.githubusercontent.com/assets/138050/23455344/883d7e60-fe6f-11e6-898e-2782b9bfd00d.png)

### Current open questions

- Should we limit this rule to variables?
- Should we make it SaSS/Less agnostic and also support [Css Variables](https://developer.mozilla.org/fr/docs/Web/CSS/Les_variables_CSS)) ?

> Applicable to standard CSS syntax only.
> Has a singular purpose.

So it's not a rule but a plugin. But then a developer should create a plugin for each type of variable (Sass, Less and Css variables?) or the SRP only applies to rules?


### Implementation questions

- How to define a rule that first extract deprecation policies over every files and then loop through decls for each files? Current implementation hope that a variable file exist, was parsed first and then use a global variable to maintain declaration policies between file parsing.
- Use walkComments instead of walkDecls for the first iteration?
- It it possible to keep this rule outside of the main repository?

### Todo

Once the previous questions are answered and implementation is stabilized, documentation and tests will come.