### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 *.log
 .coverage
 .eslintcache


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Kind of related to https://github.com/stylelint/stylelint/issues/2061#issuecomment-303603179

> Is there anything in the PR that needs further explanation?

It's uncomfortable to work with stylelint repository when npm@5 is installed. Because npm@5 automatically creates `package-lock.json`. So this file should be constantly manually deleted when switching branches or rebase. It's tedious. While we haven't decided to use `package-lock.json` we could ignore it.
