### PR TITLE
Fixed: ignore custom property sets in selector rules.

### DIFF
--- a/lib/rules/at-rule-name-newline-after/__tests__/index.js
+++ b/lib/rules/at-rule-name-newline-after/__tests__/index.js
@@ -167,7 +167,7 @@ testRule(rule, {
     code: ".class1 { .mixin(#ddd) }",
     description: "ignore mixins",
   }, {
-    code: ".button { &-ok { } }",
+    code: ".button { &-ok {} }",
     description: "ignore parent selectors",
   } ],
 })

--- a/lib/rules/at-rule-name-space-after/__tests__/index.js
+++ b/lib/rules/at-rule-name-space-after/__tests__/index.js
@@ -172,7 +172,7 @@ testRule(rule, {
     code: ".class1 { .mixin(#ddd) }",
     description: "ignore mixins",
   }, {
-    code: ".button { &-ok { } }",
+    code: ".button { &-ok {} }",
     description: "ignore parent selectors",
   } ],
 })

--- a/lib/rules/no-empty-source/__tests__/index.js
+++ b/lib/rules/no-empty-source/__tests__/index.js
@@ -12,9 +12,9 @@ testRule(rule, {
   skipBasicChecks: true,
 
   accept: [ {
-    code: ".class { }",
+    code: ".class {}",
   }, {
-    code: "   .class { }   ",
+    code: "   .class {}   ",
   }, {
     code: "/* comment */",
   }, {

--- a/lib/rules/selector-attribute-brackets-space-inside/__tests__/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/__tests__/index.js
@@ -45,7 +45,7 @@ testRule(rule, {
   }, {
     code: "option[ dataHidden ] { }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[ align=right ] { } }",
+    code: "@media screen and (max-width: 480px) { img[ align=right ] {} }",
   }, {
     code: "[ target=_blank ] .foo { }",
   }, {
@@ -64,6 +64,18 @@ testRule(rule, {
     code: "[ target ] { content: \"]\" }",
   }, {
     code: "[ foo=bar i ] { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {
@@ -197,12 +209,12 @@ testRule(rule, {
     line: 1,
     column: 18,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align=right ] { } }",
+    code: "@media screen and (max-width: 480px) { img[align=right ] {} }",
     message: messages.expectedOpening,
     line: 1,
     column: 44,
   }, {
-    code: "@media screen and (max-width: 480px) { img[ align=right] { } }",
+    code: "@media screen and (max-width: 480px) { img[ align=right] {} }",
     message: messages.expectedClosing,
     line: 1,
     column: 55,
@@ -326,7 +338,7 @@ testRule(rule, {
   }, {
     code: "option[dataHidden] { }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align=right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align=right] {} }",
   }, {
     code: "[target=_blank] .foo { }",
   }, {
@@ -478,12 +490,12 @@ testRule(rule, {
     line: 1,
     column: 18,
   }, {
-    code: "@media screen and (max-width: 480px) { img[ align=right] { } }",
+    code: "@media screen and (max-width: 480px) { img[ align=right] {} }",
     message: messages.rejectedOpening,
     line: 1,
     column: 44,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align=right ] { } }",
+    code: "@media screen and (max-width: 480px) { img[align=right ] {} }",
     message: messages.rejectedClosing,
     line: 1,
     column: 55,

--- a/lib/rules/selector-attribute-operator-blacklist/__tests__/index.js
+++ b/lib/rules/selector-attribute-operator-blacklist/__tests__/index.js
@@ -21,6 +21,18 @@ testRule(rule, {
     code: "[class^=top] { }",
   }, {
     code: "[class$=\"test\"] { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-attribute-operator-space-after/__tests__/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/__tests__/index.js
@@ -11,87 +11,87 @@ testRule(rule, {
   config: ["always"],
 
   accept: [ {
-    code: ".foo { }",
+    code: ".foo {}",
   }, {
-    code: "[target] { }",
+    code: "[target] {}",
   }, {
-    code: "[ target] { }",
+    code: "[ target] {}",
   }, {
-    code: "[target ] { }",
+    code: "[target ] {}",
   }, {
-    code: "[ target ] { }",
+    code: "[ target ] {}",
   }, {
-    code: "[target= _blank] { }",
+    code: "[target= _blank] {}",
   }, {
-    code: "[target = _blank] { }",
+    code: "[target = _blank] {}",
   }, {
-    code: "[target= _blank ] { }",
+    code: "[target= _blank ] {}",
   }, {
-    code: "[target = _blank ] { }",
+    code: "[target = _blank ] {}",
   }, {
-    code: "[ target= _blank] { }",
+    code: "[ target= _blank] {}",
   }, {
-    code: "[ target = _blank] { }",
+    code: "[ target = _blank] {}",
   }, {
-    code: "[ target= _blank ] { }",
+    code: "[ target= _blank ] {}",
   }, {
-    code: "[ target = _blank ] { }",
+    code: "[ target = _blank ] {}",
   }, {
-    code: "[target= '_blank'] { }",
+    code: "[target= '_blank'] {}",
   }, {
-    code: "[target = '_blank'] { }",
+    code: "[target = '_blank'] {}",
   }, {
-    code: "[target= ' _blank'] { }",
+    code: "[target= ' _blank'] {}",
   }, {
-    code: "[target= '_blank' ] { }",
+    code: "[target= '_blank' ] {}",
   }, {
-    code: "[target= '_blank '] { }",
+    code: "[target= '_blank '] {}",
   }, {
-    code: "[target = '_blank' ] { }",
+    code: "[target = '_blank' ] {}",
   }, {
-    code: "[target= ' _blank '] { }",
+    code: "[target= ' _blank '] {}",
   }, {
-    code: "[ target= '_blank'] { }",
+    code: "[ target= '_blank'] {}",
   }, {
-    code: "[ target = '_blank'] { }",
+    code: "[ target = '_blank'] {}",
   }, {
-    code: "[ target= ' _blank'] { }",
+    code: "[ target= ' _blank'] {}",
   }, {
-    code: "[ target= '_blank' ] { }",
+    code: "[ target= '_blank' ] {}",
   }, {
-    code: "[ target= '_blank '] { }",
+    code: "[ target= '_blank '] {}",
   }, {
-    code: "[ target = '_blank' ] { }",
+    code: "[ target = '_blank' ] {}",
   }, {
-    code: "[ target= ' _blank '] { }",
+    code: "[ target= ' _blank '] {}",
   }, {
-    code: "[target= \"_blank\"] { }",
+    code: "[target= \"_blank\"] {}",
   }, {
-    code: "[target = \"_blank\"] { }",
+    code: "[target = \"_blank\"] {}",
   }, {
-    code: "[target= \" _blank\"] { }",
+    code: "[target= \" _blank\"] {}",
   }, {
-    code: "[target= \"_blank\" ] { }",
+    code: "[target= \"_blank\" ] {}",
   }, {
-    code: "[target= \"_blank \"] { }",
+    code: "[target= \"_blank \"] {}",
   }, {
-    code: "[target = \"_blank\" ] { }",
+    code: "[target = \"_blank\" ] {}",
   }, {
-    code: "[target= \" _blank \"] { }",
+    code: "[target= \" _blank \"] {}",
   }, {
-    code: "[ target= \"_blank\"] { }",
+    code: "[ target= \"_blank\"] {}",
   }, {
-    code: "[ target = \"_blank\"] { }",
+    code: "[ target = \"_blank\"] {}",
   }, {
-    code: "[ target= \" _blank\"] { }",
+    code: "[ target= \" _blank\"] {}",
   }, {
-    code: "[ target= \"_blank\" ] { }",
+    code: "[ target= \"_blank\" ] {}",
   }, {
-    code: "[ target= \"_blank \"] { }",
+    code: "[ target= \"_blank \"] {}",
   }, {
-    code: "[ target = \"_blank\" ] { }",
+    code: "[ target = \"_blank\" ] {}",
   }, {
-    code: "[ target= \" _blank \"] { }",
+    code: "[ target= \" _blank \"] {}",
   }, {
     code: "[title~= flower] { }",
   }, {
@@ -135,9 +135,9 @@ testRule(rule, {
   }, {
     code: "option[dataHidden] { }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align= right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align= right] {} }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align = right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align = right] {} }",
   }, {
     code: "[target= _blank] .foo { }",
   }, {
@@ -174,6 +174,18 @@ testRule(rule, {
     code: "[ target] { content: \" \" }",
   }, {
     code: "[ target ] { content: \" \" }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {
@@ -457,12 +469,12 @@ testRule(rule, {
     line: 1,
     column: 20,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align=right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align=right] {} }",
     message: messages.expectedAfter("="),
     line: 1,
     column: 49,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align =right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align =right] {} }",
     message: messages.expectedAfter("="),
     line: 1,
     column: 50,
@@ -688,9 +700,9 @@ testRule(rule, {
   }, {
     code: "option[dataHidden] { }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align=right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align=right] {} }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align =right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align =right] {} }",
   }, {
     code: "[target=_blank] .foo { }",
   }, {
@@ -1010,12 +1022,12 @@ testRule(rule, {
     line: 1,
     column: 20,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align= right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align= right] {} }",
     message: messages.rejectedAfter("="),
     line: 1,
     column: 49,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align = right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align = right] {} }",
     message: messages.rejectedAfter("="),
     line: 1,
     column: 50,

--- a/lib/rules/selector-attribute-operator-space-before/__tests__/index.js
+++ b/lib/rules/selector-attribute-operator-space-before/__tests__/index.js
@@ -135,9 +135,9 @@ testRule(rule, {
   }, {
     code: "option[dataHidden] { }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align =right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align =right] {} }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align = right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align = right] {} }",
   }, {
     code: "[target =_blank] .foo { }",
   }, {
@@ -174,6 +174,18 @@ testRule(rule, {
     code: "[ target] { content: \" \" }",
   }, {
     code: "[ target ] { content: \" \" }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {
@@ -457,12 +469,12 @@ testRule(rule, {
     line: 1,
     column: 19,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align=right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align=right] {} }",
     message: messages.expectedBefore("="),
     line: 1,
     column: 49,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align= right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align= right] {} }",
     message: messages.expectedBefore("="),
     line: 1,
     column: 49,
@@ -688,9 +700,9 @@ testRule(rule, {
   }, {
     code: "option[dataHidden] { }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align=right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align=right] {} }",
   }, {
-    code: "@media screen and (max-width: 480px) { img[align= right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align= right] {} }",
   }, {
     code: "[target=_blank] .foo { }",
   }, {
@@ -1010,12 +1022,12 @@ testRule(rule, {
     line: 1,
     column: 20,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align =right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align =right] {} }",
     message: messages.rejectedBefore("="),
     line: 1,
     column: 50,
   }, {
-    code: "@media screen and (max-width: 480px) { img[align = right] { } }",
+    code: "@media screen and (max-width: 480px) { img[align = right] {} }",
     message: messages.rejectedBefore("="),
     line: 1,
     column: 50,

--- a/lib/rules/selector-attribute-operator-whitelist/__tests__/index.js
+++ b/lib/rules/selector-attribute-operator-whitelist/__tests__/index.js
@@ -17,6 +17,18 @@ testRule(rule, {
     code: "a[target=\"_blank\"] { }",
   }, {
     code: "[class|=\"top\"] { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -31,6 +31,18 @@ testRule(rule, {
     code: "[frame=\'hsides\' i] { }",
   }, {
     code: "[data-style=\'value\'][data-loading] { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-class-pattern/__tests__/index.js
+++ b/lib/rules/selector-class-pattern/__tests__/index.js
@@ -22,7 +22,17 @@ const basicAZTests = {
   }, {
     code: "a /* .foo */ {}",
   }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
     code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   }, {
     code: "@keyframes a { 0%, 48.59% {} }",
     message: "Keyframes with decimal percentages",
@@ -105,13 +115,13 @@ testRule(rule, {
   config: [ /^B+$/, { resolveNestedSelectors: true } ],
 
   reject: [ {
-    code: ".A { .B { } }",
+    code: ".A { .B {} }",
     message: messages.expected("A"),
   }, {
-    code: ".A { & .B { } }",
+    code: ".A { & .B {} }",
     message: messages.expected("A"),
   }, {
-    code: ".A { &>.B { } }",
+    code: ".A { &>.B {} }",
     message: messages.expected("A"),
   } ],
 })
@@ -122,10 +132,10 @@ testRule(rule, {
   config: [ /^[A-Z]+$/, { resolveNestedSelectors: true } ],
 
   accept: [ {
-    code: "@for $n from 1 through 5 { .A#{$n} { } }",
+    code: "@for $n from 1 through 5 { .A#{$n} {} }",
     description: "ignore sass interpolation inside @for",
   }, {
-    code: "@for $n from 1 through 5 { .A { &B#{$n} { } }}",
+    code: "@for $n from 1 through 5 { .A { &B#{$n} {} }}",
     description: "ignore sass interpolation of nested selector inside @for",
   }, {
     code: ".#{$a} {}",
@@ -157,7 +167,7 @@ testRule(rule, {
     code: ".A { #mixin-name; }",
     description: "ignore called Less id mixin",
   }, {
-    code: "#namespace { .mixin-name() { } }",
+    code: "#namespace { .mixin-name() {} }",
     description: "ignore namespaced non-ouputting Less class mixin definition",
   }, {
     code: ".A { #namespace > .mixin-name; }",

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -91,6 +91,18 @@ testRule(rule, {
   }, {
     code: "a\r\n\r\na {}",
     description: "combinator selector contain multiple CRLF",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -94,6 +94,18 @@ testRule(rule, {
   }, {
     code: "a\r\n\r\na {}",
     description: "combinator selector contain multiple CRLF",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
@@ -30,6 +30,18 @@ testRule(rule, {
   }, {
     code: ".foo  >>>  .bar {}",
     description: "shadow-piercing descendant combinator",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-id-pattern/__tests__/index.js
+++ b/lib/rules/selector-id-pattern/__tests__/index.js
@@ -22,7 +22,17 @@ const basicAZTests = {
   }, {
     code: "a /* #foo */ {}",
   }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
     code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {
@@ -54,7 +64,7 @@ testRule(rule, {
   config: [/^[A-Z]+$/],
 
   accept: [ {
-    code: "@for $n from 1 through 5 { #a#{$n} { } }",
+    code: "@for $n from 1 through 5 { #a#{$n} {} }",
     description: "ignore sass interpolation inside @for",
   }, {
     code: ".#{$a} {}",

--- a/lib/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/lib/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -55,6 +55,18 @@ testRule(rule, {
   }, {
     code: ":not(:hover, :focus) {}",
     description: "comma inside :not()",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/lib/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -49,6 +49,18 @@ testRule(rule, {
   }, {
     code: ":not(:hover, :focus) {}",
     description: "comma inside :not()",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/selector-list-comma-space-after/__tests__/index.js
@@ -30,6 +30,18 @@ testRule(rule, {
   }, {
     code: ":not(:hover,:focus) {}",
     description: "comma inside :not()",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-list-comma-space-before/__tests__/index.js
+++ b/lib/rules/selector-list-comma-space-before/__tests__/index.js
@@ -30,6 +30,18 @@ testRule(rule, {
   }, {
     code: ":not(:hover, :focus) {}",
     description: "comma inside :not()",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-max-class/__tests__/index.js
+++ b/lib/rules/selector-max-class/__tests__/index.js
@@ -11,6 +11,20 @@ testRule(rule, {
   ruleName,
   config: [0],
 
+  accept: [ {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
+  } ],
+
   reject: [{
     code: ".foo { left: 0; top: 0; }",
     description: "disallow classes",

--- a/lib/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/lib/rules/selector-max-compound-selectors/__tests__/index.js
@@ -31,6 +31,18 @@ testRule(rule, {
     code: "a { b { top: 0; }}",
   }, {
     code: "a { top: 0; d { top: 0; }}",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-max-empty-lines/__tests__/index.js
+++ b/lib/rules/selector-max-empty-lines/__tests__/index.js
@@ -344,6 +344,18 @@ testRule(rule, {
     code: "a::before\n\n\n{ }",
   }, {
     code: "a::before\r\n\r\n\r\n{ }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -29,6 +29,18 @@ testRule(rule, {
   }, {
     code: "z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z z {}",
     message: "a selector with 101 elements has a lower specificity than a selector with one classname",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-nested-pattern/__tests__/index.js
+++ b/lib/rules/selector-nested-pattern/__tests__/index.js
@@ -20,6 +20,18 @@ const basicAZTests = {
     code: "a { B {} }",
   }, {
     code: "a { DIV { SPAN {} } }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-no-attribute/__tests__/index.js
+++ b/lib/rules/selector-no-attribute/__tests__/index.js
@@ -17,7 +17,17 @@ testRule(rule, {
   }, {
     code: "foo .bar {}",
   }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
     code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-no-combinator/__tests__/index.js
+++ b/lib/rules/selector-no-combinator/__tests__/index.js
@@ -17,10 +17,17 @@ testRule(rule, {
   }, {
     code: "a.foo {}",
   }, {
-    code: ":root { --custom-property-set: {} }",
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
   }, {
-    code: ".foo\\+bar {}",
-    description: "escaped combinator-like character",
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-no-empty/__tests__/index.js
+++ b/lib/rules/selector-no-empty/__tests__/index.js
@@ -33,6 +33,18 @@ testRule(rule, {
     code: ".a, .b {}",
   }, {
     code: " a {}",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-no-id/__tests__/index.js
+++ b/lib/rules/selector-no-id/__tests__/index.js
@@ -17,7 +17,17 @@ testRule(rule, {
   }, {
     code: "[foo] {}",
   }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
     code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {
@@ -70,7 +80,7 @@ testRule(rule, {
     code: "div:nth-child(#{map-get($foo, bar)}) {}",
     description: "ignore sass map-get interpolation",
   }, {
-    code: "@for $n from 1 through 10 { .n-#{$n} #foo { } }",
+    code: "@for $n from 1 through 10 { .n-#{$n} #foo {} }",
     description: "ignore sass interpolation + id inside @for",
   } ],
 })
@@ -97,7 +107,7 @@ testRule(rule, {
     code: ".while(@n: 0) when (@n < 10) { .n-@{n} { content: %(\"n: %d\", 1 + 1); } .while(@n + 1) }",
     description: "ignore Less interpolation inside .while",
   }, {
-    code: ".for(@n: 1) when (@n <= 10) { .n-@{n} #foo { } .for(@n + 1) }",
+    code: ".for(@n: 1) when (@n <= 10) { .n-@{n} #foo {} .for(@n + 1) }",
     description: "ignore Less interpolation + id inside .for",
   } ],
 })

--- a/lib/rules/selector-no-qualifying-type/__tests__/index.js
+++ b/lib/rules/selector-no-qualifying-type/__tests__/index.js
@@ -164,6 +164,18 @@ testRule(rule, {
     code: "a:hover #id { }",
   }, {
     code: "a:hover [attribute] { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {
@@ -172,7 +184,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { div#thing { } }",
+    code: "@media (min-width: 700px) { div#thing {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -252,7 +264,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { ul.list { } }",
+    code: "@media (min-width: 700px) { ul.list {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -332,7 +344,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { a[href='place'] { } }",
+    code: "@media (min-width: 700px) { a[href='place'] {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -570,7 +582,7 @@ testRule(rule, {
   }, {
     code: "div#thing { }",
   }, {
-    code: "@media (min-width: 700px) { div#thing { } }",
+    code: "@media (min-width: 700px) { div#thing {} }",
   }, {
     code: "div#thing, a { }",
   }, {
@@ -607,7 +619,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { ul.list { } }",
+    code: "@media (min-width: 700px) { ul.list {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -687,7 +699,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { a[href='place'] { } }",
+    code: "@media (min-width: 700px) { a[href='place'] {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -927,7 +939,7 @@ testRule(rule, {
   }, {
     code: "ul.list.class { }",
   }, {
-    code: "@media (min-width: 700px) { ul.list { } }",
+    code: "@media (min-width: 700px) { ul.list {} }",
   }, {
     code: "ul.list, a { }",
   }, {
@@ -969,7 +981,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { div#thing { } }",
+    code: "@media (min-width: 700px) { div#thing {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -1054,7 +1066,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { a[href='place'] { } }",
+    code: "@media (min-width: 700px) { a[href='place'] {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -1296,7 +1308,7 @@ testRule(rule, {
   }, {
     code: "a[target][data='place'] { }",
   }, {
-    code: "@media (min-width: 700px) { a[href='place'] { } }",
+    code: "@media (min-width: 700px) { a[href='place'] {} }",
   }, {
     code: "a[href='place'], a { }",
   }, {
@@ -1343,7 +1355,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { div#thing { } }",
+    code: "@media (min-width: 700px) { div#thing {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -1433,7 +1445,7 @@ testRule(rule, {
     line: 1,
     column: 1,
   }, {
-    code: "@media (min-width: 700px) { ul.list { } }",
+    code: "@media (min-width: 700px) { ul.list {} }",
     message: messages.rejected,
     line: 1,
     column: 29,
@@ -1516,21 +1528,21 @@ testRule(rule, {
   config: [true],
 
   accept: [ {
-    code: "[target] { &[attribute] { } }",
+    code: "[target] { &[attribute] {} }",
   }, {
-    code: "[target] { &.class { } }",
+    code: "[target] { &.class {} }",
   }, {
-    code: "[target] { &#id { } }",
+    code: "[target] { &#id {} }",
   }, {
-    code: ".class { &[attribute] { } }",
+    code: ".class { &[attribute] {} }",
   }, {
-    code: ".class { &.class-two { } }",
+    code: ".class { &.class-two {} }",
   }, {
-    code: ".class { &#id { } }",
+    code: ".class { &#id {} }",
   }, {
-    code: "#id { &[attribute] { } }",
+    code: "#id { &[attribute] {} }",
   }, {
-    code: "#id { &.class-two { } }",
+    code: "#id { &.class-two {} }",
   }, {
     code: ".some-class:extend(a) {}",
   }, {
@@ -1538,47 +1550,47 @@ testRule(rule, {
   } ],
 
   reject: [ {
-    code: "a { &[attribute] { } }",
+    code: "a { &[attribute] {} }",
     message: messages.rejected,
     line: 1,
     column: 5,
   }, {
-    code: "a { &.class { } }",
+    code: "a { &.class {} }",
     message: messages.rejected,
     line: 1,
     column: 5,
   }, {
-    code: "a { &#id { } }",
+    code: "a { &#id {} }",
     message: messages.rejected,
     line: 1,
     column: 5,
   }, {
-    code: "div a { &[attribute] { } }",
+    code: "div a { &[attribute] {} }",
     message: messages.rejected,
     line: 1,
     column: 13,
   }, {
-    code: "div a { &.class { } }",
+    code: "div a { &.class {} }",
     message: messages.rejected,
     line: 1,
     column: 13,
   }, {
-    code: "div a { &#id { } }",
+    code: "div a { &#id {} }",
     message: messages.rejected,
     line: 1,
     column: 13,
   }, {
-    code: "div { & > a { &[attribute] { } } }",
+    code: "div { & > a { &[attribute] {} } }",
     message: messages.rejected,
     line: 1,
     column: 21,
   }, {
-    code: "div { & > a { &.class { } } }",
+    code: "div { & > a { &.class {} } }",
     message: messages.rejected,
     line: 1,
     column: 21,
   }, {
-    code: "div { & > a { &#id { } } }",
+    code: "div { & > a { &#id {} } }",
     message: messages.rejected,
     line: 1,
     column: 21,
@@ -1591,21 +1603,21 @@ testRule(rule, {
   config: [true],
 
   accept: [ {
-    code: "[target] { &[attribute] { } }",
+    code: "[target] { &[attribute] {} }",
   }, {
-    code: "[target] { &.class { } }",
+    code: "[target] { &.class {} }",
   }, {
-    code: "[target] { &#id { } }",
+    code: "[target] { &#id {} }",
   }, {
-    code: ".class { &[attribute] { } }",
+    code: ".class { &[attribute] {} }",
   }, {
-    code: ".class { &.class-two { } }",
+    code: ".class { &.class-two {} }",
   }, {
-    code: ".class { &#id { } }",
+    code: ".class { &#id {} }",
   }, {
-    code: "#id { &[attribute] { } }",
+    code: "#id { &[attribute] {} }",
   }, {
-    code: "#id { &.class-two { } }",
+    code: "#id { &.class-two {} }",
   }, {
     code: "a#{$selector}.class { }",
   }, {
@@ -1613,51 +1625,51 @@ testRule(rule, {
   }, {
     code: "a.class#{$selector}.class { }",
   }, {
-    code: "%foo { &.bar { } }",
+    code: "%foo { &.bar {} }",
   } ],
 
   reject: [ {
-    code: "a { &[attribute] { } }",
+    code: "a { &[attribute] {} }",
     message: messages.rejected,
     line: 1,
     column: 5,
   }, {
-    code: "a { &.class { } }",
+    code: "a { &.class {} }",
     message: messages.rejected,
     line: 1,
     column: 5,
   }, {
-    code: "a { &#id { } }",
+    code: "a { &#id {} }",
     message: messages.rejected,
     line: 1,
     column: 5,
   }, {
-    code: "div a { &[attribute] { } }",
+    code: "div a { &[attribute] {} }",
     message: messages.rejected,
     line: 1,
     column: 13,
   }, {
-    code: "div a { &.class { } }",
+    code: "div a { &.class {} }",
     message: messages.rejected,
     line: 1,
     column: 13,
   }, {
-    code: "div a { &#id { } }",
+    code: "div a { &#id {} }",
     message: messages.rejected,
     line: 1,
     column: 13,
   }, {
-    code: "div { & > a { &[attribute] { } } }",
+    code: "div { & > a { &[attribute] {} } }",
     message: messages.rejected,
     line: 1,
     column: 21,
   }, {
-    code: "div { & > a { &.class { } } }",
+    code: "div { & > a { &.class {} } }",
     message: messages.rejected,
     line: 1,
     column: 21,
   }, {
-    code: "div { & > a { &#id { } } }",
+    code: "div { & > a { &#id {} } }",
     message: messages.rejected,
     line: 1,
     column: 21,

--- a/lib/rules/selector-no-type/__tests__/index.js
+++ b/lib/rules/selector-no-type/__tests__/index.js
@@ -55,7 +55,11 @@ testRule(rule, {
     code: "@include keyframes(identifier) { to, 50.0% {} 50.01% {} 100% {} }",
     description: "non-standard usage of keyframe selectors",
   }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
     code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
   } ],
 
   reject: [ {
@@ -235,6 +239,12 @@ testRule(rule, {
     code: "my-type {}",
   }, {
     code: "my-other-type {}",
+  }, {
+    code: "my-type { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: "my-type { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-no-type/index.js
+++ b/lib/rules/selector-no-type/index.js
@@ -45,6 +45,7 @@ const rule = function (on, options) {
       if (!isStandardSyntaxRule(rule)) {
         return
       }
+
       if (!isStandardSyntaxSelector(selector)) {
         return
       }

--- a/lib/rules/selector-no-universal/__tests__/index.js
+++ b/lib/rules/selector-no-universal/__tests__/index.js
@@ -19,7 +19,17 @@ testRule(rule, {
   }, {
     code: "[foo] {}",
   }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
     code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -13,7 +13,17 @@ testRule(rule, {
   accept: [ {
     code: ":fullscreen a {}",
   }, {
-    code: ":root { --custom-property: {} }",
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   }, {
     code: "input::placeholder { color: pink; }",
   }, {

--- a/lib/rules/selector-pseudo-class-blacklist/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-blacklist/__tests__/index.js
@@ -31,6 +31,18 @@ testRule(rule, {
     code: "a:-moz-placeholder {}",
   }, {
     code: "a:-MOZ-PLACEholder {}",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-pseudo-class-blacklist/index.js
+++ b/lib/rules/selector-pseudo-class-blacklist/index.js
@@ -1,5 +1,6 @@
 "use strict"
 
+const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
 const matchesStringOrRegExp = require("../../utils/matchesStringOrRegExp")
 const parseSelector = require("../../utils/parseSelector")
@@ -26,11 +27,16 @@ const rule = function (blacklist) {
     }
 
     root.walkRules(rule => {
+      if (!isStandardSyntaxRule(rule)) {
+        return
+      }
+
       const selector = rule.selector
 
       if (!isStandardSyntaxSelector(selector)) {
         return
       }
+
       if (selector.indexOf(":") === -1) {
         return
       }

--- a/lib/rules/selector-pseudo-class-case/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-case/__tests__/index.js
@@ -67,6 +67,18 @@ testRule(rule, {
     code: "input[type=file]:active::-WEBKIT-FILE-UPLOAD-BUTTON { }",
   }, {
     code: ":-ms-input-placeholder { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -53,6 +53,18 @@ testRule(rule, {
     code: "@page :blank:left { }",
   }, {
     code: "@page foo:left { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -1,6 +1,8 @@
 "use strict"
 
 const atRuleParamIndex = require("../../utils/atRuleParamIndex")
+const isStandardSyntaxAtRule = require("../../utils/isStandardSyntaxAtRule")
+const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
 const isCustomSelector = require("../../utils/isCustomSelector")
 const optionsMatches = require("../../utils/optionsMatches")
@@ -98,8 +100,16 @@ const rule = function (actual, options) {
       let selector = null
 
       if (node.type === "rule") {
+        if (!isStandardSyntaxRule(node)) {
+          return
+        }
+
         selector = node.selector
       } else if (node.type === "atrule" && node.name === "page" && node.params) {
+        if (!isStandardSyntaxAtRule(node)) {
+          return
+        }
+
         selector = node.params
       }
 

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
@@ -24,6 +24,18 @@ testRule(rule, {
     code: "input:not( [type='radio'] ):not( [type='checkbox'] ) { }",
   }, {
     code: "a:hover:not( .active ) { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-pseudo-class-whitelist/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-whitelist/__tests__/index.js
@@ -31,6 +31,18 @@ testRule(rule, {
     code: "a:-moz-placeholder {}",
   }, {
     code: "a:-MOZ-PLACEholder {}",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-pseudo-class-whitelist/index.js
+++ b/lib/rules/selector-pseudo-class-whitelist/index.js
@@ -1,5 +1,6 @@
 "use strict"
 
+const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
 const matchesStringOrRegExp = require("../../utils/matchesStringOrRegExp")
 const parseSelector = require("../../utils/parseSelector")
@@ -26,6 +27,10 @@ const rule = function (whitelist) {
     }
 
     root.walkRules(rule => {
+      if (!isStandardSyntaxRule(rule)) {
+        return
+      }
+
       const selector = rule.selector
 
       if (!isStandardSyntaxSelector(selector)) {
@@ -40,7 +45,6 @@ const rule = function (whitelist) {
           const value = pseudoNode.value
 
           // Ignore pseudo-elements
-
           if (value.slice(0, 2) === "::") {
             return
           }

--- a/lib/rules/selector-pseudo-element-case/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-case/__tests__/index.js
@@ -52,6 +52,18 @@ testRule(rule, {
     code: "a:FOCUS { }",
   }, {
     code: "input::-moz-placeholder { color: pink; }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -32,6 +32,18 @@ testRule(rule, {
     code: "li::marker { font-variant-numeric: tabular-nums; }",
   }, {
     code: "input::placeholder { color: pink; }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
@@ -64,6 +64,18 @@ testRule(rule, {
     code: "a:hover::-moz-placeholder { }",
   }, {
     code: "a,\nb > .foo::before { }",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-root-no-composition/__tests__/index.js
+++ b/lib/rules/selector-root-no-composition/__tests__/index.js
@@ -36,6 +36,18 @@ testRule(rule, {
     code: ":ROOT {}",
   }, {
     code: "   :root\n {}",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-type-case/__tests__/index.js
+++ b/lib/rules/selector-type-case/__tests__/index.js
@@ -52,7 +52,17 @@ testRule(rule, {
     code: "@include keyframes(identifier) { TO, 50.0% {} 50.01% {} 100% {} }",
     description: "non-standard usage of keyframe selectors",
   }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
     code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -72,8 +72,17 @@ testRule(rule, {
     code: "@include keyframes(identifier) { 0% {} 100% {} }",
     description: "non-standard usage of keyframe selectors",
   }, {
-    code: "a { --custom-property-set: {}; }",
-    description: "custom property set",
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: "html { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "html { --custom-property-set: {} }",
+    description: "custom property set in selector",
   }, {
     code: "abs {}",
     description: "MathML tags",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2631

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

/cc @jeddy3 

Some note:
1. Add 
```
 {
    code: ":root { --foo: 1px; }",
    description: "custom property in root",
  }, {
    code: "html { --foo: 1px; }",
    description: "custom property in selector",
  }, {
    code: ":root { --custom-property-set: {} }",
    description: "custom property set in root",
  }, {
    code: "html { --custom-property-set: {} }",
    description: "custom property set in selector",
  }
``` 
to all `selector-*` rules, it seems some superfluous, but after spec will become Recommendation, we can move all this tests to basic.
2. All `{ }` to `{}` in tests (extra unnecessary space in `{ }`).