### PR TITLE
docs: Update PostCSS Less repo URL

### DIFF
--- a/docs/user-guide/css-processors.md
+++ b/docs/user-guide/css-processors.md
@@ -14,7 +14,7 @@ You can run the linter before or after your css processors. Depending on which p
 By default, the linter can *parse* any the following non-standard syntaxes by using special PostCSS parsers:
 
 -   SCSS (using [`postcss-scss`](https://github.com/postcss/postcss-scss))
--   Less (using [`postcss-less`](https://github.com/webschik/postcss-less))
+-   Less (using [`postcss-less`](https://github.com/shellscape/postcss-less))
 -   SugarSS (using [`sugarss`](https://github.com/postcss/sugarss))
 
 *Non-standard syntaxes can automatically be inferred from the following file extensions: `.less`, `.scss`, and `.sss`.* If you would need to specify your non-standard syntax, though, both the [CLI](cli.md) and the [Node API](node-api.md) expose a `syntax` option.

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -65,7 +65,7 @@ You'll also need to use a reporter. *The stylelint plugin registers warnings via
 
 ### Example A
 
-A separate lint task that uses the plugin via the PostCSS JS API to lint Less using [`postcss-less`](https://github.com/webschik/postcss-less).
+A separate lint task that uses the plugin via the PostCSS JS API to lint Less using [`postcss-less`](https://github.com/shellscape/postcss-less).
 
 *Note: the stylelint PostCSS plugin, unlike the stylelint CLI and node API, doesn't have a `syntax` option. Instead, the syntax must be set within the [PostCSS options](https://github.com/postcss/postcss#options) as there can only be one parser/syntax in a pipeline.*
 

--- a/lib/utils/isStandardSyntaxRule.js
+++ b/lib/utils/isStandardSyntaxRule.js
@@ -27,7 +27,7 @@ module.exports = function (rule/*: Object*/)/*: boolean*/ {
   }
 
   // Ignore mixin or &:extend rule
-  // https://github.com/webschik/postcss-less/blob/master/lib/less-parser.js#L52
+  // https://github.com/shellscape/postcss-less/blob/master/lib/less-parser.js#L52
   if (rule.params && rule.params[0]) {
     return false
   }


### PR DESCRIPTION
Pulls in the doc only changes for the new URL of the PostCSS Less repo from #2547