### PR TITLE
Migrate to postcss-values-parser

### DIFF
--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -285,12 +285,12 @@ testRule(rule, {
     code: "a { transition: -Webkit-transform 2s; }",
     message: messages.expected("-Webkit-transform", "-webkit-transform"),
     line: 1,
-    column: 17,
+    column: 18,
   }, {
     code: "a { transition: -webkit-Transform 2s; }",
     message: messages.expected("-webkit-Transform", "-webkit-transform"),
     line: 1,
-    column: 17,
+    column: 18,
   }, {
     code: "a { background-image: linear-gradient(To right, white calc(100% - 50em), silver); }",
     message: messages.expected("To", "to"),
@@ -593,6 +593,12 @@ testRule(rule, {
     code: "a { margin: @mArGiN + 10px; }",
   }, {
     code: "a { margin: @MARGIN + 10px; }",
+  }, {
+    code: "a { margin: -@margin; }",
+  }, {
+    code: "a { margin: -@mArGiN; }",
+  }, {
+    code: "a { margin: -@MARGIN; }",
   }, {
     code: ".bordered { border-bottom: solid 2px black; }",
     description: "inside mixin",
@@ -925,12 +931,12 @@ testRule(rule, {
     code: "a { transition: -Webkit-transform 2s; }",
     message: messages.expected("-Webkit-transform", "-WEBKIT-TRANSFORM"),
     line: 1,
-    column: 17,
+    column: 18,
   }, {
     code: "a { transition: -webkit-Transform 2s; }",
     message: messages.expected("-webkit-Transform", "-WEBKIT-TRANSFORM"),
     line: 1,
-    column: 17,
+    column: 18,
   }, {
     code: "a { background-image: linear-gradient(To RIGHT, WHITE calc(100% - 50em), SILVER); }",
     message: messages.expected("To", "TO"),
@@ -1233,6 +1239,12 @@ testRule(rule, {
     code: "a { margin: @mArGiN + 10px; }",
   }, {
     code: "a { margin: @MARGIN + 10px; }",
+  }, {
+    code: "a { margin: -@margin; }",
+  }, {
+    code: "a { margin: -@mArGiN; }",
+  }, {
+    code: "a { margin: -@MARGIN; }",
   }, {
     code: ".bordered { border-bottom: SOLID 2px BLOCK; }",
     description: "inside mixin",

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -11,7 +11,7 @@ const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
 const _ = require("lodash")
-const valueParser = require("postcss-value-parser")
+const valuesParser = require("postcss-values-parser")
 
 const ruleName = "value-keyword-case"
 
@@ -56,7 +56,7 @@ const rule = function (expectation, options) {
       const prop = decl.prop,
         value = decl.value
 
-      valueParser(value).walk(node => {
+      valuesParser(value, { loose: true }).parse().first.walk(node => {
         const valueLowerCase = node.value.toLowerCase()
 
         // Ignore system colors
@@ -65,14 +65,16 @@ const rule = function (expectation, options) {
         }
 
         // Ignore keywords within `url` and `var` function
-        if (node.type === "function" && (valueLowerCase === "url" || valueLowerCase === "var" || valueLowerCase === "counter" || valueLowerCase === "counters" || valueLowerCase === "attr")) {
-          return false
+        if (node.type === "func" && (valueLowerCase === "url" || valueLowerCase === "var" || valueLowerCase === "counter" || valueLowerCase === "counters" || valueLowerCase === "attr")) {
+          // Prevent further descending, but don't return false as that stops all walking
+          node.walk = null
+          return
         }
 
         const keyword = node.value
 
         // Ignore css variables, and hex values, and math operators, and sass interpolation
-        if (node.type !== "word" || !isStandardSyntaxValue(node.value) || value.indexOf("#") !== -1 || ignoredCharacters.has(keyword) || getUnitFromValueNode(node)) {
+        if (node.type !== "word" || !isStandardSyntaxValue(keyword) || value.indexOf("#") !== -1 || ignoredCharacters.has(keyword) || getUnitFromValueNode(node)) {
           return
         }
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "postcss-scss": "^0.4.0",
     "postcss-selector-parser": "^2.1.1",
     "postcss-value-parser": "^3.1.1",
+    "postcss-values-parser": "^1.2.0",
     "resolve-from": "^2.0.0",
     "specificity": "^0.3.0",
     "string-width": "^2.0.0",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#2404

> Is there anything in the PR that needs further explanation?

Uses a more detailed parser that can handle Less/SCSS expressions, even if they have no spaces.