### PR TITLE
Added: `selector-max-type` rule

### DIFF
--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -139,6 +139,7 @@ You might want to learn a little about [how rules are named and how they work to
     "selector-max-empty-lines": int,
     "selector-max-id": int,
     "selector-max-specificity": string,
+    "selector-max-type": int,
     "selector-max-universal": int,
     "selector-nested-pattern": string,
     "selector-no-attribute": true,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -170,6 +170,7 @@ Here are all the rules within stylelint, grouped by the [*thing*](http://apps.wo
 -   [`selector-max-empty-lines`](../../lib/rules/selector-max-empty-lines/README.md): Limit the number of adjacent empty lines within selectors.
 -   [`selector-max-id`](../../lib/rules/selector-max-id/README.md): Limit the number of id selectors in a selector.
 -   [`selector-max-specificity`](../../lib/rules/selector-max-specificity/README.md): Limit the specificity of selectors.
+-   [`selector-max-type`](../../lib/rules/selector-max-type/README.md): Limit the number of type in a selector.
 -   [`selector-max-universal`](../../lib/rules/selector-max-universal/README.md): Limit the number of universal selectors in a selector.
 -   [`selector-nested-pattern`](../../lib/rules/selector-nested-pattern/README.md): Specify a pattern for the selectors of rules nested within rules.
 -   [`selector-no-attribute`](../../lib/rules/selector-no-attribute/README.md): Disallow attribute selectors.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -143,7 +143,11 @@ const selectorMaxCompoundSelectors = require("./selector-max-compound-selectors"
 const selectorMaxEmptyLines = require("./selector-max-empty-lines")
 const selectorMaxId = require("./selector-max-id")
 const selectorMaxSpecificity = require("./selector-max-specificity")
+<<<<<<< HEAD
 const selectorMaxUniversal = require("./selector-max-universal")
+=======
+const selectorMaxType = require("./selector-max-type")
+>>>>>>> Added: `selector-max-type` rule.
 const selectorNestedPattern = require("./selector-nested-pattern")
 const selectorNoAttribute = require("./selector-no-attribute")
 const selectorNoCombinator = require("./selector-no-combinator")
@@ -325,6 +329,7 @@ module.exports = {
   "selector-max-empty-lines": selectorMaxEmptyLines,
   "selector-max-id": selectorMaxId,
   "selector-max-specificity": selectorMaxSpecificity,
+  "selector-max-type": selectorMaxType,
   "selector-max-universal": selectorMaxUniversal,
   "selector-nested-pattern": selectorNestedPattern,
   "selector-no-attribute": selectorNoAttribute,

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -143,11 +143,8 @@ const selectorMaxCompoundSelectors = require("./selector-max-compound-selectors"
 const selectorMaxEmptyLines = require("./selector-max-empty-lines")
 const selectorMaxId = require("./selector-max-id")
 const selectorMaxSpecificity = require("./selector-max-specificity")
-<<<<<<< HEAD
-const selectorMaxUniversal = require("./selector-max-universal")
-=======
 const selectorMaxType = require("./selector-max-type")
->>>>>>> Added: `selector-max-type` rule.
+const selectorMaxUniversal = require("./selector-max-universal")
 const selectorNestedPattern = require("./selector-nested-pattern")
 const selectorNoAttribute = require("./selector-no-attribute")
 const selectorNoCombinator = require("./selector-no-combinator")

--- a/lib/rules/selector-max-type/README.md
+++ b/lib/rules/selector-max-type/README.md
@@ -1,0 +1,128 @@
+# selector-max-type
+
+Limit the number of type selectors in a selector.
+
+```css
+    a {}
+/** ↑
+ * This type of selector */
+```
+
+This rule resolves nested selectors before counting the number of type selectors. Each selector in a [selector list](https://www.w3.org/TR/selectors4/#selector-list) is evaluated separately.
+
+The `:not()` pseudo-class is also evaluated separately. The rule processes the argument as if it were an independent selector, and the result does not count toward the total for the entire selector.
+
+## Options
+
+`int`: Maximum type selectors allowed.
+
+For example, with `2`:
+
+The following patterns are considered violations:
+
+```css
+div a span {}
+```
+
+```css
+div a {
+  & span {}
+}
+```
+
+```css
+div a {
+  & > a {}
+}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+div {}
+```
+
+```css
+div a {}
+```
+
+```css
+.foo div a {}
+```
+
+```css
+div.foo a {}
+```
+
+```css
+/* each selector in a selector list is evaluated separately */
+div,
+a span {}
+```
+
+```css
+/* `span` is inside `:not()`, so it is evaluated separately */
+div a .foo:not(span) {}
+```
+
+The following patterns are *not* considered violations:
+
+## Optional secondary options
+
+### `ignore: ["compounded", "descendant"]`
+
+#### `"compounded"`
+
+Discount compounded type selectors -- i.e. type selectors chained with other selectors.
+
+For example, with `2`:
+
+The following patterns are *not* considered violations:
+
+```css
+div span a.foo {}
+```
+
+```css
+div span a#bar {}
+```
+
+#### `"descendant"`
+
+Discount descendant type selectors.
+
+For example, with `2`:
+
+The following patterns are *not* considered violations:
+
+```css
+.foo div span a {}
+```
+
+```css
+#bar div span a {}
+```
+
+### `ignoreTypes: ["/regex/", "string"]`
+
+Given:
+
+```js
+["/^my-/", "custom"]
+```
+
+For example, with `2`.
+
+The following patterns are *not* considered violations:
+
+```css
+div a custom {}
+```
+
+```css
+div a my-type {}
+```
+
+```css
+div a my-other-type {}
+```

--- a/lib/rules/selector-max-type/__tests__/index.js
+++ b/lib/rules/selector-max-type/__tests__/index.js
@@ -1,0 +1,319 @@
+"use strict"
+
+const messages = require("..").messages
+const ruleName = require("..").ruleName
+const rules = require("../../../rules")
+
+const rule = rules[ruleName]
+
+// Sanity checks
+testRule(rule, {
+  ruleName,
+  config: [0],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: ".bar {}",
+  }, {
+    code: "#foo {}",
+  }, {
+    code: "[foo] {}",
+  }, {
+    code: ":root { --foo: 1px; }",
+    description: "custom property in root",
+  }, {
+    code: ":root { --custom-property-set: {} }",
+    description: "custom property set in root",
+  }, {
+    code: "@import \"foo.css\";",
+  }, {
+    code: ".foo { & {} }",
+  }, {
+    code: ".foo { &.bar {} }",
+  }, {
+    code: ".foo { &-bar {} }",
+  }, {
+    code: ".foo { &__bar {} }",
+  }, {
+    code: ".foo { [&] {} }",
+  }, {
+    code: ".foo { & [class*=bar] {} }",
+  }, {
+    code: ".foo { @nest & {} }",
+  }, {
+    code: ".foo:nth-child(3n + 1) {}",
+  }, {
+    code: ".foo:nth-child(n) {}",
+  }, {
+    code: ".foo:nth-child(odd) {}",
+  }, {
+    code: ".foo:nth-child(even) {}",
+  }, {
+    code: ".foo:nth-child(-n) {}",
+  }, {
+    code: ".foo { &:nth-child(3n + 1) {} }",
+  }, {
+    code: "@keyframes spin { 0% {} }",
+  }, {
+    code: "@keyframes spin { to {} from {} }",
+  }, {
+    code: "@include keyframes(identifier) { to, 50.0% {} 50.01% {} 100% {} }",
+    description: "non-standard usage of keyframe selectors",
+  } ],
+
+  reject: [ {
+    code: "foo {}",
+    message: messages.expected("foo", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".bar > foo {}",
+    message: messages.expected(".bar > foo", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: "foo.bar {}",
+    message: messages.expected("foo.bar", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".foo, .bar, foo.baz {}",
+    message: messages.expected("foo.baz", 0),
+    line: 1,
+    column: 13,
+  }, {
+    code: ".foo { div {} }",
+    description: "nested descendant",
+    message: messages.expected(".foo div", 0),
+    line: 1,
+    column: 8,
+  }, {
+    code: ".foo { .baz, div {} }",
+    description: "nested selector list of descendants",
+    message: messages.expected(".foo div", 0),
+    line: 1,
+    column: 8,
+  } ],
+})
+
+// Standard tests
+testRule(rule, {
+  ruleName,
+  config: [2],
+
+  accept: [ {
+    code: "foo {}",
+    description: "fewer than max type selectors",
+  }, {
+    code: "foo:hover {}",
+    description: "pseudo selector",
+  }, {
+    code: "foo bar {}",
+    description: "compound selector",
+  }, {
+    code: "foo, \nbar {}",
+    description: "multiple selectors: fewer than max type selectors",
+  }, {
+    code: "foo bar, \nbaz quux {}",
+    description: "multiple selectors: exactly max type selectors",
+  }, {
+    code: "foo bar:not(baz) {}",
+    description: ":not(): outside and inside",
+  }, {
+    code: "foo { bar {} }",
+    description: "nested selectors",
+  }, {
+    code: "foo { bar > & {} }",
+    description: "nested selectors: parent selector",
+  }, {
+    code: "foo, bar { & > foo {} }",
+    description: "nested selectors: superfluous parent selector",
+  }, {
+    code: "@media print { foo bar {} }",
+    description: "media query: parent",
+  }, {
+    code: "foo { @media print { bar {} } }",
+    description: "media query: nested",
+  } ],
+
+  reject: [ {
+    code: "foo bar baz {}",
+    description: "compound selector: greater than max type selectors",
+    message: messages.expected("foo bar baz", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: "foo, \nbar baz foo {}",
+    description: "multiple selectors: greater than max classes",
+    message: messages.expected("bar baz foo", 2),
+    line: 2,
+    column: 1,
+  }, {
+    code: "foo bar baz:not(quux) {}",
+    description: ":not(): greater than max type selectors, outside",
+    message: messages.expected("foo bar baz:not(quux)", 2),
+    line: 1,
+    column: 1,
+  }, {
+    code: "foo { &:hover > bar baz {} }",
+    description: "nested selectors: greater than max type selectors",
+    message: messages.expected("foo:hover > bar baz", 2),
+    line: 1,
+    column: 7,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ 0, { ignore: ["descendant"] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: ".foo div {}",
+  }, {
+    code: ".foo > div {}",
+  }, {
+    code: ".foo + div {}",
+  }, {
+    code: "#bar div.foo {}",
+    description: "compounded and descendant",
+  }, {
+    code: ".foo { div {} }",
+    description: "nested descendant",
+  }, {
+    code: ".foo { div, a {} }",
+    description: "nested selector list of descendants",
+  } ],
+
+  reject: [ {
+    code: "div {}",
+    message: messages.expected("div", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".foo, div {}",
+    message: messages.expected("div", 0),
+    line: 1,
+    column: 7,
+  }, {
+    code: "div.foo {}",
+    message: messages.expected("div.foo", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: "div .foo {}",
+    message: messages.expected("div .foo", 0),
+    line: 1,
+    column: 1,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ 0, { ignore: ["compounded"] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "div.foo {}",
+  }, {
+    code: "div#foo {}",
+  }, {
+    code: "div[something] {}",
+  }, {
+    code: "#bar div.foo {}",
+    description: "compounded and descendant",
+  } ],
+
+  reject: [ {
+    code: "div {}",
+    message: messages.expected("div", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: ".foo, div {}",
+    message: messages.expected("div", 0),
+    line: 1,
+    column: 7,
+  }, {
+    code: ".foo div {}",
+    message: messages.expected(".foo div", 0),
+    line: 1,
+    column: 1,
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ 0, { ignore: [ "compounded", "descendant" ] } ],
+  skipBasicChecks: true,
+
+  accept: [{
+    code: "#bar div.foo {}",
+    description: "compounded descendant",
+  }],
+
+  reject: [{
+    code: "bar div.foo {}",
+    message: messages.expected("bar div.foo", 0),
+    line: 1,
+    column: 1,
+  }],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [0],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [ {
+    code: "// Comment\n.c {}",
+  }, {
+    code: "@for $n from 1 through 5 { .foo-#{$n} { div { content: \"#{$n}\"; } } }",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [0],
+  skipBasicChecks: true,
+  syntax: "less",
+
+  accept: [ {
+    code: "// Comment\n.c {}",
+  }, {
+    code: ".for(@n: 1) when (@n <= 5) { .foo-@{n} { div { content: \"@{n}\"; } } .for (@n + 1); }",
+  } ],
+})
+
+testRule(rule, {
+  ruleName,
+  config: [ 0, { ignoreTypes: [ "fieldset", "/^my-/" ] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "fieldset {}",
+  }, {
+    code: "my-type {}",
+  }, {
+    code: "my-other-type {}",
+  }, {
+    code: "my-type { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: "my-type { --custom-property-set: {} }",
+    description: "custom property set in selector",
+  } ],
+
+  reject: [ {
+    code: "a {}",
+    message: messages.expected("a", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: "not-my-type {}",
+    message: messages.expected("not-my-type", 0),
+    line: 1,
+    column: 1,
+  } ],
+})

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -1,0 +1,129 @@
+"use strict"
+
+const _ = require("lodash")
+const isKeyframeSelector = require("../../utils/isKeyframeSelector")
+const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
+const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
+const optionsMatches = require("../../utils/optionsMatches")
+const parseSelector = require("../../utils/parseSelector")
+const report = require("../../utils/report")
+const ruleMessages = require("../../utils/ruleMessages")
+const validateOptions = require("../../utils/validateOptions")
+const resolvedNestedSelector = require("postcss-resolve-nested-selector")
+
+const ruleName = "selector-max-type"
+
+const messages = ruleMessages(ruleName, {
+  expected: (selector, max) => `Expected "${selector}" to have no more than ${max} type ${max === 1 ? "selector" : "selectors"}`,
+})
+
+function rule(max, options) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: max,
+      possible(max) {
+        return typeof max === "number" && max >= 0
+      },
+    }, {
+      actual: options,
+      possible: {
+        ignore: [
+          "descendant",
+          "compounded",
+        ],
+        ignoreTypes: [_.isString],
+      },
+      optional: true,
+    })
+    if (!validOptions) {
+      return
+    }
+
+    const ignoreDescendant = optionsMatches(options, "ignore", "descendant")
+    const ignoreCompounded = optionsMatches(options, "ignore", "compounded")
+
+    function checkSelector(selectorNode, ruleNode) {
+      const count = selectorNode.reduce((total, childNode) => {
+        // Only traverse inside actual selectors and :not()
+        if (childNode.type === "selector" || childNode.value === ":not") {
+          checkSelector(childNode, ruleNode)
+        }
+
+        if (optionsMatches(options, "ignoreTypes", childNode.value)) {
+          return total
+        }
+
+        if (ignoreDescendant && hasCombinatorBefore(childNode)) {
+          return total
+        }
+
+        if (ignoreCompounded && isCompounded(childNode)) {
+          return total
+        }
+
+        return total += (childNode.type === "tag" ? 1 : 0)
+      }, 0)
+
+      if (selectorNode.type !== "root" && selectorNode.type !== "pseudo" && count > max) {
+        report({
+          ruleName,
+          result,
+          node: ruleNode,
+          message: messages.expected(selectorNode, max),
+          word: selectorNode,
+        })
+      }
+    }
+
+    root.walkRules(ruleNode => {
+      const selector = ruleNode.selector,
+        selectors = ruleNode.selectors
+
+      if (!isStandardSyntaxRule(ruleNode)) {
+        return
+      }
+      if (!isStandardSyntaxSelector(selector)) {
+        return
+      }
+      if (selectors.some(s => isKeyframeSelector(s))) {
+        return
+      }
+      if (ruleNode.nodes.some(node => [ "rule", "atrule" ].indexOf(node.type) !== -1)) {
+        // Skip unresolved nested selectors
+        return
+      }
+
+      ruleNode.selectors.forEach(selector => {
+        resolvedNestedSelector(selector, ruleNode).forEach(resolvedSelector => {
+          if (!isStandardSyntaxSelector(resolvedSelector)) {
+            return
+          }
+          parseSelector(resolvedSelector, result, ruleNode, container => checkSelector(container, ruleNode))
+        })
+      })
+    })
+  }
+}
+
+function hasCombinatorBefore(node) {
+  return node.parent.nodes.slice(0, node.parent.nodes.indexOf(node)).some(isCombinator)
+}
+
+function isCompounded(node) {
+  if (node.prev() && !isCombinator(node.prev())) {
+    return true
+  }
+  if (node.next() && !isCombinator(node.next())) {
+    return true
+  }
+  return false
+}
+
+function isCombinator(node) {
+  if (!node) return false
+  return _.get(node, "type") === "combinator"
+}
+
+rule.ruleName = ruleName
+rule.messages = messages
+module.exports = rule


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2528

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Need resolve:
1. `html { --foo: 1px; }` and `html { --custom-property-set: {} }` should be rejected? I think yes, because we can have `html { --some-here: 1px; --custom-property-set: { color: red; display: block; }; color: red;}` Later we can add option `ignoreContaintCustom` (or best name for this purpose).
2. After resolve selector some non standard (example scss: `@for $n from 1 through 5 { .foo-#{$n} { div { content: \"#{$n}\"; } } }`) output error `.foo-#{$n} div`, it is valid because we contain `div`, but message is very weird. It is normal or not?

Some tests are commented.