### PR TITLE
Issue 2711

### DIFF
--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -103,6 +103,9 @@ testRule(rule, {
   }, {
     code: "html { --custom-property-set: {} }",
     description: "custom property set in selector",
+  }, {
+    code: "namespace|type#id > .foo {}",
+    description: "qualified id with namespace",
   } ],
 
   reject: [ {
@@ -153,6 +156,12 @@ testRule(rule, {
     message: messages.expectedAfter(">>>"),
     line: 1,
     column: 3,
+  }, {
+    code: "namespace|type#id >.foo {}",
+    description: "qualified id with namespace",
+    message: messages.expectedAfter(">"),
+    line: 1,
+    column: 19,
   } ],
 })
 
@@ -232,6 +241,9 @@ testRule(rule, {
   }, {
     code: "a\r\n\r\na {}",
     description: "combinator selector contain multiple CRLF",
+  }, {
+    code: "namespace|type#id >.foo {}",
+    description: "qualified id with namespace",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -109,6 +109,9 @@ testRule(rule, {
   }, {
     code: "namespace|type#id > .foo {}",
     description: "qualified id with namespace",
+  }, {
+    code: "namespace|type#id > .foo {}, space|customtype#id_withunder > a {}",
+    description: "qualified id with namespace selector list",
   } ],
 
   reject: [ {

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -106,6 +106,9 @@ testRule(rule, {
   }, {
     code: "html { --custom-property-set: {} }",
     description: "custom property set in selector",
+  }, {
+    code: "namespace|type#id > .foo {}",
+    description: "qualified id with namespace",
   } ],
 
   reject: [ {
@@ -238,6 +241,9 @@ testRule(rule, {
   }, {
     code: "a\r\n\r\na {}",
     description: "combinator selector contain multiple CRLF",
+  }, {
+    code: "namespace|type#id> .foo {}",
+    description: "qualified id with namespace",
   } ],
 
   reject: [ {

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -31,7 +31,7 @@ module.exports = function (opts) {
             ? sourceIndex
             : sourceIndex + node.value.length - 1
 
-          check(selectorTree.toString(), node.value, index, rule, sourceIndex)
+          check(selector, node.value, index, rule, sourceIndex)
         })
       })
     })


### PR DESCRIPTION
Closes #2711

Use the original selector string, rather than stringify the selector tree. Stringifying the tree also seemed wasteful.