### PR TITLE
Docs: keyframe-declaration-no-important

### DIFF
--- a/lib/rules/keyframe-declaration-no-important/README.md
+++ b/lib/rules/keyframe-declaration-no-important/README.md
@@ -11,6 +11,9 @@ Disallow `!important` within keyframe declarations.
 *     This !important */
 ```
 
+Using `!important` within keyframes declarations is completely ignored in some browsers:  
+[MDN - !important in a keyframe](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes#!important_in_a_keyframe)
+
 ## Options
 
 ### `true`


### PR DESCRIPTION
Added link to clarify that using !important within keyframes declarations is completely ignored in some browsers.