### PR TITLE
Add autofix to color-no-hex rule

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -98,6 +98,8 @@ global.testRule = (rule, schema) => {
 
                   if (!schema.fix) return;
 
+                  if (testCase.unfixable) return;
+
                   if (!testCase.fixed) {
                     throw new Error(
                       "If using { fix: true } in test schema, all reject cases must have { fixed: .. }"

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -8,9 +8,23 @@ a { color: #333 }
  * These hex colors */
 ```
 
+The `--fix` option on the command line can automatically fix all of the problems reported by this rule if applicable. See the options below.
+
 ## Options
 
-### `true`
+`boolean`: `true|false`
+
+If `false`, the rule is disabled. If `true`, the rule is enabled, but no fix will be performed.
+
+`string`: `rgb|rgba|hsl|hsla`
+
+### `rgb` | `rgba`
+
+`rgb` and `rgba` are the same. If the color format is an hex with transparency (Like #FFFFFFDC), the output will be in rgba format. Otherwise, it will be rgb. There's no way to force one or another.
+
+### `hsl` | `hsla`
+
+`hsl` and `hsla` are the same. If the color format is an hex with transparency (Like #FFFFFFDC), the output will be in hsla format. Otherwise, it will be hsl. There's no way to force one or another.
 
 The following patterns are considered violations:
 

--- a/lib/rules/color-no-hex/__tests__/index.js
+++ b/lib/rules/color-no-hex/__tests__/index.js
@@ -1,12 +1,11 @@
 "use strict";
 
+const mergeTestDescriptions = require("../../../testUtils/mergeTestDescriptions");
+
 const rule = require("..");
 const { messages, ruleName } = rule;
 
-testRule(rule, {
-  ruleName,
-  config: [true],
-
+const sharedTests = {
   accept: [
     {
       code: "a { color: pink; }"
@@ -42,56 +41,183 @@ testRule(rule, {
         "font-style: normal;\n" +
         "}"
     }
-  ],
-
-  reject: [
-    {
-      code: "a { color: #12345; }",
-      message: messages.rejected("#12345"),
-      line: 1,
-      column: 12
-    },
-    {
-      code: "a { color: #123456a; }",
-      message: messages.rejected("#123456a"),
-      line: 1,
-      column: 12
-    },
-    {
-      code: "a { color: #cccccc; }",
-      message: messages.rejected("#cccccc"),
-      line: 1,
-      column: 12
-    },
-    {
-      code: "a { something: #00c, red, white; }",
-      message: messages.rejected("#00c"),
-      line: 1,
-      column: 16
-    },
-    {
-      code: "a { something: black, #fff1a1, rgb(250, 250, 0); }",
-      message: messages.rejected("#fff1a1"),
-      line: 1,
-      column: 23
-    },
-    {
-      code: "a { something:black,white,#12345a; }",
-      message: messages.rejected("#12345a"),
-      line: 1,
-      column: 27
-    },
-    {
-      code: "a { color: #ffff; }",
-      message: messages.rejected("#ffff"),
-      line: 1,
-      column: 12
-    },
-    {
-      code: "a { color: #ffffffaa; }",
-      message: messages.rejected("#ffffffaa"),
-      line: 1,
-      column: 12
-    }
   ]
-});
+};
+
+testRule(
+  rule,
+  mergeTestDescriptions(sharedTests, {
+    ruleName,
+    config: [true],
+    fix: true,
+    reject: [
+      {
+        code: "a { color: #12345; }",
+        message: messages.rejected("#12345"),
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { color: #123456a; }",
+        message: messages.rejected("#123456a"),
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { color: #cccccc; }",
+        message: messages.rejected("#cccccc"),
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { something: #00c, red, white; }",
+        message: messages.rejected("#00c"),
+        line: 1,
+        column: 16,
+        unfixable: true
+      },
+      {
+        code: "a { something: black, #fff1a1, rgb(250, 250, 0); }",
+        message: messages.rejected("#fff1a1"),
+        line: 1,
+        column: 23,
+        unfixable: true
+      },
+      {
+        code: "a { something:black,white,#12345a; }",
+        message: messages.rejected("#12345a"),
+        line: 1,
+        column: 27,
+        unfixable: true
+      },
+      {
+        code: "a { color: #ffff; }",
+        message: messages.rejected("#ffff"),
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { color: #ffffffaa; }",
+        message: messages.rejected("#ffffffaa"),
+        line: 1,
+        column: 12,
+        unfixable: true
+      }
+    ]
+  })
+);
+
+testRule(
+  rule,
+  mergeTestDescriptions(sharedTests, {
+    ruleName,
+    config: ["rgb"],
+    fix: true,
+    reject: [
+      {
+        code: "a { color: #12345; }",
+        message: messages.rejected("#12345"),
+        description: "Invalid Hex with Fix Option will be rejected",
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { color: #123456a; }",
+        message: messages.rejected("#123456a"),
+        description: "Invalid Hex with Fix Option will be rejected",
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { something: #00c, red, white; }",
+        message: messages.rejected("#00c"),
+        line: 1,
+        column: 16,
+        fixed: "a { something: rgb(0, 0, 204), red, white; }"
+      },
+      {
+        code: "a { something:black,white,#12345a; }",
+        message: messages.rejected("#12345a"),
+        line: 1,
+        column: 27,
+        fixed: "a { something:black,white,rgb(18, 52, 90); }"
+      },
+      {
+        code: "a { color: #ffff; }",
+        message: messages.rejected("#ffff"),
+        line: 1,
+        column: 12,
+        fixed: "a { color: rgb(255, 255, 255); }"
+      },
+      {
+        code: "a { color: #ffffffaa; }",
+        message: messages.rejected("#ffffffaa"),
+        line: 1,
+        column: 12,
+        fixed: "a { color: rgba(255, 255, 255, 0.67); }"
+      }
+    ]
+  })
+);
+
+testRule(
+  rule,
+  mergeTestDescriptions(sharedTests, {
+    ruleName,
+    config: ["hsl"],
+    fix: true,
+    reject: [
+      {
+        code: "a { color: #12345; }",
+        message: messages.rejected("#12345"),
+        description: "Invalid Hex with Fix Option will be rejected",
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { color: #123456a; }",
+        message: messages.rejected("#123456a"),
+        description: "Invalid Hex with Fix Option will be rejected",
+        line: 1,
+        column: 12,
+        unfixable: true
+      },
+      {
+        code: "a { something: #00c, red, white; }",
+        message: messages.rejected("#00c"),
+        line: 1,
+        column: 16,
+        fixed: "a { something: hsl(240, 100%, 40%), red, white; }"
+      },
+      {
+        code: "a { something:black,white,#12345a; }",
+        message: messages.rejected("#12345a"),
+        line: 1,
+        column: 27,
+        fixed:
+          "a { something:black,white,hsl(211.70000000000005, 66.7%, 21.2%); }"
+      },
+      {
+        code: "a { color: #ffff; }",
+        message: messages.rejected("#ffff"),
+        line: 1,
+        column: 12,
+        fixed: "a { color: hsl(0, 0%, 100%); }"
+      },
+      {
+        code: "a { color: #ffffffaa; }",
+        message: messages.rejected("#ffffffaa"),
+        line: 1,
+        column: 12,
+        fixed: "a { color: hsla(0, 0%, 100%, 0.67); }"
+      }
+    ]
+  })
+);

--- a/lib/rules/color-no-hex/index.js
+++ b/lib/rules/color-no-hex/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const colorConverter = require("color");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const styleSearch = require("style-search");
@@ -11,15 +12,32 @@ const messages = ruleMessages(ruleName, {
   rejected: hex => `Unexpected hex color "${hex}"`
 });
 
-const rule = function(actual) {
+const fixColorFormat = (value, fixer, declaration) => {
+  try {
+    const color = colorConverter(value);
+    if (fixer.fixTo.indexOf("hsl") > -1) {
+      return declaration.replace(value, color.hsl().string());
+    }
+    return declaration.replace(value, color.rgb().string());
+  } catch (err) {
+    return declaration;
+  }
+};
+
+const rule = function(actual, options, context) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual });
+    const validOptions = validateOptions(result, ruleName, {
+      actual,
+      possible: ["rgb", "rgba", "hsl", "hsla", true]
+    });
+
     if (!validOptions) {
       return;
     }
 
     root.walkDecls(decl => {
       const declString = decl.toString();
+      const fixPositions = [];
 
       styleSearch({ source: declString, target: "#" }, match => {
         // If there's not a colon, comma, or whitespace character before, we'll assume this is
@@ -37,6 +55,16 @@ const rule = function(actual) {
         }
         const hexValue = hexMatch[0];
 
+        if (context.fix && actual !== true) {
+          fixPositions.unshift({
+            fixTo: actual,
+            hexValue,
+            startIndex: match.startIndex
+          });
+
+          return;
+        }
+
         report({
           message: messages.rejected(hexValue),
           node: decl,
@@ -45,6 +73,16 @@ const rule = function(actual) {
           ruleName
         });
       });
+
+      if (fixPositions.length) {
+        fixPositions.forEach(fixPosition => {
+          decl.value = fixColorFormat(
+            fixPosition.hexValue,
+            fixPosition,
+            decl.value
+          );
+        });
+      }
     });
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,197 +1,176 @@
 {
-  "name": "stylelint",
-  "version": "9.2.0",
-  "description": "A mighty, modern CSS linter.",
-  "keywords": [
-    "css",
-    "less",
-    "sass",
-    "scss",
-    "sugarss",
-    "lint",
-    "linter",
-    "stylelint"
-  ],
-  "authors": [
-    "David Clark",
-    "Maxime Thirouin",
-    "Richard Hallows"
-  ],
-  "license": "MIT",
-  "homepage": "https://stylelint.io",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/stylelint/stylelint.git"
-  },
-  "main": "lib/index.js",
-  "bin": "bin/stylelint.js",
-  "files": [
-    "bin",
-    "CONTRIBUTING.md",
-    "docs",
-    "lib",
-    "VISION.md",
-    "!**/__tests__",
-    "flow-typed",
-    "!flow-typed/npm"
-  ],
-  "engines": {
-    "node": ">=6"
-  },
-  "dependencies": {
-    "autoprefixer": "^8.0.0",
-    "balanced-match": "^1.0.0",
-    "chalk": "^2.4.1",
-    "cosmiconfig": "^5.0.0",
-    "debug": "^3.0.0",
-    "execall": "^1.0.0",
-    "file-entry-cache": "^2.0.0",
-    "get-stdin": "^6.0.0",
-    "globby": "^8.0.0",
-    "globjoin": "^0.1.4",
-    "html-tags": "^2.0.0",
-    "ignore": "^3.3.3",
-    "import-lazy": "^3.1.0",
-    "imurmurhash": "^0.1.4",
-    "known-css-properties": "^0.6.0",
-    "lodash": "^4.17.4",
-    "log-symbols": "^2.0.0",
-    "mathml-tag-names": "^2.0.1",
-    "meow": "^5.0.0",
-    "micromatch": "^2.3.11",
-    "normalize-selector": "^0.2.0",
-    "pify": "^3.0.0",
-    "postcss": "^6.0.16",
-    "postcss-html": "^0.18.0",
-    "postcss-less": "^1.1.5",
-    "postcss-media-query-parser": "^0.2.3",
-    "postcss-reporter": "^5.0.0",
-    "postcss-resolve-nested-selector": "^0.1.1",
-    "postcss-safe-parser": "^3.0.1",
-    "postcss-sass": "^0.3.0",
-    "postcss-scss": "^1.0.2",
-    "postcss-selector-parser": "^3.1.0",
-    "postcss-value-parser": "^3.3.0",
-    "resolve-from": "^4.0.0",
-    "signal-exit": "^3.0.2",
-    "specificity": "^0.3.1",
-    "string-width": "^2.1.0",
-    "style-search": "^0.1.0",
-    "sugarss": "^1.0.0",
-    "svg-tags": "^1.0.0",
-    "table": "^4.0.1"
-  },
-  "devDependencies": {
-    "benchmark": "^2.1.4",
-    "common-tags": "^1.4.0",
-    "coveralls": "^3.0.0",
-    "cp-file": "^5.0.0",
-    "d3-queue": "^3.0.7",
-    "del": "^3.0.0",
-    "eslint": "~4.19.0",
-    "eslint-config-stylelint": "~8.1.0",
-    "file-exists-promise": "^1.0.2",
-    "flow-bin": "^0.71.0",
-    "flow-typed": "^2.3.0",
-    "husky": "^0.14.3",
-    "jest": "^22.0.6",
-    "lint-staged": "^7.0.0",
-    "npm-run-all": "^4.0.2",
-    "npmpub": "^3.1.0",
-    "postcss-import": "^11.0.0",
-    "prettier": "~1.12.0",
-    "remark-cli": "^5.0.0",
-    "remark-lint-no-missing-blank-lines": "^1.0.1",
-    "remark-preset-lint-consistent": "^2.0.0",
-    "remark-preset-lint-recommended": "^3.0.0",
-    "remark-validate-links": "^7.0.0",
-    "request": "^2.81.0",
-    "strip-ansi": "^4.0.0",
-    "weak": "^1.0.1"
-  },
-  "scripts": {
-    "precommit": "lint-staged",
-    "benchmark-rule": "node scripts/benchmark-rule.js",
-    "dry-release": "npmpub  --dry --verbose",
-    "flow": "flow",
-    "flow-defs": "./node_modules/.bin/flow-typed install jest@22 lodash@4",
-    "jest": "jest",
-    "jest:detectleaks": "jest  --detectLeaks",
-    "lint:js": "eslint . --cache",
-    "lint:md": "remark . --quiet --frail",
-    "lint": "npm-run-all --parallel lint:*",
-    "pretest": "npm-run-all --serial lint flow",
-    "prettier:check": "prettier '**/*.js' --list-different",
-    "prettier:fix": "prettier '**/*.js' --write",
-    "release": "npmpub",
-    "test": "jest --coverage",
-    "watch": "jest --watch"
-  },
-  "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "eslintConfig": {
-    "extends": [
-      "stylelint"
-    ],
-    "globals": {
-      "testRule": true
-    }
-  },
-  "jest": {
-    "clearMocks": true,
-    "collectCoverage": false,
-    "collectCoverageFrom": [
-      "lib/**/*.js",
-      "!lib/vendor/**/*.js"
-    ],
-    "coverageDirectory": "./.coverage/",
-    "coverageReporters": [
-      "lcov",
-      "text-summary"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "branches": 75,
-        "functions": 75,
-        "lines": 75,
-        "statements": 75
-      }
-    },
-    "setupFiles": [
-      "./jest-setup.js"
-    ],
-    "testEnvironment": "node",
-    "roots": [
-      "lib",
-      "system-tests"
-    ],
-    "testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "micromatch"
-    ]
-  },
-  "remarkConfig": {
-    "plugins": [
-      "preset-lint-recommended",
-      "preset-lint-consistent",
-      [
-        "lint-no-missing-blank-lines",
-        {
-          "exceptTightLists": true
-        }
-      ],
-      [
-        "validate-links",
-        {
-          "repository": "stylelint/stylelint"
-        }
-      ]
-    ]
-  }
+	"name": "stylelint",
+	"version": "9.2.0",
+	"description": "A mighty, modern CSS linter.",
+	"keywords": [
+		"css",
+		"less",
+		"sass",
+		"scss",
+		"sugarss",
+		"lint",
+		"linter",
+		"stylelint"
+	],
+	"authors": ["David Clark", "Maxime Thirouin", "Richard Hallows"],
+	"license": "MIT",
+	"homepage": "https://stylelint.io",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/stylelint/stylelint.git"
+	},
+	"main": "lib/index.js",
+	"bin": "bin/stylelint.js",
+	"files": [
+		"bin",
+		"CONTRIBUTING.md",
+		"docs",
+		"lib",
+		"VISION.md",
+		"!**/__tests__",
+		"flow-typed",
+		"!flow-typed/npm"
+	],
+	"engines": {
+		"node": ">=6"
+	},
+	"dependencies": {
+		"autoprefixer": "^8.0.0",
+		"balanced-match": "^1.0.0",
+		"chalk": "^2.4.1",
+		"cosmiconfig": "^5.0.0",
+		"color": "^3.0.0",
+		"debug": "^3.0.0",
+		"execall": "^1.0.0",
+		"file-entry-cache": "^2.0.0",
+		"get-stdin": "^6.0.0",
+		"globby": "^8.0.0",
+		"globjoin": "^0.1.4",
+		"html-tags": "^2.0.0",
+		"ignore": "^3.3.3",
+		"import-lazy": "^3.1.0",
+		"imurmurhash": "^0.1.4",
+		"known-css-properties": "^0.6.0",
+		"lodash": "^4.17.4",
+		"log-symbols": "^2.0.0",
+		"mathml-tag-names": "^2.0.1",
+		"meow": "^5.0.0",
+		"micromatch": "^2.3.11",
+		"normalize-selector": "^0.2.0",
+		"pify": "^3.0.0",
+		"postcss": "^6.0.16",
+		"postcss-html": "^0.18.0",
+		"postcss-less": "^1.1.5",
+		"postcss-media-query-parser": "^0.2.3",
+		"postcss-reporter": "^5.0.0",
+		"postcss-resolve-nested-selector": "^0.1.1",
+		"postcss-safe-parser": "^3.0.1",
+		"postcss-sass": "^0.3.0",
+		"postcss-scss": "^1.0.2",
+		"postcss-selector-parser": "^3.1.0",
+		"postcss-value-parser": "^3.3.0",
+		"resolve-from": "^4.0.0",
+		"signal-exit": "^3.0.2",
+		"specificity": "^0.3.1",
+		"string-width": "^2.1.0",
+		"style-search": "^0.1.0",
+		"sugarss": "^1.0.0",
+		"svg-tags": "^1.0.0",
+		"table": "^4.0.1"
+	},
+	"devDependencies": {
+		"benchmark": "^2.1.4",
+		"common-tags": "^1.4.0",
+		"coveralls": "^3.0.0",
+		"cp-file": "^5.0.0",
+		"d3-queue": "^3.0.7",
+		"del": "^3.0.0",
+		"eslint": "~4.19.0",
+		"eslint-config-stylelint": "~8.1.0",
+		"file-exists-promise": "^1.0.2",
+		"flow-bin": "^0.71.0",
+		"flow-typed": "^2.3.0",
+		"husky": "^0.14.3",
+		"jest": "^22.0.6",
+		"lint-staged": "^7.0.0",
+		"npm-run-all": "^4.0.2",
+		"npmpub": "^3.1.0",
+		"postcss-import": "^11.0.0",
+		"prettier": "~1.12.0",
+		"remark-cli": "^5.0.0",
+		"remark-lint-no-missing-blank-lines": "^1.0.1",
+		"remark-preset-lint-consistent": "^2.0.0",
+		"remark-preset-lint-recommended": "^3.0.0",
+		"remark-validate-links": "^7.0.0",
+		"request": "^2.81.0",
+		"strip-ansi": "^4.0.0",
+		"weak": "^1.0.1"
+	},
+	"scripts": {
+		"precommit": "lint-staged",
+		"benchmark-rule": "node scripts/benchmark-rule.js",
+		"dry-release": "npmpub  --dry --verbose",
+		"flow": "flow",
+		"flow-defs": "./node_modules/.bin/flow-typed install jest@22 lodash@4",
+		"jest": "jest",
+		"jest:detectleaks": "jest  --detectLeaks",
+		"lint:js": "eslint . --cache",
+		"lint:md": "remark . --quiet --frail",
+		"lint": "npm-run-all --parallel lint:*",
+		"pretest": "npm-run-all --serial lint flow",
+		"prettier:check": "prettier '**/*.js' --list-different",
+		"prettier:fix": "prettier '**/*.js' --write",
+		"release": "npmpub",
+		"test": "jest --coverage",
+		"watch": "jest --watch"
+	},
+	"lint-staged": {
+		"*.js": ["prettier --write", "git add"]
+	},
+	"eslintConfig": {
+		"extends": ["stylelint"],
+		"globals": {
+			"testRule": true
+		}
+	},
+	"jest": {
+		"clearMocks": true,
+		"collectCoverage": false,
+		"collectCoverageFrom": ["lib/**/*.js", "!lib/vendor/**/*.js"],
+		"coverageDirectory": "./.coverage/",
+		"coverageReporters": ["lcov", "text-summary"],
+		"coverageThreshold": {
+			"global": {
+				"branches": 75,
+				"functions": 75,
+				"lines": 75,
+				"statements": 75
+			}
+		},
+		"setupFiles": ["./jest-setup.js"],
+		"testEnvironment": "node",
+		"roots": ["lib", "system-tests"],
+		"testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$"
+	},
+	"greenkeeper": {
+		"ignore": ["micromatch"]
+	},
+	"remarkConfig": {
+		"plugins": [
+			"preset-lint-recommended",
+			"preset-lint-consistent",
+			[
+				"lint-no-missing-blank-lines",
+				{
+					"exceptTightLists": true
+				}
+			],
+			[
+				"validate-links",
+				{
+					"repository": "stylelint/stylelint"
+				}
+			]
+		]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,176 +1,198 @@
 {
-	"name": "stylelint",
-	"version": "9.2.0",
-	"description": "A mighty, modern CSS linter.",
-	"keywords": [
-		"css",
-		"less",
-		"sass",
-		"scss",
-		"sugarss",
-		"lint",
-		"linter",
-		"stylelint"
-	],
-	"authors": ["David Clark", "Maxime Thirouin", "Richard Hallows"],
-	"license": "MIT",
-	"homepage": "https://stylelint.io",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/stylelint/stylelint.git"
-	},
-	"main": "lib/index.js",
-	"bin": "bin/stylelint.js",
-	"files": [
-		"bin",
-		"CONTRIBUTING.md",
-		"docs",
-		"lib",
-		"VISION.md",
-		"!**/__tests__",
-		"flow-typed",
-		"!flow-typed/npm"
-	],
-	"engines": {
-		"node": ">=6"
-	},
-	"dependencies": {
-		"autoprefixer": "^8.0.0",
-		"balanced-match": "^1.0.0",
-		"chalk": "^2.4.1",
-		"cosmiconfig": "^5.0.0",
-		"color": "^3.0.0",
-		"debug": "^3.0.0",
-		"execall": "^1.0.0",
-		"file-entry-cache": "^2.0.0",
-		"get-stdin": "^6.0.0",
-		"globby": "^8.0.0",
-		"globjoin": "^0.1.4",
-		"html-tags": "^2.0.0",
-		"ignore": "^3.3.3",
-		"import-lazy": "^3.1.0",
-		"imurmurhash": "^0.1.4",
-		"known-css-properties": "^0.6.0",
-		"lodash": "^4.17.4",
-		"log-symbols": "^2.0.0",
-		"mathml-tag-names": "^2.0.1",
-		"meow": "^5.0.0",
-		"micromatch": "^2.3.11",
-		"normalize-selector": "^0.2.0",
-		"pify": "^3.0.0",
-		"postcss": "^6.0.16",
-		"postcss-html": "^0.18.0",
-		"postcss-less": "^1.1.5",
-		"postcss-media-query-parser": "^0.2.3",
-		"postcss-reporter": "^5.0.0",
-		"postcss-resolve-nested-selector": "^0.1.1",
-		"postcss-safe-parser": "^3.0.1",
-		"postcss-sass": "^0.3.0",
-		"postcss-scss": "^1.0.2",
-		"postcss-selector-parser": "^3.1.0",
-		"postcss-value-parser": "^3.3.0",
-		"resolve-from": "^4.0.0",
-		"signal-exit": "^3.0.2",
-		"specificity": "^0.3.1",
-		"string-width": "^2.1.0",
-		"style-search": "^0.1.0",
-		"sugarss": "^1.0.0",
-		"svg-tags": "^1.0.0",
-		"table": "^4.0.1"
-	},
-	"devDependencies": {
-		"benchmark": "^2.1.4",
-		"common-tags": "^1.4.0",
-		"coveralls": "^3.0.0",
-		"cp-file": "^5.0.0",
-		"d3-queue": "^3.0.7",
-		"del": "^3.0.0",
-		"eslint": "~4.19.0",
-		"eslint-config-stylelint": "~8.1.0",
-		"file-exists-promise": "^1.0.2",
-		"flow-bin": "^0.71.0",
-		"flow-typed": "^2.3.0",
-		"husky": "^0.14.3",
-		"jest": "^22.0.6",
-		"lint-staged": "^7.0.0",
-		"npm-run-all": "^4.0.2",
-		"npmpub": "^3.1.0",
-		"postcss-import": "^11.0.0",
-		"prettier": "~1.12.0",
-		"remark-cli": "^5.0.0",
-		"remark-lint-no-missing-blank-lines": "^1.0.1",
-		"remark-preset-lint-consistent": "^2.0.0",
-		"remark-preset-lint-recommended": "^3.0.0",
-		"remark-validate-links": "^7.0.0",
-		"request": "^2.81.0",
-		"strip-ansi": "^4.0.0",
-		"weak": "^1.0.1"
-	},
-	"scripts": {
-		"precommit": "lint-staged",
-		"benchmark-rule": "node scripts/benchmark-rule.js",
-		"dry-release": "npmpub  --dry --verbose",
-		"flow": "flow",
-		"flow-defs": "./node_modules/.bin/flow-typed install jest@22 lodash@4",
-		"jest": "jest",
-		"jest:detectleaks": "jest  --detectLeaks",
-		"lint:js": "eslint . --cache",
-		"lint:md": "remark . --quiet --frail",
-		"lint": "npm-run-all --parallel lint:*",
-		"pretest": "npm-run-all --serial lint flow",
-		"prettier:check": "prettier '**/*.js' --list-different",
-		"prettier:fix": "prettier '**/*.js' --write",
-		"release": "npmpub",
-		"test": "jest --coverage",
-		"watch": "jest --watch"
-	},
-	"lint-staged": {
-		"*.js": ["prettier --write", "git add"]
-	},
-	"eslintConfig": {
-		"extends": ["stylelint"],
-		"globals": {
-			"testRule": true
-		}
-	},
-	"jest": {
-		"clearMocks": true,
-		"collectCoverage": false,
-		"collectCoverageFrom": ["lib/**/*.js", "!lib/vendor/**/*.js"],
-		"coverageDirectory": "./.coverage/",
-		"coverageReporters": ["lcov", "text-summary"],
-		"coverageThreshold": {
-			"global": {
-				"branches": 75,
-				"functions": 75,
-				"lines": 75,
-				"statements": 75
-			}
-		},
-		"setupFiles": ["./jest-setup.js"],
-		"testEnvironment": "node",
-		"roots": ["lib", "system-tests"],
-		"testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$"
-	},
-	"greenkeeper": {
-		"ignore": ["micromatch"]
-	},
-	"remarkConfig": {
-		"plugins": [
-			"preset-lint-recommended",
-			"preset-lint-consistent",
-			[
-				"lint-no-missing-blank-lines",
-				{
-					"exceptTightLists": true
-				}
-			],
-			[
-				"validate-links",
-				{
-					"repository": "stylelint/stylelint"
-				}
-			]
-		]
-	}
+  "name": "stylelint",
+  "version": "9.2.0",
+  "description": "A mighty, modern CSS linter.",
+  "keywords": [
+    "css",
+    "less",
+    "sass",
+    "scss",
+    "sugarss",
+    "lint",
+    "linter",
+    "stylelint"
+  ],
+  "authors": [
+    "David Clark",
+    "Maxime Thirouin",
+    "Richard Hallows"
+  ],
+  "license": "MIT",
+  "homepage": "https://stylelint.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stylelint/stylelint.git"
+  },
+  "main": "lib/index.js",
+  "bin": "bin/stylelint.js",
+  "files": [
+    "bin",
+    "CONTRIBUTING.md",
+    "docs",
+    "lib",
+    "VISION.md",
+    "!**/__tests__",
+    "flow-typed",
+    "!flow-typed/npm"
+  ],
+  "engines": {
+    "node": ">=6"
+  },
+  "dependencies": {
+    "autoprefixer": "^8.0.0",
+    "balanced-match": "^1.0.0",
+    "chalk": "^2.4.1",
+    "color": "^3.0.0",
+    "cosmiconfig": "^5.0.0",
+    "debug": "^3.0.0",
+    "execall": "^1.0.0",
+    "file-entry-cache": "^2.0.0",
+    "get-stdin": "^6.0.0",
+    "globby": "^8.0.0",
+    "globjoin": "^0.1.4",
+    "html-tags": "^2.0.0",
+    "ignore": "^3.3.3",
+    "import-lazy": "^3.1.0",
+    "imurmurhash": "^0.1.4",
+    "known-css-properties": "^0.6.0",
+    "lodash": "^4.17.4",
+    "log-symbols": "^2.0.0",
+    "mathml-tag-names": "^2.0.1",
+    "meow": "^5.0.0",
+    "micromatch": "^2.3.11",
+    "normalize-selector": "^0.2.0",
+    "pify": "^3.0.0",
+    "postcss": "^6.0.16",
+    "postcss-html": "^0.18.0",
+    "postcss-less": "^1.1.5",
+    "postcss-media-query-parser": "^0.2.3",
+    "postcss-reporter": "^5.0.0",
+    "postcss-resolve-nested-selector": "^0.1.1",
+    "postcss-safe-parser": "^3.0.1",
+    "postcss-sass": "^0.3.0",
+    "postcss-scss": "^1.0.2",
+    "postcss-selector-parser": "^3.1.0",
+    "postcss-value-parser": "^3.3.0",
+    "resolve-from": "^4.0.0",
+    "signal-exit": "^3.0.2",
+    "specificity": "^0.3.1",
+    "string-width": "^2.1.0",
+    "style-search": "^0.1.0",
+    "sugarss": "^1.0.0",
+    "svg-tags": "^1.0.0",
+    "table": "^4.0.1"
+  },
+  "devDependencies": {
+    "benchmark": "^2.1.4",
+    "common-tags": "^1.4.0",
+    "coveralls": "^3.0.0",
+    "cp-file": "^5.0.0",
+    "d3-queue": "^3.0.7",
+    "del": "^3.0.0",
+    "eslint": "~4.19.0",
+    "eslint-config-stylelint": "~8.1.0",
+    "file-exists-promise": "^1.0.2",
+    "flow-bin": "^0.71.0",
+    "flow-typed": "^2.3.0",
+    "husky": "^0.14.3",
+    "jest": "^22.0.6",
+    "lint-staged": "^7.0.0",
+    "npm-run-all": "^4.0.2",
+    "npmpub": "^3.1.0",
+    "postcss-import": "^11.0.0",
+    "prettier": "~1.12.0",
+    "remark-cli": "^5.0.0",
+    "remark-lint-no-missing-blank-lines": "^1.0.1",
+    "remark-preset-lint-consistent": "^2.0.0",
+    "remark-preset-lint-recommended": "^3.0.0",
+    "remark-validate-links": "^7.0.0",
+    "request": "^2.81.0",
+    "strip-ansi": "^4.0.0",
+    "weak": "^1.0.1"
+  },
+  "scripts": {
+    "precommit": "lint-staged",
+    "benchmark-rule": "node scripts/benchmark-rule.js",
+    "dry-release": "npmpub  --dry --verbose",
+    "flow": "flow",
+    "flow-defs": "./node_modules/.bin/flow-typed install jest@22 lodash@4",
+    "jest": "jest",
+    "jest:detectleaks": "jest  --detectLeaks",
+    "lint:js": "eslint . --cache",
+    "lint:md": "remark . --quiet --frail",
+    "lint": "npm-run-all --parallel lint:*",
+    "pretest": "npm-run-all --serial lint flow",
+    "prettier:check": "prettier '**/*.js' --list-different",
+    "prettier:fix": "prettier '**/*.js' --write",
+    "release": "npmpub",
+    "test": "jest --coverage",
+    "watch": "jest --watch"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "eslintConfig": {
+    "extends": [
+      "stylelint"
+    ],
+    "globals": {
+      "testRule": true
+    }
+  },
+  "jest": {
+    "clearMocks": true,
+    "collectCoverage": false,
+    "collectCoverageFrom": [
+      "lib/**/*.js",
+      "!lib/vendor/**/*.js"
+    ],
+    "coverageDirectory": "./.coverage/",
+    "coverageReporters": [
+      "lcov",
+      "text-summary"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 75,
+        "functions": 75,
+        "lines": 75,
+        "statements": 75
+      }
+    },
+    "setupFiles": [
+      "./jest-setup.js"
+    ],
+    "testEnvironment": "node",
+    "roots": [
+      "lib",
+      "system-tests"
+    ],
+    "testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "micromatch"
+    ]
+  },
+  "remarkConfig": {
+    "plugins": [
+      "preset-lint-recommended",
+      "preset-lint-consistent",
+      [
+        "lint-no-missing-blank-lines",
+        {
+          "exceptTightLists": true
+        }
+      ],
+      [
+        "validate-links",
+        {
+          "repository": "stylelint/stylelint"
+        }
+      ]
+    ]
+  }
 }


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #3291 

> Is there anything in the PR that needs further explanation?

I kept the option `true` working, but no fix will be performed if the option is set to `true`. This is to avoid breaking any existing project who uses this setting.

I've added the options `rgb`, `rgba`, `hsl, and `hsla`. The versions with the trailing `a` are there just for compatibility, but `rgb` and `rgba` do the same thing.

An hex color will, most of the time, be converted to `rgb` (or `hsl). The formats with an alpha are only used if the color had an alpha in the first place.

I've updated the tests with the fixes.

I also added a new option to Jest, that is to pass a `unfixable` flag to the test. I needed to do this because of two reasons:

If the options is set to true and the fix flag is passed, I needed to make sure that the test would be rejected, as expected, but I needed to mark it as unfixable. 

The second reason is when a malformed hex color is input: This can't be fixed as the color can't be parsed, so the original value is kept, but I needed a way to ensure the tests would be close to real world, so I've made this change.

Let me know if anything seems off or needs changing and I'd be happy to comply :)

Thank you all for the great plugin!