### PR TITLE
Add autofix to selector-combinator-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -298,7 +298,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`selector-attribute-operator-space-before`](../../lib/rules/selector-attribute-operator-space-before/README.md): Require a single space or disallow whitespace before operators within attribute selectors.
 -   [`selector-attribute-quotes`](../../lib/rules/selector-attribute-quotes/README.md): Require or disallow quotes for attribute values.
 -   [`selector-combinator-space-after`](../../lib/rules/selector-combinator-space-after/README.md): Require a single space or disallow whitespace after the combinators of selectors (Autofixable).
--   [`selector-combinator-space-before`](../../lib/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors.
+-   [`selector-combinator-space-before`](../../lib/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors (Autofixable).
 -   [`selector-descendant-combinator-no-non-space`](../../lib/rules/selector-descendant-combinator-no-non-space/README.md): Disallow non-space characters for descendant combinators of selectors.
 -   [`selector-pseudo-class-case`](../../lib/rules/selector-pseudo-class-case/README.md): Specify lowercase or uppercase for pseudo-class selectors.
 -   [`selector-pseudo-class-parentheses-space-inside`](../../lib/rules/selector-pseudo-class-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within pseudo-class selectors.

--- a/lib/rules/selector-combinator-space-before/README.md
+++ b/lib/rules/selector-combinator-space-before/README.md
@@ -14,6 +14,8 @@ The descendant combinator is *not* checked by this rule.
 
 Also, `+` and `-` signs within `:nth-*()` arguments are not checked (e.g. `a:nth-child(2n+1)`).
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -149,6 +150,7 @@ testRule(rule, {
   reject: [
     {
       code: "a  +a {}",
+      fixed: "a +a {}",
       description: "two spaces before + combinator",
       message: messages.expectedBefore("+"),
       line: 1,
@@ -156,6 +158,7 @@ testRule(rule, {
     },
     {
       code: "a\n+ a {}",
+      fixed: "a + a {}",
       description: "newline before + combinator",
       message: messages.expectedBefore("+"),
       line: 2,
@@ -163,6 +166,7 @@ testRule(rule, {
     },
     {
       code: "a\r\n+ a {}",
+      fixed: "a + a {}",
       description: "CRLF before + combinator",
       message: messages.expectedBefore("+"),
       line: 2,
@@ -170,6 +174,7 @@ testRule(rule, {
     },
     {
       code: "a+a {}",
+      fixed: "a +a {}",
       description: "no space before + combinator",
       message: messages.expectedBefore("+"),
       line: 1,
@@ -177,6 +182,7 @@ testRule(rule, {
     },
     {
       code: "a>a {}",
+      fixed: "a >a {}",
       description: "no space before > combinator",
       message: messages.expectedBefore(">"),
       line: 1,
@@ -184,6 +190,7 @@ testRule(rule, {
     },
     {
       code: "a~a {}",
+      fixed: "a ~a {}",
       description: "no space before ~ combinator",
       message: messages.expectedBefore("~"),
       line: 1,
@@ -191,6 +198,7 @@ testRule(rule, {
     },
     {
       code: "a + .foo.bar~ a {}",
+      fixed: "a + .foo.bar ~ a {}",
       description: "multiple combinators: no space before ~ combinator",
       message: messages.expectedBefore("~"),
       line: 1,
@@ -198,6 +206,7 @@ testRule(rule, {
     },
     {
       code: "#foo+ .foo.bar ~ a {}",
+      fixed: "#foo + .foo.bar ~ a {}",
       description: "multiple combinators: no space before + combinator",
       message: messages.expectedBefore("+"),
       line: 1,
@@ -205,6 +214,7 @@ testRule(rule, {
     },
     {
       code: "a>>> a {}",
+      fixed: "a >>> a {}",
       description: "shadow-piercing descendant combinator",
       message: messages.expectedBefore(">>>"),
       line: 1,
@@ -216,6 +226,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -319,6 +330,7 @@ testRule(rule, {
   reject: [
     {
       code: "a +a {}",
+      fixed: "a+a {}",
       description: "space before + combinator",
       message: messages.rejectedBefore("+"),
       line: 1,
@@ -326,6 +338,7 @@ testRule(rule, {
     },
     {
       code: "a >a {}",
+      fixed: "a>a {}",
       description: "space before > combinator",
       message: messages.rejectedBefore(">"),
       line: 1,
@@ -333,6 +346,7 @@ testRule(rule, {
     },
     {
       code: "a ~a {}",
+      fixed: "a~a {}",
       description: "space before ~ combinator",
       message: messages.rejectedBefore("~"),
       line: 1,
@@ -340,6 +354,7 @@ testRule(rule, {
     },
     {
       code: "a\n+a {}",
+      fixed: "a+a {}",
       description: "newline before + combinator",
       message: messages.rejectedBefore("+"),
       line: 2,
@@ -347,6 +362,7 @@ testRule(rule, {
     },
     {
       code: "a\r\n+a {}",
+      fixed: "a+a {}",
       description: "CRLF before + combinator",
       message: messages.rejectedBefore("+"),
       line: 2,
@@ -354,6 +370,7 @@ testRule(rule, {
     },
     {
       code: "a\n>a {}",
+      fixed: "a>a {}",
       description: "newline before > combinator",
       message: messages.rejectedBefore(">"),
       line: 2,
@@ -361,6 +378,7 @@ testRule(rule, {
     },
     {
       code: "a\r\n>a {}",
+      fixed: "a>a {}",
       description: "CRLF before > combinator",
       message: messages.rejectedBefore(">"),
       line: 2,
@@ -368,6 +386,7 @@ testRule(rule, {
     },
     {
       code: "a\n~a {}",
+      fixed: "a~a {}",
       description: "newline before ~ combinator",
       message: messages.rejectedBefore("~"),
       line: 2,
@@ -375,6 +394,7 @@ testRule(rule, {
     },
     {
       code: "a\r\n~a {}",
+      fixed: "a~a {}",
       description: "CRLF before ~ combinator",
       message: messages.rejectedBefore("~"),
       line: 2,
@@ -382,6 +402,7 @@ testRule(rule, {
     },
     {
       code: "a + .foo.bar~ a {}",
+      fixed: "a+ .foo.bar~ a {}",
       description: "multiple combinators: space before + combinator",
       message: messages.rejectedBefore("+"),
       line: 1,
@@ -389,6 +410,7 @@ testRule(rule, {
     },
     {
       code: "#foo+ .foo.bar ~ a {}",
+      fixed: "#foo+ .foo.bar~ a {}",
       description: "multiple combinators: no space before ~ combinator",
       message: messages.rejectedBefore("~"),
       line: 1,
@@ -396,6 +418,7 @@ testRule(rule, {
     },
     {
       code: "a >>> a {}",
+      fixed: "a>>> a {}",
       description: "space before >>> combinator",
       message: messages.rejectedBefore(">>>"),
       line: 1,
@@ -408,6 +431,7 @@ testRule(rule, {
   ruleName,
   syntax: "less",
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -419,6 +443,7 @@ testRule(rule, {
   reject: [
     {
       code: "a  +a {}",
+      fixed: "a +a {}",
       description: "two spaces before + combinator",
       message: messages.expectedBefore("+")
     }
@@ -429,6 +454,7 @@ testRule(rule, {
   ruleName,
   syntax: "scss",
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -448,6 +474,7 @@ testRule(rule, {
   reject: [
     {
       code: "a {> /*comment*/ a,> /*comment*/ .b> .c {}}",
+      fixed: "a {> /*comment*/ a,> /*comment*/ .b > .c {}}",
       description: "scss nesting, comment and comma",
       message: messages.expectedBefore(">"),
       line: 1,
@@ -460,6 +487,7 @@ testRule(rule, {
   ruleName,
   syntax: "scss",
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -479,6 +507,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { > /*comment*/ a, > /*comment*/ .b >.c {}}",
+      fixed: "a { > /*comment*/ a, > /*comment*/ .b>.c {}}",
       description: "scss nesting, comment and comma",
       message: messages.rejectedBefore(">"),
       line: 1,

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
   rejectedBefore: combinator => `Unexpected whitespace before "${combinator}"`
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -28,7 +28,18 @@ const rule = function(expectation) {
       result,
       locationChecker: checker.before,
       locationType: "before",
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? combinator => {
+            if (expectation === "always") {
+              combinator.spaces.before = " ";
+              return true;
+            } else if (expectation === "never") {
+              combinator.spaces.before = "";
+              return true;
+            }
+          }
+        : null
     });
   };
 };


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

`selector-combinator-space-before` in #2829

> Is there anything in the PR that needs further explanation?

ex.

* option: `always`

    code:
    ```css
    a> .b {}
    ```
    fixed:
    ```css
    a > .b {}
    ```

* option: `never`

    code:
    ```css
    a > .b {}
    ```

    fixed:
    ```css
    a> .b {}
    ```
