### PR TITLE
Chore: use `parseSelector` instead `postcss-selector-parser` directly.

### DIFF
--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -6,7 +6,7 @@ const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
 const resolvedNestedSelector = require("postcss-resolve-nested-selector")
-const selectorParser = require("postcss-selector-parser")
+const parseSelector = require("../../utils/parseSelector")
 
 const ruleName = "selector-max-compound-selectors"
 
@@ -73,7 +73,7 @@ const rule = function (max) {
       rule.selectors.forEach(selector => {
         resolvedNestedSelector(selector, rule).forEach(resolvedSelector => {
           // Process each resolved selector with `checkSelector` via postcss-selector-parser
-          selectorParser(s => checkSelector(s, rule)).process(resolvedSelector)
+          parseSelector(resolvedSelector, result, rule, s => checkSelector(s, rule))
         })
       })
     })


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Just code improved. See https://github.com/stylelint/stylelint/issues/1247

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
