### PR TITLE
Add pull request and issue sections to Dev Guide

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,10 +1,19 @@
 # Developer guide
 
+## Contributor guides
+
+-   [Prerequisites](developer-guide/prerequisites.md): Technical prerequisites to contributing.
 -   [Rules](developer-guide/rules.md): Working on the built-in rules.
+
+## Ecosystem guides
+
 -   [Plugins](developer-guide/plugins.md): Writing your own plugins.
 -   [Processors](developer-guide/processors.md): Writing your own processors.
 -   [Formatters](developer-guide/formatters.md): Writing your own formatters.
 -   [Rule testers](developer-guide/rule-testers.md): Using and writing rule testers.
+
+## Core team guides
+
 -   [Releases](developer-guide/releases.md): Performing releases.
 -   [Pull requests](developer-guide/pull-requests.md): Reviewing pull requests.
 -   [Issues](developer-guide/issues.md): Managing issues.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,8 +1,10 @@
 # Developer guide
 
--   [Rules](developer-guide/rules.md): Working on stylelint's rules.
+-   [Rules](developer-guide/rules.md): Working on the built-in rules.
 -   [Plugins](developer-guide/plugins.md): Writing your own plugins.
 -   [Processors](developer-guide/processors.md): Writing your own processors.
 -   [Formatters](developer-guide/formatters.md): Writing your own formatters.
 -   [Rule testers](developer-guide/rule-testers.md): Using and writing rule testers.
 -   [Releases](developer-guide/releases.md): Performing releases.
+-   [Pull requests](developer-guide/pull-requests.md): Reviewing pull requests.
+-   [Issues](developer-guide/issues.md): Managing issues.

