### PR TITLE
Add an `ignorePattern` test for URLs in comments in `max-line-length`

### DIFF
--- a/lib/rules/max-line-length/__tests__/index.js
+++ b/lib/rules/max-line-length/__tests__/index.js
@@ -238,6 +238,16 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [ 20, { ignorePattern: "/https?:\/\/[0-9,a-z]*.*/" } ],
+
+  accept: [{
+    code: "/* ignore urls https://www.example.com */",
+  }],
+
+})
+
+testRule(rule, {
+  ruleName,
   config: [ 30, { ignorePattern: "/@import\\s+/" } ],
 
   accept: [{


### PR DESCRIPTION
Ref: #2630