### PR TITLE
Prettier JS fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       sudo: required
 
 before_install:
-  - npm install -g npm@latest
+  - npm install -g npm@5.3.0
   - npm i -g greenkeeper-lockfile@1
 
 before_script: greenkeeper-lockfile-update

--- a/decls/postcss.js
+++ b/decls/postcss.js
@@ -1,64 +1,64 @@
 declare class postcss$node {
   raw: Function,
   raws: Object,
-  type: 'rule' | 'atrule' | 'root' | 'comment' | 'decl';
-  parent: Object;
-  nodes: Array<Object>;
-  next(): postcss$node | void;
-  prev(): postcss$node | void;
+  type: "rule" | "atrule" | "root" | "comment" | "decl",
+  parent: Object,
+  nodes: Array<Object>,
+  next(): postcss$node | void,
+  prev(): postcss$node | void,
   source: {
     start: {
       line: number,
-      column: number,
+      column: number
     },
     end: {
       line: number,
-      column: number,
-    },
-  };
-  error(message: string, options: { plugin: string }): void,
+      column: number
+    }
+  },
+  error(message: string, options: { plugin: string }): void
 }
 
 declare class postcss$comment extends postcss$node {
-  text: string;
+  text: string,
   raws: {
     before?: string,
-    after?: string,
-  };
+    after?: string
+  }
 }
 
 declare class postcss$atRule extends postcss$node {
-  name: string;
-  params: string;
+  name: string,
+  params: string,
   raws: {
     before?: string,
     after?: string,
-    afterName?: string,
-  };
+    afterName?: string
+  }
 }
 
 declare class postcss$rule extends postcss$node {
-  selector: string;
+  selector: string,
   raws: {
     before?: string,
-    after?: string,
-  };
+    after?: string
+  }
 }
 
 declare class postcss$decl extends postcss$node {
-  prop: string;
-  value: string;
+  prop: string,
+  value: string,
   raws: {
     before?: string,
-    after?: string,
-  };
+    after?: string
+  }
 }
 
 export type postcss$options = {
   from?: string,
   parser?: stylelint$syntaxes,
-  syntax?: stylelint$syntaxes,
-}
+  syntax?: stylelint$syntaxes
+};
 
 export type postcss$result = {
   css: string,
@@ -67,6 +67,6 @@ export type postcss$result = {
     disabledRanges: disabledRangeObject,
     ruleSeverities?: Object,
     customMessages?: Object,
-    quiet?: boolean,
-  },
-}
+    quiet?: boolean
+  }
+};

--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -1,12 +1,14 @@
-export type stylelint$configExtends = string | Array<string>
-export type stylelint$configPlugins = string | Array<string>
-export type stylelint$configProcessors = string | Array<string | [string, Object]>
-export type stylelint$configIgnoreFiles = string | Array<string>
+export type stylelint$configExtends = string | Array<string>;
+export type stylelint$configPlugins = string | Array<string>;
+export type stylelint$configProcessors =
+  | string
+  | Array<string | [string, Object]>;
+export type stylelint$configIgnoreFiles = string | Array<string>;
 
-export type stylelint$configRuleSettings = any | [any, Object]
+export type stylelint$configRuleSettings = any | [any, Object];
 export type stylelint$configRules = {
-  [ruleName: string]: stylelint$configRuleSettings,
-}
+  [ruleName: string]: stylelint$configRuleSettings
+};
 
 export type stylelint$config = {
   extends?: stylelint$configExtends,
@@ -22,9 +24,9 @@ export type stylelint$config = {
   codeProcessors?: Array<Function>,
   resultProcessors?: Array<Function>,
   quiet?: boolean
-}
+};
 
