### PR TITLE
Add autofix to `block-opening-brace-space-before`

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -289,7 +289,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`block-opening-brace-newline-after`](../../lib/rules/block-opening-brace-newline-after/README.md): Require a newline after the opening brace of blocks.
 -   [`block-opening-brace-newline-before`](../../lib/rules/block-opening-brace-newline-before/README.md): Require a newline or disallow whitespace before the opening brace of blocks.
 -   [`block-opening-brace-space-after`](../../lib/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks.
--   [`block-opening-brace-space-before`](../../lib/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks.
+-   [`block-opening-brace-space-before`](../../lib/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks (Autofixable).
 
 #### Selector
 

--- a/lib/rules/block-opening-brace-space-before/README.md
+++ b/lib/rules/block-opening-brace-space-before/README.md
@@ -8,6 +8,8 @@ Require a single space or disallow whitespace before the opening brace of blocks
  * The space before this brace */
 ```
 
+The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/block-opening-brace-space-before/__tests__/index.js
+++ b/lib/rules/block-opening-brace-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -28,30 +29,35 @@ testRule(rule, {
   reject: [
     {
       code: "a{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 1
     },
     {
       code: "a  { color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 3
     },
     {
       code: "a\t{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 2
     },
     {
       code: "a\n{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 2
     },
     {
       code: "a\r\n{ color: pink; }",
+      fixed: "a { color: pink; }",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 1,
@@ -59,12 +65,14 @@ testRule(rule, {
     },
     {
       code: "@media print\n{ a { color: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedBefore(),
       line: 1,
       column: 13
     },
     {
       code: "@media print { a\n{ color: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedBefore(),
       line: 1,
       column: 17
@@ -75,6 +83,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always", { ignoreAtRules: ["for"] }],
+  fix: true,
 
   accept: [
     {
@@ -91,6 +100,7 @@ testRule(rule, {
   reject: [
     {
       code: "a{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 1
@@ -101,6 +111,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always", { ignoreAtRules: "/fo/" }],
+  fix: true,
 
   accept: [
     {
@@ -117,6 +128,7 @@ testRule(rule, {
   reject: [
     {
       code: "a{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 1
@@ -127,6 +139,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -140,30 +153,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 2
     },
     {
       code: "a  { color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 3
     },
     {
       code: "a\t{ color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 2
     },
     {
       code: "a\n{ color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 2
     },
     {
       code: "a\r\n{ color: pink; }",
+      fixed: "a{ color: pink; }",
       description: "CRLF",
       message: messages.rejectedBefore(),
       line: 1,
@@ -171,12 +189,14 @@ testRule(rule, {
     },
     {
       code: "@media print { a{ color: pink; } }",
+      fixed: "@media print{ a{ color: pink; } }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 13
     },
     {
       code: "@media print{ a { color: pink; } }",
+      fixed: "@media print{ a{ color: pink; } }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 16
@@ -187,6 +207,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -212,30 +233,35 @@ testRule(rule, {
   reject: [
     {
       code: "a{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 1
     },
     {
       code: "a  { color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 3
     },
     {
       code: "a\t{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 2
     },
     {
       code: "a\n{ color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 2
     },
     {
       code: "a\r\n{ color: pink; }",
+      fixed: "a { color: pink; }",
       description: "CRLF",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
@@ -243,12 +269,14 @@ testRule(rule, {
     },
     {
       code: "@media print\n{ a { color: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 13
     },
     {
       code: "@media print { a\n{ color: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 17
@@ -259,6 +287,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -295,30 +324,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 2
     },
     {
       code: "a  { color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 3
     },
     {
       code: "a\t{ color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 2
     },
     {
       code: "a\n{ color: pink; }",
+      fixed: "a{ color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 2
     },
     {
       code: "a\r\n{ color: pink; }",
+      fixed: "a{ color: pink; }",
       description: "CRLF",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
@@ -326,12 +360,14 @@ testRule(rule, {
     },
     {
       code: "@media print { a{ color: pink; } }",
+      fixed: "@media print{ a{ color: pink; } }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 13
     },
     {
       code: "@media print{ a { color: pink; } }",
+      fixed: "@media print{ a{ color: pink; } }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 16
@@ -342,6 +378,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -374,30 +411,35 @@ testRule(rule, {
   reject: [
     {
       code: "a{ color: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
       column: 1
     },
     {
       code: "a  { color: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
       column: 3
     },
     {
       code: "a\t{ color: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
       column: 2
     },
     {
       code: "a\n{ color: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
       column: 2
     },
     {
       code: "a\r\n{ color: pink;\r\nbackground: orange; }",
+      fixed: "a { color: pink;\r\nbackground: orange; }",
       description: "CRLF",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
@@ -405,12 +447,14 @@ testRule(rule, {
     },
     {
       code: "@media print\n{\na { color: pink;\nbackground: orange; } }",
+      fixed: "@media print {\na { color: pink;\nbackground: orange; } }",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
       column: 13
     },
     {
       code: "@media print { a\n{ color: pink;\nbackground: orange; } }",
+      fixed: "@media print { a { color: pink;\nbackground: orange; } }",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
       column: 17
@@ -421,6 +465,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -453,42 +498,49 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\nbackground: orange; }",
+      fixed: "a{ color: pink;\nbackground: orange; }",
       message: messages.rejectedBeforeMultiLine(),
       line: 1,
       column: 2
     },
     {
       code: "a  { color: pink;\nbackground: orange; }",
+      fixed: "a{ color: pink;\nbackground: orange; }",
       message: messages.rejectedBeforeMultiLine(),
       line: 1,
       column: 3
     },
     {
       code: "a\t{ color: pink;\nbackground: orange; }",
+      fixed: "a{ color: pink;\nbackground: orange; }",
       message: messages.rejectedBeforeMultiLine(),
       line: 1,
       column: 2
     },
     {
       code: "a\n{ color: pink;\nbackground: orange; }",
+      fixed: "a{ color: pink;\nbackground: orange; }",
       message: messages.rejectedBeforeMultiLine(),
       line: 1,
       column: 2
     },
     {
       code: "@media print\n{\na{ color: pink;\nbackground: orange; } }",
+      fixed: "@media print{\na{ color: pink;\nbackground: orange; } }",
       message: messages.rejectedBeforeMultiLine(),
       line: 1,
       column: 13
     },
     {
       code: "@media print{ a\n{ color: pink;\nbackground: orange; } }",
+      fixed: "@media print{ a{ color: pink;\nbackground: orange; } }",
       message: messages.rejectedBeforeMultiLine(),
       line: 1,
       column: 16
     },
     {
       code: "@media print{ a\r\n{ color: pink;\r\nbackground: orange; } }",
+      fixed: "@media print{ a{ color: pink;\r\nbackground: orange; } }",
       description: "CRLF",
       message: messages.rejectedBeforeMultiLine(),
       line: 1,

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -26,7 +26,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before "{" of a multi-line block'
 });
 
-const rule = function(expectation, options) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(
@@ -85,6 +85,13 @@ const rule = function(expectation, options) {
         index: source.length,
         lineCheckStr: blockString(statement),
         err: m => {
+          if (context.fix) {
+            if (expectation.indexOf("always") === 0) {
+              statement.raws.between = " ";
+            } else if (expectation.indexOf("never") === 0) {
+              statement.raws.between = "";
+            }
+          }
           report({
             message: m,
             node: statement,

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -88,8 +88,10 @@ const rule = function(expectation, options, context) {
           if (context.fix) {
             if (expectation.indexOf("always") === 0) {
               statement.raws.between = " ";
+              return;
             } else if (expectation.indexOf("never") === 0) {
               statement.raws.between = "";
+              return;
             }
           }
           report({


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

`block-opening-brace-space-before` in #2829

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."

ex.

* option: `always***`

    code:
    ```css
    a{ color: pink; }
    ```
    fixed:
    ```css
    a { color: pink; }
    ```

* option: `never***`

    code:
    ```css
    a { color: pink; }
    ```

    fixed:
    ```css
    a{ color: pink; }
    ```
