### PR TITLE
Fix how "except" options are checked in *-empty-line-before rules

### DIFF
--- a/lib/rules/custom-property-empty-line-before/__tests__/index.js
+++ b/lib/rules/custom-property-empty-line-before/__tests__/index.js
@@ -294,6 +294,24 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["always", { except: ["after-comment", "first-nested"] }],
+
+  accept: [
+    {
+      code: "a {\n --custom-prop: value;\n}"
+    },
+    {
+      code: "a {\n\n /* I am a comment */ \n --custom-prop2: value;}"
+    },
+    {
+      code: "a { /* comment */\n --custom-prop: value;\n}",
+      description: "shared-line comment"
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: [
     "always",
     {

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -73,29 +73,14 @@ const rule = function(expectation, options, context) {
 
       let expectEmptyLineBefore = expectation === "always" ? true : false;
 
-      // Optionally reverse the expectation for the first nested node
+      // Optionally reverse the expectation if any exceptions apply
       if (
-        optionsMatches(options, "except", "first-nested") &&
-        isFirstNested(decl)
-      ) {
-        expectEmptyLineBefore = !expectEmptyLineBefore;
-      }
-
-      // Optionally reverse the expectation if a comment precedes this node
-      if (
-        optionsMatches(options, "except", "after-comment") &&
-        isAfterCommentLine(decl)
-      ) {
-        expectEmptyLineBefore = !expectEmptyLineBefore;
-      }
-
-      // Optionally reverse the expectation if a custom property precedes this node
-      const prevNode = getPreviousNonSharedLineCommentNode(decl);
-      if (
-        optionsMatches(options, "except", "after-custom-property") &&
-        prevNode &&
-        prevNode.prop &&
-        isCustomProperty(prevNode.prop)
+        (optionsMatches(options, "except", "first-nested") &&
+          isFirstNested(decl)) ||
+        (optionsMatches(options, "except", "after-comment") &&
+          isAfterCommentLine(decl)) ||
+        (optionsMatches(options, "except", "after-custom-property") &&
+          isAfterCustomProperty(decl))
       ) {
         expectEmptyLineBefore = !expectEmptyLineBefore;
       }
@@ -130,6 +115,11 @@ const rule = function(expectation, options, context) {
     });
   };
 };
+
+function isAfterCustomProperty(decl) {
+  const prevNode = getPreviousNonSharedLineCommentNode(decl);
+  return prevNode && prevNode.prop && isCustomProperty(prevNode.prop);
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-empty-line-before/__tests__/index.js
+++ b/lib/rules/declaration-empty-line-before/__tests__/index.js
@@ -571,6 +571,24 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["always", { except: ["first-nested", "after-comment"] }],
+
+  accept: [
+    {
+      code: "a {\n top: 15px;\n}"
+    },
+    {
+      code: "a { /* comment */\n top: 15px;\n}",
+      description: "shared-line comment"
+    },
+    {
+      code: "a {\n /* I am a comment */ \n bottom: 5px;}"
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: [
     "always",
     {

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -85,26 +85,14 @@ const rule = function(expectation, options, context) {
 
       let expectEmptyLineBefore = expectation === "always" ? true : false;
 
-      // Optionally reverse the expectation for the first nested node
+      // Optionally reverse the expectation if any exceptions apply
       if (
-        optionsMatches(options, "except", "first-nested") &&
-        isFirstNested(decl)
-      ) {
-        expectEmptyLineBefore = !expectEmptyLineBefore;
-      }
-
-      // Optionally reverse the expectation if a comment precedes this node
-      if (
-        optionsMatches(options, "except", "after-comment") &&
-        isAfterCommentLine(decl)
-      ) {
-        expectEmptyLineBefore = !expectEmptyLineBefore;
-      }
-
-      // Optionally reverse the expectation if a declaration precedes this node
-      if (
-        optionsMatches(options, "except", "after-declaration") &&
-        isAfterStandardPropertyDeclaration(decl)
+        (optionsMatches(options, "except", "first-nested") &&
+          isFirstNested(decl)) ||
+        (optionsMatches(options, "except", "after-comment") &&
+          isAfterCommentLine(decl)) ||
+        (optionsMatches(options, "except", "after-declaration") &&
+          isAfterStandardPropertyDeclaration(decl))
       ) {
         expectEmptyLineBefore = !expectEmptyLineBefore;
       }

--- a/lib/rules/rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/rule-empty-line-before/__tests__/index.js
@@ -155,6 +155,10 @@ testRule(rule, {
     {
       code: "@media {\n\na {}\nb {} }",
       description: "nested"
+    },
+    {
+      code: "a {} /* comment */\nb {}",
+      description: "shared-line comment"
     }
   ],
 
@@ -199,7 +203,8 @@ testRule(rule, {
       code: "/* comment */\na {}"
     },
     {
-      code: "@media { /* comment */\na {} }"
+      code: "@media { /* comment */\n\na {} }",
+      description: "nested shared-line comment"
     }
   ],
 
@@ -215,9 +220,16 @@ testRule(rule, {
       message: messages.rejected
     },
     {
-      code: "@media { /* comment */\n\na {} }",
-      fixed: "@media { /* comment */\na {} }",
-      message: messages.rejected
+      code: "@media { /* comment */\na {} }",
+      fixed: "@media { /* comment */\n\na {} }",
+      message: messages.expected,
+      description: "nested shared-line comment"
+    },
+    {
+      code: "a {} /* comment */\nb {}",
+      fixed: "a {} /* comment */\n\nb {}",
+      message: messages.expected,
+      description: "shared-line comment"
     }
   ]
 });
@@ -237,7 +249,7 @@ testRule(rule, {
     },
     {
       code: "@media { /* comment */\n  a {}\n\n}",
-      description: "shared-line comment boog"
+      description: "shared-line comment"
     },
     {
       code: "@media {\n  a {}\n\n  b{}\n\n}"
@@ -308,6 +320,19 @@ testRule(rule, {
       code: "@media {\n  b {}\n  a {}\n\n}",
       fixed: "@media {\n  b {}\n\n  a {}\n\n}",
       message: messages.expected
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["always", { except: ["after-single-line-comment", "first-nested"] }],
+
+  accept: [
+    {
+      code:
+        "@media screen { /* comment */\n  .foo {\n    display: none;\n  }\n}",
+      description: "shared-line comment - issue #2919"
     }
   ]
 });
@@ -450,6 +475,57 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["never", { except: ["after-rule"] }],
+  fix: true,
+
+  accept: [
+    {
+      code: "a {}\n\nb {}"
+    },
+    {
+      code: "$var: pink;\nb {}",
+      description: "scss variable"
+    },
+    {
+      code: "@media {}\na{}",
+      description: "media rule"
+    },
+    {
+      code: "@media {\na {}\n\nb {} }",
+      description: "nested"
+    },
+    {
+      code: "a {} /* comment */\n\nb {}",
+      description: "shared-line comment"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a {}\nb {}",
+      fixed: "a {}\n\nb {}",
+      message: messages.expected
+    },
+    {
+      code: "$var: pink;\n\nb {}",
+      fixed: "$var: pink;\nb {}",
+      message: messages.rejected
+    },
+    {
+      code: "@media {}\n\na{}",
+      fixed: "@media {}\na{}",
+      message: messages.rejected
+    },
+    {
+      code: "@media {\na{}\nb{}}",
+      fixed: "@media {\na{}\n\nb{}}",
+      message: messages.expected
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: ["never", { except: ["after-single-line-comment"] }],
   skipBasicChecks: true,
   fix: true,
@@ -460,6 +536,10 @@ testRule(rule, {
     },
     {
       code: "/* comment */\n\na {}"
+    },
+    {
+      code: "@media { /* comment */\na {} }",
+      description: "nested shared-line comment"
     }
   ],
 
@@ -473,6 +553,18 @@ testRule(rule, {
       code: "/* comment */\na {}",
       fixed: "/* comment */\n\na {}",
       message: messages.expected
+    },
+    {
+      code: "@media { /* comment */\n\na {} }",
+      fixed: "@media { /* comment */\na {} }",
+      message: messages.rejected,
+      description: "nested shared-line comment"
+    },
+    {
+      code: "a {} /* comment */\n\nb {}",
+      fixed: "a {} /* comment */\nb {}",
+      message: messages.rejected,
+      description: "shared-line comment"
     }
   ]
 });

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const addEmptyLineBefore = require("../../utils/addEmptyLineBefore");
+const getPreviousNonSharedLineCommentNode = require("../../utils/getPreviousNonSharedLineCommentNode");
 const hasEmptyLine = require("../../utils/hasEmptyLine");
+const isAfterSingleLineComment = require("../../utils/isAfterSingleLineComment");
 const isFirstNested = require("../../utils/isFirstNested");
 const isFirstNodeOfRoot = require("../../utils/isFirstNodeOfRoot");
 const isSingleLineString = require("../../utils/isSingleLineString");
@@ -57,9 +59,6 @@ const rule = function(expectation, options, context) {
         return;
       }
 
-      let expectEmptyLineBefore =
-        expectation.indexOf("always") !== -1 ? true : false;
-
       // Optionally ignore the expectation if a comment precedes this node
       if (
         optionsMatches(options, "ignore", "after-comment") &&
@@ -84,39 +83,20 @@ const rule = function(expectation, options, context) {
         return;
       }
 
-      // Optionally reverse the expectation for the first nested node
-      if (
-        optionsMatches(options, "except", "first-nested") &&
-        isFirstNested(rule)
-      ) {
-        expectEmptyLineBefore = !expectEmptyLineBefore;
-      }
+      let expectEmptyLineBefore =
+        expectation.indexOf("always") !== -1 ? true : false;
 
-      // Optionally reverse the expectation if a rule precedes this node
+      // Optionally reverse the expectation if any exceptions apply
       if (
-        optionsMatches(options, "except", "after-rule") &&
-        rule.prev() &&
-        rule.prev().type === "rule"
-      ) {
-        expectEmptyLineBefore = !expectEmptyLineBefore;
-      }
-
-      // Optionally reverse the expectation if a rule precedes this node and is inside a block
-      if (
-        optionsMatches(options, "except", "inside-block-and-after-rule") &&
-        rule.prev() &&
-        rule.prev().type === "rule" &&
-        rule.parent !== root
-      ) {
-        expectEmptyLineBefore = !expectEmptyLineBefore;
-      }
-
-      // Optionally reverse the expectation for single line comments
-      if (
-        optionsMatches(options, "except", "after-single-line-comment") &&
-        rule.prev() &&
-        rule.prev().type === "comment" &&
-        isSingleLineString(rule.prev().toString())
+        (optionsMatches(options, "except", "first-nested") &&
+          isFirstNested(rule)) ||
+        (optionsMatches(options, "except", "after-rule") &&
+          isAfterRule(rule)) ||
+        (optionsMatches(options, "except", "inside-block-and-after-rule") &&
+          isNested &&
+          isAfterRule(rule)) ||
+        (optionsMatches(options, "except", "after-single-line-comment") &&
+          isAfterSingleLineComment(rule))
       ) {
         expectEmptyLineBefore = !expectEmptyLineBefore;
       }
@@ -152,6 +132,11 @@ const rule = function(expectation, options, context) {
     });
   };
 };
+
+function isAfterRule(rule) {
+  const prevNode = getPreviousNonSharedLineCommentNode(rule);
+  return prevNode && prevNode.type === "rule";
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/utils/__tests__/isAfterSingleLineComment.test.js
+++ b/lib/utils/__tests__/isAfterSingleLineComment.test.js
@@ -1,0 +1,56 @@
+/* flow */
+"use strict";
+
+const isAfterSingleLineComment = require("../isAfterSingleLineComment");
+const postcss = require("postcss");
+
+describe("isAfterSingleLineComment", () => {
+  it("returns true when after a single-line comment", () => {
+    const root = postcss.parse(`
+      /* comment */
+      foo {}
+    `);
+    expect(isAfterSingleLineComment(root.nodes[1])).toBe(true);
+  });
+
+  it("returns false when after a multi-line comment", () => {
+    const root = postcss.parse(`
+      /* comment
+         and more comment */
+      foo {}
+    `);
+    expect(isAfterSingleLineComment(root.nodes[1])).toBe(false);
+  });
+
+  it("returns false when after a shared-line comment", () => {
+    const root = postcss.parse(`
+      bar {} /* comment */
+      foo {}
+    `);
+    expect(isAfterSingleLineComment(root.nodes[2])).toBe(false);
+  });
+
+  it("returns false when after a nested shared-line comment", () => {
+    const root = postcss.parse(`
+      @media { /* comment */
+        foo {}
+      }
+    `);
+    expect(isAfterSingleLineComment(root.nodes[0].nodes[1])).toBe(false);
+  });
+
+  it("returns false when after a non-comment node", () => {
+    const root = postcss.parse(`
+      bar {}
+      foo {}
+    `);
+    expect(isAfterSingleLineComment(root.nodes[1])).toBe(false);
+  });
+
+  it("returns false when after no nodes", () => {
+    const root = postcss.parse(`
+      foo {}
+    `);
+    expect(isAfterSingleLineComment(root.nodes[0])).toBe(false);
+  });
+});

--- a/lib/utils/isAfterSingleLineComment.js
+++ b/lib/utils/isAfterSingleLineComment.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const isSharedLineComment = require("./isSharedLineComment");
+
+function isAfterSingleLineComment(node /*: postcss$node*/) /*: boolean*/ {
+  const prevNode = node.prev();
+
+  return (
+    prevNode !== undefined &&
+    prevNode.type === "comment" &&
+    !isSharedLineComment(prevNode) &&
+    prevNode.source.start.line === prevNode.source.end.line
+  );
+}
+
+module.exports = isAfterSingleLineComment;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes #2919

> Is there anything in the PR that needs further explanation?

The bug reported in #2919 was being caused by multiple "except" options being checked individually, which caused the expectation to flip-flop and be incorrect if an even number of exceptions were satisfied.

This PR fixes that type of code in the various `*-empty-line-before` rules so that as soon as one exception is satisfied, it skips the rest. The other `*-empty-line-before` rules that I did not touch were already doing this correctly.