### PR TITLE
Update Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.coverage

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -155,9 +155,7 @@ describe("standalone cache", () => {
       return fileExists(expectedCacheFilePath)
         .then(() => {
           throw new Error(
-            `Cache file is supposed to be removed, ${
-              expectedCacheFilePath
-            } is found instead`
+            `Cache file is supposed to be removed, ${expectedCacheFilePath} is found instead`
           );
         })
         .catch(() => {
@@ -183,9 +181,7 @@ describe("standalone cache", () => {
       return fileExists(expectedCacheFilePath)
         .then(() => {
           throw new Error(
-            `Cache file should not be created if string is passed, ${
-              expectedCacheFilePath
-            } is found instead`
+            `Cache file should not be created if string is passed, ${expectedCacheFilePath} is found instead`
           );
         })
         .catch(() => {

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -263,9 +263,7 @@ function addPluginFunctions(
       if (!pluginRuleDefinition.ruleName) {
         throw configurationError(
           "stylelint v3+ requires plugins to expose a ruleName. " +
-            `The plugin "${
-              pluginLookup
-            }" is not doing this, so will not work ` +
+            `The plugin "${pluginLookup}" is not doing this, so will not work ` +
             "with stylelint v3+. Please file an issue with the plugin."
         );
       }

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -14,9 +14,7 @@ const ruleName = "no-duplicate-selectors";
 
 const messages = ruleMessages(ruleName, {
   rejected: (selector, firstDuplicateLine) =>
-    `Unexpected duplicate selector "${selector}", first used at line ${
-      firstDuplicateLine
-    }`
+    `Unexpected duplicate selector "${selector}", first used at line ${firstDuplicateLine}`
 });
 
 const rule = function(actual) {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -219,9 +219,7 @@ module.exports = function(
           .then(postcssResult => {
             if (postcssResult.stylelint.stylelintError && useCache) {
               debug(
-                `${
-                  absoluteFilepath
-                } contains linting errors and will not be cached.`
+                `${absoluteFilepath} contains linting errors and will not be cached.`
               );
               fileCache.removeEntry(absoluteFilepath);
             }

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -74,9 +74,7 @@ function validate(opts, ruleName, complain) {
   } else if (nothingPossible) {
     if (optional) {
       complain(
-        `Incorrect configuration for rule "${
-          ruleName
-        }". Rule should have "possible" values for options validation`
+        `Incorrect configuration for rule "${ruleName}". Rule should have "possible" values for options validation`
       );
 
       return;
@@ -110,9 +108,9 @@ function validate(opts, ruleName, complain) {
   // If possible is an object ...
   if (!_.isPlainObject(actual)) {
     complain(
-      `Invalid option value ${JSON.stringify(actual)} for rule "${
-        ruleName
-      }": ` + "should be an object"
+      `Invalid option value ${JSON.stringify(
+        actual
+      )} for rule "${ruleName}": ` + "should be an object"
     );
     return;
   }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "npm-run-all": "^4.0.2",
     "npmpub": "^3.1.0",
     "postcss-import": "^11.0.0",
-    "prettier": "^1.8.2",
+    "prettier": "~1.9.2",
     "remark-cli": "^4.0.0",
     "remark-lint-no-missing-blank-lines": "^1.0.1",
     "remark-preset-lint-consistent": "^2.0.0",


### PR DESCRIPTION
Run the latest Prettier over the entire code base. Also pinned to version to minor version with `~`, because even minor version might change code formatting.