-export type stylelint$syntaxes = "scss" | "less" | "sugarss"
+export type stylelint$syntaxes = "scss" | "less" | "sugarss";
 
 export type stylelint$options = {
   config?: stylelint$config,
@@ -37,7 +39,7 @@ export type stylelint$options = {
   syntax?: stylelint$syntaxes,
   customSyntax?: string,
   fix?: boolean
-}
+};
 
 export type stylelint$internalApi = {
   _options: stylelint$options,
@@ -55,32 +57,32 @@ export type stylelint$internalApi = {
 
   getConfigForFile: Function,
   isPathIgnored: Function,
-  lintSource: Function,
-}
+  lintSource: Function
+};
 
 export type stylelint$warning = {
   line: number,
   column: number,
   rule: string,
   severity: string,
-  text: string,
-}
+  text: string
+};
 
 export type stylelint$result = {
   source: string,
   deprecations: Array<{
     text: string,
-    reference: string,
+    reference: string
   }>,
   invalidOptionWarnings: Array<{
-    text: string,
+    text: string
   }>,
   parseErrors: Array<stylelint$warning>,
   errored?: boolean,
   warnings: Array<stylelint$warning>,
   ignored?: boolean,
-  _postcssResult?: Object,
-}
+  _postcssResult?: Object
+};
 
 export type stylelint$needlessDisablesReport = Array<{
   source: string,
@@ -88,21 +90,21 @@ export type stylelint$needlessDisablesReport = Array<{
     source: string,
     ranges: Array<{
       start: number,
-      end?: number,
-    }>,
-  }>,
-}>
+      end?: number
+    }>
+  }>
+}>;
 
 export type stylelint$standaloneReturnValue = {
   results: Array<stylelint$result>,
   errored: boolean,
   output: any,
-  needlessDisables?: stylelint$needlessDisablesReport,
-}
+  needlessDisables?: stylelint$needlessDisablesReport
+};
 
 export type stylelint$standaloneOptions = {
   files?: string | Array<string>,
-  cache?: bool,
+  cache?: boolean,
   cacheLocation?: string,
   code?: string,
   codeFilename?: string,
@@ -118,5 +120,5 @@ export type stylelint$standaloneOptions = {
   formatter?: "json" | "string" | "verbose" | Function,
   disableDefaultIgnores?: boolean,
   allowEmptyInput?: boolean,
-  fix?: boolean,
-}
+  fix?: boolean
+};

--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -429,5 +429,8 @@ it("enable rule without disabling rule", () => {
 });
 
 function testDisableRanges(source, cb) {
-  return postcss().use(assignDisabledRanges).process(source).then(cb);
+  return postcss()
+    .use(assignDisabledRanges)
+    .process(source)
+    .then(cb);
 }

--- a/lib/__tests__/plugins.test.js
+++ b/lib/__tests__/plugins.test.js
@@ -210,12 +210,15 @@ describe("module providing an array of plugins", () => {
   });
 
   it("second plugin works", () => {
-    return postcss().use(stylelint(config)).process(".foo {}").then(result => {
-      expect(result.warnings().length).toBe(1);
-      expect(result.warnings()[0].text).toBe(
-        "found .foo (plugin/warn-about-foo)"
-      );
-    });
+    return postcss()
+      .use(stylelint(config))
+      .process(".foo {}")
+      .then(result => {
+        expect(result.warnings().length).toBe(1);
+        expect(result.warnings()[0].text).toBe(
+          "found .foo (plugin/warn-about-foo)"
+        );
+      });
   });
 });
 
@@ -249,9 +252,12 @@ it("plugin with primary option array", () => {
       "plugin/primary-array": ["foo", "bar"]
     }
   };
