### PR TITLE
chore: Update `sinon` to `2.1.0`

### DIFF
--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -298,7 +298,7 @@ describe("standalone with deprecations", () => {
   let ruleDefinitionsStub, results, output
 
   beforeEach(() => {
-    ruleDefinitionsStub = sinon.stub(ruleDefinitions, "block-no-empty", () => {
+    ruleDefinitionsStub = sinon.stub(ruleDefinitions, "block-no-empty").callsFake(() => {
       return (root, result) => {
         result.warn("Some deprecation", {
           stylelintType: "deprecation",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "remark-preset-lint-recommended": "^2.0.0",
     "remark-validate-links": "^6.0.0",
     "request": "^2.69.0",
-    "sinon": "^2.0.0",
+    "sinon": "^2.1.0",
     "strip-ansi": "^3.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Update `sinon` to `2.1.0` - https://www.npmjs.com/package/sinon

Resolves the the following issue when running the tests:

```shell
 PASS  lib/__tests__/standalone.test.js
  ● Console

    console.info node_modules/sinon/lib/sinon/util/core/deprecated.js:27
      sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
       Use stub(obj, 'meth').callsFake(fn).
       Codemod available at https://github.com/hurrymaplelad/sinon-codemod

```

Code changes in `lib/__tests__/standalone.test.js` provided by the codemod noted above