### PR TITLE
isStandardSyntaxSelector should not check rules resolved as nested Less mixins

### DIFF
--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -56,6 +56,12 @@ testRule(rule, {
     {
       code: "html { --custom-property-set: {} }",
       description: "custom property set in selector"
+    },
+    {
+      code: ".foo() {\n&.bar {}}"
+    },
+    {
+      code: ".foo(@a, @b) {\n&.bar {}}"
     }
   ],
 

--- a/lib/utils/__tests__/isStandardSyntaxSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxSelector.test.js
@@ -57,7 +57,7 @@ describe("isStandardSyntaxSelector", () => {
   it("SCSS placeholder", () => {
     expect(isStandardSyntaxSelector("%foo")).toBeFalsy();
   });
-  it("Resolved nested selectors", () => {
+  it("Less mixin with resolved nested selectors", () => {
     expect(isStandardSyntaxSelector(".foo().bar")).toBeFalsy();
     expect(isStandardSyntaxSelector(".foo(@a, @b).bar")).toBeFalsy();
     expect(isStandardSyntaxSelector(".foo()#bar")).toBeFalsy();

--- a/lib/utils/__tests__/isStandardSyntaxSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxSelector.test.js
@@ -57,4 +57,16 @@ describe("isStandardSyntaxSelector", () => {
   it("SCSS placeholder", () => {
     expect(isStandardSyntaxSelector("%foo")).toBeFalsy();
   });
+  it("Resolved nested selectors", () => {
+    expect(isStandardSyntaxSelector(".foo().bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo(@a, @b).bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo()#bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo()#bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo() bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo() + bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo() > bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo() ~ bar")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo()[bar]")).toBeFalsy();
+    expect(isStandardSyntaxSelector(".foo()[bar='baz']")).toBeFalsy();
+  });
 });

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -21,7 +21,7 @@ module.exports = function(selector /*: string*/) /*: boolean*/ {
     return false;
   }
 
-  // Resolved nested selectors (e.g. .foo().bar or .foo(@a, @b)[bar])
+  // Less mixin with resolved nested selectors (e.g. .foo().bar or .foo(@a, @b)[bar])
   if (/\.[a-z0-9-_]+\(.*\).+/i.test(selector)) {
     return false;
   }

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -21,5 +21,10 @@ module.exports = function(selector /*: string*/) /*: boolean*/ {
     return false;
   }
 
+  // Resolved nested selectors (e.g. .foo().bar or .foo(@a, @b)[bar])
+  if (/\.[a-z0-9-_]+\(.*\).+/i.test(selector)) {
+    return false;
+  }
+
   return true;
 };


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2677

> Is there anything in the PR that needs further explanation?

While the original issue only covered `.myMixin(@a, @b).bar` I discovered that any nested selector would fail with a `Cannot parse selector` error. 

For example:

```less
.myMixin() {
  & > .bar {
  }
}
```

would fail as well. 

I added a check to `isStandardSyntaxSelector` to check anything that matches `.foo()` since I can't find an instance where that would be valid CSS.