### PR TITLE
Fixed: respect multiple pseudo classes for `webkit` pseudo elements in `selector-pseudo-class-no-unknown` rule.

### DIFF
--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -90,6 +90,10 @@ testRule(rule, {
     {
       code: "html { --custom-property-set: {} }",
       description: "custom property set in selector"
+    },
+    {
+      code: "::-webkit-scrollbar-button:horizontal:decrement {}",
+      description: "webkit scrollbar multiple pseudo classes"
     }
   ],
 
@@ -141,6 +145,12 @@ testRule(rule, {
       message: messages.rejected(":window-inactive"),
       line: 1,
       column: 18
+    },
+    {
+      code: "::-webkit-scrollbar-button:horizontal:unknown {}",
+      message: messages.rejected(":unknown"),
+      line: 1,
+      column: 38
     },
     {
       code: ":first { }",

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -84,12 +84,17 @@ const rule = function(actual, options) {
               return;
             }
 
-            if (pseudoNode.prev()) {
+            const firstSelectorNode =
+              pseudoNode.parent && pseudoNode.parent.nodes
+                ? pseudoNode.parent.nodes[0]
+                : null;
+
+            if (
+              firstSelectorNode &&
+              firstSelectorNode.value.slice(0, 2) === "::"
+            ) {
               const prevPseudoNodeValue = postcss.vendor.unprefixed(
-                pseudoNode
-                  .prev()
-                  .value.toLowerCase()
-                  .slice(2)
+                firstSelectorNode.value.toLowerCase().slice(2)
               );
 
               if (


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2810 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
