### PR TITLE
chore: Pin npm to version 5.3.0 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       sudo: required
 
 before_install:
-  - npm install -g npm@latest
+  - npm install -g npm@5.3.0
   - npm i -g greenkeeper-lockfile@1
 
 before_script: greenkeeper-lockfile-update


### PR DESCRIPTION
npm 5.4.0 is currently stripping execute permissione from package binaries.

See:
• https://github.com/facebook/flow/issues/4733 Flow doesn't work with npm v5.4.0
• https://github.com/npm/npm/issues/18324 npm 5.4.0 removes executable permission
• https://github.com/npm/npm/issues/18322 Npm5 destroys permissions.


See also: https://github.com/stylelint/stylelint/pull/2842#discussion_r136717774