### PR TITLE
Add non-obvious list of rule README conventions

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -189,10 +189,19 @@ Each rule must be accompanied by a README, fitting the following format:
 7.  Example patterns that are *not* considered violations (for each option value).
 8.  Optional options (if applicable).
 
-Look at the READMEs of other rules to glean more conventional patterns. These includes:
+Look at the READMEs of other rules to glean more conventional patterns. These include:
 
--   Aligning the arrows within the prototypical code example with the beginning of the construct being highlighted.
 -   Using "This rule" to refer to the rule e.g. "This rule ignores ..."
+-   Aligning the arrows within the prototypical code example with the beginning of the construct being highlighted.
+-   Aligning the text within the prototypical code example as far to the left as possible.
+
+For example:
+
+```css
+ @media screen and (min-width: 768px) {}
+/**                 ↑          ↑
+  *       These names and values */
+```
 
 #### Single line descriptions
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -189,7 +189,10 @@ Each rule must be accompanied by a README, fitting the following format:
 7.  Example patterns that are *not* considered violations (for each option value).
 8.  Optional options (if applicable).
 
-Look at the READMEs of other rules to glean more conventional patterns.
+Look at the READMEs of other rules to glean more conventional patterns. These includes:
+
+-   Aligning the arrows within the prototypical code example with the beginning of the construct being highlighted.
+-   Using "This rule" to refer to the rule e.g. "This rule ignores ..."
 
 #### Single line descriptions
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/pull/3320#discussion_r192897819

> Is there anything in the PR that needs further explanation?

I felt like these two conventions were the most non-obvious and difficult to glean from the existing READMEs.

For anyone interested, we use "This rule" to help distinguish the stylelint rule from CSS rules.