### PR TITLE
Fixing Issue when ignore does not work when passed `code`

### DIFF
--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -111,6 +111,15 @@ module.exports = function(
       codeFilename !== undefined && !path.isAbsolute(codeFilename)
         ? path.join(process.cwd(), codeFilename)
         : codeFilename;
+
+    const relativeCodeFilenames = ignorer.filter(
+      path.relative(process.cwd(), codeFilename)
+    );
+
+    if (!relativeCodeFilenames.length) {
+      return Promise.resolve(prepareReturnValue([]));
+    }
+
     return stylelint
       ._lintSource({
         code,


### PR DESCRIPTION
Hi, 

I am trying to fix an issue: when passing `code` and `codeFilename` to stylelint, it won't check for ignore files and the docs says it will:

> This can be useful, for example, when making a text editor plugin that passes in code directly but needs to still use the configuration's ignoreFiles functionality to possibly ignore that code.

I am trying to run tests but I get this error: 

`Error: lib/standalone.js:116
116:       path.relative(process.cwd(), codeFilename)
                                        ^^^^^^^^^^^^ undefined. This type is incompatible with the expected param type of
1316:   declare function relative(from: string, to: string): string;
                                                    ^^^^^^ string. See lib: /private/tmp/flow/flowlib_389bd936/node.js:1316`

I have checked and codeFilename is a string. For sure I am missing something :).

Thanks!
Nacho