### PR TITLE
Add an `ignorePattern` example for URL in comments in `max-line-length`

### DIFF
--- a/lib/rules/max-line-length/README.md
+++ b/lib/rules/max-line-length/README.md
@@ -128,7 +128,7 @@ The following pattern is *not* considered a violation:
 Given the following, with a maximum length of `20`.
 
 ```js
-["/https?:\/\/[0-9,a-z]*.*"]
+["/https?:\/\/[0-9,a-z]*.*/"]
 ```
 
 The following pattern is *not* considered a violation:

--- a/lib/rules/max-line-length/README.md
+++ b/lib/rules/max-line-length/README.md
@@ -124,3 +124,15 @@ The following pattern is *not* considered a violation:
 ```css
 @import "../../../../another/css/or/scss/file/or/something.css";
 ```
+
+Given the following, with a maximum length of `20`.
+
+```js
+["/https?:\/\/[0-9,a-z]*.*"]
+```
+
+The following pattern is *not* considered a violation:
+
+```css
+/* ignore urls https://www.example.com */
+```


### PR DESCRIPTION
Ref: #2630