### PR TITLE
fix: Ignore `:local` and `:global` pseudo classes in the `selector-max-specificity` rule

### DIFF
--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -12,7 +12,7 @@ Visit the [Specificity Calculator](https://specificity.keegan.st) for visual rep
 
 This rule ignores selectors with variable interpolation (`#{$var}`, `@{var}`, `$(var)`).
 
-This rule ignores selectors containing the `:not()` or `:matches()` pseudo-classes.
+This rule ignores selectors containing the `:not()`, `:matches()`, `:local()` or `:global()` pseudo-classes.
 
 This rule resolves nested selectors before calculating the specificity of a selector.
 

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -31,6 +31,18 @@ testRule(rule, {
       code: ".a:matches(.b, .c) {}"
     },
     {
+      code: ".a:local(.b) {}"
+    },
+    {
+      code: ".a:local(.b, .c) {}"
+    },
+    {
+      code: ".a:global(.b) {}"
+    },
+    {
+      code: ".a:global(.b, .c) {}"
+    },
+    {
       code: "div div div div div div div div div div div {}",
       message:
         "a selector with 11 elements has a lower specificity than a selector with one classname"

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -46,8 +46,16 @@ const rule = function(max) {
           if (selector.indexOf(":not(") !== -1) {
             return;
           }
-          // Return early if selector contains a matches
+          // Return early if selector contains a matches pseudo-class
           if (selector.indexOf(":matches(") !== -1) {
+            return;
+          }
+          // Return early if selector contains a local pseudo-class
+          if (selector.indexOf(":local(") !== -1) {
+            return;
+          }
+          // Return early if selector contains a global pseudo-class
+          if (selector.indexOf(":global(") !== -1) {
             return;
           }
           // Check if the selector specificity exceeds the allowed maximum


### PR DESCRIPTION
Fixes #2857 