### PR TITLE
Fix error when linting CSS string with cache enabled (issue #2492)

### DIFF
--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -135,6 +135,28 @@ describe("standalone cache", () => {
       })
     })
   })
+  it("cache doesn't do anything if string is passed", () => {
+    const config = {
+      code: ".foo {}",
+      codeFilename: "foo.css",
+      cache: true,
+      config: {
+        rules: {
+          "color-no-invalid-hex": true,
+        },
+      },
+    }
+    let cacheFileExists = true
+    return standalone(config).then((lintResults) => {
+      expect(lintResults.errored).toBe(false)
+      return fileExists(expectedCacheFilePath).then(() => {
+        throw new Error(`Cache file should not be created if string is passed, ${expectedCacheFilePath} is found instead`)
+      }).catch(() => {
+        cacheFileExists = false
+        expect(cacheFileExists).toBe(false)
+      })
+    })
+  })
 })
 describe("standalone cache uses cacheLocation", () => {
   const cacheLocationFile = path.join(fixturesPath, "cache", ".cachefile")

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -158,7 +158,12 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
     })
 
     return Promise.all(getStylelintResults)
-  }).then(prepareReturnValue)
+  }).then(stylelintResults => {
+    if (useCache) {
+      fileCache.reconcile()
+    }
+    return prepareReturnValue(stylelintResults)
+  })
 
   function prepareReturnValue(stylelintResults/*: Array<stylelint$result>*/)/*: stylelint$standaloneReturnValue*/ {
     const errored = stylelintResults.some(result => result.errored)
@@ -169,9 +174,6 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
     }
     if (reportNeedlessDisables) {
       returnValue.needlessDisables = needlessDisables(stylelintResults)
-    }
-    if (useCache) {
-      fileCache.reconcile()
     }
     debug(`Linting complete in ${Date.now() - startTime}ms`)
     return returnValue


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Issue #2492

> Is there anything in the PR that needs further explanation?

it's self explanatory

@jeddy3, @davidtheclark, @evilebottnawi, please take a look when you have time.
