### PR TITLE
Fix compatibility with non css PostCSS syntaxes

### DIFF
--- a/lib/rules/max-empty-lines/__tests__/index.js
+++ b/lib/rules/max-empty-lines/__tests__/index.js
@@ -94,6 +94,21 @@ testRule(rule, {
 
 </div>`
     }
+  ],
+
+  reject: [
+    {
+      code: `<div>
+<style>
+/* horse */
+
+
+</style>
+</div>`,
+      message: messages.expected(1),
+      line: 6,
+      column: 1
+    }
   ]
 });
 

--- a/lib/rules/max-line-length/__tests__/index.js
+++ b/lib/rules/max-line-length/__tests__/index.js
@@ -140,6 +140,42 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [20],
+  syntax: "html",
+
+  accept: [
+    {
+      code: `<div>
+<div>Very very very very very very very very very very very very very long line</div>
+<style>
+a {
+  color: red;
+}
+</style>
+
+</div>`
+    }
+  ],
+
+  reject: [
+    {
+      code: `<div>
+<style>
+a {
+  color     :      red;
+}
+</style>
+
+</div>`,
+      message: messages.expected(20),
+      line: 4,
+      column: 9
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   syntax: "scss",
   config: [20],
 

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const eachRoot = require("../../utils/eachRoot");
 const execall = require("execall");
 const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
@@ -39,19 +40,21 @@ const rule = function(maxLength, options) {
       return;
     }
 
-    const rootString = root.source.input.css;
-
     const ignoreNonComments = optionsMatches(options, "ignore", "non-comments");
     const ignoreComments = optionsMatches(options, "ignore", "comments");
 
-    // Check first line
-    checkNewline({ endIndex: 0 });
+    eachRoot(root, checkRoot);
 
-    // Check subsequent lines
-    styleSearch(
-      { source: rootString, target: ["\n"], comments: "check" },
-      checkNewline
-    );
+    function checkRoot(root) {
+      const rootString = root.source.input.css;
+      // Check first line
+      checkNewline(rootString, { endIndex: 0 });
+      // Check subsequent lines
+      styleSearch(
+        { source: rootString, target: ["\n"], comments: "check" },
+        match => checkNewline(rootString, match)
+      );
+    }
 
     function complain(index) {
       report({
@@ -63,7 +66,7 @@ const rule = function(maxLength, options) {
       });
     }
 
-    function checkNewline(match) {
+    function checkNewline(rootString, match) {
       let nextNewlineIndex = rootString.indexOf("\n", match.endIndex);
       if (rootString[nextNewlineIndex - 1] === "\r") {
         nextNewlineIndex -= 1;

--- a/lib/rules/no-eol-whitespace/__tests__/index.js
+++ b/lib/rules/no-eol-whitespace/__tests__/index.js
@@ -280,6 +280,41 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [true],
+  syntax: "html",
+
+  accept: [
+    {
+      code: `<div> /* After this comment we have eol whitespace */ 
+<style>
+a {
+  color: red;
+}
+</style>
+
+</div>`
+    }
+  ],
+
+  reject: [
+    {
+      code: `<div>
+<style>
+a {
+  color: red; 
+}
+</style>
+
+</div>`,
+      message: messages.rejected,
+      line: 4,
+      column: 14
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: [true, { ignore: ["empty-lines"] }],
   skipBasicChecks: true,
 

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const eachRoot = require("../../utils/eachRoot");
 const isOnlyWhitespace = require("../../utils/isOnlyWhitespace");
 const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
@@ -35,40 +36,45 @@ const rule = function(on, options) {
       return;
     }
 
-    const rootString = root.toString();
-    styleSearch(
-      {
-        source: rootString,
-        target: ["\n", "\r"],
-        comments: "check"
-      },
-      match => {
-        // If the character before newline is not whitespace, ignore
-        if (!whitespacesToReject.has(rootString[match.startIndex - 1])) {
-          return;
-        }
+    eachRoot(root, checkRoot);
 
-        if (optionsMatches(options, "ignore", "empty-lines")) {
-          // If there is only whitespace between the previous newline and
-          // this newline, ignore
-          const lineBefore = rootString.substring(
-            match.startIndex + 1,
-            rootString.lastIndexOf("\n", match.startIndex - 1)
-          );
-          if (isOnlyWhitespace(lineBefore)) {
+    function checkRoot(root) {
+      const rootString = root.source.input.css;
+
+      styleSearch(
+        {
+          source: rootString,
+          target: ["\n", "\r"],
+          comments: "check"
+        },
+        match => {
+          // If the character before newline is not whitespace, ignore
+          if (!whitespacesToReject.has(rootString[match.startIndex - 1])) {
             return;
           }
-        }
 
-        report({
-          message: messages.rejected,
-          node: root,
-          index: match.startIndex - 1,
-          result,
-          ruleName
-        });
-      }
-    );
+          if (optionsMatches(options, "ignore", "empty-lines")) {
+            // If there is only whitespace between the previous newline and
+            // this newline, ignore
+            const lineBefore = rootString.substring(
+              match.startIndex + 1,
+              rootString.lastIndexOf("\n", match.startIndex - 1)
+            );
+            if (isOnlyWhitespace(lineBefore)) {
+              return;
+            }
+          }
+
+          report({
+            message: messages.rejected,
+            node: root,
+            index: match.startIndex - 1,
+            result,
+            ruleName
+          });
+        }
+      );
+    }
   };
 };
 

--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -687,6 +687,49 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [true],
+  syntax: "html",
+
+  accept: [
+    {
+      code: `<div>
+<style>
+a {
+  color: red;
+}
+</style>
+</div>`
+    }
+  ],
+
+  reject: [
+    {
+      code: `<div>
+<style>
+;
+</style>
+</div>`,
+      message: messages.rejected,
+      line: 3,
+      column: 1
+    },
+    {
+      code: `<div>
+<style>
+a {
+  color: red;;
+}
+</style>
+</div>`,
+      message: messages.rejected,
+      line: 4,
+      column: 14
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true],
   syntax: "less",
 
   accept: [

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const eachRoot = require("../../utils/eachRoot");
 const isCustomPropertySet = require("../../utils/isCustomPropertySet");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const report = require("../../utils/report");
@@ -14,6 +15,9 @@ const messages = ruleMessages(ruleName, {
 });
 
 function getOffsetByNode(node) {
+  if (node.parent && node.parent.document) {
+    return 0;
+  }
   const string = node.root().source.input.css;
   const nodeColumn = node.source.start.column;
   const nodeLine = node.source.start.line;
@@ -45,130 +49,139 @@ const rule = function(actual) {
       return;
     }
 
-    const rawAfterRoot = root.raws.after;
+    eachRoot(root, checkRoot);
 
-    if (rawAfterRoot && rawAfterRoot.trim().length !== 0) {
-      styleSearch({ source: rawAfterRoot, target: ";" }, match => {
-        complain(
-          root.toString().length - rawAfterRoot.length + match.startIndex
-        );
-      });
-    }
+    function checkRoot(root) {
+      const rawAfterRoot = root.raws.after;
 
-    root.walk(node => {
-      if (
-        node.type === "rule" &&
-        !isCustomPropertySet(node) &&
-        !isStandardSyntaxRule(node)
-      ) {
-        return;
-      }
-
-      let rawBeforeNode = node.raws.before;
-
-      if (rawBeforeNode && rawBeforeNode.trim().length !== 0) {
-        let allowedSemi = 0;
-
-        const next = node.next();
-
-        // Ignore semicolon before comment if next node is custom properties sets or comment
-        if (
-          node.type === "comment" &&
-          next &&
-          isCustomPropertySet(next) &&
-          node.parent.index(next) > 0
-        ) {
-          allowedSemi = 1;
-        }
-
-        const prev = node.prev();
-
-        // Adding previous node string to custom properties set if previous node is comment
-        if (
-          isCustomPropertySet(node) &&
-          node.parent.index(node) > 0 &&
-          prev &&
-          prev.type === "comment"
-        ) {
-          rawBeforeNode = prev.toString() + rawBeforeNode;
-          allowedSemi = 0;
-        }
-
-        styleSearch({ source: rawBeforeNode, target: ";" }, (match, count) => {
-          if (count === allowedSemi) {
-            return;
-          }
-
+      if (rawAfterRoot && rawAfterRoot.trim().length !== 0) {
+        styleSearch({ source: rawAfterRoot, target: ";" }, match => {
           complain(
-            getOffsetByNode(node) - rawBeforeNode.length + match.startIndex
+            root.source.input.css.length -
+              rawAfterRoot.length +
+              match.startIndex
           );
         });
       }
 
-      const rawAfterNode = node.raws.after;
-
-      if (rawAfterNode && rawAfterNode.trim().length !== 0) {
-        /**
-         * If the last child is a Less mixin followed by more than one semicolon,
-         * node.raws.after will be populated with that semicolon.
-         * Since we ignore Less mixins, exit here
-         */
+      root.walk(node => {
         if (
-          node.last &&
-          node.last.type === "rule" &&
-          !isCustomPropertySet(node.last) &&
-          !isStandardSyntaxRule(node.last)
+          node.type === "rule" &&
+          !isCustomPropertySet(node) &&
+          !isStandardSyntaxRule(node)
         ) {
           return;
         }
 
-        styleSearch({ source: rawAfterNode, target: ";" }, match => {
-          const index =
-            getOffsetByNode(node) +
-            node.toString().length -
-            1 -
-            rawAfterNode.length +
-            match.startIndex;
+        let rawBeforeNode = node.raws.before;
 
-          complain(index);
-        });
-      }
+        if (rawBeforeNode && rawBeforeNode.trim().length !== 0) {
+          let allowedSemi = 0;
 
-      const rawOwnSemicolon = node.raws.ownSemicolon;
+          const next = node.next();
 
-      if (rawOwnSemicolon) {
-        let allowedSemi = 0;
+          // Ignore semicolon before comment if next node is custom properties sets or comment
+          if (
+            node.type === "comment" &&
+            next &&
+            isCustomPropertySet(next) &&
+            node.parent.index(next) > 0
+          ) {
+            allowedSemi = 1;
+          }
 
-        if (isCustomPropertySet(node)) {
-          allowedSemi = 1;
+          const prev = node.prev();
+
+          // Adding previous node string to custom properties set if previous node is comment
+          if (
+            isCustomPropertySet(node) &&
+            node.parent.index(node) > 0 &&
+            prev &&
+            prev.type === "comment"
+          ) {
+            rawBeforeNode = prev.toString() + rawBeforeNode;
+            allowedSemi = 0;
+          }
+
+          styleSearch(
+            { source: rawBeforeNode, target: ";" },
+            (match, count) => {
+              if (count === allowedSemi) {
+                return;
+              }
+
+              complain(
+                getOffsetByNode(node) - rawBeforeNode.length + match.startIndex
+              );
+            }
+          );
         }
 
-        styleSearch(
-          { source: rawOwnSemicolon, target: ";" },
-          (match, count) => {
-            if (count === allowedSemi) {
-              return;
-            }
+        const rawAfterNode = node.raws.after;
 
+        if (rawAfterNode && rawAfterNode.trim().length !== 0) {
+          /**
+           * If the last child is a Less mixin followed by more than one semicolon,
+           * node.raws.after will be populated with that semicolon.
+           * Since we ignore Less mixins, exit here
+           */
+          if (
+            node.last &&
+            node.last.type === "rule" &&
+            !isCustomPropertySet(node.last) &&
+            !isStandardSyntaxRule(node.last)
+          ) {
+            return;
+          }
+
+          styleSearch({ source: rawAfterNode, target: ";" }, match => {
             const index =
               getOffsetByNode(node) +
               node.toString().length -
-              rawOwnSemicolon.length +
+              1 -
+              rawAfterNode.length +
               match.startIndex;
-            complain(index);
-          }
-        );
-      }
-    });
 
-    function complain(index) {
-      report({
-        message: messages.rejected,
-        node: root,
-        index,
-        result,
-        ruleName
+            complain(index);
+          });
+        }
+
+        const rawOwnSemicolon = node.raws.ownSemicolon;
+
+        if (rawOwnSemicolon) {
+          let allowedSemi = 0;
+
+          if (isCustomPropertySet(node)) {
+            allowedSemi = 1;
+          }
+
+          styleSearch(
+            { source: rawOwnSemicolon, target: ";" },
+            (match, count) => {
+              if (count === allowedSemi) {
+                return;
+              }
+
+              const index =
+                getOffsetByNode(node) +
+                node.toString().length -
+                rawOwnSemicolon.length +
+                match.startIndex;
+              complain(index);
+            }
+          );
+        }
       });
+
+      function complain(index) {
+        report({
+          message: messages.rejected,
+          node: root,
+          index,
+          result,
+          ruleName
+        });
+      }
     }
   };
 };

--- a/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
@@ -72,6 +72,39 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: [true],
+  syntax: "html",
+
+  accept: [
+    {
+      code: `<div>
+<style>
+a {
+  color: red;
+}
+</style>
+
+</div>`
+    }
+  ],
+
+  reject: [
+    {
+      code: `<div>
+<style>a {
+  color: red;
+}</style>
+
+</div>`,
+      message: messages.rejected,
+      line: 4,
+      column: 1
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true],
   skipBasicChecks: true,
   syntax: "sugarss",
   fix: true,

--- a/lib/rules/no-missing-end-of-source-newline/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const eachRoot = require("../../utils/eachRoot");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -17,24 +18,28 @@ const rule = function(primary, _, context) {
       return;
     }
 
-    const sourceCss = root.source.input.css;
-    if (sourceCss === "" || sourceCss.slice(-1) === "\n") {
-      return;
-    }
+    eachRoot(root, checkRoot);
 
-    // Fix
-    if (context.fix) {
-      root.raws.after = context.newline;
-      return;
-    }
+    function checkRoot(root) {
+      const rootString = root.source.input.css;
+      if (rootString.trim() === "" || rootString.slice(-1) === "\n") {
+        return;
+      }
 
-    report({
-      message: messages.rejected,
-      node: root,
-      index: sourceCss.length - 1,
-      result,
-      ruleName
-    });
+      // Fix
+      if (context.fix) {
+        root.raws.after = context.newline;
+        return;
+      }
+
+      report({
+        message: messages.rejected,
+        node: root,
+        index: rootString.length - 1,
+        result,
+        ruleName
+      });
+    }
   };
 };
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#3365 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

Rules where i fix problems:
- max-line-length
- no-eol-whitespace
- no-extra-semicolons
- no-missing-end-of-source-newline