### PR TITLE
Handle valid calc functions with no whitespace in unit-no-unknown (issue #2551)

### DIFF
--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -273,7 +273,7 @@ testRule(rule, {
       code: "a { margin: calc(2*10pix); }",
       message: messages.rejected("pix"),
       line: 1,
-      column: 18,
+      column: 20,
       description: "No whitespace"
     },
     {

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -90,6 +90,13 @@ testRule(rule, {
       code: "a { top: calc(10em - 3em); }"
     },
     {
+      code: "a { top: calc(10px*2); }"
+    },
+    {
+      code: "a { top: calc(2*10px); }",
+      description: "No whitespace"
+    },
+    {
       code:
         "a { background-image: linear-gradient(to right, white calc(100% - 50em), silver); }"
     },
@@ -254,6 +261,20 @@ testRule(rule, {
       message: messages.rejected("pix"),
       line: 1,
       column: 18
+    },
+    {
+      code: "a { margin: calc(10pix*2); }",
+      message: messages.rejected("pix"),
+      line: 1,
+      column: 18,
+      description: "No whitespace"
+    },
+    {
+      code: "a { margin: calc(2*10pix); }",
+      message: messages.rejected("pix"),
+      line: 1,
+      column: 18,
+      description: "No whitespace"
     },
     {
       code: "a { -webkit-transition-delay: 10pix; }",

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -37,6 +37,9 @@ const rule = function(actual, options) {
     }
 
     function check(node, value, getIndex) {
+      // make sure multiplication operations (*) are divided - not handled
+      // by postcss-value-parser
+      value = value.replace("*", ",");
       valueParser(value).walk(function(valueNode) {
         // Ignore wrong units within `url` function
         if (


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Issue #2551 

> Is there anything in the PR that needs further explanation?

The solution is stupidly simple but it works (as in the tests pass). There might be edge cases I haven't thought of though.