### PR TITLE
Fixed: `length-zero-no-unit` now correctly handles newlines and no spaces after colon.

### DIFF
--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -94,17 +94,35 @@ testRule(rule, {
     code: "@media print and (min-resolution: 0dppx) { }",
     description: "ignore dppx",
   }, {
-    code: ".a { background: linear-gradient(0deg, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
+    code: "a { background: linear-gradient(0deg, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
     description: "ignore deg",
   }, {
-    code: ".a { background: linear-gradient(0grad, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
+    code: "a { background: linear-gradient(0grad, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
     description: "ignore grad",
   }, {
-    code: ".a { background: linear-gradient(0turn, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
+    code: "a { background: linear-gradient(0turn, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
     description: "ignore turn",
   }, {
-    code: ".a { background: linear-gradient(0rad, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
+    code: "a { background: linear-gradient(0rad, rgba(7, 29, 73, 0.12) 0%, rgba(7, 29, 73, 0) 80%) #fff; }",
     description: "ignore rad",
+  }, {
+    code: "a { margin:0; }",
+    description: "no space after colon",
+  }, {
+    code: "a { margin:\n0; }",
+    description: "newline after colon",
+  }, {
+    code: "a { margin:\r\n0; }",
+    description: "CRLF after colon",
+  }, {
+    code: "a { margin:\t0; }",
+    description: "tab after colon",
+  }, {
+    code: "a { margin :0; }",
+    description: "space before colon",
+  }, {
+    code: "a { margin : 0; }",
+    description: "space before and after colon",
   } ],
 
   reject: [ {
@@ -180,5 +198,41 @@ testRule(rule, {
     message: messages.rejected,
     line: 1,
     column: 14,
+  }, {
+    code: "a { margin:0px; }",
+    description: "no space after colon",
+    message: messages.rejected,
+    line: 1,
+    column: 13,
+  }, {
+    code: "a { margin:\n0px; }",
+    description: "newline after colon",
+    message: messages.rejected,
+    line: 2,
+    column: 2,
+  }, {
+    code: "a { margin:\r\n0px; }",
+    description: "CRLF after colon",
+    message: messages.rejected,
+    line: 2,
+    column: 2,
+  }, {
+    code: "a { margin:\t0px; }",
+    description: "tab after colon",
+    message: messages.rejected,
+    line: 1,
+    column: 14,
+  }, {
+    code: "a { margin :0px; }",
+    description: "space before colon",
+    message: messages.rejected,
+    line: 1,
+    column: 14,
+  }, {
+    code: "a { margin : 0px; }",
+    description: "space before and after colon",
+    message: messages.rejected,
+    line: 1,
+    column: 15,
   } ],
 })

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -63,6 +63,9 @@ const rule = function (actual) {
             ")",
             "(",
             "#",
+            ":",
+            "\n",
+            "\t",
           ].indexOf(char) !== -1
         })
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2475 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
