### PR TITLE
remove LESS support experimental disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A mighty, modern CSS linter that helps you enforce consistent conventions and av
     -   **Control what languages features can be used**: e.g. whitelisting specific units, properties and functions, or disallowing certain selector types.
     -   **Enforce code style conventions**: e.g. checking the spacing around the colon in declarations or specifying patterns for class selectors.
 -   **Support for the latest CSS syntax:** Including custom properties, range context for media features, calc() and nesting.
--   **Understands *CSS-like* syntaxes:** The linter is powered by [PostCSS](https://github.com/postcss/postcss), so it understands any syntax that PostCSS can parse, including SCSS, [SugarSS](https://github.com/postcss/sugarss), and *experimental support* for Less.
+-   **Understands *CSS-like* syntaxes:** The linter is powered by [PostCSS](https://github.com/postcss/postcss), so it understands any syntax that PostCSS can parse, including SCSS, [SugarSS](https://github.com/postcss/sugarss), and LESS.
 -   **Completely unopinionated:** Only enable the rules you want, and configure them with options that tailor the linter to your needs.
 -   **Support for plugins:** It's easy to create your own rules and add them to the linter.
 -   **Automatically fixes some stylistic warnings:** Save time by having stylelint fix your code with this *experimental* feature.


### PR DESCRIPTION
### Which issue, if any, is this issue related to?

None, as it's a documentation fix.

### Is there anything in the PR that needs further explanation?

Removing this disclaimer because:
* LESS support was added over a year ago (https://github.com/stylelint/stylelint/issues/810)
* [`postcss-less`](https://github.com/shellscape/postcss-less) is recommended by [`postcss`](https://github.com/postcss/postcss#syntaxes)
* The [CSS processors](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/css-processors.md) section of the stylelint user guide gives no indication that LESS support is experimental
