### PR TITLE
Add text about searching nested directories

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -16,6 +16,8 @@ The CLI outputs formatted results into `process.stdout`, which you can read with
 
 ### Examples
 
+When you run commands similar to the examples below, be sure to include the quotes. This ensures that stylelint will search nested directories and files.
+
 Looking for `.stylelintrc` and linting all `.css` files in the `foo` directory:  
 
 ```shell
@@ -57,6 +59,16 @@ In addition to `--syntax scss`, stylelint supports `--syntax less` and `--syntax
 Additionally, stylelint can accept a custom [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes). To use a custom syntax, supply a syntax module name or path to the syntax file: `--custom-syntax custom-syntax` or `--custom-syntax ./path/to/custom-syntax`.
 
 Note, however, that stylelint can provide no guarantee that core rules will work with syntaxes other than the defaults listed above.
+
+### Recursively linting a directory
+
+To recursively lint a directory, run
+
+```shell
+stylelint "foo/**/*.scss"
+```
+
+The quotes above are important because stylelint uses node-glob, which recommends passing in glob arguments as strings.
 
 ## Syntax errors
 


### PR DESCRIPTION
As suggested in issue #717, I have added a couple paragraphs about how to lint nested directories.

I added this right above the examples because that's the first place that discusses how to use the stylelint cli.

I also added a specific section titled recursively linting. I added this section to specifically call out the need for the quotes. Also, I specifically used the word recursive because it's another word that people may search for when looking for this functionality.