### PR TITLE
Fix outdated example rules object in config docs

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -36,7 +36,7 @@ The `rules` property is *an object whose keys are rule names and values are rule
     "block-no-empty": null,
     "color-no-invalid-hex": true,
     "comment-empty-line-before": [ "always", {
-      "ignore": ["stylelint-command", "after-comment"]
+      "ignore": ["stylelint-commands", "after-comment"]
     } ],
     "declaration-colon-space-after": "always",
     "indentation": ["tab", {


### PR DESCRIPTION
Copying this example into my configuration caused an error on build (`stylelint-commands` is expected):

`Invalid value "stylelint-command" for option "ignore" of rule "comment-empty-line-before"`