### PR TITLE
add ignoreAttributes for selector-max-attribute

### DIFF
--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -86,7 +86,7 @@ Given:
 ["/^my-/", "dir"]
 ```
 
-For example, with `2`.
+For example, with `0`.
 
 The following patterns are *not* considered violations:
 

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -75,3 +75,25 @@ The following patterns are *not* considered violations:
 /* `[disabled]` is inside `:not()`, so it is evaluated separately */
 [type="text"][name="message"]:not([disabled]) {}
 ```
+
+## Optional secondary options
+
+### `ignoreAttributes: ["/regex/", "string"]`
+
+Given:
+
+```js
+["/^my-/", "dir"]
+```
+
+For example, with `2`.
+
+The following patterns are *not* considered violations:
+
+```css
+[dir] [my-attr] {}
+```
+
+```css
+[dir] [my-other-attr] {}
+```

--- a/lib/rules/selector-max-attribute/__tests__/index.js
+++ b/lib/rules/selector-max-attribute/__tests__/index.js
@@ -188,3 +188,37 @@ testRule(rule, {
     description: "scss: nested properties",
   } ],
 })
+
+testRule(rule, {
+  ruleName,
+  config: [ 0, { ignoreAttributes: [ "dir", "dir=\"rtl\"", "/^my-/" ] } ],
+  skipBasicChecks: true,
+
+  accept: [ {
+    code: "[dir] {}",
+  }, {
+    code: "[dir=\"rtl\"] {}",
+  }, {
+    code: "[my-attr] {}",
+  }, {
+    code: "[my-other-attr] {}",
+  }, {
+    code: "[my-attr] { --foo: 1px; }",
+    description: "custom property in selector",
+  }, {
+    code: "[my-attr] { --custom-property-set: {} }",
+    description: "custom property set in selector",
+  } ],
+
+  reject: [ {
+    code: "[foo] {}",
+    message: messages.expected("[foo]", 0),
+    line: 1,
+    column: 1,
+  }, {
+    code: "[not-my-attr] {}",
+    message: messages.expected("[not-my-attr]", 0),
+    line: 1,
+    column: 1,
+  } ],
+})

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -1,7 +1,9 @@
 "use strict"
 
+const _ = require("lodash")
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule")
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector")
+const optionsMatches = require("../../utils/optionsMatches")
 const parseSelector = require("../../utils/parseSelector")
 const report = require("../../utils/report")
 const ruleMessages = require("../../utils/ruleMessages")
@@ -14,7 +16,7 @@ const messages = ruleMessages(ruleName, {
   expected: (selector, max) => `Expected "${selector}" to have no more than ${max} attribute ${max === 1 ? "selector" : "selectors"}`,
 })
 
-function rule(max) {
+function rule(max, options) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: max,
@@ -23,6 +25,12 @@ function rule(max) {
           return typeof max === "number" && max >= 0
         },
       ],
+    }, {
+      actual: options,
+      possible: {
+        ignoreAttributes: [_.isString],
+      },
+      optional: true,
     })
     if (!validOptions) {
       return
@@ -35,7 +43,14 @@ function rule(max) {
           checkSelector(childNode, ruleNode)
         }
 
-        return total += (childNode.type === "attribute" ? 1 : 0)
+        if (childNode.type !== "attribute") {
+          return total;
+        }
+        if (optionsMatches(options, "ignoreAttributes", childNode.attribute)) {
+          return total
+        }
+
+        return total += 1;
       }, 0)
 
       if (selectorNode.type !== "root" && selectorNode.type !== "pseudo" && count > max) {

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -44,13 +44,15 @@ function rule(max, options) {
         }
 
         if (childNode.type !== "attribute") {
-          return total;
+          // Not an attribute node -> ignore
+          return total
         }
         if (optionsMatches(options, "ignoreAttributes", childNode.attribute)) {
+          // it's an attribute that is supposed to be ignored
           return total
         }
 
-        return total += 1;
+        return total += 1
       }, 0)
 
       if (selectorNode.type !== "root" && selectorNode.type !== "pseudo" && count > max) {


### PR DESCRIPTION
This adds an `ignoreAttributes` option to the `selector-max-attribute` rule, similar to the [`ignoreTypes` option of the `selector-max-type` rule](https://github.com/stylelint/stylelint/tree/master/lib/rules/selector-max-type#ignoretypes-regex-string).

References https://github.com/stylelint/stylelint/issues/1706