### PR TITLE
Fix high-range unicode characters in font-family-name-quotes

### DIFF
--- a/lib/rules/font-family-name-quotes/__tests__/index.js
+++ b/lib/rules/font-family-name-quotes/__tests__/index.js
@@ -85,6 +85,12 @@ testRule(rule, {
     },
     {
       code: 'a { font: italic 300 16px/30px "Arial", serif; }'
+    },
+    {
+      code: 'a { font-family: "\u1100"; }'
+    },
+    {
+      code: 'a { font-family: "ሀ"; }'
     }
   ]),
 
@@ -150,6 +156,18 @@ testRule(rule, {
       message: messages.expected("Arial"),
       line: 1,
       column: 32
+    },
+    {
+      code: "a { font-family: \u1100; }",
+      message: messages.expected("\u1100"),
+      line: 1,
+      column: 18
+    },
+    {
+      code: "a { font-family: ሀ; }",
+      message: messages.expected("ሀ"),
+      line: 1,
+      column: 18
     }
   ]
 });

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -37,7 +37,8 @@ function quotesRecommended(family) {
 function quotesRequired(family) {
   return family.split(/\s+/).some(word => {
     return (
-      /^(-?\d|--)/.test(word) || !/^[-_a-zA-Z0-9\u00A0-\u10FFFF]+$/.test(word)
+      /^(-?\d|--)/.test(word) ||
+      !/^[-_a-zA-Z0-9\u{00A0}-\u{10FFFF}]+$/u.test(word)
     );
   });
 }


### PR DESCRIPTION
\u doesn't support 10000+
e.g.
```js
/[\u0000-\u10FFFF]/.test("\u1100");         // false
/[\u{0000}-\u{10FFFF}]/u.test("\u1100")  // true
```
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2974

> Is there anything in the PR that needs reviewer focus?

u flag only supported in node.js v6+.
![image](https://user-images.githubusercontent.com/13050025/31757024-b865bb76-b46c-11e7-865d-4b1c9f0927ff.png)

