### PR TITLE
Updated outdated cli doc.

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -86,9 +86,7 @@ Linting all `.css` files in the `foo` directory. And fixing source files if viol
 stylelint "foo/*.css" --fix
 ```
 
-**Note:** It's an _experimental_ feature. It currently does not respect special comments for disabling stylelint within sources (e. g. `/* stylelint-disable /*`). Autofixing will be applied regardless of these comments.
-
-If you're using both these special comments and autofixing, please run stylelint twice as a temporary solution. On the first run, some violations could be missed, or some violations might be reported incorrectly.
+**Note:** It's an _experimental_ feature.
 
 For CSS with standard syntax, stylelint will use [postcss-safe-parser](https://github.com/postcss/postcss-safe-parser) to fix syntax errors.
 


### PR DESCRIPTION
The doc said that the cli --fix option does not respect special comments for disabling stylelint within sources. This is no longer true.