### PR TITLE
Add autofix to unit-case

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -240,7 +240,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 #### Unit
 
--   [`unit-case`](../../lib/rules/unit-case/README.md): Specify lowercase or uppercase for units.
+-   [`unit-case`](../../lib/rules/unit-case/README.md): Specify lowercase or uppercase for units (Autofixable).
 
 #### Value
 

--- a/lib/rules/unit-case/README.md
+++ b/lib/rules/unit-case/README.md
@@ -8,6 +8,8 @@ Specify lowercase or uppercase for units.
  *     These units */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"lower"|"upper"`

--- a/lib/rules/unit-case/__tests__/index.js
+++ b/lib/rules/unit-case/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["lower"],
+  fix: true,
 
   accept: [
     {
@@ -134,78 +135,91 @@ testRule(rule, {
   reject: [
     {
       code: "a { width: 10pX; }",
+      fixed: "a { width: 10px; }",
       message: messages.expected("pX", "px"),
       line: 1,
       column: 12
     },
     {
       code: "a { width: 10Px; }",
+      fixed: "a { width: 10px; }",
       message: messages.expected("Px", "px"),
       line: 1,
       column: 12
     },
     {
       code: "a { width: 10PX; }",
+      fixed: "a { width: 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 12
     },
     {
       code: "a { margin: 10px 10PX; }",
+      fixed: "a { margin: 10px 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 18
     },
     {
       code: "a { font-size: .5REM; }",
+      fixed: "a { font-size: .5rem; }",
       message: messages.expected("REM", "rem"),
       line: 1,
       column: 16
     },
     {
       code: "a { font-size: 0.5REM; }",
+      fixed: "a { font-size: 0.5rem; }",
       message: messages.expected("REM", "rem"),
       line: 1,
       column: 16
     },
     {
       code: "a { margin: calc(10px + 10PX); }",
+      fixed: "a { margin: calc(10px + 10px); }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 25
     },
     {
       code: "a { top: calc(10px*2REM); }",
+      fixed: "a { top: calc(10px*2rem); }",
       message: messages.expected("REM", "rem"),
       line: 1,
       column: 20
     },
     {
       code: "a { margin: -webkit-calc(13PX + 10px); }",
+      fixed: "a { margin: -webkit-calc(13px + 10px); }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 26
     },
     {
       code: "a { margin: some-function(13PX + 10px); }",
+      fixed: "a { margin: some-function(13px + 10px); }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 27
     },
     {
       code: "root { --margin: 10PX; }",
+      fixed: "root { --margin: 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 18
     },
     {
       code: "root { --margin: 10px + 10PX; }",
+      fixed: "root { --margin: 10px + 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 25
     },
     {
       code: "a { margin: 13XPX; }",
+      fixed: "a { margin: 13xpx; }",
       message: messages.expected("XPX", "xpx"),
       description: "work with unknown units",
       line: 1,
@@ -213,6 +227,7 @@ testRule(rule, {
     },
     {
       code: "@media (min-width: 13PX) {}",
+      fixed: "@media (min-width: 13px) {}",
       message: messages.expected("PX", "px"),
       description: "@media",
       line: 1,
@@ -220,6 +235,7 @@ testRule(rule, {
     },
     {
       code: "@media (min-width: 10px)\n  and (max-width: 20PX) {}",
+      fixed: "@media (min-width: 10px)\n  and (max-width: 20px) {}",
       message: messages.expected("PX", "px"),
       description: "complex @media",
       line: 2,
@@ -227,6 +243,7 @@ testRule(rule, {
     },
     {
       code: "@media (width < 10.01REM) {}",
+      fixed: "@media (width < 10.01rem) {}",
       message: messages.expected("REM", "rem"),
       description: "media feature range",
       line: 1,
@@ -234,10 +251,26 @@ testRule(rule, {
     },
     {
       code: "@media not screen and (min-width: 100PX) {}",
+      fixed: "@media not screen and (min-width: 100px) {}",
       message: messages.expected("PX", "px"),
       description: "negation @media",
       line: 1,
       column: 35
+    },
+    {
+      code: "@media not screen and (min-width: 100PX) { width: 100Px; }",
+      fixed: "@media not screen and (min-width: 100px) { width: 100px; }",
+      message: messages.expected("PX", "px"),
+      description: "negation @media",
+      line: 1,
+      column: 35
+    },
+    {
+      code: 'a { background: url("10PX.png") 10PX 20px no-repeat; }',
+      fixed: 'a { background: url("10PX.png") 10px 20px no-repeat; }',
+      message: messages.expected("PX", "px"),
+      line: 1,
+      column: 33
     }
   ]
 });
@@ -246,6 +279,7 @@ testRule(rule, {
   ruleName,
   syntax: "scss",
   config: ["lower"],
+  fix: true,
 
   accept: [
     {
@@ -261,66 +295,77 @@ testRule(rule, {
   reject: [
     {
       code: "a { margin: 10PX; }",
+      fixed: "a { margin: 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 13
     },
     {
       code: "a { margin: 10pX; }",
+      fixed: "a { margin: 10px; }",
       message: messages.expected("pX", "px"),
       line: 1,
       column: 13
     },
     {
       code: "a { margin: 10Px; }",
+      fixed: "a { margin: 10px; }",
       message: messages.expected("Px", "px"),
       line: 1,
       column: 13
     },
     {
       code: "a { margin: 10PX + 10px; }",
+      fixed: "a { margin: 10px + 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 13
     },
     {
       code: "a { $margin: 10PX; }",
+      fixed: "a { $margin: 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 14
     },
     {
       code: "a { $margin: 10px + 10PX; }",
+      fixed: "a { $margin: 10px + 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 21
     },
     {
       code: "a { margin: $margin + 10PX; }",
+      fixed: "a { margin: $margin + 10px; }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 23
     },
     {
       code: "$breakpoints: ( small: 767px, medium: 992PX, large: 1200px );",
+      fixed: "$breakpoints: ( small: 767px, medium: 992px, large: 1200px );",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 39
     },
     {
       code: "a { font: (italic bold 10px/8PX) }",
+      fixed: "a { font: (italic bold 10px/8px) }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 29
     },
     {
       code: "font: 14PX/#{$line-height};",
+      fixed: "font: 14px/#{$line-height};",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 7
     },
     {
       code: "a { margin: calc(100% - #{$margin * 2PX}); }",
+      fixed: "a { margin: calc(100% - #{$margin * 2px}); }",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 37
@@ -332,6 +377,7 @@ testRule(rule, {
   ruleName,
   syntax: "less",
   config: ["lower"],
+  fix: true,
 
   accept: [
     {
@@ -343,18 +389,21 @@ testRule(rule, {
   reject: [
     {
       code: "@variable: 10PX",
+      fixed: "@variable: 10px",
       message: messages.expected("PX", "px"),
       line: 1,
       column: 12
     },
     {
       code: "@variable: 10pX",
+      fixed: "@variable: 10px",
       message: messages.expected("pX", "px"),
       line: 1,
       column: 12
     },
     {
       code: "@variable: 10Px",
+      fixed: "@variable: 10px",
       message: messages.expected("Px", "px"),
       line: 1,
       column: 12
@@ -365,6 +414,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["upper"],
+  fix: true,
 
   accept: [
     {
@@ -470,72 +520,84 @@ testRule(rule, {
   reject: [
     {
       code: "a { width: 10pX; }",
+      fixed: "a { width: 10PX; }",
       message: messages.expected("pX", "PX"),
       line: 1,
       column: 12
     },
     {
       code: "a { width: 10Px; }",
+      fixed: "a { width: 10PX; }",
       message: messages.expected("Px", "PX"),
       line: 1,
       column: 12
     },
     {
       code: "a { width: 10px; }",
+      fixed: "a { width: 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 12
     },
     {
       code: "a { font-size: .5rem; }",
+      fixed: "a { font-size: .5REM; }",
       message: messages.expected("rem", "REM"),
       line: 1,
       column: 16
     },
     {
       code: "a { font-size: 0.5rem; }",
+      fixed: "a { font-size: 0.5REM; }",
       message: messages.expected("rem", "REM"),
       line: 1,
       column: 16
     },
     {
       code: "a { margin: 10PX 10px; }",
+      fixed: "a { margin: 10PX 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 18
     },
     {
       code: "a { margin: calc(10PX + 10px); }",
+      fixed: "a { margin: calc(10PX + 10PX); }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 25
     },
     {
       code: "a { margin: -webkit-calc(13px + 10PX); }",
+      fixed: "a { margin: -webkit-calc(13PX + 10PX); }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 26
     },
     {
       code: "a { margin: some-function(13px + 10PX); }",
+      fixed: "a { margin: some-function(13PX + 10PX); }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 27
     },
     {
       code: "root { --margin: 10px; }",
+      fixed: "root { --margin: 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 18
     },
     {
       code: "root { --margin: 10PX + 10px; }",
+      fixed: "root { --margin: 10PX + 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 25
     },
     {
       code: "a { margin: 13xpx; }",
+      fixed: "a { margin: 13XPX; }",
       message: messages.expected("xpx", "XPX"),
       description: "work with unknown units",
       line: 1,
@@ -548,6 +610,7 @@ testRule(rule, {
   ruleName,
   syntax: "scss",
   config: ["upper"],
+  fix: true,
 
   accept: [
     {
@@ -563,66 +626,77 @@ testRule(rule, {
   reject: [
     {
       code: "a { margin: 10px; }",
+      fixed: "a { margin: 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 13
     },
     {
       code: "a { margin: 10pX; }",
+      fixed: "a { margin: 10PX; }",
       message: messages.expected("pX", "PX"),
       line: 1,
       column: 13
     },
     {
       code: "a { margin: 10Px; }",
+      fixed: "a { margin: 10PX; }",
       message: messages.expected("Px", "PX"),
       line: 1,
       column: 13
     },
     {
       code: "a { margin: 10px + 10PX; }",
+      fixed: "a { margin: 10PX + 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 13
     },
     {
       code: "a { $margin: 10px; }",
+      fixed: "a { $margin: 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 14
     },
     {
       code: "a { $margin: 10PX + 10px; }",
+      fixed: "a { $margin: 10PX + 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 21
     },
     {
       code: "a { margin: $margin + 10px; }",
+      fixed: "a { margin: $margin + 10PX; }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 23
     },
     {
       code: "$breakpoints: ( small: 767PX, medium: 992px, large: 1200PX );",
+      fixed: "$breakpoints: ( small: 767PX, medium: 992PX, large: 1200PX );",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 39
     },
     {
       code: "a { font: (italic bold 10PX/8px) }",
+      fixed: "a { font: (italic bold 10PX/8PX) }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 29
     },
     {
       code: "font: 14px/#{$line-height};",
+      fixed: "font: 14PX/#{$line-height};",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 7
     },
     {
       code: "a { margin: calc(100% - #{$margin * 2px}); }",
+      fixed: "a { margin: calc(100% - #{$margin * 2PX}); }",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 37
@@ -634,6 +708,7 @@ testRule(rule, {
   ruleName,
   syntax: "less",
   config: ["upper"],
+  fix: true,
 
   accept: [
     {
@@ -645,18 +720,21 @@ testRule(rule, {
   reject: [
     {
       code: "@variable: 10px",
+      fixed: "@variable: 10PX",
       message: messages.expected("px", "PX"),
       line: 1,
       column: 12
     },
     {
       code: "@variable: 10pX",
+      fixed: "@variable: 10PX",
       message: messages.expected("pX", "PX"),
       line: 1,
       column: 12
     },
     {
       code: "@variable: 10Px",
+      fixed: "@variable: 10PX",
       message: messages.expected("Px", "PX"),
       line: 1,
       column: 12

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -5,6 +5,7 @@ const declarationValueIndex = require("../../utils/declarationValueIndex");
 const getUnitFromValueNode = require("../../utils/getUnitFromValueNode");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
+const styleSearch = require("style-search");
 const validateOptions = require("../../utils/validateOptions");
 const valueParser = require("postcss-value-parser");
 
@@ -14,7 +15,7 @@ const messages = ruleMessages(ruleName, {
   expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -47,6 +48,25 @@ const rule = function(expectation) {
           expectation === "lower" ? unit.toLowerCase() : unit.toUpperCase();
 
         if (unit === expectedUnit) {
+          return;
+        }
+
+        if (context.fix) {
+          const source = node.name === "media" ? node.params : node.value;
+
+          styleSearch({ source, target: unit }, match => {
+            const stringStart = source.slice(0, match.startIndex);
+            const stringEnd = source.slice(match.endIndex, source.length);
+
+            const res = `${stringStart}${expectedUnit}${stringEnd}`;
+
+            if (node.name === "media") {
+              node.params = res;
+            } else {
+              node.value = res;
+            }
+          });
+
           return;
         }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2829

e.g. "#000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

## lower
```
a { width: 10PIXEL; } -> a { width: 10pixel; }
a { width: calc(10PX * 2); } -> a { width: calc(10px * 2); }
```

## uppter
```
a { width: 10pixel; } -> a { width: 10PIXEL; }
a { width: calc(10px * 2); } -> a { width: calc(10PX * 2); }
```

e.g. "No, it's self explanatory."
