### PR TITLE
Fix git commit hook for Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "npm run prettier --write",
+      "prettier --write",
       "git add"
     ]
   },


### PR DESCRIPTION
Change was made to precommit hook in #3184. This change wasn't needed.

People reported this problem: https://github.com/stylelint/stylelint/pull/3225#issuecomment-374129446.

Also, I see that Prettier wasn't run on a code: https://github.com/stylelint/stylelint/pull/3229/files#diff-c65b73210ee92c6286a9cee09c912513.