### PR TITLE
Add autofixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A mighty, modern CSS linter that helps you enforce consistent conventions and av
 -   **Understands *CSS-like* syntaxes:** The linter is powered by [PostCSS](https://github.com/postcss/postcss), so it understands any syntax that PostCSS can parse, including SCSS, [SugarSS](https://github.com/postcss/sugarss), and *experimental support* for Less.
 -   **Completely unopinionated:** Only enable the rules you want, and configure them with options that tailor the linter to your needs.
 -   **Support for plugins:** It's easy to create your own rules and add them to the linter.
--   **Automatically fix some stylistic warnings.**
+-   **Automatically fixes some stylistic warnings:** Save time by having stylelint fix your code with this *experimental* feature.
 -   **Shareable configs:** If you don't want to craft your own config, you can extend a shareable config.
 -   **Options validator:** So that you can be confident that your config is valid.
 -   **Well tested:** Nearly twenty five thousand tests cover the internals and rules.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A mighty, modern CSS linter that helps you enforce consistent conventions and av
 -   **Understands *CSS-like* syntaxes:** The linter is powered by [PostCSS](https://github.com/postcss/postcss), so it understands any syntax that PostCSS can parse, including SCSS, [SugarSS](https://github.com/postcss/sugarss), and *experimental support* for Less.
 -   **Completely unopinionated:** Only enable the rules you want, and configure them with options that tailor the linter to your needs.
 -   **Support for plugins:** It's easy to create your own rules and add them to the linter.
--   **Automatically fix some stylistic warnings:** By using [stylefmt](https://github.com/morishitter/stylefmt) which supports stylelint configuration files.
+-   **Automatically fix some stylistic warnings.**
 -   **Shareable configs:** If you don't want to craft your own config, you can extend a shareable config.
 -   **Options validator:** So that you can be confident that your config is valid.
 -   **Well tested:** Nearly twenty five thousand tests cover the internals and rules.

--- a/decls/postcss.js
+++ b/decls/postcss.js
@@ -13,24 +13,30 @@ export type postcss$comment = {
   error(message: string, options: { plugin: string }): void,
 }
 
-export type postcss$atRule = {
-  name: string,
-  params: string,
-  raw: Function,
-  raws: {
-    afterName: string,
-  },
-  type: string,
-  parent: Object,
-  nodes: Array<Object>,
+export class postcss$node {
+  name: string;
+  raw: Function;
+  type: string;
+  parent: postcss$node;
+  nodes: Array<postcss$node>;
+  raws: Object
 }
 
-export type postcss$rule = {
-  raws: Object,
-  selector: string,
-  type: string,
-  parent: Object,
-  nodes: Array<Object>,
+export class postcss$atRule extends postcss$node {
+  params: string;
+  raws: {
+    before: string,
+    after: string,
+    afterName: string,
+  };
+}
+
+export class postcss$rule extends postcss$node {
+  selector: string;
+  raws: {
+    before: string,
+    after: string,
+  };
 }
 
 export type postcss$options = {

--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -36,6 +36,7 @@ export type stylelint$options = {
   reportNeedlessDisables?: boolean,
   syntax?: stylelint$syntaxes,
   customSyntax?: string,
+  fix?: boolean
 }
 
 export type stylelint$internalApi = {
@@ -115,4 +116,5 @@ export type stylelint$standaloneOptions = {
   customSyntax?: string,
   formatter?: "json" | "string" | "verbose" | Function,
   allowEmptyInput?: boolean,
+  fix?: booean
 }

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -104,7 +104,7 @@ In particular, you will definitely want to use `validateOptions()` so that users
 
 ### Adding autofixing
 
-If you're sure it's possible to automatically fix all or some errors rule reports, you can add fixing functionality using [PostCSS API](http://api.postcss.org/) to modify PostCSS AST (Abstract Syntax Tree).
+Depending on the rule, it might be possible to automatically fix the rule's warnings by mutating the PostCSS AST (Abstract Syntax Tree) using the [PostCSS API](http://api.postcss.org/).
 
 Add `context` variable to rule parameters:
 
@@ -119,7 +119,7 @@ function rule(primary, secondary, context) {
 -   `fix`(boolean): If `true`, your rule can apply autofixes.
 -   `newline`(string): Line-ending used in current linted file.
 
-If you can write fixing funtionality, then change `root` using PostCSS API and don't report that error:
+If `context.fix` is `true`, then change `root` using PostCSS API and return early before `report()` is called.
 
 ```js
 if (context.fix) {

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -102,6 +102,34 @@ stylelint has a number of [utility functions](https://github.com/stylelint/style
 
 In particular, you will definitely want to use `validateOptions()` so that users are warned about invalid options. (Looking at other rules for examples of options validation will help a lot.)
 
+### Adding autofixing
+
+If you're sure it's possible to automatically fix all or some errors rule reports, you can add fixing functionality using [PostCSS API](http://api.postcss.org/) to modify PostCSS AST (Abstract Syntax Tree).
+
+Add `context` variable to rule parameters:
+
+```js
+function rule(primary, secondary, context) {
+  return (root, result) => {..}
+}
+```
+
+`context` is an object which could have two properties:
+
+-   `fix`(boolean): If `true`, your rule can apply autofixes.
+-   `newline`(string): Line-ending used in current linted file.
+
+If you can write fixing funtionality, then change `root` using PostCSS API and don't report that error:
+
+```js
+if (context.fix) {
+  // Apply fixes using PostCSS API
+  return // Return and don't report a problem
+}
+
+report(...)
+```
+
 ### Write tests
 
 Each rule must be accompanied by tests that contain:

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -72,7 +72,7 @@ The quotation marks around the glob are important because they will allow stylel
 
 ### Autofixing errors
 
-With `--fix` option stylelint will fix as many errors as possible. The fixes are made to the actual source files. All unfixed errors will be reported. Not all errors are fixable using this option.
+With `--fix` option stylelint will fix as many errors as possible. The fixes are made to the actual source files. All unfixed errors will be reported.
 
 Linting all `.css` files in the `foo` directory. And fixing source files if violated rules support autofixing:
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -70,6 +70,16 @@ stylelint "foo/**/*.scss"
 
 The quotation marks around the glob are important because they will allow stylelint to interpret the glob, using node-glob, instead of your shell, which might not support all the same features.
 
+### Autofixing errors
+
+With `--fix` option stylelint will fix as many errors as possible. The fixes are made to the actual source files. All unfixed errors will be reported. Not all errors are fixable using this option.
+
+Linting all `.css` files in the `foo` directory. And fixing source files if violated rules support autofixing:
+
+```shell
+stylelint "foo/*.css" --fix
+```
+
 ## Syntax errors
 
 The CLI informs you about syntax errors in your CSS.

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -123,7 +123,7 @@ Note, however, that stylelint can provide no guarantee that core rules will work
 
 ### `fix`
 
-If `true`, stylelint will fix as many errors as possible. The fixes are made to the actual source files. All unfixed errors will be reported. Not all errors are fixable using this option.
+If `true`, stylelint will fix as many errors as possible. The fixes are made to the actual source files. All unfixed errors will be reported.
 
 
 ## The returned promise

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -121,6 +121,10 @@ An absolute path to a custom [PostCSS-compatible syntax](https://github.com/post
 
 Note, however, that stylelint can provide no guarantee that core rules will work with syntaxes other than the defaults listed for the `syntax` option above.
 
+### `fix`
+
+If `true`, stylelint will fix as many errors as possible. The fixes are made to the actual source files. All unfixed errors will be reported. Not all errors are fixable using this option.
+
 
 ## The returned promise
 

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -232,7 +232,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 -   [`at-rule-blacklist`](../../lib/rules/at-rule-blacklist/README.md): Specify a blacklist of disallowed at-rules.
 -   [`at-rule-empty-line-before`](../../lib/rules/at-rule-empty-line-before/README.md): Require or disallow an empty line before at-rules.
--   [`at-rule-name-case`](../../lib/rules/at-rule-name-case/README.md): Specify lowercase or uppercase for at-rules names. Autofixable.
+-   [`at-rule-name-case`](../../lib/rules/at-rule-name-case/README.md): Specify lowercase or uppercase for at-rules names (Autofixable).
 -   [`at-rule-name-newline-after`](../../lib/rules/at-rule-name-newline-after/README.md): Require a newline after at-rule names.
 -   [`at-rule-name-space-after`](../../lib/rules/at-rule-name-space-after/README.md): Require a single space after at-rule names.
 -   [`at-rule-no-unknown`](../../lib/rules/at-rule-no-unknown/README.md): Disallow unknown at-rules.
@@ -247,7 +247,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 ### Comment
 
--   [`comment-empty-line-before`](../../lib/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments. Autofixable.
+-   [`comment-empty-line-before`](../../lib/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments (Autofixable).
 -   [`comment-no-empty`](../../lib/rules/comment-no-empty/README.md):  Disallow empty comments.
 -   [`comment-whitespace-inside`](../../lib/rules/comment-whitespace-inside/README.md): Require or disallow whitespace on the inside of comment markers.
 -   [`comment-word-blacklist`](../../lib/rules/comment-word-blacklist/README.md): Specify a blacklist of disallowed words within comments.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -232,7 +232,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 -   [`at-rule-blacklist`](../../lib/rules/at-rule-blacklist/README.md): Specify a blacklist of disallowed at-rules.
 -   [`at-rule-empty-line-before`](../../lib/rules/at-rule-empty-line-before/README.md): Require or disallow an empty line before at-rules.
--   [`at-rule-name-case`](../../lib/rules/at-rule-name-case/README.md): Specify lowercase or uppercase for at-rules names.
+-   [`at-rule-name-case`](../../lib/rules/at-rule-name-case/README.md): Specify lowercase or uppercase for at-rules names. Autofixable.
 -   [`at-rule-name-newline-after`](../../lib/rules/at-rule-name-newline-after/README.md): Require a newline after at-rule names.
 -   [`at-rule-name-space-after`](../../lib/rules/at-rule-name-space-after/README.md): Require a single space after at-rule names.
 -   [`at-rule-no-unknown`](../../lib/rules/at-rule-no-unknown/README.md): Disallow unknown at-rules.
@@ -247,7 +247,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 ### Comment
 
--   [`comment-empty-line-before`](../../lib/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments.
+-   [`comment-empty-line-before`](../../lib/rules/comment-empty-line-before/README.md): Require or disallow an empty line before comments. Autofixable.
 -   [`comment-no-empty`](../../lib/rules/comment-no-empty/README.md):  Disallow empty comments.
 -   [`comment-whitespace-inside`](../../lib/rules/comment-whitespace-inside/README.md): Require or disallow whitespace on the inside of comment markers.
 -   [`comment-word-blacklist`](../../lib/rules/comment-word-blacklist/README.md): Specify a blacklist of disallowed words within comments.

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -41,12 +41,20 @@ global.testRule = (rule, schema) => {
         passingTestCases.forEach((testCase) => {
           const spec = (testCase.only) ? it.only : it
           spec(testCase.description || "no description", () => {
-            return stylelint({
+            const options = {
               code: testCase.code,
               config: stylelintConfig,
               syntax: schema.syntax,
-            }).then((output) => {
+            }
+            return stylelint(options).then((output) => {
               expect(output.results[0].warnings).toEqual([])
+              if (!schema.fix) return
+
+              // Check the fix
+              return stylelint(Object.assign({ fix: true }, options)).then((output) => {
+                const fixedCode = getOutputCss(output)
+                expect(fixedCode).toBe(testCase.code)
+              })
             })
           })
         })
@@ -58,11 +66,12 @@ global.testRule = (rule, schema) => {
         schema.reject.forEach((testCase) => {
           const spec = (testCase.only) ? it.only : it
           spec(testCase.description || "no description", () => {
-            return stylelint({
+            const options = {
               code: testCase.code,
               config: stylelintConfig,
               syntax: schema.syntax,
-            }).then((output) => {
+            }
+            return stylelint(options).then((output) => {
               const warning = output.results[0].warnings[0]
 
               expect(testCase).toHaveMessage()
@@ -76,10 +85,29 @@ global.testRule = (rule, schema) => {
               if (testCase.column !== undefined) {
                 expect(_.get(warning, "column")).toBe(testCase.column)
               }
+
+              if (!schema.fix) return
+
+              if (!testCase.fixed) {
+                throw new Error("If using { fix: true } in test schema, all reject cases must have { fixed: .. }")
+              }
+
+              // Check the fix
+              return stylelint(Object.assign({ fix: true }, options)).then((output) => {
+                const fixedCode = getOutputCss(output)
+                expect(fixedCode).toBe(testCase.fixed)
+              })
             })
           })
         })
       })
     }
   })
+}
+
+function getOutputCss(output) {
+  const result = output.results[0]._postcssResult
+  return result.root.toString(result.opts.syntax)
+    // Less needs us to manually strip whitespace at the end of single-line comments ¯\_(ツ)_/¯
+    .replace(/(\n?\s*\/\/.*?)[ \t]*(\r?\n)/g, "$1$2")
 }

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,6 +1,7 @@
 "use strict"
 
 const _ = require("lodash")
+const less = require("postcss-less")
 const basicChecks = require("./lib/testUtils/basicChecks")
 const stylelint = require("./lib/standalone")
 
@@ -107,7 +108,10 @@ global.testRule = (rule, schema) => {
 
 function getOutputCss(output) {
   const result = output.results[0]._postcssResult
-  return result.root.toString(result.opts.syntax)
+  const css = result.root.toString(result.opts.syntax)
+  if (result.opts.syntax === less) {
     // Less needs us to manually strip whitespace at the end of single-line comments ¯\_(ツ)_/¯
-    .replace(/(\n?\s*\/\/.*?)[ \t]*(\r?\n)/g, "$1$2")
+    return css.replace(/(\n?\s*\/\/.*?)[ \t]*(\r?\n)/g, "$1$2")
+  }
+  return css
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,6 +35,7 @@ const minimistOptions = {
     "no-color",
     "quiet",
     "version",
+    "fix",
   ],
 }
 
@@ -82,6 +83,10 @@ const meowOptions = {
         If you do not specify a syntax, non-standard syntaxes will be
         automatically inferred by the file extensions .scss, .less, and .sss.
 
+      --fix
+
+        Automatically fix violations of certain rules.
+
       --custom-syntax
 
         Module name or path to a JS file exporting a PostCSS-compatible syntax.
@@ -93,23 +98,23 @@ const meowOptions = {
       --ignore-disables, --id
 
         Ignore styleline-disable comments.
-        
+
       --cache                       [default: false]
 
-        Store the info about processed files in order to only operate on the 
-        changed ones the next time you run stylelint. By default, the cache 
+        Store the info about processed files in order to only operate on the
+        changed ones the next time you run stylelint. By default, the cache
         is stored in "./.stylelintcache". To adjust this, use --cache-location.
 
       --cache-location              [default: '.stylelintcache']
 
         Path to a file or directory to be used for the cache location.
-        Default is "./.stylelintcache". If a directory is specified, a cache 
+        Default is "./.stylelintcache". If a directory is specified, a cache
         file will be created inside the specified folder, with a name derived
         from a hash of the current working directory.
 
-        If the directory for the cache does not exist, make sure you add a trailing "/" 
+        If the directory for the cache does not exist, make sure you add a trailing "/"
         on \*nix systems or "\" on Windows. Otherwise the path will be assumed to be a file.
-         
+
 
       --formatter, -f               [default: "string"]
 
@@ -207,6 +212,10 @@ if (cli.flags.cache) {
 
 if (cli.flags.cacheLocation) {
   optionsBase.cacheLocation = cli.flags.cacheLocation
+}
+
+if (cli.flags.fix) {
+  optionsBase.fix = cli.flags.fix
 }
 
 const reportNeedlessDisables = cli.flags.reportNeedlessDisables

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -1,14 +1,16 @@
 /* @flow */
 "use strict"
+
 const _ = require("lodash")
 const assignDisabledRanges = require("./assignDisabledRanges")
 const configurationError = require("./utils/configurationError")
 const path = require("path")
+const os = require("os")
 const ruleDefinitions = require("./rules")
 
 // Run stylelint on a PostCSS Result, either one that is provided
 // or one that we create
-module.exports = function (
+module.exports = function lintSource(
   stylelint/*: stylelint$internalApi*/,
   options/*: {
     code?: string,
@@ -79,11 +81,14 @@ function lintPostcssResult(
   stylelint/*: stylelint$internalApi*/,
   postcssResult/*: Object*/,
   config/*: stylelint$config*/
-)/*: Promise<>*/ {
+)/*: Promise<Array<*>>*/ {
   postcssResult.stylelint = postcssResult.stylelint || {}
   postcssResult.stylelint.ruleSeverities = {}
   postcssResult.stylelint.customMessages = {}
   postcssResult.stylelint.quiet = config.quiet
+
+  const newlineMatch = postcssResult.root.toResult().css.match(/\r?\n/)
+  const newline = newlineMatch ? newlineMatch[0] : os.EOL
 
   const postcssRoot = postcssResult.root
   assignDisabledRanges(postcssRoot, postcssResult)
@@ -119,7 +124,10 @@ function lintPostcssResult(
     postcssResult.stylelint.customMessages[ruleName] = _.get(secondaryOptions, "message")
 
     const performRule = Promise.resolve().then(() => {
-      return ruleFunction(primaryOption, secondaryOptions)(postcssRoot, postcssResult)
+      return ruleFunction(primaryOption, secondaryOptions, {
+        fix: stylelint._options.fix,
+        newline,
+      })(postcssRoot, postcssResult)
     })
     performRules.push(performRule)
   })

--- a/lib/rules/at-rule-name-case/README.md
+++ b/lib/rules/at-rule-name-case/README.md
@@ -10,6 +10,8 @@ Specify lowercase or uppercase for at-rules names.
 
 Only lowercase at-rule names are valid in SCSS.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix some of the problems reported by this rule.
+
 ## Options
 
 `string`: `"lower"|"upper"`

--- a/lib/rules/at-rule-name-case/__tests__/index.js
+++ b/lib/rules/at-rule-name-case/__tests__/index.js
@@ -10,6 +10,7 @@ testRule(rule, {
   ruleName,
   config: ["lower"],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: "@charset 'UTF-8';",
@@ -43,56 +44,67 @@ testRule(rule, {
 
   reject: [ {
     code: "@Charset 'UTF-8';",
+    fixed: "@charset 'UTF-8';",
     message: messages.expected("Charset", "charset"),
     line: 1,
     column: 1,
   }, {
     code: "@cHaRsEt 'UTF-8';",
+    fixed: "@charset 'UTF-8';",
     message: messages.expected("cHaRsEt", "charset"),
     line: 1,
     column: 1,
   }, {
     code: "@CHARSET 'UTF-8';",
+    fixed: "@charset 'UTF-8';",
     message: messages.expected("CHARSET", "charset"),
     line: 1,
     column: 1,
   }, {
     code: "@Media screen {}",
+    fixed: "@media screen {}",
     message: messages.expected("Media", "media"),
     line: 1,
     column: 1,
   }, {
     code: "@mEdIa screen {}",
+    fixed: "@media screen {}",
     message: messages.expected("mEdIa", "media"),
     line: 1,
     column: 1,
   }, {
     code: "@MEDIA screen {}",
+    fixed: "@media screen {}",
     message: messages.expected("MEDIA", "media"),
     line: 1,
     column: 1,
   }, {
     code: "@media only screen and (min-width: 415px) { @Keyframes pace-anim { 100% { opacity: 0; } } }",
+    fixed: "@media only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
     message: messages.expected("Keyframes", "keyframes"),
     line: 1,
     column: 45,
   }, {
     code: "@media only screen and (min-width: 415px) { @kEyFrAmEs pace-anim { 100% { opacity: 0; } } }",
+    fixed: "@media only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
     message: messages.expected("kEyFrAmEs", "keyframes"),
     line: 1,
     column: 45,
   }, {
     code: "@media only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
+    fixed: "@media only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
     message: messages.expected("KEYFRAMES", "keyframes"),
     line: 1,
     column: 45,
   }, {
     code: "@-WEBKIT-keyframes { 0% { top: 0; } }",
+    fixed: "@-webkit-keyframes { 0% { top: 0; } }",
     message: messages.expected("-WEBKIT-keyframes", "-webkit-keyframes"),
     line: 1,
     column: 1,
   }, {
     code: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
+    fixed: "@-webkit-keyframes { 0% { top: 0; } }",
     message: messages.expected("-WEBKIT-KEYFRAMES", "-webkit-keyframes"),
     line: 1,
     column: 1,
@@ -103,6 +115,7 @@ testRule(rule, {
   ruleName,
   config: ["upper"],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: "@CHARSET 'UTF-8';",
@@ -136,56 +149,67 @@ testRule(rule, {
 
   reject: [ {
     code: "@Charset 'UTF-8';",
+    fixed: "@CHARSET 'UTF-8';",
     message: messages.expected("Charset", "CHARSET"),
     line: 1,
     column: 1,
   }, {
     code: "@cHaRsEt 'UTF-8';",
+    fixed: "@CHARSET 'UTF-8';",
     message: messages.expected("cHaRsEt", "CHARSET"),
     line: 1,
     column: 1,
   }, {
     code: "@charset 'UTF-8';",
+    fixed: "@CHARSET 'UTF-8';",
     message: messages.expected("charset", "CHARSET"),
     line: 1,
     column: 1,
   }, {
     code: "@Media screen {}",
+    fixed: "@MEDIA screen {}",
     message: messages.expected("Media", "MEDIA"),
     line: 1,
     column: 1,
   }, {
     code: "@mEdIa screen {}",
+    fixed: "@MEDIA screen {}",
     message: messages.expected("mEdIa", "MEDIA"),
     line: 1,
     column: 1,
   }, {
     code: "@media screen {}",
+    fixed: "@MEDIA screen {}",
     message: messages.expected("media", "MEDIA"),
     line: 1,
     column: 1,
   }, {
     code: "@MEDIA only screen and (min-width: 415px) { @Keyframes pace-anim { 100% { opacity: 0; } } }",
+    fixed: "@MEDIA only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
     message: messages.expected("Keyframes", "KEYFRAMES"),
     line: 1,
     column: 45,
   }, {
     code: "@MEDIA only screen and (min-width: 415px) { @kEyFrAmEs pace-anim { 100% { opacity: 0; } } }",
+    fixed: "@MEDIA only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
     message: messages.expected("kEyFrAmEs", "KEYFRAMES"),
     line: 1,
     column: 45,
   }, {
     code: "@MEDIA only screen and (min-width: 415px) { @keyframes pace-anim { 100% { opacity: 0; } } }",
+    fixed: "@MEDIA only screen and (min-width: 415px) { @KEYFRAMES pace-anim { 100% { opacity: 0; } } }",
     message: messages.expected("keyframes", "KEYFRAMES"),
     line: 1,
     column: 45,
   }, {
     code: "@-webkit-KEYFRAMES { 0% { top: 0; } }",
+    fixed: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
     message: messages.expected("-webkit-KEYFRAMES", "-WEBKIT-KEYFRAMES"),
     line: 1,
     column: 1,
   }, {
     code: "@-webkit-keyframes { 0% { top: 0; } }",
+    fixed: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
     message: messages.expected("-webkit-keyframes", "-WEBKIT-KEYFRAMES"),
     line: 1,
     column: 1,

--- a/lib/rules/at-rule-name-case/index.js
+++ b/lib/rules/at-rule-name-case/index.js
@@ -10,7 +10,7 @@ const messages = ruleMessages(ruleName, {
   expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 })
 
-const rule = function (expectation) {
+const rule = function (expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -31,6 +31,11 @@ const rule = function (expectation) {
         : name.toUpperCase()
 
       if (name === expectedName) {
+        return
+      }
+
+      if (context.fix) {
+        atRule.name = expectedName
         return
       }
 

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -16,6 +16,8 @@ If you're using a custom syntax which support single-line comments with `//`, th
 
 **Caveat:** Comments within *selector and value lists* are currently ignored.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix some of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -32,16 +32,20 @@ const alwaysTests = {
 
   reject: [ {
     code: "/** comment */\n/** comment */",
+    fixed: "/** comment */\n\n/** comment */",
     message: messages.expected,
   }, {
     code: "/** comment */\r\n/** comment */",
+    fixed: "/** comment */\r\n\r\n/** comment */",
     description: "CRLF",
     message: messages.expected,
   }, {
     code: "a { color: pink;\n/** comment */\ntop: 0; }",
+    fixed: "a { color: pink;\n\n/** comment */\ntop: 0; }",
     message: messages.expected,
   }, {
     code: "a { color: pink;\r\n/** comment */\r\ntop: 0; }",
+    fixed: "a { color: pink;\r\n\r\n/** comment */\r\ntop: 0; }",
     description: "CRLF",
     message: messages.expected,
   } ],
@@ -50,6 +54,7 @@ const alwaysTests = {
 testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [{
     code: "a {\n\n  /* comment */\n  color: pink;\n}",
@@ -58,6 +63,7 @@ testRule(rule, mergeTestDescriptions(alwaysTests, {
 
   reject: [{
     code: "a {\n  /* comment */\n  color: pink;\n}",
+    fixed: "a {\n\n  /* comment */\n  color: pink;\n}",
     description: "first-nested without empty line before",
     message: messages.expected,
     line: 2,
@@ -68,6 +74,7 @@ testRule(rule, mergeTestDescriptions(alwaysTests, {
 testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
   config: [ "always", { except: ["first-nested"] } ],
+  fix: true,
 
   accept: [{
     code: "a {\n  /* comment */\n  color: pink;\n}",
@@ -76,6 +83,7 @@ testRule(rule, mergeTestDescriptions(alwaysTests, {
 
   reject: [{
     code: "a {\n\n  /* comment */\n  color: pink;\n}",
+    fixed: "a {\n  /* comment */\n  color: pink;\n}",
     description: "first-nested with empty line before",
     message: messages.rejected,
     line: 3,
@@ -86,6 +94,7 @@ testRule(rule, mergeTestDescriptions(alwaysTests, {
 testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
   config: [ "always", { ignore: ["stylelint-commands"] } ],
+  fix: true,
 
   accept: [{
     code: "a {\ncolor: pink;\n/* stylelint-disable something */\ntop: 0;\n}",
@@ -96,6 +105,7 @@ testRule(rule, mergeTestDescriptions(alwaysTests, {
 testRule(rule, {
   ruleName,
   config: [ "always", { ignore: ["between-comments"] } ],
+  fix: true,
 
   accept: [ {
     code: "/* a */\n/* b */\n/* c */\nbody {\n}",
@@ -107,6 +117,7 @@ testRule(rule, {
 
   reject: [{
     code: "a { color: pink;\n/** comment */\n/** comment */\ntop: 0; }",
+    fixed: "a { color: pink;\n\n/** comment */\n/** comment */\ntop: 0; }",
     message: messages.expected,
   }],
 })
@@ -114,6 +125,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [ "always", { ignore: ["after-comment"] } ],
+  fix: true,
 
   accept: [ {
     code: "/* a */\n/* b */\n/* c */\nbody {\n}",
@@ -125,6 +137,7 @@ testRule(rule, {
 
   reject: [{
     code: "a { color: pink;\n/** comment */\n/** comment */\ntop: 0; }",
+    fixed: "a { color: pink;\n\n/** comment */\n/** comment */\ntop: 0; }",
     message: messages.expected,
   }],
 })
@@ -132,6 +145,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [ {
     code: "\n\n/** comment */",
@@ -153,16 +167,20 @@ testRule(rule, {
 
   reject: [ {
     code: "/** comment */\n\n/** comment */",
+    fixed: "/** comment */\n/** comment */",
     message: messages.rejected,
   }, {
     code: "a {}\n\n\n/** comment */",
+    fixed: "a {}\n/** comment */",
     message: messages.rejected,
   }, {
     code: "a {}\r\n\r\n\r\n/** comment */",
+    fixed: "a {}\r\n/** comment */",
     description: "CRLF",
     message: messages.rejected,
   }, {
     code: "a { color: pink;\n\n/** comment */\ntop: 0; }",
+    fixed: "a { color: pink;\n/** comment */\ntop: 0; }",
     message: messages.rejected,
   } ],
 })
@@ -171,6 +189,7 @@ testRule(rule, {
   ruleName,
   config: ["always"],
   syntax: "scss",
+  fix: true,
 
   accept: [ {
     code: "a { color: pink;\n// comment\ntop: 0; }",
@@ -186,6 +205,7 @@ testRule(rule, {
   config: ["never"],
   syntax: "sugarss",
   skipBasicChecks: true,
+  fix: true,
 
   accept: [{
     code: "a\n  color: pink\n\n  // single-line comment\n  top: 0",
@@ -197,6 +217,7 @@ testRule(rule, {
   ruleName,
   config: ["always"],
   syntax: "less",
+  fix: true,
 
   accept: [ {
     code: "a { color: pink;\n// comment\ntop: 0; }",
@@ -211,6 +232,7 @@ testRule(rule, {
   ruleName,
   config: ["never"],
   syntax: "less",
+  fix: true,
 
   accept: [{
     code: "a { color: pink;\n\n// comment\ntop: 0; }",

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -6,6 +6,7 @@ const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
 const addEmptyLineBefore = require("../../utils/addEmptyLineBefore")
+const removeEmptyLinesBefore = require("../../utils/removeEmptyLinesBefore")
 
 const ruleName = "comment-empty-line-before"
 
@@ -122,7 +123,7 @@ const rule = function (expectation, options, context) {
         if (expectEmptyLineBefore) {
           addEmptyLineBefore(comment, context.newline)
         } else {
-          comment.raws.before = comment.raws.before.replace(/(\r?\n\s*\r?\n)+/g, context.newline)
+          removeEmptyLinesBefore(comment, context.newline)
         }
         return result
       }

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -1,11 +1,11 @@
 "use strict"
 
-const _ = require("lodash")
 const hasEmptyLine = require("../../utils/hasEmptyLine")
 const optionsMatches = require("../../utils/optionsMatches")
 const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
+const addEmptyLineBefore = require("../../utils/addEmptyLineBefore")
 
 const ruleName = "comment-empty-line-before"
 
@@ -120,9 +120,7 @@ const rule = function (expectation, options, context) {
       // Fix
       if (context.fix) {
         if (expectEmptyLineBefore) {
-          comment.raws.before = /\n/.test(comment.raws.before)
-            ? context.newline + comment.raws.before
-            : _.repeat(context.newline, 2) + comment.raws.before
+          addEmptyLineBefore(comment, context.newline)
         } else {
           comment.raws.before = comment.raws.before.replace(/(\r?\n\s*\r?\n)+/g, context.newline)
         }

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -1,5 +1,6 @@
 "use strict"
 
+const _ = require("lodash")
 const hasEmptyLine = require("../../utils/hasEmptyLine")
 const optionsMatches = require("../../utils/optionsMatches")
 const report = require("../../utils/report")
@@ -15,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const stylelintCommandPrefix = "stylelint-"
 
-const rule = function (expectation, options) {
+const rule = function (expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -114,6 +115,18 @@ const rule = function (expectation, options) {
       // Return if the expectation is met
       if (expectEmptyLineBefore === hasEmptyLineBefore) {
         return
+      }
+
+      // Fix
+      if (context.fix) {
+        if (expectEmptyLineBefore) {
+          comment.raws.before = /\n/.test(comment.raws.before)
+            ? context.newline + comment.raws.before
+            : _.repeat(context.newline, 2) + comment.raws.before
+        } else {
+          comment.raws.before = comment.raws.before.replace(/(\r?\n\s*\r?\n)+/g, context.newline)
+        }
+        return result
       }
 
       const message = expectEmptyLineBefore

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -1,5 +1,7 @@
 /* @flow */
 "use strict"
+const pify = require("pify")
+const fs = require("fs")
 const path = require("path")
 const formatters/*: Object*/ = require("./formatters")
 const createStylelint = require("./createStylelint")
@@ -32,15 +34,8 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
   const code = options.code
   const codeFilename = options.codeFilename
   const config = options.config
-  const configFile = options.configFile
-  const configBasedir = options.configBasedir
-  const configOverrides = options.configOverrides
-  const ignoreDisables = options.ignoreDisables
-  const ignorePath = options.ignorePath
   const reportNeedlessDisables = options.reportNeedlessDisables
   const formatter = options.formatter
-  const syntax = options.syntax
-  const customSyntax = options.customSyntax
   const allowEmptyInput = options.allowEmptyInput
   const cacheLocation = options.cacheLocation
   const useCache = options.cache || false
@@ -67,14 +62,15 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
 
   const stylelint = createStylelint({
     config,
-    configFile,
-    configBasedir,
-    configOverrides,
-    ignoreDisables,
-    ignorePath,
+    configFile: options.configFile,
+    configBasedir: options.configBasedir,
+    configOverrides: options.configOverrides,
+    ignoreDisables: options.ignoreDisables,
+    ignorePath: options.ignorePath,
     reportNeedlessDisables,
-    syntax,
-    customSyntax,
+    syntax: options.syntax,
+    customSyntax: options.customSyntax,
+    fix: options.fix,
   })
 
   if (!files) {
@@ -153,7 +149,15 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
           debug(`${absoluteFilepath} contains linting errors and will not be cached.`)
           fileCache.removeEntry(absoluteFilepath)
         }
-        return stylelint._createStylelintResult(postcssResult, absoluteFilepath)
+
+        // If we're fixing, save the file with changed code
+        let fixFile = Promise.resolve()
+        if (options.fix) {
+          const fixedCss = postcssResult.root.toString(postcssResult.opts.syntax)
+          fixFile = pify(fs.writeFile)(absoluteFilepath, fixedCss)
+        }
+
+        return fixFile.then(() => stylelint._createStylelintResult(postcssResult, absoluteFilepath))
       }).catch(handleError)
     })
 

--- a/lib/utils/__tests__/addEmptyLineBefore.test.js
+++ b/lib/utils/__tests__/addEmptyLineBefore.test.js
@@ -26,9 +26,9 @@ describe("addEmptyLineBefore", () => {
   })
 
   it("adds single newline to newline at the end with CRLF", () => {
-    return postcss().process("a {}\t\n\nb{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\n\n")
-      expect(result.root.toString()).toBe("a {}\t\n\n\n\nb{}")
+    return postcss().process("a {}\t\r\nb{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}\t\r\n\r\nb{}")
     })
   })
 

--- a/lib/utils/__tests__/addEmptyLineBefore.test.js
+++ b/lib/utils/__tests__/addEmptyLineBefore.test.js
@@ -1,0 +1,62 @@
+"use strict"
+
+const addEmptyLineBefore = require("../addEmptyLineBefore")
+const postcss = require("postcss")
+
+describe("addEmptyLineBefore", () => {
+  it("adds single newline to the newline at the beginning", () => {
+    return postcss().process("a {}\n  b{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}\n\n  b{}")
+    })
+  })
+
+  it("adds single newline to newline at the beginning with CRLF", () => {
+    return postcss().process("a {}\r\n  b{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}")
+    })
+  })
+
+  it("adds single newline to newline at the end", () => {
+    return postcss().process("a {}\t\nb{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}\t\n\nb{}")
+    })
+  })
+
+  it("adds single newline to newline at the end with CRLF", () => {
+    return postcss().process("a {}\t\n\nb{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\n\n")
+      expect(result.root.toString()).toBe("a {}\t\n\n\n\nb{}")
+    })
+  })
+
+  it("adds single newline to newline in the middle", () => {
+    return postcss().process("a {}  \n\tb{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}  \n\n\tb{}")
+    })
+  })
+
+  it("adds single newline to newline in the middle with CRLF", () => {
+    return postcss().process("a {}  \r\n\tb{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}  \r\n\r\n\tb{}")
+    })
+  })
+
+  it("adds two newlines if there aren't any existing newlines", () => {
+    return postcss().process("a {}  b{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}\n\n  b{}")
+    })
+  })
+
+  it("adds two newlines if there aren't any existing newlines with CRLF", () => {
+    return postcss().process("a {}  b{}").then(result => {
+      addEmptyLineBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}")
+    })
+  })
+})

--- a/lib/utils/__tests__/removeEmptyLineBefore.test.js
+++ b/lib/utils/__tests__/removeEmptyLineBefore.test.js
@@ -1,0 +1,76 @@
+"use strict"
+
+const removeEmptyLinesBefore = require("../removeEmptyLinesBefore")
+const postcss = require("postcss")
+
+describe("removeEmptyLinesBefore", () => {
+  it("removes single newline from the newline at the beginning", () => {
+    return postcss().process("a {}\n\n  b{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}\n  b{}")
+    })
+  })
+
+  it("removes single newline from newline at the beginning with CRLF", () => {
+    return postcss().process("a {}\r\n\r\n  b{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}\r\n  b{}")
+    })
+  })
+
+  it("removes single newline from newline at the end", () => {
+    return postcss().process("a {}\t\n\nb{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}\t\nb{}")
+    })
+  })
+
+  it("removes single newline from newline at the end with CRLF", () => {
+    return postcss().process("a {}\t\r\n\r\nb{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}\t\r\nb{}")
+    })
+  })
+
+  it("removes single newline from newline in the middle", () => {
+    return postcss().process("a {}  \n\n\tb{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}  \n\tb{}")
+    })
+  })
+
+  it("removes single newline to newline in the middle with CRLF", () => {
+    return postcss().process("a {}  \r\n\r\n\tb{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}  \r\n\tb{}")
+    })
+  })
+
+  it("removes two newlines if there are three newlines", () => {
+    return postcss().process("a {}\n\n\n  b{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}\n  b{}")
+    })
+  })
+
+  it("removes two newlines if there are three newlines with CRLF", () => {
+    return postcss().process("a {}\r\n\r\n\r\n  b{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}\r\n  b{}")
+    })
+  })
+
+  it("removes three newlines if there are four newlines", () => {
+    return postcss().process("a {}\n\n\n\n  b{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\n")
+      expect(result.root.toString()).toBe("a {}\n  b{}")
+    })
+  })
+
+  it("removes three newlines if there are four newlines with CRLF", () => {
+    return postcss().process("a {}\r\n\r\n\r\n\r\n  b{}").then(result => {
+      removeEmptyLinesBefore(result.root.nodes[1], "\r\n")
+      expect(result.root.toString()).toBe("a {}\r\n  b{}")
+    })
+  })
+})

--- a/lib/utils/addEmptyLineBefore.js
+++ b/lib/utils/addEmptyLineBefore.js
@@ -1,0 +1,23 @@
+/* @flow */
+"use strict"
+
+const _ = require("lodash")
+
+// Add an empty line before a node. Mutates the node.
+function addEmptyLineBefore(
+  node/*: postcss$node*/,
+  newline/*: '\n' | '\r\n'*/
+)/*: postcss$node*/ {
+  if (!(/\r?\n/).test(node.raws.before)) {
+    node.raws.before = _.repeat(newline, 2) + node.raws.before
+  } else if ((/^\r?\n/).test(node.raws.before)) {
+    node.raws.before = newline + node.raws.before
+  } else if ((/\r?\n$/).test(node.raws.before)) {
+    node.raws.before = node.raws.before + newline
+  } else {
+    node.raws.before = node.raws.before.replace(/(\r?\n)/, `${newline}$1`)
+  }
+  return node
+}
+
+module.exports = addEmptyLineBefore

--- a/lib/utils/checkAgainstRule.js
+++ b/lib/utils/checkAgainstRule.js
@@ -26,6 +26,6 @@ module.exports = function (
   if (!settings) { return }
 
   const tmpPostcssResult = new Result()
-  rules[options.ruleName](settings[0], settings[1])(options.root, tmpPostcssResult)
+  rules[options.ruleName](settings[0], settings[1], {})(options.root, tmpPostcssResult)
   tmpPostcssResult.warnings().forEach(callback)
 }

--- a/lib/utils/findAtRuleContext.js
+++ b/lib/utils/findAtRuleContext.js
@@ -8,7 +8,7 @@
  */
 module.exports = function findAtRuleContext(
   rule/*: postcss$rule */
-)/*: ?postcss$atRule*/ {
+)/*: ?postcss$node*/ {
   const parent = rule.parent
 
   if (parent.type === "root") {

--- a/lib/utils/removeEmptyLinesBefore.js
+++ b/lib/utils/removeEmptyLinesBefore.js
@@ -1,0 +1,14 @@
+/* @flow */
+"use strict"
+
+// Remove empty lines before a node. Mutates the node.
+function removeEmptyLinesBefore(
+  node/*: postcss$node*/,
+  newline/*: '\n' | '\r\n'*/
+)/*: postcss$node*/ {
+  node.raws.before = node.raws.before.replace(/(\r?\n\s*\r?\n)+/g, newline)
+
+  return node
+}
+
+module.exports = removeEmptyLinesBefore

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "coveralls": "^2.11.16",
     "cp-file": "^4.1.1",
     "d3-queue": "^3.0.3",
+    "del": "^2.2.2",
     "eslint": "~3.19.0",
     "eslint-config-stylelint": "^6.0.0",
     "file-exists-promise": "^1.0.2",

--- a/system-tests/fix/__snapshots__/fix.test.js.snap
+++ b/system-tests/fix/__snapshots__/fix.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fix expected fixes to PostCSS Result 1`] = `
+"a { @extend placeholder; }
+a {} @media {}
+@charset 'UTF-8';
+a { color: #000; }
+a {}
+
+/* comment */
+
+/**/
+
+/*comment*/
+
+/* TODO: */
+@custom-media --bar (min-width: 30em);
+a {
+  & .foo { /* 1 */
+    &__foo { /* 2 */
+      & > .bar {} /* 3 */
+    }
+  }
+}
+"
+`;
+
+exports[`fix expected stylelint results 1`] = `
+Array [
+  Object {
+    "deprecations": Array [],
+    "errored": true,
+    "ignored": undefined,
+    "invalidOptionWarnings": Array [],
+    "source": "../stylesheet.css",
+    "warnings": Array [
+      Object {
+        "column": 1,
+        "line": 7,
+        "rule": "comment-no-empty",
+        "severity": "error",
+        "text": "Unexpected empty comment (comment-no-empty)",
+      },
+    ],
+  },
+]
+`;

--- a/system-tests/fix/config.json
+++ b/system-tests/fix/config.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "at-rule-name-case": "lower",
+    "comment-empty-line-before": "always",
+    "comment-no-empty": true
+  }
+}

--- a/system-tests/fix/fix.test.js
+++ b/system-tests/fix/fix.test.js
@@ -1,0 +1,62 @@
+"use strict"
+
+const os = require("os")
+const path = require("path")
+const fs = require("fs")
+const _ = require("lodash")
+const pify = require("pify")
+const del = require("del")
+const cpFile = require("cp-file")
+const systemTestUtils = require("../systemTestUtils")
+const stylelint = require("../../lib")
+
+describe("fix", () => {
+  let tmpDir
+  let stylesheetPath
+
+  beforeEach(() => {
+    tmpDir = os.tmpdir()
+    stylesheetPath = path.join(tmpDir, `stylesheet-${_.uniqueId()}.css`)
+    return cpFile(path.join(__dirname, "stylesheet.css"), stylesheetPath)
+  })
+
+  afterEach(() => {
+    return del(stylesheetPath, { force: true })
+  })
+
+  it("expected stylelint results", () => {
+    return stylelint.lint({
+      files: [stylesheetPath],
+      configFile: systemTestUtils.caseConfig("fix"),
+      fix: true,
+    }).then((output) => {
+      // Remove the path to tmpDir
+      const cleanedResults = output.results.map(r => Object.assign({}, r, { source: "stylesheet.css" }))
+      expect(systemTestUtils.prepResults(cleanedResults)).toMatchSnapshot()
+    })
+  })
+
+  it("expected fixes to PostCSS Result", () => {
+    return stylelint.lint({
+      files: [stylesheetPath],
+      configFile: systemTestUtils.caseConfig("fix"),
+      fix: true,
+    }).then((output) => {
+      const result = output.results[0]._postcssResult
+      expect(result.root.toString(result.opts.syntax)).toMatchSnapshot()
+    })
+  })
+
+  it("overwrites the original file", () => {
+    return stylelint.lint({
+      files: [stylesheetPath],
+      configFile: systemTestUtils.caseConfig("fix"),
+      fix: true,
+    }).then((output) => {
+      const result = output.results[0]._postcssResult
+      return pify(fs.readFile)(stylesheetPath, "utf8").then((fileContent) => {
+        expect(fileContent).toBe(result.root.toString(result.opts.syntax))
+      })
+    })
+  })
+})

--- a/system-tests/fix/stylesheet.css
+++ b/system-tests/fix/stylesheet.css
@@ -1,0 +1,17 @@
+a { @extend placeholder; }
+a {} @media {}
+@Charset 'UTF-8';
+a { color: #000; }
+a {}
+/* comment */
+/**/
+/*comment*/
+/* TODO: */
+@custom-media --bar (min-width: 30em);
+a {
+  & .foo { /* 1 */
+    &__foo { /* 2 */
+      & > .bar {} /* 3 */
+    }
+  }
+}

--- a/system-tests/systemTestUtils.js
+++ b/system-tests/systemTestUtils.js
@@ -23,8 +23,7 @@ function prepResults(results) {
     const preppedResult = _.omit(result, "_postcssResult")
 
     // The `source` of each file will not be the same on different machines or platforms
-    preppedResult.source =
-      path.relative(__dirname, result.source)
+    preppedResult.source = path.relative(__dirname, result.source)
       .replace(new RegExp(`\\${path.sep}`, "g"), "/")
 
     return preppedResult


### PR DESCRIPTION
This builds off of #2427, but I thought it would be cleaner and a little easier for me to create a new PR, modifying things as I copy over changes, instead of adding another commit over there. Much of these changes are lifted from that PR and slightly modified.

This illustrates a way I think we could go about implementing autofixing. Here are the key elements:

- New `fix` option in Node API, `--fix` in CLI.
- Third argument, `context`, passed to rule functions. This is an object so that we can continue adding things to it, as needed. Right now it has `fix: boolean`, indicating whether to fix or not, and `newline: \n | \r\n`, determined by the first newline found in the file, which we'll use to add new newlines when fixing.
- Code in `at-rule-name-case` and `comment-empty-line-before` that implements fixes for those rules.
- Code in `standalone.js` that overwrites the input file, when fixing, with fixed CSS.
- Modifications to `jest-setup.js` to check fixes if a test schema has `fix: true`. For `accept` tests, we always check that the fixed CSS equals the original. Every `reject` test must have a `fixed` property with the fixed CSS, and we check against that. All we need to add to tests, then, when we add fixing to a rule, is `fix: true` to each schema and `fixed: ..` to each `reject` test. This is illustrated in the modified rules.
- System test ensuring both that the PostCSS Result is fixed and that the original file is overwritten with fixed CSS.

I tried via the CLI in a little local real-life test case, too, and it seemed to work!

What do you think @stylelint/core? Does this seem like a promising start? Please try it locally and give it some serious scrutiny.

After we all agree on our methodology, we should also try it out in an editor plugin, probably Atom, to ensure that the way we're doing it will work in that context.