### PR TITLE
Fix false negatives for ignore: ["inside-block"] in rule-empty-line-before

### DIFF
--- a/lib/__tests__/fixtures/rule-empty-line-before.html
+++ b/lib/__tests__/fixtures/rule-empty-line-before.html
@@ -5,6 +5,9 @@
 h1 {
   font-weight: normal;
 }
+h2 {
+  font-weight: normal;
+}
 </style>
 </head>
 </html>

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -75,7 +75,12 @@ it("standalone with postcss-html syntax", () => {
     rules: {
       "no-empty-source": true,
       "comment-empty-line-before": "always",
-      "rule-empty-line-before": "always",
+      "rule-empty-line-before": [
+        "always",
+        {
+          ignore: ["inside-block"]
+        }
+      ],
       "at-rule-empty-line-before": [
         "always",
         {
@@ -120,8 +125,12 @@ it("standalone with postcss-html syntax", () => {
     const ruleEmptyLineBeforeResult = results.find(r =>
       /[/\\]rule-empty-line-before\.html$/.test(r.source)
     );
-    expect(ruleEmptyLineBeforeResult.errored).toBeFalsy();
-    expect(ruleEmptyLineBeforeResult.warnings.length).toBe(0);
+    expect(ruleEmptyLineBeforeResult.errored).toBe(true);
+    expect(ruleEmptyLineBeforeResult.warnings.length).toBe(1);
+    expect(ruleEmptyLineBeforeResult.warnings[0].line).toBe(8);
+    expect(ruleEmptyLineBeforeResult.warnings[0].rule).toBe(
+      "rule-empty-line-before"
+    );
   });
 });
 

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -69,11 +69,10 @@ const rule = function(expectation, options, context) {
         return;
       }
 
+      const isNested = rule.parent.type !== "root";
+
       // Optionally ignore the expectation if inside a block
-      if (
-        optionsMatches(options, "ignore", "inside-block") &&
-        rule.parent !== root
-      ) {
+      if (optionsMatches(options, "ignore", "inside-block") && isNested) {
         return;
       }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2891

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
