### PR TITLE
 Remove PostCSS console warnings

### DIFF
--- a/lib/utils/__tests__/isStandardSyntaxCombinator.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxCombinator.test.js
@@ -64,7 +64,9 @@ describe("isStandardSyntaxCombinator", () => {
 
 function rules(css, cb) {
   return postcss()
-    .process(css)
+    .process(css, {
+      from: undefined
+    })
     .then(result => {
       return result.root.walkRules(rule => {
         selectorParser(selectorAST => {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "micromatch": "^2.3.11",
     "normalize-selector": "^0.2.0",
     "pify": "^3.0.0",
-    "postcss": "^6.0.15",
+    "postcss": "^6.0.16",
     "postcss-html": "^0.12.0",
     "postcss-less": "^1.1.0",
     "postcss-media-query-parser": "^0.2.3",


### PR DESCRIPTION
After merge #3088, a console warnings are displayed during test runs:
```shell
PASS lib/utils/__tests__/isStandardSyntaxCombinator.test.js
  ● Console
    console.warn node_modules/postcss/lib/warn-once.js:11
      Witout `from` option PostCSS could generate wrong source map or do not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning
```
https://ci.appveyor.com/project/stylelint/stylelint/build/5255#L213