### PR TITLE
Add support for level 4 selectors in selector-max-specificity

### DIFF
--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -87,7 +87,7 @@ div {}
 Given:
 
 ```js
-["0,1,0", {
+["0,2,0", {
   ignoreSelectors: [":global", ":local", "/my-/"]
 }];
 ```

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -12,8 +12,6 @@ Visit the [Specificity Calculator](https://specificity.keegan.st) for visual rep
 
 This rule ignores selectors with variable interpolation (`#{$var}`, `@{var}`, `$(var)`).
 
-This rule handles selectors containing the `:not()` or `:matches()` pseudo-classes per [spec](https://drafts.csswg.org/selectors/#specificity-rules).
-
 This rule resolves nested selectors before calculating the specificity of a selector.
 
 ## Options
@@ -106,7 +104,7 @@ The following patterns are *not* considered violations:
 :local(.foo, :global(.bar).baz)
 ```
 
-The following patterns are still considered violations:
+The following patterns are considered violations:
 
 ```css
 :global(.foo) .bar.baz {}

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -12,7 +12,7 @@ Visit the [Specificity Calculator](https://specificity.keegan.st) for visual rep
 
 This rule ignores selectors with variable interpolation (`#{$var}`, `@{var}`, `$(var)`).
 
-This rule ignores selectors containing the `:not()` or `:matches()` pseudo-classes.
+This rule handles selectors containing the `:not()` or `:matches()` pseudo-classes per [spec](https://drafts.csswg.org/selectors/#specificity-rules).
 
 This rule resolves nested selectors before calculating the specificity of a selector.
 
@@ -78,4 +78,44 @@ div {}
     color: blue;
   }
 }
+```
+
+## Optional secondary options
+
+### `ignoreSelectors: ["/regex/", "string"]`
+
+Given:
+
+```js
+["0,1,0", {
+  ignoreSelectors: [":global", ":local", "/my-/"]
+}];
+```
+
+The following patterns are *not* considered violations:
+
+```css
+:global(.foo) .bar {}
+```
+
+```css
+:local(.foo.bar)
+```
+
+```css
+:local(.foo, :global(.bar).baz)
+```
+
+The following patterns are still considered violations:
+
+```css
+:global(.foo) .bar.baz {}
+```
+
+```css
+:local(.foo.bar.baz)
+```
+
+```css
+:local(.foo, :global(.bar), .foo.bar.baz)
 ```

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -3,7 +3,6 @@
 const messages = require("..").messages;
 const ruleName = require("..").ruleName;
 const rules = require("../../../rules");
-const stylelint = require("../../..");
 
 const rule = rules[ruleName];
 
@@ -19,16 +18,16 @@ testRule(rule, {
       code: "span a {}"
     },
     {
-      code: ".a:not(.b) {}"
+      code: ":not(.b) {}"
     },
     {
-      code: ".a:not(.b, .c) {}"
+      code: ":not(.b, .c) {}"
     },
     {
-      code: ".a:matches(.b) {}"
+      code: ":matches(.b) {}"
     },
     {
-      code: ".a:matches(.b, .c) {}"
+      code: ":matches(.b, .c) {}"
     },
     {
       code: "div div div div div div div div div div div {}",
@@ -75,6 +74,42 @@ testRule(rule, {
     {
       code: ".ab span {}",
       message: messages.expected(".ab span", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:not(.b) {}",
+      message: messages.expected(".a:not(.b)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:not(.b, .c) {}",
+      message: messages.expected(".a:not(.b, .c)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":not(.b, .c.d) {}",
+      message: messages.expected(":not(.b, .c.d)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:matches(.b) {}",
+      message: messages.expected(".a:matches(.b)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:matches(.b, .c) {}",
+      message: messages.expected(".a:matches(.b, .c)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":matches(.b, .c.d) {}",
+      message: messages.expected(":matches(.b, .c.d)", "0,1,0"),
       line: 1,
       column: 1
     }
@@ -264,23 +299,75 @@ testRule(rule, {
   ]
 });
 
-it("cannot parse selector warning", () => {
-  const config = {
-    rules: {
-      "selector-max-specificity": ["0,3,0"]
+testRule(rule, {
+  ruleName,
+  config: [
+    "0,1,0",
+    {
+      ignoreSelectors: [":global", ":local", "/my-/"]
     }
-  };
+  ],
 
-  return stylelint
-    .lint({
-      code: ".a:unknown(.b, .d) { }",
-      config
-    })
-    .then(function(data) {
-      const parseErrors = data.results[0].parseErrors;
-      expect(parseErrors.length).toBe(1);
-      expect(parseErrors[0].text).toBe("Cannot parse selector");
-      expect(parseErrors[0].line).toBe(1);
-      expect(parseErrors[0].column).toBe(1);
-    });
+  accept: [
+    {
+      code: ":global(.b) {}"
+    },
+    {
+      code: ":global(.b, :local(.c)) {}"
+    },
+    {
+      code: ":local(.b) {}"
+    },
+    {
+      code: ":local(.b, :global(.c)) {}"
+    },
+    {
+      code: "my-tag.a {}"
+    }
+  ],
+
+  reject: [
+    {
+      code: ".a:global(.b) {}",
+      message: messages.expected(".a:global(.b)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:global(.b, .c) {}",
+      message: messages.expected(".a:global(.b, .c)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":global(.b, .c.d) {}",
+      message: messages.expected(":global(.b, .c.d)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:local(.b) {}",
+      message: messages.expected(".a:local(.b)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:local(.b, .c) {}",
+      message: messages.expected(".a:local(.b, .c)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":local(.b, .c.d) {}",
+      message: messages.expected(":local(.b, .c.d)", "0,1,0"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "my-tag.a.b {}",
+      message: messages.expected("my-tag.a.b", "0,1,0"),
+      line: 1,
+      column: 1
+    }
+  ]
 });

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -21,8 +21,8 @@ const messages = ruleMessages(ruleName, {
 // Return an array representation of zero specificity. We need a new array each time so that it can mutated
 const zeroSpecificity = () => [0, 0, 0, 0];
 
-// Calculate the sum of given specificity arrays
-const specificitySum = (...specificities) => {
+// Calculate the sum of given array of specificity arrays
+const specificitySum = specificities => {
   const sum = zeroSpecificity();
   specificities.forEach(specificityArray => {
     specificityArray.forEach((value, i) => {
@@ -88,7 +88,7 @@ const rule = function(max, options) {
             zeroSpecificity()
           : simpleSpecificity(ownValue);
 
-      return specificitySum(ownSpecificity, maxChildSpecificity(node));
+      return specificitySum([ownSpecificity, maxChildSpecificity(node)]);
     };
 
     // Calculate the specificity of a node parsed bu `postcss-selector-parser`
@@ -103,7 +103,7 @@ const rule = function(max, options) {
           return pseudoSpecificity(node);
         case "selector":
           // Calculate the sum of all the direct children
-          return specificitySum(...node.map(nodeSpecificity));
+          return specificitySum(node.map(nodeSpecificity));
         default:
           return zeroSpecificity();
       }

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -59,7 +59,7 @@ const rule = function(max, options) {
       return;
     }
 
-    // Calculate the specificity of a simple selector (type, attribute, class, id, or pseudos"s own value)
+    // Calculate the specificity of a simple selector (type, attribute, class, id, or pseudos's own value)
     const simpleSpecificity = selector => {
       if (optionsMatches(options, "ignoreSelectors", selector)) {
         return zeroSpecificity();
@@ -91,7 +91,7 @@ const rule = function(max, options) {
       return specificitySum([ownSpecificity, maxChildSpecificity(node)]);
     };
 
-    // Calculate the specificity of a node parsed bu `postcss-selector-parser`
+    // Calculate the specificity of a node parsed by `postcss-selector-parser`
     const nodeSpecificity = node => {
       switch (node.type) {
         case "attribute":

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -1,7 +1,10 @@
 "use strict";
 
+const _ = require("lodash");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector");
+const optionsMatches = require("../../utils/optionsMatches");
+const parseSelector = require("../../utils/parseSelector");
 const report = require("../../utils/report");
 const resolvedNestedSelector = require("postcss-resolve-nested-selector");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -15,21 +18,96 @@ const messages = ruleMessages(ruleName, {
     `Expected "${selector}" to have a specificity no more than "${specificity}"`
 });
 
-const rule = function(max) {
-  return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: max,
-      possible: [
-        function(max) {
-          // Check that the max specificity is in the form "a,b,c"
-          const pattern = new RegExp("^\\d+,\\d+,\\d+$");
-          return pattern.test(max);
-        }
-      ]
+// Return an array representation of zero specificity. We need a new array each time so that it can mutated
+const zeroSpecificity = () => [0, 0, 0, 0];
+
+// Calculate the sum of given specificity arrays
+const specificitySum = (...specificities) => {
+  const sum = zeroSpecificity();
+  specificities.forEach(specificityArray => {
+    specificityArray.forEach((value, i) => {
+      sum[i] += value;
     });
+  });
+  return sum;
+};
+
+const rule = function(max, options) {
+  return (root, result) => {
+    const validOptions = validateOptions(
+      result,
+      ruleName,
+      {
+        actual: max,
+        possible: [
+          function(max) {
+            // Check that the max specificity is in the form "a,b,c"
+            const pattern = new RegExp("^\\d+,\\d+,\\d+$");
+            return pattern.test(max);
+          }
+        ]
+      },
+      {
+        actual: options,
+        possible: {
+          ignoreSelectors: [_.isString]
+        },
+        optional: true
+      }
+    );
     if (!validOptions) {
       return;
     }
+
+    // Calculate the specificity of a simple selector (type, attribute, class, id, or pseudos"s own value)
+    const simpleSpecificity = selector => {
+      if (optionsMatches(options, "ignoreSelectors", selector)) {
+        return zeroSpecificity();
+      }
+      return specificity.calculate(selector)[0].specificityArray;
+    };
+
+    // Calculate the the specificity of the most specific direct child
+    const maxChildSpecificity = node =>
+      node.reduce((max, child) => {
+        // eslint-disable-next-line no-use-before-define
+        const childSpecificity = nodeSpecificity(child);
+        return specificity.compare(childSpecificity, max) === 1
+          ? childSpecificity
+          : max;
+      }, zeroSpecificity());
+
+    // Calculate the specificity of a pseudo selector including own value and children
+    const pseudoSpecificity = node => {
+      // `node.toString()` includes children which should be processed separately,
+      // so use `node.value` instead
+      const ownValue = node.value;
+      const ownSpecificity =
+        ownValue === ":not" || ownValue === ":matches"
+          ? // :not and :matches don't add specificity themselves, but their children do
+            zeroSpecificity()
+          : simpleSpecificity(ownValue);
+
+      return specificitySum(ownSpecificity, maxChildSpecificity(node));
+    };
+
+    // Calculate the specificity of a node parsed bu `postcss-selector-parser`
+    const nodeSpecificity = node => {
+      switch (node.type) {
+        case "attribute":
+        case "class":
+        case "id":
+        case "tag":
+          return simpleSpecificity(node.toString());
+        case "pseudo":
+          return pseudoSpecificity(node);
+        case "selector":
+          // Calculate the sum of all the direct children
+          return specificitySum(...node.map(nodeSpecificity));
+        default:
+          return zeroSpecificity();
+      }
+    };
 
     const maxSpecificityArray = ("0," + max).split(",").map(parseFloat);
     root.walkRules(rule => {
@@ -42,30 +120,28 @@ const rule = function(max) {
       // Using rule.selectors gets us each selector in the eventuality we have a comma separated set
       rule.selectors.forEach(selector => {
         resolvedNestedSelector(selector, rule).forEach(resolvedSelector => {
-          // Return early if selector contains a not pseudo-class
-          if (selector.indexOf(":not(") !== -1) {
-            return;
-          }
-          // Return early if selector contains a matches
-          if (selector.indexOf(":matches(") !== -1) {
-            return;
-          }
-          // Check if the selector specificity exceeds the allowed maximum
           try {
+            // Skip non-standard syntax selectors
             if (!isStandardSyntaxSelector(resolvedSelector)) {
               return;
             }
-            if (
-              specificity.compare(resolvedSelector, maxSpecificityArray) === 1
-            ) {
-              report({
-                ruleName,
-                result,
-                node: rule,
-                message: messages.expected(resolvedSelector, max),
-                word: selector
-              });
-            }
+            parseSelector(resolvedSelector, result, rule, selectorTree => {
+              // Check if the selector specificity exceeds the allowed maximum
+              if (
+                specificity.compare(
+                  maxChildSpecificity(selectorTree),
+                  maxSpecificityArray
+                ) === 1
+              ) {
+                report({
+                  ruleName,
+                  result,
+                  node: rule,
+                  message: messages.expected(resolvedSelector, max),
+                  word: selector
+                });
+              }
+            });
           } catch (e) {
             result.warn("Cannot parse selector", {
               node: rule,


### PR DESCRIPTION
This also adds `ignoreSelectors` option.

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2857#issuecomment-328304228
