### PR TITLE
fix: keep scope when using `schema.preceedingPlugins`

### DIFF
--- a/lib/testUtils/__tests__/createRuleTester.test.js
+++ b/lib/testUtils/__tests__/createRuleTester.test.js
@@ -4,14 +4,14 @@ const sinon = require("sinon")
 const createRuleTester = require("../createRuleTester")
 
 function createRuleTesterPromise(rule, schema) {
-  const assertions = []
+  const contexts = []
   return new Promise((resolve, reject) => {
     const ruleTester = createRuleTester((promise, res) => {
-      assertions.push(res)
+      contexts.push(res)
       promise.then(resolve, reject)
     })
     ruleTester(rule, schema)
-  }).then(() => assertions)
+  }).then(() => contexts)
 }
 
 describe("createRuleTester", () => {
@@ -27,8 +27,8 @@ describe("createRuleTester", () => {
     })
 
     return createRuleTesterPromise(() => rule, schema)
-      .then(assertions => {
-        expect(assertions).toEqual(
+      .then(contexts => {
+        expect(contexts).toEqual(
           [
             { comparisonCount: 1,
               caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"\"\n",

--- a/lib/testUtils/__tests__/createRuleTester.test.js
+++ b/lib/testUtils/__tests__/createRuleTester.test.js
@@ -1,45 +1,63 @@
 "use strict"
 
+const sinon = require("sinon")
 const createRuleTester = require("../createRuleTester")
 
-describe("createRuleTester", () => {
-  it("is possible to create a tester", () => {
-    const results = []
-    return new Promise((resolve, reject) => {
-      const tester = createRuleTester((promise, res) => {
-        results.push(res)
-        promise.then(resolve, reject)
-      })
-
-      const schema = {
-        ruleName: "my-test-rule",
-        preceedingPlugins: [(id) => id],
-        accept: [],
-      }
-
-      const rule = () => (root, result) => {
-        expect(root).toBeDefined()
-        expect(result).toBeDefined()
-      }
-
-      tester(rule, schema)
-    }).then(() => {
-      expect(results).toEqual(
-        [
-          { comparisonCount: 1,
-            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"\"\n",
-            completeAssertionDescription: "empty stylesheet should be accepted" },
-          { comparisonCount: 1,
-            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"a {}\"\n",
-            completeAssertionDescription: "empty rule should be accepted" },
-          { comparisonCount: 1,
-            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"@import \\\"foo.css\\\";\"\n",
-            completeAssertionDescription: "blockless statement should be accepted" },
-          { comparisonCount: 1,
-            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \":global {}\"\n",
-            completeAssertionDescription: "CSS Modules global empty rule set should be accepted" },
-        ]
-      )
+function createRuleTesterPromise(rule, schema) {
+  const assertions = []
+  return new Promise((resolve, reject) => {
+    const ruleTester = createRuleTester((promise, res) => {
+      assertions.push(res)
+      promise.then(resolve, reject)
     })
+    ruleTester(rule, schema)
+  }).then(() => assertions)
+}
+
+describe("createRuleTester", () => {
+
+  it("is possible to create a tester", () => {
+    const schema = {
+      ruleName: "my-test-rule",
+      accept: [],
+    }
+
+    const rule = sinon.spy((root, result) => {
+      expect(root).toBeDefined()
+      expect(result).toBeDefined()
+    })
+
+    return createRuleTesterPromise(() => rule, schema)
+      .then(assertions => {
+        expect(assertions).toEqual(
+          [
+            { comparisonCount: 1,
+              caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"\"\n",
+              completeAssertionDescription: "empty stylesheet should be accepted" },
+            { comparisonCount: 1,
+              caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"a {}\"\n",
+              completeAssertionDescription: "empty rule should be accepted" },
+            { comparisonCount: 1,
+              caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"@import \\\"foo.css\\\";\"\n",
+              completeAssertionDescription: "blockless statement should be accepted" },
+            { comparisonCount: 1,
+              caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \":global {}\"\n",
+              completeAssertionDescription: "CSS Modules global empty rule set should be accepted" },
+          ]
+        )
+        expect(rule.callCount).toEqual(4);
+      })
+  })
+
+  it("is possible to pass preceeding plugins to a tester", () => {
+    const postCssPlugin = sinon.spy((id) => id)
+    const schema = {
+      preceedingPlugins: [postCssPlugin],
+    }
+
+    return createRuleTesterPromise(() => () => {}, schema)
+      .then(() => {
+        expect(postCssPlugin.callCount).toEqual(4)
+      })
   })
 })

--- a/lib/testUtils/__tests__/createRuleTester.test.js
+++ b/lib/testUtils/__tests__/createRuleTester.test.js
@@ -15,7 +15,6 @@ function createRuleTesterPromise(rule, schema) {
 }
 
 describe("createRuleTester", () => {
-
   it("is possible to create a tester", () => {
     const schema = {
       ruleName: "my-test-rule",
@@ -45,7 +44,7 @@ describe("createRuleTester", () => {
               completeAssertionDescription: "CSS Modules global empty rule set should be accepted" },
           ]
         )
-        expect(rule.callCount).toEqual(4);
+        expect(rule.callCount).toEqual(4)
       })
   })
 

--- a/lib/testUtils/__tests__/createRuleTester.test.js
+++ b/lib/testUtils/__tests__/createRuleTester.test.js
@@ -1,0 +1,45 @@
+"use strict"
+
+const createRuleTester = require("../createRuleTester")
+
+describe("createRuleTester", () => {
+  it("is possible to create a tester", () => {
+    const results = []
+    return new Promise((resolve, reject) => {
+      const tester = createRuleTester((promise, res) => {
+        results.push(res)
+        promise.then(resolve, reject)
+      })
+
+      const schema = {
+        ruleName: "my-test-rule",
+        preceedingPlugins: [(id) => id],
+        accept: [],
+      }
+
+      const rule = () => (root, result) => {
+        expect(root).toBeDefined()
+        expect(result).toBeDefined()
+      }
+
+      tester(rule, schema)
+    }).then(() => {
+      expect(results).toEqual(
+        [
+          { comparisonCount: 1,
+            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"\"\n",
+            completeAssertionDescription: "empty stylesheet should be accepted" },
+          { comparisonCount: 1,
+            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"a {}\"\n",
+            completeAssertionDescription: "empty rule should be accepted" },
+          { comparisonCount: 1,
+            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \"@import \\\"foo.css\\\";\"\n",
+            completeAssertionDescription: "blockless statement should be accepted" },
+          { comparisonCount: 1,
+            caseDescription: "\n> rule: my-test-rule\n> config: \n> code: \":global {}\"\n",
+            completeAssertionDescription: "CSS Modules global empty rule set should be accepted" },
+        ]
+      )
+    })
+  })
+})

--- a/lib/testUtils/createRuleTester.js
+++ b/lib/testUtils/createRuleTester.js
@@ -160,7 +160,7 @@ function processGroup(rule, schema, equalityCheck) {
     processor.use(assignDisabledRanges)
 
     if (schema.preceedingPlugins) {
-      schema.preceedingPlugins.forEach(processor.use.bind(processor))
+      schema.preceedingPlugins.forEach(plugin => processor.use(plugin))
     }
 
     return processor.use(rule(rulePrimaryOptions, ruleSecondaryOptions)).process(code, postcssProcessOptions)

--- a/lib/testUtils/createRuleTester.js
+++ b/lib/testUtils/createRuleTester.js
@@ -160,7 +160,7 @@ function processGroup(rule, schema, equalityCheck) {
     processor.use(assignDisabledRanges)
 
     if (schema.preceedingPlugins) {
-      schema.preceedingPlugins.forEach(processor.use)
+      schema.preceedingPlugins.forEach(processor.use.bind(processor))
     }
 
     return processor.use(rule(rulePrimaryOptions, ruleSecondaryOptions)).process(code, postcssProcessOptions)


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

When creating a `ruleTester`, a `schema` can be passed in the test setup, e.g.:

```js
const postCssModuleValues = require('postcss-modules-values');
{
    preceedingPlugins: [postCssModuleValues],
    ruleName: cssImportsOrder.ruleName,
    config: { preset: 'suit' },
    skipBasicChecks: true,
    accept: [...]
    reject: [...]
}
```
when using `preceedingPlugins`, this currently fails with: 
```
   Uncaught TypeError: Cannot read property 'plugins' of undefined
      at use (node_modules/postcss/lib/processor.js:86:24)
      at Array.forEach (native)
      at postcssProcess (node_modules/stylelint/lib/testUtils/createRuleTester.js:163:32)
      at passingTestCases.forEach.acceptedCase (node_modules/stylelint/lib/testUtils/createRuleTester.js:179:29)
      at Array.forEach (native)
      at processGroup (node_modules/stylelint/lib/testUtils/createRuleTester.js:174:22)
      at process.nextTick (node_modules/stylelint/lib/testUtils/createRuleTester.js:117:9)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
      at run (bootstrap_node.js:422:7)
      at startup (bootstrap_node.js:143:9)
      at bootstrap_node.js:537:3
```

due to the fact that the `.use` method of the postcss processor needs access to `this`.

> Is there anything in the PR that needs further explanation?

Should be fairly straightforward.
