### PR TITLE
Upgrade to micromatch@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "log-symbols": "^2.0.0",
     "mathml-tag-names": "^2.0.1",
     "meow": "^5.0.0",
-    "micromatch": "^2.3.11",
+    "micromatch": "^3.1.10",
     "normalize-selector": "^0.2.0",
     "pify": "^3.0.0",
     "postcss": "^6.0.16",


### PR DESCRIPTION
There are no breaking changes in this version,
and the old version is depending on arr-diff@2.

arr-diff@2 causes problems because it fails to
properly declare arr-flatten as a dependency,
which results in failure when installed using
a strict npm client such as pnpm.

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3370

> Is there anything in the PR that needs further explanation?

No
