### PR TITLE
Fixed: `selector-type-no-unknown` now ignores MathML tags.

### DIFF
--- a/lib/rules/selector-type-no-unknown/README.md
+++ b/lib/rules/selector-type-no-unknown/README.md
@@ -8,7 +8,7 @@ Disallow unknown type selectors.
  * This type selector */
 ```
 
-This rule considers tags defined in the HTML and SVG Specifications to be known.
+This rule considers tags defined in the HTML, SVG, and MathML specifications to be known.
 
 ## Options
 

--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -74,6 +74,9 @@ testRule(rule, {
   }, {
     code: "a { --custom-property-set: {}; }",
     description: "custom property set",
+  }, {
+    code: "abs {}",
+    description: "MathML tags",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -12,6 +12,7 @@ const validateOptions = require("../../utils/validateOptions")
 const htmlTags = require("html-tags")
 const _ = require("lodash")
 const svgTags = require("svg-tags")
+const mathMLTags = require("mathml-tag-names")
 
 const ruleName = "selector-type-no-unknown"
 
@@ -100,7 +101,11 @@ const rule = function (actual, options) {
           const tagName = tagNode.value
           const tagNameLowerCase = tagName.toLowerCase()
 
-          if (htmlTags.indexOf(tagNameLowerCase) !== -1 || svgTags.indexOf(tagNameLowerCase) !== -1 || nonStandardHtmlTags.has(tagNameLowerCase)) {
+          if (htmlTags.indexOf(tagNameLowerCase) !== -1
+            || svgTags.indexOf(tagNameLowerCase) !== -1
+            || nonStandardHtmlTags.has(tagNameLowerCase)
+            || mathMLTags.indexOf(tagNameLowerCase) !== -1
+          ) {
             return
           }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "known-css-properties": "^0.0.7",
     "lodash": "^4.17.4",
     "log-symbols": "^1.0.2",
+    "mathml-tag-names": "^2.0.0",
     "meow": "^3.3.0",
     "micromatch": "^2.3.11",
     "normalize-selector": "^0.2.0",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2397 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
