### PR TITLE
Fixed: false negatives for semicolons followed by two comments in `no-extra-semicolons` rule.

### DIFF
--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -521,6 +521,24 @@ testRule(rule, {
       column: 18
     },
     {
+      code: "a {\n  color: #FFF;;\n  /* foo */\n  /* bar */\n}",
+      message: messages.rejected,
+      line: 2,
+      column: 15
+    },
+    {
+      code: "a {\n  /* foo */\n  /* bar */\n  color: #FFF;;\n}",
+      message: messages.rejected,
+      line: 4,
+      column: 15
+    },
+    {
+      code: "a {\n  /* foo */\n  color: #FFF;;\n  /* bar */\n}",
+      message: messages.rejected,
+      line: 3,
+      column: 15
+    },
+    {
       code: "@import 'x.css';;",
       message: messages.rejected,
       line: 1,
@@ -621,6 +639,12 @@ testRule(rule, {
     },
     {
       code: ":root { --foo: { color: red };/* comment */;}",
+      message: messages.rejected,
+      line: 1,
+      column: 44
+    },
+    {
+      code: ":root { --foo: { color: red };/* comment */;/* comment */}",
       message: messages.rejected,
       line: 1,
       column: 44

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -75,8 +75,8 @@ const rule = function(actual) {
         if (
           node.type === "comment" &&
           next &&
-          ((isCustomPropertySet(next) && node.parent.index(next) > 0) ||
-            next.type === "comment")
+          isCustomPropertySet(next) &&
+          node.parent.index(next) > 0
         ) {
           allowedSemi = 1;
         }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2678

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
