### PR TITLE
Add no-unsupported-browser-features plugin to docs

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -6,7 +6,7 @@ Plugins are rules and sets of rules built by the community that support methodol
 -   [`stylelint-declaration-strict-value`](https://github.com/AndyOGo/stylelint-declaration-strict-value): Specify properties for which either a variable (`$sass`, `@less`, `var(--cssnext)`), function or custom CSS keyword (`inherit`, `none`, etc.) must be used for its value.
 -   [`stylelint-declaration-use-variable`](https://github.com/sh-waqar/stylelint-declaration-use-variable): Specify properties for which a variable must be used for its value.
 -   [`stylelint-no-browser-hacks`](https://github.com/Slamdunk/stylelint-no-browser-hacks): Disallow browser hacks that are irrelevant to the browsers you are targeting; uses [stylehacks](https://github.com/ben-eb/stylehacks).
--   [`stylelint-no-unsupported-browser-features`](https://github.com/ismay/stylelint-no-unsupported-browser-features): Disallow features that are unsupported by the browsers that you are targeting
+-   [`stylelint-no-unsupported-browser-features`](https://github.com/ismay/stylelint-no-unsupported-browser-features): Disallow features that are unsupported by the browsers that you are targeting.
 -   [`stylelint-order`](https://github.com/hudochenkov/stylelint-order): Specify the ordering of things e.g. properties within declaration blocks (plugin pack).
 -   [`stylelint-rscss`](https://github.com/rstacruz/stylelint-rscss): Validate [RSCSS](http://rscss.io) conventions.
 -   [`stylelint-scss`](https://github.com/kristerkari/stylelint-scss): Enforce a wide variety of SCSS-syntax specific linting rules (plugin pack).

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -6,6 +6,7 @@ Plugins are rules and sets of rules built by the community that support methodol
 -   [`stylelint-declaration-strict-value`](https://github.com/AndyOGo/stylelint-declaration-strict-value): Specify properties for which either a variable (`$sass`, `@less`, `var(--cssnext)`), function or custom CSS keyword (`inherit`, `none`, etc.) must be used for its value.
 -   [`stylelint-declaration-use-variable`](https://github.com/sh-waqar/stylelint-declaration-use-variable): Specify properties for which a variable must be used for its value.
 -   [`stylelint-no-browser-hacks`](https://github.com/Slamdunk/stylelint-no-browser-hacks): Disallow browser hacks that are irrelevant to the browsers you are targeting; uses [stylehacks](https://github.com/ben-eb/stylehacks).
+-   [`stylelint-no-unsupported-browser-features`](https://github.com/ismay/stylelint-no-unsupported-browser-features): Disallow features that are unsupported by the browsers that you are targeting
 -   [`stylelint-order`](https://github.com/hudochenkov/stylelint-order): Specify the ordering of things e.g. properties within declaration blocks (plugin pack).
 -   [`stylelint-rscss`](https://github.com/rstacruz/stylelint-rscss): Validate [RSCSS](http://rscss.io) conventions.
 -   [`stylelint-scss`](https://github.com/kristerkari/stylelint-scss): Enforce a wide variety of SCSS-syntax specific linting rules (plugin pack).

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -268,4 +268,4 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 -   [`no-invalid-double-slash-comments`](../../lib/rules/no-invalid-double-slash-comments/README.md): Disallow double-slash comments (`//...`) which are not supported by CSS.
 -   [`no-missing-end-of-source-newline`](../../lib/rules/no-missing-end-of-source-newline/README.md): Disallow missing end-of-source newlines.
 -   [`no-unknown-animations`](../../lib/rules/no-unknown-animations/README.md): Disallow unknown animations.
--   [`no-unsupported-browser-features`](../../lib/rules/no-unsupported-browser-features/README.md): Disallow features that are unsupported by the browsers that you are targeting **(deprecated)**.
+-   [`no-unsupported-browser-features`](../../lib/rules/no-unsupported-browser-features/README.md): Disallow features that are unsupported by the browsers that you are targeting (**deprecated**, use the [stylelint-no-unsupported-browser-features](https://github.com/ismay/stylelint-no-unsupported-browser-features) plugin instead).

--- a/lib/rules/no-unsupported-browser-features/README.md
+++ b/lib/rules/no-unsupported-browser-features/README.md
@@ -1,6 +1,6 @@
 # no-unsupported-browser-features
 
-***Deprecated: See [CHANGELOG](../../../CHANGELOG.md).***
+***Deprecated: See [CHANGELOG](../../../CHANGELOG.md).*** Use the [stylelint-no-unsupported-browser-features](https://github.com/ismay/stylelint-no-unsupported-browser-features) plugin instead).
 
 Disallow features that are unsupported by the browsers that you are targeting.
 

--- a/lib/rules/no-unsupported-browser-features/README.md
+++ b/lib/rules/no-unsupported-browser-features/README.md
@@ -1,6 +1,6 @@
 # no-unsupported-browser-features
 
-***Deprecated: See [CHANGELOG](../../../CHANGELOG.md).*** Use the [stylelint-no-unsupported-browser-features](https://github.com/ismay/stylelint-no-unsupported-browser-features) plugin instead).
+***DEPRECATED! This rule was deprecated in favor of [`stylelint-no-unsupported-browser-features`](https://github.com/ismay/stylelint-no-unsupported-browser-features).***
 
 Disallow features that are unsupported by the browsers that you are targeting.
 

--- a/lib/rules/no-unsupported-browser-features/__tests__/index.js
+++ b/lib/rules/no-unsupported-browser-features/__tests__/index.js
@@ -19,7 +19,7 @@ it("deprecation warning", () => {
   return stylelint({ code, config }).then(output => {
     const result = output.results[0]
     expect(result.deprecations.length).toEqual(1)
-    expect(result.deprecations[0].text).toEqual(`\'${ruleName}\' has been deprecated and in 8.0 will be removed.`)
+    expect(result.deprecations[0].text).toEqual(`\'${ruleName}\' has been deprecated and in 8.0 will be removed. Use 'stylelint-no-unsupported-browser-features' plugin instead.`)
     expect(result.deprecations[0].reference).toEqual(`https://stylelint.io/user-guide/rules/${ruleName}/`)
   })
 })

--- a/lib/rules/no-unsupported-browser-features/index.js
+++ b/lib/rules/no-unsupported-browser-features/index.js
@@ -28,7 +28,7 @@ const rule = function (on, options) {
     }
 
     result.warn((
-      `'${ruleName}' has been deprecated and in 8.0 will be removed.`
+      `'${ruleName}' has been deprecated and in 8.0 will be removed. Use 'stylelint-no-unsupported-browser-features' plugin instead.`
     ), {
       stylelintType: "deprecation",
       stylelintReference: `https://stylelint.io/user-guide/rules/${ruleName}/`,

--- a/system-tests/005/__snapshots__/005.test.js.snap
+++ b/system-tests/005/__snapshots__/005.test.js.snap
@@ -34,7 +34,7 @@ Array [
       },
       Object {
         "reference": "https://stylelint.io/user-guide/rules/no-unsupported-browser-features/",
-        "text": "'no-unsupported-browser-features' has been deprecated and in 8.0 will be removed.",
+        "text": "'no-unsupported-browser-features' has been deprecated and in 8.0 will be removed. Use 'stylelint-no-unsupported-browser-features' plugin instead.",
       },
       Object {
         "reference": "https://stylelint.io/user-guide/rules/root-no-standard-properties/",

--- a/system-tests/deprecations/001/__snapshots__/001.test.js.snap
+++ b/system-tests/deprecations/001/__snapshots__/001.test.js.snap
@@ -34,7 +34,7 @@ Array [
       },
       Object {
         "reference": "https://stylelint.io/user-guide/rules/no-unsupported-browser-features/",
-        "text": "'no-unsupported-browser-features' has been deprecated and in 8.0 will be removed.",
+        "text": "'no-unsupported-browser-features' has been deprecated and in 8.0 will be removed. Use 'stylelint-no-unsupported-browser-features' plugin instead.",
       },
       Object {
         "reference": "https://stylelint.io/user-guide/rules/stylelint-disable-reason/",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, as it's an addition to the documentation (added the new no-unsupported-browser-features plugin to docs).

> Is there anything in the PR that needs further explanation?

Don't think so. Just added the new plugin for discoverability.