### PR TITLE
Update to new cosmiconfig API

### DIFF
--- a/decls/stylelint.js
+++ b/decls/stylelint.js
@@ -43,8 +43,8 @@ export type stylelint$options = {
 
 export type stylelint$internalApi = {
   _options: stylelint$options,
-  _extendExplorer: { load: Function },
-  _fullExplorer: { load: Function },
+  _extendExplorer: { load: Function, search: Function },
+  _fullExplorer: { load: Function, search: Function },
   _configCache: Map<string, Object>,
   _specifiedConfigCache: Map<string, Object>,
   _postcssResultCache: Map<string, Object>,

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -184,7 +184,7 @@ function loadExtendedConfig(
   extendLookup /*: string*/
 ) /*: Promise<?{ config: stylelint$config, filepath: string }>*/ {
   const extendPath = getModulePath(configDir, extendLookup);
-  return stylelint._extendExplorer.load(null, extendPath);
+  return stylelint._extendExplorer.load(extendPath);
 }
 
 // When merging configs (via extends)

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -33,11 +33,14 @@ module.exports = function(
     return augmentedResult;
   }
 
-  return stylelint._fullExplorer
-    .load(searchPath, stylelint._options.configFile)
+  const resolveConfig = stylelint._options.configFile
+    ? stylelint._fullExplorer.load(stylelint._options.configFile)
+    : stylelint._fullExplorer.search(searchPath);
+
+  return resolveConfig
     .then(config => {
       // If no config was found, try looking from process.cwd
-      if (!config) return stylelint._fullExplorer.load(process.cwd());
+      if (!config) return stylelint._fullExplorer.search(process.cwd());
       return config;
     })
     .then(config => {


### PR DESCRIPTION
- Differentiate `load` from `search` (previously `load` was overloaded
  to both load a configuration file directly and search up the
  directory tree)
<br>

> Which issue, if any, is this issue related to?

Awaiting davidtheclark/cosmiconfig#108
<br>

> Is there anything in the PR that needs further explanation?

No, it's self explanatory