### PR TITLE
Fixed: `value-keyword-case` is now ignore counter-reset property and counter, counters and attr functions.

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -318,6 +318,8 @@ keywordSets.camelCaseKeywords = new Set([
 // https://developer.mozilla.org/docs/Web/CSS/counter-increment
 keywordSets.counterIncrementKeywords = uniteSets(keywordSets.basicKeywords, ["none"])
 
+keywordSets.counterResetKeywords = uniteSets(keywordSets.basicKeywords, ["none"])
+
 keywordSets.gridRowKeywords = uniteSets(keywordSets.basicKeywords, [
   "auto",
   "span",

--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -58,6 +58,32 @@ testRule(rule, {
     code: "a::before { content: \"TeSt tEsT\"}",
     description: "ignore value within quotes",
   }, {
+    code: "a { content: url(http://www.example.com/test.png) ; }",
+  }, {
+    code: "a { content: attr(value-string); }",
+  }, {
+    code: "a { content: attr(vAlUe-StRiNg); }",
+  }, {
+    code: "a { content: attr(VALUE-STRING); }",
+  }, {
+    code: "a { content: counter(counter-name); }",
+  }, {
+    code: "a { content: counter(cOuNtEr-NaMe); }",
+  }, {
+    code: "a { content: counter(COUNTER-NAME); }",
+  }, {
+    code: "a { content: counters(counter-name); }",
+  }, {
+    code: "a { content: counters(cOuNtEr-NaMe); }",
+  }, {
+    code: "a { content: counters(COUNTER-NAME); }",
+  }, {
+    code: "a { content: '[' counter(counter-name) ']' ; }",
+  }, {
+    code: "a { content: '[' counter(cOuNtEr-NaMe) ']'; }",
+  }, {
+    code: "a { content: '[' counter(COUNTER-NAME) ']'; }",
+  }, {
     code: "a { font-size: $fsBLOCK; }",
     description: "ignore preprocessor variable includes value keyword",
   }, {
@@ -673,6 +699,32 @@ testRule(rule, {
   }, {
     code: "a::before { content: \"TeSt tEsT\"}",
     description: "ignore value within quotes",
+  }, {
+    code: "a { content: url(http://www.example.com/test.png) ; }",
+  }, {
+    code: "a { content: attr(value-string); }",
+  }, {
+    code: "a { content: attr(vAlUe-StRiNg); }",
+  }, {
+    code: "a { content: attr(VALUE-STRING); }",
+  }, {
+    code: "a { content: counter(counter-name); }",
+  }, {
+    code: "a { content: counter(cOuNtEr-NaMe); }",
+  }, {
+    code: "a { content: counter(COUNTER-NAME); }",
+  }, {
+    code: "a { content: counters(counter-name); }",
+  }, {
+    code: "a { content: counters(cOuNtEr-NaMe); }",
+  }, {
+    code: "a { content: counters(COUNTER-NAME); }",
+  }, {
+    code: "a { content: '[' counter(counter-name) ']' ; }",
+  }, {
+    code: "a { content: '[' counter(cOuNtEr-NaMe) ']'; }",
+  }, {
+    code: "a { content: '[' counter(COUNTER-NAME) ']'; }",
   }, {
     code: "a { font-size: $fsblock; }",
     description: "ignore preprocessor variable includes value keyword",

--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -150,6 +150,12 @@ testRule(rule, {
   }, {
     code: "a { counter-increment: COUNTER-NAME; }",
   }, {
+    code: "a { counter-reset: counter-name; }",
+  }, {
+    code: "a { counter-reset: cOuNtEr-NaMe; }",
+  }, {
+    code: "a { counter-reset: COUNTER-NAME; }",
+  }, {
     code: "a { grid-row: auto / auto; }",
   }, {
     code: "a { grid-row: 5 SOOMEGRIDAREA span / 2 span; }",
@@ -355,6 +361,11 @@ testRule(rule, {
     message: messages.expected("INHERIT", "inherit"),
     line: 1,
     column: 24,
+  }, {
+    code: "a { counter-reset: INHERIT; }",
+    message: messages.expected("INHERIT", "inherit"),
+    line: 1,
+    column: 20,
   }, {
     code: "a { grid-row: AUTO / auto; }",
     message: messages.expected("AUTO", "auto"),
@@ -753,6 +764,12 @@ testRule(rule, {
   }, {
     code: "a { counter-increment: COUNTER-NAME; }",
   }, {
+    code: "a { counter-reset: counter-name; }",
+  }, {
+    code: "a { counter-reset: cOuNtEr-NaMe; }",
+  }, {
+    code: "a { counter-reset: COUNTER-NAME; }",
+  }, {
     code: "a { grid-row: AUTO / AUTO; }",
   }, {
     code: "a { grid-row: 5 somegridarea SPAN / 2 SPAN; }",
@@ -953,6 +970,11 @@ testRule(rule, {
     message: messages.expected("inherit", "INHERIT"),
     line: 1,
     column: 24,
+  }, {
+    code: "a { counter-reset: inherit; }",
+    message: messages.expected("inherit", "INHERIT"),
+    line: 1,
+    column: 20,
   }, {
     code: "a { grid-row: auto / AUTO; }",
     message: messages.expected("auto", "AUTO"),

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -65,7 +65,7 @@ const rule = function (expectation, options) {
         }
 
         // Ignore keywords within `url` and `var` function
-        if (node.type === "function" && (valueLowerCase === "url" || valueLowerCase === "var")) {
+        if (node.type === "function" && (valueLowerCase === "url" || valueLowerCase === "var" || valueLowerCase === "counter" || valueLowerCase === "counters" || valueLowerCase === "attr")) {
           return false
         }
 

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -4,6 +4,7 @@ const keywordSets = require("../../reference/keywordSets")
 const declarationValueIndex = require("../../utils/declarationValueIndex")
 const getUnitFromValueNode = require("../../utils/getUnitFromValueNode")
 const isCounterIncrementCustomIdentValue = require("../../utils/isCounterIncrementCustomIdentValue")
+const isCounterResetCustomIdentValue = require("../../utils/isCounterResetCustomIdentValue")
 const isStandardSyntaxValue = require("../../utils/isStandardSyntaxValue")
 const matchesStringOrRegExp = require("../../utils/matchesStringOrRegExp")
 const report = require("../../utils/report")
@@ -88,6 +89,9 @@ const rule = function (expectation, options) {
           return
         }
         if (prop === "counter-increment" && isCounterIncrementCustomIdentValue(valueLowerCase)) {
+          return
+        }
+        if (prop === "counter-reset" && isCounterResetCustomIdentValue(valueLowerCase)) {
           return
         }
         if (prop === "grid-row" && !keywordSets.gridRowKeywords.has(valueLowerCase)) {

--- a/lib/utils/__tests__/isCounterResetCustomIdentValue.test.js
+++ b/lib/utils/__tests__/isCounterResetCustomIdentValue.test.js
@@ -1,0 +1,18 @@
+"use strict"
+
+const isCounterResetCustomIdentValue = require("../isCounterResetCustomIdentValue")
+
+it("isCustomIdents", () => {
+  expect(isCounterResetCustomIdentValue("counter")).toBeTruthy()
+  expect(isCounterResetCustomIdentValue("cOuNtEr")).toBeTruthy()
+  expect(isCounterResetCustomIdentValue("COUNTER")).toBeTruthy()
+  expect(isCounterResetCustomIdentValue("counter-name")).toBeTruthy()
+  expect(isCounterResetCustomIdentValue("counter1")).toBeTruthy()
+  expect(isCounterResetCustomIdentValue("counter2")).toBeTruthy()
+  expect(isCounterResetCustomIdentValue("none")).toBeFalsy()
+  expect(isCounterResetCustomIdentValue("inherit")).toBeFalsy()
+  expect(isCounterResetCustomIdentValue("initial")).toBeFalsy()
+  expect(isCounterResetCustomIdentValue("unset")).toBeFalsy()
+  expect(isCounterResetCustomIdentValue("-1")).toBeFalsy()
+  expect(isCounterResetCustomIdentValue("1")).toBeFalsy()
+})

--- a/lib/utils/isCounterResetCustomIdentValue.js
+++ b/lib/utils/isCounterResetCustomIdentValue.js
@@ -1,0 +1,19 @@
+/* @flow */
+"use strict"
+
+const keywordSets = require("../reference/keywordSets")
+const _ = require("lodash")
+
+/**
+ * Check value is a custom ident
+ */
+
+module.exports = function (value/*: string*/)/*: boolean*/ {
+  const valueLowerCase = value.toLowerCase()
+
+  if (keywordSets.counterResetKeywords.has(valueLowerCase) || _.isFinite(parseInt(valueLowerCase))) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2406 

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
