### PR TITLE
adding remark lint for space above headers

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -94,6 +94,7 @@ Validates the options for your rule.
 Checks CSS against a standard stylelint rule *within your own rule*. This function provides power and flexibility for plugins authors who wish to modify, constrain, or extend the functionality of existing stylelint rules.
 
 Accepts an options object and a callback that is invoked with warnings from the specified rule. The options are:
+
 -   `ruleName`: The name of the rule you are invoking.
 -   `ruleSettings`: Settings for the rule you are invoking, formatting in the same way they would be in a `.stylelintrc` configuration object.
 -   `root`: The root node to run this rule against.

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -80,6 +80,7 @@ You can use this option to see what your linting results would be like without t
 ### `disableDefaultIgnores`
 
 If `true`, stylelint will not automatically ignore the contents of `node_modules` and `bower_components`. (By default, these directories are automatically ignored.)
+
 ### `cache`
 
 Store the info about processed files in order to only operate on the changed ones the next time you run stylelint. Enabling this option can dramatically improve stylelint's speed, because only changed files will be linted.

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -94,6 +94,7 @@ a {
   custom: 10px;
 }
 ```
+
 ### `checkPrefixed: true | false` (default: `false`)
 
 If `true`, this rule will check vendor-prefixed properties.

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "postcss-import": "^11.0.0",
     "prettier": "^1.6.1",
     "remark-cli": "^4.0.0",
+    "remark-lint-no-missing-blank-lines": "^1.0.1",
     "remark-preset-lint-consistent": "^2.0.0",
     "remark-preset-lint-recommended": "^3.0.0",
     "remark-validate-links": "^7.0.0",
@@ -171,6 +172,7 @@
     "plugins": [
       "preset-lint-recommended",
       "preset-lint-consistent",
+      ["lint-no-missing-blank-lines", { "exceptTightLists": true }],
       [
         "validate-links",
         {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None as it is a remark- linting fix.

> Is there anything in the PR that needs further explanation?

Please [check comments here](https://github.com/stylelint/stylelint/pull/2941#discussion_r142831325)
