### PR TITLE
Fix not specified array as primary option for "function-url-scheme-whitelist"

### DIFF
--- a/lib/rules/function-url-scheme-whitelist/index.js
+++ b/lib/rules/function-url-scheme-whitelist/index.js
@@ -68,6 +68,8 @@ const rule = function (whitelist) {
   }
 }
 
+rule.primaryOptionArray = true
+
 rule.ruleName = ruleName
 rule.messages = messages
 module.exports = rule


### PR DESCRIPTION


<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2446

> Is there anything in the PR that needs further explanation?

For some strange reason it wasn't defined, that rule can accept an array as primary option. Test didn't break, though. I wonder why? I believe we should have tests to test this behavior, but I have no idea how to do them.

I've tested results before and after this change via Node API. It stopped throwing warnings.