### PR TITLE
Correct --allow-empty-input alias in CLI help

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -134,7 +134,7 @@ const meowOptions = {
 
         Force enabling/disabling of color.
 
-      --allow-empty-input, -aei
+      --allow-empty-input, --aei
 
         If no files match glob pattern, exits without throwing an error.
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a teeny-tiny CLI help text fix. But it threw me off for a second 😄 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
