### PR TITLE
chore: Drop NodeJS 4.x and require at least NodeJS 6.x LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ matrix:
     - node_js: '6'
       script: npm run jest -- --runInBand
       env: CI=tests 6
-    - node_js: '4'
-      script: npm run jest -- --runInBand
-      env: CI=tests 4
-      sudo: required
     - node_js: '7'
       script: npm run jest -- --runInBand  --coverage
       env: CI=coverage

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "!**/__tests__"
   ],
   "engines": {
-    "node": ">=4.2.1"
+    "node": ">=6"
   },
   "dependencies": {
     "autoprefixer": "^6.0.0",


### PR DESCRIPTION
Previously #1594 Require NodeJS 4.x LTS

NodeJS 4.x went into "maintenance mode" April 1st

NodeJS 6.x is now the "active" LTS version

See https://github.com/nodejs/LTS#lts-schedule