### PR TITLE
Add autofix to selector-combinator-space-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -297,7 +297,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`selector-attribute-operator-space-after`](../../lib/rules/selector-attribute-operator-space-after/README.md): Require a single space or disallow whitespace after operators within attribute selectors.
 -   [`selector-attribute-operator-space-before`](../../lib/rules/selector-attribute-operator-space-before/README.md): Require a single space or disallow whitespace before operators within attribute selectors.
 -   [`selector-attribute-quotes`](../../lib/rules/selector-attribute-quotes/README.md): Require or disallow quotes for attribute values.
--   [`selector-combinator-space-after`](../../lib/rules/selector-combinator-space-after/README.md): Require a single space or disallow whitespace after the combinators of selectors.
+-   [`selector-combinator-space-after`](../../lib/rules/selector-combinator-space-after/README.md): Require a single space or disallow whitespace after the combinators of selectors (Autofixable).
 -   [`selector-combinator-space-before`](../../lib/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors.
 -   [`selector-descendant-combinator-no-non-space`](../../lib/rules/selector-descendant-combinator-no-non-space/README.md): Disallow non-space characters for descendant combinators of selectors.
 -   [`selector-pseudo-class-case`](../../lib/rules/selector-pseudo-class-case/README.md): Specify lowercase or uppercase for pseudo-class selectors.

--- a/lib/rules/selector-combinator-space-after/README.md
+++ b/lib/rules/selector-combinator-space-after/README.md
@@ -14,6 +14,8 @@ The descendant combinator is *not* checked by this rule.
 
 Also, `+` and `-` signs within `:nth-*()` arguments are not checked (e.g. `a:nth-child(2n+1)`).
 
+The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/selector-combinator-space-after/README.md
+++ b/lib/rules/selector-combinator-space-after/README.md
@@ -14,7 +14,7 @@ The descendant combinator is *not* checked by this rule.
 
 Also, `+` and `-` signs within `:nth-*()` arguments are not checked (e.g. `a:nth-child(2n+1)`).
 
-The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -140,6 +140,10 @@ testRule(rule, {
     {
       code: ", a {}",
       description: "A selector that starts with a comma"
+    },
+    {
+      code: ", /*c*/a {}",
+      description: "A selector that starts with a comma & include comment"
     }
   ],
 
@@ -215,6 +219,37 @@ testRule(rule, {
       message: messages.expectedAfter(">"),
       line: 1,
       column: 19
+    },
+    {
+      code: "a >a >a {}",
+      fixed: "a > a > a {}",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 3
+    },
+    {
+      code: "a/*comment*/>/*comment*/a {}",
+      fixed: "a/*comment*/> /*comment*/a {}",
+      description: "comment",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 13
+    },
+    {
+      code: "a/*comment*/>/*comment*/a, b/*comment*/>/*comment*/b {}",
+      fixed: "a/*comment*/> /*comment*/a, b/*comment*/> /*comment*/b {}",
+      description: "comment",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 13
+    },
+    {
+      code: "a { >/*comment*/a {} }",
+      fixed: "a { > /*comment*/a {} }",
+      description: "nest + comment",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 5
     }
   ]
 });
