### PR TITLE
Improve testRule reliability

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -6,31 +6,13 @@ const stylelint = require("./lib/standalone")
 
 global.testRule = (rule, schema) => {
   expect.extend({
-    toHaveDetails(testCase) {
-      if (
-        testCase.message === undefined
-        && testCase.line === undefined
-        && testCase.column === undefined
-      ) {
-        return {
-          message: () => (
-            "Expected to have one of the following details for a test case: message, line, column"
-          ),
-          pass: false,
-        }
-      }
-
-      return {
-        pass: true,
-      }
-    },
     toHaveMessage(testCase) {
       if (
         testCase.message === undefined
       ) {
         return {
           message: () => (
-            "Expected to have a \"message\" for a test case"
+            "Expected \"reject\" test case to have a \"message\" property"
           ),
           pass: false,
         }
@@ -83,7 +65,6 @@ global.testRule = (rule, schema) => {
             }).then((output) => {
               const warning = output.results[0].warnings[0]
 
-              expect(testCase).toHaveDetails()
               expect(testCase).toHaveMessage()
 
               if (testCase.message) {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -5,6 +5,43 @@ const basicChecks = require("./lib/testUtils/basicChecks")
 const stylelint = require("./lib/standalone")
 
 global.testRule = (rule, schema) => {
+  expect.extend({
+    toHaveDetails(testCase) {
+      if (
+        testCase.message === undefined
+        && testCase.line === undefined
+        && testCase.column === undefined
+      ) {
+        return {
+          message: () => (
+            "Expected to have one of the following details for a test case: message, line, column"
+          ),
+          pass: false,
+        }
+      }
+
+      return {
+        pass: true,
+      }
+    },
+    toHaveMessage(testCase) {
+      if (
+        testCase.message === undefined
+      ) {
+        return {
+          message: () => (
+            "Expected to have a \"message\" for a test case"
+          ),
+          pass: false,
+        }
+      }
+
+      return {
+        pass: true,
+      }
+    },
+  })
+
   describe(schema.ruleName, () => {
     const stylelintConfig = {
       rules: {
@@ -45,6 +82,10 @@ global.testRule = (rule, schema) => {
               syntax: schema.syntax,
             }).then((output) => {
               const warning = output.results[0].warnings[0]
+
+              expect(testCase).toHaveDetails()
+              expect(testCase).toHaveMessage()
+
               if (testCase.message) {
                 expect(_.get(warning, "text")).toBe(testCase.message)
               }

--- a/lib/rules/function-comma-newline-after/__tests__/index.js
+++ b/lib/rules/function-comma-newline-after/__tests__/index.js
@@ -87,6 +87,7 @@ testRule(rule, {
   }, {
     code: "a {\n  transform: translate(\n    1px,  /* comment (with trailing space) */  \n" + "    1px\n  );\n}",
     description: "eol comments",
+    message: messages.expectedAfter(),
   } ],
 })
 
@@ -201,6 +202,7 @@ testRule(rule, {
   }, {
     code: "a {\n  transform: translate(\n    1px,  /* comment (with trailing space) */  \n" + "    1px\n  );\n}",
     description: "eol comments",
+    message: messages.expectedAfterMultiLine(),
   } ],
 })
 

--- a/lib/rules/function-comma-newline-before/__tests__/index.js
+++ b/lib/rules/function-comma-newline-before/__tests__/index.js
@@ -207,6 +207,7 @@ testRule(rule, {
       }
     `,
     description: "eol comments",
+    message: messages.rejectedBeforeMultiLine(),
   } ],
 })
 

--- a/lib/rules/function-comma-space-after/__tests__/index.js
+++ b/lib/rules/function-comma-space-after/__tests__/index.js
@@ -69,6 +69,7 @@ testRule(rule, {
   }, {
     code: "a { transform: translate(1,/* comment */1); }",
     description: "comments",
+    message: messages.expectedAfter(),
   } ],
 })
 
@@ -146,6 +147,7 @@ testRule(rule, {
   }, {
     code: "a { transform: translate(1, /* comment */1); }",
     description: "comments",
+    message: messages.rejectedAfter(),
   } ],
 })
 

--- a/lib/rules/function-comma-space-before/__tests__/index.js
+++ b/lib/rules/function-comma-space-before/__tests__/index.js
@@ -73,6 +73,7 @@ testRule(rule, {
       }
     `,
     description: "eol comments",
+    message: messages.expectedBefore(),
   } ],
 })
 

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -472,8 +472,10 @@ testRule(rule, {
 
   reject: [ {
     code: "@-moz-document url-prefix() {}",
+    message: messages.expected(),
   }, {
     code: "a { background: url() }",
+    message: messages.expected(),
   }, {
     code: "@import url(\"foo.css\");",
     message: messages.rejected(),

--- a/lib/rules/selector-no-type/__tests__/index.js
+++ b/lib/rules/selector-no-type/__tests__/index.js
@@ -177,6 +177,7 @@ testRule(rule, {
   reject: [{
     code: "@for $n from 1 through 5 { .foo-#{$n} { div { content: \"#{$n}\"; } } }",
     description: "ignore sass interpolation inside @for for nested descendant",
+    message: messages.rejected,
     line: 1,
     column: 41,
   }],
@@ -205,6 +206,7 @@ testRule(rule, {
   reject: [{
     code: ".for(@n: 1) when (@n <= 5) { .foo-@{n} { div { content: \"@{n}\"; } } .for (@n + 1); }",
     description: "ignore less interpolation inside @for for nested descendant",
+    message: messages.rejected,
     line: 1,
     column: 42,
   }],
@@ -237,6 +239,7 @@ testRule(rule, {
 
   reject: [ {
     code: "a {}",
+    message: messages.rejected,
     line: 1,
     column: 1,
   }, {

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -331,7 +331,9 @@ testRule(rule, {
 
   reject: [ {
     code: "a { margin: 10pixels; }",
+    message: messages.rejected("pixels"),
   }, {
     code: "a { margin: 10not-my-unit; }",
+    message: messages.rejected("not-my-unit"),
   } ],
 })


### PR DESCRIPTION
`testRule` is not fully reliable. It won't catch `rejected` test case if this test case has no `message`, `line`, and `column` defined. For example, it's possible to put any `accepted` test case with `code` property only to `rejected` array. And this test would pass!

To find unreliable tests I wrote two custom matchers. I'm not sure which one is better.

Some tests are failing now, and it's a result of improved test reliability. I'll fix failing tests as soon better matcher is chosen.

What matcher is better? Should I change selected matcher's message?