### PR TITLE
Don't lint file if it is ignored and code is added directly

### DIFF
--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -33,6 +33,8 @@ export type stylelint$options = {
   configFile?: string,
   configBasedir?: string,
   configOverrides?: Object,
+  ignoreText?: string,
+  ignorePattern?: array,
   ignoreDisables?: boolean,
   ignorePath?: string,
   reportNeedlessDisables?: boolean,

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -1,5 +1,6 @@
 /* @flow */
 "use strict";
+const ignore = require("ignore");
 const micromatch = require("micromatch");
 const path = require("path");
 
@@ -20,7 +21,14 @@ module.exports = function(
     const absoluteFilePath = path.isAbsolute(filePath)
       ? filePath
       : path.resolve(process.cwd(), filePath);
-    if (micromatch(absoluteFilePath, config.ignoreFiles).length) {
+    const relativePath = absoluteFilePath.replace(`${process.cwd()}/`, "");
+    const ignorer = ignore()
+      .add(stylelint._options.ignoreText)
+      .add(stylelint._options.ignorePattern);
+    if (
+      micromatch(absoluteFilePath, config.ignoreFiles).length ||
+      ignorer.ignores(relativePath)
+    ) {
       return true;
     }
     return false;

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -103,6 +103,8 @@ module.exports = function(
     reportNeedlessDisables,
     syntax,
     customSyntax,
+    ignoreText,
+    ignorePattern,
     fix
   });
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2833

> Is there anything in the PR that needs further explanation?

### Enviroment

.stylelintignore
`tests/fixtures/ignore/*`

folder structure
![image](https://user-images.githubusercontent.com/1640136/30433594-7c737918-9997-11e7-93c1-bec43c3ea1c2.png)

run `stylelint.lint` via node

```
 this.linterConfig.code = content; //code
 this.linterConfig.codeFilename = path.join(this.inputNodesDirectory, relativePath);// relativepath
 return stylelint.lint(this.linterConfig)....
```

### Code flow
when running the linter with `code` options it flows through https://github.com/billybonks/stylelint/blame/ignore-codefilename/lib/standalone.js#L112

which uses `micromatch` and config.ignoredFiles to test for ignores using absolutePaths
https://github.com/stylelint/stylelint/blame/master/lib/isPathIgnored.js#L4

if you run the linter with an array of file paths it flows through
https://github.com/billybonks/stylelint/blame/ignore-codefilename/lib/standalone.js#L175

which uses ignorer.filter using relativePaths.

I am not sure why there are multiple ignore strategies.

### Code change overview

- include `ignoreText` and `ignorePattern` options to stylelint
- in `isPathIgnored` test the same way that files are filtered without the code option. 
- I test both the above and the original for backward compatiblity.

### Remaining work
- if this is accepted we should add a test for the API change.
- I recommend deprecating the mini match strategy for consistency.
