### PR TITLE
Fix meow configuration for default values

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,7 +9,10 @@ const path = require("path");
 const resolveFrom = require("resolve-from");
 const standalone = require("./standalone");
 
-/*:: type minimistOptionsType = {
+/*:: type meowOptionsType = {
+  autoHelp: boolean,
+  autoVersion: boolean,
+  help: string,
   flags: {
     "allow-empty-input": {
       alias: string,
@@ -46,6 +49,7 @@ const standalone = require("./standalone");
     },
     formatter: {
       alias: string,
+      default: "string",
       type: string
     },
     help: {
@@ -83,13 +87,7 @@ const standalone = require("./standalone");
       alias: string,
       type: string
     }
-  }
-}*/
-
-/*:: type meowOptionsType = {
-  autoHelp: boolean,
-  autoVersion: boolean,
-  help: string,
+  },
   pkg: string,
 } */
 
@@ -138,83 +136,6 @@ const standalone = require("./standalone");
   disableDefaultIgnores?: any,
   ignorePattern?: any
 }*/
-
-const minimistOptions /*: minimistOptionsType*/ = {
-  flags: {
-    "allow-empty-input": {
-      alias: "aei",
-      type: "boolean"
-    },
-    cache: {
-      type: "boolean"
-    },
-    "cache-location": {
-      type: "string"
-    },
-    config: {
-      default: false,
-      type: "string"
-    },
-    "config-basedir": {
-      type: "string"
-    },
-    color: {
-      type: "boolean"
-    },
-    "custom-formatter": {
-      type: "string"
-    },
-    "custom-syntax": {
-      type: "string"
-    },
-    "disable-default-ignores": {
-      alias: "di",
-      type: "boolean"
-    },
-    fix: {
-      type: "boolean"
-    },
-    formatter: {
-      alias: "f",
-      type: "string"
-    },
-    help: {
-      alias: "h",
-      type: "boolean"
-    },
-    "ignore-disables": {
-      alias: "id",
-      type: "boolean"
-    },
-    "ignore-path": {
-      alias: "i"
-    },
-    "ignore-pattern": {
-      alias: "ip"
-    },
-    "no-color": {
-      type: "boolean"
-    },
-    "report-needless-disables": {
-      alias: "rd"
-    },
-    "stdin-filename": {
-      type: "string"
-    },
-    quiet: {
-      alias: "q",
-      type: "boolean",
-      default: false
-    },
-    syntax: {
-      alias: "s"
-    },
-    version: {
-      alias: "v",
-      type: "boolean"
-    }
-  }
-};
 
 const meowOptions /*: meowOptionsType*/ = {
   autoHelp: false,
@@ -334,10 +255,85 @@ const meowOptions /*: meowOptionsType*/ = {
 
         Show the currently installed version of stylelint.
   `,
+  flags: {
+    "allow-empty-input": {
+      alias: "aei",
+      type: "boolean"
+    },
+    cache: {
+      type: "boolean"
+    },
+    "cache-location": {
+      type: "string"
+    },
+    config: {
+      default: false,
+      type: "string"
+    },
+    "config-basedir": {
+      type: "string"
+    },
+    color: {
+      type: "boolean"
+    },
+    "custom-formatter": {
+      type: "string"
+    },
+    "custom-syntax": {
+      type: "string"
+    },
+    "disable-default-ignores": {
+      alias: "di",
+      type: "boolean"
+    },
+    fix: {
+      type: "boolean"
+    },
+    formatter: {
+      alias: "f",
+      default: "string",
+      type: "string"
+    },
+    help: {
+      alias: "h",
+      type: "boolean"
+    },
+    "ignore-disables": {
+      alias: "id",
+      type: "boolean"
+    },
+    "ignore-path": {
+      alias: "i"
+    },
+    "ignore-pattern": {
+      alias: "ip"
+    },
+    "no-color": {
+      type: "boolean"
+    },
+    "report-needless-disables": {
+      alias: "rd"
+    },
+    "stdin-filename": {
+      type: "string"
+    },
+    quiet: {
+      alias: "q",
+      type: "boolean",
+      default: false
+    },
+    syntax: {
+      alias: "s"
+    },
+    version: {
+      alias: "v",
+      type: "boolean"
+    }
+  },
   pkg: require("../package.json")
 };
 
-const cli /*: cliType*/ = meow(meowOptions, minimistOptions);
+const cli /*: cliType*/ = meow(meowOptions);
 
 let formatter = cli.flags.formatter;
 if (cli.flags.customFormatter) {


### PR DESCRIPTION
It seems like meow was perhaps misconfigured. As such, the `default` values for the flags weren’t being set. This meant that the `”json”` formatter was being used by default on the CLI, rather than the `”string”` formatter. 

I’ve moved the `flags` object into the `meow` options object (as per the [docs](https://github.com/sindresorhus/meow#flags)). The `default` property now works and the `”string”` is now correctly used by default on the CLI.

@stylelint/core Please test this branch locally as part of the review process so we can be sure everything is A-OK :)
