### PR TITLE
Fix inconsistent linebreaks docs

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -350,7 +350,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 #### General / Sheet
 
 -   [`indentation`](../../lib/rules/indentation/README.md): Specify indentation (Autofixable).
--   [`linebreaks`](../../lib/rules/linebreaks/README.md): Enforces a consistent linebreak style (Autofixable).
+-   [`linebreaks`](../../lib/rules/linebreaks/README.md): Specify unix or windows linebreaks (Autofixable).
 -   [`max-empty-lines`](../../lib/rules/max-empty-lines/README.md): Limit the number of adjacent empty lines.
 -   [`max-line-length`](../../lib/rules/max-line-length/README.md): Limit the length of a line.
 -   [`no-eol-whitespace`](../../lib/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.

--- a/lib/rules/linebreaks/README.md
+++ b/lib/rules/linebreaks/README.md
@@ -1,6 +1,6 @@
-# linebreak
+# linebreaks
 
-Enforces a consistent linebreak style.
+Specify unix or windows linebreaks.
 
 The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
 
@@ -10,12 +10,12 @@ The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofix
 
 ### `"unix"`
 
-Requires LF (`\n`) linebreaks.
+Linebreaks _must always_ be LF (`\n`).
 
 Lines with CRLF linebreaks are considered violations.
 
 ### `"windows"`
 
-Requires CRLF (\r\n) linebreaks.
+Linebreaks _must always_ be CRLF (`\r\n`).
 
 Lines with LF linebreaks are considered violations.


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

PR https://github.com/stylelint/stylelint/pull/3289

> Is there anything in the PR that needs further explanation?

I only noticed this after merging...

1. We only use "require" for `"always"` and `"never"` options
2. We don't use "enforce" anywhere else, instead we use "specify" when a choice of options is available 

This aligns the `linebreaks` docs with the other docs e.g. [`string-quotes`](https://github.com/stylelint/stylelint/blob/master/lib/rules/string-quotes/README.md)