### PR TITLE
fix: allow `/` after function right parenthesis

### DIFF
--- a/lib/rules/function-whitespace-after/README.md
+++ b/lib/rules/function-whitespace-after/README.md
@@ -8,7 +8,7 @@ a { transform: translate(1, 1) scale(3); }
  *                   This space */
 ```
 
-This rule does not check for space immediately after `)` if the very next character is `,`, `)`, or `}`, allowing some of the patterns exemplified below.
+This rule does not check for space immediately after `)` if the very next character is `,`, `)`, `/` or `}`, allowing some of the patterns exemplified below.
 
 ## Options
 

--- a/lib/rules/function-whitespace-after/__tests__/index.js
+++ b/lib/rules/function-whitespace-after/__tests__/index.js
@@ -72,6 +72,10 @@ testRule(rule, {
     {
       code: ".foo { border-$(x)-left: 10px; }",
       description: "postcss-simple-vars interpolation within property name"
+    },
+    {
+      code: ".foo { font: calc(16px + .2vw)/1 }",
+      description: "after calc in `font` property (line-height shorthand value)"
     }
   ],
 
@@ -119,6 +123,10 @@ testRule(rule, {
     },
     {
       code: "a { color: color(rgb(0,0,0)lightness(50%)) };"
+    },
+    {
+      code: ".foo { font: calc(16px + .2vw)/1 }",
+      description: "after calc in `font` property (line-height shorthand value)"
     }
   ],
 

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -13,7 +13,14 @@ const messages = ruleMessages(ruleName, {
   rejected: 'Unexpected whitespace after ")"'
 });
 
-const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([")", ",", "}", ":", undefined]);
+const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([
+  ")",
+  ",",
+  "}",
+  ":",
+  "/",
+  undefined
+]);
 
 const rule = function(expectation) {
   return (root, result) => {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

fixes #3132

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
