### PR TITLE
Add autofix to declaration-colon-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -268,7 +268,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`declaration-bang-space-before`](../../lib/rules/declaration-bang-space-before/README.md): Require a single space or disallow whitespace before the bang of declarations.
 -   [`declaration-colon-newline-after`](../../lib/rules/declaration-colon-newline-after/README.md): Require a newline or disallow whitespace after the colon of declarations.
 -   [`declaration-colon-space-after`](../../lib/rules/declaration-colon-space-after/README.md): Require a single space or disallow whitespace after the colon of declarations.
--   [`declaration-colon-space-before`](../../lib/rules/declaration-colon-space-before/README.md): Require a single space or disallow whitespace before the colon of declarations.
+-   [`declaration-colon-space-before`](../../lib/rules/declaration-colon-space-before/README.md): Require a single space or disallow whitespace before the colon of declarations (Autofixable).
 -   [`declaration-empty-line-before`](../../lib/rules/declaration-empty-line-before/README.md): Require or disallow an empty line before declarations (Autofixable).
 
 #### Declaration block

--- a/lib/rules/declaration-colon-space-before/README.md
+++ b/lib/rules/declaration-colon-space-before/README.md
@@ -8,7 +8,7 @@ a { color :pink }
  * The space before this colon */
 ```
 
-The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/lib/rules/declaration-colon-space-before/README.md
+++ b/lib/rules/declaration-colon-space-before/README.md
@@ -8,6 +8,8 @@ a { color :pink }
  * The space before this colon */
 ```
 
+The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/declaration-colon-space-before/__tests__/index.js
+++ b/lib/rules/declaration-colon-space-before/__tests__/index.js
@@ -79,6 +79,14 @@ testRule(rule, {
       message: messages.expectedBefore(),
       line: 1,
       column: 11
+    },
+    {
+      code: "a { color/*comment*/:/*comment*/pink; }",
+      fixed: "a { color/*comment*/ :/*comment*/pink; }",
+      description: "comment",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 11
     }
   ]
 });

--- a/lib/rules/declaration-colon-space-before/__tests__/index.js
+++ b/lib/rules/declaration-colon-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -41,6 +42,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a { color : pink; }",
       description: "no space before",
       message: messages.expectedBefore(),
       line: 1,
@@ -48,6 +50,7 @@ testRule(rule, {
     },
     {
       code: "a { color  : pink; }",
+      fixed: "a { color : pink; }",
       description: "two spaces before",
       message: messages.expectedBefore(),
       line: 1,
@@ -55,6 +58,7 @@ testRule(rule, {
     },
     {
       code: "a { color\t: pink; }",
+      fixed: "a { color : pink; }",
       description: "tab before",
       message: messages.expectedBefore(),
       line: 1,
@@ -62,6 +66,7 @@ testRule(rule, {
     },
     {
       code: "a { color\n: pink; }",
+      fixed: "a { color : pink; }",
       description: "newline before",
       message: messages.expectedBefore(),
       line: 2,
@@ -69,6 +74,7 @@ testRule(rule, {
     },
     {
       code: "a { color\r\n: pink; }",
+      fixed: "a { color : pink; }",
       description: "CRLF before",
       message: messages.expectedBefore(),
       line: 1,
@@ -80,6 +86,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -107,6 +114,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color : pink; }",
+      fixed: "a { color: pink; }",
       description: "space before",
       message: messages.rejectedBefore(),
       line: 1,
@@ -114,6 +122,7 @@ testRule(rule, {
     },
     {
       code: "a { color  : pink; }",
+      fixed: "a { color: pink; }",
       description: "two spaces before",
       message: messages.rejectedBefore(),
       line: 1,
@@ -121,6 +130,7 @@ testRule(rule, {
     },
     {
       code: "a { color\t: pink; }",
+      fixed: "a { color: pink; }",
       description: "tab before",
       message: messages.rejectedBefore(),
       line: 1,
@@ -128,6 +138,7 @@ testRule(rule, {
     },
     {
       code: "a { color\n: pink; }",
+      fixed: "a { color: pink; }",
       description: "newline before",
       message: messages.rejectedBefore(),
       line: 2,
@@ -135,6 +146,7 @@ testRule(rule, {
     },
     {
       code: "a { color\r\n: pink; }",
+      fixed: "a { color: pink; }",
       description: "CRLF before",
       message: messages.rejectedBefore(),
       line: 1,

--- a/lib/rules/declaration-colon-space-before/__tests__/index.js
+++ b/lib/rules/declaration-colon-space-before/__tests__/index.js
@@ -159,6 +159,14 @@ testRule(rule, {
       message: messages.rejectedBefore(),
       line: 1,
       column: 11
+    },
+    {
+      code: "a { color/*comment*/ :/*comment*/pink; }",
+      fixed: "a { color/*comment*/:/*comment*/pink; }",
+      description: "comment",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 11
     }
   ]
 });

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const declarationColonSpaceChecker = require("../declarationColonSpaceChecker");
+const declarationValueIndex = require("../../utils/declarationValueIndex");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
 const whitespaceChecker = require("../../utils/whitespaceChecker");
@@ -29,12 +30,18 @@ const rule = function(expectation, options, context) {
       locationChecker: checker.before,
       checkedRuleName: ruleName,
       fix: context.fix
-        ? decl => {
+        ? (decl, index) => {
+            const colonIndex = index - declarationValueIndex(decl);
+            const between = decl.raws.between;
             if (expectation === "always") {
-              decl.raws.between = decl.raws.between.replace(/^\s*:/, " :");
+              decl.raws.between =
+                between.slice(0, colonIndex).replace(/\s*$/, " ") +
+                between.slice(colonIndex);
               return true;
             } else if (expectation === "never") {
-              decl.raws.between = decl.raws.between.replace(/^\s*:/, ":");
+              decl.raws.between =
+                between.slice(0, colonIndex).replace(/\s*$/, "") +
+                between.slice(colonIndex);
               return true;
             }
           }

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
   rejectedBefore: () => 'Unexpected whitespace before ":"'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -27,7 +27,18 @@ const rule = function(expectation) {
       root,
       result,
       locationChecker: checker.before,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? decl => {
+            if (expectation === "always") {
+              decl.raws.between = decl.raws.between.replace(/^\s*:/, " :");
+              return true;
+            } else if (expectation === "never") {
+              decl.raws.between = decl.raws.between.replace(/^\s*:/, ":");
+              return true;
+            }
+          }
+        : null
     });
   };
 };

--- a/lib/rules/declarationColonSpaceChecker.js
+++ b/lib/rules/declarationColonSpaceChecker.js
@@ -27,6 +27,9 @@ module.exports = function(opts) {
         index: i,
         lineCheckStr: decl.value,
         err: m => {
+          if (opts.fix && opts.fix(decl)) {
+            return;
+          }
           report({
             message: m,
             node: decl,

--- a/lib/rules/declarationColonSpaceChecker.js
+++ b/lib/rules/declarationColonSpaceChecker.js
@@ -27,7 +27,7 @@ module.exports = function(opts) {
         index: i,
         lineCheckStr: decl.value,
         err: m => {
-          if (opts.fix && opts.fix(decl)) {
+          if (opts.fix && opts.fix(decl, i)) {
             return;
           }
           report({


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

`declaration-colon-space-before` in #2829

> Is there anything in the PR that needs further explanation?

ex.

* option: `always`

    code:
    ```css
    a { color: pink; }
    ```
    fixed:
    ```css
    a { color : pink; }
    ```

* option: `never`

    code:
    ```css
    a { color : pink; }
    ```

    fixed:
    ```css
    a { color: pink; }
    ```
