### PR TITLE
Add autofix to block-closing-brace-newline-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -282,7 +282,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 #### Block
 
 -   [`block-closing-brace-empty-line-before`](../../lib/rules/block-closing-brace-empty-line-before/README.md): Require or disallow an empty line before the closing brace of blocks.
--   [`block-closing-brace-newline-after`](../../lib/rules/block-closing-brace-newline-after/README.md): Require a newline or disallow whitespace after the closing brace of blocks.
+-   [`block-closing-brace-newline-after`](../../lib/rules/block-closing-brace-newline-after/README.md): Require a newline or disallow whitespace after the closing brace of blocks (Autofixable).
 -   [`block-closing-brace-newline-before`](../../lib/rules/block-closing-brace-newline-before/README.md): Require a newline or disallow whitespace before the closing brace of blocks.
 -   [`block-closing-brace-space-after`](../../lib/rules/block-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of blocks.
 -   [`block-closing-brace-space-before`](../../lib/rules/block-closing-brace-space-before/README.md): Require a single space or disallow whitespace before the closing brace of blocks.

--- a/lib/rules/block-closing-brace-newline-after/README.md
+++ b/lib/rules/block-closing-brace-newline-after/README.md
@@ -29,6 +29,8 @@ This rule allows a trailing semicolon after the closing brace of a block. For ex
 }
 ```
 
+The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/block-closing-brace-newline-after/README.md
+++ b/lib/rules/block-closing-brace-newline-after/README.md
@@ -29,7 +29,7 @@ This rule allows a trailing semicolon after the closing brace of a block. For ex
 }
 ```
 
