### PR TITLE
Added: `selector-max-attribute` rule.

### DIFF
--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -132,6 +132,7 @@ You might want to learn a little about [how rules are named and how they work to
     "selector-list-comma-space-after": "always"|"never"|"always-single-line"|"never-single-line",
     "selector-list-comma-space-before": "always"|"never"|"always-single-line"|"never-single-line",
     "selector-max-empty-lines": int,
+    "selector-max-attribute": int,
     "selector-max-class": int,
     "selector-max-compound-selectors": int,
     "selector-max-specificity": string,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -162,6 +162,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 -   [`selector-combinator-space-before`](../../lib/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors.
 -   [`selector-descendant-combinator-no-non-space`](../../lib/rules/selector-descendant-combinator-no-non-space/README.md): Disallow non-space characters for descendant combinators of selectors.
 -   [`selector-id-pattern`](../../lib/rules/selector-id-pattern/README.md): Specify a pattern for id selectors.
+-   [`selector-max-attribute`](../../lib/rules/selector-max-attribute/README.md): Limit the number of attribute selectors in a selector.
 -   [`selector-max-class`](../../lib/rules/selector-max-class/README.md): Limit the number of classes in a selector.
 -   [`selector-max-compound-selectors`](../../lib/rules/selector-max-compound-selectors/README.md): Limit the number of compound selectors in a selector.
 -   [`selector-max-specificity`](../../lib/rules/selector-max-specificity/README.md): Limit the specificity of selectors.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -137,6 +137,7 @@ const selectorListCommaSpaceAfter = require("./selector-list-comma-space-after")
 const selectorListCommaSpaceBefore = require("./selector-list-comma-space-before")
 const selectorMaxCompoundSelectors = require("./selector-max-compound-selectors")
 const selectorMaxEmptyLines = require("./selector-max-empty-lines")
+const selectorMaxAttribute = require("./selector-max-attribute")
 const selectorMaxClass = require("./selector-max-class")
 const selectorMaxSpecificity = require("./selector-max-specificity")
 const selectorNestedPattern = require("./selector-nested-pattern")
@@ -312,6 +313,7 @@ module.exports = {
   "selector-list-comma-newline-before": selectorListCommaNewlineBefore,
   "selector-list-comma-space-after": selectorListCommaSpaceAfter,
   "selector-list-comma-space-before": selectorListCommaSpaceBefore,
+  "selector-max-attribute": selectorMaxAttribute,
   "selector-max-class": selectorMaxClass,
   "selector-max-compound-selectors": selectorMaxCompoundSelectors,
   "selector-max-empty-lines": selectorMaxEmptyLines,

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -1,0 +1,77 @@
+# selector-max-attribute
+
+Limit the number of attribute selectors in a selector.
+
+```css
+    [rel="external"] {}
+/** ↑
+ * This type of selector */
+```
+
+This rule resolves nested selectors before counting the number of attribute selectors. Each selector in a [selector list](https://www.w3.org/TR/selectors4/#selector-list) is evaluated separately.
+
+The `:not()` pseudo-class is also evaluated separately. The rule processes the argument as if it were an independent selector, and the result does not count toward the total for the entire selector.
+
+## Options
+
+`int`: Maximum attribute selectors allowed.
+
+For example, with `2`:
+
+The following patterns are considered violations:
+
+```css
+[type="number"][name="quality"][data-attribute="value"] {}
+```
+
+```css
+[type="number"][name="quality"][disabled] {}
+```
+
+```css
+[type="number"][name="quality"] {
+  & [data-attribute="value"] {}
+}
+```
+
+```css
+[type="number"][name="quality"] {
+  & [disabled] {}
+}
+```
+
+```css
+[type="number"][name="quality"] {
+  & > [data-attribute="value"] {}
+}
+```
+
+```css
+/* `[type="text"][data-attribute="value"][disabled]` is inside `:not()`, so it is evaluated separately */
+input:not([type="text"][data-attribute="value"][disabled]) {}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+[type="text"] {}
+```
+
+```css
+[type="text"][name="message"] {}
+```
+
+```css
+[type="text"][disabled]
+```
+
+```css
+/* each selector in a selector list is evaluated separately */
+[type="text"][name="message"],
+[type="number"][name="quality"] {}
+```
+
+```css
+/* `[disabled]` is inside `:not()`, so it is evaluated separately */
+[type="text"][name="message"]:not([disabled]) {}
+```

--- a/lib/rules/selector-max-attribute/__tests__/index.js
+++ b/lib/rules/selector-max-attribute/__tests__/index.js
@@ -1,0 +1,190 @@
+"use strict"
+
+const messages = require("..").messages
+const ruleName = require("..").ruleName
+const rules = require("../../../rules")
+
+const rule = rules[ruleName]
+
+// Sanity checks
+testRule(rule, {
+  ruleName,
+  config: [0],
+
+  accept: [ {
+    code: "foo {}",
+  }, {
+    code: ".bar {}",
+  }, {
+    code: "foo .bar {}",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
+  } ],
+
+  reject: [ {
+    code: "[foo] {}",
+    message: messages.expected("[foo]", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: "a[rel=\"external\"] {}",
+    message: messages.expected("a[rel=\"external\"]", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: "a, .foo[type=\"text\"] {}",
+    message: messages.expected(".foo[type=\"text\"]", 0),
+    line: 1,
+    column: 4,
+  }, {
+    code: "a > [foo] {}",
+    message: messages.expected("a > [foo]", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: "a[rel='external'] {}",
+    message: messages.expected("a[rel='external']", 0),
+    line: 1,
+    column: 1,
+  } ],
+})
+
+// Standard tests
+testRule(rule, {
+  ruleName,
+  config: [2],
+
+  accept: [ {
+    code: "[type=\"text\"] {}",
+    description: "fewer than max classes",
+  }, {
+    code: "[type=\"text\"][disabled]:hover {}",
+    description: "pseudo selectors",
+  }, {
+    code: "[type=\"text\"][name=\"message\"] {}",
+    description: "exactly max classes",
+  }, {
+    code: "[type=\"text\"][disabled] {}",
+    description: "exactly max classes",
+  }, {
+    code: "[type=\"text\"] [type=\"number\"] {}",
+    description: "compound selector",
+  }, {
+    code: "[type=\"text\"], \n[type=\"number\"] {}",
+    description: "multiple selectors: fewer than max classes",
+  }, {
+    code: "[type=\"text\"][name=\"message\"], \n[type=\"password\"][name=\"password\"] {}",
+    description: "multiple selectors: exactly max classes",
+  }, {
+    code: "[type=\"text\"][disabled], \n[type=\"password\"][disabled] {}",
+    description: "multiple selectors: exactly max classes",
+  }, {
+    code: "[type=\"text\"][name=\"message\"]:not([type=\"number\"][name=\"quality\"]) {}",
+    description: ":not(): inside and outside",
+  }, {
+    code: "[type=\"text\"] { [name=\"message\"] {} }",
+    description: "nested selectors",
+  }, {
+    code: "[type=\"text\"] { [name=\"message\"] > & {} }",
+    description: "nested selectors: parent selector",
+  }, {
+    code: "[type=\"text\"], [name=\"message\"] { & > [data-attribute=\"value\"] {} }",
+    description: "nested selectors: superfluous parent selector",
+  }, {
+    code: "@media print { [type=\"text\"][name=\"message\"] {} }",
+    description: "media query: parent",
+  }, {
+    code: "[type=\"text\"] { @media print { [name=\"message\"] {} } }",
+    description: "media query: nested",
+  } ],
+
+  reject: [ {
+    code: "[type=\"text\"][name=\"message\"][data-attribute=\"value\"] {}",
+    description: "greater than max classes",
+    message: messages.expected("[type=\"text\"][name=\"message\"][data-attribute=\"value\"]", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: "[type=\"text\"][name=\"message\"][disabled] {}",
+    description: "greater than max classes with attribute selector without value",
+    message: messages.expected("[type=\"text\"][name=\"message\"][disabled]", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: "[type=\"text\"] [name=\"message\"] [data-attribute=\"value\"] {}",
+    description: "compound selector: greater than max classes",
+    message: messages.expected("[type=\"text\"] [name=\"message\"] [data-attribute=\"value\"]", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: "[type=\"text\"], \n[type=\"number\"][name=\"quality\"][data-attribute=\"value\"] {}",
+    description: "multiple selectors: greater than max classes",
+    message: messages.expected("[type=\"number\"][name=\"quality\"][data-attribute=\"value\"]", 2),
+    line: 2,
+    column: 1,
+  }, {
+    code: "[type=\"text\"], \n[type=\"number\"][name=\"quality\"][disabled] {}",
+    description: "multiple selectors: greater than max classes",
+    message: messages.expected("[type=\"number\"][name=\"quality\"][disabled]", 2),
+    line: 2,
+    column: 1,
+  }, {
+    code: ":not([type=\"text\"][name=\"message\"][data-attribute=\"value\"]) {}",
+    description: ":not(): greater than max classes, inside",
+    message: messages.expected("[type=\"text\"][name=\"message\"][data-attribute=\"value\"]", 2),
+    line: 1,
+    column: 6,
+  }, {
+    code: ":not([type=\"text\"][name=\"message\"][disabled]) {}",
+    description: ":not(): greater than max classes, inside",
+    message: messages.expected("[type=\"text\"][name=\"message\"][disabled]", 2),
+    line: 1,
+    column: 6,
+  }, {
+    code: "[type=\"text\"][name=\"message\"][data-attribute=\"value\"] :not([data-attribute-2=\"value\"]) {}",
+    description: ":not(): greater than max classes, outside",
+    message: messages.expected("[type=\"text\"][name=\"message\"][data-attribute=\"value\"] :not([data-attribute-2=\"value\"])", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: "[type=\"text\"][name=\"message\"][data-attribute=\"value\"]:not([disabled]) {}",
+    description: ":not(): greater than max classes, outside",
+    message: messages.expected("[type=\"text\"][name=\"message\"][data-attribute=\"value\"]:not([disabled])", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: "[type=\"text\"] { &:hover > [data-attribute=\"value\"][data-attribute-2=\"value\"] {} }",
+    description: "nested selectors: greater than max classes",
+    message: messages.expected("[type=\"text\"]:hover > [data-attribute=\"value\"][data-attribute-2=\"value\"]", 2),
+    line: 1,
+    column: 17,
+  } ],
+})
+
+// SCSS tests
+testRule(rule, {
+  ruleName,
+  config: [0],
+  syntax: "scss",
+
+  accept: [ {
+    code: ".[#{$interpolation}] {}",
+    description: "scss: ignore variable interpolation",
+  }, {
+    code: "#{$interpolation}[type=\"text\"] {}",
+    description: "scss: ignore variable interpolation",
+  }, {
+    code: "[type=\"text\"]#{$interpolation} { margin: { left: 0; top: 0; }; }",
+    description: "scss: nested properties",
+  } ],
+})

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -8,10 +8,10 @@ const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
 const resolvedNestedSelector = require("postcss-resolve-nested-selector")
 
-const ruleName = "selector-max-class"
+const ruleName = "selector-max-attribute"
 
 const messages = ruleMessages(ruleName, {
-  expected: (selector, max) => `Expected "${selector}" to have no more than ${max} ${max === 1 ? "class" : "classes"}`,
+  expected: (selector, max) => `Expected "${selector}" to have no more than ${max} attribute ${max === 1 ? "selector" : "selectors"}`,
 })
 
 function rule(max) {
@@ -35,7 +35,7 @@ function rule(max) {
           checkSelector(childNode, ruleNode)
         }
 
-        return total += (childNode.type === "class" ? 1 : 0)
+        return total += (childNode.type === "attribute" ? 1 : 0)
       }, 0)
 
       if (selectorNode.type !== "root" && selectorNode.type !== "pseudo" && count > max) {

--- a/lib/rules/selector-max-class/README.md
+++ b/lib/rules/selector-max-class/README.md
@@ -19,7 +19,7 @@ The `:not()` pseudo-class is also evaluated separately. The rule processes the a
 
 For example, with `2`:
 
-The following patterns are considered warnings:
+The following patterns are considered violations:
 
 ```css
 .foo.bar.baz {}
@@ -31,7 +31,7 @@ The following patterns are considered warnings:
 }
 ```
 
-The following patterns are *not* considered warnings:
+The following patterns are *not* considered violations:
 
 ```css
 div {}

--- a/lib/rules/selector-max-class/__tests__/index.js
+++ b/lib/rules/selector-max-class/__tests__/index.js
@@ -26,7 +26,7 @@ testRule(rule, {
   } ],
 
   reject: [{
-    code: ".foo { left: 0; top: 0; }",
+    code: ".foo {}",
     description: "disallow classes",
     message: messages.expected(".foo", 0),
     line: 1,
@@ -40,93 +40,93 @@ testRule(rule, {
   config: [2],
 
   accept: [ {
-    code: ".ab { left: 0; top: 0; }",
+    code: ".ab {}",
     description: "fewer than max classes",
   }, {
-    code: ".ab.cd { left: 0; top: 0; }",
+    code: ".ab.cd {}",
     description: "exactly max classes",
   }, {
-    code: ".ab .cd { left: 0; top: 0; }",
+    code: ".ab .cd {}",
     description: "compound selector",
   }, {
-    code: ".ab, \n.cd { left: 0; top: 0; }",
+    code: ".ab, \n.cd {}",
     description: "multiple selectors: fewer than max classes",
   }, {
-    code: ".ab.cd, \n.ef.gh { left: 0; top: 0; }",
+    code: ".ab.cd, \n.ef.gh {}",
     description: "multiple selectors: exactly max classes",
   }, {
-    code: ".ab.cd :not(.ef.gh) { left: 0; top: 0; }",
+    code: ".ab.cd :not(.ef.gh) {}",
     description: ":not(): inside and outside",
   }, {
-    code: ".ab.cd[disabled]:hover { left: 0; top: 0; }",
+    code: ".ab.cd[disabled]:hover {}",
     description: "pseudo selectors, attribute selectors",
   }, {
-    code: ".ab { .cd: { left: 0; top: 0; } }",
+    code: ".ab { .cd {} }",
     description: "nested selectors",
   }, {
-    code: ".ab { .cd > & { left: 0; top: 0; } }",
+    code: ".ab { .cd > & {} }",
     description: "nested selectors: parent selector",
   }, {
-    code: ".ab, .cd { & > .ef { left: 0; top: 0; } }",
+    code: ".ab, .cd { & > .ef {} }",
     description: "nested selectors: superfluous parent selector",
   }, {
-    code: "@media print { .ab.cd { left: 0; top: 0; } }",
+    code: "@media print { .ab.cd {} }",
     description: "media query: parent",
   }, {
-    code: ".ab { @media print { .cd { left: 0; top: 0; } } }",
+    code: ".ab { @media print { .cd {} } }",
     description: "media query: nested",
   } ],
 
   reject: [ {
-    code: ".ab.cd.ef { left: 0; top: 0; }",
+    code: ".ab.cd.ef {}",
     description: "greater than max classes",
     message: messages.expected(".ab.cd.ef", 2),
     line: 1,
     column: 1,
   }, {
-    code: ".ab .cd .ef { left: 0; top: 0; }",
+    code: ".ab .cd .ef {}",
     description: "compound selector: greater than max classes",
     message: messages.expected(".ab .cd .ef", 2),
     line: 1,
     column: 1,
   }, {
-    code: ".ab, \n.cd.ef.gh { left: 0; top: 0; }",
+    code: ".ab, \n.cd.ef.gh {}",
     description: "multiple selectors: greater than max classes",
     message: messages.expected(".cd.ef.gh", 2),
     line: 2,
     column: 1,
   }, {
-    code: ":not(.ab.cd.ef) { left: 0; top: 0; }",
+    code: ":not(.ab.cd.ef) {}",
     description: ":not(): greater than max classes, inside",
     message: messages.expected(".ab.cd.ef", 2),
     line: 1,
     column: 6,
   }, {
-    code: ".ab.cd.ef :not(.gh) { left: 0; top: 0; }",
+    code: ".ab.cd.ef :not(.gh) {}",
     description: ":not(): greater than max classes, outside",
     message: messages.expected(".ab.cd.ef :not(.gh)", 2),
     line: 1,
     column: 1,
   }, {
-    code: ".ab, .cd { &:hover > .ef.gh { left: 0; top: 0; } }",
+    code: ".ab { &:hover > .ef.gh {} }",
     description: "nested selectors: greater than max classes",
     message: messages.expected(".ab:hover > .ef.gh", 2),
     line: 1,
-    column: 12,
+    column: 7,
   } ],
 })
 
 // SCSS tests
 testRule(rule, {
   ruleName,
-  config: [1],
+  config: [0],
   syntax: "scss",
 
   accept: [ {
-    code: ".foo #{$test} { left: 0; top: 0; }",
+    code: ".foo #{$test} {}",
     description: "scss: ignore variable interpolation",
   }, {
-    code: ".foo.bar #{$test} { left: 0; top: 0; }",
+    code: ".foo.bar #{$test} {}",
     description: "scss: ignore variable interpolation",
   }, {
     code: ".foo { margin: { left: 0; top: 0; }; }",
@@ -137,11 +137,11 @@ testRule(rule, {
 // LESS tests
 testRule(rule, {
   ruleName,
-  config: [1],
+  config: [0],
   syntax: "less",
 
   accept: [ {
-    code: ".foo @{test} { left: 0; top: 0; }",
+    code: ".foo @{test} {}",
     description: "less: ignore variable interpolation",
   }, {
     code: ".setFont(@size) { font-size: @size; }",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2528

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Some Fixes in test `selector-max-class`:
1. Remove properties, because it is unused for tests.
2. Set `config: [0]` for less/sass syntax, because this construction should be ignored **always**, using `1` potential can to skip something, what we should ignore.
3. `.ab { .cd: { left: 0; top: 0; } }` -> `.ab { .cd { left: 0; top: 0; } }` (seems just typo)
4. `.ab, .cd { &:hover > .ef.gh { left: 0; top: 0; } }` -> `.ab { &:hover > .ef.gh { left: 0; top: 0; } }`, because for this case we have two errors, one for `.ab`, second for `.cd`. @davidtheclark @hudochenkov @jeddy3 can we throw error if we have more than one error on test block?
