### PR TITLE
Update PostCSS to v6.0.15

### DIFF
--- a/lib/__tests__/defaultSeverity.test.js
+++ b/lib/__tests__/defaultSeverity.test.js
@@ -9,10 +9,12 @@ it("`defaultSeverity` option set to warning", () => {
       "block-no-empty": true
     }
   };
-  return postcssPlugin.process("a {}", {}, config).then(result => {
-    const warnings = result.warnings();
-    expect(warnings.length).toBe(1);
-    expect(warnings[0].text.indexOf("block-no-empty")).not.toBe(-1);
-    expect(warnings[0].severity).toBe("warning");
-  });
+  return postcssPlugin
+    .process("a {}", { from: undefined }, config)
+    .then(result => {
+      const warnings = result.warnings();
+      expect(warnings.length).toBe(1);
+      expect(warnings[0].text.indexOf("block-no-empty")).not.toBe(-1);
+      expect(warnings[0].severity).toBe("warning");
+    });
 });

--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -235,7 +235,7 @@ it("SCSS // line-disabling comment", () => {
   }`;
   return postcss()
     .use(assignDisabledRanges)
-    .process(scssSource, { syntax: scss })
+    .process(scssSource, { syntax: scss, from: undefined })
     .then(result => {
       expect(result.stylelint.disabledRanges).toEqual({
         all: [],
@@ -255,7 +255,7 @@ it("Less // line-disabling comment", () => {
   }`;
   return postcss()
     .use(assignDisabledRanges)
-    .process(lessSource, { syntax: less })
+    .process(lessSource, { syntax: less, from: undefined })
     .then(result => {
       expect(result.stylelint.disabledRanges).toEqual({
         all: [],
@@ -431,6 +431,6 @@ it("enable rule without disabling rule", () => {
 function testDisableRanges(source, cb) {
   return postcss()
     .use(assignDisabledRanges)
-    .process(source)
+    .process(source, { from: undefined })
     .then(cb);
 }

--- a/lib/__tests__/ignoreDisables.test.js
+++ b/lib/__tests__/ignoreDisables.test.js
@@ -23,7 +23,7 @@ describe("ignoreDisables with postcssPlugins", () => {
     return postcssPlugin
       .process(
         css,
-        {},
+        { from: undefined },
         {
           config,
           ignoreDisables: true

--- a/lib/__tests__/integration.test.js
+++ b/lib/__tests__/integration.test.js
@@ -53,7 +53,7 @@ describe("integration test expecting warnings", () => {
   beforeEach(() => {
     return postcss()
       .use(stylelint(config))
-      .process(css)
+      .process(css, { from: undefined })
       .then(data => (result = data));
   });
 
@@ -100,7 +100,7 @@ it("Less integration test", () => {
 
   return postcss()
     .use(stylelint({ rules: {} }))
-    .process(less, { syntax: lessSyntax })
+    .process(less, { syntax: lessSyntax, from: undefined })
     .then(result => {
       expect(result.messages.length).toBe(0);
     });
@@ -114,7 +114,7 @@ it("Scss integration test", () => {
 
   return postcss()
     .use(stylelint({ rules: {} }))
-    .process(scss, { syntax: scssSyntax })
+    .process(scss, { syntax: scssSyntax, from: undefined })
     .then(result => {
       expect(result.messages.length).toBe(0);
     });

--- a/lib/__tests__/plugins.test.js
+++ b/lib/__tests__/plugins.test.js
@@ -53,47 +53,55 @@ const processorRelativeAndExtendRelative = postcss().use(
 );
 
 it("one plugin runs", () => {
-  return processorRelative.process(cssWithFoo).then(result => {
-    expect(result.warnings().length).toBe(2);
-    expect(result.warnings()[0].text).toBe(
-      "found .foo (plugin/warn-about-foo)"
-    );
-    expect(result.warnings()[0].node).toBeTruthy();
-  });
+  return processorRelative
+    .process(cssWithFoo, { from: undefined })
+    .then(result => {
+      expect(result.warnings().length).toBe(2);
+      expect(result.warnings()[0].text).toBe(
+        "found .foo (plugin/warn-about-foo)"
+      );
+      expect(result.warnings()[0].node).toBeTruthy();
+    });
 });
 
 it("another plugin runs", () => {
-  return processorRelative.process(cssWithoutFoo).then(result => {
-    expect(result.warnings().length).toBe(1);
-    expect(result.warnings()[0].text).toBe(
-      "Unexpected empty block (block-no-empty)"
-    );
-  });
+  return processorRelative
+    .process(cssWithoutFoo, { from: undefined })
+    .then(result => {
+      expect(result.warnings().length).toBe(1);
+      expect(result.warnings()[0].text).toBe(
+        "Unexpected empty block (block-no-empty)"
+      );
+    });
 });
 
 it("plugin with absolute path and no configBasedir", () => {
-  return processorAbsolute.process(cssWithFoo).then(result => {
-    expect(result.warnings().length).toBe(2);
-    expect(result.warnings()[0].text).toBe(
-      "found .foo (plugin/warn-about-foo)"
-    );
-    expect(result.warnings()[0].node).toBeTruthy();
-  });
+  return processorAbsolute
+    .process(cssWithFoo, { from: undefined })
+    .then(result => {
+      expect(result.warnings().length).toBe(2);
+      expect(result.warnings()[0].text).toBe(
+        "found .foo (plugin/warn-about-foo)"
+      );
+      expect(result.warnings()[0].node).toBeTruthy();
+    });
 });
 
 it("config extending another config that invokes a plugin with a relative path", () => {
-  return processorExtendRelative.process(cssWithFoo).then(result => {
-    expect(result.warnings().length).toBe(1);
-    expect(result.warnings()[0].text).toBe(
-      "found .foo (plugin/warn-about-foo)"
-    );
-    expect(result.warnings()[0].node).toBeTruthy();
-  });
+  return processorExtendRelative
+    .process(cssWithFoo, { from: undefined })
+    .then(result => {
+      expect(result.warnings().length).toBe(1);
+      expect(result.warnings()[0].text).toBe(
+        "found .foo (plugin/warn-about-foo)"
+      );
+      expect(result.warnings()[0].node).toBeTruthy();
+    });
 });
 
 it("config with its own plugins extending another config that invokes a plugin with a relative path", () => {
   return processorRelativeAndExtendRelative
-    .process(cssWithFooAndBar)
+    .process(cssWithFooAndBar, { from: undefined })
     .then(result => {
       expect(result.warnings().length).toBe(2);
       expect(result.warnings()[0].text).toBe(
@@ -130,7 +138,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
   it("with uppercase expectation and lowercase color", () => {
     return postcss()
       .use(stylelint(config("upper")))
-      .process(cssWithDirectiveLower)
+      .process(cssWithDirectiveLower, { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(1);
         expect(result.warnings()[0].text).toBe(
@@ -142,7 +150,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
   it("with uppercase expectation and uppercase color", () => {
     return postcss()
       .use(stylelint(config("upper")))
-      .process(cssWithDirectiveUpper)
+      .process(cssWithDirectiveUpper, { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(0);
       });
@@ -151,7 +159,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
   it("with lowercase expectation and uppercase color", () => {
     return postcss()
       .use(stylelint(config("lower")))
-      .process(cssWithDirectiveUpper)
+      .process(cssWithDirectiveUpper, { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(1);
         expect(result.warnings()[0].text).toBe(
@@ -163,7 +171,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
   it("with lowercase expectation and lowercase color", () => {
     return postcss()
       .use(stylelint(config("lower")))
-      .process(cssWithDirectiveLower)
+      .process(cssWithDirectiveLower, { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(0);
       });
@@ -172,7 +180,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
   it("with uppercase expectation and lowercase color without directive", () => {
     return postcss()
       .use(stylelint(config("upper")))
-      .process(cssWithoutDirectiveLower)
+      .process(cssWithoutDirectiveLower, { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(0);
       });
@@ -181,7 +189,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
   it("with uppercase expectation and uppercase color without directive", () => {
     return postcss()
       .use(stylelint(config("lower")))
-      .process(cssWithoutDirectiveUpper)
+      .process(cssWithoutDirectiveUpper, { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(0);
       });
@@ -200,7 +208,7 @@ describe("module providing an array of plugins", () => {
   it("first plugin works", () => {
     return postcss()
       .use(stylelint(config))
-      .process("@@check-color-hex-case a { color: #eee; }")
+      .process("@@check-color-hex-case a { color: #eee; }", { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(1);
         expect(result.warnings()[0].text).toBe(
@@ -212,7 +220,7 @@ describe("module providing an array of plugins", () => {
   it("second plugin works", () => {
     return postcss()
       .use(stylelint(config))
-      .process(".foo {}")
+      .process(".foo {}", { from: undefined })
       .then(result => {
         expect(result.warnings().length).toBe(1);
         expect(result.warnings()[0].text).toBe(
@@ -232,7 +240,7 @@ it("slashless plugin causes configuration error", () => {
 
   return postcss()
     .use(stylelint(config))
-    .process(".foo {}")
+    .process(".foo {}", { from: undefined })
     .then(() => {
       throw new Error("should not have succeeded");
     })
@@ -254,7 +262,7 @@ it("plugin with primary option array", () => {
   };
   return postcss()
     .use(stylelint(config))
-    .process("a {}")
+    .process("a {}", { from: undefined })
     .then(result => {
       expect(result.warnings().length).toBe(0);
     });
@@ -269,7 +277,7 @@ it("plugin with primary option array within options array", () => {
   };
   return postcss()
     .use(stylelint(config))
-    .process("a {}")
+    .process("a {}", { from: undefined })
     .then(result => {
       expect(result.warnings().length).toBe(0);
     });
@@ -284,7 +292,7 @@ it("plugin with async rule", () => {
   };
   return postcss()
     .use(stylelint(config))
-    .process("a {}")
+    .process("a {}", { from: undefined })
     .then(result => {
       expect(result.warnings().length).toBe(1);
     });
@@ -313,7 +321,7 @@ describe("loading a plugin from process.cwd", () => {
   beforeEach(() => {
     return postcss()
       .use(stylelint(config))
-      .process(".foo {}")
+      .process(".foo {}", { from: undefined })
       .then(data => (result = data));
   });
 

--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -6,7 +6,7 @@ const postcssPlugin = require("../postcssPlugin");
 
 it("`config` option is `null`", () => {
   return postcssPlugin
-    .process("a {}")
+    .process("a {}", { from: undefined })
     .then(() => {
       throw new Error("should not have succeeded");
     })
@@ -19,16 +19,18 @@ it("`configFile` option with absolute path", () => {
   const config = {
     configFile: path.join(__dirname, "fixtures/config-block-no-empty.json")
   };
-  return postcssPlugin.process("a {}", {}, config).then(postcssResult => {
-    const warnings = postcssResult.warnings();
-    expect(warnings.length).toBe(1);
-    expect(warnings[0].text.indexOf("block-no-empty")).not.toBe(-1);
-  });
+  return postcssPlugin
+    .process("a {}", { from: undefined }, config)
+    .then(postcssResult => {
+      const warnings = postcssResult.warnings();
+      expect(warnings.length).toBe(1);
+      expect(warnings[0].text.indexOf("block-no-empty")).not.toBe(-1);
+    });
 });
 
 it("`configFile` with bad path", () => {
   return postcssPlugin
-    .process("a {}", {}, { configFile: "./herby.json" })
+    .process("a {}", { from: undefined }, { configFile: "./herby.json" })
     .then(() => {
       throw new Error("should not have succeeded");
     })
@@ -42,7 +44,7 @@ it("`configFile` option without rules", () => {
     configFile: path.join(__dirname, "fixtures/config-without-rules.json")
   };
   return postcssPlugin
-    .process("a {}", {}, config)
+    .process("a {}", { from: undefined }, config)
     .then(() => {
       throw new Error("should not have succeeded");
     })
@@ -61,7 +63,7 @@ it("`configFile` option with undefined rule", () => {
   };
   const ruleName = "unknown-rule";
   return postcssPlugin
-    .process("a {}", {}, config)
+    .process("a {}", { from: undefined }, config)
     .then(() => {
       throw new Error("should not have succeeded");
     })
@@ -78,9 +80,11 @@ it("`ignoreFiles` options is not empty and file ignored", () => {
     ignoreFiles: "**/foo.css",
     from: "foo.css"
   };
-  return postcssPlugin.process("a {}", {}, config).then(postcssResult => {
-    expect(postcssResult.stylelint.ignored).toBeTruthy();
-  });
+  return postcssPlugin
+    .process("a {}", { from: undefined }, config)
+    .then(postcssResult => {
+      expect(postcssResult.stylelint.ignored).toBeTruthy();
+    });
 });
 
 it("`ignoreFiles` options is not empty and file not ignored", () => {
@@ -91,7 +95,9 @@ it("`ignoreFiles` options is not empty and file not ignored", () => {
     ignoreFiles: "**/bar.css",
     from: "foo.css"
   };
-  return postcssPlugin.process("a {}", {}, config).then(postcssResult => {
-    expect(postcssResult.stylelint.ignored).toBeFalsy();
-  });
+  return postcssPlugin
+    .process("a {}", { from: undefined }, config)
+    .then(postcssResult => {
+      expect(postcssResult.stylelint.ignored).toBeFalsy();
+    });
 });

--- a/lib/testUtils/createRuleTester.js
+++ b/lib/testUtils/createRuleTester.js
@@ -167,7 +167,7 @@ function processGroup(rule, schema, equalityCheck) {
 
     return processor
       .use(rule(rulePrimaryOptions, ruleSecondaryOptions))
-      .process(code, postcssProcessOptions);
+      .process(code, { postcssProcessOptions, from: undefined });
   }
 
   // Apply the basic positive checks unless

--- a/lib/utils/__tests__/addEmptyLineBefore.test.js
+++ b/lib/utils/__tests__/addEmptyLineBefore.test.js
@@ -6,7 +6,7 @@ const postcss = require("postcss");
 describe("addEmptyLineBefore", () => {
   it("adds single newline to the newline at the beginning", () => {
     return postcss()
-      .process("a {}\n  b{}")
+      .process("a {}\n  b{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}\n\n  b{}");
@@ -15,7 +15,7 @@ describe("addEmptyLineBefore", () => {
 
   it("adds single newline to newline at the beginning with CRLF", () => {
     return postcss()
-      .process("a {}\r\n  b{}")
+      .process("a {}\r\n  b{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}");
@@ -24,7 +24,7 @@ describe("addEmptyLineBefore", () => {
 
   it("adds single newline to newline at the end", () => {
     return postcss()
-      .process("a {}\t\nb{}")
+      .process("a {}\t\nb{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}\t\n\nb{}");
@@ -33,7 +33,7 @@ describe("addEmptyLineBefore", () => {
 
   it("adds single newline to newline at the end with CRLF", () => {
     return postcss()
-      .process("a {}\t\r\nb{}")
+      .process("a {}\t\r\nb{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}\t\r\n\r\nb{}");
@@ -42,7 +42,7 @@ describe("addEmptyLineBefore", () => {
 
   it("adds single newline to newline in the middle", () => {
     return postcss()
-      .process("a {}  \n\tb{}")
+      .process("a {}  \n\tb{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}  \n\n\tb{}");
@@ -51,7 +51,7 @@ describe("addEmptyLineBefore", () => {
 
   it("adds single newline to newline in the middle with CRLF", () => {
     return postcss()
-      .process("a {}  \r\n\tb{}")
+      .process("a {}  \r\n\tb{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}  \r\n\r\n\tb{}");
@@ -60,7 +60,7 @@ describe("addEmptyLineBefore", () => {
 
   it("adds two newlines if there aren't any existing newlines", () => {
     return postcss()
-      .process("a {}  b{}")
+      .process("a {}  b{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}\n\n  b{}");
@@ -69,7 +69,7 @@ describe("addEmptyLineBefore", () => {
 
   it("adds two newlines if there aren't any existing newlines with CRLF", () => {
     return postcss()
-      .process("a {}  b{}")
+      .process("a {}  b{}", { from: undefined })
       .then(result => {
         addEmptyLineBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}\r\n\r\n  b{}");

--- a/lib/utils/__tests__/atRuleParamIndex.test.js
+++ b/lib/utils/__tests__/atRuleParamIndex.test.js
@@ -31,7 +31,7 @@ describe("atRuleParamIndex", () => {
 
 function atRules(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkAtRules(cb);
     });

--- a/lib/utils/__tests__/declarationValueIndex.test.js
+++ b/lib/utils/__tests__/declarationValueIndex.test.js
@@ -37,7 +37,7 @@ describe("declarationValueIndex", () => {
 
 function rules(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkDecls(cb);
     });

--- a/lib/utils/__tests__/findAtRuleContext.test.js
+++ b/lib/utils/__tests__/findAtRuleContext.test.js
@@ -16,7 +16,7 @@ it("findAtRuleContext", () => {
   `;
 
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       result.root.walkRules(rule => {
         switch (rule.selector) {

--- a/lib/utils/__tests__/isCustomPropertySet.test.js
+++ b/lib/utils/__tests__/isCustomPropertySet.test.js
@@ -19,7 +19,7 @@ describe("isCustomPropertySet", () => {
 
 function customPropertySet(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       result.root.walk(cb);
     });

--- a/lib/utils/__tests__/isKeyframeRule.test.js
+++ b/lib/utils/__tests__/isKeyframeRule.test.js
@@ -67,7 +67,7 @@ describe("isKeyframeRule", () => {
 
 function rules(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkDecls(cb);
     });

--- a/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
@@ -87,7 +87,7 @@ describe("isStandardSyntaxAtRule", () => {
 
 function atRules(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkAtRules(cb);
     });
@@ -95,7 +95,7 @@ function atRules(css, cb) {
 
 function scssAtRules(css, cb) {
   return postcss()
-    .process(css, { syntax: scss })
+    .process(css, { syntax: scss, from: undefined })
     .then(result => {
       return result.root.walkAtRules(cb);
     });
@@ -103,7 +103,7 @@ function scssAtRules(css, cb) {
 
 function lessAtRules(css, cb) {
   return postcss()
-    .process(css, { syntax: less })
+    .process(css, { syntax: less, from: undefined })
     .then(result => {
       return result.root.walkAtRules(cb);
     });

--- a/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
@@ -135,7 +135,7 @@ describe("isStandardSyntaxDeclaration", () => {
 
 function decls(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkDecls(cb);
     });
@@ -143,7 +143,7 @@ function decls(css, cb) {
 
 function scssDecls(css, cb) {
   return postcss()
-    .process(css, { syntax: scss })
+    .process(css, { syntax: scss, from: undefined })
     .then(result => {
       return result.root.walkDecls(cb);
     });
@@ -151,7 +151,7 @@ function scssDecls(css, cb) {
 
 function lessDecls(css, cb) {
   return postcss()
-    .process(css, { syntax: less })
+    .process(css, { syntax: less, from: undefined })
     .then(result => {
       return result.root.walkDecls(cb);
     });

--- a/lib/utils/__tests__/isStandardSyntaxFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxFunction.test.js
@@ -32,7 +32,7 @@ describe("isStandardSyntaxFunction", () => {
 
 function funcs(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkDecls(decl => {
         valueParser(decl.value).walk(valueNode => {

--- a/lib/utils/__tests__/isStandardSyntaxRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxRule.test.js
@@ -159,7 +159,7 @@ describe("isStandardSyntaxRule", () => {
 
 function rules(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkRules(cb);
     });
@@ -167,7 +167,7 @@ function rules(css, cb) {
 
 function lessRules(css, cb) {
   return postcss()
-    .process(css, { syntax: less })
+    .process(css, { syntax: less, from: undefined })
     .then(result => {
       return result.root.walkRules(cb);
     });

--- a/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
@@ -94,7 +94,7 @@ describe("isStandardSyntaxTypeSelector", () => {
 
 function rules(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       return result.root.walkRules(rule => {
         selectorParser(selectorAST => {

--- a/lib/utils/__tests__/nextNonCommentNode.test.js
+++ b/lib/utils/__tests__/nextNonCommentNode.test.js
@@ -20,7 +20,7 @@ describe("nextNonCommentNode", () => {
 
   it("next node is a selector preceded by a comment", () => {
     return postcss()
-      .process(caseA)
+      .process(caseA, { from: undefined })
       .then(result => {
         result.root.walkRules(rule => {
           if (rule.selector === "a") {
@@ -36,7 +36,7 @@ describe("nextNonCommentNode", () => {
 
   it("next node does not exist", () => {
     return postcss()
-      .process(caseA)
+      .process(caseA, { from: undefined })
       .then(result => {
         result.root.walkRules(rule => {
           if (rule.selector === "a") {
@@ -52,7 +52,7 @@ describe("nextNonCommentNode", () => {
 
   it("next node is a declaration preceded by a comment", () => {
     return postcss()
-      .process(caseB)
+      .process(caseB, { from: undefined })
       .then(result => {
         result.root.walkRules(rule => {
           aNode = rule;
@@ -66,7 +66,7 @@ describe("nextNonCommentNode", () => {
 
   it("next node is null preceded by a comment", () => {
     return postcss()
-      .process(caseB)
+      .process(caseB, { from: undefined })
       .then(result => {
         result.root.walkDecls(rule => {
           colorNode = rule;

--- a/lib/utils/__tests__/removeEmptyLineBefore.test.js
+++ b/lib/utils/__tests__/removeEmptyLineBefore.test.js
@@ -6,7 +6,7 @@ const removeEmptyLinesBefore = require("../removeEmptyLinesBefore");
 describe("removeEmptyLinesBefore", () => {
   it("removes single newline from the newline at the beginning", () => {
     return postcss()
-      .process("a {}\n\n  b{}")
+      .process("a {}\n\n  b{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}\n  b{}");
@@ -15,7 +15,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes single newline from newline at the beginning with CRLF", () => {
     return postcss()
-      .process("a {}\r\n\r\n  b{}")
+      .process("a {}\r\n\r\n  b{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}\r\n  b{}");
@@ -24,7 +24,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes single newline from newline at the end", () => {
     return postcss()
-      .process("a {}\t\n\nb{}")
+      .process("a {}\t\n\nb{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}\t\nb{}");
@@ -33,7 +33,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes single newline from newline at the end with CRLF", () => {
     return postcss()
-      .process("a {}\t\r\n\r\nb{}")
+      .process("a {}\t\r\n\r\nb{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}\t\r\nb{}");
@@ -42,7 +42,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes single newline from newline in the middle", () => {
     return postcss()
-      .process("a {}  \n\n\tb{}")
+      .process("a {}  \n\n\tb{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}  \n\tb{}");
@@ -51,7 +51,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes single newline to newline in the middle with CRLF", () => {
     return postcss()
-      .process("a {}  \r\n\r\n\tb{}")
+      .process("a {}  \r\n\r\n\tb{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}  \r\n\tb{}");
@@ -60,7 +60,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes two newlines if there are three newlines", () => {
     return postcss()
-      .process("a {}\n\n\n  b{}")
+      .process("a {}\n\n\n  b{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}\n  b{}");
@@ -69,7 +69,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes two newlines if there are three newlines with CRLF", () => {
     return postcss()
-      .process("a {}\r\n\r\n\r\n  b{}")
+      .process("a {}\r\n\r\n\r\n  b{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}\r\n  b{}");
@@ -78,7 +78,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes three newlines if there are four newlines", () => {
     return postcss()
-      .process("a {}\n\n\n\n  b{}")
+      .process("a {}\n\n\n\n  b{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\n");
         expect(result.root.toString()).toBe("a {}\n  b{}");
@@ -87,7 +87,7 @@ describe("removeEmptyLinesBefore", () => {
 
   it("removes three newlines if there are four newlines with CRLF", () => {
     return postcss()
-      .process("a {}\r\n\r\n\r\n\r\n  b{}")
+      .process("a {}\r\n\r\n\r\n\r\n  b{}", { from: undefined })
       .then(result => {
         removeEmptyLinesBefore(result.root.nodes[1], "\r\n");
         expect(result.root.toString()).toBe("a {}\r\n  b{}");

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "micromatch": "^2.3.11",
     "normalize-selector": "^0.2.0",
     "pify": "^3.0.0",
-    "postcss": "^6.0.6",
+    "postcss": "^6.0.15",
     "postcss-html": "^0.12.0",
     "postcss-less": "^1.1.0",
     "postcss-media-query-parser": "^0.2.3",


### PR DESCRIPTION
After updating to PostCSS v6.0.15 a bunch of console warnings are displayed during test runs:

```shell
 PASS  lib/testUtils/__tests__/createRuleTester.test.js
  ● Console

    console.warn node_modules/postcss/lib/warn-once.js:11
      Witout `from` option PostCSS could generate wrong source map or do not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning
```

[PostCSS v6.0.15 release notes](https://github.com/postcss/postcss/releases/tag/6.0.15): _"Add warning about missed from option on `process().then()` call."_