### PR TITLE
Document rules that ignore @import in Less

### DIFF
--- a/lib/rules/at-rule-blacklist/README.md
+++ b/lib/rules/at-rule-blacklist/README.md
@@ -8,6 +8,8 @@ Specify a blacklist of disallowed at-rules.
  * At-rules like this */
 ```
 
+This rule ignores `@import` in Less.
+
 ## Options
 
 `array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`

--- a/lib/rules/at-rule-blacklist/__tests__/index.js
+++ b/lib/rules/at-rule-blacklist/__tests__/index.js
@@ -163,3 +163,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["import"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import 'x.css';",
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -10,7 +10,7 @@ a {}
  *   This line */
 ```
 
-If the at-rule is the very first node in a stylesheet then it is ignored.
+If the at-rule is the very first node in a stylesheet then it is ignored. `@import` in Less will also be ignored.
 
 The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule. We recommend to enable [`indentation`](../indentation/README.md) rule for better autofixing results with this rule.
 

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -1269,3 +1269,19 @@ testRule(
     ]
   })
 );
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: stripIndent`
+      @media {}
+      @import 'x.css';
+    `,
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/at-rule-name-case/README.md
+++ b/lib/rules/at-rule-name-case/README.md
@@ -8,6 +8,8 @@ Specify lowercase or uppercase for at-rules names.
  * These at-rule names */
 ```
 
+This rule ignores `@import` in Less.
+
 Only lowercase at-rule names are valid in SCSS.
 
 The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix some of the problems reported by this rule.

--- a/lib/rules/at-rule-name-case/__tests__/index.js
+++ b/lib/rules/at-rule-name-case/__tests__/index.js
@@ -287,3 +287,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["upper"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import 'x.css';",
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/at-rule-name-newline-after/README.md
+++ b/lib/rules/at-rule-name-newline-after/README.md
@@ -9,6 +9,8 @@ Require a newline after at-rule names.
  * The newline after this at-rule name */
 ```
 
+This rule ignores `@import` in Less.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"`

--- a/lib/rules/at-rule-name-newline-after/__tests__/index.js
+++ b/lib/rules/at-rule-name-newline-after/__tests__/index.js
@@ -405,3 +405,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import 'x.css';",
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/at-rule-name-space-after/README.md
+++ b/lib/rules/at-rule-name-space-after/README.md
@@ -8,6 +8,8 @@ Require a single space after at-rule names.
  * The space after at-rule names */
 ```
 
+This rule ignores `@import` in Less.
+
 ## Options
 
 `string`: `"always"|"always-single-line"`
@@ -31,7 +33,7 @@ The following patterns are considered violations:
 ```
 
 ```css
-@media 
+@media
 (min-width: 700px) {}
 ```
 
@@ -82,7 +84,7 @@ The following patterns are *not* considered violations:
 ```
 
 ```css
-@media 
+@media
 (min-width: 700px) {}
 ```
 

--- a/lib/rules/at-rule-name-space-after/__tests__/index.js
+++ b/lib/rules/at-rule-name-space-after/__tests__/index.js
@@ -439,3 +439,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import'x.css';",
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/at-rule-semicolon-newline-after/README.md
+++ b/lib/rules/at-rule-semicolon-newline-after/README.md
@@ -9,6 +9,8 @@ Require a newline after the semicolon of at-rules.
  * The newline after these semicolons */
 ```
 
+This rule ignores `@import` in Less.
+
 This rule allows an end-of-line comment followed by a newline. For example:
 
 ```css

--- a/lib/rules/at-rule-semicolon-newline-after/__tests__/index.js
+++ b/lib/rules/at-rule-semicolon-newline-after/__tests__/index.js
@@ -121,3 +121,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import 'x.css';",
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/at-rule-semicolon-space-before/README.md
+++ b/lib/rules/at-rule-semicolon-space-before/README.md
@@ -8,6 +8,8 @@ Require a single space or disallow whitespace before the semicolons at-rules.
  * The space before this semicolon */
 ```
 
+This rule ignores `@import` in Less.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/at-rule-semicolon-space-before/__tests__/index.js
+++ b/lib/rules/at-rule-semicolon-space-before/__tests__/index.js
@@ -154,3 +154,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import 'x.css';",
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/at-rule-whitelist/README.md
+++ b/lib/rules/at-rule-whitelist/README.md
@@ -8,6 +8,8 @@ Specify a whitelist of allowed at-rules.
  * At-rules like this */
 ```
 
+This rule ignores `@import` in Less.
+
 ## Options
 
 `array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`

--- a/lib/rules/at-rule-whitelist/__tests__/index.js
+++ b/lib/rules/at-rule-whitelist/__tests__/index.js
@@ -155,3 +155,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["media"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import 'x.css';",
+      description: "ignore less @imports"
+    }
+  ]
+});

--- a/lib/rules/function-url-quotes/README.md
+++ b/lib/rules/function-url-quotes/README.md
@@ -8,6 +8,8 @@ a { background: url("x.jpg") }
  *             These quotes */
 ```
 
+This rule ignores `@import` in Less.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -668,3 +668,16 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  syntax: "less",
+
+  accept: [
+    {
+      code: "@import url(foo.css);",
+      description: "ignore less @imports"
+    }
+  ]
+});


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2703

> Is there anything in the PR that needs further explanation?

I think I got all of the affected rules, but an extra set of eyes would be appreciated.
