### PR TITLE
Update Cosmiconfig

### DIFF
--- a/flow-typed/stylelint.js
+++ b/flow-typed/stylelint.js
@@ -44,8 +44,14 @@ export type stylelint$options = {
 
 export type stylelint$internalApi = {
   _options: stylelint$options,
-  _extendExplorer: { load: Function },
-  _fullExplorer: { load: Function },
+  _extendExplorer: {
+    search: string => Promise<null | Object>,
+    load: string => Promise<null | Object>
+  },
+  _fullExplorer: {
+    search: string => Promise<null | Object>,
+    load: string => Promise<null | Object>
+  },
   _configCache: Map<string, Object>,
   _specifiedConfigCache: Map<string, Object>,
   _postcssResultCache: Map<string, Object>,

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -184,7 +184,7 @@ function loadExtendedConfig(
   extendLookup /*: string*/
 ) /*: Promise<?{ config: stylelint$config, filepath: string }>*/ {
   const extendPath = getModulePath(configDir, extendLookup);
-  return stylelint._extendExplorer.load(null, extendPath);
+  return stylelint._extendExplorer.load(extendPath);
 }
 
 // When merging configs (via extends)

--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -21,12 +21,9 @@ module.exports = function(
   // Two separate explorers so they can each have their own transform
   // function whose results are cached by cosmiconfig
   stylelint._fullExplorer = cosmiconfig("stylelint", {
-    argv: false,
-    rcExtensions: true,
     transform: _.partial(augmentConfig.augmentConfigFull, stylelint)
   });
   stylelint._extendExplorer = cosmiconfig(null, {
-    argv: false,
     transform: _.partial(augmentConfig.augmentConfigExtended, stylelint)
   });
 

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -33,11 +33,14 @@ module.exports = function(
     return augmentedResult;
   }
 
-  return stylelint._fullExplorer
-    .load(searchPath, stylelint._options.configFile)
+  const searchForConfig = stylelint._options.configFile
+    ? stylelint._fullExplorer.load(stylelint._options.configFile)
+    : stylelint._fullExplorer.search(searchPath);
+
+  return searchForConfig
     .then(config => {
       // If no config was found, try looking from process.cwd
-      if (!config) return stylelint._fullExplorer.load(process.cwd());
+      if (!config) return stylelint._fullExplorer.search(process.cwd());
       return config;
     })
     .then(config => {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "autoprefixer": "^8.0.0",
     "balanced-match": "^1.0.0",
     "chalk": "^2.4.1",
-    "cosmiconfig": "^4.0.0",
+    "cosmiconfig": "^5.0.0",
     "debug": "^3.0.0",
     "execall": "^1.0.0",
     "file-entry-cache": "^2.0.0",


### PR DESCRIPTION
:wave: 

Replaces https://github.com/stylelint/stylelint/pull/3295.

The relevant changes in Cosmiconfig are:

- `search` and `load` are now separate functions, since they do fundamentally different things.
- `rc` files with extensions (e.g. `.stylelintrc.json`) are among the default `searchPlaces`, and the `rcExtensions` option was removed.
- The `argv` option was removed in an earlier version, so no need to turn it off anymore.

If tests on CI pass (they did locally), is there anything else you think we should try to ensure things work the same as before?