### PR TITLE
tests: Refactor `isCustomElement` tests

### DIFF
--- a/lib/utils/__tests__/isCustomElement.test.js
+++ b/lib/utils/__tests__/isCustomElement.test.js
@@ -2,35 +2,51 @@
 
 const isCustomElement = require("../isCustomElement");
 
-it("isCustomElement", () => {
-  expect(isCustomElement("x-foo")).toBeTruthy();
-  expect(isCustomElement("math-α")).toBeTruthy();
-  expect(isCustomElement("emotion-😍")).toBeTruthy();
+describe("isCustomElement", () => {
+  it("custom element", () => {
+    expect(isCustomElement("x-foo")).toBeTruthy();
+    expect(isCustomElement("math-α")).toBeTruthy();
+    expect(isCustomElement("emotion-😍")).toBeTruthy();
 
-  expect(isCustomElement("X-foo")).toBeFalsy();
-  expect(isCustomElement("x-Foo")).toBeFalsy();
-  expect(isCustomElement("X-FOO")).toBeFalsy();
+    expect(isCustomElement("X-foo")).toBeFalsy();
+    expect(isCustomElement("x-Foo")).toBeFalsy();
+    expect(isCustomElement("X-FOO")).toBeFalsy();
+
+    expect(isCustomElement(".foo")).toBeFalsy();
+    expect(isCustomElement(".foo-bar")).toBeFalsy();
+    expect(isCustomElement("#foo")).toBeFalsy();
+    expect(isCustomElement("#foo-bar")).toBeFalsy();
+    expect(isCustomElement(":foo")).toBeFalsy();
+    expect(isCustomElement(":foo-bar")).toBeFalsy();
+    expect(isCustomElement("::foo")).toBeFalsy();
+    expect(isCustomElement("::foo-bar")).toBeFalsy();
+  });
 
   // Html tags
-  expect(isCustomElement("div")).toBeFalsy();
-  expect(isCustomElement("dIv")).toBeFalsy();
-  expect(isCustomElement("DiV")).toBeFalsy();
-  expect(isCustomElement("DIV")).toBeFalsy();
-  expect(isCustomElement("foo")).toBeFalsy();
-  expect(isCustomElement("acronym")).toBeFalsy();
-  // Svg tags
-  expect(isCustomElement("font-face")).toBeFalsy();
-  expect(isCustomElement("clipPath")).toBeFalsy();
-  // Mathml tags
-  expect(isCustomElement("abs")).toBeFalsy();
-  expect(isCustomElement("annotation-xml")).toBeFalsy();
+  it("html tags", () => {
+    expect(isCustomElement("div")).toBeFalsy();
+    expect(isCustomElement("dIv")).toBeFalsy();
+    expect(isCustomElement("DiV")).toBeFalsy();
+    expect(isCustomElement("DIV")).toBeFalsy();
+    expect(isCustomElement("foo")).toBeFalsy();
+    expect(isCustomElement("acronym")).toBeFalsy();
+  });
 
-  expect(isCustomElement(".foo")).toBeFalsy();
-  expect(isCustomElement(".foo-bar")).toBeFalsy();
-  expect(isCustomElement("#foo")).toBeFalsy();
-  expect(isCustomElement("#foo-bar")).toBeFalsy();
-  expect(isCustomElement(":foo")).toBeFalsy();
-  expect(isCustomElement(":foo-bar")).toBeFalsy();
-  expect(isCustomElement("::foo")).toBeFalsy();
-  expect(isCustomElement("::foo-bar")).toBeFalsy();
+  // Svg tags
+  it("Svg tags", () => {
+    expect(isCustomElement("font-face")).toBeFalsy();
+    expect(isCustomElement("clipPath")).toBeFalsy();
+  });
+
+  // Mathml tags
+  it("Mathml tags", () => {
+    expect(isCustomElement("abs")).toBeFalsy();
+    expect(isCustomElement("annotation-xml")).toBeFalsy();
+  });
+
+  // keywordSets tags
+  it("keywordSets tags", () => {
+    expect(isCustomElement("acronym")).toBeFalsy();
+    expect(isCustomElement("applet")).toBeFalsy();
+  });
 });


### PR DESCRIPTION
A quick refactor of the `isCustomElement` tests to aid in investigating code coverage issues of `lib/utils/isCustomElement.js ` 

https://coveralls.io/builds/13227466/source?filename=lib%2Futils%2FisCustomElement.js