### PR TITLE
Fixed: `selector-type-no-unknown` is now ignore `/deep/` shadow-piercing descendant combinator.

### DIFF
--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -77,6 +77,18 @@ testRule(rule, {
   }, {
     code: "abs {}",
     description: "MathML tags",
+  }, {
+    code: ".foo /deep/ .bar {}",
+    description: "shadow-piercing descendant combinator",
+  }, {
+    code: ".foo /dEeP/ .bar {}",
+    description: "shadow-piercing descendant combinator",
+  }, {
+    code: ".foo /DEEP/ .bar {}",
+    description: "shadow-piercing descendant combinator",
+  }, {
+    code: ".foo /for/ .bar {}",
+    description: "reference combinators",
   } ],
 
   reject: [ {

--- a/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
@@ -10,8 +10,18 @@ describe("isStandardSyntaxTypeSelector", () => {
       expect(isStandardSyntaxTypeSelector(func)).toBeTruthy()
     })
   })
-  it("nth-child pseudo selector", () => {
+  it("lowercase nth-child pseudo selector", () => {
     return rules(".foo:nth-child(n) {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("mixedcase nth-child pseudo selector", () => {
+    return rules(".foo:nTh-ChIlD(n) {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("uppercase nth-child pseudo selector", () => {
+    return rules(".foo:NTH-CHILD(n) {}", func => {
       expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
     })
   })
@@ -25,8 +35,18 @@ describe("isStandardSyntaxTypeSelector", () => {
       expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
     })
   })
-  it("lang pseudo selector", () => {
+  it("lowercase lang pseudo selector", () => {
     return rules(":lang(en) {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("mixedcase lang pseudo selector", () => {
+    return rules(":lAnG(en) {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("uppercase lang pseudo selector", () => {
+    return rules(":LANG(en) {}", func => {
       expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
     })
   })
@@ -47,6 +67,26 @@ describe("isStandardSyntaxTypeSelector", () => {
   })
   it("placeholder selector", () => {
     return rules("%foo {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("shadow-piercing descendant combinator", () => {
+    return rules(".foo /deep/ .bar {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("lowercase reference combinators", () => {
+    return rules(".foo /for/ .bar {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("mixedcase reference combinators", () => {
+    return rules(".foo /fOr/ .bar {}", func => {
+      expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
+    })
+  })
+  it("uppercase reference combinators", () => {
+    return rules(".foo /FOR/ .bar {}", func => {
       expect(isStandardSyntaxTypeSelector(func)).toBeFalsy()
     })
   })

--- a/lib/utils/isStandardSyntaxTypeSelector.js
+++ b/lib/utils/isStandardSyntaxTypeSelector.js
@@ -9,6 +9,7 @@
  */
 
 const keywordSets = require("../reference/keywordSets")
+const _ = require("lodash")
 
 module.exports = function (node/*: Object*/)/*: boolean*/ {
   // postcss-selector-parser includes the arguments to nth-child() functions
@@ -32,6 +33,11 @@ module.exports = function (node/*: Object*/)/*: boolean*/ {
   }
 
   if (node.value[0] === "%") {
+    return false
+  }
+
+  // Reference combinators like `/deep/`
+  if (_.startsWith(node.value, "/") && _.endsWith(node.value, "/")) {
     return false
   }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2506

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Maybe need update docs :question: or just add example to `valid` :question:
