### PR TITLE
Enhancement: run `--report-needless-disables` before linting, rather …

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -257,8 +257,6 @@ Promise.resolve().then(() => {
       process.stdout.write(needlessDisablesStringFormatter(linted.needlessDisables))
       process.exitCode = 2
     }
-
-    return
   }
 
   if (!linted.output) {


### PR DESCRIPTION
…than instead of it.

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2369

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

One note: should be `errored` in true if we contain needless disables, `parseErrors` set `errored` to `true`.