@@ -423,6 +458,30 @@ testRule(rule, {
       message: messages.rejectedAfter(">>>"),
       line: 1,
       column: 3
+    },
+    {
+      code: "a/*comment*/ > /*comment*/a {}",
+      fixed: "a/*comment*/ >/*comment*/a {}",
+      description: "comment",
+      message: messages.rejectedAfter(">"),
+      line: 1,
+      column: 14
+    },
+    {
+      code: "a/*comment*/ > /*comment*/a, b/*comment*/ > /*comment*/b {}",
+      fixed: "a/*comment*/ >/*comment*/a, b/*comment*/ >/*comment*/b {}",
+      description: "comment",
+      message: messages.rejectedAfter(">"),
+      line: 1,
+      column: 14
+    },
+    {
+      code: "a { > /*comment*/a {} }",
+      fixed: "a { >/*comment*/a {} }",
+      description: "nest + comment",
+      message: messages.rejectedAfter(">"),
+      line: 1,
+      column: 5
     }
   ]
 });

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -136,6 +136,10 @@ testRule(rule, {
     {
       code: "namespace|type#id > .foo {}",
       description: "qualified id with namespace"
+    },
+    {
+      code: ", a {}",
+      description: "A selector that starts with a comma"
     }
   ],
 

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -138,12 +138,16 @@ testRule(rule, {
       description: "qualified id with namespace"
     },
     {
-      code: ", a {}",
-      description: "A selector that starts with a comma"
+      code: ".a { &.b {} }",
+      description: "nesting and no combinators"
     },
     {
-      code: ", /*c*/a {}",
-      description: "A selector that starts with a comma & include comment"
+      code: ".a { & .b {} }",
+      description: "nesting and no combinators"
+    },
+    {
+      code: ".a { &:first-child {} }",
+      description: "nesting and no combinators"
     }
   ],
 
@@ -228,6 +232,22 @@ testRule(rule, {
       column: 3
     },
     {
+      code: ".a { &>.b {} }",
+      fixed: ".a { &> .b {} }",
+      description: "nesting",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 7
+    },
+    {
+      code: ".a { &+.b {} }",
+      fixed: ".a { &+ .b {} }",
+      description: "nesting",
+      message: messages.expectedAfter("+"),
+      line: 1,
+      column: 7
+    },
+    {
       code: "a/*comment*/>/*comment*/a {}",
       fixed: "a/*comment*/> /*comment*/a {}",
       description: "comment",
@@ -242,22 +262,6 @@ testRule(rule, {
       message: messages.expectedAfter(">"),
       line: 1,
       column: 13
-    },
-    {
-      code: "a { >/*comment*/a {} }",
-      fixed: "a { > /*comment*/a {} }",
-      description: "nest + comment",
-      message: messages.expectedAfter(">"),
-      line: 1,
-      column: 5
-    },
-    {
-      code: "a { >/*comment*/a, >/*comment*/.b{} }",
-      fixed: "a { > /*comment*/a, > /*comment*/.b{} }",
-      description: "nest + comment",
-      message: messages.expectedAfter(">"),
-      line: 1,
-      column: 5
     }
   ]
 });
@@ -482,22 +486,6 @@ testRule(rule, {
       message: messages.rejectedAfter(">"),
       line: 1,
       column: 14
-    },
-    {
-      code: "a { > /*comment*/a {} }",
-      fixed: "a { >/*comment*/a {} }",
-      description: "nest + comment",
-      message: messages.rejectedAfter(">"),
-      line: 1,
-      column: 5
-    },
-    {
-      code: "a { > /*comment*/a, > /*comment*/.b {} }",
-      fixed: "a { >/*comment*/a, >/*comment*/.b {} }",
-      description: "nest + comment",
-      message: messages.rejectedAfter(">"),
-      line: 1,
-      column: 5
     }
   ]
 });
@@ -524,6 +512,7 @@ testRule(rule, {
     }
   ]
 });
