### PR TITLE
Allow non-standalone Webkit pseudoclasses (#3151)

### DIFF
--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -91,6 +91,10 @@ testRule(rule, {
     {
       code: "::-webkit-scrollbar-button:horizontal:decrement {}",
       description: "webkit scrollbar multiple pseudo classes"
+    },
+    {
+      code: ".test::-webkit-scrollbar-button:horizontal:decrement {}",
+      description: "non-standalone webkit scrollbar multiple pseudo classes"
     }
   ],
 
@@ -166,6 +170,12 @@ testRule(rule, {
       message: messages.rejected(":unknown"),
       line: 1,
       column: 10
+    },
+    {
+      code: ":horizontal:decrement {}",
+      message: messages.rejected(":horizontal"),
+      line: 1,
+      column: 1
     }
   ]
 });

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -84,22 +84,25 @@ const rule = function(actual, options) {
               return;
             }
 
-            const firstSelectorNode =
-              pseudoNode.parent && pseudoNode.parent.nodes
-                ? pseudoNode.parent.nodes[0]
-                : null;
+            let prevPseudoElement = pseudoNode;
+            do {
+              prevPseudoElement = prevPseudoElement.prev();
+              if (
+                prevPseudoElement &&
+                prevPseudoElement.value.slice(0, 2) === "::"
+              ) {
+                break;
+              }
+            } while (prevPseudoElement);
 
-            if (
-              firstSelectorNode &&
-              firstSelectorNode.value.slice(0, 2) === "::"
-            ) {
-              const prevPseudoNodeValue = postcss.vendor.unprefixed(
-                firstSelectorNode.value.toLowerCase().slice(2)
+            if (prevPseudoElement) {
+              const prevPseudoElementValue = postcss.vendor.unprefixed(
+                prevPseudoElement.value.toLowerCase().slice(2)
               );
 
               if (
                 keywordSets.webkitProprietaryPseudoElements.has(
-                  prevPseudoNodeValue
+                  prevPseudoElementValue
                 ) &&
                 keywordSets.webkitProprietaryPseudoClasses.has(name)
               ) {


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #3151 referring to Webkit-specified pseudo classes. Test cases included.

> Is there anything in the PR that needs further explanation?

It's self explanatory, and some comments are attached on the issue to explain why the newly added cases are allowed.

(It's my first time to contribute to this repository so let me know if I did anything wrong. Stylelint applied to my codebases's SASS files well and thanks for your awesome works!) :)
