### PR TITLE
Indentation autofixing

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -255,7 +255,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 ### General / Sheet
 
--   [`indentation`](../../lib/rules/indentation/README.md): Specify indentation.
+-   [`indentation`](../../lib/rules/indentation/README.md): Specify indentation (Autofixable).
 -   [`max-empty-lines`](../../lib/rules/max-empty-lines/README.md): Limit the number of adjacent empty lines.
 -   [`max-line-length`](../../lib/rules/max-line-length/README.md): Limit the length of a line.
 -   [`max-nesting-depth`](../../lib/rules/max-nesting-depth/README.md): Limit the depth of nesting.

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -99,6 +99,7 @@ global.testRule = (rule, schema) => {
               return stylelint(Object.assign({ fix: true }, options)).then((output) => {
                 const fixedCode = getOutputCss(output)
                 expect(fixedCode).toBe(testCase.fixed)
+                expect(fixedCode).not.toBe(testCase.code)
               })
             })
           })

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -12,7 +12,7 @@ a {}
 
 If the at-rule is the very first node in a stylesheet then it is ignored.
 
-The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](../indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -16,7 +16,7 @@ If you're using a custom syntax which support single-line comments with `//`, th
 
 **Caveat:** Comments within *selector and value lists* are currently ignored.
 
-The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](../indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -12,7 +12,7 @@ a {
  *                   This line */
 ```
 
-The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](../indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/lib/rules/declaration-empty-line-before/README.md
+++ b/lib/rules/declaration-empty-line-before/README.md
@@ -14,7 +14,7 @@ a {
 
 This rule only applies to standard property declarations. Use the [`custom-property-empty-line-before`](../custom-property-empty-line-before/README.md) rule for custom property declarations.
 
-The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](../indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 

--- a/lib/rules/indentation/README.md
+++ b/lib/rules/indentation/README.md
@@ -13,6 +13,8 @@ Specify indentation.
  * The indentation at these three points */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `int|"tab"`, where `int` is the number of spaces
@@ -188,7 +190,7 @@ a {
 @media print {
   a {
     color: pink;
-  }  
+  }
 }
 ```
 
@@ -204,7 +206,7 @@ a {
 @media print {
   a {
     color: pink;
-    }  
+    }
   }
 ```
 

--- a/lib/rules/indentation/__tests__/at-rules.js
+++ b/lib/rules/indentation/__tests__/at-rules.js
@@ -14,9 +14,13 @@ testRule(rule, {
   accept: [ {
     code: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
   }, {
+    code: "@media\n" + "  print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
+  }, {
     code: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}\n" + "\n" + "@media screen {\n" + "  b { color: orange; }\n" + "}",
   }, {
     code: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
+  }, {
+    code: "@media\r\n" + "  print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
   }, {
     code: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}\r\n" + "\r\n" + "@media screen {\r\n" + "  b { color: orange; }\r\n" + "}",
   } ],
@@ -91,6 +95,22 @@ testRule(rule, {
     message: messages.expected("0 spaces"),
     line: 5,
     column: 2,
+  }, {
+    code: "@media\n" + " print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
+    fixed: "@media\n" + "  print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
+    description: "at-rule parameters on the next line",
+
+    message: messages.expected("2 spaces"),
+    line: 2,
+    column: 2,
+  }, {
+    code: "@media\r\n" + " print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
+    fixed: "@media\r\n" + "  print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
+    description: "at-rule parameters on the next line (CRLF)",
+
+    message: messages.expected("2 spaces"),
+    line: 2,
+    column: 2,
   } ],
 })
 
@@ -119,14 +139,22 @@ testRule(rule, {
     message: messages.expected("1 tab"),
     line: 4,
     column: 1,
-  // }, {
-  //   code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "\t(min-resolution: 120dpi) {}",
-  //   fixed: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "\t(min-resolution: 120dpi) {}",
+  }, {
+    code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "\t(min-resolution: 120dpi) {}",
+    fixed: "@media print,\n" + "\t(-webkit-min-device-pixel-ratio: 1.25),\n" + "\t(min-resolution: 120dpi) {}",
 
-  //   description: "multi-line at-rule params",
-  //   message: messages.expected("1 tab"),
-  //   line: 2,
-  //   column: 3,
+    description: "multi-line at-rule params",
+    message: messages.expected("1 tab"),
+    line: 2,
+    column: 3,
+  }, {
+    code: "@media print,\r\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\r\n" + "\t(min-resolution: 120dpi) {}",
+    fixed: "@media print,\r\n" + "\t(-webkit-min-device-pixel-ratio: 1.25),\r\n" + "\t(min-resolution: 120dpi) {}",
+
+    description: "multi-line at-rule params (CRLF)",
+    message: messages.expected("1 tab"),
+    line: 2,
+    column: 3,
   } ],
 })
 
@@ -139,14 +167,23 @@ testRule(rule, {
     code: "@media print,\n" + "(-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
   }],
 
-  // reject: [{
-  //   code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
-  //   fixed: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
+  reject: [ {
+    code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
+    fixed: "@media print,\n" + "(-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
 
-  //   message: messages.expected("0 spaces"),
-  //   line: 2,
-  //   column: 3,
-  // }],
+    description: "multi-line at-rule params, no params indent",
+    message: messages.expected("0 spaces"),
+    line: 2,
+    column: 3,
+  }, {
+    code: "@media print,\r\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\r\n" + "(min-resolution: 120dpi) {}",
+    fixed: "@media print,\r\n" + "(-webkit-min-device-pixel-ratio: 1.25),\r\n" + "(min-resolution: 120dpi) {}",
+
+    description: "multi-line at-rule params, no params indent (CRLF)",
+    message: messages.expected("0 spaces"),
+    line: 2,
+    column: 3,
+  } ],
 })
 
 testRule(rule, {

--- a/lib/rules/indentation/__tests__/at-rules.js
+++ b/lib/rules/indentation/__tests__/at-rules.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
   config: [2],
+  fix: true,
 
   accept: [ {
     code: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
@@ -22,60 +23,70 @@ testRule(rule, {
 
   reject: [ {
     code: "\n" + "  @media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
+    fixed: "\n" + "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 2,
     column: 3,
   }, {
     code: "@media print {\n" + "a {\n" + "    color: pink;\n" + "  }\n" + "}",
+    fixed: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 1,
   }, {
     code: "@media print {\n" + "  a {\n" + "  color: pink;\n" + "  }\n" + "}",
+    fixed: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
 
     message: messages.expected("4 spaces"),
     line: 3,
     column: 3,
   }, {
     code: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "}\n" + "}",
+    fixed: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 4,
     column: 1,
   }, {
     code: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "\t}",
+    fixed: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 5,
     column: 2,
   }, {
     code: "\r\n" + "  @media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
+    fixed: "\r\n" + "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 2,
     column: 3,
   }, {
     code: "@media print {\r\n" + "a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
+    fixed: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 1,
   }, {
     code: "@media print {\r\n" + "  a {\r\n" + "  color: pink;\r\n" + "  }\r\n" + "}",
+    fixed: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
 
     message: messages.expected("4 spaces"),
     line: 3,
     column: 3,
   }, {
     code: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "}\r\n" + "}",
+    fixed: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 4,
     column: 1,
   }, {
     code: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "\t}",
+    fixed: "@media print {\r\n" + "  a {\r\n" + "    color: pink;\r\n" + "  }\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 5,
@@ -86,6 +97,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [ "tab", { except: ["block"] } ],
+  fix: true,
 
   accept: [ {
     code: "@media print {\n" + "\n" + "a {\n" + "\tcolor: pink;\n" + "}\n" + "\n" + "}",
@@ -95,46 +107,52 @@ testRule(rule, {
 
   reject: [ {
     code: "@media print {\n" + "\n" + "\ta {\n" + "\tcolor: pink;\n" + "}\n" + "\n" + "}",
+    fixed: "@media print {\n" + "\n" + "a {\n" + "\tcolor: pink;\n" + "}\n" + "\n" + "}",
 
     message: messages.expected("0 tabs"),
     line: 3,
     column: 2,
   }, {
     code: "@media print {\n" + "\n" + "a {\n" + "color: pink;\n" + "}\n" + "\n" + "}",
+    fixed: "@media print {\n" + "\n" + "a {\n" + "\tcolor: pink;\n" + "}\n" + "\n" + "}",
 
     message: messages.expected("1 tab"),
     line: 4,
     column: 1,
-  }, {
-    code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "\t(min-resolution: 120dpi) {}",
+  // }, {
+  //   code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "\t(min-resolution: 120dpi) {}",
+  //   fixed: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "\t(min-resolution: 120dpi) {}",
 
-    description: "multi-line at-rule params",
-    message: messages.expected("1 tab"),
-    line: 2,
-    column: 3,
+  //   description: "multi-line at-rule params",
+  //   message: messages.expected("1 tab"),
+  //   line: 2,
+  //   column: 3,
   } ],
 })
 
 testRule(rule, {
   ruleName,
   config: [ 4, { except: ["param"] } ],
+  fix: true,
 
   accept: [{
     code: "@media print,\n" + "(-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
   }],
 
-  reject: [{
-    code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
+  // reject: [{
+  //   code: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
+  //   fixed: "@media print,\n" + "  (-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
 
-    message: messages.expected("0 spaces"),
-    line: 2,
-    column: 3,
-  }],
+  //   message: messages.expected("0 spaces"),
+  //   line: 2,
+  //   column: 3,
+  // }],
 })
 
 testRule(rule, {
   ruleName,
   config: [ 2, { ignore: ["param"] } ],
+  fix: true,
 
   accept: [ {
     code: "@media print,\n" + "(-webkit-min-device-pixel-ratio: 1.25),\n" + "(min-resolution: 120dpi) {}",
@@ -144,6 +162,7 @@ testRule(rule, {
 
   reject: [{
     code: "\n" + "  @media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
+    fixed: "\n" + "@media print {\n" + "  a {\n" + "    color: pink;\n" + "  }\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 2,
@@ -156,6 +175,7 @@ testRule(rule, {
   config: [ 2, {
     indentClosingBrace: true,
   } ],
+  fix: true,
 
   accept: [ {
     code: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "    }\n" + "  }",
@@ -165,12 +185,14 @@ testRule(rule, {
 
   reject: [ {
     code: "\n" + "@media print {\n" + "  a {\n" + "    color: pink;\n" + "    }\n" + " }",
+    fixed: "\n" + "@media print {\n" + "  a {\n" + "    color: pink;\n" + "    }\n" + "  }",
 
     message: messages.expected("2 spaces"),
     line: 6,
     column: 2,
   }, {
     code: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "   }\n" + "  }",
+    fixed: "@media print {\n" + "  a {\n" + "    color: pink;\n" + "    }\n" + "  }",
 
     message: messages.expected("4 spaces"),
     line: 4,

--- a/lib/rules/indentation/__tests__/comments.js
+++ b/lib/rules/indentation/__tests__/comments.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
   config: ["tab"],
+  fix: true,
 
   accept: [ {
     code: "/* blergh */",
@@ -26,34 +27,34 @@ testRule(rule, {
 
   reject: [ {
     code: " /* blergh */",
+    fixed: "/* blergh */",
     message: messages.expected("0 tabs"),
     line: 1,
     column: 2,
   }, {
     code: ".foo {\n" + "\t\t/* blergh */\n" + "\ttop: 0;\n" + "}",
+    fixed: ".foo {\n" + "\t/* blergh */\n" + "\ttop: 0;\n" + "}",
 
     message: messages.expected("1 tab"),
     line: 2,
     column: 3,
   }, {
     code: "@media print {\n" + "\t.foo {\n" + "\t/* blergh */\n" + "\t\ttop: 0;\n" + "\t}\n" + "}",
+    fixed: "@media print {\n" + "\t.foo {\n" + "\t\t/* blergh */\n" + "\t\ttop: 0;\n" + "\t}\n" + "}",
 
     message: messages.expected("2 tabs"),
     line: 3,
     column: 2,
   }, {
-    code: " /* blergh */",
-    message: messages.expected("0 tabs"),
-    line: 1,
-    column: 2,
-  }, {
     code: ".foo {\r\n" + "\t\t/* blergh */\r\n" + "\ttop: 0;\r\n" + "}",
+    fixed: ".foo {\r\n" + "\t/* blergh */\r\n" + "\ttop: 0;\r\n" + "}",
 
     message: messages.expected("1 tab"),
     line: 2,
     column: 3,
   }, {
     code: "@media print {\r\n" + "\t.foo {\r\n" + "\t/* blergh */\r\n" + "\t\ttop: 0;\r\n" + "\t}\r\n" + "}",
+    fixed: "@media print {\r\n" + "\t.foo {\r\n" + "\t\t/* blergh */\r\n" + "\t\ttop: 0;\r\n" + "\t}\r\n" + "}",
 
     message: messages.expected("2 tabs"),
     line: 3,

--- a/lib/rules/indentation/__tests__/functions.js
+++ b/lib/rules/indentation/__tests__/functions.js
@@ -1,6 +1,6 @@
 "use strict"
 
-// const messages = require("..").messages
+const messages = require("..").messages
 const ruleName = require("..").ruleName
 const rules = require("../../../rules")
 
@@ -40,59 +40,66 @@ testRule(rule, {
     description: "nested parenthetical inside multiline value",
   } ],
 
-  // reject: [ {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
-  //   message: messages.expected("4 spaces"),
-  //   line: 4,
-  //   column: 1,
-  // }, {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "    );\n" + "  top: 0;\n" + "}",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "    );\n" + "  top: 0;\n" + "}",
-  //   message: messages.expected("2 spaces"),
-  //   line: 6,
-  //   column: 5,
-  // }, {
-  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + ");",
-  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + ");",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 4,
-  //   column: 2,
-  // }, {
-  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
-  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("0 spaces"),
-  //   line: 5,
-  //   column: 3,
-  // }, {
-  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
-  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
-  //   message: messages.expected("4 spaces"),
-  //   line: 4,
-  //   column: 1,
-  // }, {
-  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
-  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
-  //   message: messages.expected("2 spaces"),
-  //   line: 6,
-  //   column: 5,
-  // }, {
-  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + ");",
-  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + ");",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 4,
-  //   column: 2,
-  // }, {
-  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
-  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("0 spaces"),
-  //   line: 5,
-  //   column: 3,
-  // } ],
+  reject: [ {
+    code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
+    message: messages.expected("4 spaces"),
+    line: 4,
+    column: 1,
+  }, {
+    code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "    );\n" + "  top: 0;\n" + "}",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
+    message: messages.expected("2 spaces"),
+    line: 6,
+    column: 5,
+  }, {
+    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + ");",
+    fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 4,
+    column: 2,
+  }, {
+    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+    fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
+    description: "sass-list",
+    message: messages.expected("0 spaces"),
+    line: 5,
+    column: 3,
+  }, {
+    code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
+    fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
+    message: messages.expected("4 spaces"),
+    line: 4,
+    column: 1,
+  }, {
+    code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+    fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
+    message: messages.expected("2 spaces"),
+    line: 6,
+    column: 5,
+  }, {
+    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + ");",
+    fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 4,
+    column: 2,
+  }, {
+    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+    fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
+    description: "sass-list",
+    message: messages.expected("0 spaces"),
+    line: 5,
+    column: 3,
+  }, {
+    code: "background:\n" + "linear-gradient(\n" + "    to bottom,\n" + "    transparentize($gray-dark, 1) 0%,\n" + "    transparentize($gray-dark, 0.1) 100%\n" + "  );",
+    fixed: "background:\n" + "  linear-gradient(\n" + "    to bottom,\n" + "    transparentize($gray-dark, 1) 0%,\n" + "    transparentize($gray-dark, 0.1) 100%\n" + "  );",
+
+    message: messages.expected("2 spaces"),
+    line: 2,
+    column: 1,
+  } ],
 })
 
 testRule(rule, {
@@ -128,14 +135,14 @@ testRule(rule, {
     description: "tabbed sass-list with property value pairs",
   }],
 
-  // reject: [{
-  //   code: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\t\tvar: value\n" + ");",
-  //   fixed: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\t\tvar: value\n" + ");",
-  //   description: "tabbed sass-list with property value pairs",
-  //   message: messages.expected("1 tab"),
-  //   line: 4,
-  //   column: 3,
-  // }],
+  reject: [{
+    code: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\t\tvar: value\n" + ");",
+    fixed: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\tvar: value\n" + ");",
+    description: "tabbed sass-list with property value pairs",
+    message: messages.expected("1 tab"),
+    line: 4,
+    column: 3,
+  }],
 })
 
 testRule(rule, {
@@ -156,47 +163,47 @@ testRule(rule, {
     description: "sass-list",
   } ],
 
-  // reject: [ {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
-  //   message: messages.expected("6 spaces"),
-  //   line: 4,
-  //   column: 5,
-  // }, {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
-  //   message: messages.expected("4 spaces"),
-  //   line: 6,
-  //   column: 6,
-  // }, {
-  //   code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "   0\n" + "  );",
-  //   fixed: "$some-list: (\n" + "    0,\n" + "    0,\n" + "   0\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("4 spaces"),
-  //   line: 4,
-  //   column: 4,
-  // }, {
-  //   code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + " );",
-  //   fixed: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + " );",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 5,
-  //   column: 2,
-  // }, {
-  //   code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "   0\r\n" + "  );",
-  //   fixed: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "   0\r\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("4 spaces"),
-  //   line: 4,
-  //   column: 4,
-  // }, {
-  //   code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + " );",
-  //   fixed: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + " );",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 5,
-  //   column: 2,
-  // } ],
+  reject: [ {
+    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+    message: messages.expected("6 spaces"),
+    line: 4,
+    column: 5,
+  }, {
+    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+    message: messages.expected("4 spaces"),
+    line: 6,
+    column: 6,
+  }, {
+    code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "   0\n" + "  );",
+    fixed: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("4 spaces"),
+    line: 4,
+    column: 4,
+  }, {
+    code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + " );",
+    fixed: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 5,
+    column: 2,
+  }, {
+    code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "   0\r\n" + "  );",
+    fixed: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("4 spaces"),
+    line: 4,
+    column: 4,
+  }, {
+    code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + " );",
+    fixed: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 5,
+    column: 2,
+  } ],
 })
 
 testRule(rule, {
@@ -217,45 +224,45 @@ testRule(rule, {
     description: "sass-list",
   } ],
 
-  // reject: [ {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
-  //   message: messages.expected("6 spaces"),
-  //   line: 4,
-  //   column: 5,
-  // }, {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
-  //   message: messages.expected("4 spaces"),
-  //   line: 6,
-  //   column: 6,
-  // }, {
-  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
-  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("0 spaces"),
-  //   line: 5,
-  //   column: 3,
-  // }, {
-  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
-  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
-  //   message: messages.expected("6 spaces"),
-  //   line: 4,
-  //   column: 5,
-  // }, {
-  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "}",
-  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "}",
-  //   message: messages.expected("4 spaces"),
-  //   line: 6,
-  //   column: 6,
-  // }, {
-  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
-  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("0 spaces"),
-  //   line: 5,
-  //   column: 3,
-  // } ],
+  reject: [ {
+    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+    message: messages.expected("6 spaces"),
+    line: 4,
+    column: 5,
+  }, {
+    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+    message: messages.expected("4 spaces"),
+    line: 6,
+    column: 6,
+  }, {
+    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+    fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
+    description: "sass-list",
+    message: messages.expected("0 spaces"),
+    line: 5,
+    column: 3,
+  }, {
+    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+    fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+    message: messages.expected("6 spaces"),
+    line: 4,
+    column: 5,
+  }, {
+    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "}",
+    fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+    message: messages.expected("4 spaces"),
+    line: 6,
+    column: 6,
+  }, {
+    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+    fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
+    description: "sass-list",
+    message: messages.expected("0 spaces"),
+    line: 5,
+    column: 3,
+  } ],
 })
 
 testRule(rule, {
@@ -277,73 +284,73 @@ testRule(rule, {
     description: "sass-list",
   } ],
 
-  // reject: [ {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
-  //   message: messages.expected("6 spaces"),
-  //   line: 4,
-  //   column: 5,
-  // }, {
-  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "  }",
-  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "  }",
-  //   message: messages.expected("6 spaces"),
-  //   line: 6,
-  //   column: 6,
-  // }, {
-  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + "  );",
-  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 4,
-  //   column: 2,
-  // }, {
-  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
-  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 5,
-  //   column: 1,
-  // }, {
-  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
-  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
-  //   message: messages.expected("6 spaces"),
-  //   line: 4,
-  //   column: 5,
-  // }, {
-  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "  }",
-  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "  }",
-  //   message: messages.expected("6 spaces"),
-  //   line: 6,
-  //   column: 6,
-  // }, {
-  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + "  );",
-  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + "  );",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 4,
-  //   column: 2,
-  // }, {
-  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
-  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
-  //   description: "sass-list",
-  //   message: messages.expected("2 spaces"),
-  //   line: 5,
-  //   column: 1,
-  // } ],
+  reject: [ {
+    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
+    message: messages.expected("6 spaces"),
+    line: 4,
+    column: 5,
+  }, {
+    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "  }",
+    fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
+    message: messages.expected("6 spaces"),
+    line: 6,
+    column: 6,
+  }, {
+    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + "  );",
+    fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 4,
+    column: 2,
+  }, {
+    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
+    fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 5,
+    column: 1,
+  }, {
+    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
+    fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
+    message: messages.expected("6 spaces"),
+    line: 4,
+    column: 5,
+  }, {
+    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "  }",
+    fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
+    message: messages.expected("6 spaces"),
+    line: 6,
+    column: 6,
+  }, {
+    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + "  );",
+    fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 4,
+    column: 2,
+  }, {
+    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
+    fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+    description: "sass-list",
+    message: messages.expected("2 spaces"),
+    line: 5,
+    column: 1,
+  } ],
 })
 
-// testRule(rule, {
-//   ruleName,
-//   config: [2],
-//   syntax: "less",
-//   skipBasicChecks: true,
-//   fix: true,
+testRule(rule, {
+  ruleName,
+  config: [2],
+  syntax: "less",
+  skipBasicChecks: true,
+  // fix: true,
 
-//   accept: [ {
-//     code: ".foo {\n" + "  .mixin(\n" + "    @foo,\n" + "    @bar,\n" + "    @baz\n" + "  );\n" + "}",
-//     description: "Less mixin with multi-line arguments",
-//   }, {
-//     code: ".foo {\r\n" + "  .mixin(\r\n" + "    @foo,\r\n" + "    @bar,\r\n" + "    @baz\r\n" + "  );\r\n" + "}",
-//     description: "Less mixin with multi-line arguments",
-//   } ],
-// })
+  accept: [ {
+    code: ".foo {\n" + "  .mixin(\n" + "    @foo,\n" + "    @bar,\n" + "    @baz\n" + "  );\n" + "}",
+    description: "Less mixin with multi-line arguments",
+  }, {
+    code: ".foo {\r\n" + "  .mixin(\r\n" + "    @foo,\r\n" + "    @bar,\r\n" + "    @baz\r\n" + "  );\r\n" + "}",
+    description: "Less mixin with multi-line arguments",
+  } ],
+})

--- a/lib/rules/indentation/__tests__/functions.js
+++ b/lib/rules/indentation/__tests__/functions.js
@@ -1,6 +1,6 @@
 "use strict"
 
-const messages = require("..").messages
+// const messages = require("..").messages
 const ruleName = require("..").ruleName
 const rules = require("../../../rules")
 
@@ -10,6 +10,7 @@ testRule(rule, {
   ruleName,
   config: [2],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: ".foo {\n" + "  color: rgb(0, 0, 0);\n" + "}",
@@ -39,57 +40,66 @@ testRule(rule, {
     description: "nested parenthetical inside multiline value",
   } ],
 
-  reject: [ {
-    code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
-    message: messages.expected("4 spaces"),
-    line: 4,
-    column: 1,
-  }, {
-    code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "    );\n" + "  top: 0;\n" + "}",
-    message: messages.expected("2 spaces"),
-    line: 6,
-    column: 5,
-  }, {
-    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + ");",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 4,
-    column: 2,
-  }, {
-    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("0 spaces"),
-    line: 5,
-    column: 3,
-  }, {
-    code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
-    message: messages.expected("4 spaces"),
-    line: 4,
-    column: 1,
-  }, {
-    code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
-    message: messages.expected("2 spaces"),
-    line: 6,
-    column: 5,
-  }, {
-    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + ");",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 4,
-    column: 2,
-  }, {
-    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("0 spaces"),
-    line: 5,
-    column: 3,
-  } ],
+  // reject: [ {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "0,\n" + "    0\n" + "  );\n" + "  top: 0;\n" + "}",
+  //   message: messages.expected("4 spaces"),
+  //   line: 4,
+  //   column: 1,
+  // }, {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "    );\n" + "  top: 0;\n" + "}",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "    );\n" + "  top: 0;\n" + "}",
+  //   message: messages.expected("2 spaces"),
+  //   line: 6,
+  //   column: 5,
+  // }, {
+  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + ");",
+  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + ");",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 4,
+  //   column: 2,
+  // }, {
+  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("0 spaces"),
+  //   line: 5,
+  //   column: 3,
+  // }, {
+  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
+  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "0,\r\n" + "    0\r\n" + "  );\r\n" + "  top: 0;\r\n" + "}",
+  //   message: messages.expected("4 spaces"),
+  //   line: 4,
+  //   column: 1,
+  // }, {
+  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+  //   message: messages.expected("2 spaces"),
+  //   line: 6,
+  //   column: 5,
+  // }, {
+  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + ");",
+  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + ");",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 4,
+  //   column: 2,
+  // }, {
+  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("0 spaces"),
+  //   line: 5,
+  //   column: 3,
+  // } ],
 })
 
 testRule(rule, {
   ruleName,
   config: [ 2, { ignore: ["inside-parens"] } ],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: ".foo {\n" + "  color: rgb(\n" + "    0,\n" + "    0,\n" + "    0\n" + "  );\n" + "}",
@@ -111,25 +121,28 @@ testRule(rule, {
   ruleName,
   config: [ "tab", { "indentClosingBrace": false } ],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [{
     code: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\tvar: value\n" + ");",
     description: "tabbed sass-list with property value pairs",
   }],
 
-  reject: [{
-    code: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\t\tvar: value\n" + ");",
-    description: "tabbed sass-list with property value pairs",
-    message: messages.expected("1 tab"),
-    line: 4,
-    column: 3,
-  }],
+  // reject: [{
+  //   code: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\t\tvar: value\n" + ");",
+  //   fixed: "$some-list: (\n" + "\tvar: value,\n" + "\tvar: value,\n" + "\t\tvar: value\n" + ");",
+  //   description: "tabbed sass-list with property value pairs",
+  //   message: messages.expected("1 tab"),
+  //   line: 4,
+  //   column: 3,
+  // }],
 })
 
 testRule(rule, {
   ruleName,
   config: [ 2, { indentInsideParens: "twice" } ],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
@@ -143,47 +156,54 @@ testRule(rule, {
     description: "sass-list",
   } ],
 
-  reject: [ {
-    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
-    message: messages.expected("6 spaces"),
-    line: 4,
-    column: 5,
-  }, {
-    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
-    message: messages.expected("4 spaces"),
-    line: 6,
-    column: 6,
-  }, {
-    code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "   0\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("4 spaces"),
-    line: 4,
-    column: 4,
-  }, {
-    code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + " );",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 5,
-    column: 2,
-  }, {
-    code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "   0\r\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("4 spaces"),
-    line: 4,
-    column: 4,
-  }, {
-    code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + " );",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 5,
-    column: 2,
-  } ],
+  // reject: [ {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+  //   message: messages.expected("6 spaces"),
+  //   line: 4,
+  //   column: 5,
+  // }, {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
+  //   message: messages.expected("4 spaces"),
+  //   line: 6,
+  //   column: 6,
+  // }, {
+  //   code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "   0\n" + "  );",
+  //   fixed: "$some-list: (\n" + "    0,\n" + "    0,\n" + "   0\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("4 spaces"),
+  //   line: 4,
+  //   column: 4,
+  // }, {
+  //   code: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + " );",
+  //   fixed: "$some-list: (\n" + "    0,\n" + "    0,\n" + "    0\n" + " );",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 5,
+  //   column: 2,
+  // }, {
+  //   code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "   0\r\n" + "  );",
+  //   fixed: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "   0\r\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("4 spaces"),
+  //   line: 4,
+  //   column: 4,
+  // }, {
+  //   code: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + " );",
+  //   fixed: "$some-list: (\r\n" + "    0,\r\n" + "    0,\r\n" + "    0\r\n" + " );",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 5,
+  //   column: 2,
+  // } ],
 })
 
 testRule(rule, {
   ruleName,
   config: [ 2, { indentInsideParens: "once-at-root-twice-in-block" } ],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
@@ -197,39 +217,45 @@ testRule(rule, {
     description: "sass-list",
   } ],
 
-  reject: [ {
-    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
-    message: messages.expected("6 spaces"),
-    line: 4,
-    column: 5,
-  }, {
-    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
-    message: messages.expected("4 spaces"),
-    line: 6,
-    column: 6,
-  }, {
-    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("0 spaces"),
-    line: 5,
-    column: 3,
-  }, {
-    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
-    message: messages.expected("6 spaces"),
-    line: 4,
-    column: 5,
-  }, {
-    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "}",
-    message: messages.expected("4 spaces"),
-    line: 6,
-    column: 6,
-  }, {
-    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("0 spaces"),
-    line: 5,
-    column: 3,
-  } ],
+  // reject: [ {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "    );\n" + "  top: 0;\n" + "}",
+  //   message: messages.expected("6 spaces"),
+  //   line: 4,
+  //   column: 5,
+  // }, {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "}",
+  //   message: messages.expected("4 spaces"),
+  //   line: 6,
+  //   column: 6,
+  // }, {
+  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("0 spaces"),
+  //   line: 5,
+  //   column: 3,
+  // }, {
+  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "    );\r\n" + "  top: 0;\r\n" + "}",
+  //   message: messages.expected("6 spaces"),
+  //   line: 4,
+  //   column: 5,
+  // }, {
+  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "}",
+  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "}",
+  //   message: messages.expected("4 spaces"),
+  //   line: 6,
+  //   column: 6,
+  // }, {
+  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("0 spaces"),
+  //   line: 5,
+  //   column: 3,
+  // } ],
 })
 
 testRule(rule, {
@@ -239,6 +265,7 @@ testRule(rule, {
     indentClosingBrace: true,
   } ],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
@@ -250,64 +277,73 @@ testRule(rule, {
     description: "sass-list",
   } ],
 
-  reject: [ {
-    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
-    message: messages.expected("6 spaces"),
-    line: 4,
-    column: 5,
-  }, {
-    code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "  }",
-    message: messages.expected("6 spaces"),
-    line: 6,
-    column: 6,
-  }, {
-    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 4,
-    column: 2,
-  }, {
-    code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 5,
-    column: 1,
-  }, {
-    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
-    message: messages.expected("6 spaces"),
-    line: 4,
-    column: 5,
-  }, {
-    code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "  }",
-    message: messages.expected("6 spaces"),
-    line: 6,
-    column: 6,
-  }, {
-    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + "  );",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 4,
-    column: 2,
-  }, {
-    code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
-    description: "sass-list",
-    message: messages.expected("2 spaces"),
-    line: 5,
-    column: 1,
-  } ],
+  // reject: [ {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "    0,\n" + "      0\n" + "      );\n" + "  top: 0;\n" + "  }",
+  //   message: messages.expected("6 spaces"),
+  //   line: 4,
+  //   column: 5,
+  // }, {
+  //   code: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "  }",
+  //   fixed: ".foo {\n" + "  color: rgb(\n" + "      0,\n" + "      0,\n" + "      0\n" + "     );\n" + "  top: 0;\n" + "  }",
+  //   message: messages.expected("6 spaces"),
+  //   line: 6,
+  //   column: 6,
+  // }, {
+  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + "  );",
+  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + " 0\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 4,
+  //   column: 2,
+  // }, {
+  //   code: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
+  //   fixed: "$some-list: (\n" + "  0,\n" + "  0,\n" + "  0\n" + ");",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 5,
+  //   column: 1,
+  // }, {
+  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
+  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "    0,\r\n" + "      0\r\n" + "      );\r\n" + "  top: 0;\r\n" + "  }",
+  //   message: messages.expected("6 spaces"),
+  //   line: 4,
+  //   column: 5,
+  // }, {
+  //   code: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "  }",
+  //   fixed: ".foo {\r\n" + "  color: rgb(\r\n" + "      0,\r\n" + "      0,\r\n" + "      0\r\n" + "     );\r\n" + "  top: 0;\r\n" + "  }",
+  //   message: messages.expected("6 spaces"),
+  //   line: 6,
+  //   column: 6,
+  // }, {
+  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + "  );",
+  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + " 0\r\n" + "  );",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 4,
+  //   column: 2,
+  // }, {
+  //   code: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
+  //   fixed: "$some-list: (\r\n" + "  0,\r\n" + "  0,\r\n" + "  0\r\n" + ");",
+  //   description: "sass-list",
+  //   message: messages.expected("2 spaces"),
+  //   line: 5,
+  //   column: 1,
+  // } ],
 })
 
-testRule(rule, {
-  ruleName,
-  config: [2],
-  syntax: "less",
-  skipBasicChecks: true,
+// testRule(rule, {
+//   ruleName,
+//   config: [2],
+//   syntax: "less",
+//   skipBasicChecks: true,
+//   fix: true,
 
-  accept: [ {
-    code: ".foo {\n" + "  .mixin(\n" + "    @foo,\n" + "    @bar,\n" + "    @baz\n" + "  );\n" + "}",
-    description: "Less mixin with multi-line arguments",
-  }, {
-    code: ".foo {\r\n" + "  .mixin(\r\n" + "    @foo,\r\n" + "    @bar,\r\n" + "    @baz\r\n" + "  );\r\n" + "}",
-    description: "Less mixin with multi-line arguments",
-  } ],
-})
+//   accept: [ {
+//     code: ".foo {\n" + "  .mixin(\n" + "    @foo,\n" + "    @bar,\n" + "    @baz\n" + "  );\n" + "}",
+//     description: "Less mixin with multi-line arguments",
+//   }, {
+//     code: ".foo {\r\n" + "  .mixin(\r\n" + "    @foo,\r\n" + "    @bar,\r\n" + "    @baz\r\n" + "  );\r\n" + "}",
+//     description: "Less mixin with multi-line arguments",
+//   } ],
+// })

--- a/lib/rules/indentation/__tests__/rules.js
+++ b/lib/rules/indentation/__tests__/rules.js
@@ -48,6 +48,8 @@ testRule(rule, {
   }, {
     code: "@media print {\n" + "  * { color: pink; }\n" + "}",
   }, {
+    code: "a {\n" + "  @media print { color: pink; }\n" + "}",
+  }, {
     code: "/* anything\r\n" + "    goes\r\n" + "\t\t\twithin a comment */\r\n" + "",
   }, {
     code: "a {\r\n" + "  top: 0;\r\n" + "}\r\n" + "b { top: 1px; bottom: 4px; }",
@@ -146,20 +148,20 @@ testRule(rule, {
     message: messages.expected("2 spaces"),
     line: 3,
     column: 2,
-  // }, {
-  //   code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
-  //   fixed: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+  }, {
+    code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
 
-  //   message: messages.expected("4 spaces"),
-  //   line: 3,
-  //   column: 3,
-  // }, {
-  //   code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
-  //   fixed: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+    message: messages.expected("4 spaces"),
+    line: 3,
+    column: 3,
+  }, {
+    code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
 
-  //   message: messages.expected("4 spaces"),
-  //   line: 4,
-  //   column: 3,
+    message: messages.expected("4 spaces"),
+    line: 4,
+    column: 3,
   }, {
     code: "@media print {\n" + "   * { color: pink; }\n" + "}",
     fixed: "@media print {\n" + "  * { color: pink; }\n" + "}",
@@ -167,6 +169,13 @@ testRule(rule, {
     message: messages.expected("2 spaces"),
     line: 2,
     column: 4,
+  }, {
+    code: "a {\n" + " @media print { color: pink; }\n" + "}",
+    fixed: "a {\n" + "  @media print { color: pink; }\n" + "}",
+
+    message: messages.expected("2 spaces"),
+    line: 2,
+    column: 2,
   }, {
     code: "\ta {\r\n" + "  color: pink;\r\n" + "}",
     fixed: "a {\r\n" + "  color: pink;\r\n" + "}",
@@ -230,20 +239,20 @@ testRule(rule, {
     message: messages.expected("2 spaces"),
     line: 3,
     column: 2,
-  // }, {
-  //   code: "a {\r\n" + "  background-position: top left,\r\n" + "  top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
-  //   fixed: "a {\r\n" + "  background-position: top left,\r\n" + "  top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
+  }, {
+    code: "a {\r\n" + "  background-position: top left,\r\n" + "  top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
+    fixed: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
 
-  //   message: messages.expected("4 spaces"),
-  //   line: 3,
-  //   column: 3,
-  // }, {
-  //   code: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "  bottom left;\r\n" + "  color: pink;\r\n" + "}",
-  //   fixed: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "  bottom left;\r\n" + "  color: pink;\r\n" + "}",
+    message: messages.expected("4 spaces"),
+    line: 3,
+    column: 3,
+  }, {
+    code: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "  bottom left;\r\n" + "  color: pink;\r\n" + "}",
+    fixed: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
 
-  //   message: messages.expected("4 spaces"),
-  //   line: 4,
-  //   column: 3,
+    message: messages.expected("4 spaces"),
+    line: 4,
+    column: 3,
   }, {
     code: "@media print {\r\n" + "   * { color: pink; }\r\n" + "}",
     fixed: "@media print {\r\n" + "  * { color: pink; }\r\n" + "}",
@@ -341,21 +350,21 @@ testRule(rule, {
     code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
   } ],
 
-  // reject: [ {
-  //   code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
-  //   fixed: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+  reject: [ {
+    code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
 
-  //   message: messages.expected("2 spaces"),
-  //   line: 3,
-  //   column: 5,
-  // }, {
-  //   code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
-  //   fixed: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+    message: messages.expected("2 spaces"),
+    line: 3,
+    column: 5,
+  }, {
+    code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
 
-  //   message: messages.expected("2 spaces"),
-  //   line: 4,
-  //   column: 5,
-  // } ],
+    message: messages.expected("2 spaces"),
+    line: 4,
+    column: 5,
+  } ],
 })
 
 testRule(rule, {

--- a/lib/rules/indentation/__tests__/rules.js
+++ b/lib/rules/indentation/__tests__/rules.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName]
 testRule(rule, {
   ruleName,
   config: [2],
+  fix: true,
 
   accept: [ {
     code: "/* anything\n" + "    goes\n" + "\t\t\twithin a comment */\n" + "",
@@ -84,150 +85,179 @@ testRule(rule, {
 
   reject: [ {
     code: "\ta {\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "  color: pink;\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 1,
     column: 2,
   }, {
     code: "a {\n" + "  color: pink;\n" + "  }",
+    fixed: "a {\n" + "  color: pink;\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 3,
     column: 3,
   }, {
     code: "a,\n" + "b {\n" + "  color: pink;\n" + "  }",
+    fixed: "a,\n" + "b {\n" + "  color: pink;\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 4,
     column: 3,
   }, {
     code: "a { color: pink;\n" + "  }",
+    fixed: "a { color: pink;\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 2,
     column: 3,
   }, {
     code: "a {\n" + "  color: pink\n" + "}\n" + " b {\n" + "  color: orange\n" + "}",
+    fixed: "a {\n" + "  color: pink\n" + "}\n" + "b {\n" + "  color: orange\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 4,
     column: 2,
   }, {
     code: "a {\n" + "  color: pink\n" + "}\n" + "b {\n" + "  color: orange\n" + " }",
+    fixed: "a {\n" + "  color: pink\n" + "}\n" + "b {\n" + "  color: orange\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 6,
     column: 2,
   }, {
     code: "a {\n" + "color: pink;\n" + "}",
+    fixed: "a {\n" + "  color: pink;\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 1,
   }, {
     code: "a {\n" + "\tcolor: pink;\n" + "}",
+    fixed: "a {\n" + "  color: pink;\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 2,
   }, {
     code: "a {\n" + "  color: pink;\n" + " background: orange;\n" + "}",
+    fixed: "a {\n" + "  color: pink;\n" + "  background: orange;\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 3,
     column: 2,
-  }, {
-    code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+  // }, {
+  //   code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+  //   fixed: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
 
-    message: messages.expected("4 spaces"),
-    line: 3,
-    column: 3,
-  }, {
-    code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+  //   message: messages.expected("4 spaces"),
+  //   line: 3,
+  //   column: 3,
+  // }, {
+  //   code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+  //   fixed: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
 
-    message: messages.expected("4 spaces"),
-    line: 4,
-    column: 3,
+  //   message: messages.expected("4 spaces"),
+  //   line: 4,
+  //   column: 3,
   }, {
     code: "@media print {\n" + "   * { color: pink; }\n" + "}",
+    fixed: "@media print {\n" + "  * { color: pink; }\n" + "}",
 
     message: messages.expected("2 spaces"),
+    line: 2,
+    column: 4,
   }, {
     code: "\ta {\r\n" + "  color: pink;\r\n" + "}",
+    fixed: "a {\r\n" + "  color: pink;\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 1,
     column: 2,
   }, {
     code: "a {\r\n" + "  color: pink;\r\n" + "  }",
+    fixed: "a {\r\n" + "  color: pink;\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 3,
     column: 3,
   }, {
     code: "a,\r\n" + "b {\r\n" + "  color: pink;\r\n" + "  }",
+    fixed: "a,\r\n" + "b {\r\n" + "  color: pink;\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 4,
     column: 3,
   }, {
     code: "a { color: pink;\r\n" + "  }",
+    fixed: "a { color: pink;\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 2,
     column: 3,
   }, {
     code: "a {\r\n" + "  color: pink\r\n" + "}\r\n" + " b {\r\n" + "  color: orange\r\n" + "}",
+    fixed: "a {\r\n" + "  color: pink\r\n" + "}\r\n" + "b {\r\n" + "  color: orange\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 4,
     column: 2,
   }, {
     code: "a {\r\n" + "  color: pink\r\n" + "}\r\n" + "b {\r\n" + "  color: orange\r\n" + " }",
+    fixed: "a {\r\n" + "  color: pink\r\n" + "}\r\n" + "b {\r\n" + "  color: orange\r\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 6,
     column: 2,
   }, {
     code: "a {\r\n" + "color: pink;\r\n" + "}",
+    fixed: "a {\r\n" + "  color: pink;\r\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 1,
   }, {
     code: "a {\r\n" + "\tcolor: pink;\r\n" + "}",
+    fixed: "a {\r\n" + "  color: pink;\r\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 2,
   }, {
     code: "a {\r\n" + "  color: pink;\r\n" + " background: orange;\r\n" + "}",
+    fixed: "a {\r\n" + "  color: pink;\r\n" + "  background: orange;\r\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 3,
     column: 2,
-  }, {
-    code: "a {\r\n" + "  background-position: top left,\r\n" + "  top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
+  // }, {
+  //   code: "a {\r\n" + "  background-position: top left,\r\n" + "  top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
+  //   fixed: "a {\r\n" + "  background-position: top left,\r\n" + "  top right,\r\n" + "    bottom left;\r\n" + "  color: pink;\r\n" + "}",
 
-    message: messages.expected("4 spaces"),
-    line: 3,
-    column: 3,
-  }, {
-    code: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "  bottom left;\r\n" + "  color: pink;\r\n" + "}",
+  //   message: messages.expected("4 spaces"),
+  //   line: 3,
+  //   column: 3,
+  // }, {
+  //   code: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "  bottom left;\r\n" + "  color: pink;\r\n" + "}",
+  //   fixed: "a {\r\n" + "  background-position: top left,\r\n" + "    top right,\r\n" + "  bottom left;\r\n" + "  color: pink;\r\n" + "}",
 
-    message: messages.expected("4 spaces"),
-    line: 4,
-    column: 3,
+  //   message: messages.expected("4 spaces"),
+  //   line: 4,
+  //   column: 3,
   }, {
     code: "@media print {\r\n" + "   * { color: pink; }\r\n" + "}",
+    fixed: "@media print {\r\n" + "  * { color: pink; }\r\n" + "}",
 
     message: messages.expected("2 spaces"),
+    line: 2,
+    column: 4,
   } ],
 })
 
 testRule(rule, {
   ruleName,
   config: ["tab"],
+  fix: true,
 
   accept: [ {
     code: "",
@@ -243,48 +273,56 @@ testRule(rule, {
 
   reject: [ {
     code: "\ta {\n" + "\tcolor: pink;\n" + "}",
+    fixed: "a {\n" + "\tcolor: pink;\n" + "}",
 
     message: messages.expected("0 tabs"),
     line: 1,
     column: 2,
   }, {
     code: "a {\n" + "\tcolor: pink;\n" + "  }",
+    fixed: "a {\n" + "\tcolor: pink;\n" + "}",
 
     message: messages.expected("0 tabs"),
     line: 3,
     column: 3,
   }, {
     code: "a {\n" + "\tcolor: pink\n" + "}\n" + " b {\n" + "\tcolor: orange\n" + "}",
+    fixed: "a {\n" + "\tcolor: pink\n" + "}\n" + "b {\n" + "\tcolor: orange\n" + "}",
 
     message: messages.expected("0 tabs"),
     line: 4,
     column: 2,
   }, {
     code: "a {\n" + "\tcolor: pink\n" + "}\n" + "b {\n" + "\tcolor: orange\n" + " }",
+    fixed: "a {\n" + "\tcolor: pink\n" + "}\n" + "b {\n" + "\tcolor: orange\n" + "}",
 
     message: messages.expected("0 tabs"),
     line: 6,
     column: 2,
   }, {
     code: "a {\n" + "color: pink;\n" + "}",
+    fixed: "a {\n" + "\tcolor: pink;\n" + "}",
 
     message: messages.expected("1 tab"),
     line: 2,
     column: 1,
   }, {
     code: "a {\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "\tcolor: pink;\n" + "}",
 
     message: messages.expected("1 tab"),
     line: 2,
     column: 3,
   }, {
     code: "a {\n" + "\tcolor: pink;\n" + " background: orange;\n" + "}",
+    fixed: "a {\n" + "\tcolor: pink;\n" + "\tbackground: orange;\n" + "}",
 
     message: messages.expected("1 tab"),
     line: 3,
     column: 2,
   }, {
     code: "a { color: pink;\n" + "top: 0; background: orange;\n" + "}",
+    fixed: "a { color: pink;\n" + "\ttop: 0; background: orange;\n" + "}",
 
     message: messages.expected("1 tab"),
     line: 2,
@@ -295,6 +333,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [ 2, { except: ["value"] } ],
+  fix: true,
 
   accept: [ {
     code: "a {\n" + "  background-position: top left, top right, bottom left;\n" + "  color: pink;\n" + "}",
@@ -302,24 +341,27 @@ testRule(rule, {
     code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
   } ],
 
-  reject: [ {
-    code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+  // reject: [ {
+  //   code: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
+  //   fixed: "a {\n" + "  background-position: top left,\n" + "    top right,\n" + "  bottom left;\n" + "  color: pink;\n" + "}",
 
-    message: messages.expected("2 spaces"),
-    line: 3,
-    column: 5,
-  }, {
-    code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+  //   message: messages.expected("2 spaces"),
+  //   line: 3,
+  //   column: 5,
+  // }, {
+  //   code: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
+  //   fixed: "a {\n" + "  background-position: top left,\n" + "  top right,\n" + "    bottom left;\n" + "  color: pink;\n" + "}",
 
-    message: messages.expected("2 spaces"),
-    line: 4,
-    column: 5,
-  } ],
+  //   message: messages.expected("2 spaces"),
+  //   line: 4,
+  //   column: 5,
+  // } ],
 })
 
 testRule(rule, {
   ruleName,
   config: [ 2, { ignore: ["value"] } ],
+  fix: true,
 
   accept: [ {
     code: "a {\n" + "  background-position: top left, top right, bottom left;\n" + "  color: pink;\n" + "}",
@@ -333,6 +375,7 @@ testRule(rule, {
 
   reject: [{
     code: "\ta {\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "  color: pink;\n" + "}",
 
     message: messages.expected("0 spaces"),
     line: 1,
@@ -345,6 +388,7 @@ testRule(rule, {
   config: [ 2, {
     indentClosingBrace: true,
   } ],
+  fix: true,
 
   accept: [ {
     code: "a {\n" + "  color: pink;\n" + "  }",
@@ -354,11 +398,13 @@ testRule(rule, {
 
   reject: [ {
     code: "a {\n" + "  color: pink;\n" + "}",
+    fixed: "a {\n" + "  color: pink;\n" + "  }",
     message: messages.expected("2 spaces"),
     line: 3,
     column: 1,
   }, {
     code: "a {\n" + "  color: pink;\n" + "  & b {\n" + "    top: 0;\n" + "   }\n" + "  }",
+    fixed: "a {\n" + "  color: pink;\n" + "  & b {\n" + "    top: 0;\n" + "    }\n" + "  }",
     message: messages.expected("4 spaces"),
     line: 5,
     column: 4,

--- a/lib/rules/indentation/__tests__/selectors.js
+++ b/lib/rules/indentation/__tests__/selectors.js
@@ -33,68 +33,68 @@ testRule(rule, {
   } ],
 
   reject: [ {
-  //   code: "a,\n" + "  b { color: pink; }",
-  //   fixed: "a,\n" + "  b { color: pink; }",
+    code: "a,\n" + "  b { color: pink; }",
+    fixed: "a,\n" + "b { color: pink; }",
 
-  //   message: messages.expected("0 spaces"),
-  //   line: 2,
-  //   column: 3,
-  // }, {
-  //   code: "a,\n" + "b,\n" + " c { color: pink; }",
-  //   fixed: "a,\n" + "b,\n" + " c { color: pink; }",
+    message: messages.expected("0 spaces"),
+    line: 2,
+    column: 3,
+  }, {
+    code: "a,\n" + "b,\n" + " c { color: pink; }",
+    fixed: "a,\n" + "b,\n" + "c { color: pink; }",
 
-  //   message: messages.expected("0 spaces"),
-  //   line: 3,
-  //   column: 2,
-  // }, {
-  //   code: "@media print {\n" + "  a,\n" + "b { color: pink;}\n" + "}",
-  //   fixed: "@media print {\n" + "  a,\n" + "b { color: pink;}\n" + "}",
+    message: messages.expected("0 spaces"),
+    line: 3,
+    column: 2,
+  }, {
+    code: "@media print {\n" + "  a,\n" + "b { color: pink;}\n" + "}",
+    fixed: "@media print {\n" + "  a,\n" + "  b { color: pink;}\n" + "}",
 
-  //   message: messages.expected("2 spaces"),
-  //   line: 3,
-  //   column: 1,
-  // }, {
-  //   code: "@media print {\n" + "  a,\n" + "   b { color: pink;}\n" + "}",
-  //   fixed: "@media print {\n" + "  a,\n" + "   b { color: pink;}\n" + "}",
+    message: messages.expected("2 spaces"),
+    line: 3,
+    column: 1,
+  }, {
+    code: "@media print {\n" + "  a,\n" + "   b { color: pink;}\n" + "}",
+    fixed: "@media print {\n" + "  a,\n" + "  b { color: pink;}\n" + "}",
 
-  //   message: messages.expected("2 spaces"),
-  //   line: 3,
-  //   column: 4,
-  // }, {
+    message: messages.expected("2 spaces"),
+    line: 3,
+    column: 4,
+  }, {
     code: "@media print {\n" + "   a,\n" + "  b { color: pink;}\n" + "}",
     fixed: "@media print {\n" + "  a,\n" + "  b { color: pink;}\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 4,
-  // }, {
-  //   code: "a,\r\n" + "  b { color: pink; }",
-  //   fixed: "a,\r\n" + "  b { color: pink; }",
+  }, {
+    code: "a,\r\n" + "  b { color: pink; }",
+    fixed: "a,\r\n" + "b { color: pink; }",
 
-  //   message: messages.expected("0 spaces"),
-  //   line: 2,
-  //   column: 3,
-  // }, {
-  //   code: "a,\r\n" + "b,\r\n" + " c { color: pink; }",
-  //   fixed: "a,\r\n" + "b,\r\n" + " c { color: pink; }",
+    message: messages.expected("0 spaces"),
+    line: 2,
+    column: 3,
+  }, {
+    code: "a,\r\n" + "b,\r\n" + " c { color: pink; }",
+    fixed: "a,\r\n" + "b,\r\n" + "c { color: pink; }",
 
-  //   message: messages.expected("0 spaces"),
-  //   line: 3,
-  //   column: 2,
-  // }, {
-  //   code: "@media print {\r\n" + "  a,\r\n" + "b { color: pink;}\r\n" + "}",
-  //   fixed: "@media print {\r\n" + "  a,\r\n" + "b { color: pink;}\r\n" + "}",
+    message: messages.expected("0 spaces"),
+    line: 3,
+    column: 2,
+  }, {
+    code: "@media print {\r\n" + "  a,\r\n" + "b { color: pink;}\r\n" + "}",
+    fixed: "@media print {\r\n" + "  a,\r\n" + "  b { color: pink;}\r\n" + "}",
 
-  //   message: messages.expected("2 spaces"),
-  //   line: 3,
-  //   column: 1,
-  // }, {
-  //   code: "@media print {\r\n" + "  a,\r\n" + "   b { color: pink;}\r\n" + "}",
-  //   fixed: "@media print {\r\n" + "  a,\r\n" + "   b { color: pink;}\r\n" + "}",
+    message: messages.expected("2 spaces"),
+    line: 3,
+    column: 1,
+  }, {
+    code: "@media print {\r\n" + "  a,\r\n" + "   b { color: pink;}\r\n" + "}",
+    fixed: "@media print {\r\n" + "  a,\r\n" + "  b { color: pink;}\r\n" + "}",
 
-  //   message: messages.expected("2 spaces"),
-  //   line: 3,
-  //   column: 4,
+    message: messages.expected("2 spaces"),
+    line: 3,
+    column: 4,
   }, {
     code: "@media print {\r\n" + "   a,\r\n" + "  b { color: pink;}\r\n" + "}",
     fixed: "@media print {\r\n" + "  a,\r\n" + "  b { color: pink;}\r\n" + "}",

--- a/lib/rules/indentation/__tests__/selectors.js
+++ b/lib/rules/indentation/__tests__/selectors.js
@@ -10,6 +10,7 @@ testRule(rule, {
   ruleName,
   config: [2],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [ {
     code: "a { color: pink; }",
@@ -32,61 +33,71 @@ testRule(rule, {
   } ],
 
   reject: [ {
-    code: "a,\n" + "  b { color: pink; }",
+  //   code: "a,\n" + "  b { color: pink; }",
+  //   fixed: "a,\n" + "  b { color: pink; }",
 
-    message: messages.expected("0 spaces"),
-    line: 2,
-    column: 3,
-  }, {
-    code: "a,\n" + "b,\n" + " c { color: pink; }",
+  //   message: messages.expected("0 spaces"),
+  //   line: 2,
+  //   column: 3,
+  // }, {
+  //   code: "a,\n" + "b,\n" + " c { color: pink; }",
+  //   fixed: "a,\n" + "b,\n" + " c { color: pink; }",
 
-    message: messages.expected("0 spaces"),
-    line: 3,
-    column: 2,
-  }, {
-    code: "@media print {\n" + "  a,\n" + "b { color: pink;}\n" + "}",
+  //   message: messages.expected("0 spaces"),
+  //   line: 3,
+  //   column: 2,
+  // }, {
+  //   code: "@media print {\n" + "  a,\n" + "b { color: pink;}\n" + "}",
+  //   fixed: "@media print {\n" + "  a,\n" + "b { color: pink;}\n" + "}",
 
-    message: messages.expected("2 spaces"),
-    line: 3,
-    column: 1,
-  }, {
-    code: "@media print {\n" + "  a,\n" + "   b { color: pink;}\n" + "}",
+  //   message: messages.expected("2 spaces"),
+  //   line: 3,
+  //   column: 1,
+  // }, {
+  //   code: "@media print {\n" + "  a,\n" + "   b { color: pink;}\n" + "}",
+  //   fixed: "@media print {\n" + "  a,\n" + "   b { color: pink;}\n" + "}",
 
-    message: messages.expected("2 spaces"),
-    line: 3,
-    column: 4,
-  }, {
+  //   message: messages.expected("2 spaces"),
+  //   line: 3,
+  //   column: 4,
+  // }, {
     code: "@media print {\n" + "   a,\n" + "  b { color: pink;}\n" + "}",
+    fixed: "@media print {\n" + "  a,\n" + "  b { color: pink;}\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,
     column: 4,
-  }, {
-    code: "a,\r\n" + "  b { color: pink; }",
+  // }, {
+  //   code: "a,\r\n" + "  b { color: pink; }",
+  //   fixed: "a,\r\n" + "  b { color: pink; }",
 
-    message: messages.expected("0 spaces"),
-    line: 2,
-    column: 3,
-  }, {
-    code: "a,\r\n" + "b,\r\n" + " c { color: pink; }",
+  //   message: messages.expected("0 spaces"),
+  //   line: 2,
+  //   column: 3,
+  // }, {
+  //   code: "a,\r\n" + "b,\r\n" + " c { color: pink; }",
+  //   fixed: "a,\r\n" + "b,\r\n" + " c { color: pink; }",
 
-    message: messages.expected("0 spaces"),
-    line: 3,
-    column: 2,
-  }, {
-    code: "@media print {\r\n" + "  a,\r\n" + "b { color: pink;}\r\n" + "}",
+  //   message: messages.expected("0 spaces"),
+  //   line: 3,
+  //   column: 2,
+  // }, {
+  //   code: "@media print {\r\n" + "  a,\r\n" + "b { color: pink;}\r\n" + "}",
+  //   fixed: "@media print {\r\n" + "  a,\r\n" + "b { color: pink;}\r\n" + "}",
 
-    message: messages.expected("2 spaces"),
-    line: 3,
-    column: 1,
-  }, {
-    code: "@media print {\r\n" + "  a,\r\n" + "   b { color: pink;}\r\n" + "}",
+  //   message: messages.expected("2 spaces"),
+  //   line: 3,
+  //   column: 1,
+  // }, {
+  //   code: "@media print {\r\n" + "  a,\r\n" + "   b { color: pink;}\r\n" + "}",
+  //   fixed: "@media print {\r\n" + "  a,\r\n" + "   b { color: pink;}\r\n" + "}",
 
-    message: messages.expected("2 spaces"),
-    line: 3,
-    column: 4,
+  //   message: messages.expected("2 spaces"),
+  //   line: 3,
+  //   column: 4,
   }, {
     code: "@media print {\r\n" + "   a,\r\n" + "  b { color: pink;}\r\n" + "}",
+    fixed: "@media print {\r\n" + "  a,\r\n" + "  b { color: pink;}\r\n" + "}",
 
     message: messages.expected("2 spaces"),
     line: 2,

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -211,6 +211,9 @@ const rule = function (space, options, context) {
         return
       }
 
+      // Data for current node fixing
+      const fixPositions = []
+
       // `outsideParens` because function arguments and also non-standard parenthesized stuff like
       // Sass maps are ignored to allow for arbitrary indentation
       let parentheticalDepth = 0
@@ -290,17 +293,88 @@ const rule = function (space, options, context) {
         }
 
         const afterNewlineSpace = afterNewlineSpaceMatches[1]
+        const expectedIndentation = _.repeat(indentChar, expectedIndentLevel)
 
-        if (afterNewlineSpace !== _.repeat(indentChar, expectedIndentLevel)) {
-          report({
-            message: messages.expected(legibleExpectation(expectedIndentLevel)),
-            node,
-            index: match.startIndex + afterNewlineSpace.length + 1,
-            result,
-            ruleName,
-          })
+        if (afterNewlineSpace !== expectedIndentation) {
+          if (context.fix) {
+            // Adding fixes position in reverse order, because if we change indent in the beginning of the string it will break all following fixes for that string
+            fixPositions.unshift({
+              expectedIndentation,
+              currentIndentation: afterNewlineSpace,
+              startIndex: match.startIndex,
+            })
+          } else {
+            report({
+              message: messages.expected(legibleExpectation(expectedIndentLevel)),
+              node,
+              index: match.startIndex + afterNewlineSpace.length + 1,
+              result,
+              ruleName,
+            })
+          }
         }
       })
+
+      if (fixPositions.length) {
+        if (node.type === "rule") {
+          fixPositions.forEach(function (fixPosition) {
+            node.selector = replaceIndentation(
+              node.selector,
+              fixPosition.currentIndentation,
+              fixPosition.expectedIndentation,
+              fixPosition.startIndex
+            )
+          })
+        }
+
+        if (node.type === "decl") {
+          const declProp = node.prop
+          const declBetween = node.raws.between
+
+          fixPositions.forEach(function (fixPosition) {
+            if (fixPosition.startIndex < (declProp.length + declBetween.length)) {
+              node.raws.between = replaceIndentation(
+                declBetween,
+                fixPosition.currentIndentation,
+                fixPosition.expectedIndentation,
+                fixPosition.startIndex - declProp.length
+              )
+            } else {
+              node.value = replaceIndentation(
+                node.value,
+                fixPosition.currentIndentation,
+                fixPosition.expectedIndentation,
+                fixPosition.startIndex - declProp.length - declBetween.length
+              )
+            }
+          })
+        }
+
+        if (node.type === "atrule") {
+          const atRuleName = node.name
+          const atRuleAfterName = node.raws.afterName
+          const atRuleParams = node.params
+
+          fixPositions.forEach(function (fixPosition) {
+            // 1 — it's a @ length
+            if (fixPosition.startIndex < (1 + atRuleName.length + atRuleAfterName.length)) {
+              node.raws.afterName = replaceIndentation(
+                atRuleAfterName,
+                fixPosition.currentIndentation,
+                fixPosition.expectedIndentation,
+                fixPosition.startIndex - atRuleName.length - 1
+              )
+            } else {
+              node.params = replaceIndentation(
+                atRuleParams,
+                fixPosition.currentIndentation,
+                fixPosition.expectedIndentation,
+                fixPosition.startIndex - atRuleName.length - atRuleAfterName.length - 1
+              )
+            }
+          })
+        }
+      }
     }
   }
 
@@ -332,6 +406,14 @@ function fixIndentation(str, whitespace) {
   const stringStart = str.slice(0, str.lastIndexOf("\n") + 1)
 
   return stringStart + whitespace + stringEnd
+}
+
+function replaceIndentation(input, searchString, replaceString, startIndex) {
+  const offset = startIndex + 1
+  const stringStart = input.slice(0, offset)
+  const stringEnd = input.slice(offset + searchString.length)
+
+  return stringStart + replaceString + stringEnd
 }
 
 rule.ruleName = ruleName

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -19,8 +19,8 @@ const messages = ruleMessages(ruleName, {
  *   keyword "tab" for single `\t`
  * @param {object} [options]
  */
-const rule = function (space) {
-  const options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {}
+const rule = function (space, options) {
+  options = options || {}
 
   const isTab = space === "tab"
   const indentChar = isTab ? "\t" : _.repeat(" ", space)
@@ -73,14 +73,19 @@ const rule = function (space) {
       // there is no "indentation" to check.)
       const inspectBefore = root.first === node || before.indexOf("\n") !== -1
 
-      // Cut out any * hacks from `before`
-      before = before[before.length - 1] === "*" || before[before.length - 1] === "_" ? before.slice(0, before.length - 1) : before
+      // Cut out any * and _ hacks from `before`
+      if (before[before.length - 1] === "*" || before[before.length - 1] === "_") {
+        before = before.slice(0, before.length - 1)
+      }
 
       // Inspect whitespace in the `before` string that is
       // *after* the *last* newline character,
       // because anything besides that is not indentation for this node:
       // it is some other kind of separation, checked by some separate rule
-      if (inspectBefore && before.slice(before.lastIndexOf("\n") + 1) !== expectedWhitespace) {
+      if (
+        inspectBefore
+        && before.slice(before.lastIndexOf("\n") + 1) !== expectedWhitespace
+      ) {
         report({
           message: messages.expected(legibleExpectation(nodeLevel)),
           node,
@@ -94,7 +99,12 @@ const rule = function (space) {
       // otherwise there's no indentation involved.
       // And check `indentClosingBrace` to see if it should be indented an extra level.
       const closingBraceLevel = options.indentClosingBrace ? nodeLevel + 1 : nodeLevel
-      if (hasBlock(node) && after && after.indexOf("\n") !== -1 && after.slice(after.lastIndexOf("\n") + 1) !== _.repeat(indentChar, closingBraceLevel)) {
+      if (
+        hasBlock(node)
+        && after
+        && after.indexOf("\n") !== -1
+        && after.slice(after.lastIndexOf("\n") + 1) !== _.repeat(indentChar, closingBraceLevel)
+      ) {
         report({
           message: messages.expected(legibleExpectation(closingBraceLevel)),
           node,
@@ -120,8 +130,8 @@ const rule = function (space) {
       }
     })
 
-    function indentationLevel(node) {
-      const level = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0
+    function indentationLevel(node, level) {
+      level = level || 0
 
       if (node.parent.type === "root") {
         return level
@@ -137,7 +147,11 @@ const rule = function (space) {
       // If options.except includes "block",
       // blocks are taken down one from their calculated level
       // (all blocks are the same level as their parents)
-      if (optionsMatches(options, "except", "block") && (node.type === "rule" || node.type === "atrule") && hasBlock(node)) {
+      if (
+        optionsMatches(options, "except", "block")
+        && (node.type === "rule" || node.type === "atrule")
+        && hasBlock(node)
+      ) {
         calculatedLevel--
       }
 
@@ -176,7 +190,10 @@ const rule = function (space) {
 
       // @nest rules should be treated like regular rules, not expected
       // to have their params (selectors) indented
-      const paramLevel = optionsMatches(options, "except", "param") || atRule.name === "nest" ? ruleLevel : ruleLevel + 1
+      const paramLevel = optionsMatches(options, "except", "param") || atRule.name === "nest"
+        ? ruleLevel
+        : ruleLevel + 1
+
       checkMultilineBit(beforeBlockString(atRule).trim(), paramLevel, atRule)
     }
 
@@ -184,9 +201,11 @@ const rule = function (space) {
       if (source.indexOf("\n") === -1) {
         return
       }
+
       // `outsideParens` because function arguments and also non-standard parenthesized stuff like
       // Sass maps are ignored to allow for arbitrary indentation
       let parentheticalDepth = 0
+
       styleSearch({
         source,
         target: "\n",
@@ -194,25 +213,36 @@ const rule = function (space) {
       }, (match, matchCount) => {
         const precedesClosingParenthesis = /^[ \t]*\)/.test(source.slice(match.startIndex + 1))
 
-        if (optionsMatches(options, "ignore", "inside-parens") && (precedesClosingParenthesis || match.insideParens)) {
+        if (
+          optionsMatches(options, "ignore", "inside-parens")
+          && (precedesClosingParenthesis || match.insideParens)
+        ) {
           return
         }
 
         let expectedIndentLevel = newlineIndentLevel
+
         // Modififications for parenthetical content
-        if (!optionsMatches(options, "ignore", "inside-parens") && match.insideParens) {
+        if (
+          !optionsMatches(options, "ignore", "inside-parens")
+          && match.insideParens
+        ) {
           // If the first match in is within parentheses, reduce the parenthesis penalty
           if (matchCount === 1) parentheticalDepth -= 1
+
           // Account for windows line endings
           let newlineIndex = match.startIndex
           if (source[match.startIndex - 1] === "\r") {
             newlineIndex--
           }
+
           const followsOpeningParenthesis = /\([ \t]*$/.test(source.slice(0, newlineIndex))
           if (followsOpeningParenthesis) {
             parentheticalDepth += 1
           }
+
           expectedIndentLevel += parentheticalDepth
+
           if (precedesClosingParenthesis) {
             parentheticalDepth -= 1
           }
@@ -245,9 +275,11 @@ const rule = function (space) {
         // check that the whitespace characters (excluding newlines) before the first
         // non-whitespace character equal the expected indentation
         const afterNewlineSpaceMatches = /^([ \t]*)\S/.exec(source.slice(match.startIndex + 1))
+
         if (!afterNewlineSpaceMatches) {
           return
         }
+
         const afterNewlineSpace = afterNewlineSpaceMatches[1]
 
         if (afterNewlineSpace !== _.repeat(indentChar, expectedIndentLevel)) {
@@ -266,6 +298,7 @@ const rule = function (space) {
   function legibleExpectation(level) {
     const count = isTab ? level : level * space
     const quantifiedWarningWord = count === 1 ? warningWord : warningWord + "s"
+
     return `${count} ${quantifiedWarningWord}`
   }
 }

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
  *   keyword "tab" for single `\t`
  * @param {object} [options]
  */
-const rule = function (space, options) {
+const rule = function (space, options, context) {
   options = options || {}
 
   const isTab = space === "tab"
@@ -86,12 +86,16 @@ const rule = function (space, options) {
         inspectBefore
         && before.slice(before.lastIndexOf("\n") + 1) !== expectedWhitespace
       ) {
-        report({
-          message: messages.expected(legibleExpectation(nodeLevel)),
-          node,
-          result,
-          ruleName,
-        })
+        if (context.fix) {
+          node.raws.before = fixIndentation(node.raws.before, expectedWhitespace)
+        } else {
+          report({
+            message: messages.expected(legibleExpectation(nodeLevel)),
+            node,
+            result,
+            ruleName,
+          })
+        }
       }
 
       // Only blocks have the `after` string to check.
@@ -99,19 +103,24 @@ const rule = function (space, options) {
       // otherwise there's no indentation involved.
       // And check `indentClosingBrace` to see if it should be indented an extra level.
       const closingBraceLevel = options.indentClosingBrace ? nodeLevel + 1 : nodeLevel
+      const expectedClosingBraceIndentation = _.repeat(indentChar, closingBraceLevel)
       if (
         hasBlock(node)
         && after
         && after.indexOf("\n") !== -1
-        && after.slice(after.lastIndexOf("\n") + 1) !== _.repeat(indentChar, closingBraceLevel)
+        && after.slice(after.lastIndexOf("\n") + 1) !== expectedClosingBraceIndentation
       ) {
-        report({
-          message: messages.expected(legibleExpectation(closingBraceLevel)),
-          node,
-          index: node.toString().length - 1,
-          result,
-          ruleName,
-        })
+        if (context.fix) {
+          node.raws.after = fixIndentation(node.raws.after, expectedClosingBraceIndentation)
+        } else {
+          report({
+            message: messages.expected(legibleExpectation(closingBraceLevel)),
+            node,
+            index: node.toString().length - 1,
+            result,
+            ruleName,
+          })
+        }
       }
 
       // If this is a declaration, check the value
@@ -301,6 +310,28 @@ const rule = function (space, options) {
 
     return `${count} ${quantifiedWarningWord}`
   }
+}
+
+function fixIndentation(str, whitespace) {
+  if (!_.isString(str)) {
+    return str
+  }
+
+  const strLength = str.length
+
+  if (!strLength) {
+    return str
+  }
+
+  let stringEnd = str[strLength - 1]
+
+  if (stringEnd !== "*" && stringEnd !== "_") {
+    stringEnd = ""
+  }
+
+  const stringStart = str.slice(0, str.lastIndexOf("\n") + 1)
+
+  return stringStart + whitespace + stringEnd
 }
 
 rule.ruleName = ruleName

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -254,7 +254,6 @@ module.exports = {
   "function-url-scheme-whitelist": functionUrlSchemeWhitelist,
   "function-whitelist": functionWhitelist,
   "function-whitespace-after": functionWhitespaceAfter,
-  "indentation": indentation, // eslint-disable-line object-shorthand
   "keyframe-declaration-no-important": keyframeDeclarationNoImportant,
   "length-zero-no-unit": lengthZeroNoUnit,
   "max-empty-lines": maxEmptyLines,
@@ -354,4 +353,5 @@ module.exports = {
   "value-list-comma-space-before": valueListCommaSpaceBefore,
   "value-list-max-empty-lines": valueListMaxEmptyLines,
   "value-no-vendor-prefix": valueNoVendorPrefix,
+  "indentation": indentation, /* Placed here for better autofixing */ // eslint-disable-line object-shorthand
 }

--- a/lib/rules/rule-empty-line-before/README.md
+++ b/lib/rules/rule-empty-line-before/README.md
@@ -12,7 +12,7 @@ b {}  /* ↑ */
 
 If the rule is the very first node in a stylesheet then it is ignored.
 
-The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](../indentation/README.md) rule for better autofixing results with this rule.
 
 ## Options
 


### PR DESCRIPTION
I've made autofixing for most use cases. These use cases was analyzed with PostCSS AST, so I could easily apply fixes. But for big number of other use cases this rule uses `style-search`. It's used for indentation inside declaration values, selectors, and at-rule parameters.

I haven't figured out how to deal with this yet. I've commented all `reject` cases which isn't covered by current autofixing.

Any suggestions how to deal with this problem?

Also there is a problem with Less syntax. I haven't investigate what causes the problem yet.

In order to finish this PR we need:

- [x] Finish autofixing for all other use cases
- [x] Add a note to rule's readme and rules list about autofixing
- [x] Add a note to `*-empty-line-before` rules with recommendation to enable `indentation` rule

P. S. It was total surprise to me, that this rule has secondary options 😯

<details>
<summary>Error log with Less mixins and autofixing</summary>

Semicolon gets removed.

```
 FAIL  lib/rules/indentation/__tests__/functions.js
  ● indentation › accept › Less mixin with multi-line arguments

    expect(received).toBe(expected)

    Expected value to be (using ===):
      ".foo {
      .mixin(
        @foo,
        @bar,
        @baz
      );
    }"
    Received:
      ".foo {
      .mixin(
        @foo,
        @bar,
        @baz
      )
    }"

    Difference:

    - Expected
    + Received

     .foo {
       .mixin(
         @foo,
         @bar,
         @baz
    -  );
    +  )
     }

      at stylelint.then.output (jest-setup.js:59:35)

  ● indentation › accept › Less mixin with multi-line arguments

    Error
      Error: expect(received).toBe(expected)

      Expected value to be (using ===):
        ".foo {
        .mixin(
          @foo,
          @bar,
          @baz
        );
      }"
      Received:
        ".foo {
        .mixin(
          @foo,
          @bar,
          @baz
        )
      }"

      Difference:

      - Expected
      + Received

       .foo {
         .mixin(
           @foo,
           @bar,
           @baz
      -  );
      +  )
       }
      at stylelint.then.output (jest-setup.js:59:35)
```

</details>