-The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/lib/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/lib/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -72,30 +73,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }b { color: red; }",
+      fixed: "a { color: pink; }\nb { color: red; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; } b { color: red; }",
+      fixed: "a { color: pink; }\n b { color: red; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; }  b { color: red; }",
+      fixed: "a { color: pink; }\n  b { color: red; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; }\tb { color: red; }",
+      fixed: "a { color: pink; }\n\tb { color: red; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
     },
     {
       code: "@media print { a { color: pink; } b { color: red; }}",
+      fixed: "@media print { a { color: pink; }\n b { color: red; }}",
       message: messages.expectedAfter(),
       line: 1,
       column: 34
@@ -103,24 +109,29 @@ testRule(rule, {
     {
       code:
         "@media print { a { color: pink; }} @media screen { b { color: red; }}",
+      fixed:
+        "@media print { a { color: pink; }}\n @media screen { b { color: red; }}",
       message: messages.expectedAfter(),
       line: 1,
       column: 35
     },
     {
       code: ".a {} /* stylelint-disable-line block-no-empty */ b {}",
+      fixed: ".a {} /* stylelint-disable-line block-no-empty */\n b {}",
       message: messages.expectedAfter(),
       line: 1,
       column: 6
     },
     {
       code: ":root {\n --x { color: pink; } ; \n --y { color: red; };\n }",
+      fixed: ":root {\n --x { color: pink; } ;\n --y { color: red; };\n }",
       message: messages.expectedAfter(),
       line: 2,
       column: 24
     },
     {
       code: ":root {\n --x { color: pink; }; \n --y { color: red; };\n }",
+      fixed: ":root {\n --x { color: pink; };\n --y { color: red; };\n }",
       message: messages.expectedAfter(),
       line: 2,
       column: 23
@@ -128,6 +139,8 @@ testRule(rule, {
     {
       code:
         ".foo {\n --my-theme: { color: red; }; \n --toolbar-theme: { color: green; };\n }",
+      fixed:
+        ".foo {\n --my-theme: { color: red; };\n --toolbar-theme: { color: green; };\n }",
       description:
         "Make sure trailing semicolon works well for blocks outside :root",
       message: messages.expectedAfter(),
@@ -140,6 +153,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always", { ignoreAtRules: ["if", "else"] }],
+  fix: true,
 
   accept: [
     {
@@ -160,6 +174,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }b{}",
+      fixed: "a { color: pink; }\nb{}",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
@@ -170,6 +185,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always", { ignoreAtRules: "/if/" }],
+  fix: true,
 
   accept: [
     {
@@ -183,6 +199,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }b{}",
+      fixed: "a { color: pink; }\nb{}",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
@@ -193,6 +210,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -234,30 +252,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }b { color: red; }",
+      fixed: "a { color: pink; }\nb { color: red; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; } b { color: red; }",
+      fixed: "a { color: pink; }\n b { color: red; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; }  b { color: red; }",
+      fixed: "a { color: pink; }\n  b { color: red; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; }\tb { color: red; }",
+      fixed: "a { color: pink; }\n\tb { color: red; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "@media print { a { color: pink; } b { color: red; }}",
+      fixed: "@media print { a { color: pink; }\n b { color: red; }}",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 34
@@ -265,6 +288,8 @@ testRule(rule, {
     {
       code:
         "@media print { a { color: pink; }} @media screen { b { color: red; }}",
+      fixed:
+        "@media print { a { color: pink; }}\n @media screen { b { color: red; }}",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 35
@@ -275,6 +300,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -304,30 +330,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }\nb { color: red; }",
+      fixed: "a { color: pink; }b { color: red; }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; } b { color: red; }",
+      fixed: "a { color: pink; }b { color: red; }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; }  b { color: red; }",
+      fixed: "a { color: pink; }b { color: red; }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; }\tb { color: red; }",
+      fixed: "a { color: pink; }b { color: red; }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 19
     },
     {
       code: "@media print { a { color: pink; }\nb { color: red; }}",
+      fixed: "@media print { a { color: pink; }b { color: red; }}",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 34
@@ -335,6 +366,8 @@ testRule(rule, {
     {
       code:
         "@media print { a { color: pink; }}\n @media screen { b { color: red; }}",
+      fixed:
+        "@media print { a { color: pink; }}@media screen { b { color: red; }}",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 35
@@ -345,6 +378,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -378,12 +412,14 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\ntop: 0; }b { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }\nb { color: red; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "a { color: pink;\r\ntop: 0; }b { color: red; }",
+      fixed: "a { color: pink;\r\ntop: 0; }\r\nb { color: red; }",
       description: "CRLF",
       message: messages.expectedAfterMultiLine(),
       line: 2,
@@ -391,24 +427,28 @@ testRule(rule, {
     },
     {
       code: "a { color: pink;\ntop: 0; } b { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }\n b { color: red; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "a { color: pink;\ntop: 0; }  b { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }\n  b { color: red; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "a { color: pink;\ntop: 0; }\tb { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }\n\tb { color: red; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "@media print { a {\ncolor: pink; } b { color: red; }}",
+      fixed: "@media print { a {\ncolor: pink; }\n b { color: red; }}",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 15
@@ -416,6 +456,8 @@ testRule(rule, {
     {
       code:
         "@media print { a {\ncolor: pink; }} @media screen { b {\ncolor: red; }}",
+      fixed:
+        "@media print { a {\ncolor: pink; }}\n @media screen { b {\ncolor: red; }}",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 16
@@ -426,6 +468,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -468,12 +511,14 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\ntop: 0; }\nb { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }b { color: red; }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "a { color: pink;\r\ntop: 0; }\r\nb { color: red; }",
+      fixed: "a { color: pink;\r\ntop: 0; }b { color: red; }",
       description: "CRLF",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
@@ -481,24 +526,28 @@ testRule(rule, {
     },
     {
       code: "a { color: pink;\ntop: 0; } b { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }b { color: red; }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "a { color: pink;\ntop: 0; }  b { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }b { color: red; }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "a { color: pink;\ntop: 0; }\tb { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; }b { color: red; }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 10
     },
     {
       code: "@media print { a {\ncolor: pink; }\nb { color: red; }}",
+      fixed: "@media print { a {\ncolor: pink; }b { color: red; }}",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 15
@@ -506,6 +555,8 @@ testRule(rule, {
     {
       code:
         "@media print { a {\ncolor: pink; }}\n@media screen { b {\ncolor: red; }}",
+      fixed:
+        "@media print { a {\ncolor: pink; }}@media screen { b {\ncolor: red; }}",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 16

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -24,7 +24,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace after "}" of a multi-line block'
 });
 
-const rule = function(expectation, options) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("newline", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(
@@ -99,6 +99,22 @@ const rule = function(expectation, options) {
         index: -1,
         lineCheckStr: blockString(statement),
         err: msg => {
+          if (context.fix) {
+            if (expectation.indexOf("always") === 0) {
+              const index = nodeToCheck.raws.before.search(/\r?\n/);
+              if (index >= 0) {
+                nodeToCheck.raws.before = nodeToCheck.raws.before.slice(index);
+              } else {
+                nodeToCheck.raws.before =
+                  context.newline + nodeToCheck.raws.before;
+              }
+              return;
+            } else if (expectation.indexOf("never") === 0) {
+              nodeToCheck.raws.before = "";
+              return;
+            }
+          }
+
           report({
             message: msg,
             node: statement,


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

`block-closing-brace-newline-after` in #2829

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."

ex.

* option: `always***`

    code:
    ```css
    a { color: pink; } .b { color: red; }
    ```
    fixed:
    ```css
    a { color: pink; }
     .b { color: red; }
    ```

* option: `never***`

    code:
    ```css
    a { color: pink; }
    .b { color: red; }
    ```

    fixed:
    ```css
    a { color: pink; }.b { color: red; }
    ```
