### PR TITLE
Fix isPathIgnored regression for .stylelintignore files

### DIFF
--- a/lib/__tests__/createLinter.test.js
+++ b/lib/__tests__/createLinter.test.js
@@ -43,3 +43,21 @@ it("createLinter().isPathIgnored", () => {
     expect(results).toEqual([true, true, false, false]);
   });
 });
+
+it("createLinter().isPathIgnored with a .stylelintignore file", () => {
+  const config = {
+    rules: { "block-no-empty": true }
+  };
+  const linter = stylelint.createLinter({
+    config,
+    ignorePath: "./stylelintignore-test/.stylelintignore"
+  });
+  return Promise.all([
+    linter.isPathIgnored("a.css"),
+    linter.isPathIgnored("foo/bar/baz.css"),
+    linter.isPathIgnored("foo/bar/baz.scss"),
+    linter.isPathIgnored("foo/invalid-hex.css")
+  ]).then(results => {
+    expect(results).toEqual([true, true, false, false]);
+  });
+});

--- a/lib/__tests__/createLinter.test.js
+++ b/lib/__tests__/createLinter.test.js
@@ -50,14 +50,12 @@ it("createLinter().isPathIgnored with a .stylelintignore file", () => {
   };
   const linter = stylelint.createLinter({
     config,
-    ignorePath: "./stylelintignore-test/.stylelintignore"
+    ignorePath: "./lib/__tests__/stylelintignore-test/.stylelintignore"
   });
   return Promise.all([
-    linter.isPathIgnored("a.css"),
-    linter.isPathIgnored("foo/bar/baz.css"),
-    linter.isPathIgnored("foo/bar/baz.scss"),
-    linter.isPathIgnored("foo/invalid-hex.css")
+    linter.isPathIgnored("./fixtures/empty-block.css"),
+    linter.isPathIgnored("./fixtures/invalid-hex.css")
   ]).then(results => {
-    expect(results).toEqual([true, true, false, false]);
+    expect(results).toEqual([true, false]);
   });
 });

--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -8,6 +8,12 @@ const getConfigForFile = require("./getConfigForFile");
 const getPostcssResult = require("./getPostcssResult");
 const isPathIgnored = require("./isPathIgnored");
 const lintSource = require("./lintSource");
+const fs = require("fs");
+const path = require("path");
+const ignore = require("ignore");
+
+const DEFAULT_IGNORE_FILENAME = ".stylelintignore";
+const FILE_NOT_FOUND_ERROR_CODE = "ENOENT";
 
 // The stylelint "internal API" is passed among functions
 // so that methods on a stylelint instance can invoke
@@ -17,6 +23,24 @@ module.exports = function(
 ) /*: stylelint$internalApi*/ {
   options = options || {};
   const stylelint /*: Object*/ = { _options: options };
+
+  // The ignorer will be used to filter file paths after the glob is checked,
+  // before any files are actually read
+  const ignoreFilePath = options.ignorePath || DEFAULT_IGNORE_FILENAME;
+  const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
+    ? ignoreFilePath
+    : path.resolve(process.cwd(), ignoreFilePath);
+  let ignoreText = "";
+  try {
+    ignoreText = fs.readFileSync(absoluteIgnoreFilePath, "utf8");
+  } catch (readError) {
+    if (readError.code !== FILE_NOT_FOUND_ERROR_CODE) throw readError;
+  }
+  const ignorePattern = options.ignorePattern || [];
+  stylelint.ignorer = ignore()
+    .add(ignoreText)
+    .add(options.ignoreFiles)
+    .add(ignorePattern);
 
   // Two separate explorers so they can each have their own transform
   // function whose results are cached by cosmiconfig

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -20,7 +20,10 @@ module.exports = function(
     const absoluteFilePath = path.isAbsolute(filePath)
       ? filePath
       : path.resolve(process.cwd(), filePath);
-    if (micromatch(absoluteFilePath, config.ignoreFiles).length) {
+    if (
+      micromatch(absoluteFilePath, config.ignoreFiles).length ||
+      stylelint.ignorer.ignores(path.relative(process.cwd(), absoluteFilePath))
+    ) {
       return true;
     }
     return false;

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -7,14 +7,11 @@ const formatters /*: Object*/ = require("./formatters");
 const fs = require("fs");
 const globby /*: Function*/ = require("globby");
 const hash = require("./utils/hash");
-const ignore = require("ignore");
 const needlessDisables /*: Function*/ = require("./needlessDisables");
 const path = require("path");
 const pify = require("pify");
 const pkg = require("../package.json");
 
-const DEFAULT_IGNORE_FILENAME = ".stylelintignore";
-const FILE_NOT_FOUND_ERROR_CODE = "ENOENT";
 const ALWAYS_IGNORED_GLOBS = ["**/node_modules/**", "**/bower_components/**"];
 
 /*::type CssSyntaxErrorT = {
@@ -54,23 +51,6 @@ module.exports = function(
   let fileCache;
   const startTime = Date.now();
 
-  // The ignorer will be used to filter file paths after the glob is checked,
-  // before any files are actually read
-  const ignoreFilePath = options.ignorePath || DEFAULT_IGNORE_FILENAME;
-  const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
-    ? ignoreFilePath
-    : path.resolve(process.cwd(), ignoreFilePath);
-  let ignoreText = "";
-  try {
-    ignoreText = fs.readFileSync(absoluteIgnoreFilePath, "utf8");
-  } catch (readError) {
-    if (readError.code !== FILE_NOT_FOUND_ERROR_CODE) throw readError;
-  }
-  const ignorePattern = options.ignorePattern || [];
-  const ignorer = ignore()
-    .add(ignoreText)
-    .add(ignorePattern);
-
   const isValidCode = typeof code === "string";
   if ((!files && !isValidCode) || (files && (code || isValidCode))) {
     throw new Error(
@@ -103,7 +83,10 @@ module.exports = function(
     reportNeedlessDisables,
     syntax,
     customSyntax,
-    fix
+    fix,
+    ignorePath: options.ignorePath,
+    ignorePattern: options.ignorePattern,
+    ignoreFiles: options.ignoreFiles
   });
 
   if (!files) {
@@ -149,8 +132,9 @@ module.exports = function(
         // if file is ignored, return nothing
         if (
           absoluteCodeFilename &&
-          !ignorer.filter(path.relative(process.cwd(), absoluteCodeFilename))
-            .length
+          !stylelint.ignorer.filter(
+            path.relative(process.cwd(), absoluteCodeFilename)
+          ).length
         ) {
           returnValue.output = "";
         } else if (
@@ -189,7 +173,7 @@ module.exports = function(
   return globby(fileList)
     .then(filePaths => {
       // The ignorer filter needs to check paths relative to cwd
-      filePaths = ignorer.filter(
+      filePaths = stylelint.ignorer.filter(
         filePaths.map(p => path.relative(process.cwd(), p))
       );
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2833 

> Is there anything in the PR that needs further explanation?

I have an appropriate test, but I cannot get the implementation. Would appreciate some help from either @stylelint/core or @billybonks on resolving relative/absolute filepaths as I feel like I've tried everything and I'm just going in circles.

The basic approach is moving building the ignorer from standalone.js to createLinter.js, and assigning it as a property of stylelint (main object). We can then call it both where it's needed within standalone as well as isPathIgnored.