### PR TITLE
Swap chalk for turbocolor

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,6 @@
 /* @flow */
 "use strict";
 
-const chalk = require("chalk");
 const dynamicRequire = require("./dynamicRequire");
 const EOL = require("os").EOL;
 const getModulePath = require("./utils/getModulePath");
@@ -11,6 +10,7 @@ const needlessDisablesStringFormatter = require("./formatters/needlessDisablesSt
 const path = require("path");
 const resolveFrom = require("resolve-from");
 const standalone = require("./standalone");
+const tc = require("turbocolor");
 
 /*:: type meowOptionsType = {
   argv?: string[],
@@ -502,9 +502,9 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
             const foundWarnings = linted.maxWarningsExceeded.foundWarnings;
 
             process.stdout.write(
-              chalk.red(`Max warnings exceeded: `) +
+              tc.red(`Max warnings exceeded: `) +
                 `${foundWarnings} found. ` +
-                chalk.dim(`${maxWarnings} allowed${EOL}${EOL}`)
+                tc.dim(`${maxWarnings} allowed${EOL}${EOL}`)
             );
             process.exitCode = 2;
           }

--- a/lib/formatters/needlessDisablesStringFormatter.js
+++ b/lib/formatters/needlessDisablesStringFormatter.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const chalk = require("chalk");
 const path = require("path");
+const tc = require("turbocolor");
 
 function logFrom(fromValue) {
   if (fromValue.charAt(0) === "<") return fromValue;
@@ -19,7 +19,7 @@ module.exports = function(report) {
       return;
     }
     output += "\n";
-    output += chalk.underline(logFrom(sourceReport.source)) + "\n";
+    output += tc.underline(logFrom(sourceReport.source)) + "\n";
     sourceReport.ranges.forEach(range => {
       output += `start: ${range.start}`;
       if (range.end !== undefined) {

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -1,11 +1,11 @@
 "use strict";
 
 const _ = require("lodash");
-const chalk = require("chalk");
 const path = require("path");
 const stringWidth = require("string-width");
 const symbols = require("log-symbols");
 const table = require("table");
+const tc = require("turbocolor");
 const utils = require("postcss-reporter/lib/util");
 
 const MARGIN_WIDTHS = 9;
@@ -25,11 +25,11 @@ function deprecationsFormatter(results) {
   }
 
   return uniqueDeprecationWarnings.reduce((output, warning) => {
-    output += chalk.yellow("Deprecation Warning: ");
+    output += tc.yellow("Deprecation Warning: ");
     output += warning.text;
     if (warning.reference) {
-      output += chalk.dim(" See: ");
-      output += chalk.dim.underline(warning.reference);
+      output += tc.dim(" See: ");
+      output += tc.dim.underline(warning.reference);
     }
     return output + "\n";
   }, "\n");
@@ -42,7 +42,7 @@ function invalidOptionsFormatter(results) {
   const uniqueInvalidOptionWarnings = _.uniq(allInvalidOptionWarnings);
 
   return uniqueInvalidOptionWarnings.reduce((output, warning) => {
-    output += chalk.red("Invalid Option: ");
+    output += tc.red("Invalid Option: ");
     output += warning;
     return output + "\n";
   }, "\n");
@@ -102,7 +102,7 @@ function formatter(messages, source) {
   let output = "\n";
 
   if (source) {
-    output += chalk.underline(logFrom(source)) + "\n";
+    output += tc.underline(logFrom(source)) + "\n";
   }
 
   const cleanedMessages = orderedMessages.map(message => {
@@ -112,7 +112,7 @@ function formatter(messages, source) {
       location.line || "",
       location.column || "",
       symbols[severity]
-        ? chalk[levelColors[severity]](symbols[severity])
+        ? tc[levelColors[severity]](symbols[severity])
         : severity,
       message.text
         // Remove all control characters (newline, tab and etc)
@@ -122,7 +122,7 @@ function formatter(messages, source) {
           new RegExp(_.escapeRegExp("(" + message.rule + ")") + "$"),
           ""
         ),
-      chalk.dim(message.rule || "")
+      tc.dim(message.rule || "")
     ];
 
     calculateWidths(row);
@@ -148,7 +148,7 @@ function formatter(messages, source) {
     })
     .split("\n")
     .map(el =>
-      el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => chalk.dim(p1 + ":" + p2))
+      el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => tc.dim(p1 + ":" + p2))
     )
     .join("\n");
 

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const _ = require("lodash");
-const chalk = require("chalk");
 const stringFormatter = require("./stringFormatter");
+const tc = require("turbocolor");
 
 module.exports = function(results) {
   let output = stringFormatter(results);
@@ -16,7 +16,7 @@ module.exports = function(results) {
   const checkedDisplay = ignoredCount
     ? `${results.length - ignoredCount} of ${results.length}`
     : results.length;
-  output += chalk.underline(`${checkedDisplay} ${sourceWord} checked\n`);
+  output += tc.underline(`${checkedDisplay} ${sourceWord} checked\n`);
   results.forEach(result => {
     let formatting = "green";
     if (result.errored) {
@@ -30,20 +30,20 @@ module.exports = function(results) {
     if (result.ignored) {
       sourceText += " (ignored)";
     }
-    output += _.get(chalk, formatting)(` ${sourceText}\n`);
+    output += _.get(tc, formatting)(` ${sourceText}\n`);
   });
 
   const warnings = _.flatten(results.map(r => r.warnings));
   const warningsBySeverity = _.groupBy(warnings, "severity");
   const problemWord = warnings.length === 1 ? "problem" : "problems";
 
-  output += chalk.underline(`\n${warnings.length} ${problemWord} found\n`);
+  output += tc.underline(`\n${warnings.length} ${problemWord} found\n`);
 
   _.forOwn(warningsBySeverity, (warningList, severityLevel) => {
     const warningsByRule = _.groupBy(warningList, "rule");
     output += ` severity level "${severityLevel}": ${warningList.length}\n`;
     _.forOwn(warningsByRule, (list, rule) => {
-      output += chalk.dim(`  ${rule}: ${list.length}\n`);
+      output += tc.dim(`  ${rule}: ${list.length}\n`);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "autoprefixer": "^9.0.0",
     "balanced-match": "^1.0.0",
-    "chalk": "^2.4.1",
     "cosmiconfig": "^5.0.0",
     "debug": "^3.0.0",
     "execall": "^1.0.0",
@@ -81,7 +80,8 @@
     "style-search": "^0.1.0",
     "sugarss": "^1.0.0",
     "svg-tags": "^1.0.0",
-    "table": "^4.0.1"
+    "table": "^4.0.1",
+    "turbocolor": "2.3.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",

--- a/scripts/benchmark-rule.js
+++ b/scripts/benchmark-rule.js
@@ -2,11 +2,11 @@
 
 /* eslint-disable no-console */
 const Benchmark = require("benchmark");
-const chalk = require("chalk");
 const normalizeRuleSettings = require("../lib/normalizeRuleSettings");
 const postcss = require("postcss");
 const request = require("request");
 const rules = require("../lib/rules");
+const tc = require("turbocolor");
 
 const ruleName = process.argv[2];
 const ruleOptions = process.argv[3];
@@ -41,10 +41,8 @@ request(CSS_URL, (error, response, body) => {
   });
 
   bench.on("complete", () => {
-    console.log(`${chalk.bold("Mean")}: ${bench.stats.mean * 1000} ms`);
-    console.log(
-      `${chalk.bold("Deviation")}: ${bench.stats.deviation * 1000} ms`
-    );
+    console.log(`${tc.bold("Mean")}: ${bench.stats.mean * 1000} ms`);
+    console.log(`${tc.bold("Deviation")}: ${bench.stats.deviation * 1000} ms`);
   });
 
   bench.run();
@@ -60,9 +58,9 @@ function benchFn(css, done) {
         result.messages
           .filter(m => m.stylelintType === "invalidOption")
           .forEach(m => {
-            console.log(chalk.bold.yellow(`>> ${m.text}`));
+            console.log(tc.bold.yellow(`>> ${m.text}`));
           });
-        console.log(`${chalk.bold("Warnings")}: ${result.warnings().length}`);
+        console.log(`${tc.bold("Warnings")}: ${result.warnings().length}`);
       }
       done();
     })


### PR DESCRIPTION
**Which issue, if any, is this issue related to?**

- None, as it's a miscellaneous perf improvement.

**Is there anything in the PR that needs further explanation?**

- No, it's self explanatory.

---

Hi! This PR swaps chalk for [turbocolor](https://github.com/jorgebucaran/turbocolor) that is ligther (no deps) and has ~20x faster load time and runtime. This is a non-breaking change. This is effectively a "drop-in" replacement.

Let me know if this looks good to you and if you'd like to accept my contribution. 👋 

###### turbocolor/chalk

```
# Load Time
chalk: 15.190ms
turbocolor: 0.777ms

# All Colors
chalk × 8,729 ops/sec
turbocolor × 158,383 ops/sec

# Chained Colors
chalk × 1,838 ops/sec
turbocolor × 39,830 ops/sec

# Nested Colors
chalk × 4,049 ops/sec
turbocolor × 59,833 ops/sec
```
