### PR TITLE
Docs: Mention supported .yml extension for config files

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -10,7 +10,7 @@ Finding and loading of your configuration object is done with [cosmiconfig](http
 -   a `.stylelintrc` file
 -   a `stylelint.config.js` file exporting a JS object
 
-The `.stylelintrc` file (without extension) can be in JSON or YAML format. Alternately, you can add a filename extension to designate JSON, YAML, or JS format: `.stylelintrc.json`, `.stylelintrc.yaml`, `.stylelintrc.js`. You may want to use an extension so that your text editor can better interpret the file, and help with syntax checking and highlighting.
+The `.stylelintrc` file (without extension) can be in JSON or YAML format. Alternately, you can add a filename extension to designate JSON, YAML, or JS format: `.stylelintrc.json`, `.stylelintrc.yaml`, `.stylelintrc.yml`, `.stylelintrc.js`. You may want to use an extension so that your text editor can better interpret the file, and help with syntax checking and highlighting.
 
 Once one of these is found and parsed, the search will stop and that object will be used.
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -58,7 +58,7 @@ const meowOptions = {
         the following places, in this order:
           - a stylelint property in package.json
           - a .stylelintrc file (with or without filename extension:
-            .json, .yaml, and .js are available)
+            .json, .yaml, .yml and .js are available)
           - a stylelint.config.js file exporting a JS object
         The search will begin in the working directory and move up the directory
         tree until a configuration file is found.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -58,7 +58,7 @@ const meowOptions = {
         the following places, in this order:
           - a stylelint property in package.json
           - a .stylelintrc file (with or without filename extension:
-            .json, .yaml, .yml and .js are available)
+            .json, .yaml, .yml, and .js are available)
           - a stylelint.config.js file exporting a JS object
         The search will begin in the working directory and move up the directory
         tree until a configuration file is found.


### PR DESCRIPTION
Turns out cosmiconfig supports the .yml extension so it's worth mentioning it.