### PR TITLE
Add ignore: ["first-nested"] to custom-property-empty-line-before

### DIFF
--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -206,7 +206,7 @@ a {
 }
 ```
 
-### `ignore: ["after-comment", "inside-single-line-block"]`
+### `ignore: ["after-comment", "first-nested", "inside-single-line-block"]`
 
 #### `"after-comment"`
 
@@ -220,6 +220,21 @@ The following patterns are *not* considered violations:
 a {
   /* comment */
   --foo: pink;
+}
+```
+
+#### `"first-nested"`
+
+Ignore custom properties that are nested and the first child of their parent node.
+
+For example, with `"always"`:
+
+The following patterns are *not* considered violations:
+
+```css
+a {
+  --foo: pink;
+  --bar: red;
 }
 ```
 

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -234,6 +234,7 @@ The following patterns are *not* considered violations:
 ```css
 a {
   --foo: pink;
+
   --bar: red;
 }
 ```

--- a/lib/rules/custom-property-empty-line-before/__tests__/index.js
+++ b/lib/rules/custom-property-empty-line-before/__tests__/index.js
@@ -134,6 +134,61 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: ["always", { ignore: ["first-nested"] }],
+  fix: true,
+
+  accept: [
+    {
+      code: "a {\n --custom-prop: value;\n\n --custom-prop2: value;\n}"
+    },
+    {
+      code: "a {\n\n --custom-prop: value;\n\n --custom-prop2: value;\n}"
+    },
+    {
+      code: "a {\r\n --custom-prop: value;\r\n\r\n --custom-prop2: value;\r\n}"
+    },
+    {
+      code:
+        "a {\r\n\r\n --custom-prop: value;\r\n\r\n --custom-prop2: value;\r\n}"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a {\n --custom-prop: value;\n --custom-prop2: value;\n}",
+      fixed: "a {\n --custom-prop: value;\n\n --custom-prop2: value;\n}",
+      message: messages.expected,
+      line: 3,
+      column: 2
+    },
+    {
+      code: "a {\n\n --custom-prop: value;\n --custom-prop2: value;\n}",
+      fixed: "a {\n\n --custom-prop: value;\n\n --custom-prop2: value;\n}",
+      message: messages.expected,
+      line: 4,
+      column: 2
+    },
+    {
+      code: "a {\r\n --custom-prop: value;\r\n --custom-prop2: value;\r\n}",
+      fixed:
+        "a {\r\n --custom-prop: value;\r\n\r\n --custom-prop2: value;\r\n}",
+      message: messages.expected,
+      line: 3,
+      column: 2
+    },
+    {
+      code: "a {\r\n\r\n --custom-prop: value;\r\n --custom-prop2: value;\r\n}",
+      fixed:
+        "a {\r\n\r\n --custom-prop: value;\r\n\r\n --custom-prop2: value;\r\n}",
+      message: messages.expected,
+      line: 4,
+      column: 2
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: ["always", { ignore: ["inside-single-line-block"] }],
   fix: true,
 

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -35,7 +35,7 @@ const rule = function(expectation, options, context) {
         actual: options,
         possible: {
           except: ["first-nested", "after-comment", "after-custom-property"],
-          ignore: ["after-comment", "inside-single-line-block"]
+          ignore: ["after-comment", "first-nested", "inside-single-line-block"]
         },
         optional: true
       }
@@ -59,6 +59,14 @@ const rule = function(expectation, options, context) {
       if (
         optionsMatches(options, "ignore", "after-comment") &&
         isAfterComment(decl)
+      ) {
+        return;
+      }
+
+      // Optionally ignore the node if it is the first nested
+      if (
+        optionsMatches(options, "ignore", "first-nested") &&
+        isFirstNested(decl)
       ) {
         return;
       }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3102 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
