### PR TITLE
Standardise options documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/lib/rules/at-rule-blacklist/README.md
+++ b/lib/rules/at-rule-blacklist/README.md
@@ -10,9 +10,11 @@ Specify a blacklist of disallowed at-rules.
 
 This rule ignores `@import` in Less.
 
+This rule removes vendor prefixes before any checks.
+
 ## Options
 
-`array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`
+Type: `array|string`
 
 Given:
 

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -19,7 +19,8 @@ The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofix
 
 ## Options
 
-`string`: `"always"|"never"`
+Type: `string`  
+Value: `"always"|"never"`
 
 ### `"always"`
 

--- a/lib/rules/at-rule-name-case/README.md
+++ b/lib/rules/at-rule-name-case/README.md
@@ -16,7 +16,8 @@ The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofix
 
 ## Options
 
-`string`: `"lower"|"upper"`
+Type: `string`  
+Value: `"lower"|"upper"`
 
 ### `"lower"`
 

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -12,6 +12,9 @@ This rule considers at-rules defined in the CSS Specifications, up to and includ
 
 ## Options
 
+Type: `boolean`  
+Value: `true`
+
 ### `true`
 
 The following patterns are considered violations:

--- a/lib/rules/declaration-property-value-whitelist/README.md
+++ b/lib/rules/declaration-property-value-whitelist/README.md
@@ -8,20 +8,30 @@ a { text-transform: uppercase; }
  * These properties and these values */
 ```
 
+This rule removes vendor prefixes before any checks.
+
 ## Options
 
-`object`: `{
-  "unprefixed-property-name": ["array", "of", "values"],
-  "unprefixed-property-name": ["/regex/", "non-regex"]
-}`
+Type: `object`  
+Structure:   
 
-If a property name is found in the object, only its whitelisted property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
+```json
+{
+  string: array|string
+}
+```
 
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
+Each property in the `object` is compared against a declaration's property name. The paired value in the `object` represents the allowed values for that property name.
+
+Any `string` surrounded with `"/"` (e.g. `"/^string/"`) is interpreted as a regular expression.
+
+Regular expressions allow, for example, the easy targeting of shorthand properties: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
 The same goes for values. Keep in mind that a regular expression value is matched against the entire value of the declaration, not specific parts of it. For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will *not* match `"/^solid/"` (notice beginning of the line boundary) but *will* match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
 
 Be careful with regex matching not to accidentally consider quoted string values and `url()` arguments. For example, `"/red/"` will match value such as `"1px dotted red"` as well as `"\"foo\""` and `"white url(/mysite.com/red.png)"`.
+
+If a property name is found in the object, only its whitelisted property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 
 Given:
 

--- a/lib/rules/font-family-name-quotes/README.md
+++ b/lib/rules/font-family-name-quotes/README.md
@@ -14,7 +14,8 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 ## Options
 
-`string`: `"always-where-required"|"always-where-recommended"|"always-unless-keyword"`
+Type: `string`  
+Value: `"always-where-required"|"always-where-recommended"|"always-unless-keyword"`
 
 *Please read the following to understand these options*:
 

--- a/lib/rules/property-blacklist/README.md
+++ b/lib/rules/property-blacklist/README.md
@@ -12,7 +12,7 @@ This rule removes vendor prefixes before any checks.
 
 ## Options
 
-`array|string`
+Type: `array|string`
 
 Any `string` surrounded with `"/"` (e.g. `"/^string/"`) is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 

--- a/lib/rules/property-blacklist/README.md
+++ b/lib/rules/property-blacklist/README.md
@@ -8,11 +8,13 @@ a { text-rendering: optimizeLegibility; }
  * These properties */
 ```
 
+This rule removes vendor prefixes before any checks.
+
 ## Options
 
-`array|string`: `["array", "of", "unprefixed", "properties" or "regex"]|"property"|"/regex/"`
+`array|string`
 
-If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
+Any `string` surrounded with `"/"` (e.g. `"/^string/"`) is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 
 Given:
 

--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -14,9 +14,9 @@ Escaped selectors (e.g. `.u-size-11\/12\@sm`) are parsed as escaped twice (e.g. 
 
 ## Options
 
-`regex|string`
+Type: `regex|string`
 
-A string will be translated into a RegExp — `new RegExp(yourString)` — so *be sure to escape properly*.
+A `string` value will be interpreted as a regular expression.
 
 The selector value *after `.`* will be checked. No need to include `.` in your pattern.
 

--- a/lib/rules/selector-max-class/README.md
+++ b/lib/rules/selector-max-class/README.md
@@ -15,7 +15,9 @@ The `:not()` pseudo-class is also evaluated separately. The rule processes the a
 
 ## Options
 
-`int`: Maximum classes allowed.
+Type: `int`
+
+Maximum classes allowed.
 
 For example, with `2`:
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3372

> Is there anything in the PR that needs further explanation?

I dug deeper while reviewing PR https://github.com/stylelint/stylelint/pull/3389 as I was unsatisfied with the consistency of options _across the board_, rather than just with the rules that accept objects.

This PR is a WIP to solicit feedback. It contains examples for the different types of options that rules accept e.g. arrays, strings, booleans, regexs, objects etc.

If a rule removes prefixes, I moved this to the rule description. I think dealing with prefixes is an edge-case, and so we don't need to pollute the "Options" section with it.

I think the `"array", "of", ...` stuff is confusing. I believe it's clearer to consistently specify what types are accepted first, then go into more detail only when necessary. Usually, the `"array", "of", ...` stuff is redundant as the "Given:" example communicates this better.

The proposed solution also takes into https://github.com/stylelint/stylelint/issues/3008. The existing approach doesn't really work here e.g. when`property-whitelist` is enhanced to accept naked regex, the existing approach will produce:

> ...
>
> ## Options
>
> `array|regex|string`: `["array", "of", "unprefixed", "properties" or "regex" or regex]|"property"|"/regex/"|regex`
>
> If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
>
> Given:
>
> ```js
> ["display", "animation", "/^background/"]
> ```
>
> ...

Becomes:

> ...
>
> This rule removes vendor prefixes before any checks.
>
> ## Options
>
> Type: `array|regex|string`
>
> An `array` can contain any number of `string` or `regex`.
>
> Any `string` surrounded with `"/"` (e.g. `"/string/"`) is interpreted as a regular expression.
>
> Regular expressions allow, for example, the easy targeting of shorthand properties: `/^background/` will match `background`, `background-size`, `background-color`, etc.
>
> Given:
>
> ```js
> ["text-rendering", "animation", "/^background/"]
> ```
>
> ...

Suggestions or thoughts?




