### PR TITLE
Update postcss-less

### DIFF
--- a/lib/rules/indentation/__tests__/rules.js
+++ b/lib/rules/indentation/__tests__/rules.js
@@ -176,6 +176,9 @@ testRule(rule, {
     },
     {
       code: "@media print {\r\n" + "  * { color: pink; }\r\n" + "}"
+    },
+    {
+      code: ".a[disabled],\n" + ".b {\n" + "  color: pink;\n" + "}"
     }
   ],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pify": "^3.0.0",
     "postcss": "^6.0.16",
     "postcss-html": "^0.15.0",
-    "postcss-less": "^1.1.0",
+    "postcss-less": "^1.1.5",
     "postcss-media-query-parser": "^0.2.3",
     "postcss-reporter": "^5.0.0",
     "postcss-resolve-nested-selector": "^0.1.1",


### PR DESCRIPTION
added rule test to check for bracket selectors in a selector list.

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #2791 

> Is there anything in the PR that needs further explanation?

Nope, new version of postcss-less fixes issue.
