### PR TITLE
chore: Add a npm script to help update flow-type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "benchmark-rule": "node scripts/benchmark-rule.js",
     "dry-release": "npmpub  --dry --verbose",
     "flow": "flow",
+    "flow-defs": "npx flow-typed --libdefDir decls/ install jest@22 lodash@4 && mv -fv decls/npm/lodash_v4.x.x.js decls/flow-typed/lodash.js && mv -fv decls/npm/jest_v22.x.x.js decls/flow-typed/jest.js",
     "jest": "jest",
     "jest:detectleaks": "jest  --detectLeaks",
     "lint:js": "eslint . --cache",


### PR DESCRIPTION
Follow up to #3141

Running `npm run flow-defs` will automatically pull in any changes to the Flow Typed definitions (JEst and Lodash) that I've been manually perform.

It's not perfect, requires npm 5.x's `npx` binary

Will need updating when a major release of Jest or Lodash is released

The file header comments will be changed from our custom header to that of flow-typed's which I see no issue using, e.g.:

```diff
-// https://raw.githubusercontent.com/flowtype/flow-typed/master/definitions/npm/lodash_v4.x.x/flow_v0.55.x-/lodash_v4.x.x.js
+// flow-typed signature: ecb7b8a61ec89cf960fc7107c631a878
+// flow-typed version: 4bb4517f17/lodash_v4.x.x/flow_>=v0.63.x
```