### PR TITLE
Fix false positives on non-standard syntax in declaration-block-no-*

### DIFF
--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -49,10 +49,6 @@ testRule(rule, {
 
   reject: [
     {
-      code: "color: pink; color: orange",
-      message: messages.rejected("color")
-    },
-    {
       code: "a { color: pink; color: orange }",
       message: messages.rejected("color")
     },
@@ -238,6 +234,45 @@ testRule(rule, {
     },
     {
       code: "p { background: orange; color: pink; background: white; }",
+      message: messages.rejected("background")
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  skipBasicChecks: true,
+  syntax: "html",
+
+  accept: [
+    {
+      code: "<style>a { color: pink; }</style>"
+    },
+    {
+      code: '<a style="color: pink;"></a>'
+    },
+    {
+      code: "<style>a { color: pink; }</style><style>a { color: pink; }</style>"
+    },
+    {
+      code: '<a style="color: pink;"></a><a style="color: pink;"></a>'
+    }
+  ],
+
+  reject: [
+    {
+      code: '<a style="color: pink; color: orange"></a>',
+      message: messages.rejected("color")
+    },
+    {
+      code:
+        "<style>p { color: pink; background: orange; background: white; }</style>",
+      message: messages.rejected("background")
+    },
+    {
+      code:
+        '<a style="background: orange; color: pink; background: white;"></a>',
       message: messages.rejected("background")
     }
   ]

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -49,6 +49,10 @@ testRule(rule, {
 
   reject: [
     {
+      code: "color: pink; color: orange",
+      message: messages.rejected("color")
+    },
+    {
       code: "a { color: pink; color: orange }",
       message: messages.rejected("color")
     },

--- a/lib/rules/declaration-block-no-duplicate-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const eachDeclarationBlock = require("../../utils/eachDeclarationBlock");
 const isCustomProperty = require("../../utils/isCustomProperty");
 const isStandardSyntaxProperty = require("../../utils/isStandardSyntaxProperty");
 const optionsMatches = require("../../utils/optionsMatches");
@@ -36,32 +37,12 @@ const rule = function(on, options) {
       return;
     }
 
-    // In order to accommodate nested blocks (postcss-nested),
-    // we need to run a shallow loop (instead of eachDecl() or eachRule(),
-    // which loop recursively) and allow each nested block to accumulate
-    // its own list of properties -- so that a property in a nested rule
-    // does not conflict with the same property in the parent rule
-    root.each(node => {
-      if (node.type === "rule" || node.type === "atrule") {
-        checkRulesInNode(node);
-      }
-    });
-
-    function checkRulesInNode(node) {
+    eachDeclarationBlock(root, eachDecl => {
       const decls = [];
       const values = [];
-
-      node.each(child => {
-        if (child.nodes && child.nodes.length) {
-          checkRulesInNode(child);
-        }
-
-        if (child.type !== "decl") {
-          return;
-        }
-
-        const prop = child.prop;
-        const value = child.value;
+      eachDecl(decl => {
+        const prop = decl.prop;
+        const value = decl.value;
 
         if (!isStandardSyntaxProperty(prop)) {
           return;
@@ -94,7 +75,7 @@ const rule = function(on, options) {
             if (indexDuplicate !== decls.length - 1) {
               report({
                 message: messages.rejected(prop),
-                node: child,
+                node: decl,
                 result,
                 ruleName
               });
@@ -104,7 +85,7 @@ const rule = function(on, options) {
             if (value === values[indexDuplicate]) {
               report({
                 message: messages.rejected(value),
-                node: child,
+                node: decl,
                 result,
                 ruleName
               });
@@ -122,7 +103,7 @@ const rule = function(on, options) {
 
           report({
             message: messages.rejected(prop),
-            node: child,
+            node: decl,
             result,
             ruleName
           });
@@ -131,7 +112,7 @@ const rule = function(on, options) {
         decls.push(prop.toLowerCase());
         values.push(value.toLowerCase());
       });
-    }
+    });
   };
 };
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -37,11 +37,6 @@ testRule(rule, {
   reject: [
     {
       code:
-        "margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px;",
-      message: messages.expected("margin")
-    },
-    {
-      code:
         "a { margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }",
       message: messages.expected("margin")
     },
@@ -107,6 +102,38 @@ testRule(rule, {
     {
       code:
         "a { margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }",
+      message: messages.expected("margin")
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "html",
+
+  accept: [
+    {
+      code: "<style>a { margin-right: 10px; margin-top: 20px; }</style>"
+    },
+    {
+      code: '<a style="margin-right: 10px; margin-top: 20px;"></a>'
+    },
+    {
+      code:
+        '<a style="margin-left: 10px; margin-right: 10px;"></a><a style="margin-top: 20px; margin-bottom: 30px;"></a>'
+    }
+  ],
+
+  reject: [
+    {
+      code:
+        "<style>p { margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }</style>",
+      message: messages.expected("margin")
+    },
+    {
+      code:
+        '<a style="margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px;"></a>',
       message: messages.expected("margin")
     }
   ]

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -37,6 +37,11 @@ testRule(rule, {
   reject: [
     {
       code:
+        "margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px;",
+      message: messages.expected("margin")
+    },
+    {
+      code:
         "a { margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }",
       message: messages.expected("margin")
     },

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const eachDeclarationBlock = require("../../utils/eachDeclarationBlock");
 const optionsMatches = require("../../utils/optionsMatches");
 const postcss = require("postcss");
 const report = require("../../utils/report");
@@ -45,19 +46,10 @@ const rule = function(actual, options) {
       }
     );
 
-    root.walkRules(check);
-    root.walkAtRules(check);
-
-    function check(statement) {
+    eachDeclarationBlock(root, eachDecl => {
       const longhandDeclarations = {};
-      // Shallow iteration so nesting doesn't produce
-      // false positives
-      statement.each(node => {
-        if (node.type !== "decl") {
-          return;
-        }
-
-        const prop = node.prop.toLowerCase();
+      eachDecl(decl => {
+        const prop = decl.prop.toLowerCase();
         const unprefixedProp = postcss.vendor.unprefixed(prop);
         const prefix = postcss.vendor.prefix(prop);
 
@@ -94,12 +86,12 @@ const rule = function(actual, options) {
           report({
             ruleName,
             result,
-            node,
+            node: decl,
             message: messages.expected(prefixedShorthandProperty)
           });
         });
       });
-    }
+    });
   };
 };
 

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -44,10 +44,6 @@ testRule(rule, {
 
   reject: [
     {
-      code: "padding-left: 10px; padding: 20px;",
-      message: messages.rejected("padding", "padding-left")
-    },
-    {
       code: "a { padding-left: 10px; padding: 20px; }",
       message: messages.rejected("padding", "padding-left")
     },
@@ -104,6 +100,39 @@ testRule(rule, {
         "-webKIT-transition",
         "-WEBKIT-transition-property"
       )
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "html",
+
+  accept: [
+    {
+      code: "<style>a { padding: 10px; }</style>"
+    },
+    {
+      code:
+        "<style>a { padding-left: 10px; }</style><style>a { padding: 10px; }</style>"
+    },
+    {
+      code: '<a style="padding: 10px;"></a>'
+    },
+    {
+      code: '<a style="padding-left: 10px;"></a><a style="padding: 10px;"></a>'
+    }
+  ],
+
+  reject: [
+    {
+      code: "<style>p { padding-left: 10px; padding: 20px; }</style>",
+      message: messages.rejected("padding", "padding-left")
+    },
+    {
+      code: '<a style="padding-left: 10px; padding: 20px;"></a>',
+      message: messages.rejected("padding", "padding-left")
     }
   ]
 });

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -44,6 +44,10 @@ testRule(rule, {
 
   reject: [
     {
+      code: "padding-left: 10px; padding: 20px;",
+      message: messages.rejected("padding", "padding-left")
+    },
+    {
       code: "a { padding-left: 10px; padding: 20px; }",
       message: messages.rejected("padding", "padding-left")
     },

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const eachDeclarationBlock = require("../../utils/eachDeclarationBlock");
 const postcss = require("postcss");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -20,19 +21,11 @@ const rule = function(actual) {
       return;
     }
 
-    root.walkRules(check);
-    root.walkAtRules(check);
-
-    function check(statement) {
+    eachDeclarationBlock(root, eachDecl => {
       const declarations = {};
-      // Shallow iteration so nesting doesn't produce
-      // false positives
-      statement.each(node => {
-        if (node.type !== "decl") {
-          return;
-        }
 
-        const prop = node.prop;
+      eachDecl(decl => {
+        const prop = decl.prop;
         const unprefixedProp = postcss.vendor.unprefixed(prop);
         const prefix = postcss.vendor.prefix(prop).toLowerCase();
 
@@ -48,7 +41,7 @@ const rule = function(actual) {
           report({
             ruleName,
             result,
-            node,
+            node: decl,
             message: messages.rejected(
               prop,
               declarations[prefix + longhandProp]
@@ -56,7 +49,7 @@ const rule = function(actual) {
           });
         });
       });
-    }
+    });
   };
 };
 

--- a/lib/utils/eachDeclarationBlock.js
+++ b/lib/utils/eachDeclarationBlock.js
@@ -1,0 +1,28 @@
+"use strict";
+// In order to accommodate nested blocks (postcss-nested),
+// we need to run a shallow loop (instead of eachDecl() or eachRule(),
+// which loop recursively) and allow each nested block to accumulate
+// its own list of properties -- so that a property in a nested rule
+// does not conflict with the same property in the parent rule
+/**
+ * executes a provided function once for each declaration block.
+ * @param {Root|Document} root - root element of file.
+ * @param {function} cb - Function to execute for each declaration block
+ */
+module.exports = function(root /*: Object */, cb /* Function */) {
+  function each(statement) {
+    if (statement.nodes && statement.nodes.length) {
+      const decls = statement.nodes.filter(node => {
+        if (node.type === "decl") {
+          return true;
+        } else {
+          each(node);
+        }
+      });
+      if (decls.length) {
+        cb(decls.forEach.bind(decls));
+      }
+    }
+  }
+  each(root);
+};


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#3380 
emotion-js/emotion#686 (comment)

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