-  return postcss().use(stylelint(config)).process("a {}").then(result => {
-    expect(result.warnings().length).toBe(0);
-  });
+  return postcss()
+    .use(stylelint(config))
+    .process("a {}")
+    .then(result => {
+      expect(result.warnings().length).toBe(0);
+    });
 });
 
 it("plugin with primary option array within options array", () => {
@@ -261,9 +267,12 @@ it("plugin with primary option array within options array", () => {
       "plugin/primary-array": [["foo", "bar"], { something: true }]
     }
   };
-  return postcss().use(stylelint(config)).process("a {}").then(result => {
-    expect(result.warnings().length).toBe(0);
-  });
+  return postcss()
+    .use(stylelint(config))
+    .process("a {}")
+    .then(result => {
+      expect(result.warnings().length).toBe(0);
+    });
 });
 
 it("plugin with async rule", () => {
@@ -273,9 +282,12 @@ it("plugin with async rule", () => {
       "plugin/async": true
     }
   };
-  return postcss().use(stylelint(config)).process("a {}").then(result => {
-    expect(result.warnings().length).toBe(1);
-  });
+  return postcss()
+    .use(stylelint(config))
+    .process("a {}")
+    .then(result => {
+      expect(result.warnings().length).toBe(1);
+    });
 });
 
 describe("loading a plugin from process.cwd", () => {

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -380,7 +380,7 @@ describe("nonexistent codeFilename with loaded config", () => {
 
 describe("existing codeFilename for nested config detection", () => {
   let actualCwd;
-  
+
   beforeAll(() => {
     actualCwd = process.cwd();
     process.chdir(path.join(__dirname, "./fixtures/getConfigForFile"));
@@ -393,9 +393,9 @@ describe("existing codeFilename for nested config detection", () => {
   it("loads config from a nested directory", () => {
     return standalone({
       code: "a {}",
-      codeFilename: "a/b/foo.css",
-    }).then((linted) => {
-      expect(linted.results[0].warnings.length).toBe(1)
+      codeFilename: "a/b/foo.css"
+    }).then(linted => {
+      expect(linted.results[0].warnings.length).toBe(1);
     });
   });
 });

--- a/lib/formatters/needlessDisablesStringFormatter.js
+++ b/lib/formatters/needlessDisablesStringFormatter.js
@@ -5,7 +5,10 @@ const path = require("path");
 
 function logFrom(fromValue) {
   if (fromValue.charAt(0) === "<") return fromValue;
-  return path.relative(process.cwd(), fromValue).split(path.sep).join("/");
+  return path
+    .relative(process.cwd(), fromValue)
+    .split(path.sep)
+    .join("/");
 }
 
 module.exports = function(report) {

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -50,7 +50,10 @@ function invalidOptionsFormatter(results) {
 
 function logFrom(fromValue) {
   if (fromValue.charAt(0) === "<") return fromValue;
-  return path.relative(process.cwd(), fromValue).split(path.sep).join("/");
+  return path
+    .relative(process.cwd(), fromValue)
+    .split(path.sep)
+    .join("/");
 }
 
 function getMessageWidth(columnWidths) {

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -6,17 +6,19 @@ const path = require("path");
 
 /*:: type configPromise = Promise<?{ config: stylelint$config, filepath: string }>*/
 
-module.exports = function (
-  stylelint/*: stylelint$internalApi*/,
-  searchPath/*:: ?: string*/
-)/*: configPromise*/ {
-  searchPath = searchPath || process.cwd()
+module.exports = function(
+  stylelint /*: stylelint$internalApi*/,
+  searchPath /*:: ?: string*/
+) /*: configPromise*/ {
+  searchPath = searchPath || process.cwd();
 
   const optionsConfig = stylelint._options.config;
 
   if (optionsConfig !== undefined) {
-    const cached/*: configPromise*/ = stylelint._specifiedConfigCache.get(optionsConfig)
-    if (cached) return cached
+    const cached /*: configPromise*/ = stylelint._specifiedConfigCache.get(
+      optionsConfig
+    );
+    if (cached) return cached;
 
     // stylelint._fullExplorer (cosmiconfig) is already configured to
     // run augmentConfigFull; but since we're making up the result here,

--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -1,7 +1,7 @@
 /* @flow */
-"use strict"
-const _ = require("lodash")
-const rules/*: Object*/ = require("./rules")
+"use strict";
+const _ = require("lodash");
+const rules /*: Object*/ = require("./rules");
 
 // Rule settings can take a number of forms, e.g.
 // a. "rule-name": null
@@ -15,9 +15,9 @@ const rules/*: Object*/ = require("./rules")
 // standard form: [primaryOption, secondaryOption]
 // Except in the cases with null, a & b, in which case
 // null is returned
-module.exports = function (
-  rawSettings/*: ?stylelint$configRuleSettings*/,
-  ruleName/*: string*/,
+module.exports = function(
+  rawSettings /*: ?stylelint$configRuleSettings*/,
+  ruleName /*: string*/,
   // If primaryOptionArray is not provided, we try to get it from the
   // rules themselves, which will not work for plugins
   primaryOptionArray /*:: ?: boolean*/
@@ -36,8 +36,8 @@ module.exports = function (
   }
 
   if (primaryOptionArray === undefined) {
-    const rule/*: Function*/ = rules[ruleName]
-    primaryOptionArray = _.get(rule, "primaryOptionArray")
+    const rule /*: Function*/ = rules[ruleName];
+    primaryOptionArray = _.get(rule, "primaryOptionArray");
   }
 
   if (!primaryOptionArray) {

--- a/lib/postcssPlugin.js
+++ b/lib/postcssPlugin.js
@@ -110,10 +110,8 @@ module.exports = postcss.plugin("stylelint", function(
     tailoredOptions
   );
 
-  return (
-    root /*: rootParamT*/,
-    result /*: Promise<any>*/ /*: resultParamT*/
-  ) => {
+  // prettier-ignore
+  return (root/*: rootParamT*/, result/*: resultParamT*/)/*: Promise<any>*/ => {
     let filePath = options.from || _.get(root, "source.input.file");
     if (filePath !== undefined && !path.isAbsolute(filePath)) {
       filePath = path.join(process.cwd(), filePath);

--- a/lib/postcssPlugin.js
+++ b/lib/postcssPlugin.js
@@ -1,5 +1,5 @@
 /* @flow */
-"use strict"
+"use strict";
 /*:: type postcssType = {
   atRule: Function,
   comment: Function,
@@ -12,10 +12,10 @@
   stringify: any,
   vendor: any,
 } */
-const _ = require("lodash")
-const createStylelint = require("./createStylelint")
-const path = require("path")
-const postcss/*: postcssType*/ = require("postcss")
+const _ = require("lodash");
+const createStylelint = require("./createStylelint");
+const path = require("path");
+const postcss /*: postcssType*/ = require("postcss");
 //'block-no-empty': bool || Array
 /*:: type OptionsT = {
   config?: {
@@ -98,16 +98,23 @@ const postcss/*: postcssType*/ = require("postcss")
 
 /*:: type postcssPromise = Promise<?{ config: stylelint$config, filepath: string }>*/
 
-module.exports = postcss.plugin("stylelint", function (options/*: OptionsT*/)/*: Function*/ {
-  options = options || {}
+module.exports = postcss.plugin("stylelint", function(
+  options /*: OptionsT*/
+) /*: Function*/ {
+  options = options || {};
 
   const tailoredOptions /*: Object*/ = options.rules
     ? { config: options }
-    : options
-  const stylelint/*: stylelint$internalApi*/ = createStylelint(tailoredOptions)
+    : options;
+  const stylelint /*: stylelint$internalApi*/ = createStylelint(
+    tailoredOptions
+  );
 
-  return (root/*: rootParamT*/, result/*: resultParamT*/)/*: Promise<any>*/ => {
-    let filePath = options.from || _.get(root, "source.input.file")
+  return (
+    root /*: rootParamT*/,
+    result /*: Promise<any>*/ /*: resultParamT*/
+  ) => {
+    let filePath = options.from || _.get(root, "source.input.file");
     if (filePath !== undefined && !path.isAbsolute(filePath)) {
       filePath = path.join(process.cwd(), filePath);
     }

--- a/lib/rules/indentation/__tests__/functions.js
+++ b/lib/rules/indentation/__tests__/functions.js
@@ -842,7 +842,8 @@ testRule(rule, {
         "  );\r\n" +
         "}",
       description: "Less mixin with multi-line arguments with rule parameter"
-    }, {
+    },
+    {
       code:
         ".foo {\r\n" +
         "  .mixin(@foo, {\r\n" +
@@ -850,11 +851,9 @@ testRule(rule, {
         "  });\r\n" +
         "}",
       description: "Less mixin with multi-line arguments with rule parameter 2"
-    }, {
-      code:
-        ".mixin({\r\n" +
-        "  @foo\r\n" +
-        "}, @bar);",
+    },
+    {
+      code: ".mixin({\r\n" + "  @foo\r\n" + "}, @bar);",
       description: "Less mixin with multi-line arguments with rule parameter 3"
     }
   ]

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -268,12 +268,16 @@ const rule = function(space, options, context) {
               parentheticalDepth += 1;
             }
 
-            const followsOpeningBrace = /\{[ \t]*$/.test(source.slice(0, newlineIndex));
+            const followsOpeningBrace = /\{[ \t]*$/.test(
+              source.slice(0, newlineIndex)
+            );
             if (followsOpeningBrace) {
               parentheticalDepth += 1;
             }
 
-            const startingClosingBrace = /^[ \t]*}/.test(source.slice(match.startIndex + 1));
+            const startingClosingBrace = /^[ \t]*}/.test(
+              source.slice(match.startIndex + 1)
+            );
             if (startingClosingBrace) {
               parentheticalDepth -= 1;
             }

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -86,7 +86,10 @@ const rule = function(actual, options) {
 
             if (pseudoNode.prev()) {
               const prevPseudoNodeValue = postcss.vendor.unprefixed(
-                pseudoNode.prev().value.toLowerCase().slice(2)
+                pseudoNode
+                  .prev()
+                  .value.toLowerCase()
+                  .slice(2)
               );
 
               if (

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -67,7 +67,9 @@ module.exports = function(
     if (readError.code !== FILE_NOT_FOUND_ERROR_CODE) throw readError;
   }
   const ignorePattern = options.ignorePattern || [];
-  const ignorer = ignore().add(ignoreText).add(ignorePattern);
+  const ignorer = ignore()
+    .add(ignoreText)
+    .add(ignorePattern);
 
   const isValidCode = typeof code === "string";
   if ((!files && !isValidCode) || (files && (code || isValidCode))) {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -118,22 +118,27 @@ module.exports = function(
         // Check for file existence
         return new Promise((resolve, reject) => {
           if (!absoluteCodeFilename) {
-            reject()
-            return
+            reject();
+            return;
           }
 
-          fs.stat(absoluteCodeFilename, (err) => {
+          fs.stat(absoluteCodeFilename, err => {
             if (err) {
-              reject()
+              reject();
             } else {
-              resolve()
+              resolve();
             }
-          })
-        }).then(() => {
-          return stylelint._createStylelintResult(postcssResult, absoluteCodeFilename)
-        }).catch(() => {
-          return stylelint._createStylelintResult(postcssResult)
+          });
         })
+          .then(() => {
+            return stylelint._createStylelintResult(
+              postcssResult,
+              absoluteCodeFilename
+            );
+          })
+          .catch(() => {
+            return stylelint._createStylelintResult(postcssResult);
+          });
       })
       .catch(handleError)
       .then(stylelintResult => {

--- a/lib/utils/__tests__/addEmptyLineBefore.test.js
+++ b/lib/utils/__tests__/addEmptyLineBefore.test.js
@@ -5,58 +5,74 @@ const postcss = require("postcss");
 
 describe("addEmptyLineBefore", () => {
   it("adds single newline to the newline at the beginning", () => {
-    return postcss().process("a {}\n  b{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}\n\n  b{}");
-    });
+    return postcss()
+      .process("a {}\n  b{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}\n\n  b{}");
+      });
   });
 
   it("adds single newline to newline at the beginning with CRLF", () => {
-    return postcss().process("a {}\r\n  b{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}");
-    });
+    return postcss()
+      .process("a {}\r\n  b{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}");
+      });
   });
 
   it("adds single newline to newline at the end", () => {
-    return postcss().process("a {}\t\nb{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}\t\n\nb{}");
-    });
+    return postcss()
+      .process("a {}\t\nb{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}\t\n\nb{}");
+      });
   });
 
   it("adds single newline to newline at the end with CRLF", () => {
-    return postcss().process("a {}\t\r\nb{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}\t\r\n\r\nb{}");
-    });
+    return postcss()
+      .process("a {}\t\r\nb{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}\t\r\n\r\nb{}");
+      });
   });
 
   it("adds single newline to newline in the middle", () => {
-    return postcss().process("a {}  \n\tb{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}  \n\n\tb{}");
-    });
+    return postcss()
+      .process("a {}  \n\tb{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}  \n\n\tb{}");
+      });
   });
 
   it("adds single newline to newline in the middle with CRLF", () => {
-    return postcss().process("a {}  \r\n\tb{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}  \r\n\r\n\tb{}");
-    });
+    return postcss()
+      .process("a {}  \r\n\tb{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}  \r\n\r\n\tb{}");
+      });
   });
 
   it("adds two newlines if there aren't any existing newlines", () => {
-    return postcss().process("a {}  b{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}\n\n  b{}");
-    });
+    return postcss()
+      .process("a {}  b{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}\n\n  b{}");
+      });
   });
 
   it("adds two newlines if there aren't any existing newlines with CRLF", () => {
-    return postcss().process("a {}  b{}").then(result => {
-      addEmptyLineBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}");
-    });
+    return postcss()
+      .process("a {}  b{}")
+      .then(result => {
+        addEmptyLineBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}");
+      });
   });
 });

--- a/lib/utils/__tests__/atRuleParamIndex.test.js
+++ b/lib/utils/__tests__/atRuleParamIndex.test.js
@@ -30,7 +30,9 @@ describe("atRuleParamIndex", () => {
 });
 
 function atRules(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkAtRules(cb);
-  });
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkAtRules(cb);
+    });
 }

