### PR TITLE
chore(package): update jest to version 22.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "file-exists-promise": "^1.0.2",
     "flow-bin": "^0.61.0",
     "husky": "^0.14.3",
-    "jest": "^21.1.0",
+    "jest": "^22.0.1",
     "lint-staged": "^6.0.0",
     "npm-run-all": "^4.0.2",
     "npmpub": "^3.1.0",


### PR DESCRIPTION
DO NOT MERGE

Testing for #3069

Tests currently failing here with v22.0.1: `JavaScript heap out of memory`
