### PR TITLE
Fixed: ignore less guards in `selector-descendant-combinator-no-non-space`.

### DIFF
--- a/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
@@ -54,3 +54,15 @@ testRule(rule, {
     column: 5,
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "less",
+
+  accept: [ {
+    code: ":hover when (@variable = true) { color: red; }",
+  }, {
+    code: "a:hover when (@variable = true) { color: red; }",
+  } ],
+})

--- a/lib/utils/__tests__/isStandardSyntaxRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxRule.test.js
@@ -10,6 +10,16 @@ describe("isStandardSyntaxRule", () => {
       expect(isStandardSyntaxRule(rule)).toBeTruthy()
     })
   })
+  it("when type selector before selector", () => {
+    return rules("when a {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeTruthy()
+    })
+  })
+  it("when type selector after selector", () => {
+    return rules("a when {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeTruthy()
+    })
+  })
   it("pseudo-class", () => {
     return rules("a:last-child {}", rule => {
       expect(isStandardSyntaxRule(rule)).toBeTruthy()
@@ -97,6 +107,51 @@ describe("isStandardSyntaxRule", () => {
   })
   it("less detached rulesets", () => {
     return lessRules("@foo: {};", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("less guarded namespaces", () => {
+    return lessRules("#namespace when (@mode=huge) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("mixin guards", () => {
+    return lessRules(".mixin (@variable) when (@variable = 10px) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("css guards", () => {
+    return lessRules(".foo() when (@variable = true) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("css guards without spaces", () => {
+    return lessRules(".foo()when(@variable = true) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("css guards with multiple spaces", () => {
+    return lessRules(".foo()   when   (@variable = true) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("css guards with newlines", () => {
+    return lessRules(".foo()\nwhen\n(@variable = true) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("css guards with CLRF", () => {
+    return lessRules(".foo()\r\nwhen\r\n(@variable = true) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("css guards with parenthesis", () => {
+    return lessRules(".foo() when (default()) {}", rule => {
+      expect(isStandardSyntaxRule(rule)).toBeFalsy()
+    })
+  })
+  it("css guards with not", () => {
+    return lessRules(".foo() when not (@variable = true) {}", rule => {
       expect(isStandardSyntaxRule(rule)).toBeFalsy()
     })
   })

--- a/lib/utils/isStandardSyntaxRule.js
+++ b/lib/utils/isStandardSyntaxRule.js
@@ -37,6 +37,11 @@ module.exports = function (rule/*: Object*/)/*: boolean*/ {
     return false
   }
 
+  // Less guards
+  if ((/when\s+(not\s+)*\(/).test(selector)) {
+    return false
+  }
+
   // Ignore Scss nested properties
   if (selector.slice(-1) === ":") {
     return false


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2110

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
