### PR TITLE
Fix inconsistent behaviour for escaped characters in selector-class-pattern

### DIFF
--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -10,6 +10,8 @@ Specify a pattern for class selectors.
 
 This rule ignores non-outputting Less mixin definitions and called Less mixins.
 
+Escaped selectors (e.g. `.u-size-11\/12\@sm`) are parsed as escaped twice (e.g. `.u-size-11\\/12\\@sm`). Your RegExp should account for that.
+
 ## Options
 
 `regex|string`

--- a/lib/rules/selector-class-pattern/__tests__/index.js
+++ b/lib/rules/selector-class-pattern/__tests__/index.js
@@ -118,6 +118,17 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["^.u-size-([\\][/]?[0-9]+){2,}\\@sm$"],
+
+  accept: [{
+    only: true,
+    code: ".u-size-11\\/12\\@sm {}",
+    description: "escaped characters",
+  }],
+})
+
+testRule(rule, {
+  ruleName,
   syntax: "scss",
   config: [ /^[A-Z]+$/, { resolveNestedSelectors: true } ],
 

--- a/lib/rules/selector-class-pattern/__tests__/index.js
+++ b/lib/rules/selector-class-pattern/__tests__/index.js
@@ -118,17 +118,6 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: ["^.u-size-([\\][/]?[0-9]+){2,}\\@sm$"],
-
-  accept: [{
-    only: true,
-    code: ".u-size-11\\/12\\@sm {}",
-    description: "escaped characters",
-  }],
-})
-
-testRule(rule, {
-  ruleName,
   syntax: "scss",
   config: [ /^[A-Z]+$/, { resolveNestedSelectors: true } ],
 

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -39,8 +39,8 @@ const rule = function (pattern, options) {
     const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern
 
     root.walkRules(rule => {
-      const selector = rule.selector,
-        selectors = rule.selectors
+      const selector = rule.selector
+      const selectors = rule.selectors
 
       if (!isStandardSyntaxRule(rule)) {
         return
@@ -68,8 +68,8 @@ const rule = function (pattern, options) {
 
     function checkSelector(fullSelector, rule) {
       fullSelector.walkClasses(classNode => {
-        const value = classNode.value,
-          sourceIndex = classNode.sourceIndex
+        const value = classNode.value
+        const sourceIndex = classNode.sourceIndex
 
         if (normalizedPattern.test(value)) {
           return


### PR DESCRIPTION
Ref #2263.

cc @hudochenkov 