### PR TITLE
chore: cache node_modules

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,9 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
 
+cache:
+  - node_modules
+
 test_script:
   - node --version
   - npm --version


### PR DESCRIPTION
This PR caches the node_modules directory on Appveyor which is not the case currently.

> Is there anything in the PR that needs further explanation?

"No, it's self explanatory."
