### PR TITLE
Revert jest lint staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,7 @@
   "lint-staged": {
     "*.js": [
       "prettier --write",
-      "git add",
-      "jest --bail --findRelatedTests"
+      "git add"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
I’m afraid that experiment didn’t last long. It seemingly broke adding commits to Github Desktop.