### PR TITLE
Update CoC

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of conduct
+
+You should adhere to GitHub's [Acceptable Use](https://help.github.com/articles/github-terms-of-service/#c-acceptable-use) policy.
+
+You can use GitHub's [grievance process](https://github.com/contact/report-abuse) to report breaches of this policy.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,0 @@
-# Code of conduct
-
-Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer, merely an optimal answer given a set of values and circumstances. Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
-
-Participants should not engage in public or private harassment as we are committed to making participation in this project a harassment-free experience for everyone.
-
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
-
-Instances of harassing may be reported by opening an issue or contacting one or more of the project maintainers.


### PR DESCRIPTION
GitHub has updated their [Acceptable Use](https://help.github.com/articles/github-terms-of-service/#c-acceptable-use) policy to include [restrictions on conduct](https://help.github.com/articles/github-terms-of-service/#3-conduct-restrictions).

They have also added a [grievance process](https://github.com/contact/report-abuse) that users can use to report breaches of this policy, including those related to conduct.

This PR updates the CoC to direct users to both these. This is beneficial for users as they can access a consistent grievance process across GitHub, one that offers consistent responses times as well as a team trained to arbitrate. 
