### PR TITLE
Add `selector-max-class` rule

### DIFF
--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -132,6 +132,7 @@ You might want to learn a little about [how rules are named and how they work to
     "selector-list-comma-space-after": "always"|"never"|"always-single-line"|"never-single-line",
     "selector-list-comma-space-before": "always"|"never"|"always-single-line"|"never-single-line",
     "selector-max-empty-lines": int,
+    "selector-max-class": int,
     "selector-max-compound-selectors": int,
     "selector-max-specificity": string,
     "selector-nested-pattern": string,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -162,6 +162,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 -   [`selector-combinator-space-before`](../../lib/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors.
 -   [`selector-descendant-combinator-no-non-space`](../../lib/rules/selector-descendant-combinator-no-non-space/README.md): Disallow non-space characters for descendant combinators of selectors.
 -   [`selector-id-pattern`](../../lib/rules/selector-id-pattern/README.md): Specify a pattern for id selectors.
+-   [`selector-max-class`](../../lib/rules/selector-max-class/README.md): Limit the number of classes in a selector.
 -   [`selector-max-compound-selectors`](../../lib/rules/selector-max-compound-selectors/README.md): Limit the number of compound selectors in a selector.
 -   [`selector-max-specificity`](../../lib/rules/selector-max-specificity/README.md): Limit the specificity of selectors.
 -   [`selector-nested-pattern`](../../lib/rules/selector-nested-pattern/README.md): Specify a pattern for the selectors of rules nested within rules.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -137,6 +137,7 @@ const selectorListCommaSpaceAfter = require("./selector-list-comma-space-after")
 const selectorListCommaSpaceBefore = require("./selector-list-comma-space-before")
 const selectorMaxCompoundSelectors = require("./selector-max-compound-selectors")
 const selectorMaxEmptyLines = require("./selector-max-empty-lines")
+const selectorMaxClass = require("./selector-max-class")
 const selectorMaxSpecificity = require("./selector-max-specificity")
 const selectorNestedPattern = require("./selector-nested-pattern")
 const selectorNoAttribute = require("./selector-no-attribute")
@@ -312,6 +313,7 @@ module.exports = {
   "selector-list-comma-newline-before": selectorListCommaNewlineBefore,
   "selector-list-comma-space-after": selectorListCommaSpaceAfter,
   "selector-list-comma-space-before": selectorListCommaSpaceBefore,
+  "selector-max-class": selectorMaxClass,
   "selector-max-compound-selectors": selectorMaxCompoundSelectors,
   "selector-max-empty-lines": selectorMaxEmptyLines,
   "selector-max-specificity": selectorMaxSpecificity,

--- a/lib/rules/selector-max-class/README.md
+++ b/lib/rules/selector-max-class/README.md
@@ -1,0 +1,51 @@
+# selector-max-class
+
+Limit the number of classes in a selector.
+
+```css
+div .foo.bar[data-val] > a.baz {}
+/*  ↑   ↑                 ↑
+    |   |                 |
+    1   2                 3  -- this selector contains three classes */
+```
+
+This rule resolves nested selectors before counting the number of classes in a selector. Each selector in a [selector list](https://www.w3.org/TR/selectors4/#selector-list) is evaluated separately.
+
+The `:not()` pseudo-class is also evaluated separately. The rule processes the argument as if it were an independent selector, and the result does not count toward the total for the entire selector.
+
+## Options
+
+`int`: Maximum classes allowed.
+
+For example, with `2`:
+
+The following patterns are considered warnings:
+
+```css
+.foo.bar.baz {}
+```
+
+```css
+.foo .bar {
+  & > .baz {}
+}
+```
+
+The following patterns are *not* considered warnings:
+
+```css
+div {}
+```
+
+```css
+.foo .bar {}
+```
+
+```css
+.foo.bar,
+.lorem.ipsum {} /* each selector in a selector list is evaluated separately */
+```
+
+```css
+.foo .bar :not(.lorem.ipsum) {} /* `.lorem.ipsum` is inside `:not()`, so it is evaluated separately */
+```

--- a/lib/rules/selector-max-class/__tests__/index.js
+++ b/lib/rules/selector-max-class/__tests__/index.js
@@ -1,0 +1,139 @@
+"use strict"
+
+const messages = require("..").messages
+const ruleName = require("..").ruleName
+const rules = require("../../../rules")
+
+const rule = rules[ruleName]
+
+// Sanity checks
+testRule(rule, {
+  ruleName,
+  config: [0],
+
+  reject: [{
+    code: ".foo { left: 0; top: 0; }",
+    description: "disallow classes",
+    message: messages.expected(".foo", 0),
+    line: 1,
+    column: 1,
+  }],
+})
+
+// Standard tests
+testRule(rule, {
+  ruleName,
+  config: [2],
+
+  accept: [ {
+    code: ".ab { left: 0; top: 0; }",
+    description: "fewer than max classes",
+  }, {
+    code: ".ab.cd { left: 0; top: 0; }",
+    description: "exactly max classes",
+  }, {
+    code: ".ab .cd { left: 0; top: 0; }",
+    description: "compound selector",
+  }, {
+    code: ".ab, \n.cd { left: 0; top: 0; }",
+    description: "multiple selectors: fewer than max classes",
+  }, {
+    code: ".ab.cd, \n.ef.gh { left: 0; top: 0; }",
+    description: "multiple selectors: exactly max classes",
+  }, {
+    code: ".ab.cd :not(.ef.gh) { left: 0; top: 0; }",
+    description: ":not(): inside and outside",
+  }, {
+    code: ".ab.cd[disabled]:hover { left: 0; top: 0; }",
+    description: "pseudo selectors, attribute selectors",
+  }, {
+    code: ".ab { .cd: { left: 0; top: 0; } }",
+    description: "nested selectors",
+  }, {
+    code: ".ab { .cd > & { left: 0; top: 0; } }",
+    description: "nested selectors: parent selector",
+  }, {
+    code: ".ab, .cd { & > .ef { left: 0; top: 0; } }",
+    description: "nested selectors: superfluous parent selector",
+  }, {
+    code: "@media print { .ab.cd { left: 0; top: 0; } }",
+    description: "media query: parent",
+  }, {
+    code: ".ab { @media print { .cd { left: 0; top: 0; } } }",
+    description: "media query: nested",
+  } ],
+
+  reject: [ {
+    code: ".ab.cd.ef { left: 0; top: 0; }",
+    description: "greater than max classes",
+    message: messages.expected(".ab.cd.ef", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".ab .cd .ef { left: 0; top: 0; }",
+    description: "compound selector: greater than max classes",
+    message: messages.expected(".ab .cd .ef", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".ab, \n.cd.ef.gh { left: 0; top: 0; }",
+    description: "multiple selectors: greater than max classes",
+    message: messages.expected(".cd.ef.gh", 2),
+    line: 2,
+    column: 1,
+  }, {
+    code: ":not(.ab.cd.ef) { left: 0; top: 0; }",
+    description: ":not(): greater than max classes, inside",
+    message: messages.expected(".ab.cd.ef", 2),
+    line: 1,
+    column: 6,
+  }, {
+    code: ".ab.cd.ef :not(.gh) { left: 0; top: 0; }",
+    description: ":not(): greater than max classes, outside",
+    message: messages.expected(".ab.cd.ef :not(.gh)", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".ab, .cd { &:hover > .ef.gh { left: 0; top: 0; } }",
+    description: "nested selectors: greater than max classes",
+    message: messages.expected(".ab:hover > .ef.gh", 2),
+    line: 1,
+    column: 12,
+  } ],
+})
+
+// SCSS tests
+testRule(rule, {
+  ruleName,
+  config: [1],
+  syntax: "scss",
+
+  accept: [ {
+    code: ".foo #{$test} { left: 0; top: 0; }",
+    description: "scss: ignore variable interpolation",
+  }, {
+    code: ".foo.bar #{$test} { left: 0; top: 0; }",
+    description: "scss: ignore variable interpolation",
+  }, {
+    code: ".foo { margin: { left: 0; top: 0; }; }",
+    description: "scss: nested properties",
+  } ],
+})
+
+// LESS tests
+testRule(rule, {
+  ruleName,
+  config: [1],
+  syntax: "less",
+
+  accept: [ {
+    code: ".foo @{test} { left: 0; top: 0; }",
+    description: "less: ignore variable interpolation",
+  }, {
+    code: ".setFont(@size) { font-size: @size; }",
+    description: "less: ignore mixins",
+  }, {
+    code: ".foo { .setFont(12px) }",
+    description: "less: ignore called mixins",
+  } ],
+})

--- a/lib/rules/selector-max-class/index.js
+++ b/lib/rules/selector-max-class/index.js
@@ -1,0 +1,75 @@
+"use strict"
+
+const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
+const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
+const parseSelector = require("../../utils/parseSelector")
+const report = require("../../utils/report")
+const ruleMessages = require("../../utils/ruleMessages")
+const validateOptions = require("../../utils/validateOptions")
+const resolvedNestedSelector = require("postcss-resolve-nested-selector")
+
+const ruleName = "selector-max-class"
+
+const messages = ruleMessages(ruleName, {
+  expected: (selector, max) => `Expected "${selector}" to have no more than ${max} classes`,
+})
+
+function rule(max) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: max,
+      possible: [
+        function (max) {
+          return typeof max === "number" && max >= 0
+        },
+      ],
+    })
+    if (!validOptions) {
+      return
+    }
+
+    function checkSelector(selectorNode, ruleNode) {
+      const count = selectorNode.reduce((total, childNode) => {
+        // Only traverse inside actual selectors and :not()
+        if (childNode.type === "selector" || childNode.value === ":not") {
+          checkSelector(childNode, ruleNode)
+        }
+
+        return total += (childNode.type === "class" ? 1 : 0)
+      }, 0)
+
+      if (selectorNode.type !== "root" && selectorNode.type !== "pseudo" && count > max) {
+        report({
+          ruleName,
+          result,
+          node: ruleNode,
+          message: messages.expected(selectorNode, max),
+          word: selectorNode,
+        })
+      }
+    }
+
+    root.walkRules(ruleNode => {
+      if (!isStandardSyntaxRule(ruleNode)) {
+        return
+      }
+      if (!isStandardSyntaxSelector(ruleNode.selector)) {
+        return
+      }
+      if (ruleNode.nodes.some(node => [ "rule", "atrule" ].indexOf(node.type) !== -1)) {
+        // Skip unresolved nested selectors
+        return
+      }
+
+      ruleNode.selectors.forEach(selector => {
+        resolvedNestedSelector(selector, ruleNode).forEach(resolvedSelector => {
+          parseSelector(resolvedSelector, result, ruleNode, container => checkSelector(container, ruleNode))
+        })
+      })
+    })
+  }
+}
+
+rule.ruleName = ruleName
+rule.messages = messages
+module.exports = rule


### PR DESCRIPTION
This rule verifies that the number of classes in a selector doesn't exceed some maximum. Rather than measuring specificity, it counts classes explicitly.

> Which issue, if any, is this issue related to?

#2458

> Is there anything in the PR that needs further explanation?

- ~~I'll add a README once we agree this is ready~~
- Based this rule on [`selector-max-compound-selectors`](https://stylelint.io/user-guide/rules/selector-max-compound-selectors/), since the operation is similar
- Could write a util, `isFullyResolvedSelector()`, but I'm not sure I want to write a bunch of tests for it 😅 