### PR TITLE
Fix false positives for shared-line comments in comment-empty-line-before

### DIFF
--- a/lib/utils/__tests__/isSharedLineComment.test.js
+++ b/lib/utils/__tests__/isSharedLineComment.test.js
@@ -103,4 +103,41 @@ describe("isSharedLineComment", () => {
     `);
     expect(isSharedLineComment(root.nodes[0])).toBe(true);
   });
+
+  it("returns true when comment shares a line with the end of a multi-line rule block, after it", () => {
+    const root = postcss.parse(`
+      a {
+        color: pink;
+      } /* comment */
+    `);
+    root.walkComments(comment => {
+      expect(isSharedLineComment(comment)).toBe(true);
+    });
+  });
+
+  it("returns true when comment shares a line with the end of a multi-line property declaration, after it", () => {
+    const root = postcss.parse(`
+      a {
+        border-radius:
+          1em
+          0; /* comment */
+      }
+    `);
+    root.walkComments(comment => {
+      expect(isSharedLineComment(comment)).toBe(true);
+    });
+  });
+
+  it("returns true when comment shares a line with the start of a multi-line property declaration, before it", () => {
+    const root = postcss.parse(`
+      a {
+        /* comment */ border-radius:
+          1em
+          0;
+      }
+    `);
+    root.walkComments(comment => {
+      expect(isSharedLineComment(comment)).toBe(true);
+    });
+  });
 });

--- a/lib/utils/isSharedLineComment.js
+++ b/lib/utils/isSharedLineComment.js
@@ -6,7 +6,7 @@ const getNextNonSharedLineCommentNode = require("./getNextNonSharedLineCommentNo
 const getPreviousNonSharedLineCommentNode = require("./getPreviousNonSharedLineCommentNode");
 
 function nodesShareLines(a, b) {
-  return _.get(a, "source.start.line") === _.get(b, "source.start.line");
+  return _.get(a, "source.end.line") === _.get(b, "source.start.line");
 }
 
 module.exports = function isSharedLineComment(
@@ -19,7 +19,7 @@ module.exports = function isSharedLineComment(
   const previousNonSharedLineCommentNode = getPreviousNonSharedLineCommentNode(
     node
   );
-  if (nodesShareLines(node, previousNonSharedLineCommentNode)) {
+  if (nodesShareLines(previousNonSharedLineCommentNode, node)) {
     return true;
   }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2980

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
