### PR TITLE
Add autofixing for color-hex-case

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -10,7 +10,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 
 ### Color
 
--   [`color-hex-case`](../../lib/rules/color-hex-case/README.md): Specify lowercase or uppercase for hex colors.
+-   [`color-hex-case`](../../lib/rules/color-hex-case/README.md): Specify lowercase or uppercase for hex colors (Autofixable).
 -   [`color-hex-length`](../../lib/rules/color-hex-length/README.md): Specify short or long notation for hex colors.
 -   [`color-named`](../../lib/rules/color-named/README.md): Require (where possible) or disallow named colors.
 -   [`color-no-hex`](../../lib/rules/color-no-hex/README.md): Disallow hex colors.

--- a/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
+++ b/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
@@ -4,8 +4,8 @@ const stylelint = require("../../")
 
 const ruleName = "plugin/conditionally-check-color-hex-case"
 
-module.exports = stylelint.createPlugin(ruleName, function (expectation) {
-  const colorHexCaseRule = stylelint.rules["color-hex-case"](expectation)
+module.exports = stylelint.createPlugin(ruleName, function (expectation, options, context) {
+  const colorHexCaseRule = stylelint.rules["color-hex-case"](expectation, options, context)
   return (root, result) => {
     if (root.toString().indexOf("@@check-color-hex-case") === -1) return
     colorHexCaseRule(root, result)

--- a/lib/rules/color-hex-case/README.md
+++ b/lib/rules/color-hex-case/README.md
@@ -8,6 +8,8 @@ a { color: #fff }
  * These hex colors */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"lower"|"upper"`

--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -24,6 +24,7 @@ const sharedTests = {
 testRule(rule, mergeTestDescriptions(sharedTests, {
   ruleName,
   config: ["lower"],
+  fix: true,
 
   accept: [ {
     code: "a { color: pink; }",
@@ -47,21 +48,29 @@ testRule(rule, mergeTestDescriptions(sharedTests, {
 
   reject: [ {
     code: "a { color: #Ababa; }",
+    fixed: "a { color: #ababa; }",
+
     message: messages.expected("#Ababa", "#ababa"),
     line: 1,
     column: 12,
   }, {
     code: "a { something: #000F, #fff, #ababab; }",
+    fixed: "a { something: #000f, #fff, #ababab; }",
+
     message: messages.expected("#000F", "#000f"),
     line: 1,
     column: 16,
   }, {
     code: "a { something: #000, #FFFFAZ, #ababab; }",
+    fixed: "a { something: #000, #ffffaz, #ababab; }",
+
     message: messages.expected("#FFFFAZ", "#ffffaz"),
     line: 1,
     column: 22,
   }, {
     code: "a { something: #000, #fff, #12345AA; }",
+    fixed: "a { something: #000, #fff, #12345aa; }",
+
     message: messages.expected("#12345AA", "#12345aa"),
     line: 1,
     column: 28,
@@ -71,6 +80,7 @@ testRule(rule, mergeTestDescriptions(sharedTests, {
 testRule(rule, mergeTestDescriptions(sharedTests, {
   ruleName,
   config: ["upper"],
+  fix: true,
 
   accept: [ {
     code: "a { color: pink; }",
@@ -94,21 +104,29 @@ testRule(rule, mergeTestDescriptions(sharedTests, {
 
   reject: [ {
     code: "a { color: #aBABA; }",
+    fixed: "a { color: #ABABA; }",
+
     message: messages.expected("#aBABA", "#ABABA"),
     line: 1,
     column: 12,
   }, {
     code: "a { something: #000f, #FFF, #ABABAB; }",
+    fixed: "a { something: #000F, #FFF, #ABABAB; }",
+
     message: messages.expected("#000f", "#000F"),
     line: 1,
     column: 16,
   }, {
     code: "a { something: #000, #ffffaz, #ABABAB; }",
+    fixed: "a { something: #000, #FFFFAZ, #ABABAB; }",
+
     message: messages.expected("#ffffaz", "#FFFFAZ"),
     line: 1,
     column: 22,
   }, {
     code: "a { something: #000, #FFF, #12345aa; }",
+    fixed: "a { something: #000, #FFF, #12345AA; }",
+
     message: messages.expected("#12345aa", "#12345AA"),
     line: 1,
     column: 28,

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
   expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 })
 
-const rule = function (expectation) {
+const rule = function (expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -27,6 +27,8 @@ const rule = function (expectation) {
 
     root.walkDecls(decl => {
       const declString = blurFunctionArguments(decl.toString(), "url")
+      const fixPositions = []
+
       styleSearch({ source: declString, target: "#" }, match => {
         const hexMatch = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex))
         if (!hexMatch) {
@@ -44,6 +46,16 @@ const rule = function (expectation) {
           return
         }
 
+        if (context.fix) {
+          fixPositions.unshift({
+            expectedHex,
+            currentHex: hexValue,
+            startIndex: match.startIndex,
+          })
+
+          return
+        }
+
         report({
           message: messages.expected(hexValue, expectedHex),
           node: decl,
@@ -52,8 +64,31 @@ const rule = function (expectation) {
           ruleName,
         })
       })
+
+      if (fixPositions.length) {
+        const declProp = decl.prop
+        const declBetween = decl.raws.between
+
+        fixPositions.forEach(function (fixPosition) {
+          // 1 — it's a # length
+          decl.value = replaceHex(
+            decl.value,
+            fixPosition.currentHex,
+            fixPosition.expectedHex,
+            fixPosition.startIndex - declProp.length - declBetween.length - 1
+          )
+        })
+      }
     })
   }
+}
+
+function replaceHex(input, searchString, replaceString, startIndex) {
+  const offset = startIndex + 1
+  const stringStart = input.slice(0, offset)
+  const stringEnd = input.slice(offset + searchString.length)
+
+  return stringStart + replaceString + stringEnd
 }
 
 rule.ruleName = ruleName


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Tests throw an error on `plugins.test.js`. I'm not sure how to fixed it. The problem in tests themselves, or maybe `context` doesn't go to some areas of stylelint core.
