### PR TITLE
Update postcss-less to 1.0

### DIFF
--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -86,7 +86,9 @@ function lintPostcssResult(
   postcssResult.stylelint.customMessages = {}
   postcssResult.stylelint.quiet = config.quiet
 
-  const newlineMatch = postcssResult.root.toResult().css.match(/\r?\n/)
+  const newlineMatch = postcssResult.root.toResult({
+    stringifier: postcssResult.opts.syntax,
+  }).css.match(/\r?\n/)
   const newline = newlineMatch ? newlineMatch[0] : getOsEol()
 
   const postcssRoot = postcssResult.root

--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -555,6 +555,6 @@ testRule(rule, {
     code: "a { .mixin();\ncolor: red;; }",
     message: messages.rejected,
     line: 2,
-    column: 11,
+    column: 12,
   }],
 })

--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -555,6 +555,6 @@ testRule(rule, {
     code: "a { .mixin();\ncolor: red;; }",
     message: messages.rejected,
     line: 2,
-    column: 10,
+    column: 11,
   }],
 })

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -53,6 +53,10 @@ const rule = function (actual) {
     }
 
     root.walk(node => {
+      if (node.mixin) {
+        return
+      }
+
       let rawBeforeNode = node.raws.before
 
       if (rawBeforeNode && rawBeforeNode.trim().length !== 0) {
@@ -87,6 +91,15 @@ const rule = function (actual) {
       const rawAfterNode = node.raws.after
 
       if (rawAfterNode && rawAfterNode.trim().length !== 0) {
+        /**
+         * If the last child is a Less mixin followed by more than one semicolon,
+         * node.raws.after will be populated with that semicolon.
+         * Since we ignore Less mixins, exit here
+         */
+        if (node.last && node.last.mixin) {
+          return
+        }
+
         styleSearch({ source: rawAfterNode, target: ";" }, (match) => {
           const index = getOffsetByNode(node) + node.toString().length - 1 - rawAfterNode.length + match.startIndex
 

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -1,6 +1,7 @@
 "use strict"
 
 const isCustomPropertySet = require("../../utils/isCustomPropertySet")
+const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
 const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
 const validateOptions = require("../../utils/validateOptions")
@@ -53,7 +54,11 @@ const rule = function (actual) {
     }
 
     root.walk(node => {
-      if (node.mixin) {
+      if (
+        node.type === "rule"
+        && !isCustomPropertySet(node)
+        && !isStandardSyntaxRule(node)
+      ) {
         return
       }
 
@@ -96,7 +101,12 @@ const rule = function (actual) {
          * node.raws.after will be populated with that semicolon.
          * Since we ignore Less mixins, exit here
          */
-        if (node.last && node.last.mixin) {
+        if (
+          node.last
+          && node.last.type === "rule"
+          && !isCustomPropertySet(node.last)
+          && !isStandardSyntaxRule(node.last)
+        ) {
           return
         }
 

--- a/lib/utils/isStandardSyntaxRule.js
+++ b/lib/utils/isStandardSyntaxRule.js
@@ -17,12 +17,17 @@ module.exports = function (rule/*: Object*/)/*: boolean*/ {
   }
 
   // Called Less mixin (e.g. a { .mixin() })
-  if (rule.ruleWithoutBody) {
+  if (rule.mixin) {
     return false
   }
 
   // Less detached rulesets
   if (selector.slice(0, 1) === "@" && selector.slice(-1) === ":") {
+    return false
+  }
+
+  // Ignore Less &:extend rule
+  if (rule.extend) {
     return false
   }
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "normalize-selector": "^0.2.0",
     "pify": "^2.3.0",
     "postcss": "^6.0.4",
-    "postcss-less": "^0.14.0",
+    "postcss-less": "^1.0.2",
     "postcss-media-query-parser": "^0.2.0",
     "postcss-reporter": "^4.0.0",
     "postcss-resolve-nested-selector": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "normalize-selector": "^0.2.0",
     "pify": "^2.3.0",
     "postcss": "^6.0.4",
-    "postcss-less": "^1.0.2",
+    "postcss-less": "^1.1.0",
     "postcss-media-query-parser": "^0.2.0",
     "postcss-reporter": "^4.0.0",
     "postcss-resolve-nested-selector": "^0.1.1",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Superseeds #2637.

> Is there anything in the PR that needs further explanation?

This is still a WIP, two issues in `no-extra-semicolons` remains.

The big thing however, which isn't reflected by the tests are stringifying of the new `Import` node type in a couple of rules (`string-quotes` for example) and the use of `node.positionBy()` in `utils/report`. It would fail with the same `TypeError: this[node.type] is not a function` errors since the `Root` node there wasn't from `postcss-less` but from `postcss`. I found those issues while running `stylelint` via the CLI. However, I have a fix for that pending in https://github.com/shellscape/postcss-less/pull/82. So as soon as that is merged and a new version is tagged there we should be good to go (after I've fixed `no-extra-semicolons` too of course).

The current changes I've made are just minor ones, passing the current syntax's stringifier to `toResult` when checking the file's newlines and updating `isStandardSyntaxRule` to use new property names for Less mixins/extends.