### PR TITLE
Fix selector-max-id tests

### DIFF
--- a/lib/rules/selector-max-id/__tests__/index.js
+++ b/lib/rules/selector-max-id/__tests__/index.js
@@ -204,7 +204,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [true],
+  config: [0],
   skipBasicChecks: true,
   syntax: "scss",
 
@@ -250,7 +250,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [true],
+  config: [0],
   skipBasicChecks: true,
   syntax: "less",
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Some tests are using incorrect config value. As it fixes tests, which were not run previously, #3113 might break.
