### PR TITLE
Update micromatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "log-symbols": "^1.0.2",
     "mathml-tag-names": "^2.0.0",
     "meow": "^3.3.0",
-    "micromatch": "^2.3.11",
+    "micromatch": "^3.0.3",
     "normalize-selector": "^0.2.0",
     "pify": "^2.3.0",
     "postcss": "^5.0.20",


### PR DESCRIPTION
Going into `v8` as the ignore feature has changed there.

Some tests still fail though on windows. Let's try the suggestion in  https://github.com/micromatch/micromatch/issues/95#issuecomment-311142456

Replaces: https://github.com/stylelint/stylelint/pull/2597.