### PR TITLE
Fix incorrect font-family-no-missing-generic-family-keyword configuration #3038

### DIFF
--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -16,17 +16,9 @@ const messages = ruleMessages(ruleName, {
 const isFamilyNameKeyword = node =>
   !node.quote && keywordSets.fontFamilyKeywords.has(node.value.toLowerCase());
 
-const rule = function(actual, options) {
+const rule = function(actual) {
   return (root, result) => {
-    const validOptions = validateOptions(
-      result,
-      ruleName,
-      { actual },
-      {
-        actual: options,
-        optional: true
-      }
-    );
+    const validOptions = validateOptions(result, ruleName, { actual });
     if (!validOptions) {
       return;
     }

--- a/lib/utils/__tests__/validateOptions.test.js
+++ b/lib/utils/__tests__/validateOptions.test.js
@@ -143,6 +143,18 @@ describe("validateOptions for secondary options objects", () => {
       'Invalid option value 2 for rule "foo": should be an object'
     );
   });
+
+  it(`should have "possible" if "optional" is set`, () => {
+    validateOptions(result, "foo", {
+      optional: true,
+      actual: { foo: "always" }
+    });
+
+    expect(result.warn.mock.calls[0]).toHaveLength(2);
+    expect(result.warn.mock.calls[0][0]).toEqual(
+      'Incorrect configuration for rule "foo". Rule should have "possible" values for options validation'
+    );
+  });
 });
 
 it("validateOptions for secondary options objects with subarrays", () => {

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -72,6 +72,16 @@ function validate(opts, ruleName, complain) {
     complain(`Expected option value for rule "${ruleName}"`);
     return;
   } else if (nothingPossible) {
+    if (optional) {
+      complain(
+        `Incorrect configuration for rule "${
+          ruleName
+        }". Rule should have "possible" values for options validation`
+      );
+
+      return;
+    }
+
     complain(`Unexpected option value "${actual}" for rule "${ruleName}"`);
     return;
   }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/3038

> Is there anything in the PR that needs further explanation?

I've added a test to `validateOptions`, but it doesn't catch an error. It will only show an error if test with configuration like in #3038 run.

I think we can add a new type of test in `jest-setup.js`. Take first `accept` test, add `severity` secondary option, and run test. There is a little warning: most test cases use `config: ["value"]`, while very few use `config: [["value"]]` (which is probably should be fixed). I can't think straight anymore today, so I'm not including this change for `jest-setup.js` in this PR.