### PR TITLE
Add autofix to *-no-vendor-prefix

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -116,7 +116,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 #### Value
 
--   [`value-no-vendor-prefix`](../../lib/rules/value-no-vendor-prefix/README.md): Disallow vendor prefixes for values.
+-   [`value-no-vendor-prefix`](../../lib/rules/value-no-vendor-prefix/README.md): Disallow vendor prefixes for values (Autofixable).
 
 #### Custom property
 
@@ -125,7 +125,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 #### Property
 
 -   [`property-blacklist`](../../lib/rules/property-blacklist/README.md): Specify a blacklist of disallowed properties.
--   [`property-no-vendor-prefix`](../../lib/rules/property-no-vendor-prefix/README.md): Disallow vendor prefixes for properties.
+-   [`property-no-vendor-prefix`](../../lib/rules/property-no-vendor-prefix/README.md): Disallow vendor prefixes for properties (Autofixable).
 -   [`property-whitelist`](../../lib/rules/property-whitelist/README.md): Specify a whitelist of allowed properties.
 
 #### Declaration
@@ -161,7 +161,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`selector-max-universal`](../../lib/rules/selector-max-universal/README.md): Limit the number of universal selectors in a selector.
 -   [`selector-nested-pattern`](../../lib/rules/selector-nested-pattern/README.md): Specify a pattern for the selectors of rules nested within rules.
 -   [`selector-no-qualifying-type`](../../lib/rules/selector-no-qualifying-type/README.md): Disallow qualifying a selector by type.
--   [`selector-no-vendor-prefix`](../../lib/rules/selector-no-vendor-prefix/README.md): Disallow vendor prefixes for selectors.
+-   [`selector-no-vendor-prefix`](../../lib/rules/selector-no-vendor-prefix/README.md): Disallow vendor prefixes for selectors (Autofixable).
 -   [`selector-pseudo-class-blacklist`](../../lib/rules/selector-pseudo-class-blacklist/README.md): Specify a blacklist of disallowed pseudo-class selectors.
 -   [`selector-pseudo-class-whitelist`](../../lib/rules/selector-pseudo-class-whitelist/README.md): Specify a whitelist of allowed pseudo-class selectors.
 -   [`selector-pseudo-element-blacklist`](../../lib/rules/selector-pseudo-element-blacklist/README.md): Specify a blacklist of disallowed pseudo-element selectors.
@@ -170,7 +170,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 #### Media feature
 
 -   [`media-feature-name-blacklist`](../../lib/rules/media-feature-name-blacklist/README.md): Specify a blacklist of disallowed media feature names.
