### PR TITLE
Add link to stylelint-color-format plugin

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -3,6 +3,7 @@
 Plugins are rules and sets of rules built by the community that support methodologies, toolsets, *non-standard* CSS features, or very specific use cases. Their *package* names are prefixed with "stylelint". Their *rule* names are namespaced so that they do not clash with stylelint's core rules.
 
 -   [`stylelint-at-rule-no-children`](https://github.com/adityavm/stylelint-at-rule-no-children): Disallow block rule declarations inside at-rules (with a few exceptions).
+-   [`stylelint-color-format`](https://github.com/filipekiss/stylelint-color-format): Convert HEX colors to either RGB or HSL.
 -   [`stylelint-csstree-validator`](https://github.com/csstree/stylelint-validator): Validate CSS values to match W3C specs and browsers extensions.
 -   [`stylelint-declaration-block-no-ignored-properties`](https://github.com/kristerkari/stylelint-declaration-block-no-ignored-properties): Disallow property values that are ignored due to another property value in the same rule.
 -   [`stylelint-declaration-strict-value`](https://github.com/AndyOGo/stylelint-declaration-strict-value): Specify properties for which either a variable (`$sass`, `@less`, `var(--cssnext)`), function or custom CSS keyword (`inherit`, `none`, etc.) must be used for its value.


### PR DESCRIPTION
As discussed [here], I've created a `stylelint-color-format` plugin. This adds the plugin link to the `plugins.md` file. :)

[here]: https://github.com/stylelint/stylelint/pull/3292#discussion_r188789340