--- a/lib/utils/__tests__/declarationValueIndex.test.js
+++ b/lib/utils/__tests__/declarationValueIndex.test.js
@@ -36,7 +36,9 @@ describe("declarationValueIndex", () => {
 });
 
 function rules(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkDecls(cb);
-  });
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkDecls(cb);
+    });
 }

--- a/lib/utils/__tests__/findAtRuleContext.test.js
+++ b/lib/utils/__tests__/findAtRuleContext.test.js
@@ -15,23 +15,25 @@ it("findAtRuleContext", () => {
     d {}
   `;
 
-  return postcss().process(css).then(result => {
-    result.root.walkRules(rule => {
-      switch (rule.selector) {
-        case "a":
-          expect(findAtRuleContext(rule)).toBe(null);
-          break;
-        case "b":
-          expect(findAtRuleContext(rule).params).toBe("print");
-          break;
-        case "c":
-          expect(findAtRuleContext(rule).params).toBe("(min-width: 900px)");
-          break;
-        case "d":
-          expect(findAtRuleContext(rule)).toBe(null);
-          break;
-        default:
-      }
+  return postcss()
+    .process(css)
+    .then(result => {
+      result.root.walkRules(rule => {
+        switch (rule.selector) {
+          case "a":
+            expect(findAtRuleContext(rule)).toBe(null);
+            break;
+          case "b":
+            expect(findAtRuleContext(rule).params).toBe("print");
+            break;
+          case "c":
+            expect(findAtRuleContext(rule).params).toBe("(min-width: 900px)");
+            break;
+          case "d":
+            expect(findAtRuleContext(rule)).toBe(null);
+            break;
+          default:
+        }
+      });
     });
-  });
 });

--- a/lib/utils/__tests__/isCustomPropertySet.test.js
+++ b/lib/utils/__tests__/isCustomPropertySet.test.js
@@ -18,7 +18,9 @@ describe("isCustomPropertySet", () => {
 });
 
 function customPropertySet(css, cb) {
-  return postcss().process(css).then(result => {
-    result.root.walk(cb);
-  });
+  return postcss()
+    .process(css)
+    .then(result => {
+      result.root.walk(cb);
+    });
 }

--- a/lib/utils/__tests__/isKeyframeRule.test.js
+++ b/lib/utils/__tests__/isKeyframeRule.test.js
@@ -66,7 +66,9 @@ describe("isKeyframeRule", () => {
 });
 
 function rules(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkDecls(cb);
-  });
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkDecls(cb);
+    });
 }

--- a/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
@@ -86,19 +86,25 @@ describe("isStandardSyntaxAtRule", () => {
 });
 
 function atRules(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkAtRules(cb);
-  });
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkAtRules(cb);
+    });
 }
 
 function scssAtRules(css, cb) {
-  return postcss().process(css, { syntax: scss }).then(result => {
-    return result.root.walkAtRules(cb);
-  });
+  return postcss()
+    .process(css, { syntax: scss })
+    .then(result => {
+      return result.root.walkAtRules(cb);
+    });
 }
 
 function lessAtRules(css, cb) {
-  return postcss().process(css, { syntax: less }).then(result => {
-    return result.root.walkAtRules(cb);
-  });
+  return postcss()
+    .process(css, { syntax: less })
+    .then(result => {
+      return result.root.walkAtRules(cb);
+    });
 }

--- a/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
@@ -134,19 +134,25 @@ describe("isStandardSyntaxDeclaration", () => {
 });
 
 function decls(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkDecls(cb);
-  });
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkDecls(cb);
+    });
 }
 
 function scssDecls(css, cb) {
-  return postcss().process(css, { syntax: scss }).then(result => {
-    return result.root.walkDecls(cb);
-  });
+  return postcss()
+    .process(css, { syntax: scss })
+    .then(result => {
+      return result.root.walkDecls(cb);
+    });
 }
 
 function lessDecls(css, cb) {
-  return postcss().process(css, { syntax: less }).then(result => {
-    return result.root.walkDecls(cb);
-  });
+  return postcss()
+    .process(css, { syntax: less })
+    .then(result => {
+      return result.root.walkDecls(cb);
+    });
 }

--- a/lib/utils/__tests__/isStandardSyntaxFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxFunction.test.js
@@ -31,14 +31,16 @@ describe("isStandardSyntaxFunction", () => {
 });
 
 function funcs(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkDecls(decl => {
-      valueParser(decl.value).walk(valueNode => {
-        if (valueNode.type !== "function") {
-          return;
-        }
-        cb(valueNode);
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkDecls(decl => {
+        valueParser(decl.value).walk(valueNode => {
+          if (valueNode.type !== "function") {
+            return;
+          }
+          cb(valueNode);
+        });
       });
     });
-  });
 }

--- a/lib/utils/__tests__/isStandardSyntaxRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxRule.test.js
@@ -158,13 +158,17 @@ describe("isStandardSyntaxRule", () => {
 });
 
 function rules(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkRules(cb);
-  });
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkRules(cb);
+    });
 }
 
 function lessRules(css, cb) {
-  return postcss().process(css, { syntax: less }).then(result => {
-    return result.root.walkRules(cb);
-  });
+  return postcss()
+    .process(css, { syntax: less })
+    .then(result => {
+      return result.root.walkRules(cb);
+    });
 }

--- a/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
@@ -93,11 +93,13 @@ describe("isStandardSyntaxTypeSelector", () => {
 });
 
 function rules(css, cb) {
-  return postcss().process(css).then(result => {
-    return result.root.walkRules(rule => {
-      selectorParser(selectorAST => {
-        selectorAST.walkTags(cb);
-      }).process(rule.selector);
+  return postcss()
+    .process(css)
+    .then(result => {
+      return result.root.walkRules(rule => {
+        selectorParser(selectorAST => {
+          selectorAST.walkTags(cb);
+        }).process(rule.selector);
+      });
     });
-  });
 }

--- a/lib/utils/__tests__/nextNonCommentNode.test.js
+++ b/lib/utils/__tests__/nextNonCommentNode.test.js
@@ -19,51 +19,59 @@ describe("nextNonCommentNode", () => {
   });
 
   it("next node is a selector preceded by a comment", () => {
-    return postcss().process(caseA).then(result => {
-      result.root.walkRules(rule => {
-        if (rule.selector === "a") {
-          aNode = rule;
-        }
-        if (rule.selector === "b") {
-          bNode = rule;
-        }
+    return postcss()
+      .process(caseA)
+      .then(result => {
+        result.root.walkRules(rule => {
+          if (rule.selector === "a") {
+            aNode = rule;
+          }
+          if (rule.selector === "b") {
+            bNode = rule;
+          }
+        });
+        expect(nextNonCommentNode(aNode.next())).toBe(bNode);
       });
-      expect(nextNonCommentNode(aNode.next())).toBe(bNode);
-    });
   });
 
   it("next node does not exist", () => {
-    return postcss().process(caseA).then(result => {
-      result.root.walkRules(rule => {
-        if (rule.selector === "a") {
-          aNode = rule;
-        }
-        if (rule.selector === "b") {
-          bNode = rule;
-        }
+    return postcss()
+      .process(caseA)
+      .then(result => {
+        result.root.walkRules(rule => {
+          if (rule.selector === "a") {
+            aNode = rule;
+          }
+          if (rule.selector === "b") {
+            bNode = rule;
+          }
+        });
+        expect(nextNonCommentNode(bNode.next())).toBe(null);
       });
-      expect(nextNonCommentNode(bNode.next())).toBe(null);
-    });
   });
 
   it("next node is a declaration preceded by a comment", () => {
-    return postcss().process(caseB).then(result => {
-      result.root.walkRules(rule => {
-        aNode = rule;
+    return postcss()
+      .process(caseB)
+      .then(result => {
+        result.root.walkRules(rule => {
+          aNode = rule;
+        });
+        result.root.walkDecls(rule => {
+          colorNode = rule;
+        });
+        expect(nextNonCommentNode(aNode.first)).toBe(colorNode);
       });
-      result.root.walkDecls(rule => {
-        colorNode = rule;
-      });
-      expect(nextNonCommentNode(aNode.first)).toBe(colorNode);
-    });
   });
 
   it("next node is null preceded by a comment", () => {
-    return postcss().process(caseB).then(result => {
-      result.root.walkDecls(rule => {
-        colorNode = rule;
+    return postcss()
+      .process(caseB)
+      .then(result => {
+        result.root.walkDecls(rule => {
+          colorNode = rule;
+        });
+        expect(nextNonCommentNode(colorNode.next())).toBe(null);
       });
-      expect(nextNonCommentNode(colorNode.next())).toBe(null);
-    });
   });
 });

--- a/lib/utils/__tests__/removeEmptyLineBefore.test.js
+++ b/lib/utils/__tests__/removeEmptyLineBefore.test.js
@@ -5,72 +5,92 @@ const removeEmptyLinesBefore = require("../removeEmptyLinesBefore");
 
 describe("removeEmptyLinesBefore", () => {
   it("removes single newline from the newline at the beginning", () => {
-    return postcss().process("a {}\n\n  b{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}\n  b{}");
-    });
+    return postcss()
+      .process("a {}\n\n  b{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}\n  b{}");
+      });
   });
 
   it("removes single newline from newline at the beginning with CRLF", () => {
-    return postcss().process("a {}\r\n\r\n  b{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}\r\n  b{}");
-    });
+    return postcss()
+      .process("a {}\r\n\r\n  b{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}\r\n  b{}");
+      });
   });
 
   it("removes single newline from newline at the end", () => {
-    return postcss().process("a {}\t\n\nb{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}\t\nb{}");
-    });
+    return postcss()
+      .process("a {}\t\n\nb{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}\t\nb{}");
+      });
   });
 
   it("removes single newline from newline at the end with CRLF", () => {
-    return postcss().process("a {}\t\r\n\r\nb{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}\t\r\nb{}");
-    });
+    return postcss()
+      .process("a {}\t\r\n\r\nb{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}\t\r\nb{}");
+      });
   });
 
   it("removes single newline from newline in the middle", () => {
-    return postcss().process("a {}  \n\n\tb{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}  \n\tb{}");
-    });
+    return postcss()
+      .process("a {}  \n\n\tb{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}  \n\tb{}");
+      });
   });
 
   it("removes single newline to newline in the middle with CRLF", () => {
-    return postcss().process("a {}  \r\n\r\n\tb{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}  \r\n\tb{}");
-    });
+    return postcss()
+      .process("a {}  \r\n\r\n\tb{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}  \r\n\tb{}");
+      });
   });
 
   it("removes two newlines if there are three newlines", () => {
-    return postcss().process("a {}\n\n\n  b{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}\n  b{}");
-    });
+    return postcss()
+      .process("a {}\n\n\n  b{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}\n  b{}");
+      });
   });
 
   it("removes two newlines if there are three newlines with CRLF", () => {
-    return postcss().process("a {}\r\n\r\n\r\n  b{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}\r\n  b{}");
-    });
+    return postcss()
+      .process("a {}\r\n\r\n\r\n  b{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}\r\n  b{}");
+      });
   });
 
   it("removes three newlines if there are four newlines", () => {
-    return postcss().process("a {}\n\n\n\n  b{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\n");
-      expect(result.root.toString()).toBe("a {}\n  b{}");
-    });
+    return postcss()
+      .process("a {}\n\n\n\n  b{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\n");
+        expect(result.root.toString()).toBe("a {}\n  b{}");
+      });
   });
 
   it("removes three newlines if there are four newlines with CRLF", () => {
-    return postcss().process("a {}\r\n\r\n\r\n\r\n  b{}").then(result => {
-      removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
-      expect(result.root.toString()).toBe("a {}\r\n  b{}");
-    });
+    return postcss()
+      .process("a {}\r\n\r\n\r\n\r\n  b{}")
+      .then(result => {
+        removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
+        expect(result.root.toString()).toBe("a {}\r\n  b{}");
+      });
   });
 });

--- a/lib/utils/hash.js
+++ b/lib/utils/hash.js
@@ -7,5 +7,7 @@ const murmur = require("imurmurhash");
  * @returns {string}    the hash
  */
 module.exports = function hash(str) {
-  return murmur(str).result().toString(36);
+  return murmur(str)
+    .result()
+    .toString(36);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6057,9 +6057,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.5.3.tgz",
-      "integrity": "sha1-WdrcaDNF7GuI+IuU7Urn4do5S/4=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.6.1.tgz",
+      "integrity": "sha512-f85qBoQiqiFM/sCmJaN4Lagj9bqMcv38vCftqp4GfVessAqq3Ns6g+3gd8UXReStLLE/DGEdwiZXoFKxphKqwg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "postcss-html": "^0.9.0",
     "postcss-import": "^10.0.0",
     "postcss-safe-parser": "^3.0.1",
-    "prettier": "^1.5.3",
+    "prettier": "^1.6.1",
     "remark-cli": "^4.0.0",
     "remark-preset-lint-consistent": "^2.0.0",
     "remark-preset-lint-recommended": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,8 @@
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",
     "pretest": "npm-run-all --serial lint flow",
+    "prettier:check": "prettier '**/*.js' --list-different",
+    "prettier:fix": "prettier '**/*.js' --write",
     "release": "npmpub",
     "test": "jest --coverage",
     "watch": "jest --watch"


### PR DESCRIPTION
As noted at https://github.com/stylelint/stylelint/pull/2834#pullrequestreview-58393680 there was a strange _prettier_ change in that PR that was unexpected, this PR is to to test against `master` any missing changes that should have been added by Prettier already.

• I've added `prettier:check` and `prettier:fix` npm commands, `npm run prettier:check` and `npm run prettier:fix` respectively to help test changes in this PR

Running `npm run prettier:check` results in:
```shell
prettier '**/*.js'  --list-different

.coverage/lcov-report/prettify.js
.coverage/lcov-report/sorter.js
decls/flow-typed/lodash.js

decls/flow-typed/lodash.js: SyntaxError: default is a reserved word (463:55)
  461 |     conforms(source: Object): Function;
  462 |     constant<T>(value: T): () => T;
> 463 |     defaultTo<T1:string|boolean|Object,T2>(value: T1, default: T2): T1;
      |                                                       ^
  464 |     // NaN is a number instead of its own type, otherwise it would behave like null/void
  465 |     defaultTo<T1:number,T2>(value: T1, default: T2): T1|T2;
  466 |     defaultTo<T1:void|null,T2>(value: T1, default: T2): T2;
decls/postcss.js
decls/stylelint.js
lib/__tests__/standalone.test.js
lib/getConfigForFile.js
lib/normalizeRuleSettings.js
lib/postcssPlugin.js
lib/rules/indentation/__tests__/functions.js
lib/rules/indentation/index.js
lib/standalone.js
```

The results after running `npm run prettier:fix` are the file changes in this PR (apart from `package.json` change adding the two script commands)

- [ ] decls/postcss.js
- [ ] decls/stylelint.js
- [ ] lib/__tests__/standalone.test.js
- [ ] lib/getConfigForFile.js
- [ ] lib/normalizeRuleSettings.js
- [ ] lib/postcssPlugin.js
- [ ] lib/rules/indentation/__tests__/functions.js
- [ ] lib/rules/indentation/index.js
- [ ] lib/standalone.js

@stylelint/core could you review this PR please and we'll get this shipped in 8.1.0 