### PR TITLE
Fix keyframes-name-pattern not supporting RegExp notation

### DIFF
--- a/lib/rules/keyframes-name-pattern/__tests__/index.js
+++ b/lib/rules/keyframes-name-pattern/__tests__/index.js
@@ -54,3 +54,25 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: [/^foo-bar$/],
+
+  accept: [
+    {
+      code: "@keyframes foo-bar {}",
+      description: "Accepts pattern in RegExp notation"
+    }
+  ],
+
+  reject: [
+    {
+      code: "@keyframes foo-baz {}",
+      description: "Accepts pattern in RegExp notation",
+      message: messages.expected("foo-baz"),
+      line: 1,
+      column: 12
+    }
+  ]
+});

--- a/lib/rules/keyframes-name-pattern/index.js
+++ b/lib/rules/keyframes-name-pattern/index.js
@@ -17,7 +17,7 @@ const rule = function(pattern) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: pattern,
-      possible: [_.isString]
+      possible: [_.isRegExp, _.isString]
     });
 
     if (!validOptions) {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/3436

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
