### PR TITLE
Improve search keywords for turning off a rule

### DIFF
--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,8 +1,8 @@
 # FAQ
 
-## How do I disable a rule?
+## How do I turn off, disable or ignore a rule?
 
-You can disable a rule by setting its config value to `null`.
+You can turn off a rule by setting its config value to `null`.
 
 For example, to use `stylelint-config-standard` without the `at-rule-empty-line-before` rule:
 
@@ -15,7 +15,7 @@ For example, to use `stylelint-config-standard` without the `at-rule-empty-line-
 }
 ```
 
-You can also disable a rule for specific sections of your CSS. Refer to the rules section of the [configuration guide](configuration.md#rules) for more information.
+You can also turn off a rule for specific sections of your CSS. Refer to the rules section of the [configuration guide](configuration.md#rules) for more information.
 
 ## How do I lint from the command line?
 


### PR DESCRIPTION
Closes #2669

We consistently use the term “turn off”. I suggest we keep it that way in the main docs for consistency.

However, this PR adds “ignore” to the FAQ heading, so that it will appear in the search results.

As we position the FAQ as the first port of call for help, I think it makes sense to make searching improvements only there. It then acts as the jumping off point to the consistent docs.