+
 testRule(rule, {
   ruleName,
   syntax: "scss",
@@ -532,47 +521,60 @@ testRule(rule, {
 
   accept: [
     {
-      code: ".a { &.b {} }",
-      description: "ignore constructs"
-    },
-    {
-      code: ".a { & .b {} }",
-      description: "ignore constructs"
+      code: "a { > /*comment*/a, > /*comment*/.b{} }",
+      description: "scss nesting and comment"
     }
   ],
 
   reject: [
     {
-      code: ".a { &+.b {} }",
-      fixed: ".a { &+ .b {} }",
-      message: messages.expectedAfter("+")
+      code: "a { >/*comment*/a {} }",
+      fixed: "a { > /*comment*/a {} }",
+      description: "scss nesting and comment",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 5
+    },
+    {
+      code: "a { >/*comment*/a, >/*comment*/.b{} }",
+      fixed: "a { > /*comment*/a, > /*comment*/.b{} }",
+      description: "scss nesting, comment and comma",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 5
     }
   ]
 });
 
-// cssnext
 testRule(rule, {
   ruleName,
-  config: ["always"],
+  syntax: "scss",
+  config: ["never"],
   fix: true,
 
   accept: [
     {
-      code: ".a { &.b {} }"
-    },
-    {
-      code: ".a { & .b {} }"
-    },
-    {
-      code: ".a { &:first-child {} }"
+      code: "a { >/*comment*/a, >/*comment*/.b {} }",
+      description: "scss nesting and comment"
     }
   ],
 
   reject: [
     {
-      code: ".a { &>.b {} }",
-      fixed: ".a { &> .b {} }",
-      message: messages.expectedAfter(">")
+      code: "a { > /*comment*/a {} }",
+      fixed: "a { >/*comment*/a {} }",
+      description: "scss nesting and comment",
+      message: messages.rejectedAfter(">"),
+      line: 1,
+      column: 5
+    },
+    {
+      code: "a { > /*comment*/a, > /*comment*/.b {} }",
+      fixed: "a { >/*comment*/a, >/*comment*/.b {} }",
+      description: "scss nesting, comment and comma",
+      message: messages.rejectedAfter(">"),
+      line: 1,
+      column: 5
     }
   ]
 });

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -250,6 +250,14 @@ testRule(rule, {
       message: messages.expectedAfter(">"),
       line: 1,
       column: 5
+    },
+    {
+      code: "a { >/*comment*/a, >/*comment*/.b{} }",
+      fixed: "a { > /*comment*/a, > /*comment*/.b{} }",
+      description: "nest + comment",
+      message: messages.expectedAfter(">"),
+      line: 1,
+      column: 5
     }
   ]
 });
