### PR TITLE
Add a "compact" formatter

### DIFF
--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -75,7 +75,7 @@ For more detail usage, see [Globby Guide](https://github.com/sindresorhus/globby
 
 ### `formatter`
 
-Options: `"json"|"string"|"verbose"`, or a function. Default is `"json"`.
+Options: `"compact"|"json"|"string"|"verbose"`, or a function. Default is `"json"`.
 
 Specify the formatter that you would like to use to format your results.
 

--- a/flow-typed/stylelint.js
+++ b/flow-typed/stylelint.js
@@ -144,7 +144,7 @@ export type stylelint$standaloneOptions = {
   maxWarnings?: number,
   syntax?: stylelint$syntaxes,
   customSyntax?: string,
-  formatter?: "json" | "string" | "verbose" | Function,
+  formatter?: "compact" | "json" | "string" | "verbose" | Function,
   disableDefaultIgnores?: boolean,
   fix?: boolean
 };

--- a/lib/formatters/__tests__/compactFormatter.test.js
+++ b/lib/formatters/__tests__/compactFormatter.test.js
@@ -1,0 +1,136 @@
+"use strict";
+
+const compactFormatter = require("../compactFormatter");
+const prepareFormatterOutput = require("./prepareFormatterOutput");
+const stripIndent = require("common-tags").stripIndent;
+
+describe("compactFormatter", () => {
+  let actualTTY;
+  let actualColumns;
+
+  beforeAll(() => {
+    actualTTY = process.stdout.isTTY;
+    actualColumns = process.stdout.columns;
+  });
+
+  afterAll(() => {
+    process.stdout.isTTY = actualTTY;
+    process.stdout.columns = actualColumns;
+  });
+
+  it("outputs no warnings", () => {
+    const results = [
+      {
+        source: "path/to/file.css",
+        errored: false,
+        warnings: [],
+        deprecations: [],
+        invalidOptionWarnings: []
+      }
+    ];
+
+    const output = compactFormatter(results);
+    expect(output).toBe("");
+  });
+
+  it("outputs warnings", () => {
+    const results = [
+      {
+        source: "path/to/file.css",
+        errored: true,
+        warnings: [
+          {
+            line: 1,
+            column: 1,
+            rule: "bar",
+            severity: "error",
+            text: "Unexpected foo"
+          }
+        ],
+        deprecations: [],
+        invalidOptionWarnings: []
+      }
+    ];
+
+    const output = prepareFormatterOutput(results, compactFormatter);
+
+    expect(output).toBe(stripIndent`
+      path/to/file.css: line 1, col 1, error - Unexpected foo
+    `);
+  });
+
+  it("outputs warnings without stdout `TTY`", () => {
+    process.stdout.isTTY = false;
+
+    const results = [
+      {
+        source: "path/to/file.css",
+        errored: true,
+        warnings: [
+          {
+            line: 1,
+            column: 1,
+            rule: "bar",
+            severity: "error",
+            text: "Unexpected foo"
+          }
+        ],
+        deprecations: [],
+        invalidOptionWarnings: []
+      }
+    ];
+
+    const output = prepareFormatterOutput(results, compactFormatter);
+
+    expect(output).toBe(stripIndent`
+      path/to/file.css: line 1, col 1, error - Unexpected foo
+    `);
+  });
+
+  it("output warnings with more than 80 characters and `process.stdout.columns` equal 90 characters", () => {
+    // For Windows tests
+    process.stdout.isTTY = true;
+    process.stdout.columns = 90;
+
+    const results = [
+      {
+        source: "path/to/file.css",
+        errored: true,
+        warnings: [
+          {
+            line: 1,
+            column: 1,
+            rule: "bar-very-very-very-very-very-long",
+            severity: "error",
+            text:
+              "Unexpected very very very very very very very very very very very very very long foo"
+          }
+        ],
+        deprecations: [],
+        invalidOptionWarnings: []
+      }
+    ];
+
+    const output = prepareFormatterOutput(results, compactFormatter);
+
+    expect(output).toBe(stripIndent`
+        path/to/file.css: line 1, col 1, error - Unexpected very very very very very very very very very very very very very long foo
+    `);
+  });
+
+  it("handles ignored file", () => {
+    const results = [
+      {
+        source: "file.css",
+        warnings: [],
+        deprecations: [],
+        invalidOptionWarnings: [],
+        ignored: true
+      }
+    ];
+
+    const output = prepareFormatterOutput(results, compactFormatter);
+
+    expect(output).toBe("");
+  });
+});

--- a/lib/formatters/compactFormatter.js
+++ b/lib/formatters/compactFormatter.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const _ = require("lodash");
+
+const formatter = results =>
+  _.flatMap(results, result =>
+    _.map(
+      result.warnings,
+      warning =>
+        `${result.source}: ` +
+        `line ${warning.line}, ` +
+        `col ${warning.column}, ` +
+        `${warning.severity} - ` +
+        `${warning.text}`
+    )
+  ).join("\n");
+
+module.exports = formatter;

--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 module.exports = {
+  compact: require("./compactFormatter"),
   json: require("./jsonFormatter"),
   string: require("./stringFormatter"),
   verbose: require("./verboseFormatter")

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -73,7 +73,7 @@ module.exports = function(
     if (formatterFunction === undefined) {
       return Promise.reject(
         new Error(
-          "You must use a valid formatter option: 'json', 'string', 'verbose', or a function"
+          "You must use a valid formatter option: 'compact', 'json', 'string', 'verbose', or a function"
         )
       );
     }


### PR DESCRIPTION
Fixes #3415

This PR seeks to add a new _compact_ formatter.

This _compact_ formatter was previously in its own repo at [ntwb/stylelint-formatter-compact](https://github.com/ntwb/stylelint-formatter-compact)

If this PR is accepted and  merged I'll deprecate the npm package [stylelint-formatter-compact](https://www.npmjs.com/package/stylelint-formatter-compact)

The tests are copied from the [__tests/stringFormatter.test.js](https://github.com/stylelint/stylelint/blob/2d380692173fb9c67d566d440c6cba0fc33d3b4d/lib/formatters/__tests__/stringFormatter.test.js)