### PR TITLE
Add autofix for selector-pseudo-element-colon-notation

### DIFF
--- a/lib/rules/selector-pseudo-element-colon-notation/README.md
+++ b/lib/rules/selector-pseudo-element-colon-notation/README.md
@@ -12,6 +12,8 @@ The `::` notation was chosen for *pseudo-elements* to establish a discrimination
 
 However, for compatibility with existing style sheets, user agents also accept the previous one-colon notation for *pseudo-elements* introduced in CSS levels 1 and 2 (namely, `:first-line`, `:first-letter`, `:before` and `:after`).
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"single"|"double"`

--- a/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["single"],
+  fix: true,
 
   accept: [
     {
@@ -62,36 +63,49 @@ testRule(rule, {
   reject: [
     {
       code: "a::before { color: pink; }",
+      fixed: "a:before { color: pink; }",
       message: messages.expected("single"),
       line: 1,
       column: 3
     },
     {
       code: "a::bEfOrE { color: pink; }",
+      fixed: "a:bEfOrE { color: pink; }",
       message: messages.expected("single"),
       line: 1,
       column: 3
     },
     {
       code: "a::BEFORE { color: pink; }",
+      fixed: "a:BEFORE { color: pink; }",
       message: messages.expected("single"),
       line: 1,
       column: 3
     },
     {
       code: "a::after { color: pink; }",
+      fixed: "a:after { color: pink; }",
       message: messages.expected("single"),
       line: 1,
       column: 3
     },
     {
       code: "a::first-line { color: pink; }",
+      fixed: "a:first-line { color: pink; }",
       message: messages.expected("single"),
       line: 1,
       column: 3
     },
     {
       code: "a::first-letter { color: pink; }",
+      fixed: "a:first-letter { color: pink; }",
+      message: messages.expected("single"),
+      line: 1,
+      column: 3
+    },
+    {
+      code: "a::before, a::after, a::first-letter { color: pink; }",
+      fixed: "a:before, a:after, a:first-letter { color: pink; }",
       message: messages.expected("single"),
       line: 1,
       column: 3
@@ -102,6 +116,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["double"],
+  fix: true,
 
   accept: [
     {
@@ -142,24 +157,35 @@ testRule(rule, {
   reject: [
     {
       code: "a:before { color: pink; }",
+      fixed: "a::before { color: pink; }",
       message: messages.expected("double"),
       line: 1,
       column: 2
     },
     {
       code: "a:after { color: pink; }",
+      fixed: "a::after { color: pink; }",
       message: messages.expected("double"),
       line: 1,
       column: 2
     },
     {
       code: "a:first-line { color: pink; }",
+      fixed: "a::first-line { color: pink; }",
       message: messages.expected("double"),
       line: 1,
       column: 2
     },
     {
       code: "a:first-letter { color: pink; }",
+      fixed: "a::first-letter { color: pink; }",
+      message: messages.expected("double"),
+      line: 1,
+      column: 2
+    },
+    {
+      code: "a:before, a:after, a:first-letter { color: pink; }",
+      fixed: "a::before, a::after, a::first-letter { color: pink; }",
       message: messages.expected("double"),
       line: 1,
       column: 2

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
   expected: q => `Expected ${q} colon pseudo-element notation`
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -35,6 +35,8 @@ const rule = function(expectation) {
         return;
       }
 
+      const fixPositions = [];
+
       // match only level 1 and 2 pseudo elements
       const pseudoElementsWithColons = _
         .toArray(keywordSets.levelOneAndTwoPseudoElements)
@@ -51,6 +53,11 @@ const rule = function(expectation) {
             return;
           }
 
+          if (context.fix) {
+            fixPositions.unshift({ rule, startIndex: match.startIndex });
+            return;
+          }
+
           report({
             message: messages.expected(expectation),
             node: rule,
@@ -60,6 +67,21 @@ const rule = function(expectation) {
           });
         }
       );
+
+      if (fixPositions.length) {
+        // If expecting : then we found :: so remove one of the colons
+        // If expecting :: then we found : so add one extra colon
+        const expectedSingle = expectation === "single";
+        const offset = expectedSingle ? 1 : 0;
+        const extraColon = expectedSingle ? "" : ":";
+
+        fixPositions.forEach(function(fixPosition) {
+          rule.selector =
+            rule.selector.substring(0, fixPosition.startIndex - offset) +
+            extraColon +
+            rule.selector.substring(fixPosition.startIndex);
+        });
+      }
     });
   };
 };


### PR DESCRIPTION
selector-pseudo-element-colon-notation allows you to enforce using double or single colons on level 1 and level 2 pseudo-elements (back when `:before` and `:after` were considered valid before spec updates made ::before and ::after the preferred format).

For example using the "double" value, `a::before { display: block; }` is valid, while `a:before { display:block; }` is invalid.

This PR adds autofix support to the rule so that:

- If the value of double is set then `a:before { display: block; }` will be automatically fixed to `a::before { display: block; }`
- If the value of single is set then `a::before { display: block; }` will be automatically fixed to `a:before { display: block; }`

Fixes #3344
