### PR TITLE
Exemplify testing of primaryOptionArray

### DIFF
--- a/lib/rules/at-rule-blacklist/__tests__/index.js
+++ b/lib/rules/at-rule-blacklist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "extend", "supports", "keyframes" ]],
+  config: [ "extend", "supports", "keyframes" ],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/lib/rules/at-rule-whitelist/__tests__/index.js
+++ b/lib/rules/at-rule-whitelist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "extend", "import", "keyframes" ]],
+  config: [ "extend", "import", "keyframes" ],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/lib/rules/comment-word-blacklist/__tests__/index.js
+++ b/lib/rules/comment-word-blacklist/__tests__/index.js
@@ -45,7 +45,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [[ "/^TODO:/", "bad-word" ]],
+  config: [ "/^TODO:/", "bad-word" ],
 
   accept: [ {
     code: "/* comment */",
@@ -209,7 +209,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   syntax: "less",
-  config: [[ "/^TODO:/", "bad-word" ]],
+  config: [ "/^TODO:/", "bad-word" ],
 
   accept: [ {
     code: "// comment",

--- a/lib/rules/function-blacklist/__tests__/index.js
+++ b/lib/rules/function-blacklist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "rgba", "scale", "linear-gradient" ]],
+  config: [ "rgba", "scale", "linear-gradient" ],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/lib/rules/function-url-scheme-whitelist/__tests__/index.js
+++ b/lib/rules/function-url-scheme-whitelist/__tests__/index.js
@@ -8,7 +8,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [[ "https", "data" ]],
+  config: [ "https", "data" ],
 
   accept: [ {
     code: "a { background: url(); }",

--- a/lib/rules/function-url-scheme-whitelist/__tests__/index.js
+++ b/lib/rules/function-url-scheme-whitelist/__tests__/index.js
@@ -176,7 +176,8 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: ["https"],
+  // primaryOptionArray
+  config: [ "uri", "file", "https" ],
 
   accept: [{
     code: "a { background: url(https://example.com/file.jpg); }",

--- a/lib/rules/function-whitelist/__tests__/index.js
+++ b/lib/rules/function-whitelist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "rotate", "rgb", "radial-gradient", "lightness", "color" ]],
+  config: [ "rotate", "rgb", "radial-gradient", "lightness", "color" ],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/lib/rules/property-blacklist/__tests__/index.js
+++ b/lib/rules/property-blacklist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "transform", "background-size" ]],
+  config: [ "transform", "background-size" ],
 
   accept: [ {
     code: "a { color: pink; }",

--- a/lib/rules/property-whitelist/__tests__/index.js
+++ b/lib/rules/property-whitelist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "transform", "background-size" ]],
+  config: [ "transform", "background-size" ],
 
   accept: [ {
     code: "a { background-size: cover; }",

--- a/lib/rules/selector-attribute-operator-blacklist/__tests__/index.js
+++ b/lib/rules/selector-attribute-operator-blacklist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "*=", "~=" ]],
+  config: [ "*=", "~=" ],
 
   accept: [ {
     code: "a[target] { }",

--- a/lib/rules/selector-attribute-operator-whitelist/__tests__/index.js
+++ b/lib/rules/selector-attribute-operator-whitelist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "=", "|=" ]],
+  config: [ "=", "|=" ],
 
   accept: [ {
     code: "a[target] { }",

--- a/lib/rules/selector-pseudo-class-blacklist/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-blacklist/__tests__/index.js
@@ -8,7 +8,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [[ "focus", "global", "input-placeholder", "not", "nth-last-child" ]],
+  config: [ "focus", "global", "input-placeholder", "not", "nth-last-child" ],
   skipBasicChecks: true,
 
   accept: [ {

--- a/lib/rules/selector-pseudo-class-whitelist/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-whitelist/__tests__/index.js
@@ -8,7 +8,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [[ "hover", "nth-child", "root", "placeholder" ]],
+  config: [ "hover", "nth-child", "root", "placeholder" ],
   skipBasicChecks: true,
 
   accept: [ {

--- a/lib/rules/unit-blacklist/__tests__/index.js
+++ b/lib/rules/unit-blacklist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "px", "vmin" ]],
+  config: [ "px", "vmin" ],
 
   accept: [ {
     code: "a { line-height: 1; }",

--- a/lib/rules/unit-whitelist/__tests__/index.js
+++ b/lib/rules/unit-whitelist/__tests__/index.js
@@ -9,7 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
 
-  config: [[ "px", "em" ]],
+  config: [ "px", "em" ],
 
   accept: [ {
     code: "a { line-height: 1; }",


### PR DESCRIPTION
Relates to #2459, followup to #2447.

@hudochenkov, I think this is what should be done for every rule with `primaryOptionArray`: ensure there is a test that would fail if the primary option were not interpreted correctly.

Without `rule.primaryOptionArray` for `function-ur-schema-whitelist`, this test will fail, because it relies on a correct interpretation of the array as the primary option. *With* `rule.primaryOptionArray` in that rule, the test passes.

All `primaryOptionArray` rules should have something similar.