--   [`media-feature-name-no-vendor-prefix`](../../lib/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names.
+-   [`media-feature-name-no-vendor-prefix`](../../lib/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names (Autofixable).
 -   [`media-feature-name-whitelist`](../../lib/rules/media-feature-name-whitelist/README.md): Specify a whitelist of allowed media feature names.
 
 #### Custom media
@@ -180,7 +180,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 #### At-rule
 
 -   [`at-rule-blacklist`](../../lib/rules/at-rule-blacklist/README.md): Specify a blacklist of disallowed at-rules.
--   [`at-rule-no-vendor-prefix`](../../lib/rules/at-rule-no-vendor-prefix/README.md): Disallow vendor prefixes for at-rules.
+-   [`at-rule-no-vendor-prefix`](../../lib/rules/at-rule-no-vendor-prefix/README.md): Disallow vendor prefixes for at-rules (Autofixable).
 -   [`at-rule-whitelist`](../../lib/rules/at-rule-whitelist/README.md): Specify a whitelist of allowed at-rules.
 
 #### Comment

--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -8,6 +8,8 @@ Disallow vendor prefixes for at-rules.
  * These prefixes */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/at-rule-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/at-rule-no-vendor-prefix/__tests__/index.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName];
 testRule(rule, {
   ruleName,
   config: [true],
+  fix: true,
 
   accept: [
     {
@@ -21,23 +22,34 @@ testRule(rule, {
 
   reject: [
     {
+      code:
+        "@-webkit-keyframes { 0% { top: 0; } } @keyframes { 0% { top: 0; } }",
+      fixed: "@keyframes { 0% { top: 0; } }",
+      message: messages.rejected("-webkit-keyframes")
+    },
+    {
       code: "@-webkit-keyframes { 0% { top: 0; } }",
+      fixed: "@keyframes { 0% { top: 0; } }",
       message: messages.rejected("-webkit-keyframes")
     },
     {
       code: "@-wEbKiT-kEyFrAmEs { 0% { top: 0; } }",
+      fixed: "@kEyFrAmEs { 0% { top: 0; } }",
       message: messages.rejected("-wEbKiT-kEyFrAmEs")
     },
     {
       code: "@-WEBKIT-KEYFRAMES { 0% { top: 0; } }",
+      fixed: "@KEYFRAMES { 0% { top: 0; } }",
       message: messages.rejected("-WEBKIT-KEYFRAMES")
     },
     {
       code: "@-moz-keyframes { 0% { top: 0; } }",
+      fixed: "@keyframes { 0% { top: 0; } }",
       message: messages.rejected("-moz-keyframes")
     },
     {
       code: "@-ms-viewport { orientation: landscape; }",
+      fixed: "@viewport { orientation: landscape; }",
       message: messages.rejected("-ms-viewport")
     }
   ]

--- a/lib/rules/at-rule-no-vendor-prefix/index.js
+++ b/lib/rules/at-rule-no-vendor-prefix/index.js
@@ -4,6 +4,7 @@ const isAutoprefixable = require("../../utils/isAutoprefixable");
 const isStandardSyntaxAtRule = require("../../utils/isStandardSyntaxAtRule");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
+const unprefixAtRule = require("postcss-unprefix/lib/clearAtRule");
 const validateOptions = require("../../utils/validateOptions");
 
 const ruleName = "at-rule-no-vendor-prefix";
@@ -12,9 +13,11 @@ const messages = ruleMessages(ruleName, {
   rejected: p => `Unexpected vendor-prefixed at-rule "@${p}"`
 });
 
-const rule = function(actual) {
+const rule = function(expectation, options, context) {
   return function(root, result) {
-    const validOptions = validateOptions(result, ruleName, { actual });
+    const validOptions = validateOptions(result, ruleName, {
+      actual: expectation
+    });
     if (!validOptions) {
       return;
     }
@@ -32,6 +35,14 @@ const rule = function(actual) {
 
       if (!isAutoprefixable.atRuleName(name)) {
         return;
+      }
+
+      // Fix
+      if (context.fix) {
+        unprefixAtRule(atRule);
+        if (!atRule.parent || atRule.name !== atRule) {
+          return;
+        }
       }
 
       report({

--- a/lib/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/lib/rules/media-feature-name-no-vendor-prefix/README.md
@@ -10,6 +10,8 @@ Disallow vendor prefixes for media feature names.
 
 Right now this rule simply checks for prefixed *resolutions*.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName];
 testRule(rule, {
   ruleName,
   config: [true],
+  fix: true,
 
   accept: [
     {
@@ -21,32 +22,45 @@ testRule(rule, {
 
   reject: [
     {
+      code:
+        "@media (min-resolution: 96dpi), (-webkit-min-device-pixel-ratio: 1`) {}",
+      fixed: "@media (min-resolution: 96dpi) {}",
+      message: messages.rejected("-webkit-min-device-pixel-ratio"),
+      line: 1,
+      column: 34
+    },
+    {
       code: "@media (-webkit-min-device-pixel-ratio: 1) {}",
-      message: messages.rejected,
+      fixed: "@media (min-resolution: 1dppx) {}",
+      message: messages.rejected("-webkit-min-device-pixel-ratio"),
       line: 1,
       column: 9
     },
     {
       code: "@media (-wEbKiT-mIn-DeViCe-PiXeL-rAtIo: 1) {}",
-      message: messages.rejected,
+      fixed: "@media (min-resolution: 1dppx) {}",
+      message: messages.rejected("-wEbKiT-mIn-DeViCe-PiXeL-rAtIo"),
       line: 1,
       column: 9
     },
     {
       code: "@media (-WEBKIT-MIN-DEVICE-PIXEL-RATIO: 1) {}",
-      message: messages.rejected,
+      fixed: "@media (min-resolution: 1dppx) {}",
+      message: messages.rejected("-WEBKIT-MIN-DEVICE-PIXEL-RATIO"),
       line: 1,
       column: 9
     },
     {
-      code: "@media\n\t(min--moz-device-pixel-ratio: 1) {}",
-      message: messages.rejected,
+      code: "@media\n\t(-moz-min-device-pixel-ratio: 1) {}",
+      fixed: "@media\n\t(min-resolution: 1dppx) {}",
+      message: messages.rejected("-moz-min-device-pixel-ratio"),
       line: 2,
       column: 3
     },
     {
       code: "@media   (-o-max-device-pixel-ratio: 1/1) {}",
-      message: messages.rejected,
+      fixed: "@media   (max-resolution: 1dppx) {}",
+      message: messages.rejected("-o-max-device-pixel-ratio"),
       line: 1,
       column: 11
     }

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.js
@@ -3,17 +3,21 @@
 const isAutoprefixable = require("../../utils/isAutoprefixable");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
+const unprefixAtRule = require("postcss-unprefix/lib/clearAtRule");
 const validateOptions = require("../../utils/validateOptions");
 
 const ruleName = "media-feature-name-no-vendor-prefix";
+const reDevicePixelRatio = /-\w+-(?:\w+-)*device-pixel-ratio\b/gi;
 
 const messages = ruleMessages(ruleName, {
-  rejected: "Unexpected vendor-prefix"
+  rejected: name => `Unexpected vendor-prefix "${name}"`
 });
 
-const rule = function(actual) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual });
+    const validOptions = validateOptions(result, ruleName, {
+      actual: expectation
+    });
     if (!validOptions) {
       return;
     }
@@ -24,21 +28,34 @@ const rule = function(actual) {
       if (!isAutoprefixable.mediaFeatureName(params)) {
         return;
       }
-      const matches = atRule.toString().match(/[a-z-]+device-pixel-ratio/gi);
+      reDevicePixelRatio.lastIndex = 0;
+      const source = atRule.toString();
+      let match;
+      function exec() {
+        return (match = reDevicePixelRatio.exec(source));
+      }
 
-      if (!matches) {
+      if (!exec()) {
         return;
       }
 
-      matches.forEach(match => {
+      // Fix
+      if (context.fix) {
+        unprefixAtRule(atRule);
+        if (!atRule.parent || atRule.name !== atRule) {
+          return;
+        }
+      }
+      do {
         report({
-          message: messages.rejected,
+          message: messages.rejected(match[0]),
           node: atRule,
-          word: match,
+          index: match.index,
+          // word: match[0],
           result,
           ruleName
         });
-      });
+      } while (exec());
     });
   };
 };

--- a/lib/rules/property-no-vendor-prefix/README.md
+++ b/lib/rules/property-no-vendor-prefix/README.md
@@ -10,6 +10,8 @@ a { -webkit-transform: scale(1); }
 
 This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a violation or not. *If you've included a vendor prefixed property that has a standard alternative, one that Autoprefixer could take care of for you, this rule will complain about it*. If, however, you use a non-standard vendor-prefixed property, one that Autoprefixer would ignore and could not provide (such as `-webkit-touch-callout`), this rule will ignore it.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/property-no-vendor-prefix/__tests__/index.js
@@ -122,23 +122,18 @@ testRule(rule, {
   accept: [
     {
       code: "a { -webkit-transform: scale(1); }",
-      fixed: "a { -webkit-transform: scale(1); }",
     },
     {
       code: "a { -moz-columns: 2; }",
-      fixed: "a { -moz-columns: 2; }",
     },
     {
       code: "a { -webkit-animation-delay: 0.5s; }",
-      fixed: "a { -webkit-animation-delay: 0.5s; }",
     },
     {
       code: "a { -webkit-ANIMATION-DeLaY: 0.5s; }",
-      fixed: "a { -webkit-ANIMATION-DeLaY: 0.5s; }",
     },
     {
       code: "a { width: 320px; }",
-      fixed: "a { width: 320px; }",
     }
   ],
   reject: [

--- a/lib/rules/property-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/property-no-vendor-prefix/__tests__/index.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName];
 testRule(rule, {
   ruleName,
   config: [true],
+  fix: true,
 
   accept: [
     {
@@ -44,48 +45,56 @@ testRule(rule, {
   reject: [
     {
       code: "a { -webkit-transform: scale(1); }",
+      fixed: "a { transform: scale(1); }",
       message: messages.rejected("-webkit-transform"),
       line: 1,
       column: 5
     },
     {
       code: "a { -wEbKiT-tRaNsFoRm: scale(1); }",
+      fixed: "a { transform: scale(1); }",
       message: messages.rejected("-wEbKiT-tRaNsFoRm"),
       line: 1,
       column: 5
     },
     {
       code: "a { -WEBKIT-TRANSFORM: scale(1); }",
+      fixed: "a { transform: scale(1); }",
       message: messages.rejected("-WEBKIT-TRANSFORM"),
       line: 1,
       column: 5
     },
     {
       code: "a { -webkit-transform: scale(1); transform: scale(1); }",
+      fixed: "a { transform: scale(1); }",
       message: messages.rejected("-webkit-transform"),
       line: 1,
       column: 5
     },
     {
       code: "a { transform: scale(1); -webkit-transform: scale(1); }",
+      fixed: "a { transform: scale(1); }",
       message: messages.rejected("-webkit-transform"),
       line: 1,
       column: 26
     },
     {
       code: "a { -moz-transition: all 3s; }",
+      fixed: "a { transition: all 3s; }",
       message: messages.rejected("-moz-transition"),
       line: 1,
       column: 5
     },
     {
       code: "a { -moz-columns: 2; }",
+      fixed: "a { columns: 2; }",
       message: messages.rejected("-moz-columns"),
       line: 1,
       column: 5
     },
     {
       code: "a { -o-columns: 2; }",
+      fixed: "a { columns: 2; }",
       description: "mistaken prefix",
       message: messages.rejected("-o-columns"),
       line: 1,
@@ -93,6 +102,7 @@ testRule(rule, {
     },
     {
       code: "a { -ms-interpolation-mode: nearest-neighbor; }",
+      fixed: "a { image-rendering: pixelated; }",
       description: '"hack" prefix',
       message: messages.rejected("-ms-interpolation-mode"),
       line: 1,
@@ -107,39 +117,48 @@ testRule(rule, {
     true,
     { ignoreProperties: ["transform", "columns", "/^animation-/i"] }
   ],
+  fix: true,
 
   accept: [
     {
-      code: "a { -webkit-transform: scale(1); }"
+      code: "a { -webkit-transform: scale(1); }",
+      fixed: "a { -webkit-transform: scale(1); }",
     },
     {
-      code: "a { -moz-columns: 2; }"
+      code: "a { -moz-columns: 2; }",
+      fixed: "a { -moz-columns: 2; }",
     },
     {
-      code: "a { -webkit-animation-delay: 0.5s; }"
+      code: "a { -webkit-animation-delay: 0.5s; }",
+      fixed: "a { -webkit-animation-delay: 0.5s; }",
     },
     {
-      code: "a { -webkit-ANIMATION-DeLaY: 0.5s; }"
+      code: "a { -webkit-ANIMATION-DeLaY: 0.5s; }",
+      fixed: "a { -webkit-ANIMATION-DeLaY: 0.5s; }",
     },
     {
-      code: "a { width: 320px; }"
+      code: "a { width: 320px; }",
+      fixed: "a { width: 320px; }",
     }
   ],
   reject: [
     {
       code: "a { -webkit-border-radius: 10px; }",
+      fixed: "a { border-radius: 10px; }",
       message: messages.rejected("-webkit-border-radius"),
       line: 1,
       column: 5
     },
     {
       code: "a { -moz-background-size: cover; }",
+      fixed: "a { background-size: cover; }",
       message: messages.rejected("-moz-background-size"),
       line: 1,
       column: 5
     },
     {
       code: "a { -WEBKIT-tranSFoRM: translateY(-50%); }",
+      fixed: "a { transform: translateY(-50%); }",
       message: messages.rejected("-WEBKIT-tranSFoRM"),
       line: 1,
       column: 5

--- a/lib/rules/property-no-vendor-prefix/index.js
+++ b/lib/rules/property-no-vendor-prefix/index.js
@@ -6,6 +6,7 @@ const optionsMatches = require("../../utils/optionsMatches");
 const postcss = require("postcss");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
+const unprefixDecl = require("postcss-unprefix/lib/clearDecl");
 const validateOptions = require("../../utils/validateOptions");
 
 const ruleName = "property-no-vendor-prefix";
@@ -14,12 +15,14 @@ const messages = ruleMessages(ruleName, {
   rejected: property => `Unexpected vendor-prefix "${property}"`
 });
 
-const rule = function(actual, options) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(
       result,
       ruleName,
-      { actual },
+      {
+        actual: expectation
+      },
       {
         optional: true,
         actual: options,
@@ -52,6 +55,15 @@ const rule = function(actual, options) {
       if (!isAutoprefixable.property(prop)) {
         return;
       }
+
+      // Fix
+      if (context.fix) {
+        unprefixDecl(decl);
+        if (!decl.parent || decl.prop !== prop) {
+          return;
+        }
+      }
+
       report({
         message: messages.rejected(prop),
         node: decl,

--- a/lib/rules/selector-no-vendor-prefix/README.md
+++ b/lib/rules/selector-no-vendor-prefix/README.md
@@ -10,6 +10,8 @@ input::-moz-placeholder {}
 
 This rule does not blanketly condemn vendor prefixes. Instead, it uses [Autoprefixer's](https://github.com/postcss/autoprefixer) up-to-date data (from [caniuse.com](http://caniuse.com/)) to know whether a vendor prefix should cause a violation or not. *If you've included a vendor prefixed selector that has a standard alternative, one that Autoprefixer could take care of for you, this rule will complain about it*. If, however, you use a non-standard vendor-prefixed selector, one that Autoprefixer would ignore and could not provide, this rule will ignore it.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName];
 testRule(rule, {
   ruleName,
   config: [true],
+  fix: true,
 
   accept: [
     {
@@ -50,42 +51,49 @@ testRule(rule, {
   reject: [
     {
       code: ":-webkit-full-screen a {}",
+      fixed: ":fullscreen a {}",
       message: messages.rejected(":-webkit-full-screen"),
       line: 1,
       column: 1
     },
     {
       code: ":-wEbKiT-fUlL-sCrEeN a {}",
+      fixed: ":fullscreen a {}",
       message: messages.rejected(":-wEbKiT-fUlL-sCrEeN"),
       line: 1,
       column: 1
     },
     {
       code: ":-WEBKIT-FULL-SCREEN a {}",
+      fixed: ":fullscreen a {}",
       message: messages.rejected(":-WEBKIT-FULL-SCREEN"),
       line: 1,
       column: 1
     },
     {
       code: "body, :-ms-fullscreen a {}",
+      fixed: "body, :fullscreen a {}",
       message: messages.rejected(":-ms-fullscreen"),
       line: 1,
       column: 7
     },
     {
       code: "input:-moz-placeholder, input::placeholder { color: pink; }",
+      fixed: "input::placeholder { color: pink; }",
       message: messages.rejected(":-moz-placeholder"),
       line: 1,
       column: 6
     },
     {
       code: "input::-moz-placeholder { color: pink; }",
+      fixed: "input::placeholder { color: pink; }",
       message: messages.rejected("::-moz-placeholder"),
       line: 1,
       column: 6
     },
     {
       code: "input::-webkit-input-placeholder { color: pink; }",
+      fixed: "input::placeholder { color: pink; }",
       message: messages.rejected("::-webkit-input-placeholder")
     }
   ]

--- a/lib/rules/selector-no-vendor-prefix/index.js
+++ b/lib/rules/selector-no-vendor-prefix/index.js
@@ -6,6 +6,7 @@ const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
 const parseSelector = require("../../utils/parseSelector");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
+const unprefixRule = require("postcss-unprefix/lib/clearRule");
 const validateOptions = require("../../utils/validateOptions");
 
 const ruleName = "selector-no-vendor-prefix";
@@ -14,9 +15,11 @@ const messages = ruleMessages(ruleName, {
   rejected: selector => `Unexpected vendor-prefix "${selector}"`
 });
 
-const rule = function(actual) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual });
+    const validOptions = validateOptions(result, ruleName, {
+      actual: expectation
+    });
     if (!validOptions) {
       return;
     }
@@ -30,6 +33,15 @@ const rule = function(actual) {
       if (!isStandardSyntaxSelector(selector)) {
         return;
       }
+
+      // Fix
+      if (context.fix) {
+        unprefixRule(rule);
+        if (!rule.parent || rule.selector !== selector) {
+          return;
+        }
+      }
+
       parseSelector(selector, result, rule, selectorTree => {
         selectorTree.walkPseudos(pseudoNode => {
           if (isAutoprefixable.selector(pseudoNode.value)) {

--- a/lib/rules/value-no-vendor-prefix/README.md
+++ b/lib/rules/value-no-vendor-prefix/README.md
@@ -10,6 +10,8 @@ a { display: -webkit-flex; }
 
 This rule will only complain for prefixed *standard* values, and not for prefixed *proprietary* or *unknown* ones.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/value-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/value-no-vendor-prefix/__tests__/index.js
@@ -9,6 +9,7 @@ const rule = rules[ruleName];
 testRule(rule, {
   ruleName,
   config: [true],
+  fix: true,
 
   accept: [
     {
@@ -37,54 +38,63 @@ testRule(rule, {
   reject: [
     {
       code: ".foo { display: -webkit-flex; }",
+      fixed: ".foo { display: flex; }",
       message: messages.rejected("-webkit-flex"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { display: -wEbKiT-fLeX; }",
+      fixed: ".foo { display: flex; }",
       message: messages.rejected("-wEbKiT-fLeX"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { display: -WEBKIT-FLEX; }",
+      fixed: ".foo { display: flex; }",
       message: messages.rejected("-WEBKIT-FLEX"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { dIsPlAy: -webkit-flex; }",
+      fixed: ".foo { dIsPlAy: flex; }",
       message: messages.rejected("-webkit-flex"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { DISPLAY: -webkit-flex; }",
+      fixed: ".foo { DISPLAY: flex; }",
       message: messages.rejected("-webkit-flex"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { color: pink; display: -webkit-flex; }",
+      fixed: ".foo { color: pink; display: flex; }",
       message: messages.rejected("-webkit-flex"),
       line: 1,
       column: 30
     },
     {
       code: ".foo { display: -webkit-box; }",
+      fixed: ".foo { display: flex; }",
       message: messages.rejected("-webkit-box"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { background: -webkit-linear-gradient(bottom, #000, #fff); }",
+      fixed: ".foo { background: linear-gradient(to top, #000, #fff); }",
       message: messages.rejected("-webkit-linear-gradient"),
       line: 1,
       column: 20
     },
     {
       code: ".foo { max-width: -moz-max-content; }",
+      fixed: ".foo { max-width: max-content; }",
       message: messages.rejected("-moz-max-content"),
       line: 1,
       column: 19
@@ -96,6 +106,7 @@ testRule(rule, {
   ruleName,
   config: [true],
   syntax: "scss",
+  fix: true,
 
   accept: [
     {
@@ -117,6 +128,7 @@ testRule(rule, {
   ruleName,
   config: [true],
   syntax: "less",
+  fix: true,
 
   accept: [
     {
@@ -131,33 +143,40 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [true, { ignoreValues: ["grab", "max-content", "/^linear-/"] }],
+  fix: true,
 
   accept: [
     {
-      code: "cursor: -webkit-grab;"
+      code: "cursor: -webkit-grab;",
+      fixed: "cursor: -webkit-grab;",
     },
     {
-      code: ".foo { max-width: -moz-max-content; }"
+      code: ".foo { max-width: -moz-max-content; }",
+      fixed: ".foo { max-width: -moz-max-content; }",
     },
     {
-      code: ".foo { background: -webkit-linear-gradient(bottom, #000, #fff); }"
+      code: ".foo { background: -webkit-linear-gradient(bottom, #000, #fff); }",
+      fixed: ".foo { background: -webkit-linear-gradient(bottom, #000, #fff); }",
     }
   ],
   reject: [
     {
       code: ".foo { display: -webkit-flex; }",
+      fixed: ".foo { display: flex; }",
       message: messages.rejected("-webkit-flex"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { display: -wEbKiT-fLeX; }",
+      fixed: ".foo { display: flex; }",
       message: messages.rejected("-wEbKiT-fLeX"),
       line: 1,
       column: 17
     },
     {
       code: ".foo { display: -WEBKIT-FLEX; }",
+      fixed: ".foo { display: flex; }",
       message: messages.rejected("-WEBKIT-FLEX"),
       line: 1,
       column: 17

--- a/lib/rules/value-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/value-no-vendor-prefix/__tests__/index.js
@@ -148,15 +148,12 @@ testRule(rule, {
   accept: [
     {
       code: "cursor: -webkit-grab;",
-      fixed: "cursor: -webkit-grab;",
     },
     {
       code: ".foo { max-width: -moz-max-content; }",
-      fixed: ".foo { max-width: -moz-max-content; }",
     },
     {
       code: ".foo { background: -webkit-linear-gradient(bottom, #000, #fff); }",
-      fixed: ".foo { background: -webkit-linear-gradient(bottom, #000, #fff); }",
     }
   ],
   reject: [

--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -9,6 +9,7 @@ const postcss = require("postcss");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const styleSearch = require("style-search");
+const unprefixDecl = require("postcss-unprefix/lib/clearDecl");
 const validateOptions = require("../../utils/validateOptions");
 
 const ruleName = "value-no-vendor-prefix";
@@ -19,12 +20,14 @@ const messages = ruleMessages(ruleName, {
 
 const valuePrefixes = ["-webkit-", "-moz-", "-ms-", "-o-"];
 
-const rule = function(actual, options) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(
       result,
       ruleName,
-      { actual },
+      {
+        actual: expectation
+      },
       {
         optional: true,
         actual: options,
@@ -66,6 +69,14 @@ const rule = function(actual, options) {
           )[1];
           if (!isAutoprefixable.propertyValue(prop, fullIdentifier)) {
             return;
+          }
+
+          // Fix
+          if (context.fix) {
+            unprefixDecl(decl);
+            if (!decl.parent || decl.value !== value) {
+              return;
+            }
           }
 
           report({

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "postcss-sass": "^0.3.0",
     "postcss-scss": "^1.0.2",
     "postcss-selector-parser": "^3.1.0",
+    "postcss-unprefix": "^2.1.2",
     "postcss-value-parser": "^3.3.0",
     "resolve-from": "^4.0.0",
     "signal-exit": "^3.0.2",

--- a/system-tests/005/__snapshots__/005.test.js.snap
+++ b/system-tests/005/__snapshots__/005.test.js.snap
@@ -11401,7 +11401,7 @@ Array [
         "line": 135,
         "rule": "media-feature-name-no-vendor-prefix",
         "severity": "error",
-        "text": "Unexpected vendor-prefix (media-feature-name-no-vendor-prefix)",
+        "text": "Unexpected vendor-prefix \\"-webkit-min-device-pixel-ratio\\" (media-feature-name-no-vendor-prefix)",
       },
       Object {
         "column": 9,


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

[#2467](https://github.com/stylelint/stylelint/pull/2467)

> Is there anything in the PR that needs further explanation?

Autofixing for rules:
- value-no-vendor-prefix
- property-no-vendor-prefix
- selector-no-vendor-prefix
- media-feature-name-no-vendor-prefix
- at-rule-no-vendor-prefix

Update message for `media-feature-name-no-vendor-prefix`