### PR TITLE
Fail the rule tester on any parseErrors

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -50,6 +50,7 @@ global.testRule = (rule, schema) => {
                 };
                 return stylelint(options).then(output => {
                   expect(output.results[0].warnings).toEqual([]);
+                  expect(output.results[0].parseErrors).toEqual([]);
                   if (!schema.fix) return;
 
                   // Check the fix
@@ -82,6 +83,7 @@ global.testRule = (rule, schema) => {
                 return stylelint(options).then(output => {
                   const warning = output.results[0].warnings[0];
 
+                  expect(output.results[0].parseErrors).toEqual([]);
                   expect(testCase).toHaveMessage();
 
                   if (testCase.message !== undefined) {


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/issues/2783#issuecomment-328334610

The rule tester should always fail on any unexpected `parseError`s - for both `reject` and `accept` tests.

This change correctly triggers a fail for the problem in https://github.com/stylelint/stylelint/issues/2783:

```console
 FAIL  lib/rules/selector-max-id/__tests__/index.js
  ● selector-max-id › accept › [0] › ":root { --test-property-set: { & any-selector { & any-selector { color: #00ff00; } } }; }" › custom property set in root with nested selectors
```

Testing for legitimate `parseError`s should be handled on a per rule basis, as in this example from [here](https://github.com/stylelint/stylelint/blob/c63b50d90b5e2d49dbe0b10397979d96e63de453/lib/rules/selector-max-specificity/__tests__/index.js#L267-L286):

```js
it("cannot parse selector warning", () => {
  const config = {
    rules: {
      "selector-max-specificity": ["0,3,0"]
    }
  };

  return stylelint
    .lint({
      code: ".a:unknown(.b, .d) { }",
      config
    })
    .then(function(data) {
      const parseErrors = data.results[0].parseErrors;
      expect(parseErrors.length).toBe(1);
      expect(parseErrors[0].text).toBe("Cannot parse selector");
      expect(parseErrors[0].line).toBe(1);
      expect(parseErrors[0].column).toBe(1);
    });
});
```
