### PR TITLE
Add postcss-sass as dependency, because postcss-html needs it

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "postcss-reporter": "^5.0.0",
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-safe-parser": "^3.0.1",
+    "postcss-sass": "^0.2.0",
     "postcss-scss": "^1.0.2",
     "postcss-selector-parser": "^3.1.0",
     "postcss-value-parser": "^3.3.0",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/3035

> Is there anything in the PR that needs further explanation?

We don't use `postcss-sass` in our codebase, but it's a peer dependency of `postcss-html`, which we use. Luckily `postcss-html` doesn't fail if not every its dependency installed. But it might change theoretically, and we'll have a problem. Also we don't want annoy people by unmeet dependency messages.
