### PR TITLE
Upgrade to postcss-selector-parser 3.1.0

### DIFF
--- a/lib/rules/selector-attribute-operator-blacklist/index.js
+++ b/lib/rules/selector-attribute-operator-blacklist/index.js
@@ -46,7 +46,8 @@ const rule = function(blacklistInput) {
           report({
             message: messages.rejected(operator),
             node: rule,
-            index: attributeNode.attribute.length + 1,
+            index:
+              attributeNode.sourceIndex + attributeNode.offsetOf("operator"),
             result,
             ruleName
           });

--- a/lib/rules/selector-attribute-operator-whitelist/index.js
+++ b/lib/rules/selector-attribute-operator-whitelist/index.js
@@ -46,7 +46,8 @@ const rule = function(whitelistInput) {
           report({
             message: messages.rejected(operator),
             node: rule,
-            index: attributeNode.attribute.length + 1,
+            index:
+              attributeNode.sourceIndex + attributeNode.offsetOf("operator"),
             result,
             ruleName
           });

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -83,7 +83,7 @@ testRule(rule, {
       code: "[class ^= top] { }",
       message: messages.expected("top"),
       line: 1,
-      column: 10
+      column: 11
     },
     {
       code: "[frame=hsides i] { }",
@@ -145,7 +145,7 @@ testRule(rule, {
       code: '[class |= "top"] { }',
       message: messages.rejected("top"),
       line: 1,
-      column: 10
+      column: 11
     },
     {
       code: "[title~='text'] { }",

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -191,21 +191,9 @@ testRule(rule, {
     },
     {
       code: "[data-attribute^='#{$variable}'] { }"
-    }
-  ],
-
-  reject: [
-    {
-      code: "[class=#{$variable}] { }",
-      message: messages.expected("#{$variable}"),
-      line: 1,
-      column: 8
     },
     {
-      code: "[class^=#{$variable}] { }",
-      message: messages.expected("#{$variable}"),
-      line: 1,
-      column: 9
+      code: "[class=#{$variable}] { } { }"
     }
   ]
 });
@@ -221,21 +209,9 @@ testRule(rule, {
     },
     {
       code: "[data-attribute^=#{$variable}] { }"
-    }
-  ],
-
-  reject: [
-    {
-      code: '[class="#{$variable}"] { }',
-      message: messages.rejected("#{$variable}"),
-      line: 1,
-      column: 8
     },
     {
-      code: "[data-attribute^='#{$variable}'] { }",
-      message: messages.rejected("#{$variable}"),
-      line: 1,
-      column: 18
+      code: '[class="#{$variable}"] { }'
     }
   ]
 });
@@ -251,21 +227,9 @@ testRule(rule, {
     },
     {
       code: "[data-attribute^='@{variable}'] { }"
-    }
-  ],
-
-  reject: [
-    {
-      code: "[class=@{variable}] { }",
-      message: messages.expected("@{variable}"),
-      line: 1,
-      column: 8
     },
     {
-      code: "[data-attribute^=@{variable}] { }",
-      message: messages.expected("@{variable}"),
-      line: 1,
-      column: 18
+      code: "[class=@{variable}] { }"
     }
   ]
 });
@@ -281,21 +245,9 @@ testRule(rule, {
     },
     {
       code: "[data-attribute^=@{variable}] { }"
-    }
-  ],
-
-  reject: [
-    {
-      code: '[class="@{variable}"] { }',
-      message: messages.rejected("@{variable}"),
-      line: 1,
-      column: 8
     },
     {
-      code: "[data-attribute^='@{variable}'] { }",
-      message: messages.rejected("@{variable}"),
-      line: 1,
-      column: 18
+      code: '[class="@{variable}"] { }'
     }
   ]
 });

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
+const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector");
 const parseSelector = require("../../utils/parseSelector");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -27,13 +28,15 @@ const rule = function(expectation) {
       if (!isStandardSyntaxRule(rule)) {
         return;
       }
+      if (!isStandardSyntaxSelector(rule.selector)) {
+        return;
+      }
       if (
         rule.selector.indexOf("[") === -1 ||
         rule.selector.indexOf("=") === -1
       ) {
         return;
       }
-
       parseSelector(rule.selector, result, rule, selectorTree => {
         selectorTree.walkAttributes(attributeNode => {
           if (!attributeNode.operator) {

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -71,7 +71,7 @@ const rule = function(actual, options) {
 
           if (
             optionsMatches(options, "ignore", "default-namespace") &&
-            !tagNode.hasOwnProperty("namespace")
+            !(typeof tagNode.namespace === "string")
           ) {
             return;
           }

--- a/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
@@ -99,7 +99,7 @@ function rules(css, cb) {
       return result.root.walkRules(rule => {
         selectorParser(selectorAST => {
           selectorAST.walkTags(cb);
-        }).process(rule.selector);
+        }).processSync(rule.selector);
       });
     });
 }

--- a/lib/utils/parseSelector.js
+++ b/lib/utils/parseSelector.js
@@ -10,7 +10,7 @@ module.exports = function(
   cb /*: Function*/
 ) {
   try {
-    selectorParser(cb).process(selector);
+    selectorParser(cb).processSync(selector);
   } catch (e) {
     result.warn("Cannot parse selector", { node, stylelintType: "parseError" });
   }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-safe-parser": "^3.0.1",
     "postcss-scss": "^1.0.2",
-    "postcss-selector-parser": "^2.2.3",
+    "postcss-selector-parser": "^3.0.0",
     "postcss-value-parser": "^3.3.0",
     "resolve-from": "^4.0.0",
     "specificity": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-safe-parser": "^3.0.1",
     "postcss-scss": "^1.0.2",
-    "postcss-selector-parser": "^3.0.0",
+    "postcss-selector-parser": "^3.1.0",
     "postcss-value-parser": "^3.3.0",
     "resolve-from": "^4.0.0",
     "specificity": "^0.3.1",


### PR DESCRIPTION
This is a courtesy PR that updates to postcss-selector-parser 3.0 which is just released.

This addresses the issue for the upgrade originally created here:
https://github.com/stylelint/stylelint/issues/2757

The problems with attribute operators are fixed.

Two test cases were updated, the assertions for the column number were actually invalid to begin with and are now correct in this release.

There's still two failing tests, but as noted in this comment:

https://github.com/stylelint/stylelint/issues/2757#issuecomment-331698623

The syntax is non-standard and postcss-selector-parser does not plan to handle it, the suggested  workarounds in that comment seem reasonable.