### PR TITLE
Add autofix to property-case

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -260,7 +260,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 #### Property
 
--   [`property-case`](../../lib/rules/property-case/README.md): Specify lowercase or uppercase for properties.
+-   [`property-case`](../../lib/rules/property-case/README.md): Specify lowercase or uppercase for properties (Autofixable).
 
 #### Declaration
 

--- a/lib/rules/property-case/README.md
+++ b/lib/rules/property-case/README.md
@@ -8,6 +8,8 @@ Specify lowercase or uppercase for properties.
  * These properties */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"lower"|"upper"`
@@ -41,14 +43,14 @@ a {
 ```
 
 ```css
-a { 
-  -WEBKIT-animation-duration: 3s; 
+a {
+  -WEBKIT-animation-duration: 3s;
 }
 ```
 
 ```css
-@media screen and (orientation: landscape) { 
-  WiDtH: 500px; 
+@media screen and (orientation: landscape) {
+  WiDtH: 500px;
 }
 ```
 
@@ -67,14 +69,14 @@ a {
 ```
 
 ```css
-a { 
-  -webkit-animation-duration: 3s; 
+a {
+  -webkit-animation-duration: 3s;
 }
 ```
 
 ```css
-@media screen and (orientation: landscape) { 
-  width: 500px; 
+@media screen and (orientation: landscape) {
+  width: 500px;
 }
 ```
 
@@ -107,14 +109,14 @@ a {
 ```
 
 ```css
-a { 
-  -WEBKIT-animation-duration: 3s; 
+a {
+  -WEBKIT-animation-duration: 3s;
 }
 ```
 
 ```css
-@media screen and (orientation: landscape) { 
-  WiDtH: 500px; 
+@media screen and (orientation: landscape) {
+  WiDtH: 500px;
 }
 ```
 
@@ -133,13 +135,13 @@ a {
 ```
 
 ```css
-a { 
-  -WEBKIT-ANIMATION-DURATION: 3s; 
+a {
+  -WEBKIT-ANIMATION-DURATION: 3s;
 }
 ```
 
 ```css
-@media screen and (orientation: landscape) { 
-  WIDTH: 500px; 
+@media screen and (orientation: landscape) {
+  WIDTH: 500px;
 }
 ```

--- a/lib/rules/property-case/__tests__/index.js
+++ b/lib/rules/property-case/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["lower"],
+  fix: true,
 
   accept: [
     {
@@ -56,48 +57,56 @@ testRule(rule, {
   reject: [
     {
       code: "a { Display: block; }",
+      fixed: "a { display: block; }",
       message: messages.expected("Display", "display"),
       line: 1,
       column: 5
     },
     {
       code: "a { DisplaY: block; }",
+      fixed: "a { display: block; }",
       message: messages.expected("DisplaY", "display"),
       line: 1,
       column: 5
     },
     {
       code: "a { DISPLAY: block; }",
+      fixed: "a { display: block; }",
       message: messages.expected("DISPLAY", "display"),
       line: 1,
       column: 5
     },
     {
       code: "a { border-Radius: block; }",
+      fixed: "a { border-radius: block; }",
       message: messages.expected("border-Radius", "border-radius"),
       line: 1,
       column: 5
     },
     {
       code: "a { border-RADIUS: block; }",
+      fixed: "a { border-radius: block; }",
       message: messages.expected("border-RADIUS", "border-radius"),
       line: 1,
       column: 5
     },
     {
       code: "a { BORDER-radius: block; }",
+      fixed: "a { border-radius: block; }",
       message: messages.expected("BORDER-radius", "border-radius"),
       line: 1,
       column: 5
     },
     {
       code: "a { BORDER-RADIUS: block; }",
+      fixed: "a { border-radius: block; }",
       message: messages.expected("BORDER-RADIUS", "border-radius"),
       line: 1,
       column: 5
     },
     {
       code: "a { -WEBKIT-animation-duration: 3s; }",
+      fixed: "a { -webkit-animation-duration: 3s; }",
       message: messages.expected(
         "-WEBKIT-animation-duration",
         "-webkit-animation-duration"
@@ -107,6 +116,7 @@ testRule(rule, {
     },
     {
       code: "a { -webkit-Animation-duration: 3s; }",
+      fixed: "a { -webkit-animation-duration: 3s; }",
       message: messages.expected(
         "-webkit-Animation-duration",
         "-webkit-animation-duration"
@@ -116,42 +126,49 @@ testRule(rule, {
     },
     {
       code: "a:hover { Display: block; }",
+      fixed: "a:hover { display: block; }",
       message: messages.expected("Display", "display"),
       line: 1,
       column: 11
     },
     {
       code: "a:focus { Display: block; }",
+      fixed: "a:focus { display: block; }",
       message: messages.expected("Display", "display"),
       line: 1,
       column: 11
     },
     {
       code: "a:other { Display: block; }",
+      fixed: "a:other { display: block; }",
       message: messages.expected("Display", "display"),
       line: 1,
       column: 11
     },
     {
       code: "a::before { Display: block; }",
+      fixed: "a::before { display: block; }",
       message: messages.expected("Display", "display"),
       line: 1,
       column: 13
     },
     {
       code: "a::other { Display: block; }",
+      fixed: "a::other { display: block; }",
       message: messages.expected("Display", "display"),
       line: 1,
       column: 12
     },
     {
       code: "@media screen and (orientation: landscape) { Width: 500px; }",
+      fixed: "@media screen and (orientation: landscape) { width: 500px; }",
       message: messages.expected("Width", "width"),
       line: 1,
       column: 46
     },
     {
       code: "a { Property: value; }",
+      fixed: "a { property: value; }",
       description: "non-standard property",
       message: messages.expected("Property", "property"),
       line: 1,
@@ -164,6 +181,7 @@ testRule(rule, {
   ruleName,
   syntax: "scss",
   config: ["lower"],
+  fix: true,
 
   accept: [
     {
@@ -227,6 +245,7 @@ testRule(rule, {
   reject: [
     {
       code: "&-sidebar { Border: 1px solid; }",
+      fixed: "&-sidebar { border: 1px solid; }",
       description: "referencing parent selectors",
       message: messages.expected("Border", "border"),
       line: 1,
@@ -234,12 +253,14 @@ testRule(rule, {
     },
     {
       code: "a { Font: (italic bold 10px/8px) }",
+      fixed: "a { font: (italic bold 10px/8px) }",
       message: messages.expected("Font", "font"),
       line: 1,
       column: 5
     },
     {
       code: "a { font: { Size: 30em; } }",
+      fixed: "a { font: { size: 30em; } }",
       description: "nested properties",
       message: messages.expected("Size", "size"),
       line: 1,
@@ -247,6 +268,7 @@ testRule(rule, {
     },
     {
       code: "#context a%extreme { Color: red; }",
+      fixed: "#context a%extreme { color: red; }",
       description: "extend only selectors",
       message: messages.expected("Color", "color"),
       line: 1,
@@ -254,6 +276,7 @@ testRule(rule, {
     },
     {
       code: ".parent { @at-root { .child1 { Display: block; } } }",
+      fixed: ".parent { @at-root { .child1 { display: block; } } }",
       description: "as-root",
       message: messages.expected("Display", "display"),
       line: 1,
@@ -261,6 +284,7 @@ testRule(rule, {
     },
     {
       code: "@mixin large-text { Font-size: 20px; }",
+      fixed: "@mixin large-text { font-size: 20px; }",
       description: "inside mixin",
       message: messages.expected("Font-size", "font-size"),
       line: 1,
@@ -268,6 +292,7 @@ testRule(rule, {
     },
     {
       code: "p { @if 1 + 1 == 2 { Border: 1px solid;  } }",
+      fixed: "p { @if 1 + 1 == 2 { border: 1px solid;  } }",
       description: "inside custom at-rule",
       message: messages.expected("Border", "border"),
       line: 1,
@@ -280,6 +305,7 @@ testRule(rule, {
   ruleName,
   syntax: "less",
   config: ["lower"],
+  fix: true,
 
   accept: [
     {
@@ -347,12 +373,14 @@ testRule(rule, {
   reject: [
     {
       code: "a { Color: @light-blue; }",
+      fixed: "a { color: @light-blue; }",
       message: messages.expected("Color", "color"),
       line: 1,
       column: 5
     },
     {
       code: ".@{my-selector} { Font-weight: bold; }",
+      fixed: ".@{my-selector} { font-weight: bold; }",
       description: "selector interpolation",
       message: messages.expected("Font-weight", "font-weight"),
       line: 1,
@@ -360,6 +388,7 @@ testRule(rule, {
     },
     {
       code: ".mixin(@color: black) { Color: @color; }",
+      fixed: ".mixin(@color: black) { color: @color; }",
       description: "inside mixin",
       message: messages.expected("Color", "color"),
       line: 1,
@@ -367,6 +396,7 @@ testRule(rule, {
     },
     {
       code: "@media screen { @media (min-width: 768px) { Color: red; }}",
+      fixed: "@media screen { @media (min-width: 768px) { color: red; }}",
       description: "nested directives",
       message: messages.expected("Color", "color"),
       line: 1,
@@ -374,6 +404,7 @@ testRule(rule, {
     },
     {
       code: ".bucket { tr & { Color: blue; } }",
+      fixed: ".bucket { tr & { color: blue; } }",
       description: "nested selector",
       message: messages.expected("Color", "color"),
       line: 1,
@@ -385,6 +416,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["upper"],
+  fix: true,
 
   accept: [
     {
@@ -435,48 +467,56 @@ testRule(rule, {
   reject: [
     {
       code: "a { Display: block; }",
+      fixed: "a { DISPLAY: block; }",
       message: messages.expected("Display", "DISPLAY"),
       line: 1,
       column: 5
     },
     {
       code: "a { DisplaY: block; }",
+      fixed: "a { DISPLAY: block; }",
       message: messages.expected("DisplaY", "DISPLAY"),
       line: 1,
       column: 5
     },
     {
       code: "a { display: block; }",
+      fixed: "a { DISPLAY: block; }",
       message: messages.expected("display", "DISPLAY"),
       line: 1,
       column: 5
     },
     {
       code: "a { border-Radius: block; }",
+      fixed: "a { BORDER-RADIUS: block; }",
       message: messages.expected("border-Radius", "BORDER-RADIUS"),
       line: 1,
       column: 5
     },
     {
       code: "a { border-RADIUS: block; }",
+      fixed: "a { BORDER-RADIUS: block; }",
       message: messages.expected("border-RADIUS", "BORDER-RADIUS"),
       line: 1,
       column: 5
     },
     {
       code: "a { BORDER-radius: block; }",
+      fixed: "a { BORDER-RADIUS: block; }",
       message: messages.expected("BORDER-radius", "BORDER-RADIUS"),
       line: 1,
       column: 5
     },
     {
       code: "a { border-radius: block; }",
+      fixed: "a { BORDER-RADIUS: block; }",
       message: messages.expected("border-radius", "BORDER-RADIUS"),
       line: 1,
       column: 5
     },
     {
       code: "a { -WEBKIT-animation-duration: 3s; }",
+      fixed: "a { -WEBKIT-ANIMATION-DURATION: 3s; }",
       message: messages.expected(
         "-WEBKIT-animation-duration",
         "-WEBKIT-ANIMATION-DURATION"
@@ -486,6 +526,7 @@ testRule(rule, {
     },
     {
       code: "a { -webkit-Animation-duration: 3s; }",
+      fixed: "a { -WEBKIT-ANIMATION-DURATION: 3s; }",
       message: messages.expected(
         "-webkit-Animation-duration",
         "-WEBKIT-ANIMATION-DURATION"
@@ -495,42 +536,49 @@ testRule(rule, {
     },
     {
       code: "a:hover { Display: block; }",
+      fixed: "a:hover { DISPLAY: block; }",
       message: messages.expected("Display", "DISPLAY"),
       line: 1,
       column: 11
     },
     {
       code: "a:focus { Display: block; }",
+      fixed: "a:focus { DISPLAY: block; }",
       message: messages.expected("Display", "DISPLAY"),
       line: 1,
       column: 11
     },
     {
       code: "a:other { Display: block; }",
+      fixed: "a:other { DISPLAY: block; }",
       message: messages.expected("Display", "DISPLAY"),
       line: 1,
       column: 11
     },
     {
       code: "a::before { Display: block; }",
+      fixed: "a::before { DISPLAY: block; }",
       message: messages.expected("Display", "DISPLAY"),
       line: 1,
       column: 13
     },
     {
       code: "a::other { Display: block; }",
+      fixed: "a::other { DISPLAY: block; }",
       message: messages.expected("Display", "DISPLAY"),
       line: 1,
       column: 12
     },
     {
       code: "@media screen and (orientation: landscape) { Width: 500px; }",
+      fixed: "@media screen and (orientation: landscape) { WIDTH: 500px; }",
       message: messages.expected("Width", "WIDTH"),
       line: 1,
       column: 46
     },
     {
       code: "a { Property: value; }",
+      fixed: "a { PROPERTY: value; }",
       description: "non-standard property",
       message: messages.expected("Property", "PROPERTY"),
       line: 1,
@@ -543,6 +591,7 @@ testRule(rule, {
   ruleName,
   syntax: "scss",
   config: ["upper"],
+  fix: true,
 
   accept: [
     {
@@ -606,6 +655,7 @@ testRule(rule, {
   reject: [
     {
       code: "&-sidebar { Border: 1px solid; }",
+      fixed: "&-sidebar { BORDER: 1px solid; }",
       description: "referencing parent selectors",
       message: messages.expected("Border", "BORDER"),
       line: 1,
@@ -613,12 +663,14 @@ testRule(rule, {
     },
     {
       code: "a { Font: (italic bold 10px/8px) }",
+      fixed: "a { FONT: (italic bold 10px/8px) }",
       message: messages.expected("Font", "FONT"),
       line: 1,
       column: 5
     },
     {
       code: "a { font: { Size: 30em; } }",
+      fixed: "a { font: { SIZE: 30em; } }",
       description: "nested properties",
       message: messages.expected("Size", "SIZE"),
       line: 1,
@@ -626,6 +678,7 @@ testRule(rule, {
     },
     {
       code: "#context a%extreme { Color: red; }",
+      fixed: "#context a%extreme { COLOR: red; }",
       description: "extend only selectors",
       message: messages.expected("Color", "COLOR"),
       line: 1,
@@ -633,6 +686,7 @@ testRule(rule, {
     },
     {
       code: ".parent { @at-root { .child1 { Display: block; } } }",
+      fixed: ".parent { @at-root { .child1 { DISPLAY: block; } } }",
       description: "as-root",
       message: messages.expected("Display", "DISPLAY"),
       line: 1,
@@ -640,6 +694,7 @@ testRule(rule, {
     },
     {
       code: "@mixin large-text { Font-size: 20px; }",
+      fixed: "@mixin large-text { FONT-SIZE: 20px; }",
       description: "inside mixin",
       message: messages.expected("Font-size", "FONT-SIZE"),
       line: 1,
@@ -647,6 +702,7 @@ testRule(rule, {
     },
     {
       code: "p { @if 1 + 1 == 2 { Border: 1px solid;  } }",
+      fixed: "p { @if 1 + 1 == 2 { BORDER: 1px solid;  } }",
       description: "inside custom at-rule",
       message: messages.expected("Border", "BORDER"),
       line: 1,
@@ -659,6 +715,7 @@ testRule(rule, {
   ruleName,
   syntax: "less",
   config: ["upper"],
+  fix: true,
 
   accept: [
     {
@@ -726,12 +783,14 @@ testRule(rule, {
   reject: [
     {
       code: "a { Color: @light-blue; }",
+      fixed: "a { COLOR: @light-blue; }",
       message: messages.expected("Color", "COLOR"),
       line: 1,
       column: 5
     },
     {
       code: ".@{my-selector} { Font-weight: bold; }",
+      fixed: ".@{my-selector} { FONT-WEIGHT: bold; }",
       description: "selector interpolation",
       message: messages.expected("Font-weight", "FONT-WEIGHT"),
       line: 1,
@@ -739,6 +798,7 @@ testRule(rule, {
     },
     {
       code: ".mixin(@color: black) { Color: @color; }",
+      fixed: ".mixin(@color: black) { COLOR: @color; }",
       description: "inside mixin",
       message: messages.expected("Color", "COLOR"),
       line: 1,
@@ -746,6 +806,7 @@ testRule(rule, {
     },
     {
       code: "@media screen { @media (min-width: 768px) { Color: red; }}",
+      fixed: "@media screen { @media (min-width: 768px) { COLOR: red; }}",
       description: "nested directives",
       message: messages.expected("Color", "COLOR"),
       line: 1,
@@ -753,6 +814,7 @@ testRule(rule, {
     },
     {
       code: ".bucket { tr & { Color: blue; } }",
+      fixed: ".bucket { tr & { COLOR: blue; } }",
       description: "nested selector",
       message: messages.expected("Color", "COLOR"),
       line: 1,

--- a/lib/rules/property-case/index.js
+++ b/lib/rules/property-case/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
   expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -34,7 +34,13 @@ const rule = function(expectation) {
 
       const expectedProp =
         expectation === "lower" ? prop.toLowerCase() : prop.toUpperCase();
+
       if (prop === expectedProp) {
+        return;
+      }
+
+      if (context.fix) {
+        decl.prop = expectedProp;
         return;
       }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

We enable fix option for `property-case`.