### PR TITLE
Use default greenkeeper label

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$"
   },
   "greenkeeper": {
-    "label": "PR: greenkeeper",
     "ignore": [
       "micromatch"
     ]


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a GitHub labelling fix.

> Is there anything in the PR that needs further explanation?

Greenkeeper also creates issues (e.g. https://github.com/stylelint/stylelint/issues/3172), so it doesn't make sense to prefix with `PR: `. We can treat the `greenkeeper` label like the `help wanted` and `good first issue` ones i.e. they're standard meta labels used by other systems.
