### PR TITLE
Remove Open Collective postinstall message

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "meow": "^4.0.0",
     "micromatch": "^2.3.11",
     "normalize-selector": "^0.2.0",
-    "opencollective": "^1.0.3",
     "pify": "^3.0.0",
     "postcss": "^6.0.16",
     "postcss-html": "^0.12.0",
@@ -123,8 +122,7 @@
     "prettier:fix": "prettier '**/*.js' --write",
     "release": "npmpub",
     "test": "jest --coverage",
-    "watch": "jest --watch",
-    "postinstall": "opencollective postinstall"
+    "watch": "jest --watch"
   },
   "lint-staged": {
     "*.js": [
@@ -193,10 +191,5 @@
         }
       ]
     ]
-  },
-  "collective": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/stylelint",
-    "logo": "https://opencollective.com/opencollective/logo.txt"
   }
 }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Comment at https://github.com/stylelint/stylelint/pull/2955#issuecomment-366766373

> Is there anything in the PR that needs further explanation?

This removes the stylelint / Open Collective banner that appears after installing stylelint.

As stylelint is designed to be installed alongside other tools, we should probably err on the side of subtlety. What do you think @stylelint/core? I'm ok with this being closed if folks think we should keep the banner. 
