### PR TITLE
Fix false positives for non-CSS blocks in string-no-newline

### DIFF
--- a/lib/rules/string-no-newline/__tests__/index.js
+++ b/lib/rules/string-no-newline/__tests__/index.js
@@ -37,22 +37,57 @@ testRule(rule, {
     }`,
 
       description: "attribute containing double-slash"
+    },
+    {
+      code: `<span
+  class="
+    className
+  "
+/>
+<style>
+.selector {
+  --property: value;
+}
+</style>`,
+      description: "newline in html"
+    },
+    {
+      code: `<p>this is fine.</p>
+      <p>this isn't.</p>
+      <span>this line is still affected.</span>
+      <div style="ttt: auto">actual issues are still reported</div>`,
+      description: "single quotes"
     }
   ],
 
   reject: [
     {
       code: "a::before { content: 'one\ntwo'; }",
+      description: "content LF",
       message: messages.rejected,
       line: 1,
       column: 26
     },
     {
       code: "a::before { content: 'one\r\ntwo'; }",
-      description: "CRLF",
+      description: "content CRLF",
       message: messages.rejected,
       line: 1,
       column: 26
+    },
+    {
+      code: "a[href^='one\r\ntwo'] { display: block; }",
+      description: "attribute CRLF",
+      message: messages.rejected,
+      line: 1,
+      column: 12
+    },
+    {
+      code: "@charset 'utf-8\n';",
+      description: "atRule CRLF",
+      message: messages.rejected,
+      line: 1,
+      column: 16
     }
   ]
 });

--- a/lib/rules/string-no-newline/index.js
+++ b/lib/rules/string-no-newline/index.js
@@ -1,11 +1,15 @@
 "use strict";
 
+const atRuleParamIndex = require("../../utils/atRuleParamIndex");
+const declarationValueIndex = require("../../utils/declarationValueIndex");
+const parseSelector = require("../../utils/parseSelector");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
-const styleSearch = require("style-search");
 const validateOptions = require("../../utils/validateOptions");
+const valueParser = require("postcss-value-parser");
 
 const ruleName = "string-no-newline";
+const reNewLine = /(\r?\n)/;
 
 const messages = ruleMessages(ruleName, {
   rejected: "Unexpected newline in string"
@@ -17,30 +21,82 @@ const rule = function(actual) {
     if (!validOptions) {
       return;
     }
+    root.walk(node => {
+      switch (node.type) {
+        case "atrule":
+          checkDeclOrAtRule(node, node.params, atRuleParamIndex);
+          break;
+        case "decl":
+          checkDeclOrAtRule(node, node.value, declarationValueIndex);
+          break;
+        case "rule":
+          checkRule(node);
+          break;
+      }
+    });
+    function checkRule(rule) {
+      // Get out quickly if there are no new line
+      if (!reNewLine.test(rule.selector)) {
+        return;
+      }
 
-    const cssString = root.toString();
-    styleSearch(
-      {
-        source: cssString,
-        target: "\n",
-        strings: "only"
-      },
-      match => {
-        const charBefore = cssString[match.startIndex - 1];
-        let index = match.startIndex;
-        if (charBefore === "\\") {
+      parseSelector(rule.selector, result, rule, selectorTree => {
+        selectorTree.walkAttributes(attributeNode => {
+          if (!reNewLine.test(attributeNode.value)) {
+            return;
+          }
+
+          const openIndex = [
+            // length of our attribute
+            attributeNode.attribute,
+            // length of our operator , ie '='
+            attributeNode.operator,
+            // length of the contents before newline
+            RegExp.leftContext
+          ].reduce(
+            (index, str) => index + str.length,
+            // index of the start of our attribute node in our source
+            attributeNode.sourceIndex
+          );
+
+          report({
+            message: messages.rejected,
+            node: rule,
+            index: openIndex,
+            result,
+            ruleName
+          });
+        });
+      });
+    }
+
+    function checkDeclOrAtRule(node, value, getIndex) {
+      // Get out quickly if there are no new line
+      if (!reNewLine.test(value)) {
+        return;
+      }
+
+      valueParser(value).walk(valueNode => {
+        if (valueNode.type !== "string" || !reNewLine.test(valueNode.value)) {
           return;
         }
-        if (charBefore === "\r") index -= 1;
+
+        const openIndex = [
+          // length of the quote
+          valueNode.quote,
+          // length of the contents before newline
+          RegExp.leftContext
+        ].reduce((index, str) => index + str.length, valueNode.sourceIndex);
+
         report({
           message: messages.rejected,
-          node: root,
-          index,
+          node,
+          index: getIndex(node) + openIndex,
           result,
           ruleName
         });
-      }
-    );
+      });
+    }
   };
 };
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#3219 #3226

> Is there anything in the PR that needs further explanation?

Refactoring the code for rule `string-no-newline`