### PR TITLE
add autofixing support to no-missing-end-of-source-newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+-   Added: autofixing support to `no-missing-end-of-source-newline`
 -   Fixed: `indentation` false positives for Less parametric mixins with rule block/snippet ([#2744](https://github.com/stylelint/stylelint/pull/2744)).
 -   Fixed: `selector-max-specificity` cannot parse selector violation for Less mixins ([#2677](https://github.com/stylelint/stylelint/pull/2677)).
 

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -332,4 +332,4 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`max-empty-lines`](../../lib/rules/max-empty-lines/README.md): Limit the number of adjacent empty lines.
 -   [`max-line-length`](../../lib/rules/max-line-length/README.md): Limit the length of a line.
 -   [`no-eol-whitespace`](../../lib/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
--   [`no-missing-end-of-source-newline`](../../lib/rules/no-missing-end-of-source-newline/README.md): Disallow missing end-of-source newlines.
+-   [`no-missing-end-of-source-newline`](../../lib/rules/no-missing-end-of-source-newline/README.md): Disallow missing end-of-source newlines (Autofixable).

--- a/lib/rules/no-missing-end-of-source-newline/README.md
+++ b/lib/rules/no-missing-end-of-source-newline/README.md
@@ -11,6 +11,8 @@ Disallow missing end-of-source newlines.
 
 Completely empty files are not considered violations.
 
+The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
@@ -10,6 +10,7 @@ testRule(rule, {
   ruleName,
   config: [true],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [
     {
@@ -35,30 +36,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a { color: pink; }\n",
       message: messages.rejected,
       line: 1,
       column: 18
     },
     {
       code: "a { color: pink; }\n\n\nb{ color: orange; }",
+      fixed: "a { color: pink; }\n\n\nb{ color: orange; }\n",
       message: messages.rejected,
       line: 4,
       column: 19
     },
     {
       code: "a { color: pink; }\r\n\r\n\r\nb{ color: orange; }",
+      fixed: "a { color: pink; }\r\n\r\n\r\nb{ color: orange; }\r\n",
       message: messages.rejected,
       line: 4,
       column: 19
     },
     {
       code: "&.active {\n    top:\n    .tab {}\n}",
+      fixed: "&.active {\n    top:\n    .tab {}\n}\n",
       message: messages.rejected,
       line: 4,
       column: 1
     },
     {
       code: "&.active {\r\n    top:\r\n    .tab {}\r\n}",
+      fixed: "&.active {\r\n    top:\r\n    .tab {}\r\n}\r\n",
       message: messages.rejected,
       line: 4,
       column: 1
@@ -71,6 +77,7 @@ testRule(rule, {
   config: [true],
   skipBasicChecks: true,
   syntax: "sugarss",
+  fix: true,
 
   accept: [
     {
@@ -84,18 +91,21 @@ testRule(rule, {
   reject: [
     {
       code: "a",
+      fixed: "a\n",
       message: messages.rejected,
       line: 1,
       column: 1
     },
     {
       code: "body\n  padding: 5% 2% 5%",
+      fixed: "body\n  padding: 5% 2% 5%\n",
       message: messages.rejected,
       line: 2,
       column: 17
     },
     {
       code: "body\r\n  padding: 5% 2% 5%",
+      fixed: "body\r\n  padding: 5% 2% 5%\r\n",
       message: messages.rejected,
       line: 2,
       column: 17

--- a/lib/rules/no-missing-end-of-source-newline/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/index.js
@@ -10,15 +10,21 @@ const messages = ruleMessages(ruleName, {
   rejected: "Unexpected missing end-of-source newline"
 });
 
-const rule = function(actual) {
+const rule = function(primary, _, context) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual });
+    const validOptions = validateOptions(result, ruleName, { primary });
     if (!validOptions) {
       return;
     }
 
     const sourceCss = root.source.input.css;
     if (sourceCss === "" || sourceCss.slice(-1) === "\n") {
+      return;
+    }
+
+    // Fix
+    if (context.fix) {
+      root.raws.after = context.newline;
       return;
     }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2771

> Is there anything in the PR that needs further explanation?

"No, it's self explanatory."
