### PR TITLE
Add ignoreUnits option to number-max-precision rule

### DIFF
--- a/lib/rules/number-max-precision/README.md
+++ b/lib/rules/number-max-precision/README.md
@@ -37,3 +37,57 @@ a { top: 3.24px; }
 ```css
 @media (min-width: 3.23em) {}
 ```
+
+## Optional secondary options
+
+### `ignoreUnits: ["/regex/", "string"]`
+
+Ignore the precision of numbers for values with the specified units.
+
+For example, with `2`.
+
+Given:
+
+```js
+["/^my-/", "%"]
+```
+
+The following patterns are considered violations:
+
+```css
+a { top: 3.245px; }
+```
+
+```css
+a { top: 3.245634px; }
+```
+
+```css
+@media (min-width: 3.234em) {}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+a { top: 3.245%; }
+```
+
+```css
+@media (min-width: 3.23em) {}
+```
+
+```css
+a {
+  width: 10.5432%;
+}
+```
+
+```css
+a { top: 3.245my-unit; }
+```
+
+```css
+a {
+  width: 10.989my-other-unit;
+}
+```

--- a/lib/rules/number-max-precision/__tests__/index.js
+++ b/lib/rules/number-max-precision/__tests__/index.js
@@ -150,3 +150,59 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: [0, { ignoreUnits: ["%", "/^my-/"] }],
+
+  accept: [
+    {
+      code: "a { top: 3%; }"
+    },
+    {
+      code: "a { top: 3.1%; }"
+    },
+    {
+      code: "a { top: 3.123456%; }"
+    },
+    {
+      code: "a { top: 3px; }"
+    },
+    {
+      code: "a { color: #ff00; }"
+    },
+    {
+      code: "a { padding: 6.123% 3.1234%; }"
+    },
+    {
+      code: "a { top: 3.245my-unit; }"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a { top: 3.1px; }",
+      message: messages.expected(3.1, 0),
+      line: 1,
+      column: 10
+    },
+    {
+      code: "a { top: 3.123em; }",
+      message: messages.expected(3.123, 0),
+      line: 1,
+      column: 10
+    },
+    {
+      code: "a { padding: 6.123px 3.1234px; }",
+      message: messages.expected(6.123, 0),
+      line: 1,
+      column: 14
+    },
+    {
+      code: "a { top: 6.123other-unit; }",
+      message: messages.expected(6.123, 0),
+      line: 1,
+      column: 10
+    }
+  ]
+});

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -2,6 +2,8 @@
 
 const atRuleParamIndex = require("../../utils/atRuleParamIndex");
 const declarationValueIndex = require("../../utils/declarationValueIndex");
+const getUnitFromValueNode = require("../../utils/getUnitFromValueNode");
+const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -16,12 +18,23 @@ const messages = ruleMessages(ruleName, {
     `Expected "${number}" to be "${number.toFixed(precision)}"`
 });
 
-const rule = function(precision) {
+const rule = function(precision, options) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: precision,
-      possible: [_.isNumber]
-    });
+    const validOptions = validateOptions(
+      result,
+      ruleName,
+      {
+        actual: precision,
+        possible: [_.isNumber]
+      },
+      {
+        optional: true,
+        actual: options,
+        possible: {
+          ignoreUnits: [_.isString]
+        }
+      }
+    );
     if (!validOptions) {
       return;
     }
@@ -43,6 +56,12 @@ const rule = function(precision) {
       }
 
       valueParser(value).walk(valueNode => {
+        const unit = getUnitFromValueNode(valueNode);
+
+        if (optionsMatches(options, "ignoreUnits", unit)) {
+          return;
+        }
+
         // Ignore `url` function
         if (
           valueNode.type === "function" &&


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2785 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory
