### PR TITLE
Add ignoreMediaFeatureNames for unit-blacklist

### DIFF
--- a/lib/rules/unit-blacklist/README.md
+++ b/lib/rules/unit-blacklist/README.md
@@ -113,27 +113,27 @@ Given:
 The following patterns are *not* considered violations:
 
 ```css
-@media (min-width: 960px) { }
+@media (min-width: 960px) {}
 ```
 
 ```css
-@media (max-height: 280px) { }
+@media (max-height: 280px) {}
 ```
 
 ```css
-@media not (resolution: 300dpi) { }
+@media not (resolution: 300dpi) {}
 ```
 
 The following patterns are considered violations:
 
 ```css
-a { @media screen and (max-device-width: 500px) { } }
+@media screen and (max-device-width: 500px) {}
 ```
 
 ```css
-@media all and (min-width: 500px) and (max-width: 200px) { }
+@media all and (min-width: 500px) and (max-width: 200px) {}
 ```
 
 ```css
-@media print and (max-resolution: 100dpi) { }
+@media print and (max-resolution: 100dpi) {}
 ```

--- a/lib/rules/unit-blacklist/README.md
+++ b/lib/rules/unit-blacklist/README.md
@@ -94,3 +94,46 @@ a { -moz-border-radius-topright: 40px; }
 ```css
 a { height: 100vmin; }
 ```
+
+### `ignoreMediaFeatureNames: { unit: ["property", "/regex/"] }`
+
+Ignore units for specific feature names.
+
+For example, with `["px", "dpi"]`.
+
+Given:
+
+```js
+{
+  "px": [ "min-width", "/height$/" ],
+  "dpi": [ "resolution" ]  
+}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+@media (min-width: 960px) { }
+```
+
+```css
+@media (max-height: 280px) { }
+```
+
+```css
+@media not (resolution: 300dpi) { }
+```
+
+The following patterns are considered violations:
+
+```css
+a { @media screen and (max-device-width: 500px) { } }
+```
+
+```css
+@media all and (min-width: 500px) and (max-width: 200px) { }
+```
+
+```css
+@media print and (max-resolution: 100dpi) { }
+```

--- a/lib/rules/unit-blacklist/__tests__/index.js
+++ b/lib/rules/unit-blacklist/__tests__/index.js
@@ -318,3 +318,169 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+
+  config: [
+    ["px", "dpi", "%"],
+    {
+      ignoreMediaFeatureNames: {
+        px: ["min-width", "height"],
+        dpi: ["min-resolution", "resolution"],
+        "%": ["width", "/^min/"]
+      }
+    }
+  ],
+
+  accept: [
+    {
+      code: "@media (min-width: 960px) { body { font-size: 13em } }"
+    },
+    {
+      code: "@media (width: 960%) { /* body { font-size: 13em } */ }"
+    },
+    {
+      code: "@media (min-width: 960%) { /* body { font-size: 13em } */ }"
+    },
+    {
+      code: "a { @media (min-width: 960px) { body { font-size: 13em } } }"
+    },
+    {
+      code:
+        "@media print and (min-resolution: 300dpi) { body { font-size: 13em } }"
+    },
+    {
+      code: "@media print { body { font-size: 40pt } }"
+    },
+    {
+      code: "@media screen, print { body { line-height: 1.2 } }"
+    },
+    {
+      code: "@MEDIA (min-width: 960px) { body { font-size: 13em } }"
+    },
+    {
+      code: "@media (MIN-WIDTH: 960px) { body { font-size: 13em } }"
+    },
+    {
+      code: "@media (height > -100px) { body { background: green; } }"
+    },
+    {
+      code: "@media not (resolution: -300dpi) { body { background: green; } }"
+    },
+    {
+      code: "@media only screen and (min-width: 500px) { }"
+    },
+    {
+      code: "@media only speech and (width > 20%) { }"
+    },
+    {
+      code: "@media speech and (device-aspect-ratio: 16/9) { }"
+    },
+    {
+      code:
+        "@media only screen and (min-width: 320px) and (height: 480px) and (-webkit-min-device-pixel-ratio: 2) { body { line-height: 1.4 } }"
+    },
+    {
+      code: "@media screen, print { }"
+    },
+    {
+      code: "@media speech and (aspect-ratio: 11/5) { }"
+    },
+    {
+      code:
+        "@media (min-width: 700px), handheld and (orientation: landscape) { }"
+    }
+  ],
+
+  reject: [
+    {
+      code: "@media screen and (max-width: 500px) { }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 31
+    },
+    {
+      code: "@media (width: 960px) { /* body { font-size: 13em } */ }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 16
+    },
+    {
+      code: "@media (min-height: 960px) { /* body { font-size: 13em } */ }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 21
+    },
+    {
+      code: "a { @media screen and (max-width: 500px) { } }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 35
+    },
+    {
+      code: "@media all and (min-width: 500px) and (max-width: 200px) { }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 51
+    },
+    {
+      code: "@MEDIA print { body { font-size: 60dpi } }",
+      message: messages.rejected("dpi"),
+      line: 1,
+      column: 34
+    },
+    {
+      code: "@media (MAX-WIDTH: 10px) { }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 20
+    },
+    {
+      code: "@media (min-width: 10em)\n  and (max-width: 20px) { }",
+      message: messages.rejected("px"),
+      line: 2,
+      column: 19
+    },
+    {
+      code: "@media (width < 10.01px) {}",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 17
+    },
+    {
+      code: "@media only speech and (max-device-width > 20%) { }",
+      message: messages.rejected("%"),
+      line: 1,
+      column: 44
+    },
+    {
+      code:
+        "@media not (max-resolution: -300dpi) { body { background: green; } }",
+      message: messages.rejected("dpi"),
+      line: 1,
+      column: 29
+    },
+    {
+      code:
+        "@media only screen and (min-width: 320px) and (height: 480px) and (-webkit-min-device-pixel-ratio: 2) { body { line-height: 1.4px } }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 125
+    },
+    {
+      code:
+        "@media only screen and (min-width: 320px) and (height: 480px) and (-webkit-min-device-pixel-ratio: 2px) { body { line-height: 1.4 } }",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 100
+    },
+    {
+      code:
+        "@media screen and (min-width: 699px) and (min-width: 520px), (max-width: 1151px)",
+      message: messages.rejected("px"),
+      line: 1,
+      column: 74
+    }
+  ]
+});

--- a/lib/rules/unit-blacklist/index.js
+++ b/lib/rules/unit-blacklist/index.js
@@ -4,6 +4,7 @@ const _ = require("lodash");
 const atRuleParamIndex = require("../../utils/atRuleParamIndex");
 const declarationValueIndex = require("../../utils/declarationValueIndex");
 const getUnitFromValueNode = require("../../utils/getUnitFromValueNode");
+const mediaParser = require("postcss-media-query-parser").default;
 const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -16,6 +17,14 @@ const ruleName = "unit-blacklist";
 const messages = ruleMessages(ruleName, {
   rejected: unit => `Unexpected unit "${unit}"`
 });
+
+// a function to retrieve only the media feature name
+// could be externalized in an utils function if needed in other code
+const getMediaFeatureName = mediaFeatureNode => {
+  const value = mediaFeatureNode.value.toLowerCase();
+
+  return /((-?\w*)*)/i.exec(value)[1];
+};
 
 const rule = function(blacklistInput, options) {
   const blacklist = [].concat(blacklistInput);
@@ -31,7 +40,8 @@ const rule = function(blacklistInput, options) {
         optional: true,
         actual: options,
         possible: {
-          ignoreProperties: validateObjectWithStringArrayProps
+          ignoreProperties: validateObjectWithStringArrayProps,
+          ignoreMediaFeatureNames: validateObjectWithStringArrayProps
         }
       }
     );
@@ -39,10 +49,55 @@ const rule = function(blacklistInput, options) {
       return;
     }
 
-    function check(node, value, getIndex) {
+    function checkMedia(node, value, getIndex) {
+      value = value.replace(/\*/g, ",");
+
+      mediaParser(node.params).walk(/^media-feature$/i, mediaFeatureNode => {
+        const mediaName = getMediaFeatureName(mediaFeatureNode),
+          parentValue = mediaFeatureNode.parent.value;
+
+        valueParser(value).walk(function(valueNode) {
+          // Ignore all non-word valueNode and
+          // the values not included in the parentValue string
+          if (
+            valueNode.type !== "word" ||
+            !parentValue.includes(valueNode.value)
+          ) {
+            return;
+          }
+
+          const unit = getUnitFromValueNode(valueNode);
+          if (!unit || (unit && blacklist.indexOf(unit.toLowerCase()) === -1)) {
+            return;
+          }
+
+          if (
+            options &&
+            optionsMatches(
+              options.ignoreMediaFeatureNames,
+              unit.toLowerCase(),
+              mediaName
+            )
+          ) {
+            return;
+          }
+          report({
+            index: getIndex(node) + valueNode.sourceIndex,
+            message: messages.rejected(unit),
+            node,
+            result,
+            ruleName
+          });
+        });
+        return;
+      });
+    }
+
+    function checkDecl(node, value, getIndex) {
       // make sure multiplication operations (*) are divided - not handled
       // by postcss-value-parser
       value = value.replace(/\*/g, ",");
+
       valueParser(value).walk(function(valueNode) {
         // Ignore wrong units within `url` function
         if (
@@ -80,9 +135,9 @@ const rule = function(blacklistInput, options) {
     }
 
     root.walkAtRules(/^media$/i, atRule =>
-      check(atRule, atRule.params, atRuleParamIndex)
+      checkMedia(atRule, atRule.params, atRuleParamIndex)
     );
-    root.walkDecls(decl => check(decl, decl.value, declarationValueIndex));
+    root.walkDecls(decl => checkDecl(decl, decl.value, declarationValueIndex));
   };
 };
 

--- a/lib/rules/unit-blacklist/index.js
+++ b/lib/rules/unit-blacklist/index.js
@@ -49,9 +49,29 @@ const rule = function(blacklistInput, options) {
       return;
     }
 
-    function checkMedia(node, value, getIndex) {
-      value = value.replace(/\*/g, ",");
+    function check(node, nodeIndex, valueNode, input, option) {
+      const unit = getUnitFromValueNode(valueNode);
 
+      // There is not unit or it is not configured as a violation
+      if (!unit || (unit && blacklist.indexOf(unit.toLowerCase()) === -1)) {
+        return;
+      }
+
+      // The unit has an ignore option for the specific input
+      if (optionsMatches(option, unit.toLowerCase(), input)) {
+        return;
+      }
+
+      report({
+        index: nodeIndex + valueNode.sourceIndex,
+        message: messages.rejected(unit),
+        node,
+        result,
+        ruleName
+      });
+    }
+
+    function checkMedia(node, value, getIndex) {
       mediaParser(node.params).walk(/^media-feature$/i, mediaFeatureNode => {
         const mediaName = getMediaFeatureName(mediaFeatureNode),
           parentValue = mediaFeatureNode.parent.value;
@@ -65,29 +85,13 @@ const rule = function(blacklistInput, options) {
           ) {
             return;
           }
-
-          const unit = getUnitFromValueNode(valueNode);
-          if (!unit || (unit && blacklist.indexOf(unit.toLowerCase()) === -1)) {
-            return;
-          }
-
-          if (
-            options &&
-            optionsMatches(
-              options.ignoreMediaFeatureNames,
-              unit.toLowerCase(),
-              mediaName
-            )
-          ) {
-            return;
-          }
-          report({
-            index: getIndex(node) + valueNode.sourceIndex,
-            message: messages.rejected(unit),
+          check(
             node,
-            result,
-            ruleName
-          });
+            getIndex(node),
+            valueNode,
+            mediaName,
+            options ? options.ignoreMediaFeatureNames : {}
+          );
         });
         return;
       });
@@ -106,31 +110,13 @@ const rule = function(blacklistInput, options) {
         ) {
           return false;
         }
-
-        const unit = getUnitFromValueNode(valueNode);
-
-        if (!unit || (unit && blacklist.indexOf(unit.toLowerCase()) === -1)) {
-          return;
-        }
-
-        if (
-          options &&
-          optionsMatches(
-            options.ignoreProperties,
-            unit.toLowerCase(),
-            node.prop
-          )
-        ) {
-          return;
-        }
-
-        report({
-          index: getIndex(node) + valueNode.sourceIndex,
-          message: messages.rejected(unit),
+        check(
           node,
-          result,
-          ruleName
-        });
+          getIndex(node),
+          valueNode,
+          node.prop,
+          options ? options.ignoreProperties : {}
+        );
       });
     }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#3006 

> Is there anything in the PR that needs further explanation?

The PR is easy to understand.

NB:
I am not sure this solution is the most optimized since I have one loop for the value `valueParser` inside the one for the media `mediaParser` but it feels safer than doing matches only on the returned `mediaFeatureNode` and having to add `column` size for error handling.

Since this is my first PR for stylelint, this is widely open to discussion. I may have missed a util or anything else that could be used.
