### PR TITLE
Fixed: `media-feature-name-whitelist` and `media-feature-name-blacklist` now accept array as first option.

### DIFF
--- a/lib/rules/media-feature-name-blacklist/__tests__/index.js
+++ b/lib/rules/media-feature-name-blacklist/__tests__/index.js
@@ -8,7 +8,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [[ "max-width", "--wide-viewport", "width", "/^my-/", "color" ]],
+  config: [ "max-width", "--wide-viewport", "width", "/^my-/", "color" ],
 
   accept: [ {
     code: "@media (min-width: 50em) { }",
@@ -66,7 +66,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [["feature-name"]],
+  config: ["feature-name"],
   syntax: "less",
 
   accept: [ {
@@ -78,7 +78,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [[ "feature-name", "width" ]],
+  config: [ "feature-name", "width" ],
   syntax: "scss",
 
   accept: [ {

--- a/lib/rules/media-feature-name-blacklist/index.js
+++ b/lib/rules/media-feature-name-blacklist/index.js
@@ -53,6 +53,8 @@ const rule = function (blacklist) {
   }
 }
 
+rule.primaryOptionArray = true
+
 rule.ruleName = ruleName
 rule.messages = messages
 module.exports = rule

--- a/lib/rules/media-feature-name-whitelist/__tests__/index.js
+++ b/lib/rules/media-feature-name-whitelist/__tests__/index.js
@@ -8,7 +8,7 @@ const rule = rules[ruleName]
 
 testRule(rule, {
   ruleName,
-  config: [[ "max-width", "/^my-/", "color" ]],
+  config: [ "max-width", "/^my-/", "color" ],
 
   accept: [ {
     code: "@media (max-width: 50em) { }",
@@ -61,7 +61,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [[ "max-width", "orientation" ]],
+  config: [ "max-width", "orientation" ],
   syntax: "less",
 
   accept: [ {
@@ -73,7 +73,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [["max-width"]],
+  config: ["max-width"],
   syntax: "scss",
 
   accept: [ {

--- a/lib/rules/media-feature-name-whitelist/index.js
+++ b/lib/rules/media-feature-name-whitelist/index.js
@@ -53,6 +53,8 @@ const rule = function (whitelist) {
   }
 }
 
+rule.primaryOptionArray = true
+
 rule.ruleName = ruleName
 rule.messages = messages
 module.exports = rule


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2536

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Let's close all major bugs with new version and release `patch` version asap.

@hudochenkov @jeddy3 
