### PR TITLE
Fixed: ignore mergeable less property.

### DIFF
--- a/lib/rules/property-case/__tests__/index.js
+++ b/lib/rules/property-case/__tests__/index.js
@@ -261,6 +261,12 @@ testRule(rule, {
   }, {
     code: ".bucket { tr & { color: blue; } }",
     description: "nested selector",
+  }, {
+    code: "a { Box-shadow+: inset 0 0 10px #555; }",
+    description: "mergeable property",
+  }, {
+    code: "a { Transform+_: scale(2); }",
+    description: "mergeable property with space",
   } ],
 
   reject: [ {
@@ -280,18 +286,6 @@ testRule(rule, {
     message: messages.expected("Color", "color"),
     line: 1,
     column: 25,
-  }, {
-    code: "a { Box-shadow+: inset 0 0 10px #555; }",
-    description: "mergeable property",
-    message: messages.expected("Box-shadow+", "box-shadow+"),
-    line: 1,
-    column: 5,
-  }, {
-    code: "a { Transform+_: scale(2); }",
-    description: "mergeable property with space",
-    message: messages.expected("Transform+_", "transform+_"),
-    line: 1,
-    column: 5,
   }, {
     code: "@media screen { @media (min-width: 768px) { Color: red; }}",
     description: "nested directives",
@@ -562,6 +556,12 @@ testRule(rule, {
   }, {
     code: ".bucket { tr & { COLOR: blue; } }",
     description: "nested selector",
+  }, {
+    code: "a { Box-shadow+: inset 0 0 10px #555; }",
+    description: "mergeable property",
+  }, {
+    code: "a { Transform+_: scale(2); }",
+    description: "mergeable property with space",
   } ],
 
   reject: [ {
@@ -581,18 +581,6 @@ testRule(rule, {
     message: messages.expected("Color", "COLOR"),
     line: 1,
     column: 25,
-  }, {
-    code: "a { Box-shadow+: inset 0 0 10px #555; }",
-    description: "mergeable property",
-    message: messages.expected("Box-shadow+", "BOX-SHADOW+"),
-    line: 1,
-    column: 5,
-  }, {
-    code: "a { Transform+_: scale(2); }",
-    description: "mergeable property with space",
-    message: messages.expected("Transform+_", "TRANSFORM+_"),
-    line: 1,
-    column: 5,
   }, {
     code: "@media screen { @media (min-width: 768px) { Color: red; }}",
     description: "nested directives",

--- a/lib/rules/property-no-unknown/__tests__/index.js
+++ b/lib/rules/property-no-unknown/__tests__/index.js
@@ -87,6 +87,12 @@ testRule(rule, {
   }, {
     code: ".foo { @{prop}: black; }",
     description: "ignore property interpolation",
+  }, {
+    code: ".foo { transform+: rotate(15deg); }",
+    descritpion: "Append property value with space usign +",
+  }, {
+    code: ".foo { transform+_: rotate(15deg); }",
+    descritpion: "Append property value with space using +_",
   } ],
 })
 

--- a/lib/utils/__tests__/isStandardSyntaxProperty.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxProperty.test.js
@@ -24,4 +24,10 @@ describe("isStandardSyntaxProperty", () => {
   it("less variable", () => {
     expect(isStandardSyntaxProperty("@{Attr}-color")).toBeFalsy()
   })
+  it("less append property value with comma", () => {
+    expect(isStandardSyntaxProperty("transform+")).toBeFalsy()
+  })
+  it("less append property value with space", () => {
+    expect(isStandardSyntaxProperty("transform+_")).toBeFalsy()
+  })
 })

--- a/lib/utils/isStandardSyntaxProperty.js
+++ b/lib/utils/isStandardSyntaxProperty.js
@@ -1,6 +1,7 @@
 /* @flow */
 "use strict"
 
+const _ = require("lodash")
 const hasInterpolation = require("../utils/hasInterpolation")
 /**
  * Check whether a property is standard
@@ -13,6 +14,11 @@ module.exports = function (property/*: string*/)/*: boolean*/ {
 
   // Less var (e.g. @var: x)
   if (property[0] === "@") {
+    return false
+  }
+
+  // Less append property value with space (e.g. transform+_: scale(2))
+  if (_.endsWith(property, "+") || _.endsWith(property, "+_")) {
     return false
   }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

No

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

I don't known why we check non standard less properties, i think we should ignore this.
