### PR TITLE
Add autofix to selector-list-comma-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -311,7 +311,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`selector-list-comma-newline-after`](../../lib/rules/selector-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of selector lists.
 -   [`selector-list-comma-newline-before`](../../lib/rules/selector-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of selector lists.
 -   [`selector-list-comma-space-after`](../../lib/rules/selector-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of selector lists.
--   [`selector-list-comma-space-before`](../../lib/rules/selector-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of selector lists.
+-   [`selector-list-comma-space-before`](../../lib/rules/selector-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of selector lists (Autofixable).
 
 #### Rule
 

--- a/lib/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/lib/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -77,6 +77,10 @@ testRule(rule, {
     {
       code: "html { --custom-property-set: {} }",
       description: "custom property set in selector"
+    },
+    {
+      code: "a/*comment,comment*/\n,/*comment*/b {}",
+      description: "comment"
     }
   ],
 
@@ -117,6 +121,13 @@ testRule(rule, {
       message: messages.expectedBefore(),
       line: 2,
       column: 3
+    },
+    {
+      code: "a/*comment*/,/*comment*/b {}",
+      description: "comment",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 13
     }
   ]
 });
@@ -198,6 +209,10 @@ testRule(rule, {
     {
       code: ":not(:hover, :focus) {}",
       description: "comma inside :not()"
+    },
+    {
+      code: "a/*comment\n,comment*/,/*comment*/b {\n}",
+      description: "comment"
     }
   ],
 
@@ -220,6 +235,13 @@ testRule(rule, {
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 3
+    },
+    {
+      code: "a/*comment*/\n,/*comment*/b {\n}",
+      description: "comment",
+      message: messages.rejectedBeforeMultiLine(),
+      line: 2,
+      column: 1
     }
   ]
 });

--- a/lib/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/selector-list-comma-space-after/__tests__/index.js
@@ -51,6 +51,10 @@ testRule(rule, {
     {
       code: "html { --custom-property-set: {} }",
       description: "custom property set in selector"
+    },
+    {
+      code: "a/*comment,comment*/, /*comment*/b {}",
+      description: "comment"
     }
   ],
 
@@ -97,6 +101,12 @@ testRule(rule, {
       message: messages.expectedAfter(),
       line: 1,
       column: 5
+    },
+    {
+      code: "a/*comment*/,/*comment*/b {}",
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 13
     }
   ]
 });
@@ -133,6 +143,10 @@ testRule(rule, {
     {
       code: ":not(:hover, :focus) {}",
       description: "comma inside :not()"
+    },
+    {
+      code: "a/*comment, comment*/,/*comment*/b {}",
+      description: "comment"
     }
   ],
 
@@ -179,6 +193,12 @@ testRule(rule, {
       message: messages.rejectedAfter(),
       line: 1,
       column: 4
+    },
+    {
+      code: "a/*comment*/, /*comment*/b {}",
+      message: messages.rejectedAfter(),
+      line: 1,
+      column: 13
     }
   ]
 });

--- a/lib/rules/selector-list-comma-space-before/README.md
+++ b/lib/rules/selector-list-comma-space-before/README.md
@@ -8,7 +8,7 @@ Require a single space or disallow whitespace before the commas of selector list
  * The space before this comma */
 ```
 
-The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/lib/rules/selector-list-comma-space-before/README.md
+++ b/lib/rules/selector-list-comma-space-before/README.md
@@ -8,6 +8,8 @@ Require a single space or disallow whitespace before the commas of selector list
  * The space before this comma */
 ```
 
+The `--fix` option on the command line can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"`

--- a/lib/rules/selector-list-comma-space-before/__tests__/index.js
+++ b/lib/rules/selector-list-comma-space-before/__tests__/index.js
@@ -52,6 +52,10 @@ testRule(rule, {
     {
       code: "html { --custom-property-set: {} }",
       description: "custom property set in selector"
+    },
+    {
+      code: "a/*comment,comment*/ ,/*comment*/b {}",
+      description: "comment"
     }
   ],
 
@@ -112,6 +116,13 @@ testRule(rule, {
       message: messages.expectedBefore(),
       line: 1,
       column: 2
+    },
+    {
+      code: "a/*comment*/,/*comment*/b {}",
+      fixed: "a/*comment*/ ,/*comment*/b {}",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 13
     }
   ]
 });
