### PR TITLE
Fixed: descendant combinator in `selector-descendant-combinator-no-non-space` and `selector-combinator-space-before/after`

### DIFF
--- a/lib/reference/punctuationSets.js
+++ b/lib/reference/punctuationSets.js
@@ -16,6 +16,7 @@ punctuationSets.nonSpaceCombinators = new Set([
   "+",
   "~",
   ">>>",
+  "/deep/",
 ])
 
 module.exports = punctuationSets

--- a/lib/reference/punctuationSets.js
+++ b/lib/reference/punctuationSets.js
@@ -15,6 +15,7 @@ punctuationSets.nonSpaceCombinators = new Set([
   ">",
   "+",
   "~",
+  ">>>",
 ])
 
 module.exports = punctuationSets

--- a/lib/rules/selector-combinator-space-after/README.md
+++ b/lib/rules/selector-combinator-space-after/README.md
@@ -3,8 +3,8 @@
 Require a single space or disallow whitespace after the combinators of selectors.
 
 ```css
-  a > b + c ~ d e { color: pink; }
-/** ↑   ↑   ↑  ↑
+  a > b + c ~ d e >>> f { color: pink; }
+/** ↑   ↑   ↑  ↑  ↑
  * These are combinators */
 ```
 

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -20,6 +20,9 @@ testRule(rule, {
     code: "a ~ a {}",
     description: "space before and after ~ combinator",
   }, {
+    code: "a >>> a {}",
+    description: "shadow-piercing descendant combinator",
+  }, {
     code: ".foo ~ a + bar {}",
     description: "multiple spaced combinators",
   }, {
@@ -32,8 +35,14 @@ testRule(rule, {
     code: "a~ a {}",
     description: "no before and one after ~ combinator",
   }, {
+    code: "a>>> a {}",
+    description: "no before and one after >>> combinator",
+  }, {
     code: "a\n+ a {}",
     description: "newline before space after + combinator",
+  }, {
+    code: "a\r\n+ a {}",
+    description: "CRLF before space after + combinator",
   }, {
     code: "a\n> a {}",
     description: "newline before space after > combinator",
@@ -44,7 +53,13 @@ testRule(rule, {
     code: "a\n~ a {}",
     description: "newline before space after ~ combinator",
   }, {
-    code: ".foo~ a+ bar {}",
+    code: "a\n>>> a {}",
+    description: "newline before space after >>> combinator",
+  }, {
+    code: "a\r\n>>> a {}",
+    description: "CRLF before space after >>> combinator",
+  }, {
+    code: "a~ a+ bar {}",
     description: "multiple combinators with no space before and one after",
   }, {
     code: ".foo:nth-child(2n+1) {}",
@@ -58,12 +73,32 @@ testRule(rule, {
   }, {
     code: ".foo\\+bar {}",
     description: "escaped combinator-like character",
+  }, {
+    code: "a [type='button'] {}",
+    description: "combinator between selectors and attribute selector",
+  }, {
+    code: "a  a {}",
+    description: "combinator selector contain multiple spaces",
+  }, {
+    code: "a\na {}",
+    description: "combinator selector contain newline",
+  }, {
+    code: "a\r\na {}",
+    description: "combinator selector contain CRLF",
+  }, {
+    code: "a\n\na {}",
+    description: "combinator selector contain multiple newline",
+  }, {
+    code: "a\r\n\r\na {}",
+    description: "combinator selector contain multiple CRLF",
   } ],
 
   reject: [ {
     code: "a+  a {}",
     description: "two spaces after + combinator",
     message: messages.expectedAfter("+"),
+    line: 1,
+    column: 2,
   }, {
     code: "a+\na {}",
     description: "newline after + combinator",
@@ -100,6 +135,12 @@ testRule(rule, {
     message: messages.expectedAfter("+"),
     line: 1,
     column: 6,
+  }, {
+    code: "a >>>a {}",
+    description: "shadow-piercing descendant combinator",
+    message: messages.expectedAfter(">>>"),
+    line: 1,
+    column: 3,
   } ],
 })
 
@@ -116,6 +157,9 @@ testRule(rule, {
   }, {
     code: "a ~a {}",
     description: "space before none after ~ combinator",
+  }, {
+    code: "a >>>a {}",
+    description: "space before none after >>> combinator",
   }, {
     code: ".foo ~a +bar {}",
     description: "multiple combinators with no space after",
@@ -144,6 +188,12 @@ testRule(rule, {
     code: "a\r\n~a {}",
     description: "CRLF before and no space after ~ combinator",
   }, {
+    code: "a\n>>>a {}",
+    description: "newline before and no space after >>> combinator",
+  }, {
+    code: "a\r\n>>>a {}",
+    description: "CRLF before and no space after >>> combinator",
+  }, {
     code: ".foo:nth-child(2n + 1) {}",
     description: "spaced + in nth-child argument",
   }, {
@@ -152,6 +202,24 @@ testRule(rule, {
   }, {
     code: "a[rel~='copyright'] {}",
     description: "attribute selector with ~=",
+  }, {
+    code: "a [type='button'] {}",
+    description: "combinator between selectors and attribute selector",
+  }, {
+    code: "a  a {}",
+    description: "combinator selector contain multiple spaces",
+  }, {
+    code: "a\na {}",
+    description: "combinator selector contain newline",
+  }, {
+    code: "a\r\na {}",
+    description: "combinator selector contain CRLF",
+  }, {
+    code: "a\n\na {}",
+    description: "combinator selector contain multiple newline",
+  }, {
+    code: "a\r\n\r\na {}",
+    description: "combinator selector contain multiple CRLF",
   } ],
 
   reject: [ {
@@ -191,6 +259,12 @@ testRule(rule, {
     line: 1,
     column: 2,
   }, {
+    code: "a>\r\na{}",
+    description: "newline after > combinator",
+    message: messages.rejectedAfter(">"),
+    line: 1,
+    column: 2,
+  }, {
     code: "a~\na{}",
     description: "newline after ~ combinator",
     message: messages.rejectedAfter("~"),
@@ -214,6 +288,12 @@ testRule(rule, {
     message: messages.rejectedAfter("~"),
     line: 1,
     column: 16,
+  }, {
+    code: "a >>> a {}",
+    description: "space after >>> combinator",
+    message: messages.rejectedAfter(">>>"),
+    line: 1,
+    column: 3,
   } ],
 })
 

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -30,6 +30,7 @@ const rule = function (expectation) {
       root,
       result,
       locationChecker: checker.after,
+      locationType: "after",
       checkedRuleName: ruleName,
     })
   }

--- a/lib/rules/selector-combinator-space-before/README.md
+++ b/lib/rules/selector-combinator-space-before/README.md
@@ -3,8 +3,8 @@
 Require a single space or disallow whitespace before the combinators of selectors.
 
 ```css
-  a > b + c ~ d e { color: pink; }
-/** ↑   ↑   ↑  ↑
+  a > b + c ~ d e >>> f { color: pink; }
+/** ↑   ↑   ↑  ↑  ↑
  * These are combinators */
 ```
 

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -20,6 +20,9 @@ testRule(rule, {
     code: "a ~ a {}",
     description: "space before and after ~ combinator",
   }, {
+    code: "a >>> a {}",
+    description: "shadow-piercing descendant combinator",
+  }, {
     code: ".foo ~ a + bar {}",
     description: "multiple spaced combinators",
   }, {
@@ -31,6 +34,9 @@ testRule(rule, {
   }, {
     code: "a ~a {}",
     description: "space before and none after ~ combinator",
+  }, {
+    code: "a >>>a {}",
+    description: "space before and none after >>> combinator",
   }, {
     code: "a +\na {}",
     description: "space before and newline after + combinator",
@@ -47,7 +53,13 @@ testRule(rule, {
     code: "a ~\r\na {}",
     description: "space before and CRLF after ~ combinator",
   }, {
-    code: ".foo ~a +bar {}",
+    code: "a >>>\na {}",
+    description: "space before and newline after >>> combinator",
+  }, {
+    code: "a >>>\r\na {}",
+    description: "space before and CRLF after >>> combinator",
+  }, {
+    code: "a ~a +bar {}",
     description: "multiple combinators with space before and none after",
   }, {
     code: ".foo:nth-child(2n+1) {}",
@@ -64,6 +76,24 @@ testRule(rule, {
   }, {
     code: ".foo\\+bar {}",
     description: "escaped combinator-like character",
+  }, {
+    code: "a [type='button'] {}",
+    description: "combinator between selectors and attribute selector",
+  }, {
+    code: "a  a {}",
+    description: "combinator selector contain multiple spaces",
+  }, {
+    code: "a\na {}",
+    description: "combinator selector contain newline",
+  }, {
+    code: "a\r\na {}",
+    description: "combinator selector contain CRLF",
+  }, {
+    code: "a\n\na {}",
+    description: "combinator selector contain multiple newline",
+  }, {
+    code: "a\r\n\r\na {}",
+    description: "combinator selector contain multiple CRLF",
   } ],
 
   reject: [ {
@@ -114,6 +144,12 @@ testRule(rule, {
     message: messages.expectedBefore("+"),
     line: 1,
     column: 5,
+  }, {
+    code: "a>>> a {}",
+    description: "shadow-piercing descendant combinator",
+    message: messages.expectedBefore(">>>"),
+    line: 1,
+    column: 2,
   } ],
 })
 
@@ -130,6 +166,12 @@ testRule(rule, {
   }, {
     code: "a~ a {}",
     description: "no space before one after ~ combinator",
+  }, {
+    code: "a>>> a {}",
+    description: "shadow-piercing descendant combinator",
+  }, {
+    code: ".foo~ a+ bar {}",
+    description: "multiple combinators with no space after",
   }, {
     code: "a+a {}",
     description: "no space before or after + combinator",
@@ -152,8 +194,11 @@ testRule(rule, {
     code: "a~\na {}",
     description: "no space before and newline after ~ combinator",
   }, {
-    code: ".foo~ a+ bar {}",
-    description: "multiple combinators with no space before",
+    code: "a>>>\na {}",
+    description: "no space before and newline after >>> combinator",
+  }, {
+    code: "a>>>\r\na {}",
+    description: "no space before and CRLF after >>> combinator",
   }, {
     code: ".foo:nth-child(2n + 1) {}",
     description: "spaced + in nth-child argument",
@@ -163,6 +208,24 @@ testRule(rule, {
   }, {
     code: "a[rel~='copyright'] {}",
     description: "attribute selector with ~=",
+  }, {
+    code: "a [type='button'] {}",
+    description: "combinator between selectors and attribute selector",
+  }, {
+    code: "a  a {}",
+    description: "combinator selector contain multiple spaces",
+  }, {
+    code: "a\na {}",
+    description: "combinator selector contain newline",
+  }, {
+    code: "a\r\na {}",
+    description: "combinator selector contain CRLF",
+  }, {
+    code: "a\n\na {}",
+    description: "combinator selector contain multiple newline",
+  }, {
+    code: "a\r\n\r\na {}",
+    description: "combinator selector contain multiple CRLF",
   } ],
 
   reject: [ {
@@ -190,8 +253,20 @@ testRule(rule, {
     line: 2,
     column: 1,
   }, {
+    code: "a\r\n+a {}",
+    description: "CRLF before + combinator",
+    message: messages.rejectedBefore("+"),
+    line: 2,
+    column: 1,
+  }, {
     code: "a\n>a {}",
     description: "newline before > combinator",
+    message: messages.rejectedBefore(">"),
+    line: 2,
+    column: 1,
+  }, {
+    code: "a\r\n>a {}",
+    description: "CRLF before > combinator",
     message: messages.rejectedBefore(">"),
     line: 2,
     column: 1,
@@ -219,6 +294,12 @@ testRule(rule, {
     message: messages.rejectedBefore("~"),
     line: 1,
     column: 16,
+  }, {
+    code: "a >>> a {}",
+    description: "space before >>> combinator",
+    message: messages.rejectedBefore(">>>"),
+    line: 1,
+    column: 3,
   } ],
 })
 

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -30,6 +30,7 @@ const rule = function (expectation) {
       root,
       result,
       locationChecker: checker.before,
+      locationType: "before",
       checkedRuleName: ruleName,
     })
   }

--- a/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
@@ -24,6 +24,12 @@ testRule(rule, {
     code: ".foo\n>\n.bar {}",
   }, {
     code: ".foo\r\n>\r\n.bar {}",
+  }, {
+    code: ".foo >>> .bar {}",
+    description: "shadow-piercing descendant combinator",
+  }, {
+    code: ".foo  >>>  .bar {}",
+    description: "shadow-piercing descendant combinator",
   } ],
 
   reject: [ {

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -1,45 +1,47 @@
 "use strict"
 
+const isStandardSyntaxRule = require("../utils/isStandardSyntaxRule")
+const parseSelector = require("../utils/parseSelector")
 const report = require("../utils/report")
-const _ = require("lodash")
-const punctuationSets = require("../reference/punctuationSets")
-const styleSearch = require("style-search")
 
 module.exports = function (opts) {
   opts.root.walkRules(rule => {
+    if (!isStandardSyntaxRule(rule)) {
+      return
+    }
     // Check each selector individually, instead of all as one string,
     // in case some that aren't the first begin with combinators (nesting syntax)
     rule.selectors.forEach(selector => {
-      styleSearch({
-        source: selector,
-        target: _.toArray(punctuationSets.nonSpaceCombinators),
-        parentheticals: "skip",
-      }, match => {
-        const endIndex = match.endIndex,
-          startIndex = match.startIndex,
-          target = match.target
+      parseSelector(selector, opts.result, rule, selectorTree => {
+        selectorTree.walkCombinators(node => {
+          // Ignore spaced descendant combinator
+          if ((/\s/).test(node.value)) {
+            return
+          }
 
-        // Catch ~= in attribute selectors
+          const parentParentNode = node.parent && node.parent.parent
 
-        if (target === "~" && selector[endIndex] === "=") {
-          return
-        }
+          // Ignore pseudo-classes selector like `.foo:nth-child(2n + 1) {}`
+          if (parentParentNode && parentParentNode.type === "pseudo") {
+            return
+          }
 
-        // Catch escaped combinator-like character
-        if (selector[startIndex - 1] === "\\") {
-          return
-        }
+          const sourceIndex = node.sourceIndex
+          const index = node.value.length > 1 && opts.locationType === "before"
+            ? sourceIndex
+            : sourceIndex + node.value.length - 1
 
-        check(selector, startIndex, rule)
+          check(selectorTree.toString(), node.value, index, rule, sourceIndex)
+        })
       })
     })
   })
 
-  function check(source, index, node) {
-    opts.locationChecker({ source, index, err: m => report({
+  function check(source, errTarget, index, node, sourceIndex) {
+    opts.locationChecker({ source, index, errTarget, err: m => report({
       message: m,
       node,
-      index,
+      index: sourceIndex,
       result: opts.result,
       ruleName: opts.checkedRuleName,
     }),


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2506

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
