### PR TITLE
Fix false positives for non-CSS blocks in max-empty-lines

### DIFF
--- a/lib/rules/max-empty-lines/__tests__/index.js
+++ b/lib/rules/max-empty-lines/__tests__/index.js
@@ -34,6 +34,20 @@ testRule(rule, {
     },
     {
       code: "a{}\r\n\r\n/** horse */\r\n\r\nb{}"
+    },
+    {
+      code: `<div>
+
+
+
+
+<style>
+/* horse */
+</style>
+
+
+
+</div>`
     }
   ],
 

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -37,14 +37,18 @@ const rule = function(max, options) {
       return;
     }
 
-    const rootString = root.toString();
     const repeatLFNewLines = _.repeat("\n", maxAdjacentNewlines);
     const repeatCRLFNewLines = _.repeat("\r\n", maxAdjacentNewlines);
     const ignoreComments = optionsMatches(options, "ignore", "comments");
 
-    styleSearch({ source: rootString, target: "\n" }, match => {
-      checkMatch(rootString, match.endIndex, root);
-    });
+    // class `Document` is a part of `postcss-html`,
+    // It is collection of roots in HTML File.
+    // See: https://github.com/gucong3000/postcss-html/blob/master/lib/document.js
+    if (root.constructor.name === "Document") {
+      root.nodes.map(checkRoot);
+    } else {
+      checkRoot(root);
+    }
 
     // We must check comments separately in order to accommodate stupid
     // `//`-comments from SCSS, which postcss-scss converts to `/* ... */`,
@@ -57,6 +61,13 @@ const rule = function(max, options) {
         styleSearch({ source, target: "\n" }, match => {
           checkMatch(source, match.endIndex, comment, 2);
         });
+      });
+    }
+
+    function checkRoot(root) {
+      const rootString = root.toString();
+      styleSearch({ source: rootString, target: "\n" }, match => {
+        checkMatch(rootString, match.endIndex, root);
       });
     }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3221

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
