### PR TITLE
Fix newline for autofixing

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -5,6 +5,8 @@ const less = require("postcss-less")
 const basicChecks = require("./lib/testUtils/basicChecks")
 const stylelint = require("./lib/standalone")
 
+jest.mock("./lib/utils/getOsEol", () => () => "\n")
+
 global.testRule = (rule, schema) => {
   expect.extend({
     toHaveMessage(testCase) {

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -5,7 +5,6 @@ const _ = require("lodash")
 const assignDisabledRanges = require("./assignDisabledRanges")
 const configurationError = require("./utils/configurationError")
 const path = require("path")
-const os = require("os")
 const ruleDefinitions = require("./rules")
 
 // Run stylelint on a PostCSS Result, either one that is provided
@@ -88,7 +87,7 @@ function lintPostcssResult(
   postcssResult.stylelint.quiet = config.quiet
 
   const newlineMatch = postcssResult.root.toResult().css.match(/\r?\n/)
-  const newline = newlineMatch ? newlineMatch[0] : os.EOL
+  const newline = newlineMatch ? newlineMatch[0] : "\n"
 
   const postcssRoot = postcssResult.root
   assignDisabledRanges(postcssRoot, postcssResult)

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -4,6 +4,7 @@
 const _ = require("lodash")
 const assignDisabledRanges = require("./assignDisabledRanges")
 const configurationError = require("./utils/configurationError")
+const getOsEol = require("./utils/getOsEol")
 const path = require("path")
 const ruleDefinitions = require("./rules")
 
@@ -87,7 +88,7 @@ function lintPostcssResult(
   postcssResult.stylelint.quiet = config.quiet
 
   const newlineMatch = postcssResult.root.toResult().css.match(/\r?\n/)
-  const newline = newlineMatch ? newlineMatch[0] : "\n"
+  const newline = newlineMatch ? newlineMatch[0] : getOsEol()
 
   const postcssRoot = postcssResult.root
   assignDisabledRanges(postcssRoot, postcssResult)

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -28,17 +28,21 @@ const alwaysTests = {
     description: "Mixed",
   }, {
     code: "a { color: pink;\n\n/** comment */\ntop: 0; }",
+  }, {
+    code: "/** comment */ /** comment */",
+    description: "no newline between comments",
   } ],
 
   reject: [ {
     code: "/** comment */\n/** comment */",
     fixed: "/** comment */\n\n/** comment */",
     message: messages.expected,
+    description: "one newline between comments",
   }, {
     code: "/** comment */\r\n/** comment */",
     fixed: "/** comment */\r\n\r\n/** comment */",
-    description: "CRLF",
     message: messages.expected,
+    description: "CRLF newline between comments",
   }, {
     code: "a { color: pink;\n/** comment */\ntop: 0; }",
     fixed: "a { color: pink;\n\n/** comment */\ntop: 0; }",

--- a/lib/utils/getOsEol.js
+++ b/lib/utils/getOsEol.js
@@ -1,0 +1,12 @@
+/* @flow */
+"use strict"
+
+const os = require("os")
+
+// This function simply provides roundabout way of getting os.EOL
+// so we can mock this for Jest tests
+function getOsEl()/*: string*/ {
+  return os.EOL
+}
+
+module.exports = getOsEl


### PR DESCRIPTION
If source file have no line endings, autofixing will set `newline` depends on current OS. There is no problem for users, I think. But there is problems for tests, because lots of our `code` doesn't have line endings in it. We always assume in tests that it will be `\n`, but on AppVeyor [tests are failing](https://github.com/stylelint/stylelint/pull/2500).

@davidtheclark what do you think?