### PR TITLE
Proof of concept: Add autofixing

### DIFF
--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -115,4 +115,5 @@ export type stylelint$standaloneOptions = {
   customSyntax?: string,
   formatter?: "json" | "string" | "verbose" | Function,
   allowEmptyInput?: boolean,
+  fix?: boolean,
 }

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -81,5 +81,43 @@ global.testRule = (rule, schema) => {
         })
       })
     }
+
+    if (schema.fixingCases && schema.fixingCases.length) {
+      describe("fix", () => {
+        schema.fixingCases.forEach((testCase) => {
+          const spec = (testCase.only) ? it.only : it
+          let code = testCase.code
+
+          // Fix testCase
+          spec(testCase.description || "no description. fix", () => {
+            return stylelint({
+              code,
+              config: stylelintConfig,
+              syntax: schema.syntax,
+              fix: true,
+            }).then((output) => {
+              code = output.results[0]._postcssResult.root.toResult().css
+
+              if (testCase.same) {
+                expect(code).toEqual(testCase.code)
+              } else if (testCase.expected) {
+                expect(code).toEqual(testCase.expected)
+              }
+            })
+          })
+
+          // Lint fixed testCase, it shouldn't show warnings
+          spec(testCase.description || "no description. lint fixed", () => {
+            return stylelint({
+              code,
+              config: stylelintConfig,
+              syntax: schema.syntax,
+            }).then((output) => {
+              expect(output.results[0].warnings).toEqual([])
+            })
+          })
+        })
+      })
+    }
   })
 }

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -96,7 +96,9 @@ global.testRule = (rule, schema) => {
               syntax: schema.syntax,
               fix: true,
             }).then((output) => {
-              code = output.results[0]._postcssResult.root.toResult().css
+              const result = output.results[0]._postcssResult
+
+              code = result.root.toString(result.opts.syntax)
 
               if (testCase.same) {
                 expect(code).toEqual(testCase.code)

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -249,7 +249,7 @@ Promise.resolve().then(() => {
   if (optionsBase.fix) {
     linted.results.forEach((result) => {
       if (result._postcssResult) {
-        fs.writeFile(result.source, result._postcssResult.root.toResult().css)
+        fs.writeFile(result.source, result._postcssResult.root.toString(result._postcssResult.opts.syntax))
       }
     })
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 "use strict"
 const getModulePath = require("./utils/getModulePath")
 const getStdin = require("get-stdin")
+const fs = require("fs")
 const meow = require("meow")
 const needlessDisablesStringFormatter = require("./formatters/needlessDisablesStringFormatter")
 const path = require("path")
@@ -30,6 +31,7 @@ const minimistOptions = {
   boolean: [
     "allow-empty-input",
     "color",
+    "fix",
     "help",
     "ignore-disables",
     "no-color",
@@ -93,23 +95,23 @@ const meowOptions = {
       --ignore-disables, --id
 
         Ignore styleline-disable comments.
-        
+
       --cache                       [default: false]
 
-        Store the info about processed files in order to only operate on the 
-        changed ones the next time you run stylelint. By default, the cache 
+        Store the info about processed files in order to only operate on the
+        changed ones the next time you run stylelint. By default, the cache
         is stored in "./.stylelintcache". To adjust this, use --cache-location.
 
       --cache-location              [default: '.stylelintcache']
 
         Path to a file or directory to be used for the cache location.
-        Default is "./.stylelintcache". If a directory is specified, a cache 
+        Default is "./.stylelintcache". If a directory is specified, a cache
         file will be created inside the specified folder, with a name derived
         from a hash of the current working directory.
 
-        If the directory for the cache does not exist, make sure you add a trailing "/" 
+        If the directory for the cache does not exist, make sure you add a trailing "/"
         on \*nix systems or "\" on Windows. Otherwise the path will be assumed to be a file.
-         
+
 
       --formatter, -f               [default: "string"]
 
@@ -209,6 +211,10 @@ if (cli.flags.cacheLocation) {
   optionsBase.cacheLocation = cli.flags.cacheLocation
 }
 
+if (cli.flags.fix) {
+  optionsBase.fix = cli.flags.fix
+}
+
 const reportNeedlessDisables = cli.flags.reportNeedlessDisables
 
 if (reportNeedlessDisables) {
@@ -238,6 +244,14 @@ Promise.resolve().then(() => {
       process.exitCode = 2
     }
     return
+  }
+
+  if (optionsBase.fix) {
+    linted.results.forEach((result) => {
+      if (result._postcssResult) {
+        fs.writeFile(result.source, result._postcssResult.root.toResult().css)
+      }
+    })
   }
 
   if (!linted.output) {

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -19,6 +19,8 @@ module.exports = function (
 )/*: Promise<Object>*/ {
   options = options || {}
 
+  const fix = options.fix || false
+
   if (!options.filePath && options.code === undefined && !options.existingPostcssResult) {
     return Promise.reject(new Error("You must provide filePath, code, or existingPostcssResult"))
   }
@@ -60,7 +62,7 @@ module.exports = function (
       const existingPostcssResult = options.existingPostcssResult
 
       if (existingPostcssResult) {
-        return lintPostcssResult(stylelint, existingPostcssResult, config).then(() => existingPostcssResult)
+        return lintPostcssResult(stylelint, existingPostcssResult, config, fix).then(() => existingPostcssResult)
       }
 
       return stylelint._getPostcssResult({
@@ -69,7 +71,7 @@ module.exports = function (
         filePath: inputFilePath,
         codeProcessors: config.codeProcessors,
       }).then(postcssResult => {
-        return lintPostcssResult(stylelint, postcssResult, config).then(() => postcssResult)
+        return lintPostcssResult(stylelint, postcssResult, config, fix).then(() => postcssResult)
       })
     })
   })
@@ -78,7 +80,8 @@ module.exports = function (
 function lintPostcssResult(
   stylelint/*: stylelint$internalApi*/,
   postcssResult/*: Object*/,
-  config/*: stylelint$config*/
+  config/*: stylelint$config*/,
+  fix
 )/*: Promise<>*/ {
   postcssResult.stylelint = postcssResult.stylelint || {}
   postcssResult.stylelint.ruleSeverities = {}
@@ -119,7 +122,7 @@ function lintPostcssResult(
     postcssResult.stylelint.customMessages[ruleName] = _.get(secondaryOptions, "message")
 
     const performRule = Promise.resolve().then(() => {
-      return ruleFunction(primaryOption, secondaryOptions)(postcssRoot, postcssResult)
+      return ruleFunction(primaryOption, secondaryOptions)(postcssRoot, postcssResult, fix)
     })
     performRules.push(performRule)
   })

--- a/lib/rules/at-rule-name-case/__tests__/fixing.js
+++ b/lib/rules/at-rule-name-case/__tests__/fixing.js
@@ -1,0 +1,172 @@
+"use strict"
+
+const ruleName = require("..").ruleName
+const rules = require("../../../rules")
+
+const rule = rules[ruleName]
+
+testRule(rule, {
+  ruleName,
+  config: ["lower"],
+  skipBasicChecks: true,
+
+  fixingCases: [ {
+    code: "@charset 'UTF-8';",
+    same: true,
+  }, {
+    code: "@import 'test.css'",
+    same: true,
+  }, {
+    code: "@namespace url(XML-namespace-URL);",
+    same: true,
+  }, {
+    code: "@media screen {}",
+    same: true,
+  }, {
+    code: "@media (min-width: 50em) {}",
+    same: true,
+  }, {
+    code: "@media only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
+    same: true,
+  }, {
+    code: "@supports (animation-name: test) {}",
+    same: true,
+  }, {
+    code: "@document url(http://www.w3.org/), url-prefix(http://www.w3.org/Style/), domain(mozilla.org), regexp('https:.*')",
+    same: true,
+  }, {
+    code: "@page :first { margin: 1cm; }",
+    same: true,
+  }, {
+    code: "@keyframes { 0% { top: 0; } }",
+    same: true,
+  }, {
+    code: "@-webkit-keyframes { 0% { top: 0; } }",
+    same: true,
+  }, {
+    code: "@viewport { orientation: landscape; }",
+    same: true,
+  }, {
+    code: "@counter-style win-list { system: fixed; symbols: url(gold-medal.svg) url(silver-medal.svg) ; suffix: ' ';}",
+    same: true,
+  }, {
+    code: "@font-feature-values Font One { @styleset { nice-style: 12; } }",
+    same: true,
+  }, {
+    code: "@Charset 'UTF-8';",
+    expected: "@charset 'UTF-8';",
+  }, {
+    code: "@cHaRsEt 'UTF-8';",
+    expected: "@charset 'UTF-8';",
+  }, {
+    code: "@CHARSET 'UTF-8';",
+    expected: "@charset 'UTF-8';",
+  }, {
+    code: "@Media screen {}",
+    expected: "@media screen {}",
+  }, {
+    code: "@mEdIa screen {}",
+    expected: "@media screen {}",
+  }, {
+    code: "@MEDIA screen {}",
+    expected: "@media screen {}",
+  }, {
+    code: "@media only screen and (min-width: 415px) { @Keyframes pace-anim { 100% { opacity: 0; } } }",
+    expected: "@media only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
+  }, {
+    code: "@media only screen and (min-width: 415px) { @kEyFrAmEs pace-anim { 100% { opacity: 0; } } }",
+    expected: "@media only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
+  }, {
+    code: "@media only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
+    expected: "@media only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
+  }, {
+    code: "@-WEBKIT-keyframes { 0% { top: 0; } }",
+    expected: "@-webkit-keyframes { 0% { top: 0; } }",
+  }, {
+    code: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
+    expected: "@-webkit-keyframes { 0% { top: 0; } }",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["upper"],
+  skipBasicChecks: true,
+
+  fixingCases: [ {
+    code: "@CHARSET 'UTF-8';",
+    same: true,
+  }, {
+    code: "@IMPORT 'test.css'",
+    same: true,
+  }, {
+    code: "@NAMESPACE url(XML-namespace-URL);",
+    same: true,
+  }, {
+    code: "@MEDIA screen {}",
+    same: true,
+  }, {
+    code: "@MEDIA (min-width: 50em) {}",
+    same: true,
+  }, {
+    code: "@MEDIA only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
+    same: true,
+  }, {
+    code: "@SUPPORTS (animation-name: test) {}",
+    same: true,
+  }, {
+    code: "@DOCUMENT url(http://www.w3.org/), url-prefix(http://www.w3.org/Style/), domain(mozilla.org), regexp('https:.*')",
+    same: true,
+  }, {
+    code: "@PAGE :first { margin: 1cm; }",
+    same: true,
+  }, {
+    code: "@KEYFRAMES { 0% { top: 0; } }",
+    same: true,
+  }, {
+    code: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
+    same: true,
+  }, {
+    code: "@VIEWPORT { orientation: landscape; }",
+    same: true,
+  }, {
+    code: "@COUNTER-STYLE win-list { system: fixed; symbols: url(gold-medal.svg) url(silver-medal.svg) ; suffix: ' ';}",
+    same: true,
+  }, {
+    code: "@FONT-FEATURE-VALUES Font One { @STYLESET { nice-style: 12; } }",
+    same: true,
+  }, {
+    code: "@Charset 'UTF-8';",
+    expected: "@CHARSET 'UTF-8';",
+  }, {
+    code: "@cHaRsEt 'UTF-8';",
+    expected: "@CHARSET 'UTF-8';",
+  }, {
+    code: "@charset 'UTF-8';",
+    expected: "@CHARSET 'UTF-8';",
+  }, {
+    code: "@Media screen {}",
+    expected: "@MEDIA screen {}",
+  }, {
+    code: "@mEdIa screen {}",
+    expected: "@MEDIA screen {}",
+  }, {
+    code: "@media screen {}",
+    expected: "@MEDIA screen {}",
+  }, {
+    code: "@MEDIA only screen and (min-width: 415px) { @Keyframes pace-anim { 100% { opacity: 0; } } }",
+    expected: "@MEDIA only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
+  }, {
+    code: "@MEDIA only screen and (min-width: 415px) { @kEyFrAmEs pace-anim { 100% { opacity: 0; } } }",
+    expected: "@MEDIA only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
+  }, {
+    code: "@MEDIA only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
+    expected: "@MEDIA only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
+  }, {
+    code: "@-webkit-KEYFRAMES { 0% { top: 0; } }",
+    expected: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
+  }, {
+    code: "@-webkit-keyframes { 0% { top: 0; } }",
+    expected: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
+  } ],
+})

--- a/lib/rules/at-rule-name-case/index.js
+++ b/lib/rules/at-rule-name-case/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 })
 
 const rule = function (expectation) {
-  return (root, result) => {
+  return (root, result, fix) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
@@ -34,12 +34,16 @@ const rule = function (expectation) {
         return
       }
 
-      report({
-        message: messages.expected(name, expectedName),
-        node: atRule,
-        ruleName,
-        result,
-      })
+      if (fix) {
+        atRule.name = expectedName
+      } else {
+        report({
+          message: messages.expected(name, expectedName),
+          node: atRule,
+          ruleName,
+          result,
+        })
+      }
     })
   }
 }

--- a/lib/rules/comment-empty-line-before/__tests__/fixing.js
+++ b/lib/rules/comment-empty-line-before/__tests__/fixing.js
@@ -152,34 +152,34 @@ testRule(rule, {
   } ],
 })
 
-// testRule(rule, {
-//   ruleName,
-//   config: ["always"],
-//   syntax: "scss",
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "scss",
 
-//   fixingCases: [ {
-//     code: "a { color: pink;\n// comment\ntop: 0; }",
-//     description: "single-line comment ignored",
-//     same: true,
-//   }, {
-//     code: "// first line\n// second line\na { color: pink; }",
-//     description: "subsequent single-line comments ingnored",
-//     same: true,
-//   } ],
-// })
+  fixingCases: [ {
+    code: "a { color: pink;\n// comment\ntop: 0; }",
+    description: "single-line comment ignored",
+    same: true,
+  }, {
+    code: "// first line\n// second line\na { color: pink; }",
+    description: "subsequent single-line comments ingnored",
+    same: true,
+  } ],
+})
 
-// testRule(rule, {
-//   ruleName,
-//   config: ["never"],
-//   syntax: "sugarss",
-//   skipBasicChecks: true,
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  syntax: "sugarss",
+  skipBasicChecks: true,
 
-//   fixingCases: [{
-//     code: "a\n  color: pink\n\n  // single-line comment\n  top: 0",
-//     description: "single-line comment ignored",
-//     same: true,
-//   }],
-// })
+  fixingCases: [{
+    code: "a\n  color: pink\n\n  // single-line comment\n  top: 0",
+    description: "single-line comment ignored",
+    same: true,
+  }],
+})
 
 // testRule(rule, {
 //   ruleName,

--- a/lib/rules/comment-empty-line-before/__tests__/fixing.js
+++ b/lib/rules/comment-empty-line-before/__tests__/fixing.js
@@ -1,0 +1,210 @@
+"use strict"
+
+const mergeTestDescriptions = require("../../../testUtils/mergeTestDescriptions")
+
+const ruleName = require("..").ruleName
+const rules = require("../../../rules")
+
+const rule = rules[ruleName]
+
+const alwaysTests = {
+  fixingCases: [ {
+    code: "/** comment */",
+    description: "first node ignored",
+    same: true,
+  }, {
+    code: "a { color: pink; /** comment */\ntop: 0; }",
+    description: "shared-line comment ignored",
+    same: true,
+  }, {
+    code: "a {} /** comment */",
+    description: "shared-line comment ignored",
+    same: true,
+  }, {
+    code: "a {}\n\n/** comment */",
+    same: true,
+  }, {
+    code: "a {}\r\n\r\n/** comment */",
+    description: "CRLF",
+    same: true,
+  }, {
+    code: "a {}\n\r\n/** comment */",
+    description: "Mixed",
+    same: true,
+  }, {
+    code: "a { color: pink;\n\n/** comment */\ntop: 0; }",
+    same: true,
+  }, {
+    code: "/** comment */\n/** comment */",
+    expected: "/** comment */\n\n/** comment */",
+  }, {
+    code: "/** comment */\r\n/** comment */",
+    expected: "/** comment */\n\r\n/** comment */",
+    description: "CRLF",
+  }, {
+    code: "a { color: pink;\n/** comment */\ntop: 0; }",
+    expected: "a { color: pink;\n\n/** comment */\ntop: 0; }",
+  }, {
+    code: "a { color: pink;\r\n/** comment */\r\ntop: 0; }",
+    expected: "a { color: pink;\n\r\n/** comment */\r\ntop: 0; }",
+    description: "CRLF",
+  } ],
+}
+
+testRule(rule, mergeTestDescriptions(alwaysTests, {
+  ruleName,
+  config: ["always"],
+
+  fixingCases: [ {
+    code: "a {\n\n  /* comment */\n  color: pink;\n}",
+    description: "first-nested with empty line before",
+    same: true,
+  }, {
+    code: "a {\n  /* comment */\n  color: pink;\n}",
+    expected: "a {\n\n  /* comment */\n  color: pink;\n}",
+    description: "first-nested without empty line before",
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(alwaysTests, {
+  ruleName,
+  config: [ "always", { except: ["first-nested"] } ],
+
+  fixingCases: [ {
+    code: "a {\n  /* comment */\n  color: pink;\n}",
+    description: "first-nested without empty line before",
+    same: true,
+  }, {
+    code: "a {\n\n  /* comment */\n  color: pink;\n}",
+    expected: "a {\n  /* comment */\n  color: pink;\n}",
+    description: "first-nested with empty line before",
+  } ],
+}))
+
+testRule(rule, mergeTestDescriptions(alwaysTests, {
+  ruleName,
+  config: [ "always", { ignore: ["stylelint-commands"] } ],
+
+  fixingCases: [{
+    code: "a {\ncolor: pink;\n/* stylelint-disable something */\ntop: 0;\n}",
+    description: "no newline before a stylelint command comment",
+    same: true,
+  }],
+}))
+
+testRule(rule, {
+  ruleName,
+  config: [ "always", { ignore: ["after-comment"] } ],
+
+  fixingCases: [ {
+    code: "/* a */\n/* b */\n/* c */\nbody {\n}",
+    description: "no newline between comments",
+    same: true,
+  }, {
+    code: "a { color: pink;\n\n/** comment */\n/** comment */\ntop: 0; }",
+    description: "no newline between comments",
+    same: true,
+  }, {
+    code: "a { color: pink;\n/** comment */\n/** comment */\ntop: 0; }",
+    expected: "a { color: pink;\n\n/** comment */\n/** comment */\ntop: 0; }",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+
+  fixingCases: [ {
+    code: "\n\n/** comment */",
+    description: "first node ignored",
+    same: true,
+  }, {
+    code: "\r\n\r\n/** comment */",
+    description: "first node ignored and CRLF",
+    same: true,
+  }, {
+    code: "a { color: pink; /** comment */\ntop: 0; }",
+    description: "shared-line comment ignored",
+    same: true,
+  }, {
+    code: "a {} /** comment */",
+    same: true,
+  }, {
+    code: "a { color: pink;\n/** comment */\n\ntop: 0; }",
+    same: true,
+  }, {
+    code: "a { color: pink;\r\n/** comment */\r\n\r\ntop: 0; }",
+    description: "CRLF",
+    same: true,
+  }, {
+    code: "/** comment */\n\n/** comment */",
+    expected: "/** comment */\n/** comment */",
+  }, {
+    code: "a {}\n\n\n/** comment */",
+    expected: "a {}\n/** comment */",
+  }, {
+    code: "a {}\r\n\r\n\r\n/** comment */",
+    expected: "a {}\r\n/** comment */",
+    description: "CRLF",
+  }, {
+    code: "a { color: pink;\n\n/** comment */\ntop: 0; }",
+    expected: "a { color: pink;\n/** comment */\ntop: 0; }",
+  } ],
+})
+
+// testRule(rule, {
+//   ruleName,
+//   config: ["always"],
+//   syntax: "scss",
+
+//   fixingCases: [ {
+//     code: "a { color: pink;\n// comment\ntop: 0; }",
+//     description: "single-line comment ignored",
+//     same: true,
+//   }, {
+//     code: "// first line\n// second line\na { color: pink; }",
+//     description: "subsequent single-line comments ingnored",
+//     same: true,
+//   } ],
+// })
+
+// testRule(rule, {
+//   ruleName,
+//   config: ["never"],
+//   syntax: "sugarss",
+//   skipBasicChecks: true,
+
+//   fixingCases: [{
+//     code: "a\n  color: pink\n\n  // single-line comment\n  top: 0",
+//     description: "single-line comment ignored",
+//     same: true,
+//   }],
+// })
+
+// testRule(rule, {
+//   ruleName,
+//   config: ["always"],
+//   syntax: "less",
+
+//   fixingCases: [ {
+//     code: "a { color: pink;\n// comment\ntop: 0; }",
+//     description: "single-line comment ignored",
+//     same: true,
+//   }, {
+//     code: "// first line\n// second line\na { color: pink; }",
+//     description: "subsequent single-line comments ingnored",
+//     same: true,
+//   } ],
+// })
+
+// testRule(rule, {
+//   ruleName,
+//   config: ["never"],
+//   syntax: "less",
+
+//   fixingCases: [{
+//     code: "a { color: pink;\n\n// comment\ntop: 0; }",
+//     description: "single-line comment ignored",
+//     same: true,
+//   }],
+// })

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -1,5 +1,7 @@
 "use strict"
 
+const cleanEmptyLines = require("../../utils/cleanEmptyLines")
+const createEmptyLines = require("../../utils/createEmptyLines")
 const hasEmptyLine = require("../../utils/hasEmptyLine")
 const optionsMatches = require("../../utils/optionsMatches")
 const report = require("../../utils/report")
@@ -16,7 +18,7 @@ const messages = ruleMessages(ruleName, {
 const stylelintCommandPrefix = "stylelint-"
 
 const rule = function (expectation, options) {
-  return (root, result) => {
+  return (root, result, fix) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
       possible: [
@@ -116,16 +118,24 @@ const rule = function (expectation, options) {
         return
       }
 
-      const message = expectEmptyLineBefore
-        ? messages.expected
-        : messages.rejected
+      if (fix) {
+        if (expectEmptyLineBefore) {
+          comment.raws.before = createEmptyLines(1) + comment.raws.before
+        } else {
+          comment.raws.before = cleanEmptyLines(comment.raws.before)
+        }
+      } else {
+        const message = expectEmptyLineBefore
+          ? messages.expected
+          : messages.rejected
 
-      report({
-        message,
-        node: comment,
-        result,
-        ruleName,
-      })
+        report({
+          message,
+          node: comment,
+          result,
+          ruleName,
+        })
+      }
     })
   }
 }

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -42,6 +42,7 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
   const syntax = options.syntax
   const customSyntax = options.customSyntax
   const allowEmptyInput = options.allowEmptyInput
+  const fix = options.fix
   const cacheLocation = options.cacheLocation
   const useCache = options.cache || false
   let fileCache
@@ -75,6 +76,7 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
     reportNeedlessDisables,
     syntax,
     customSyntax,
+    fix,
   })
 
   if (!files) {
@@ -84,6 +86,7 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
     return stylelint._lintSource({
       code,
       codeFilename: absoluteCodeFilename,
+      fix,
     }).then(postcssResult => {
       return stylelint._createStylelintResult(postcssResult)
     }).catch(handleError).then(stylelintResult => {
@@ -148,6 +151,7 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
       debug(`Processing ${absoluteFilepath}`)
       return stylelint._lintSource({
         filePath: absoluteFilepath,
+        fix,
       }).then(postcssResult => {
         if (postcssResult.stylelint.stylelintError && useCache) {
           debug(`${absoluteFilepath} contains linting errors and will not be cached.`)

--- a/lib/utils/cleanEmptyLines.js
+++ b/lib/utils/cleanEmptyLines.js
@@ -1,0 +1,5 @@
+"use strict"
+
+module.exports = function cleanEmptyLines(input) {
+  return input.replace(/\r\n\s*\r\n/g, "\r\n").replace(/\n\s*\n/g, "\n")
+}

--- a/lib/utils/createEmptyLines.js
+++ b/lib/utils/createEmptyLines.js
@@ -1,0 +1,5 @@
+"use strict"
+
+module.exports = function createEmptyLines(lineBreaksCount) {
+  return new Array(lineBreaksCount + 1).join("\n")
+}

--- a/system-tests/fixing/__snapshots__/fixing.test.js.snap
+++ b/system-tests/fixing/__snapshots__/fixing.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fixing 1`] = `
+Array [
+  Object {
+    "deprecations": Array [],
+    "errored": true,
+    "ignored": undefined,
+    "invalidOptionWarnings": Array [],
+    "source": "fixing/stylesheet.css",
+    "warnings": Array [
+      Object {
+        "column": 1,
+        "line": 7,
+        "rule": "comment-no-empty",
+        "severity": "error",
+        "text": "Unexpected empty comment (comment-no-empty)",
+      },
+    ],
+  },
+]
+`;
+
+exports[`fixing 2`] = `
+"a { @extend placeholder; }
+a {} @media {}
+@charset 'UTF-8';
+a { color: #000; }
+a {}
+
+/* comment */
+
+/**/
+
+/*comment*/
+
+/* TODO: */
+@custom-media --bar (min-width: 30em);
+a {
+  & .foo { /* 1 */
+    &__foo { /* 2 */
+      & > .bar {} /* 3 */
+    }
+  }
+}
+"
+`;

--- a/system-tests/fixing/config.json
+++ b/system-tests/fixing/config.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "at-rule-name-case": "lower",
+    "comment-empty-line-before": "always",
+    "comment-no-empty": true
+  }
+}

--- a/system-tests/fixing/fixing.test.js
+++ b/system-tests/fixing/fixing.test.js
@@ -1,0 +1,16 @@
+/* @flow */
+"use strict"
+
+const systemTestUtils = require("../systemTestUtils")
+const stylelint = require("../../lib")
+
+it("fixing", () => {
+  return stylelint.lint({
+    files: [systemTestUtils.caseStylesheetGlob("fixing")],
+    configFile: systemTestUtils.caseConfig("fixing"),
+    fix: true,
+  }).then((output) => {
+    expect(systemTestUtils.prepResults(output.results)).toMatchSnapshot()
+    expect(output.results[0]._postcssResult.root.toResult().css).toMatchSnapshot()
+  })
+})

--- a/system-tests/fixing/stylesheet.css
+++ b/system-tests/fixing/stylesheet.css
@@ -1,0 +1,17 @@
+a { @extend placeholder; }
+a {} @media {}
+@Charset 'UTF-8';
+a { color: #000; }
+a {}
+/* comment */
+/**/
+/*comment*/
+/* TODO: */
+@custom-media --bar (min-width: 30em);
+a {
+  & .foo { /* 1 */
+    &__foo { /* 2 */
+      & > .bar {} /* 3 */
+    }
+  }
+}


### PR DESCRIPTION
I had an [idea how to make autofixing](https://github.com/stylelint/stylelint/pull/2096#issuecomment-279242941) before, but I didn't found a way how to do it ¯﻿\﻿_﻿(﻿ツ﻿)﻿_﻿/﻿¯

I came up with another idea. I think it's even simpler than my first idea. The rule will either report a warning or change PostCSS AST, depends on whether `fix` option was enabled.

Added autofixing for two rules:
* `at-rule-name-case`
* `comment-empty-line-before`

Added new tests for fixing. It would fix input and compare to expected output. And then lint fixed input. It's useful if there no expected output provided, and for extra safety.

Tests made from linting tests. Each `accept` test case received `same: true` property, to avoid duplication in tests files. Each `reject` test case received `expected` property. I did this manually, but believe it could be automated.

Also, there is an integration test. It verifies that stylesheet is fixed, and needed warnings shown.

I didn't found out anything better than `output.results[0]._postcssResult.root.toResult().css` to receive processed CSS. But this method transforms inline comments in non-standard syntaxes (`// inline`) to standard comments (`/* inline */`). I don't know yet how to preserve these comments in their non-standard form. This is why I've commented some tests for `comment-empty-line-before`.

Added `--fix` parameter to CLI.

P. S. I didn't understand how stylelint works because the code is very complicated. But I understood one thing:

![74146842](https://cloud.githubusercontent.com/assets/654597/23990006/b547f02a-0a45-11e7-8900-7090872ee03d.jpg)
