### PR TITLE
Add autofix to declaration-block-no-redundant-longhand-properties

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest All",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": ["--runInBand"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+          },
+          {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest Current File",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": ["${relativeFile}"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+          }
+    ]
+}

--- a/lib/reference/shorthandFormats.js
+++ b/lib/reference/shorthandFormats.js
@@ -3,13 +3,12 @@
 module.exports = {
   margin: ["margin-top", "margin-right", "margin-bottom", "margin-left"],
   padding: {
-    resolveValue: function(declarationNodes, postcss, prefixedShorthandData) {
+    resolveValue(declarationNodes, postcss) {
       const values = "padding-top padding-right padding-bottom padding-left";
       const property = declarationNodes[0].prop.toLowerCase();
-      const unprefixedProp = postcss.vendor.unprefixed(property);
       const prefix = postcss.vendor.prefix(property);
+      const transformedDeclarationNodes = {};
 
-      var transformedDeclarationNodes = {};
       declarationNodes.forEach(declarationNode => {
         transformedDeclarationNodes[declarationNode.prop] = declarationNode;
       });

--- a/lib/reference/shorthandFormats.js
+++ b/lib/reference/shorthandFormats.js
@@ -1,0 +1,189 @@
+"use strict";
+
+module.exports = {
+  margin: ["margin-top", "margin-right", "margin-bottom", "margin-left"],
+  padding: {
+    resolveValue: function(declarationNodes, postcss, prefixedShorthandData) {
+      const values = "padding-top padding-right padding-bottom padding-left";
+      const property = declarationNodes[0].prop.toLowerCase();
+      const unprefixedProp = postcss.vendor.unprefixed(property);
+      const prefix = postcss.vendor.prefix(property);
+
+      var transformedDeclarationNodes = {};
+      declarationNodes.forEach(declarationNode => {
+        transformedDeclarationNodes[declarationNode.prop] = declarationNode;
+      });
+
+      return values
+        .split(" ")
+        .map(value => transformedDeclarationNodes[prefix + value]["value"])
+        .join(" ");
+    }
+  },
+  background: [
+    "background-image",
+    "background-size",
+    "background-position",
+    "background-repeat",
+    "background-origin",
+    "background-clip",
+    "background-attachment",
+    "background-color"
+  ],
+  font: [
+    "font-style",
+    "font-variant",
+    "font-weight",
+    "font-stretch",
+    "font-size",
+    "font-family",
+    "line-height"
+  ],
+  border: [
+    "border-top-width",
+    "border-bottom-width",
+    "border-left-width",
+    "border-right-width",
+    "border-top-style",
+    "border-bottom-style",
+    "border-left-style",
+    "border-right-style",
+    "border-top-color",
+    "border-bottom-color",
+    "border-left-color",
+    "border-right-color"
+  ],
+  "border-top": ["border-top-width", "border-top-style", "border-top-color"],
+  "border-bottom": [
+    "border-bottom-width",
+    "border-bottom-style",
+    "border-bottom-color"
+  ],
+  "border-left": [
+    "border-left-width",
+    "border-left-style",
+    "border-left-color"
+  ],
+  "border-right": [
+    "border-right-width",
+    "border-right-style",
+    "border-right-color"
+  ],
+  "border-width": [
+    "border-top-width",
+    "border-bottom-width",
+    "border-left-width",
+    "border-right-width"
+  ],
+  "border-style": [
+    "border-top-style",
+    "border-bottom-style",
+    "border-left-style",
+    "border-right-style"
+  ],
+  "border-color": [
+    "border-top-color",
+    "border-bottom-color",
+    "border-left-color",
+    "border-right-color"
+  ],
+  "list-style": ["list-style-type", "list-style-position", "list-style-image"],
+  "border-radius": [
+    "border-top-right-radius",
+    "border-top-left-radius",
+    "border-bottom-right-radius",
+    "border-bottom-left-radius"
+  ],
+  transition: [
+    "transition-delay",
+    "transition-duration",
+    "transition-property",
+    "transition-timing-function"
+  ],
+  animation: [
+    "animation-name",
+    "animation-duration",
+    "animation-timing-function",
+    "animation-delay",
+    "animation-iteration-count",
+    "animation-direction",
+    "animation-fill-mode",
+    "animation-play-state"
+  ],
+  "border-block-end": [
+    "border-block-end-width",
+    "border-block-end-style",
+    "border-block-end-color"
+  ],
+  "border-block-start": [
+    "border-block-start-width",
+    "border-block-start-style",
+    "border-block-start-color"
+  ],
+  "border-image": [
+    "border-image-source",
+    "border-image-slice",
+    "border-image-width",
+    "border-image-outset",
+    "border-image-repeat"
+  ],
+  "border-inline-end": [
+    "border-inline-end-width",
+    "border-inline-end-style",
+    "border-inline-end-color"
+  ],
+  "border-inline-start": [
+    "border-inline-start-width",
+    "border-inline-start-style",
+    "border-inline-start-color"
+  ],
+  "column-rule": [
+    "column-rule-width",
+    "column-rule-style",
+    "column-rule-color"
+  ],
+  columns: ["column-width", "column-count"],
+  flex: ["flex-grow", "flex-shrink", "flex-basis"],
+  "flex-flow": ["flex-direction", "flex-wrap"],
+  grid: [
+    "grid-template-rows",
+    "grid-template-columns",
+    "grid-template-areas",
+    "grid-auto-rows",
+    "grid-auto-columns",
+    "grid-auto-flow",
+    "grid-column-gap",
+    "grid-row-gap"
+  ],
+  "grid-area": [
+    "grid-row-start",
+    "grid-column-start",
+    "grid-row-end",
+    "grid-column-end"
+  ],
+  "grid-column": ["grid-column-start", "grid-column-end"],
+  "grid-gap": ["grid-row-gap", "grid-column-gap"],
+  "grid-row": ["grid-row-start", "grid-row-end"],
+  "grid-template": [
+    "grid-template-columns",
+    "grid-template-rows",
+    "grid-template-areas"
+  ],
+  outline: ["outline-color", "outline-style", "outline-width"],
+  "text-decoration": [
+    "text-decoration-color",
+    "text-decoration-style",
+    "text-decoration-line"
+  ],
+  "text-emphasis": ["text-emphasis-style", "text-emphasis-color"],
+  mask: [
+    "mask-image",
+    "mask-mode",
+    "mask-position",
+    "mask-size",
+    "mask-repeat",
+    "mask-origin",
+    "mask-clip",
+    "mask-composite"
+  ]
+};

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -6,7 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: [true],
-
+  fix: true,
   accept: [
     {
       code: "a { margin-right: 10px; margin-top: 20px; }"
@@ -86,7 +86,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [true, { ignoreShorthands: ["/border/", "padding"] }],
-
+  fix: true,
   accept: [
     {
       code:

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -6,6 +6,7 @@ const postcss = require("postcss");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const shorthandData = require("../../reference/shorthandData");
+const shorthandFormats = require("../../reference/shorthandFormats");
 const validateOptions = require("../../utils/validateOptions");
 
 const ruleName = "declaration-block-no-redundant-longhand-properties";
@@ -14,7 +15,7 @@ const messages = ruleMessages(ruleName, {
   expected: props => `Expected shorthand property "${props}"`
 });
 
-const rule = function(actual, options) {
+const rule = function(actual, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(
       result,
@@ -50,6 +51,7 @@ const rule = function(actual, options) {
 
     function check(statement) {
       const longhandDeclarations = {};
+      const longhandDeclarationNodes = [];
       // Shallow iteration so nesting doesn't produce
       // false positives
       statement.each(node => {
@@ -75,6 +77,7 @@ const rule = function(actual, options) {
           }
 
           longhandDeclarations[prefixedShorthandProperty].push(prop);
+          longhandDeclarationNodes.push(node);
 
           const prefixedShorthandData = shorthandData[shorthandProperty].map(
             item => {
@@ -89,6 +92,29 @@ const rule = function(actual, options) {
             )
           ) {
             return;
+          }
+
+          if (context.fix) {
+            const shorthandValue = shorthandFormats[
+              shorthandProperty
+            ].resolveValue(
+              longhandDeclarationNodes,
+              postcss,
+              prefixedShorthandData
+            );
+
+            const referenceNode = longhandDeclarationNodes[0];
+            // create a new shorthandDeclarationNode
+            const newshorthandDeclarationNode = referenceNode.clone({
+              prop: prefix + shorthandProperty,
+              value: shorthandValue
+            });
+
+            // push the new shorthandDeclarationNode to parent.nodes
+            referenceNode.replaceWith(newshorthandDeclarationNode);
+
+            // delete the longhandDeclarationNodes
+            longhandDeclarationNodes.forEach(node => node.remove());
           }
 
           report({

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -97,11 +97,7 @@ const rule = function(actual, options, context) {
           if (context.fix) {
             const shorthandValue = shorthandFormats[
               shorthandProperty
-            ].resolveValue(
-              longhandDeclarationNodes,
-              postcss,
-              prefixedShorthandData
-            );
+            ].resolveValue(longhandDeclarationNodes, postcss);
 
             const referenceNode = longhandDeclarationNodes[0];
             // create a new shorthandDeclarationNode


### PR DESCRIPTION
WIP. 
As discussed [here](https://github.com/stylelint/stylelint/issues/3304) I have a initial version of autofix written. Before writing more, I would like to get feedback on the approach.

**Overview of the approach:**
On rule violation, it creates a shorthand value using references/shorthandFormats/resolveValue. For now I have created for padding.



