### PR TITLE
Fix nested property scss syntax false positive

### DIFF
--- a/lib/rules/no-descending-specificity/__tests__/index.js
+++ b/lib/rules/no-descending-specificity/__tests__/index.js
@@ -76,6 +76,9 @@ testRule(rule, {
     },
     {
       code: ":root { --foo: {}; }"
+    },
+    {
+      code: ":root { foo: {}; }"
     }
   ],
 

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -29,7 +29,7 @@ const rule = function(actual) {
     const selectorContextLookup = nodeContextLookup();
 
     root.walkRules(rule => {
-      // Ignore custom property set `--foo: {};`
+      // Ignore custom property set `--foo: {};` and nested property `foo: {};`
       if (isCustomPropertySet(rule) || isNestedProperty(rule)) {
         return;
       }

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -3,6 +3,7 @@
 const _ = require("lodash");
 const findAtRuleContext = require("../../utils/findAtRuleContext");
 const isCustomPropertySet = require("../../utils/isCustomPropertySet");
+const isNestedProperty = require("../../utils/isNestedProperty");
 const keywordSets = require("../../reference/keywordSets");
 const nodeContextLookup = require("../../utils/nodeContextLookup");
 const parseSelector = require("../../utils/parseSelector");
@@ -29,7 +30,7 @@ const rule = function(actual) {
 
     root.walkRules(rule => {
       // Ignore custom property set `--foo: {};`
-      if (isCustomPropertySet(rule)) {
+      if (isCustomPropertySet(rule) || isNestedProperty(rule)) {
         return;
       }
 

--- a/lib/utils/__tests__/isNestedProperty.test.js
+++ b/lib/utils/__tests__/isNestedProperty.test.js
@@ -10,7 +10,7 @@ describe("isNestedProperty", () => {
     });
   });
 
-  it("rejects nested property", () => {
+  it("rejects not nested property", () => {
     return nestedProperty("foo: red;", nestedProperty => {
       expect(isNestedProperty(nestedProperty)).toBeFalsy();
     });

--- a/lib/utils/__tests__/isNestedProperty.test.js
+++ b/lib/utils/__tests__/isNestedProperty.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const isNestedProperty = require("../isNestedProperty");
+const postcss = require("postcss");
+
+describe("isNestedProperty", () => {
+  it("accepts nested property", () => {
+    return nestedProperty("foo: {};", nestedProperty => {
+      expect(isNestedProperty(nestedProperty)).toBeTruthy();
+    });
+  });
+
+  it("rejects nested property", () => {
+    return nestedProperty("foo: red;", nestedProperty => {
+      expect(isNestedProperty(nestedProperty)).toBeFalsy();
+    });
+  });
+});
+
+function nestedProperty(css, cb) {
+  return postcss()
+    .process(css, { from: undefined })
+    .then(result => {
+      result.root.walk(cb);
+    });
+}

--- a/lib/utils/isNestedProperty.js
+++ b/lib/utils/isNestedProperty.js
@@ -1,0 +1,14 @@
+/* @flow */
+"use strict";
+
+const _ = require("lodash");
+const hasBlock = require("../utils/hasBlock");
+
+/**
+ * Check whether a Node is a nested property
+ */
+module.exports = function(node /*: Object*/) /*: boolean*/ {
+  const selector = _.get(node, "raws.selector.raw", node.selector);
+
+  return node.type === "rule" && hasBlock(node) && selector.slice(-1) === ":";
+};


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

issues #3230 #3130 #2642  

> Is there anything in the PR that needs further explanation?

 The problem was in the `no-descending-specificity` rule. When it was calling PostCSS API method `root.walkRules` it was treating `padding:` as a selector and passing it to parseSelector directly, which was throwing the error `✖ Cannot parse selector parseError`.
