### PR TITLE
chore: Update `balance-match` to `1.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -524,9 +524,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "autoprefixer": "^7.1.2",
-    "balanced-match": "^0.4.0",
+    "balanced-match": "^1.0.0",
     "chalk": "^2.0.1",
     "cosmiconfig": "^2.1.3",
     "debug": "^2.6.8",


### PR DESCRIPTION
Replaces #2747
See #2745 