### PR TITLE
Fix false positives for at-charset and single quotes in string-quotes #2788 

### DIFF
--- a/lib/rules/string-quotes/README.md
+++ b/lib/rules/string-quotes/README.md
@@ -10,6 +10,8 @@ a[id="foo"] { content: "x"; }
 
 Quotes within comments are ignored.
 
+Also, the quotes in a `charset` @-rule are ignored as using single quotes in this context is incorrect according the [CSS specification](https://www.w3.org/TR/CSS2/syndata.html#x57).
+
 ```css
 /* "This is fine" */
 /* 'And this is also fine' */

--- a/lib/rules/string-quotes/README.md
+++ b/lib/rules/string-quotes/README.md
@@ -10,12 +10,19 @@ a[id="foo"] { content: "x"; }
 
 Quotes within comments are ignored.
 
-Also, the quotes in a `charset` @-rule are ignored as using single quotes in this context is incorrect according the [CSS specification](https://www.w3.org/TR/CSS2/syndata.html#x57).
 
 ```css
 /* "This is fine" */
 /* 'And this is also fine' */
 ```
+
+Single quotes in a charset @-rule are ignored as using single quotes in this context is incorrect according the [CSS specification](https://www.w3.org/TR/CSS2/syndata.html#x57).
+
+```css
+@charset "utf-8"
+/* fine regardless of configuration */
+```
+
 
 ## Options
 

--- a/lib/rules/string-quotes/__tests__/index.js
+++ b/lib/rules/string-quotes/__tests__/index.js
@@ -40,6 +40,10 @@ testRule(rule, {
     {
       code: 'a { /* "horse" */ }',
       description: "ignores comment"
+    },
+    {
+      code: '@charset "utf-8"',
+      description: "ignore @charset rules"
     }
   ],
 

--- a/lib/rules/string-quotes/__tests__/index.js
+++ b/lib/rules/string-quotes/__tests__/index.js
@@ -71,6 +71,12 @@ testRule(rule, {
       message: messages.expected("single"),
       line: 2,
       column: 19
+    },
+    {
+      code: '@import "base.css"',
+      message: messages.expected("single"),
+      line: 1,
+      column: 9
     }
   ]
 });

--- a/lib/rules/string-quotes/__tests__/index.js
+++ b/lib/rules/string-quotes/__tests__/index.js
@@ -156,6 +156,10 @@ testRule(rule, {
     {
       code: "a {\n  // 'horse'\n}",
       description: "ignores single-line SCSS comment"
+    },
+    {
+      code: '@charset "utf-8"',
+      description: "ignore @charset rules"
     }
   ],
 

--- a/lib/rules/string-quotes/__tests__/index.js
+++ b/lib/rules/string-quotes/__tests__/index.js
@@ -115,6 +115,10 @@ testRule(rule, {
     {
       code: "a { /* 'horse' */ }",
       description: "ignores comment"
+    },
+    {
+      code: '@charset "utf-8"',
+      description: "ignore @charset rules"
     }
   ],
 

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -23,7 +23,19 @@ const rule = function(expectation) {
       return;
     }
 
-    const cssString = root.toString();
+    let cssString = root.toString();
+
+    // allow @charset rules to have double quotes, in spite of the configuration
+    if (erroneousQuote === '"') {
+      root.walkAtRules(atRule => {
+        if (atRule.name === "charset") {
+          const badAtRule = atRule.toString();
+          const goodAtRule = badAtRule.split('"').join("'");
+          cssString = cssString.replace(badAtRule, goodAtRule);
+        }
+      });
+    }
+
     styleSearch({ source: cssString, target: erroneousQuote }, match => {
       report({
         message: messages.expected(expectation),


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Adding a rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-rule

- Adding an option: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-options-to-existing-rules

- Fixing a bug: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-bugs

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2788 

> Is there anything in the PR that needs further explanation?

No, self-explanatory