@@ -478,6 +486,14 @@ testRule(rule, {
     {
       code: "a { > /*comment*/a {} }",
       fixed: "a { >/*comment*/a {} }",
+      description: "nest + comment",
+      message: messages.rejectedAfter(">"),
+      line: 1,
+      column: 5
+    },
+    {
+      code: "a { > /*comment*/a, > /*comment*/.b {} }",
+      fixed: "a { >/*comment*/a, >/*comment*/.b {} }",
       description: "nest + comment",
       message: messages.rejectedAfter(">"),
       line: 1,

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -141,6 +142,7 @@ testRule(rule, {
   reject: [
     {
       code: "a+  a {}",
+      fixed: "a+ a {}",
       description: "two spaces after + combinator",
       message: messages.expectedAfter("+"),
       line: 1,
@@ -148,6 +150,7 @@ testRule(rule, {
     },
     {
       code: "a+\na {}",
+      fixed: "a+ a {}",
       description: "newline after + combinator",
       message: messages.expectedAfter("+"),
       line: 1,
@@ -155,6 +158,7 @@ testRule(rule, {
     },
     {
       code: "a+a {}",
+      fixed: "a+ a {}",
       description: "no space after + combinator",
       message: messages.expectedAfter("+"),
       line: 1,
@@ -162,6 +166,7 @@ testRule(rule, {
     },
     {
       code: "a>a {}",
+      fixed: "a> a {}",
       description: "no space after > combinator",
       message: messages.expectedAfter(">"),
       line: 1,
@@ -169,6 +174,7 @@ testRule(rule, {
     },
     {
       code: "a~a {}",
+      fixed: "a~ a {}",
       description: "no space after ~ combinator",
       message: messages.expectedAfter("~"),
       line: 1,
@@ -176,6 +182,7 @@ testRule(rule, {
     },
     {
       code: "a + .foo.bar ~a {}",
+      fixed: "a + .foo.bar ~ a {}",
       description: "multiple combinators: no space after ~ combinator",
       message: messages.expectedAfter("~"),
       line: 1,
@@ -183,6 +190,7 @@ testRule(rule, {
     },
     {
       code: "#foo +.foo.bar ~ a {}",
+      fixed: "#foo + .foo.bar ~ a {}",
       description: "multiple combinators: no space after + combinator",
       message: messages.expectedAfter("+"),
       line: 1,
@@ -190,6 +198,7 @@ testRule(rule, {
     },
     {
       code: "a >>>a {}",
+      fixed: "a >>> a {}",
       description: "shadow-piercing descendant combinator",
       message: messages.expectedAfter(">>>"),
       line: 1,
@@ -197,6 +206,7 @@ testRule(rule, {
     },
     {
       code: "namespace|type#id >.foo {}",
+      fixed: "namespace|type#id > .foo {}",
       description: "qualified id with namespace",
       message: messages.expectedAfter(">"),
       line: 1,
@@ -208,6 +218,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -315,6 +326,7 @@ testRule(rule, {
   reject: [
     {
       code: "a+ a {}",
+      fixed: "a+a {}",
       description: "space after + combinator",
       message: messages.rejectedAfter("+"),
       line: 1,
@@ -322,6 +334,7 @@ testRule(rule, {
     },
     {
       code: "a> a {}",
+      fixed: "a>a {}",
       description: "space after > combinator",
       message: messages.rejectedAfter(">"),
       line: 1,
@@ -329,6 +342,7 @@ testRule(rule, {
     },
     {
       code: "a~ a {}",
+      fixed: "a~a {}",
       description: "space after ~ combinator",
       message: messages.rejectedAfter("~"),
       line: 1,
@@ -336,6 +350,7 @@ testRule(rule, {
     },
     {
       code: "a+\na{}",
+      fixed: "a+a{}",
       description: "newline after + combinator",
       message: messages.rejectedAfter("+"),
       line: 1,
@@ -343,6 +358,7 @@ testRule(rule, {
     },
     {
       code: "a+\r\na{}",
+      fixed: "a+a{}",
       description: "CRLF after + combinator",
       message: messages.rejectedAfter("+"),
       line: 1,
@@ -350,6 +366,7 @@ testRule(rule, {
     },
     {
       code: "a>\na{}",
+      fixed: "a>a{}",
       description: "newline after > combinator",
       message: messages.rejectedAfter(">"),
       line: 1,
@@ -357,6 +374,7 @@ testRule(rule, {
     },
     {
       code: "a>\r\na{}",
+      fixed: "a>a{}",
       description: "newline after > combinator",
       message: messages.rejectedAfter(">"),
       line: 1,
@@ -364,6 +382,7 @@ testRule(rule, {
     },
     {
       code: "a~\na{}",
+      fixed: "a~a{}",
       description: "newline after ~ combinator",
       message: messages.rejectedAfter("~"),
       line: 1,
@@ -371,6 +390,7 @@ testRule(rule, {
     },
     {
       code: "a~\r\na{}",
+      fixed: "a~a{}",
       description: "CRLF after ~ combinator",
       message: messages.rejectedAfter("~"),
       line: 1,
@@ -378,6 +398,7 @@ testRule(rule, {
     },
     {
       code: "a + .foo.bar ~a {}",
+      fixed: "a +.foo.bar ~a {}",
       description: "multiple combinators: space after + combinator",
       message: messages.rejectedAfter("+"),
       line: 1,
@@ -385,6 +406,7 @@ testRule(rule, {
     },
     {
       code: "#foo +.foo.bar ~ a {}",
+      fixed: "#foo +.foo.bar ~a {}",
       description: "multiple combinators: no space after ~ combinator",
       message: messages.rejectedAfter("~"),
       line: 1,
@@ -392,6 +414,7 @@ testRule(rule, {
     },
     {
       code: "a >>> a {}",
+      fixed: "a >>>a {}",
       description: "space after >>> combinator",
       message: messages.rejectedAfter(">>>"),
       line: 1,
@@ -404,6 +427,7 @@ testRule(rule, {
   ruleName,
   syntax: "less",
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -415,8 +439,61 @@ testRule(rule, {
   reject: [
     {
       code: "a+  a {}",
+      fixed: "a+ a {}",
       description: "two spaces after + combinator",
       message: messages.expectedAfter("+")
+    }
+  ]
+});
+testRule(rule, {
+  ruleName,
+  syntax: "scss",
+  config: ["always"],
+  fix: true,
+
+  accept: [
+    {
+      code: ".a { &.b {} }",
+      description: "ignore constructs"
+    },
+    {
+      code: ".a { & .b {} }",
+      description: "ignore constructs"
+    }
+  ],
+
+  reject: [
+    {
+      code: ".a { &+.b {} }",
+      fixed: ".a { &+ .b {} }",
+      message: messages.expectedAfter("+")
+    }
+  ]
+});
+
+// cssnext
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  fix: true,
+
+  accept: [
+    {
+      code: ".a { &.b {} }"
+    },
+    {
+      code: ".a { & .b {} }"
+    },
+    {
+      code: ".a { &:first-child {} }"
+    }
+  ],
+
+  reject: [
+    {
+      code: ".a { &>.b {} }",
+      fixed: ".a { &> .b {} }",
+      message: messages.expectedAfter(">")
     }
   ]
 });

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
   rejectedAfter: combinator => `Unexpected whitespace after "${combinator}"`
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -28,7 +28,18 @@ const rule = function(expectation) {
       result,
       locationChecker: checker.after,
       locationType: "after",
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? combinator => {
+            if (expectation === "always") {
+              combinator.spaces.after = " ";
+              return true;
+            } else if (expectation === "never") {
+              combinator.spaces.after = "";
+              return true;
+            }
+          }
+        : null
     });
   };
 };

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -143,18 +143,6 @@ testRule(rule, {
     {
       code: "namespace|type#id > .foo {}, space|customtype#id_withunder > a {}",
       description: "qualified id with namespace selector list"
-    },
-    {
-      code: "a {> a {}}",
-      description: "nest"
-    },
-    {
-      code: "a {> a,> .b {}}",
-      description: "nest + list"
-    },
-    {
-      code: "a {> /*comment*/ a,> /*comment*/ .b {}}",
-      description: "nest + list + comment"
     }
   ],
 
@@ -221,13 +209,6 @@ testRule(rule, {
       message: messages.expectedBefore(">>>"),
       line: 1,
       column: 2
-    },
-    {
-      code: "a {> /*comment*/ a,> /*comment*/ .b> .c {}}",
-      description: "nest + list + comment",
-      message: messages.expectedBefore(">"),
-      line: 1,
-      column: 36
     }
   ]
 });
@@ -332,18 +313,6 @@ testRule(rule, {
     {
       code: "namespace|type#id> .foo {}",
       description: "qualified id with namespace"
-    },
-    {
-      code: "a { > a {}}",
-      description: "nest"
-    },
-    {
-      code: "a { > a, > .b {}}",
-      description: "nest + list"
-    },
-    {
-      code: "a { > /*comment*/ a, > /*commenttest*/ .b {}}",
-      description: "nest + list + comment"
     }
   ],
 
@@ -431,13 +400,6 @@ testRule(rule, {
       message: messages.rejectedBefore(">>>"),
       line: 1,
       column: 3
-    },
-    {
-      code: "a { > /*comment*/ a, > /*comment*/ .b >.c {}}",
-      description: "nest + list + comment",
-      message: messages.rejectedBefore(">"),
-      line: 1,
-      column: 39
     }
   ]
 });
@@ -459,6 +421,68 @@ testRule(rule, {
       code: "a  +a {}",
       description: "two spaces before + combinator",
       message: messages.expectedBefore("+")
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  syntax: "scss",
+  config: ["always"],
+
+  accept: [
+    {
+      code: "a {> a {}}",
+      description: "scss nesting"
+    },
+    {
+      code: "a {> a,> .b {}}",
+      description: "scss nesting"
+    },
+    {
+      code: "a {> /*comment*/ a,> /*comment*/ .b {}}",
+      description: "scss nesting, comment and comma"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a {> /*comment*/ a,> /*comment*/ .b> .c {}}",
+      description: "scss nesting, comment and comma",
+      message: messages.expectedBefore(">"),
+      line: 1,
+      column: 36
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  syntax: "scss",
+  config: ["never"],
+
+  accept: [
+    {
+      code: "a { > a {}}",
+      description: "scss nesting"
+    },
+    {
+      code: "a { > a, > .b {}}",
+      description: "scss nesting"
+    },
+    {
+      code: "a { > /*comment*/ a, > /*commenttest*/ .b {}}",
+      description: "scss nesting, comment and comma"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a { > /*comment*/ a, > /*comment*/ .b >.c {}}",
+      description: "scss nesting, comment and comma",
+      message: messages.rejectedBefore(">"),
+      line: 1,
+      column: 39
     }
   ]
 });

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -143,6 +143,18 @@ testRule(rule, {
     {
       code: "namespace|type#id > .foo {}, space|customtype#id_withunder > a {}",
       description: "qualified id with namespace selector list"
+    },
+    {
+      code: "a {> a {}}",
+      description: "nest"
+    },
+    {
+      code: "a {> a,> .b {}}",
+      description: "nest + list"
+    },
+    {
+      code: "a {> /*comment*/ a,> /*comment*/ .b {}}",
+      description: "nest + list + comment"
     }
   ],
 
@@ -209,6 +221,13 @@ testRule(rule, {
       message: messages.expectedBefore(">>>"),
       line: 1,
       column: 2
+    },
+    {
+      code: "a {> /*comment*/ a,> /*comment*/ .b> .c {}}",
+      description: "nest + list + comment",
+      message: messages.expectedBefore(">"),
+      line: 1,
+      column: 36
     }
   ]
 });
@@ -313,6 +332,18 @@ testRule(rule, {
     {
       code: "namespace|type#id> .foo {}",
       description: "qualified id with namespace"
+    },
+    {
+      code: "a { > a {}}",
+      description: "nest"
+    },
+    {
+      code: "a { > a, > .b {}}",
+      description: "nest + list"
+    },
+    {
+      code: "a { > /*comment*/ a, > /*commenttest*/ .b {}}",
+      description: "nest + list + comment"
     }
   ],
 
@@ -400,6 +431,13 @@ testRule(rule, {
       message: messages.rejectedBefore(">>>"),
       line: 1,
       column: 3
+    },
+    {
+      code: "a { > /*comment*/ a, > /*comment*/ .b >.c {}}",
+      description: "nest + list + comment",
+      message: messages.rejectedBefore(">"),
+      line: 1,
+      column: 39
     }
   ]
 });

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -11,8 +11,9 @@ module.exports = function(opts) {
     }
     // Check each selector individually, instead of all as one string,
     // in case some that aren't the first begin with combinators (nesting syntax)
+    const fixedSelectors = [];
     rule.selectors.forEach(selector => {
-      parseSelector(selector, opts.result, rule, selectorTree => {
+      const fixed = parseSelector(selector, opts.result, rule, selectorTree => {
         selectorTree.walkCombinators(node => {
           // Ignore spaced descendant combinator
           if (/\s/.test(node.value)) {
@@ -32,25 +33,33 @@ module.exports = function(opts) {
               ? sourceIndex
               : sourceIndex + node.value.length - 1;
 
-          check(selector, node.value, index, rule, sourceIndex);
+          check(selector, node, index, rule, sourceIndex);
         });
       });
+      fixedSelectors.push(fixed);
     });
+    if (opts.fix) {
+      rule.selectors = fixedSelectors;
+    }
   });
 
-  function check(source, errTarget, index, node, sourceIndex) {
+  function check(source, combinator, index, node, sourceIndex) {
     opts.locationChecker({
       source,
       index,
-      errTarget,
-      err: m =>
+      errTarget: combinator.value,
+      err: m => {
+        if (opts.fix && opts.fix(combinator)) {
+          return;
+        }
         report({
           message: m,
           node,
           index: sourceIndex,
           result: opts.result,
           ruleName: opts.checkedRuleName
-        })
+        });
+      }
     });
   }
 };

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -11,17 +11,23 @@ module.exports = function(opts) {
       return;
     }
     hasFixed = false;
-    const selectors = rule.raws.selector
-      ? [rule.raws.selector.raw]
-      : // Check each selector individually, instead of all as one string,
-        // in case some that aren't the first begin with combinators (nesting syntax)
-        rule.selectors;
+    const selector = rule.raws.selector
+      ? rule.raws.selector.raw
+      : rule.selector;
 
-    const fixedSelectors = selectors.map(selector => {
-      return parseSelector(selector, opts.result, rule, selectorTree => {
+    const fixedSelector = parseSelector(
+      selector,
+      opts.result,
+      rule,
+      selectorTree => {
         selectorTree.walkCombinators(node => {
           // Ignore spaced descendant combinator
           if (/\s/.test(node.value)) {
+            return;
+          }
+          // Check the exist of node in prev of the combinator.
+          // in case some that aren't the first begin with combinators (nesting syntax)
+          if (opts.locationType === "before" && !node.prev()) {
             return;
           }
 
@@ -40,13 +46,13 @@ module.exports = function(opts) {
 
           check(selector, node, index, rule, sourceIndex);
         });
-      });
-    });
+      }
+    );
     if (hasFixed) {
       if (!rule.raws.selector) {
-        rule.selectors = fixedSelectors;
+        rule.selector = fixedSelector;
       } else {
-        rule.raws.selector.raw = fixedSelectors[0];
+        rule.raws.selector.raw = fixedSelector;
       }
     }
   });

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -11,9 +11,8 @@ module.exports = function(opts) {
     }
     // Check each selector individually, instead of all as one string,
     // in case some that aren't the first begin with combinators (nesting syntax)
-    const fixedSelectors = [];
-    rule.selectors.forEach(selector => {
-      const fixed = parseSelector(selector, opts.result, rule, selectorTree => {
+    const fixedSelectors = rule.selectors.map(selector => {
+      return parseSelector(selector, opts.result, rule, selectorTree => {
         selectorTree.walkCombinators(node => {
           // Ignore spaced descendant combinator
           if (/\s/.test(node.value)) {
@@ -36,9 +35,11 @@ module.exports = function(opts) {
           check(selector, node, index, rule, sourceIndex);
         });
       });
-      fixedSelectors.push(fixed);
     });
-    if (opts.fix) {
+    if (
+      opts.fix &&
+      fixedSelectors.some((fixed, i) => rule.selectors[i] !== fixed)
+    ) {
       rule.selectors = fixedSelectors;
     }
   });

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -5,13 +5,19 @@ const parseSelector = require("../utils/parseSelector");
 const report = require("../utils/report");
 
 module.exports = function(opts) {
+  let hasFixed;
   opts.root.walkRules(rule => {
     if (!isStandardSyntaxRule(rule)) {
       return;
     }
-    // Check each selector individually, instead of all as one string,
-    // in case some that aren't the first begin with combinators (nesting syntax)
-    const fixedSelectors = rule.selectors.map(selector => {
+    hasFixed = false;
+    const selectors = rule.raws.selector
+      ? [rule.raws.selector.raw]
+      : // Check each selector individually, instead of all as one string,
+        // in case some that aren't the first begin with combinators (nesting syntax)
+        rule.selectors;
+
+    const fixedSelectors = selectors.map(selector => {
       return parseSelector(selector, opts.result, rule, selectorTree => {
         selectorTree.walkCombinators(node => {
           // Ignore spaced descendant combinator
@@ -36,11 +42,12 @@ module.exports = function(opts) {
         });
       });
     });
-    if (
-      opts.fix &&
-      fixedSelectors.some((fixed, i) => rule.selectors[i] !== fixed)
-    ) {
-      rule.selectors = fixedSelectors;
+    if (hasFixed) {
+      if (!rule.raws.selector) {
+        rule.selectors = fixedSelectors;
+      } else {
+        rule.raws.selector.raw = fixedSelectors[0];
+      }
     }
   });
 
@@ -51,6 +58,7 @@ module.exports = function(opts) {
       errTarget: combinator.value,
       err: m => {
         if (opts.fix && opts.fix(combinator)) {
+          hasFixed = true;
           return;
         }
         report({

--- a/lib/utils/parseSelector.js
+++ b/lib/utils/parseSelector.js
@@ -10,7 +10,7 @@ module.exports = function(
   cb /*: Function*/
 ) {
   try {
-    selectorParser(cb).processSync(selector);
+    return selectorParser(cb).processSync(selector);
   } catch (e) {
     result.warn("Cannot parse selector", { node, stylelintType: "parseError" });
   }


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

`selector-combinator-space-after` in #2829

> Is there anything in the PR that needs further explanation?

ex.

* option: `always`

    code:
    ```css
    a >.b {}
    ```
    fixed:
    ```css
    a > .b {}
    ```

* option: `never`

    code:
    ```css
    a > .b {}
    ```

    fixed:
    ```css
    a >.b {}
    ```
