### PR TITLE
Fixed: ignore `extend` in less.

### DIFF
--- a/lib/utils/__tests__/isStandardSyntaxSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxSelector.test.js
@@ -45,6 +45,9 @@ describe("isStandardSyntaxSelector", () => {
   it("Less interpolation", () => {
     expect(isStandardSyntaxSelector(".n-@{n}")).toBeFalsy()
   })
+  it("Less extend", () => {
+    expect(isStandardSyntaxSelector(".a:extend(.a all)")).toBeFalsy()
+  })
   it("SCSS placeholder", () => {
     expect(isStandardSyntaxSelector("%foo")).toBeFalsy()
   })

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -16,5 +16,10 @@ module.exports = function (selector/*: string*/)/*: boolean*/ {
     return false
   }
 
+  // Less :extend()
+  if ((/\:extend\(.*?\)/).test(selector)) {
+    return false
+  }
+
   return true
 }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

No

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Ref: http://lesscss.org/features/#import-options-reference-example
