### PR TITLE
Update node api docs to have new postcss api docs link

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -38,7 +38,7 @@ In order for your plugin rule to work with the [standard configuration format](.
 
 If your plugin rule supports [autofixing](rules.md#adding-autofixing), then `ruleFunction` should also accept a third argument: context. Also, it's highly recommended to support the `disableFix` option in your secondary options object. Within the rule, don't perform autofixing if the user has passed a `disableFix` option for your rule.
 
-`ruleFunction` should return a function that is essentially a little [PostCSS plugin](https://github.com/postcss/postcss/blob/master/docs/writing-a-plugin.md): it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult. You'll have to [learn about the PostCSS API](http://api.postcss.org/).
+`ruleFunction` should return a function that is essentially a little [PostCSS plugin](https://github.com/postcss/postcss/blob/master/docs/writing-a-plugin.md): it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult. You'll have to [learn about the PostCSS API](https://api.postcss.org/).
 
 ### Asynchronous rules
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -38,7 +38,7 @@ In order for your plugin rule to work with the [standard configuration format](.
 
 If your plugin rule supports [autofixing](rules.md#adding-autofixing), then `ruleFunction` should also accept a third argument: context. Also, it's highly recommended to support the `disableFix` option in your secondary options object. Within the rule, don't perform autofixing if the user has passed a `disableFix` option for your rule.
 
-`ruleFunction` should return a function that is essentially a little [PostCSS plugin](https://github.com/postcss/postcss/blob/master/docs/writing-a-plugin.md): it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult. You'll have to [learn about the PostCSS API](https://github.com/postcss/postcss/blob/master/docs/api.md).
+`ruleFunction` should return a function that is essentially a little [PostCSS plugin](https://github.com/postcss/postcss/blob/master/docs/writing-a-plugin.md): it takes 2 arguments: the PostCSS Root (the parsed AST), and the PostCSS LazyResult. You'll have to [learn about the PostCSS API](http://api.postcss.org/).
 
 ### Asynchronous rules
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -88,7 +88,7 @@ Look at the messages of other rules to glean more conventions and patterns.
 
 *When writing the rule, always look to other similar rules for conventions and patterns to start from and mimic.*
 
-You will use the simple [PostCSS API](http://api.postcss.org/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes.
+You will use the simple [PostCSS API](https://api.postcss.org/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes.
 
 Depending on the rule, we also recommend using [postcss-value-parser](https://github.com/TrySound/postcss-value-parser) and [postcss-selector-parser](https://github.com/postcss/postcss-selector-parser). There are significant benefits to using these parsers instead of regular expressions or `indexOf` searches (even if they aren't always the most performant method).
 

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -160,7 +160,7 @@ A string displaying the formatted violations (using the default formatter or whi
 
 ### `postcssResults`
 
-An array containing all the [PostCSS LazyResults](https://github.com/postcss/postcss/blob/master/docs/api.md#lazyresult-class) that were accumulated during processing.
+An array containing all the [PostCSS LazyResults](http://api.postcss.org/LazyResult.html) that were accumulated during processing.
 
 ### `results`
 

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -160,7 +160,7 @@ A string displaying the formatted violations (using the default formatter or whi
 
 ### `postcssResults`
 
-An array containing all the [PostCSS LazyResults](http://api.postcss.org/LazyResult.html) that were accumulated during processing.
+An array containing all the [PostCSS LazyResults](https://api.postcss.org/LazyResult.html) that were accumulated during processing.
 
 ### `results`
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's pretty self explanatory. Just saves users a click through to the new links.
