### PR TITLE
Exit with non-zero code on postcss warnings

### DIFF
--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -75,6 +75,7 @@ export type stylelint$result = {
   invalidOptionWarnings: Array<{
     text: string,
   }>,
+  parseErrors: Array<stylelint$warning>,
   errored?: boolean,
   warnings: Array<stylelint$warning>,
   ignored?: boolean,

--- a/lib/__tests__/standalone-parseErrors.test.js
+++ b/lib/__tests__/standalone-parseErrors.test.js
@@ -1,0 +1,29 @@
+"use strict"
+
+const configBlockNoEmpty = require("./fixtures/config-block-no-empty")
+const ruleDefinitions = require("../rules")
+const standalone = require("../standalone")
+
+describe("standalone with deprecations", () => {
+  beforeAll(() => {
+    ruleDefinitions["block-no-empty"] = jest.fn(() => {
+      return (root, result) => {
+        result.warn("Some parseError", {
+          stylelintType: "parseError",
+        })
+      }
+    })
+  })
+
+  it("works", () => {
+    standalone({
+      code: "a {}",
+      config: configBlockNoEmpty,
+    }).then(data => {
+      expect(data.output.indexOf("Some parseError")).not.toBe(-1)
+      expect(data.results.length).toBe(1)
+      expect(data.results[0].parseErrors.length).toBe(1)
+      expect(data.results[0].parseErrors[0].text).toBe("Some parseError")
+    })
+  })
+})

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -110,6 +110,10 @@ describe("standalone passing code with syntax error", () => {
     expect(results[0].invalidOptionWarnings.length).toBe(0)
   })
 
+  it("empty parseError", () => {
+    expect(results[0].parseErrors.length).toBe(0)
+  })
+
   it("error registered", () => {
     expect(results[0].errored).toBeTruthy()
   })
@@ -142,6 +146,15 @@ it("syntax error sets errored to true", () => {
   return standalone({
     code: "a { color: 'red; }",
     config: { rules: { "block-no-empty": true } },
+  }).then((linted) => {
+    expect(linted.errored).toBe(true)
+  })
+})
+
+it("error `Cannot parse selector` sets errored to true", () => {
+  return standalone({
+    code: "data-something='true'] { }",
+    config: { rules: { "selector-type-no-unknown": true } },
   }).then((linted) => {
     expect(linted.errored).toBe(true)
   })

--- a/lib/createStylelintResult.js
+++ b/lib/createStylelintResult.js
@@ -26,11 +26,14 @@ module.exports = function (
     }
   })
 
+  const parseErrors = _.remove(postcssResult.messages, { stylelintType: "parseError" })
+
   // This defines the stylelint result object that formatters receive
   let stylelintResult = {
     source,
     deprecations,
     invalidOptionWarnings,
+    parseErrors,
     errored: postcssResult.stylelint.stylelintError,
     warnings: postcssResult.messages.map(message => {
       return {

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -126,15 +126,17 @@ module.exports = function (results) {
 
   output = results.reduce((output, result) => {
     // Treat parseErrors as warnings
-    result.parseErrors.forEach(error =>
-      result.warnings.push({
-        line: error.line,
-        column: error.column,
-        rule: error.stylelintType,
-        severity: "error",
-        text: `${error.text} (${error.stylelintType})`,
-      })
-    )
+    if (result.parseErrors) {
+      result.parseErrors.forEach(error =>
+        result.warnings.push({
+          line: error.line,
+          column: error.column,
+          rule: error.stylelintType,
+          severity: "error",
+          text: `${error.text} (${error.stylelintType})`,
+        })
+      )
+    }
     output += formatter(result.warnings, result.source)
     return output
   }, output)

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -125,6 +125,16 @@ module.exports = function (results) {
   output += deprecationsFormatter(results)
 
   output = results.reduce((output, result) => {
+    // Treat parseErrors as warnings
+    result.parseErrors.forEach(error =>
+      result.warnings.push({
+        line: error.line,
+        column: error.column,
+        rule: error.stylelintType,
+        severity: "error",
+        text: `${error.text} (${error.stylelintType})`,
+      })
+    )
     output += formatter(result.warnings, result.source)
     return output
   }, output)

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -205,10 +205,10 @@ it("cannot parse selector warning", () => {
     code: ".a:unknown(.b, .d) { }",
     config,
   }).then(function (data) {
-    const invalidOptionWarnings = data.results[0].warnings
-    expect(invalidOptionWarnings.length).toBe(1)
-    expect(invalidOptionWarnings[0].text).toBe("Cannot parse selector")
-    expect(invalidOptionWarnings[0].line).toBe(1)
-    expect(invalidOptionWarnings[0].column).toBe(1)
+    const parseErrors = data.results[0].parseErrors
+    expect(parseErrors.length).toBe(1)
+    expect(parseErrors[0].text).toBe("Cannot parse selector")
+    expect(parseErrors[0].line).toBe(1)
+    expect(parseErrors[0].column).toBe(1)
   })
 })

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -61,7 +61,7 @@ const rule = function (max) {
               })
             }
           } catch (e) {
-            result.warn("Cannot parse selector", { node: rule })
+            result.warn("Cannot parse selector", { node: rule, stylelintType: "parseError" })
           }
         })
       })

