### PR TITLE
Add `eslint-plugin-node` using `"recommended" config

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "del": "^3.0.0",
     "eslint": "~4.9.0",
     "eslint-config-stylelint": "^7.0.0",
-    "eslint-plugin-node": "^5.2.0",
+    "eslint-plugin-node": "^5.2.1",
     "file-exists-promise": "^1.0.2",
     "flow-bin": "^0.57.2",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "del": "^3.0.0",
     "eslint": "~4.9.0",
     "eslint-config-stylelint": "^7.0.0",
+    "eslint-plugin-node": "^5.2.0",
     "file-exists-promise": "^1.0.2",
     "flow-bin": "^0.57.2",
     "husky": "^0.14.3",
@@ -126,11 +127,15 @@
   },
   "eslintConfig": {
     "extends": [
+      "plugin:node/recommended",
       "stylelint"
     ],
     "globals": {
       "testRule": true
-    }
+    },
+    "plugins": [
+      "node"
+    ]
   },
   "jest": {
     "clearMocks": true,


### PR DESCRIPTION
Ref: https://github.com/stylelint/stylelint/pull/2977#issuecomment-337961524

Here's an initial pass at adding `eslint-plugin-node` using the "recommended" config.

• https://github.com/mysticatea/eslint-plugin-node

Here's the 19 errors reported:

```shell
❯ npm run lint:js

> stylelint@8.2.0 lint:js /Users/netweb/dev/stylelint/stylelint
> eslint . --cache


/Users/netweb/dev/stylelint/stylelint/lib/__tests__/fixtures/postcss-html-syntax.js
  3:26  error  "postcss-html" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/__tests__/ignoreDisables.test.js
  5:29  error  "common-tags" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/__tests__/needlessDisables.test.js
  6:29  error  "common-tags" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/__tests__/standalone-cache.test.js
  11:24  error  "cp-file" is not published              node/no-unpublished-require
  12:28  error  "file-exists-promise" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/__tests__/standalone-formatter.test.js
  6:27  error  "strip-ansi" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/__tests__/standalone-syntax.test.js
  10:27  error  "strip-ansi" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/cli.js
  3:1  error  This file needs no shebang  node/shebang

/Users/netweb/dev/stylelint/stylelint/lib/formatters/__tests__/needlessDisablesStringFormatter.test.js
  4:27  error  "strip-ansi" is not published   node/no-unpublished-require
  5:29  error  "common-tags" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/formatters/__tests__/prepareFormatterOutput.js
  3:27  error  "strip-ansi" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/formatters/__tests__/stringFormatter.test.js
  5:29  error  "common-tags" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/formatters/__tests__/verboseFormatter.test.js
  4:29  error  "common-tags" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/rules/at-rule-empty-line-before/__tests__/index.js
  8:29  error  "common-tags" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/rules/no-duplicate-selectors/__tests__/index.js
  6:31  error  "postcss-import" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/rules/selector-nested-pattern/__tests__/index.js
  8:29  error  "common-tags" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/lib/utils/__tests__/nodeContextLookup.test.js
  6:31  error  "postcss-import" is not published  node/no-unpublished-require

/Users/netweb/dev/stylelint/stylelint/scripts/benchmark-rule.js
  32:30  error  Spread operators are not supported yet on Node 4.2.1  node/no-unsupported-features

/Users/netweb/dev/stylelint/stylelint/system-tests/004/stylelint.config.js
  2:26  error  "./someUnknownFile.js" is not found  node/no-missing-require

✖ 19 problems (19 errors, 0 warnings)
  1 error, 0 warnings potentially fixable with the `--fix` option.

```

The 4 rules from above:
  -  16 x [no-unpublished-require](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unpublished-require.md) - Disallow `require()` expressions which import unpublished files/modules 
  - 1 x [no-missing-require](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-missing-require.md) - Disallow `require()`s for files that don't exist
  - 1 x [no-unsupported-features](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features.md) - Disallow unsupported ECMAScript features on the specified version 
  - 1 x [shebang](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/shebang.md) - Suggest correct usage of shebang

Personally I'm not a fan of the `no-unpublished-require` and `no-missing-require` rules and I believe they should most likely be disabled from the _recommended_ config, I've raised my concerns with the first of these rules previously in https://github.com/mysticatea/eslint-plugin-node/issues/47

That leaves us 2 errors detected the use of _spread operator_ in `scripts/benchmark-rule.js` and the removal of the _shebang_ in `lib/cli.js`