### PR TITLE
Fix postcssPlugin tests for postcss@6

### DIFF
--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -16,7 +16,7 @@ it("`configFile` option with absolute path", () => {
   const config = {
     configFile: path.join(__dirname, "fixtures/config-block-no-empty.json"),
   }
-  return postcssPlugin.process("a {}", config).then(postcssResult => {
+  return postcssPlugin.process("a {}", {}, config).then(postcssResult => {
     const warnings = postcssResult.warnings()
     expect(warnings.length).toBe(1)
     expect(warnings[0].text.indexOf("block-no-empty")).not.toBe(-1)
@@ -24,7 +24,7 @@ it("`configFile` option with absolute path", () => {
 })
 
 it("`configFile` with bad path", () => {
-  return postcssPlugin.process("a {}", { configFile: "./herby.json" }).then(() => {
+  return postcssPlugin.process("a {}", {}, { configFile: "./herby.json" }).then(() => {
     throw new Error("should not have succeeded")
   }).catch(err => {
     expect(err.code).toBe("ENOENT")
@@ -35,7 +35,7 @@ it("`configFile` option without rules", () => {
   const config = {
     configFile: path.join(__dirname, "fixtures/config-without-rules.json"),
   }
-  return postcssPlugin.process("a {}", config).then(() => {
+  return postcssPlugin.process("a {}", {}, config).then(() => {
     throw new Error("should not have succeeded")
   }).catch(err => {
     expect(err).toEqual(configurationError("No rules found within configuration. Have you provided a \"rules\" property?"))
@@ -47,7 +47,7 @@ it("`configFile` option with undefined rule", () => {
     configFile: path.join(__dirname, "fixtures/config-with-undefined-rule.json"),
   }
   const ruleName = "unknown-rule"
-  return postcssPlugin.process("a {}", config).then(() => {
+  return postcssPlugin.process("a {}", {}, config).then(() => {
     throw new Error("should not have succeeded")
   }).catch(err => {
     expect(err).toEqual(configurationError(`Undefined rule ${ruleName}`))
@@ -62,7 +62,7 @@ it("`ignoreFiles` options is not empty and file ignored", () => {
     ignoreFiles: "**/foo.css",
     from: "foo.css",
   }
-  return postcssPlugin.process("a {}", config).then(postcssResult => {
+  return postcssPlugin.process("a {}", {}, config).then(postcssResult => {
     expect(postcssResult.stylelint.ignored).toBeTruthy()
   })
 })
@@ -75,7 +75,7 @@ it("`ignoreFiles` options is not empty and file not ignored", () => {
     ignoreFiles: "**/bar.css",
     from: "foo.css",
   }
-  return postcssPlugin.process("a {}", config).then(postcssResult => {
+  return postcssPlugin.process("a {}", {}, config).then(postcssResult => {
     expect(postcssResult.stylelint.ignored).toBeFalsy()
   })
 })


### PR DESCRIPTION
In 6.0 the `plugin.process` shortcut splits the process and plugin options.