### PR TITLE
fix(package): update postcss-syntax to version 0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "postcss-sass": "^0.3.0",
     "postcss-scss": "^1.0.2",
     "postcss-selector-parser": "^3.1.0",
-    "postcss-syntax": "^0.10.0",
+    "postcss-syntax": "^0.26.0",
     "postcss-value-parser": "^3.3.0",
     "resolve-from": "^4.0.0",
     "signal-exit": "^3.0.2",


### PR DESCRIPTION
Closes #3331

Possibly also closes `Closes: #3332 #3333 #3335 #3336` per https://github.com/stylelint/stylelint/pull/3331#issuecomment-392431192 

cc @gucong3000 

