### PR TITLE
Fix error for at-nest in selector-max-compound-selectors

### DIFF
--- a/lib/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/lib/rules/selector-max-compound-selectors/__tests__/index.js
@@ -146,6 +146,9 @@ testRule(rule, {
     code: ".cd { .de { &:hover > .fg {} } }",
     message: messages.expected(".cd .de:hover > .fg", 2),
   }, {
+    code: ".de { @nest .cd:not(:hover, :focus) & { & .fg {} } }",
+    message: messages.expected(".cd:not(:hover, :focus) .de .fg", 2),
+  }, {
     code: ".cd { .de { .fg > & {} } }",
     message: messages.expected(".fg > .cd .de", 2),
   }, {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2269#issuecomment-290139342

> Is there anything in the PR that needs further explanation?

The rule is expected to be rejected.
