### PR TITLE
Fixed: ignore less `:extend` in `selector-pseudo-class-no-unknown`.

### DIFF
--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -132,6 +132,19 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [true],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [ {
+    code: "a { &:extend(.extended); }",
+  }, {
+    code: "a { &:extend(.extended all); }",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
   config: [ true, { ignorePseudoClasses: [ "unknown", "/^my-/" ] } ],
   skipBasicChecks: true,
 

--- a/lib/utils/__tests__/isStandardSyntaxSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxSelector.test.js
@@ -46,7 +46,13 @@ describe("isStandardSyntaxSelector", () => {
     expect(isStandardSyntaxSelector(".n-@{n}")).toBeFalsy()
   })
   it("Less extend", () => {
+    expect(isStandardSyntaxSelector(".a:extend(.a)")).toBeFalsy()
+  })
+  it("Less extend `all`", () => {
     expect(isStandardSyntaxSelector(".a:extend(.a all)")).toBeFalsy()
+  })
+  it("Less extend inside ruleset", () => {
+    expect(isStandardSyntaxSelector("a { &:extend(.a all) }")).toBeFalsy()
   })
   it("SCSS placeholder", () => {
     expect(isStandardSyntaxSelector("%foo")).toBeFalsy()

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -17,7 +17,7 @@ module.exports = function (selector/*: string*/)/*: boolean*/ {
   }
 
   // Less :extend()
-  if ((/\:extend\(.*?\)/).test(selector)) {
+  if ((/\:extend(\(.*?\))?/).test(selector)) {
     return false
   }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2618

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