--- a/docs/developer-guide/issues.md
+++ b/docs/developer-guide/issues.md
@@ -1,0 +1,34 @@
+# Managing issues
+
+-   Use [labels](https://github.com/stylelint/stylelint/labels):
+    -   Add _one_ of the `status: *` labels.
+    -   Add _zero or one_ of the `type: *` labels.
+    -   Add _zero, one or more_ of the `non-standard syntax: *` labels.
+    -   Optionally, add the `beginner friendly` label.
+-   Rename the title into a consistent format:
+    -   Lead with the [CHANGELOG group names](pull-requests.md), but in the present tense:
+        -   "Remove y" e.g. "Remove unit-blacklist".
+        -   "Deprecate x in y" e.g. "Deprecate resolvedNested option in selector-class-pattern".
+        -   "Add y" e.g. "Add unit-blacklist".
+        -   "Add x to y" e.g. "Add ignoreProperties: [] to property-blacklist".
+        -   "Fix false positives/negatives for x in y" e.g. "Fix false positives for Less mixins in color-no-hex".
+    -   Use `*` if the issue applies to a group of rules e.g. "Fix false negatives for SCSS variables in selector-*-pattern"
+-   Provide a link to the relevant section of the [Developer Guide](../developer-guide.md) when:
+    -   Adding the `status: help wanted` label to encourage the original poster to contribute., e.g. [adding an option to an existing rule](../developer-guide/rules.md#adding-an-option-to-an-existing-rule) or [fixing a bug in an existing rule](../developer-guide/rules.md#fixing-a-bug-in-an-existing-rule).
+    -   Closing an issue because the feature is best part of ecosystem e.g. [a plugin](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/plugins.md) or [processor](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/processors.md).
+-   Use milestones only on issues and not on pull requests:
+    -   Use the `future-major` milestone for issues that introduce breaking changes.
+    -   Optionally, create version milestones (e.g. `8.x`) to manage upcoming releases.
+-   Use the following saved reply to close any issue that do not use the template:
+
+```md
+Thanks for creating this issue but we are closing it as issues need to follow our issue template, so that we can clearly understand your particular circumstances.
+
+Please help us to help you by [recreating the issue](https://github.com/stylelint/stylelint/issues/new) using the template.
+```
+
+General rules of thumb:
+
+-   Use the `status: discussion`, `status: needs clarification` or `status: needs investigation` label when first triaging an issue.
+-   Use the `status: help wanted`, a `type` (and `non-standard syntax: *` and `beginner friendly`) labels when a course of action is agreed.
+-   Use the `status: wip` label when your are, or someone has said they are, about to start working on an issue.

--- a/docs/developer-guide/prerequisites.md
+++ b/docs/developer-guide/prerequisites.md
@@ -1,0 +1,4 @@
+# Technical prerequisites to contributing
+
+-   [Node.JS](https://nodejs.org/en/) 8+.
+-   Latest [npm](https://www.npmjs.com/).

--- a/docs/developer-guide/prerequisites.md
+++ b/docs/developer-guide/prerequisites.md
@@ -1,4 +1,4 @@
 # Technical prerequisites to contributing
 
--   [Node.JS](https://nodejs.org/en/) 8+.
+-   [Node.js](https://nodejs.org/en/) 4.2.1+.
 -   Latest [npm](https://www.npmjs.com/).

--- a/docs/developer-guide/pull-requests.md
+++ b/docs/developer-guide/pull-requests.md
@@ -1,0 +1,13 @@
+# Reviewing pull requests
+
+-   Use the [GitHub review system](https://help.github.com/articles/about-pull-request-reviews/).
+-   Review against the [Developer Guide criteria](rules.md).
+-   Assign one or more of the appropriate [`PR: needs *` labels](https://github.com/stylelint/stylelint/labels) when requesting a change.
+-   Merge simple documentation fixes after one approval and all other PRs after two approvals.
+-   Update the [CHANGELOG](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md) directly via the [GitHub website](https://github.com/stylelint/stylelint/edit/master/CHANGELOG.md) for all merged PRs (except documentation changes).
+    -   Create a `# Head` heading if one does not exist already.
+    -   Prefix the item with either: Removed, Changed, Deprecated, Added, or Fixed.
+    -   Order the item within the group by the widest reaching first to the smallest, and then alphabetically by rule name.
+    -   Suffix the item with the relevant PR number, using the complete GitHub URL so that it works on [the website](https://stylelint.io/CHANGELOG/).
+    -   If applicable, lead the item with the name of rule e.g. "Fixed: `unit-blacklist` false positives for SCSS nested properties".
+-   Lastly, post the item as a comment to the PR.

--- a/docs/developer-guide/pull-requests.md
+++ b/docs/developer-guide/pull-requests.md
@@ -3,11 +3,15 @@
 -   Use the [GitHub review system](https://help.github.com/articles/about-pull-request-reviews/).
 -   Review against the [Developer Guide criteria](rules.md).
 -   Assign one or more of the appropriate [`PR: needs *` labels](https://github.com/stylelint/stylelint/labels) when requesting a change.
--   Merge simple documentation fixes after one approval and all other PRs after two approvals.
+-   Resolve conficts by [rebasing](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase), rather than merging the target branch into the pull request branch.
+-   Merge simple documentation fixes after one approval and all other pull requests after two approvals.
+-   "Squash and merge" commits, ensuring the resulting commit message is consistently formatted:
+    -   Sentence case.
+    -   Descriptive.
 -   Update the [CHANGELOG](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md) directly via the [GitHub website](https://github.com/stylelint/stylelint/edit/master/CHANGELOG.md) for all merged PRs (except documentation changes).
     -   Create a `# Head` heading if one does not exist already.
     -   Prefix the item with either: Removed, Changed, Deprecated, Added, or Fixed.
     -   Order the item within the group by the widest reaching first to the smallest, and then alphabetically by rule name.
-    -   Suffix the item with the relevant PR number, using the complete GitHub URL so that it works on [the website](https://stylelint.io/CHANGELOG/).
+    -   Suffix the item with the relevant pull request number, using the complete GitHub URL so that it works on [the website](https://stylelint.io/CHANGELOG/).
     -   If applicable, lead the item with the name of rule e.g. "Fixed: `unit-blacklist` false positives for SCSS nested properties".
--   Lastly, post the item as a comment to the PR.
+-   Lastly, post the item as a comment to the pull request.

--- a/docs/developer-guide/releases.md
+++ b/docs/developer-guide/releases.md
@@ -19,10 +19,7 @@ The secondary goals are:
 3.  Locally test `master` in the `stylelint.io` repo.
 4.  Locally test `master` in the `stylelint-demo` repo.
 5.  Both the publishing of the package to npm and the creating a github release are done with [`npmpub`](https://github.com/MoOx/npmpub):
-    1.  Ensure the CHANGELOG is consistently formatted:
-        -   If a CHANGELOG item affects only one rule, then it should lead with its name.
-        -   The order of items is: Removed, Changed, Deprecated, Added, Fixed.
-        -   The items within each group are ordered by the widest reaching first to the smallest, and then alphabetically by rule name.
+    1.  Ensure the CHANGELOG is [consistently formatted](pull-requests.md).
     2.  Run `npm --no-git-tag-version version major|minor|patch` to increment the `version` number in `package.json` and `package-lock.json`, according to whether it's a patch, minor or major release.
     3.  Replace `# Head` in `CHANGELOG.md` with this new version number e.g. `# 8.1.2`
     4.  Commit and _push up_ these changes.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,15 +1,26 @@
 # User guide
 
+## Introduction
+
+-   [FAQ](user-guide/faq.md): Frequently asked questions about using and configuring stylelint.
+-   [About rules](user-guide/about-rules.md): An explanation of rule names and how rules work together.
+
+## Configuration
+
+-   [Configuration](user-guide/configuration.md): How to configure stylelint.
+    -   [Rules](user-guide/rules.md): A list of stylelint's rules.
+    -   [Plugins](user-guide/plugins.md): A list of community plugins.
+    -   [Processors](user-guide/processors.md): A list of community processors.
+-   [Example config](user-guide/example-config.md): An example config that you can use as a blueprint for your own.
+-   [CSS processors](user-guide/css-processors.md): How to use the linter with a CSS processor, like SCSS or PostCSS plugins.
+
+## Usage
+
 -   [The CLI](user-guide/cli.md): Examples and exit codes for using the CLI.
 -   [The Node API](user-guide/node-api.md): Options and examples for using the Node API.
 -   [The PostCSS plugin](user-guide/postcss-plugin.md): Options and examples for using the PostCSS plugin.
--   [Configuration](user-guide/configuration.md): How to configure stylelint.
--   [Example config](user-guide/example-config.md): An example config that you can use as a blueprint for your own.
--   [CSS processors](user-guide/css-processors.md): How to use the linter with a CSS processor, like SCSS or PostCSS plugins.
--   [About rules](user-guide/about-rules.md): An explanation of rule names and how rules work together.
--   [Rules](user-guide/rules.md): A list of stylelint's rules.
--   [Plugins](user-guide/plugins.md): A list of community plugins.
--   [Processors](user-guide/processors.md): A list of community processors.
 -   [Complementary tools](user-guide/complementary-tools.md): List of community editor plugins, build tool plugins and other tools.
--   [FAQ](user-guide/faq.md): Frequently asked questions about using and configuring stylelint.
+
+## Further reading
+
 -   [Articles](user-guide/articles.md): A collection of articles and tutorials about stylelint.


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/issues/2866

@hudochenkov Thanks for [digging out](https://github.com/stylelint/stylelint/issues/2866#issuecomment-328209568) those comments. I had completely forgotten about them :)

I’ve tried to streamline the pr and issue processes where I can e.g. I’ve removed the labels which we add to closed issues. Adding these labels is unnecessary work as this info is either: 

1. Communicated in the closing comment e.g. “Best suited as a plugin”, “Dupe of xxxx” etc.
2. Implicit e.g. the PR was merged after a review, the PR is open and doesn’t have a “PR: needs tests/docs/revision” label and therefore needs reviewing.

The actual documents themselves are pretty terse (and a bit dry I’m afraid) as I wanted to get something up before we add any new members (and it's for a small audience).

---

I'll also try to make some time over the next few days to help work through the backlog of issues so there's a clean-ish slate for any new members...