### PR TITLE
Remove link to stylelint-processor-html

### DIFF
--- a/docs/user-guide/processors.md
+++ b/docs/user-guide/processors.md
@@ -6,7 +6,6 @@ Processors are community packages that enable stylelint to lint the CSS within n
 
 -   [stylelint-processor-arbitrary-tags](https://github.com/mapbox/stylelint-processor-arbitrary-tags): Lint within user-specified tags.
 -   [stylelint-processor-glamorous](https://github.com/zabute/stylelint-processor-glamorous): Lint [glamorous](https://github.com/paypal/glamorous) and related css-in-js libraries using object literals.
--   [stylelint-processor-html](https://github.com/ccbikai/stylelint-processor-html): Lint within HTML `<style>` tags.
 -   [stylelint-processor-markdown](https://github.com/mapbox/stylelint-processor-markdown): Lint within Markdown's [fenced code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/).
 -   [stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components): Lint [styled-components](https://styled-components.com) and related CSS-in-JS libraries using tagged template literals.
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/pull/3261

> Is there anything in the PR that needs further explanation?

As deprecated by `stylelint-processor-arbitrary-tags`
