### PR TITLE
fix: `max-nesting-depth` now ignores `SCSS` nester properties

### DIFF
--- a/lib/rules/max-nesting-depth/__tests__/index.js
+++ b/lib/rules/max-nesting-depth/__tests__/index.js
@@ -144,3 +144,17 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: [1],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [
+    {
+      code: ".foo { .bar { margin: { bottom: 0; } } }",
+      description: "SCSS nested properties"
+    }
+  ]
+});

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -2,6 +2,7 @@
 
 const _ = require("lodash");
 const hasBlock = require("../../utils/hasBlock");
+const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -44,6 +45,9 @@ const rule = function(max, options) {
         return;
       }
       if (!hasBlock(statement)) {
+        return;
+      }
+      if (statement.selector && !isStandardSyntaxRule(statement)) {
         return;
       }
       const depth = nestingDepth(statement);


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#3030

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
