### PR TITLE
Remove files with syntax errors from cache

### DIFF
--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -13,6 +13,7 @@ const fileExists = require("file-exists-promise");
 
 const cwd = process.cwd();
 const invalidFile = path.join(fixturesPath, "empty-block.css");
+const syntaxErrorFile = path.join(fixturesPath, "syntax_error.css");
 const validFile = path.join(fixturesPath, "cache", "valid.css");
 const newFileDest = path.join(fixturesPath, "cache", "newFile.css");
 
@@ -142,6 +143,21 @@ describe("standalone cache", () => {
         return JSON.parse(fileContents);
       })
       .then(cachedFiles => {
+        expect(typeof cachedFiles[validFile] === "object").toBe(true);
+        expect(typeof cachedFiles[newFileDest] === "undefined").toBe(true);
+      });
+  });
+  it("files with syntax errors are not cached", () => {
+    return cpFile(syntaxErrorFile, newFileDest)
+      .then(() => {
+        // Should lint only changed files
+        return standalone(getConfig());
+      })
+      .then(() => {
+        return readFile(expectedCacheFilePath, "utf8");
+      })
+      .then(fileContents => {
+        const cachedFiles = JSON.parse(fileContents);
         expect(typeof cachedFiles[validFile] === "object").toBe(true);
         expect(typeof cachedFiles[newFileDest] === "undefined").toBe(true);
       });

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -227,7 +227,11 @@ module.exports = function(
               stylelint._createStylelintResult(postcssResult, absoluteFilepath)
             );
           })
-          .catch(_.partial(handleError, stylelint));
+          .catch(error => {
+            // On any error, we should not cache the lint result
+            fileCache.removeEntry(absoluteFilepath);
+            return handleError(stylelint, error);
+          });
       });
 
       return Promise.all(getStylelintResults);


### PR DESCRIPTION
Close #3254

I think we should remove files from cache on any types of error, not only `CssSyntaxError`, however I don't know how to create other types of error, so the test case only covers `CssSyntaxError`