@@ -149,6 +160,10 @@ testRule(rule, {
     {
       code: ":not(:hover , :focus) {}",
       description: "comma inside :not()"
+    },
+    {
+      code: "a/*comment ,comment*/,/*comment*/b {}",
+      description: "comment"
     }
   ],
 
@@ -202,6 +217,13 @@ testRule(rule, {
       message: messages.rejectedBefore(),
       line: 1,
       column: 6
+    },
+    {
+      code: "a/*comment*/ ,/*comment*/b {}",
+      fixed: "a/*comment*/,/*comment*/b {}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 14
     }
   ]
 });
@@ -247,6 +269,13 @@ testRule(rule, {
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 2
+    },
+    {
+      code: "a/*comment*/,/*comment*/b {\n}",
+      fixed: "a/*comment*/ ,/*comment*/b {\n}",
+      message: messages.expectedBeforeSingleLine(),
+      line: 1,
+      column: 13
     }
   ]
 });
@@ -292,6 +321,13 @@ testRule(rule, {
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 3
+    },
+    {
+      code: "a/*comment*/ ,/*comment*/b {\n}",
+      fixed: "a/*comment*/,/*comment*/b {\n}",
+      message: messages.rejectedBeforeSingleLine(),
+      line: 1,
+      column: 14
     }
   ]
 });

