### PR TITLE
Remove incorrect non-violation

### DIFF
--- a/lib/rules/function-comma-newline-after/README.md
+++ b/lib/rules/function-comma-newline-after/README.md
@@ -89,10 +89,3 @@ a { transform: translate(1, 1) }
 ```css
 a { transform: translate(1 , 1) }
 ```
-
-```css
-a {
-  transform: translate(1
-    ,1)
-}
-```


### PR DESCRIPTION
I believe there was an incorrect example of a non-violation for `"never-multi-line"`