### PR TITLE
Add Table of Contents marker to docs

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -4,6 +4,8 @@ Plugins are rules and sets of rules built by the community.
 
 We recommend familiarising yourself and adhering to stylelint's [conventions for writing rules](rules.md), including those for names, options, messages, tests and docs.
 
+<!-- TOC -->
+
 ## The anatomy of a plugin
 
 ```js

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -10,6 +10,8 @@ If you like stylelint and open source software (since you're reading this, you a
 
 Also: we hope that your participation in the project isn't a one-off. *We'd love to add more members to the organization and see more regulars pop up in issues and pull requests!*
 
+<!-- TOC -->
+
 ## Creating a new rule
 
 First, open [an issue](https://github.com/stylelint/stylelint/issues/new) with your idea for the new rule.

--- a/docs/user-guide/about-rules.md
+++ b/docs/user-guide/about-rules.md
@@ -4,6 +4,8 @@ We have taken great care to consistently name rules.
 
 The rules have been designed to work in conjunction with one another so that strict conventions can be enforced.
 
+<!-- TOC -->
+
 ## About rule names
 
 -   Made of lowercase words separated by hyphens.

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -8,6 +8,8 @@ stylelint is an [npm package](https://www.npmjs.com/package/stylelint). Install 
 npm install -g stylelint
 ```
 
+<!-- TOC -->
+
 ## Usage
 
 `stylelint --help` prints the CLI documentation.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -2,6 +2,8 @@
 
 The linter *expects a configuration object*. You can either craft your own config or extend an existing one.
 
+<!-- TOC -->
+
 ## Loading the configuration object
 
 Finding and loading of your configuration object is done with [cosmiconfig](https://github.com/davidtheclark/cosmiconfig). Starting from the current working directory, it will look for the following possible sources, in this order:

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,5 +1,7 @@
 # FAQ
 
+<!-- TOC -->
+
 ## How do I turn off, disable or ignore a rule?
 
 You can turn off a rule by setting its config value to `null`.

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -7,6 +7,8 @@ stylelint.lint(options)
   .then(function(resultObject) { .. });
 ```
 
+<!-- TOC -->
+
 ## Installation
 
 stylelint is an [npm package](https://www.npmjs.com/package/stylelint). Install it using:

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -4,6 +4,8 @@ As with any other [PostCSS plugin](https://github.com/postcss/postcss#plugins), 
 
 *However, if a dedicated stylelint task runner plugin [is available](complementary-tools.md) (e.g. [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) or [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint)) we recommend you use that rather than this plugin, as they provide better reporting.*
 
+<!-- TOC -->
+
 ## Installation
 
 stylelint is an [npm package](https://www.npmjs.com/package/stylelint). Install it using:

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -10,6 +10,8 @@ In addition to these rules there are [plugins](plugins.md), which are rules buil
 
 Here are all the rules within stylelint, grouped first [by category](../../VISION.md) and then by the [*thing*](http://apps.workflower.fi/vocabs/css/en) they apply to.
 
+<!-- TOC -->
+
 ### Possible errors
 
 #### Color

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -10,7 +10,9 @@ In addition to these rules there are [plugins](plugins.md), which are rules buil
 
 Here are all the rules within stylelint, grouped first [by category](../../VISION.md) and then by the [*thing*](http://apps.workflower.fi/vocabs/css/en) they apply to.
 
-<!-- TOC -->
+-   [Possible errors](#possible-errors)
+-   [Limit language features](#limit-language-features)
+-   [Stylistic issues](#stylistic-issues)
 
 ### Possible errors
 


### PR DESCRIPTION
Continue making our site better https://github.com/stylelint/stylelint.io/issues/42. Added TOC for pages, where it makes sense.

Looks pretty good:

![screen shot 2018-01-03 at 23 14 56](https://user-images.githubusercontent.com/654597/34542845-9c0ae628-f0de-11e7-87d0-0031a8c744ca.png)

I have concerns about List of rules, though:

![localhost_3333_user-guide_rules_](https://user-images.githubusercontent.com/654597/34542869-ada09a90-f0de-11e7-83ad-b82341dbecec.png)
