### PR TITLE
fix CssSyntaxError when config processors is a empty array

### DIFF
--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -237,6 +237,29 @@ describe("standalone with syntax set by extension", () => {
       });
     });
   });
+
+  describe("By extension with config processors to a empty array", () => {
+    beforeEach(() => {
+      return standalone({
+        files: `${fixturesPath}/extension-sensitive.*`,
+        config: {
+          rules: { "color-no-invalid-hex": true },
+          processors: [],
+        }
+      }).then(data => (results = data.results));
+    });
+
+    it("parsed each according to its extension", () => {
+      const sssResult = results.find(r => path.extname(r.source) === ".sss");
+      const lessResult = results.find(r => path.extname(r.source) === ".less");
+      const sassResult = results.find(r => path.extname(r.source) === ".sass");
+      const scssResult = results.find(r => path.extname(r.source) === ".scss");
+      expect(sssResult._postcssResult.root.source.lang).toBe("sugarss");
+      expect(lessResult._postcssResult.root.source.lang).toBe("less");
+      expect(sassResult._postcssResult.root.source.lang).toBe("sass");
+      expect(scssResult._postcssResult.root.source.lang).toBe("scss");
+    });
+  });
 });
 
 it("standalone with automatic syntax inference", () => {

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -86,7 +86,7 @@ module.exports = function(
             "You must use a valid syntax option, either: scss, sass, less or sugarss"
           );
         }
-      } else if (!options.codeProcessors || (options.filePath && /\.(scss|sass|less)$/.test(options.filePath))) {
+      } else if (!(options.codeProcessors && options.codeProcessors.length) || (options.filePath && /\.(scss|sass|less)$/.test(options.filePath))) {
         syntaxes.css.parse = stylelint._options.fix
           ? importLazy("postcss-safe-parser")
           : postcss.parse


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#3327

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
