### PR TITLE
Add except: ["after-closing-brace"] to block-closing-brace-empty-line…

### DIFF
--- a/lib/rules/block-closing-brace-empty-line-before/README.md
+++ b/lib/rules/block-closing-brace-empty-line-before/README.md
@@ -65,7 +65,7 @@ a { color: pink; }
 
 ### `except: ["after-closing-brace"]`
 
-When a rule is nested, and `"never"` is specified for empty lines before closing braces, force a new line before the closing brace of the nested block.
+When a rule is nested, `after-closing-brace` brace will reverse the primary option.
 
 For example, with `"never"` and `except: ["after-closing-brace"]`:
 
@@ -134,5 +134,82 @@ The following patterns are *not* considered violations:
     color: aquamarine;
   }
 
+}
+```
+
+For example, with `"always-multi-line"` and `except: ["after-closing-brace"]`:
+
+The following patterns are considered violations:
+
+```css
+@media print {
+
+  a {
+    color: aquamarine;
+
+  }
+
+}
+```
+
+```css
+@supports (animation-name: test) {
+
+  a {
+    color: aquamarine;
+
+  }
+
+}
+```
+
+```css
+@keyframes test {
+
+  100% {
+    color: aquamarine;
+
+  }
+
+}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+@media print {
+
+  a {
+    color: aquamarine;
+
+  }
+}
+```
+
+```css
+@font-face {
+  font-family: "MyFont";
+  src: url("myfont.woff2") format("woff2");
+
+}
+```
+
+```css
+@supports (animation-name: test) {
+
+  a {
+    color: aquamarine;
+
+  }
+}
+```
+
+```css
+@keyframes test {
+
+  100% {
+    color: aquamarine;
+
+  }
 }
 ```

--- a/lib/rules/block-closing-brace-empty-line-before/README.md
+++ b/lib/rules/block-closing-brace-empty-line-before/README.md
@@ -60,3 +60,79 @@ a {
 ```css
 a { color: pink; }
 ```
+
+## Optional secondary options
+
+### `except: ["after-closing-brace"]`
+
+When a rule is nested, and `"never"` is specified for empty lines before closing braces, force a new line before the closing brace of the nested block.
+
+For example, with `"never"` and `except: ["after-closing-brace"]`:
+
+The following patterns are considered violations:
+
+```css
+@media print {
+
+  a {
+    color: aquamarine;
+  }
+}
+```
+
+```css
+@supports (animation-name: test) {
+
+  a {
+    color: aquamarine;
+  }
+}
+```
+
+```css
+@keyframes test {
+
+  100% {
+    color: aquamarine;
+  }
+}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+@media print {
+
+  a {
+    color: aquamarine;
+  }
+
+}
+```
+
+```css
+@font-face {
+  font-family: "MyFont";
+  src: url("myfont.woff2") format("woff2");
+}
+```
+
+```css
+@supports (animation-name: test) {
+
+  a {
+    color: aquamarine;
+  }
+
+}
+```
+
+```css
+@keyframes test {
+
+  100% {
+    color: aquamarine;
+  }
+
+}
+```

--- a/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
@@ -195,3 +195,58 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["never", { except: ["after-closing-brace"] }],
+
+  accept: [
+    {
+      code: "a {\n\tcolor: aquamarine;\n}"
+    },
+    {
+      code: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n}"
+    },
+    {
+      code:
+        '@font-face {\n\tfont-family: "MyFont";\n\tsrc: url("myfont.woff2") format("woff2");\n}'
+    },
+    {
+      code:
+        "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n}"
+    },
+    {
+      code: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\t}\n\n}"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a {\n\tcolor: aquamarine;\n\n}",
+      message: messages.rejected
+    },
+    {
+      code: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n}",
+      message: messages.expected
+    },
+    {
+      code:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n}",
+      message: messages.expected
+    },
+    {
+      code:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n}",
+      message: messages.rejected
+    },
+    {
+      code:
+        "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n}",
+      message: messages.expected
+    },
+    {
+      code: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\t}\n}",
+      message: messages.expected
+    }
+  ]
+});

--- a/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
@@ -223,30 +223,112 @@ testRule(rule, {
   reject: [
     {
       code: "a {\n\tcolor: aquamarine;\n\n}",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 4,
+      column: 1
     },
     {
       code: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n}",
-      message: messages.expected
+      message: messages.expected,
+      line: 6,
+      column: 1
     },
     {
       code:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n}",
-      message: messages.expected
+      message: messages.expected,
+      line: 10,
+      column: 1
     },
     {
       code:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n}",
-      message: messages.rejected
+      message: messages.rejected,
+      line: 10,
+      column: 2
     },
     {
       code:
         "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n}",
-      message: messages.expected
+      message: messages.expected,
+      line: 6,
+      column: 1
     },
     {
       code: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\t}\n}",
-      message: messages.expected
+      message: messages.expected,
+      line: 6,
+      column: 1
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["always-multi-line", { except: ["after-closing-brace"] }],
+
+  accept: [
+    {
+      code: "a {\n\tcolor: aquamarine;\n\n}"
+    },
+    {
+      code: "a { color: aquamarine; }"
+    },
+    {
+      code: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n}"
+    },
+    {
+      code:
+        '@font-face {\n\tfont-family: "MyFont";\n\tsrc: url("myfont.woff2") format("woff2");\n\n}'
+    },
+    {
+      code:
+        "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n}"
+    },
+    {
+      code: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\n\t}\n}"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a {\n\tcolor: aquamarine;\n}",
+      message: messages.expected,
+      line: 3,
+      column: 1
+    },
+    {
+      code: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n}",
+      message: messages.rejected,
+      line: 8,
+      column: 1
+    },
+    {
+      code:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n\n}",
+      message: messages.rejected,
+      line: 13,
+      column: 1
+    },
+    {
+      code:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n\n}",
+      message: messages.rejected,
+      line: 13,
+      column: 1
+    },
+    {
+      code:
+        "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n}",
+      message: messages.rejected,
+      line: 8,
+      column: 1
+    },
+    {
+      code: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\n\t}\n\n}",
+      message: messages.rejected,
+      line: 8,
+      column: 1
     }
   ]
 });

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -65,12 +65,12 @@ const rule = function(expectation, options) {
       const expectEmptyLineBefore = (() => {
         const childNodeTypes = statement.nodes.map(item => item.type);
 
+        // Reverse the primary options if `after-closing-brace` is set
         if (
           optionsMatches(options, "except", "after-closing-brace") &&
-          expectation === "never" &&
           (statement.type === "atrule" && childNodeTypes.indexOf("decl") === -1)
         ) {
-          return true;
+          return expectation === "never" ? true : false;
         }
 
         return expectation === "always-multi-line" &&

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -5,6 +5,7 @@ const hasBlock = require("../../utils/hasBlock");
 const hasEmptyBlock = require("../../utils/hasEmptyBlock");
 const hasEmptyLine = require("../../utils/hasEmptyLine");
 const isSingleLineString = require("../../utils/isSingleLineString");
+const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -16,12 +17,23 @@ const messages = ruleMessages(ruleName, {
   rejected: "Unexpected empty line before closing brace"
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, {
-      actual: expectation,
-      possible: ["always-multi-line", "never"]
-    });
+    const validOptions = validateOptions(
+      result,
+      ruleName,
+      {
+        actual: expectation,
+        possible: ["always-multi-line", "never"]
+      },
+      {
+        actual: options,
+        possible: {
+          except: ["after-closing-brace"]
+        },
+        optional: true
+      }
+    );
     if (!validOptions) {
       return;
     }
@@ -50,11 +62,22 @@ const rule = function(expectation) {
       }
 
       // Set expectation
-      const expectEmptyLineBefore =
-        expectation === "always-multi-line" &&
-        !isSingleLineString(blockString(statement))
+      const expectEmptyLineBefore = (() => {
+        const childNodeTypes = statement.nodes.map(item => item.type);
+
+        if (
+          optionsMatches(options, "except", "after-closing-brace") &&
+          expectation === "never" &&
+          (statement.type === "atrule" && !childNodeTypes.includes("decl"))
+        ) {
+          return true;
+        }
+
+        return expectation === "always-multi-line" &&
+          !isSingleLineString(blockString(statement))
           ? true
           : false;
+      })();
 
       // Check for at least one empty line
       const hasEmptyLineBefore = hasEmptyLine(before);

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -68,7 +68,7 @@ const rule = function(expectation, options) {
         if (
           optionsMatches(options, "except", "after-closing-brace") &&
           expectation === "never" &&
-          (statement.type === "atrule" && !childNodeTypes.includes("decl"))
+          (statement.type === "atrule" && childNodeTypes.indexOf("decl") === -1)
         ) {
           return true;
         }


### PR DESCRIPTION
Add `except: ["after-closing-brace"]` to `block-closing-brace-empty-line-before`

When `"never"` is specified for `block-closing-brace-empty-line-before` the option will be reversed when nested in at-rules.

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2090 

> Is there anything in the PR that needs further explanation?

No, I don’t believe so.
