### PR TITLE
Ignore functions without parameters in function-parentheses-space-inside

### DIFF
--- a/lib/rules/function-parentheses-space-inside/__tests__/index.js
+++ b/lib/rules/function-parentheses-space-inside/__tests__/index.js
@@ -1,12 +1,24 @@
 "use strict"
 
+const mergeTestDescriptions = require("../../../testUtils/mergeTestDescriptions")
+
 const messages = require("..").messages
 const ruleName = require("..").ruleName
 const rules = require("../../../rules")
 
 const rule = rules[ruleName]
 
-testRule(rule, {
+const alwaysTests = {
+  accept: [ {
+    code: "a { filter: grayscale(); }",
+    description: "ignore funtion without parameters",
+  }, {
+    code: "a { filter: grayscale( ); }",
+    description: "ignore funtion without parameters",
+  } ],
+}
+
+testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
   config: ["always"],
 
@@ -103,9 +115,9 @@ testRule(rule, {
     line: 1,
     column: 26,
   } ],
-})
+}))
 
-testRule(rule, {
+testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
   config: ["always-single-line"],
 
@@ -197,9 +209,9 @@ testRule(rule, {
     line: 1,
     column: 35,
   } ],
-})
+}))
 
-testRule(rule, {
+testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
   config: ["never"],
 
@@ -295,9 +307,9 @@ testRule(rule, {
     line: 3,
     column: 2,
   } ],
-})
+}))
 
-testRule(rule, {
+testRule(rule, mergeTestDescriptions(alwaysTests, {
   ruleName,
   config: ["never-single-line"],
 
@@ -389,4 +401,4 @@ testRule(rule, {
     line: 1,
     column: 27,
   } ],
-})
+}))

--- a/lib/rules/function-parentheses-space-inside/index.js
+++ b/lib/rules/function-parentheses-space-inside/index.js
@@ -50,6 +50,11 @@ const rule = function (expectation) {
           return
         }
 
+        // Ignore function without parameters
+        if (!valueNode.nodes.length) {
+          return
+        }
+
         const functionString = valueParser.stringify(valueNode)
         const isSingleLine = isSingleLineString(functionString)
 


### PR DESCRIPTION


<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2581