### PR TITLE
feat(typings): add `TypeScript` typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/stylelint/stylelint.git"
   },
   "main": "lib/index.js",
+  "typings": "typings/index.d.ts",
   "bin": "bin/stylelint.js",
   "files": [
     "bin",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,48 @@
+// Type definitions for stylelint 7.9
+// Project: https://github.com/stylelint/stylelint
+// Definitions by: Alan Agius <https://github.com/alan-agius4/>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export type FormatterType = "json" | "string" | "verbose";
+
+export type SyntaxType = "scss" | "less" | "sugarss";
+
+export interface LinterOptions {
+  code?: string;
+  codeFilename?: string;
+  config?: JSON;
+  configBasedir?: string;
+  configFile?: string;
+  configOverrides?: JSON;
+  files?: string | string[];
+  formatter?: FormatterType;
+  ignoreDisables?: boolean;
+  reportNeedlessDisables?: boolean;
+  ignorePath?: boolean;
+  syntax?: SyntaxType;
+  customSyntax?: string;
+}
+
+export interface LinterResult {
+  errored: boolean;
+  output: string;
+  postcssResults: any[];
+  results: LintResult[];
+}
+
+export interface LintResult {
+  source: string;
+  errored: boolean | undefined;
+  ignored: boolean | undefined;
+  warnings: string[];
+  deprecations: string[];
+  invalidOptionWarnings: any[];
+}
+
+export namespace formatters {
+  function json(results: LintResult[]): string;
+  function string(results: LintResult[]): string;
+  function verbose(results: LintResult[]): string;
+}
+
+export function lint(options?: LinterOptions): Promise<LinterResult>;


### PR DESCRIPTION
Adding typings for `stylelint` to enable user using `TypeScript`.

By no means the is all the API that you are exposing however so far this is what I discovered and should be a good starting point, to enable users to consume your lib with typescript. If you have any other useful methods that users that use let me know and I can create the typyings for them as well.

Thanks

#2444 

