### PR TITLE
Update CI engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
     - node_js: '8'
       script: npm run pretest
       env: CI=pretest
+    - node_js: '8'
+      script: npm run jest -- --runInBand  --coverage
+      env: CI=coverage
     - node_js: '6'
       script: npm run jest -- --runInBand
       env: CI=tests 6
@@ -15,9 +18,6 @@ matrix:
       script: npm run jest -- --runInBand
       env: CI=tests 4
       sudo: required
-    - node_js: '8'
-      script: npm run jest -- --runInBand  --coverage
-      env: CI=coverage
 before_install:
   - npm prune
   - npm update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,9 @@ cache:
     - node_modules
 matrix:
   include:
-    - node_js: '7'
+    - node_js: '8'
       script: npm run pretest
       env: CI=pretest
-    - node_js: '8'
-      script: npm run jest -- --runInBand
-      env: CI=tests 8
-    - node_js: '7'
-      script: npm run jest -- --runInBand
-      env: CI=tests 7
     - node_js: '6'
       script: npm run jest -- --runInBand
       env: CI=tests 6
@@ -21,7 +15,7 @@ matrix:
       script: npm run jest -- --runInBand
       env: CI=tests 4
       sudo: required
-    - node_js: '7'
+    - node_js: '8'
       script: npm run jest -- --runInBand  --coverage
       env: CI=coverage
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 
 environment:
   matrix:
-    - nodejs_version: 7
+    - nodejs_version: 8
 
 version: "{build}"
 build: off


### PR DESCRIPTION
This should lop a few minutes off the total time. It was pretty painful watching the CI tick over after merging the various pre-`7.11.1` branches.

- Drops 7
- The coverage task also runs the tests on 8, so we don’t need a specific 8 one.
- Bumps coverage up the order as it takes the longest.
- Uses 8 for pretests and coverage quicker than 7.
- Uses 8 on appveyor for speed.