### PR TITLE
Fixes error in postcss example

### DIFF
--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -104,13 +104,13 @@ var stylelint = require("stylelint")
 var css = fs.readFileSync("lib/app.css", "utf8")
 
 postcss(
-  processors: [
+  [
     require("postcss-import")({
       plugins: [
         require("stylelint")({ /* your options */ })
       ]
     }),
-    require("postcss-cssnext")
+    require("postcss-cssnext"),
     require("postcss-reporter")({ clearReportedMessages: true })
   ]
 )


### PR DESCRIPTION
PostCSS example usage included a json style attribute in the parameters and was missing a comma.