--- a/lib/rules/selector-list-comma-space-before/__tests__/index.js
+++ b/lib/rules/selector-list-comma-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -57,24 +58,28 @@ testRule(rule, {
   reject: [
     {
       code: "a,b {}",
+      fixed: "a ,b {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 2
     },
     {
       code: "a  ,b {}",
+      fixed: "a ,b {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 4
     },
     {
       code: "a\n,b {}",
+      fixed: "a ,b {}",
       message: messages.expectedBefore(),
       line: 2,
       column: 1
     },
     {
       code: "a\r\n,b {}",
+      fixed: "a ,b {}",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 2,
@@ -82,21 +87,31 @@ testRule(rule, {
     },
     {
       code: "a\t,b {}",
+      fixed: "a ,b {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 3
     },
     {
       code: "a ,b,c {}",
+      fixed: "a ,b ,c {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 5
     },
     {
       code: "a ,b  ,c {}",
+      fixed: "a ,b ,c {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 7
+    },
+    {
+      code: "a,b,c {}",
+      fixed: "a ,b ,c {}",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 2
     }
   ]
 });
@@ -104,6 +119,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -139,24 +155,28 @@ testRule(rule, {
   reject: [
     {
       code: "a ,b {}",
+      fixed: "a,b {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 3
     },
     {
       code: "a  ,b {}",
+      fixed: "a,b {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 4
     },
     {
       code: "a\n,b {}",
+      fixed: "a,b {}",
       message: messages.rejectedBefore(),
       line: 2,
       column: 1
     },
     {
       code: "a\r\n,b {}",
+      fixed: "a,b {}",
       description: "CRLF",
       message: messages.rejectedBefore(),
       line: 2,
@@ -164,18 +184,21 @@ testRule(rule, {
     },
     {
       code: "a\t,b {}",
+      fixed: "a,b {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 3
     },
     {
       code: "a,b ,c {}",
+      fixed: "a,b,c {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 5
     },
     {
       code: "a,b  ,c {}",
+      fixed: "a,b,c {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 6
@@ -186,6 +209,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -204,18 +228,21 @@ testRule(rule, {
   reject: [
     {
       code: "a,b {}",
+      fixed: "a ,b {}",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 2
     },
     {
       code: "a,b {\n}",
+      fixed: "a ,b {\n}",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 2
     },
     {
       code: "a,b {\r\n}",
+      fixed: "a ,b {\r\n}",
       description: "CRLF",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
@@ -227,6 +254,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -245,18 +273,21 @@ testRule(rule, {
   reject: [
     {
       code: "a ,b {}",
+      fixed: "a,b {}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 3
     },
     {
       code: "a ,b {\n}",
+      fixed: "a,b {\n}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 3
     },
     {
       code: "a ,b {\r\n}",
+      fixed: "a,b {\r\n}",
       description: "CRLF",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before "," in a single-line list'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -27,12 +27,42 @@ const rule = function(expectation) {
       return;
     }
 
+    let fixData;
+
     selectorListCommaWhitespaceChecker({
       root,
       result,
       locationChecker: checker.before,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (ruleNode, index) => {
+            fixData = fixData || new Map();
+            const commaIndices = fixData.get(ruleNode) || [];
+            commaIndices.push(index);
+            fixData.set(ruleNode, commaIndices);
+            return true;
+          }
+        : null
     });
+    if (fixData) {
+      fixData.forEach((commaIndices, ruleNode) => {
+        let selector = ruleNode.selector;
+        commaIndices
+          .sort()
+          .reverse()
+          .forEach(index => {
+            let beforeSelector = selector.slice(0, index);
+            const afterSelector = selector.slice(index);
+            if (expectation.indexOf("always") >= 0) {
+              beforeSelector = beforeSelector.replace(/\s*$/, " ");
+            } else if (expectation.indexOf("never") >= 0) {
+              beforeSelector = beforeSelector.replace(/\s*$/, "");
+            }
+            selector = beforeSelector + afterSelector;
+          });
+        ruleNode.selector = selector;
+      });
+    }
   };
 };
 

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -46,7 +46,9 @@ const rule = function(expectation, options, context) {
     });
     if (fixData) {
       fixData.forEach((commaIndices, ruleNode) => {
-        let selector = ruleNode.selector;
+        let selector = ruleNode.raws.selector
+          ? ruleNode.raws.selector.raw
+          : ruleNode.selector;
         commaIndices
           .sort()
           .reverse()
@@ -60,7 +62,11 @@ const rule = function(expectation, options, context) {
             }
             selector = beforeSelector + afterSelector;
           });
-        ruleNode.selector = selector;
+        if (ruleNode.raws.selector) {
+          ruleNode.raws.selector.raw = selector;
+        } else {
+          ruleNode.selector = selector;
+        }
       });
     }
   };

--- a/lib/rules/selectorListCommaWhitespaceChecker.js
+++ b/lib/rules/selectorListCommaWhitespaceChecker.js
@@ -9,7 +9,10 @@ module.exports = function(opts) {
     if (!isStandardSyntaxRule(rule)) {
       return;
     }
-    const selector = rule.selector;
+
+    const selector = rule.raws.selector
+      ? rule.raws.selector.raw
+      : rule.selector;
     styleSearch(
       {
         source: selector,

--- a/lib/rules/selectorListCommaWhitespaceChecker.js
+++ b/lib/rules/selectorListCommaWhitespaceChecker.js
@@ -26,14 +26,18 @@ module.exports = function(opts) {
     opts.locationChecker({
       source,
       index,
-      err: m =>
+      err: m => {
+        if (opts.fix && opts.fix(node, index)) {
+          return;
+        }
         report({
           message: m,
           node,
           index,
           result: opts.result,
           ruleName: opts.checkedRuleName
-        })
+        });
+      }
     });
   }
 };


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

`selector-list-comma-space-before` in #2829

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    a,b {}
    ```
    fixed:
    ```css
    a ,b {}
    ```

* option: `never***`

    code:
    ```css
    a ,b {}
    ```

    fixed:
    ```css
    a,b {}
    ```