--- a/lib/rules/selector-type-case/__tests__/index.js
+++ b/lib/rules/selector-type-case/__tests__/index.js
@@ -86,11 +86,6 @@ testRule(rule, {
   }, {
     code: "A { &:nth-child(3n + 1) {} }",
     message: messages.expected("A", "a"),
-  }, {
-    code: "a { color: .panel {} }",
-    message: "Cannot parse selector",
-    line: 1,
-    column: 5,
   } ],
 })
 

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -177,7 +177,7 @@ module.exports = function (options/*: stylelint$standaloneOptions */)/*: Promise
   })
 
   function prepareReturnValue(stylelintResults/*: Array<stylelint$result>*/)/*: stylelint$standaloneReturnValue*/ {
-    const errored = stylelintResults.some(result => result.errored)
+    const errored = stylelintResults.some(result => result.errored || result.parseErrors.length > 0)
     const returnValue/*: stylelint$standaloneReturnValue*/ = {
       errored,
       output: formatterFunction(stylelintResults),
@@ -212,6 +212,7 @@ function convertCssSyntaxErrorToResult(error/*: CssSyntaxErrorT*/)/*: stylelint$
     source: error.file || "<input css 1>",
     deprecations: [],
     invalidOptionWarnings: [],
+    parseErrors: [],
     errored: true,
     warnings: [{
       line: error.line,

--- a/lib/utils/parseSelector.js
+++ b/lib/utils/parseSelector.js
@@ -12,6 +12,6 @@ module.exports = function (
   try {
     selectorParser(cb).process(selector)
   } catch (e) {
-    result.warn("Cannot parse selector", { node })
+    result.warn("Cannot parse selector", { node, stylelintType: "parseError" })
   }
 }

--- a/system-tests/001/__snapshots__/001.test.js.snap
+++ b/system-tests/001/__snapshots__/001.test.js.snap
@@ -7,6 +7,7 @@ Array [
     "errored": true,
     "ignored": undefined,
     "invalidOptionWarnings": Array [],
+    "parseErrors": Array [],
     "source": "001/stylesheet.css",
     "warnings": Array [
       Object {

--- a/system-tests/002/__snapshots__/002.test.js.snap
+++ b/system-tests/002/__snapshots__/002.test.js.snap
@@ -7,6 +7,7 @@ Array [
     "errored": undefined,
     "ignored": undefined,
     "invalidOptionWarnings": Array [],
+    "parseErrors": Array [],
     "source": "002/stylesheet.css",
     "warnings": Array [],
   },

--- a/system-tests/003/__snapshots__/003.test.js.snap
+++ b/system-tests/003/__snapshots__/003.test.js.snap
@@ -7,6 +7,7 @@ Array [
     "errored": undefined,
     "ignored": undefined,
     "invalidOptionWarnings": Array [],
+    "parseErrors": Array [],
     "source": "003/stylesheet.css",
     "warnings": Array [],
   },

--- a/system-tests/005/__snapshots__/005.test.js.snap
+++ b/system-tests/005/__snapshots__/005.test.js.snap
@@ -7,6 +7,7 @@ Array [
     "errored": true,
     "ignored": undefined,
     "invalidOptionWarnings": Array [],
+    "parseErrors": Array [],
     "source": "005/stylesheet.css",
     "warnings": Array [
       Object {

--- a/system-tests/fix/__snapshots__/fix.test.js.snap
+++ b/system-tests/fix/__snapshots__/fix.test.js.snap
@@ -32,6 +32,7 @@ Array [
     "errored": true,
     "ignored": undefined,
     "invalidOptionWarnings": Array [],
+    "parseErrors": Array [],
     "source": "../stylesheet.css",
     "warnings": Array [
       Object {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2545

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

I think we should be default exist with non zero code on all postcss warnings. But we can use regexp to filter only `Cannot parse selector`.