### PR TITLE
Enable fix option for function-name-case

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -213,7 +213,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`function-comma-space-after`](../../lib/rules/function-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of functions.
 -   [`function-comma-space-before`](../../lib/rules/function-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of functions.
 -   [`function-max-empty-lines`](../../lib/rules/function-max-empty-lines/README.md): Limit the number of adjacent empty lines within functions.
--   [`function-name-case`](../../lib/rules/function-name-case/README.md): Specify lowercase or uppercase for function names.
+-   [`function-name-case`](../../lib/rules/function-name-case/README.md): Specify lowercase or uppercase for function names (Autofixable).
 -   [`function-parentheses-newline-inside`](../../lib/rules/function-parentheses-newline-inside/README.md): Require a newline or disallow whitespace on the inside of the parentheses of functions.
 -   [`function-parentheses-space-inside`](../../lib/rules/function-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses of functions.
 -   [`function-url-quotes`](../../lib/rules/function-url-quotes/README.md): Require or disallow quotes for urls.

--- a/lib/rules/function-name-case/__tests__/index.js
+++ b/lib/rules/function-name-case/__tests__/index.js
@@ -512,3 +512,59 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: ["upper"],
+  fix: true,
+  reject: [
+    {
+      code: "a { width: Calc(5% - 10em); }",
+      message: messages.expected("Calc", "CALC"),
+      fixed: "a { width: CALC(5% - 10em); }"
+    },
+    {
+      code: "a { padding: calc(1px * 2) calc(1px * 2); }",
+      message: messages.expected("calc", "CALC"),
+      fixed: "a { padding: CALC(1px * 2) CALC(1px * 2); }"
+    },
+    {
+      code: "a { width: calC(var($calC) - 3%) - 10em); }",
+      message: messages.expected("calC", "CALC"),
+      fixed: "a { width: CALC(VAR($calC) - 3%) - 10em); }"
+    },
+    {
+      code: "a { color: GetColor(); }",
+      message: messages.expected("GetColor", "GETCOLOR"),
+      fixed: "a { color: GETCOLOR(); }"
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["lower"],
+  fix: true,
+  reject: [
+    {
+      code: "a { width: Calc(5% - 10em); }",
+      message: messages.expected("Calc", "calc"),
+      fixed: "a { width: calc(5% - 10em); }"
+    },
+    {
+      code: "a { padding: Calc(1px * 2) CALC(1px * 2); }",
+      message: messages.expected("Calc", "calc"),
+      fixed: "a { padding: calc(1px * 2) calc(1px * 2); }"
+    },
+    {
+      code: "a { width: calC(vAr($calC) - 3%) - 10em); }",
+      message: messages.expected("calC", "calc"),
+      fixed: "a { width: calc(var($calC) - 3%) - 10em); }"
+    },
+    {
+      code: "a { color: GetColor(); }",
+      message: messages.expected("GetColor", "getcolor"),
+      fixed: "a { color: getcolor(); }"
+    }
+  ]
+});

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const styleSearch = require("style-search");
 const declarationValueIndex = require("../../utils/declarationValueIndex");
 const isStandardSyntaxFunction = require("../../utils/isStandardSyntaxFunction");
 const keywordSets = require("../../reference/keywordSets");
@@ -21,7 +22,7 @@ keywordSets.camelCaseFunctionNames.forEach(func => {
   mapLowercaseFunctionNamesToCamelCase.set(func.toLowerCase(), func);
 });
 
-const rule = function(expectation, options) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(
       result,
@@ -88,6 +89,24 @@ const rule = function(expectation, options) {
           result,
           ruleName
         });
+
+        if (context.fix) {
+          const source = decl.value;
+
+          styleSearch(
+            {
+              source: decl.value,
+              target: functionName,
+              functionNames: "only"
+            },
+            match => {
+              const stringStart = source.slice(0, match.startIndex);
+              const stringEnd = source.slice(match.endIndex, source.length);
+
+              decl.value = `${stringStart}${expectedFunctionName}${stringEnd}`;
+            }
+          );
+        }
       });
     });
   };


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/2829

> Is there anything in the PR that needs further explanation?

### Problems
1. We can not search a function name which has `-` because `style-search` 
 does not include this pattern.(https://github.com/davidtheclark/style-search/blob/master/index.js#L182).

2. A function which is written by CamelCase is broken if a user does not specify `ignoreFunctions`.

Do we have any ideas?