### PR TITLE
Fix support for *-empty-line-before in HTML

### DIFF
--- a/lib/__tests__/fixtures/at-rule-empty-line-before.html
+++ b/lib/__tests__/fixtures/at-rule-empty-line-before.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <style>
-h1 {
-  font-weight: normal;
+@keyframes foo {
+
 }
 </style>
 </head>

--- a/lib/__tests__/fixtures/at-rule-empty-line-before.html
+++ b/lib/__tests__/fixtures/at-rule-empty-line-before.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+h1 {
+  font-weight: normal;
+}
+</style>
+</head>
+</html>

--- a/lib/__tests__/fixtures/comment-empty-line-before.html
+++ b/lib/__tests__/fixtures/comment-empty-line-before.html
@@ -3,9 +3,6 @@
 <head>
 <style>
 /* comment-empty-line-before */
-h1 {
-  font-weight: normal;
-}
 </style>
 </head>
 </html>

--- a/lib/__tests__/fixtures/comment-empty-line-before.html
+++ b/lib/__tests__/fixtures/comment-empty-line-before.html
@@ -2,8 +2,9 @@
 <html>
 <head>
 <style>
-@supports ( display: flex ) {
-  @import url(global.css);
+/* comment-empty-line-before */
+h1 {
+  font-weight: normal;
 }
 </style>
 </head>

--- a/lib/__tests__/fixtures/rule-empty-line-before.html
+++ b/lib/__tests__/fixtures/rule-empty-line-before.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+h1 {
+  font-weight: normal;
+}
+</style>
+</head>
+</html>

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -73,21 +73,42 @@ it("standalone with Less syntax", () => {
 it("standalone with postcss-html syntax", () => {
   const config = {
     rules: {
-      "no-empty-source": true
+      "no-empty-source": true,
+      "rule-empty-line-before": "always",
+      "at-rule-empty-line-before": "always"
     }
   };
 
   return standalone({
     config,
     customSyntax: `${fixturesPath}/postcss-html-syntax`,
-    files: [`${fixturesPath}/no-empty-source.html`],
+    files: [
+      `${fixturesPath}/at-rule-empty-line-before.html`,
+      `${fixturesPath}/no-empty-source.html`,
+      `${fixturesPath}/rule-empty-line-before.html`
+    ],
     formatter: stringFormatter
   }).then(linted => {
     const results = linted.results;
+    expect(results.length).toBe(3);
 
-    expect(results.length).toBe(1);
-    expect(results[0].errored).toBeFalsy();
-    expect(results[0].warnings.length).toBe(0);
+    const atRuleEmptyLineBeforeResult = results.find(r =>
+      /[/\\]at-rule-empty-line-before\.html$/.test(r.source)
+    );
+    expect(atRuleEmptyLineBeforeResult.errored).toBeFalsy();
+    expect(atRuleEmptyLineBeforeResult.warnings.length).toBe(0);
+
+    const noEmptySourceResult = results.find(r =>
+      /[/\\]no-empty-source\.html$/.test(r.source)
+    );
+    expect(noEmptySourceResult.errored).toBeFalsy();
+    expect(noEmptySourceResult.warnings.length).toBe(0);
+
+    const ruleEmptyLineBeforeResult = results.find(r =>
+      /[/\\]rule-empty-line-before\.html$/.test(r.source)
+    );
+    expect(ruleEmptyLineBeforeResult.errored).toBeFalsy();
+    expect(ruleEmptyLineBeforeResult.warnings.length).toBe(0);
   });
 });
 

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -74,8 +74,14 @@ it("standalone with postcss-html syntax", () => {
   const config = {
     rules: {
       "no-empty-source": true,
+      "comment-empty-line-before": "always",
       "rule-empty-line-before": "always",
-      "at-rule-empty-line-before": "always"
+      "at-rule-empty-line-before": [
+        "always",
+        {
+          except: ["inside-block"]
+        }
+      ]
     }
   };
 
@@ -84,19 +90,26 @@ it("standalone with postcss-html syntax", () => {
     customSyntax: `${fixturesPath}/postcss-html-syntax`,
     files: [
       `${fixturesPath}/at-rule-empty-line-before.html`,
+      `${fixturesPath}/comment-empty-line-before.html`,
       `${fixturesPath}/no-empty-source.html`,
       `${fixturesPath}/rule-empty-line-before.html`
     ],
     formatter: stringFormatter
   }).then(linted => {
     const results = linted.results;
-    expect(results.length).toBe(3);
+    expect(results.length).toBe(4);
 
     const atRuleEmptyLineBeforeResult = results.find(r =>
       /[/\\]at-rule-empty-line-before\.html$/.test(r.source)
     );
     expect(atRuleEmptyLineBeforeResult.errored).toBeFalsy();
     expect(atRuleEmptyLineBeforeResult.warnings.length).toBe(0);
+
+    const commentEmptyLineBeforeResult = results.find(r =>
+      /[/\\]comment-empty-line-before\.html$/.test(r.source)
+    );
+    expect(commentEmptyLineBeforeResult.errored).toBeFalsy();
+    expect(commentEmptyLineBeforeResult.warnings.length).toBe(0);
 
     const noEmptySourceResult = results.find(r =>
       /[/\\]no-empty-source\.html$/.test(r.source)

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -8,6 +8,7 @@ const isAfterCommentLine = require("../../utils/isAfterCommentLine");
 const isBlocklessAtRuleAfterBlocklessAtRule = require("../../utils/isBlocklessAtRuleAfterBlocklessAtRule");
 const isBlocklessAtRuleAfterSameNameBlocklessAtRule = require("../../utils/isBlocklessAtRuleAfterSameNameBlocklessAtRule");
 const isFirstNested = require("../../utils/isFirstNested");
+const isFirstNodeOfRoot = require("../../utils/isFirstNodeOfRoot");
 const optionsMatches = require("../../utils/optionsMatches");
 const removeEmptyLinesBefore = require("../../utils/removeEmptyLinesBefore");
 const report = require("../../utils/report");
@@ -56,14 +57,9 @@ const rule = function(expectation, options, context) {
     }
 
     root.walkAtRules(atRule => {
-      const isNested = atRule.parent !== root;
-
-      if (
-        // Ignore the first node of file
-        atRule === root.first ||
-        // Ignores the first node in each <style> tag of HTML document.
-        atRule === atRule.root().first
-      ) {
+      const isNested = atRule.parent.type !== "root";
+      // Ignore the first node
+      if (isFirstNodeOfRoot(atRule)) {
         return;
       }
 

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -59,7 +59,7 @@ const rule = function(expectation, options, context) {
       const isNested = atRule.parent !== root;
 
       // Ignore the first node
-      if (atRule === root.first) {
+      if (atRule === root.first || atRule === atRule.root().first) {
         return;
       }
 

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -58,8 +58,12 @@ const rule = function(expectation, options, context) {
     root.walkAtRules(atRule => {
       const isNested = atRule.parent !== root;
 
-      // Ignore the first node
-      if (atRule === root.first || atRule === atRule.root().first) {
+      if (
+        // Ignore the first node of file
+        atRule === root.first ||
+        // Ignores the first node in each <style> tag of HTML document.
+        atRule === atRule.root().first
+      ) {
         return;
       }
 

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -4,6 +4,7 @@ const addEmptyLineBefore = require("../../utils/addEmptyLineBefore");
 const hasEmptyLine = require("../../utils/hasEmptyLine");
 const isAfterCommentLine = require("../../utils/isAfterCommentLine");
 const isFirstNested = require("../../utils/isFirstNested");
+const isFirstNodeOfRoot = require("../../utils/isFirstNodeOfRoot");
 const isSharedLineComment = require("../../utils/isSharedLineComment");
 const optionsMatches = require("../../utils/optionsMatches");
 const removeEmptyLinesBefore = require("../../utils/removeEmptyLinesBefore");
@@ -44,7 +45,7 @@ const rule = function(expectation, options, context) {
 
     root.walkComments(comment => {
       // Ignore the first node
-      if (comment === root.first) {
+      if (isFirstNodeOfRoot(comment)) {
         return;
       }
 

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -52,7 +52,7 @@ const rule = function(expectation, options, context) {
       }
 
       // Ignore the first node
-      if (rule === root.first) {
+      if (rule === root.first || rule === rule.root().first) {
         return;
       }
 

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -51,8 +51,12 @@ const rule = function(expectation, options, context) {
         return;
       }
 
-      // Ignore the first node
-      if (rule === root.first || rule === rule.root().first) {
+      if (
+        // Ignore the first node of file
+        rule === root.first ||
+        // Ignores the first node in each <style> tag of HTML document.
+        rule === rule.root().first
+      ) {
         return;
       }
 

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -53,7 +53,7 @@ const rule = function(expectation, options, context) {
       }
 
       // Ignore the first node
-      if (isFirstNodeOfRoot(rule, root)) {
+      if (isFirstNodeOfRoot(rule)) {
         return;
       }
 

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -3,6 +3,7 @@
 const addEmptyLineBefore = require("../../utils/addEmptyLineBefore");
 const hasEmptyLine = require("../../utils/hasEmptyLine");
 const isFirstNested = require("../../utils/isFirstNested");
+const isFirstNodeOfRoot = require("../../utils/isFirstNodeOfRoot");
 const isSingleLineString = require("../../utils/isSingleLineString");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const optionsMatches = require("../../utils/optionsMatches");
@@ -51,12 +52,8 @@ const rule = function(expectation, options, context) {
         return;
       }
 
-      if (
-        // Ignore the first node of file
-        rule === root.first ||
-        // Ignores the first node in each <style> tag of HTML document.
-        rule === rule.root().first
-      ) {
+      // Ignore the first node
+      if (isFirstNodeOfRoot(rule, root)) {
         return;
       }
 

--- a/lib/utils/isFirstNodeOfRoot.js
+++ b/lib/utils/isFirstNodeOfRoot.js
@@ -1,0 +1,7 @@
+/* @flow */
+"use strict";
+
+module.exports = function(node /*: postcss$node*/) /*: boolean*/ {
+  const parentNode = node.parent;
+  return parentNode.type === "root" && node === parentNode.first;
+};


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2853

> Is there anything in the PR that needs further explanation?

"No, it's self explanatory."
