### PR TITLE
Remove aei references

### DIFF
--- a/flow-typed/stylelint.js
+++ b/flow-typed/stylelint.js
@@ -146,6 +146,5 @@ export type stylelint$standaloneOptions = {
   customSyntax?: string,
   formatter?: "json" | "string" | "verbose" | Function,
   disableDefaultIgnores?: boolean,
-  allowEmptyInput?: boolean,
   fix?: boolean
 };

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,10 +18,6 @@ const standalone = require("./standalone");
   autoVersion: boolean,
   help: string,
   flags: {
-    "allow-empty-input": {
-      alias: string,
-      type: string
-    },
     cache: {
       type: string
     },
@@ -100,7 +96,6 @@ const standalone = require("./standalone");
 
 /*:: type cliType = {
   flags: {
-    allowEmptyInput: any,
     cache: any,
     cacheLocation: any,
     config: any,
@@ -131,7 +126,6 @@ const standalone = require("./standalone");
 }*/
 
 /*:: type optionBaseType = {
-  allowEmptyInput?: any,
   formater?: any,
   cache?: boolean,
   cacheLocation?: any,
@@ -256,10 +250,6 @@ const meowOptions /*: meowOptionsType*/ = {
 
         Force enabling/disabling of color.
 
-      --allow-empty-input, --aei
-
-        If no files match glob pattern, exits without throwing an error.
-
       --report-needless-disables, --rd
 
         Report stylelint-disable comments that are not blocking a lint warning.
@@ -277,10 +267,6 @@ const meowOptions /*: meowOptionsType*/ = {
         Show the currently installed version of stylelint.
   `,
   flags: {
-    "allow-empty-input": {
-      alias: "aei",
-      type: "boolean"
-    },
     cache: {
       type: "boolean"
     },


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/pull/2117#issuecomment-398280562

> Is there anything in the PR that needs further explanation?

The `allowEmptyInput` option [was removed](https://github.com/stylelint/stylelint/pull/2464) in `8.0.0`, but the option still lingers in the CLI `--help` and type defs. I suspect this happened during some conflict resolution work.
