### PR TITLE
Fix `isFirstNested` util to handle shared-line comments

### DIFF
--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -345,6 +345,10 @@ testRule(
     accept: [
       {
         code: "a {\n  @mixin foo;\n  color: pink;\n}"
+      },
+      {
+        code: "a { /* comment */\n  @mixin foo;\n  color: pink;\n}",
+        description: "shared-line comment"
       }
     ],
 
@@ -357,6 +361,11 @@ testRule(
       {
         code: "a {\n\n  @mixin foo;\n  color: pink;\n}",
         fixed: "a {\n  @mixin foo;\n  color: pink;\n}",
+        message: messages.rejected
+      },
+      {
+        code: "a {/* comment */\n\n  @mixin foo;\n  color: pink;\n}",
+        fixed: "a {/* comment */\n  @mixin foo;\n  color: pink;\n}",
         message: messages.rejected
       }
     ]

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -103,6 +103,12 @@ testRule(
       {
         code: "a {\n  /* comment */\n  color: pink;\n}",
         description: "first-nested without empty line before"
+      },
+      {
+        code:
+          "a { /* shared-line comment */\n  /* comment */\n  color: pink;\n}",
+        description:
+          "first-nested without empty line before and shared-line comment"
       }
     ],
 
@@ -110,6 +116,16 @@ testRule(
       {
         code: "a {\n\n  /* comment */\n  color: pink;\n}",
         fixed: "a {\n  /* comment */\n  color: pink;\n}",
+        description: "first-nested with empty line before",
+        message: messages.rejected,
+        line: 3,
+        column: 3
+      },
+      {
+        code:
+          "a { /* shared-line comment */\n\n  /* comment */\n  color: pink;\n}",
+        fixed:
+          "a { /* shared-line comment */\n  /* comment */\n  color: pink;\n}",
         description: "first-nested with empty line before",
         message: messages.rejected,
         line: 3,

--- a/lib/rules/custom-property-empty-line-before/__tests__/index.js
+++ b/lib/rules/custom-property-empty-line-before/__tests__/index.js
@@ -171,6 +171,10 @@ testRule(rule, {
     },
     {
       code: "a {\r\n --custom-prop: value;\r\n}"
+    },
+    {
+      code: "a { /* comment */\n --custom-prop: value;\n}",
+      description: "shared-line comment"
     }
   ],
 
@@ -185,6 +189,13 @@ testRule(rule, {
     {
       code: "a {\r\n\r\n --custom-prop: value;\r\n}",
       fixed: "a {\r\n --custom-prop: value;\r\n}",
+      message: messages.rejected,
+      line: 3,
+      column: 2
+    },
+    {
+      code: "a { /* comment*/\n\n --custom-prop: value;\n}",
+      fixed: "a { /* comment*/\n --custom-prop: value;\n}",
       message: messages.rejected,
       line: 3,
       column: 2

--- a/lib/rules/declaration-empty-line-before/__tests__/index.js
+++ b/lib/rules/declaration-empty-line-before/__tests__/index.js
@@ -365,6 +365,10 @@ testRule(rule, {
     },
     {
       code: "a {\r\n top: 15px;\r\n}"
+    },
+    {
+      code: "a { /* comment */\n top: 15px;\n}",
+      description: "shared-line comment"
     }
   ],
 
@@ -379,6 +383,13 @@ testRule(rule, {
     {
       code: "a {\r\n\r\n top: 15px;\r\n}",
       fixed: "a {\r\n top: 15px;\r\n}",
+      message: messages.rejected,
+      line: 3,
+      column: 2
+    },
+    {
+      code: "a { /* comment */\n\n top: 15px;\n}",
+      fixed: "a { /* comment */\n top: 15px;\n}",
       message: messages.rejected,
       line: 3,
       column: 2

--- a/lib/rules/rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/rule-empty-line-before/__tests__/index.js
@@ -236,6 +236,10 @@ testRule(rule, {
       description: "CRLF"
     },
     {
+      code: "@media { /* comment */\n  a {}\n\n}",
+      description: "shared-line comment boog"
+    },
+    {
       code: "@media {\n  a {}\n\n  b{}\n\n}"
     },
     {
@@ -266,6 +270,16 @@ testRule(rule, {
     {
       code: "@media {\n\n  a {}\n}",
       fixed: "@media {\n  a {}\n}",
+      message: messages.rejected
+    },
+    {
+      code: "@media { /* comment */\n\n  a {}\n}",
+      fixed: "@media { /* comment */\n  a {}\n}",
+      message: messages.rejected
+    },
+    {
+      code: "@media { /* comment */\n\n  a {}\n}",
+      fixed: "@media { /* comment */\n  a {}\n}",
       message: messages.rejected
     },
     {

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -2,6 +2,7 @@
 
 const addEmptyLineBefore = require("../../utils/addEmptyLineBefore");
 const hasEmptyLine = require("../../utils/hasEmptyLine");
+const isFirstNested = require("../../utils/isFirstNested");
 const isSingleLineString = require("../../utils/isSingleLineString");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const optionsMatches = require("../../utils/optionsMatches");
@@ -86,7 +87,7 @@ const rule = function(expectation, options, context) {
       // Optionally reverse the expectation for the first nested node
       if (
         optionsMatches(options, "except", "first-nested") &&
-        rule === rule.parent.first
+        isFirstNested(rule)
       ) {
         expectEmptyLineBefore = !expectEmptyLineBefore;
       }

--- a/lib/utils/__tests__/isFirstNested.test.js
+++ b/lib/utils/__tests__/isFirstNested.test.js
@@ -17,6 +17,9 @@ describe("isFirstNested", () => {
       @media (min-width: 0px) {
         a { color: 'pink'; }
       }
+      @media (min-width: 0px) { /* comment */
+        a { color: 'pink'; }
+      }
     `);
 
     root.walkRules(rule => {
@@ -29,6 +32,9 @@ describe("isFirstNested", () => {
       a {
         @include foo;
       }
+      b { /* comment */
+        @include foo;
+      }
     `);
 
     root.walkAtRules(atRule => {
@@ -36,9 +42,27 @@ describe("isFirstNested", () => {
     });
   });
 
+  it("returns true with the first-nested declaration", () => {
+    const root = postcss.parse(`
+      a {
+        color: pink;
+      }
+      b { /* comment */
+        color: pink;
+      }
+    `);
+
+    root.walkDecls(atRule => {
+      expect(isFirstNested(atRule)).toBe(true);
+    });
+  });
+
   it("returns true with first-nested non-statement", () => {
     const root = postcss.parse(`
       a {
+        /* comment */
+      }
+      b { /* shared-line comment */
         /* comment */
       }
     `);
@@ -54,6 +78,10 @@ describe("isFirstNested", () => {
         a { color: 'pink'; }
         b { color: 'pink'; }
       }
+      @media (min-width: 0px) {
+        /* comment */
+        b { color: 'pink'; }
+      }
     `);
 
     root.walkRules("b", rule => {
@@ -67,9 +95,38 @@ describe("isFirstNested", () => {
         @include foo;
         @expect bar;
       }
+      b {
+        /* comment */
+        @expect bar;
+      }
     `);
 
     root.walkAtRules("expect", atRule => {
+      expect(isFirstNested(atRule)).toBe(false);
+    });
+  });
+
+  it("returns false with not-first-nested declaration", () => {
+    const root = postcss.parse(`
+      a {
+        font-size: 0;
+        color: pink;
+      }
+      b {
+        /* comment */
+        color: pink;
+      }
+      c { /* comment */ /* comment */
+        /* comment */
+        color: pink;
+      }
+      d { /* shared-line/multi-line
+             comment */
+        color: pink;
+      }
+    `);
+
+    root.walkDecls("color", atRule => {
       expect(isFirstNested(atRule)).toBe(false);
     });
   });

--- a/lib/utils/isFirstNested.js
+++ b/lib/utils/isFirstNested.js
@@ -4,9 +4,44 @@
 module.exports = function(statement /*: postcss$node*/) /*: boolean*/ {
   const parentNode = statement.parent;
 
-  return (
-    parentNode !== undefined &&
-    parentNode.type !== "root" &&
-    statement === parentNode.first
-  );
+  if (parentNode === undefined || parentNode.type === "root") {
+    return false;
+  }
+
+  if (statement === parentNode.first) {
+    return true;
+  }
+
+  /*
+   * Search for the statement in the parent's nodes, ignoring comment
+   * nodes on the same line as the parent's opening brace.
+   */
+
+  const parentNodes = parentNode.nodes;
+  const firstNode = parentNodes[0];
+
+  if (firstNode.type !== "comment" || firstNode.raws.before.includes("\n")) {
+    return false;
+  }
+
+  const openingBraceLine = firstNode.source.start.line;
+
+  if (openingBraceLine !== firstNode.source.end.line) {
+    return false;
+  }
+
+  for (let i = 1; i < parentNodes.length; i++) {
+    const node = parentNodes[i];
+
+    if (node === statement) {
+      return true;
+    }
+
+    if (node.type !== "comment" || node.source.end.line !== openingBraceLine) {
+      return false;
+    }
+  }
+
+  /* istanbul ignore next: Should always return in the loop */
+  return false;
 };


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Fixes #2764

> Is there anything in the PR that needs further explanation?

This changes the `isFirstNested` util to ignore comments that are on the same line as the opening brace of a block when checking if the provided node is the first node in the block.
