### PR TITLE
Simplify README structure and language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,124 +1,140 @@
 # stylelint
 
-[![Backers on Open Collective](https://opencollective.com/stylelint/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/stylelint/sponsors/badge.svg)](#sponsors) [![NPM version](https://img.shields.io/npm/v/stylelint.svg)](https://www.npmjs.org/package/stylelint) [![Build Status](https://travis-ci.org/stylelint/stylelint.svg?branch=master)](https://travis-ci.org/stylelint/stylelint) [![Build status](https://ci.appveyor.com/api/projects/status/wwajr0886e00g8je/branch/master?svg=true)](https://ci.appveyor.com/project/stylelint/stylelint/branch/master) [![NPM Downloads](https://img.shields.io/npm/dm/stylelint.svg)](https://npmcharts.com/compare/stylelint?minimal=true) [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=9282518)](https://www.bountysource.com/trackers/9282518-stylelint?utm_source=9282518&utm_medium=shield&utm_campaign=TRACKER_BADGE)
+[![NPM version](https://img.shields.io/npm/v/stylelint.svg)](https://www.npmjs.org/package/stylelint) [![Build Status](https://travis-ci.org/stylelint/stylelint.svg?branch=master)](https://travis-ci.org/stylelint/stylelint) [![Build status](https://ci.appveyor.com/api/projects/status/wwajr0886e00g8je/branch/master?svg=true)](https://ci.appveyor.com/project/stylelint/stylelint/branch/master) [![NPM Downloads](https://img.shields.io/npm/dm/stylelint.svg)](https://npmcharts.com/compare/stylelint?minimal=true) [![Backers on Open Collective](https://opencollective.com/stylelint/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/stylelint/sponsors/badge.svg)](#sponsors)
 
-A mighty, modern CSS linter and fixer that helps you avoid errors and enforce consistent conventions in your stylesheets.
+A mighty, modern linter that helps you avoid errors and enforce conventions in your styles.
 
 ## Features
 
--   **Over one hundred and sixty built-in rules.** Geared towards standard CSS syntax, these can:
-    -   **Catch possible errors:** e.g., invalid standard CSS syntax, duplicates, and overrides.
-    -   **Limit language features:** e.g.:
-        -   Disallow specific units, properties, functions, and at-rules.
-        -   Limit the specificity and quantity of selectors.
-        -   Enforce patterns for selectors and custom properties.
-    -   **Enforce stylistic conventions:** e.g., whitespace, case, notation, and quotes.
--   **Understands the latest CSS syntax:** Including custom properties, `calc()` and level 4 selectors.
--   **Completely unopinionated:** Only enable the rules you want, and configure them with options that tailor the linter to your needs.
--   **Support for plugins:** It's easy to create your own rules and add them to the linter, or make use of plugins written by the community.
--   **Automatically fixes some stylistic violations:** Save time by having stylelint fix your code with this *experimental* feature.
--   **Shareable configs:** If you don't want to craft your own config, you can extend a shareable config. Or you can craft your own config and share with your team and/or the community.
--   **Works with embedded styles:** Within `<style>` tags (used by Vue and Web Components) and Markdown code fences.
--   **Parses *CSS-like* syntaxes:** The linter is powered by [PostCSS](https://github.com/postcss/postcss), so it can be configured and extended to understand any syntax that PostCSS can parse, including Sass, [SugarSS](https://github.com/postcss/sugarss), and Less.
--   **Options validator:** So that you can be confident that your config is valid.
--   **Well tested:** Over ten thousand tests cover the internals and rules.
--   **Growing community**: Used by [Facebook](https://code.facebook.com/posts/879890885467584/improving-css-quality-at-facebook-and-beyond/), [GitHub](https://github.com/primer/stylelint-config-primer), [Wikimedia](https://github.com/wikimedia/stylelint-config-wikimedia), [GSA](https://github.com/18F/stylelint-rules/), and [WordPress](https://github.com/ntwb/stylelint-config-wordpress/) among others.
+It's mighty because it:
+
+-   has over **160 built-in rules** to catch errors, apply limits and enforce stylistic conventions
+-   understands the **latest CSS syntax** including custom properties and level 4 selectors
+-   parses **CSS-like syntaxes** like Scss, Sass, Less and SugarSS
+-   extracts **embedded styles** from markdown code fences, template literals and style tags & attributes
+-   automatically **fixes** some violations to save you time
+-   supports **plugins** so you can create your own rules or make use of plugins written by the community
+-   has **shareable configs** that you can share with your team and/or the community
+-   is **well tested** with over 10000 tests
+-   is **unopinionated** so you can tailor the linter to your needs
+-   has a **growing community** and is used by [Facebook](https://code.facebook.com/posts/879890885467584/improving-css-quality-at-facebook-and-beyond/), [GitHub](https://github.com/primer/stylelint-config-primer) and [WordPress](https://github.com/ntwb/stylelint-config-wordpress/)
 
 ## Example output
+
+The built-in rules help you:
+
+-   **catch possible errors**, for example invalid CSS syntax, duplicates and overrides
+-   **limit language features**, for example:
+    -   specific units, properties, functions and at-rules
+    -   the specificity and quantity of selectors
+    -   the patterns for selectors and custom properties
+-   **enforce stylistic conventions**, for example whitespace, case, notation and quotes
+
+And produce this kind of output for you:
 
 ![Example](https://github.com/stylelint/stylelint/raw/master/example.png?raw=true)
 
 ## Getting started
 
-With stylelint, it's easy to start linting your CSS:
+You can lint styles in:
 
-1.  Decide how you want to use stylelint:
-    -   [via the stylelint CLI](docs/user-guide/cli.md)
-    -   [via a plugin for your text editor](docs/user-guide/complementary-tools.md#editor-plugins) (atom, vscode etc)
-    -   [via a plugin for your build tool](docs/user-guide/complementary-tools.md#build-tool-plugins) (webpack, gulp etc)
-    -   [via the stylelint Node API](docs/user-guide/node-api.md)
-    -   [via the stylelint PostCSS plugin](docs/user-guide/postcss-plugin.md)
-2.  Create your [configuration object](docs/user-guide/configuration.md) by either extending a shared config or crafting your own:
-    -   To extend a shared config, we suggest using either [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard) or [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended). We update the configs with each new release of stylelint, so it's easy to stay up to date. Both configs are geared towards standard CSS syntax. If you use non-standard syntax (like `@if` etc.) then you might want to use a community config designed for that syntax e.g. [`stylelint-config-recommended-scss`](https://github.com/kristerkari/stylelint-config-recommended-scss). The recommended config turns on just the [possible error](docs/user-guide/rules.md#possible-errors) rules. The standard config builds on top of the recommended config by additionally turning on over 60 of stylelint's [stylistic rules](docs/user-guide/rules.md#stylistic-issues) with sensible defaults. You can always override specific rules after extending either config. When using either config, you'll likely want to add (and configure to your specific needs) some of the rules that [limit language features](docs/user-guide/rules.md#limit-language-features). Alternately, you can [search for another](https://www.npmjs.com/browse/keyword/stylelint-config) community config and [extend](docs/user-guide/configuration.md#extends) that instead.
-    -   To craft your own config, first [learn about how rules are named and how they work together](docs/user-guide/about-rules.md), then either:
-        -   Start small and only learn about [the rules](docs/user-guide/rules.md) you want to turn on and enforce. *All of the rules are off by default*, and so you can start small, growing your config over time as you have a chance to explore more of the rules.
-        -   Or copy-paste [this example configuration](docs/user-guide/example-config.md), which lists all of stylelint's rules and their primary options. Then you can edit the options of each rule to your liking, and remove (or turn off with `null`) the rules that you don't care to enforce.
-3.  Lint!
+-   CSS, Scss, Less, Sass and SugarSS files
+-   CSS-in-JS template literals, for example styled-components and Emotion
+-   HTML style tags and attributes, for example Vue and Web Components
+-   Markdown fences
+
+It's easy to get started.
+
+First, decide how you want to use stylelint:
+
+-   [on the command line](docs/user-guide/cli.md)
+-   [in your text editor](docs/user-guide/complementary-tools.md#editor-plugins), for example in VS Code
+-   [in for your build tool](docs/user-guide/complementary-tools.md#build-tool-plugins), for example in webpack
+-   [via the Node API](docs/user-guide/node-api.md)
+-   [as a PostCSS plugin](docs/user-guide/postcss-plugin.md)
+
+Then, create your [configuration object](docs/user-guide/configuration.md).
+
+You can either extend a shared configuration or craft your own.
+
+### Extend a shared configuration
+
+This is the quickest way to get started. We suggest extending either:
+
+-   [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended) - possible error rules
+-   [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard) - possible error and stylistic rules
+
+The recommended one turns on the [possible error](docs/user-guide/rules.md#possible-errors) rules. The standard config builds on top of it by turning on over 60 of stylelint's [stylistic rules](docs/user-guide/rules.md#stylistic-issues) with sensible defaults.
+
+We update these configs with each release of stylelint, so it's easy to stay up to date.
+
+If you use non-standard syntax (like `@if` etc.), you can use a community config designed for it, for example [`stylelint-config-recommended-scss`](https://github.com/kristerkari/stylelint-config-recommended-scss).
+
+You can override rules after extending any config.
+
+You'll likely want to add some of the rules that [limit language features](docs/user-guide/rules.md#limit-language-features) as these will be specific to your team/project.
+
+### Craft your own config
+
+Alternatively, you can first learn about how rules are [named and how they work together](docs/user-guide/about-rules.md) and then either:
+
+-   start small and only learn about [the rules](docs/user-guide/rules.md) you want to turn on and enforce
+-   copy-paste and then adapt [this example configuration](docs/user-guide/example-config.md), which lists all of stylelint's rules and their primary options
 
 ## Guides
 
-You'll find more detailed information on using stylelint and tailoring it to your needs in our guides:
+You'll find detailed information on customising stylelint in our guides:
 
--   [User guide](docs/user-guide.md) - Usage, configuration, FAQ and complementary tools.
--   [Developer guide](docs/developer-guide.md) - Contributing to stylelint and writing your own plugins & formatters.
+-   [user guide](docs/user-guide.md) - how to use and configure stylelint
+-   [developer guide](docs/developer-guide.md) - how to develop for stylelint
 
 ## Need help?
 
-If you're looking for help or have a support question, then check out our [FAQ](docs/user-guide/faq.md) first. If the answer to your problem isn't there, then go to [stackoverflow](https://stackoverflow.com/questions/tagged/stylelint). stackoverflow is a huge Question and Answer community, and tagging your post there with "stylelint" will catch the stylelint team's attention.
+Read our [FAQ](docs/user-guide/faq.md) first. If the answer to your problem isn't there, then post it on [stackoverflow](https://stackoverflow.com/questions/tagged/stylelint).
 
-If you think you've found a bug or if you have feature request, then create a [new GitHub issue](https://github.com/stylelint/stylelint/issues/new). Be sure to follow the issue template, answering each question, as this helps us greatly in understanding your problem or request.
+Please create a [new issue](https://github.com/stylelint/stylelint/issues/new/choose) if you think you've found a bug or if you have feature request.
 
-Upgrading? Please read our [CHANGELOG](CHANGELOG.md) to learn what changes to expect in the latest version, whether that's new features, bug fixes, renamed rules, or whatever else.
+If you're upgrading, read our [CHANGELOG](CHANGELOG.md) to learn what changes to expect in the latest version.
 
 ## Help out
 
-There is always a lot of work to do, and already well over 150 rules to maintain. So please help out in any way that you can:
+There is a lot of work to do. Please help out in any way. You can:
 
--   Chime in on any open [issue](https://github.com/stylelint/stylelint/issues) or [pull request](https://github.com/stylelint/stylelint/pulls).
--   Create, enhance, and debug rules (see our guide to ["Working on rules"](docs/developer-guide/rules.md)).
--   Improve [documentation](docs/).
--   Add new tests to *absolutely anything*.
--   Work on [improving performance of rules](docs/developer-guide/rules.md#improving-the-performance-of-a-new-or-an-existing-rule).
--   Open new issues about your ideas for making stylelint better, and pull requests to show us how your idea works.
--   Create or contribute to ecosystem tools, like the plugins for [Atom](https://github.com/AtomLinter/linter-stylelint) and [Sublime Text](https://github.com/kungfusheep/SublimeLinter-contrib-stylelint).
+-   get involved in any open [issue](https://github.com/stylelint/stylelint/issues) or [pull request](https://github.com/stylelint/stylelint/pulls)
+-   create, enhance and debug rules using our [working on rules](docs/developer-guide/rules.md) guide
+-   improve the [documentation](docs/)
+-   add new tests to *absolutely anything*
+-   improve the [performance of rules](docs/developer-guide/rules.md#improving-the-performance-of-a-new-or-an-existing-rule)
+-   open [new issues](https://github.com/stylelint/stylelint/issues/new/choose) about your ideas for making stylelint better
+-   open [a pull request](https://github.com/stylelint/stylelint/compare) to show us how your idea works
+-   create or contribute to [ecosystem tools](docs/user-guide/complementary-tools.md), for example the plugin for [VS Code](https://github.com/shinnn/vscode-stylelint)
 
-Interested in the project vision? Please read our [VISION document](VISION.md).
+If you're interested in the project vision, you can read our [VISION document](VISION.md).
 
 ## Semantic Versioning Policy
 
-stylelint follows [semantic versioning](http://semver.org). However, due to the nature of stylelint as a code quality tool, it's not always clear when a minor or major version bump occurs. To help clarify this for everyone, based on ESLint's [semantic versioning policy](https://github.com/eslint/eslint#semantic-versioning-policy) we've defined the following semantic versioning policy for stylelint:
+We have a [semantic versioning policy](docs/user-guide/semantic-versioning-policy.md). Any minor update may report more errors than the previous release.
 
--   Patch release (intended to not break your lint build)
-    -   A bug fix in a rule that results in stylelint reporting fewer errors.
-    -   A bug fix to the CLI or core (including formatters).
-    -   Improvements to documentation.
-    -   Non-user-facing changes such as refactoring code, adding, deleting, or modifying tests, and increasing test coverage.
-    -   Re-releasing after a failed release (i.e., publishing a release that doesn't work for anyone).
+As such, we recommend using the tilde (`~`) in `package.json` e.g. `"stylelint": "~7.2.0"` to guarantee the results of your builds.
 
--   Minor release (might break your lint build)
-    -   A bug fix in a rule that results in stylelint reporting more errors.
-    -   A new rule is created.
-    -   A new option to an existing rule that does not result in stylelint reporting more errors by default.
-    -   An existing rule is deprecated.
-    -   A new CLI capability is created.
-    -   New capabilities to the public API are added (new classes, new methods, new arguments to existing methods, etc.).
-    -   A new formatter is created.
+## License
 
--   Major release (likely to break your lint build)
-    -   A change in the documented behaviour of an existing rule results in stylelint reporting more errors by default.
-    -   An existing rule is removed.
-    -   An existing formatter is removed.
-    -   Part of the public API is removed or changed in an incompatible way.
-
-According to our policy, any minor update may report more errors than the previous release (ex: from a bug fix). As such, we recommend using the tilde (`~`) in `package.json` e.g. `"stylelint": "~7.2.0"` to guarantee the results of your builds.
-
-[License](https://raw.githubusercontent.com/stylelint/stylelint/master/LICENSE)
+[The MIT License](https://raw.githubusercontent.com/stylelint/stylelint/master/LICENSE).
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
+This project exists thanks to all these people. [Contribute](CONTRIBUTING.md).
 <a href="https://github.com/stylelint/stylelint/graphs/contributors"><img src="https://opencollective.com/stylelint/contributors.svg?width=890" /></a>
-
 
 ## Backers
 
-Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/stylelint#backer)]
+Thank you to all our backers! [Become a backer](https://opencollective.com/stylelint#backer).
 
 <a href="https://opencollective.com/stylelint#backers" target="_blank"><img src="https://opencollective.com/stylelint/backers.svg?width=890"></a>
 
 
 ## Sponsors
 
-Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/stylelint#sponsor)]
+Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [Become a sponsor](https://opencollective.com/stylelint#sponsor).
 
 <a href="https://opencollective.com/stylelint/sponsor/0/website" target="_blank"><img src="https://opencollective.com/stylelint/sponsor/0/avatar.svg"></a>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,6 +4,7 @@
 
 -   [FAQ](user-guide/faq.md): Frequently asked questions about using and configuring stylelint.
 -   [About rules](user-guide/about-rules.md): An explanation of rule names and how rules work together.
+-   [Semantic versioning policy](user-guide/semantic-versioning-policy.md): An explanation of our policy on semantic versioning.
 
 ## Configuration
 

--- a/docs/user-guide/about-rules.md
+++ b/docs/user-guide/about-rules.md
@@ -2,16 +2,20 @@
 
 We have taken great care to consistently name rules.
 
-The rules have been designed to work in conjunction with one another so that strict conventions can be enforced.
+The rules have been designed to work together to enforce strict conventions.
 
 <!-- TOC -->
 
 ## About rule names
 
--   Made of lowercase words separated by hyphens.
--   Split into two parts:
-    -   The first describes what [*thing*](http://apps.workflower.fi/vocabs/css/en) the rule applies to.
-    -   The second describes what the rule is checking.
+Rule names are:
+
+-   made up of lowercase words separated by hyphens
+-   split into two parts
+
+The first part describes what [*thing*](http://apps.workflower.fi/vocabs/css/en) the rule applies to. The second part describes what the rule is checking.
+
+For example:
 
 ```js
 "number-leading-zero"
@@ -19,7 +23,9 @@ The rules have been designed to work in conjunction with one another so that str
 // the thing  what the rule is checking
 ```
 
--   Except when the rule applies to the whole stylesheet:
+There is no first part when the rule applies to the whole stylesheet.
+
+For example:
 
 ```js
 "no-eol-whitespace"
@@ -30,13 +36,13 @@ The rules have been designed to work in conjunction with one another so that str
 
 ### No rules
 
-Most rules allow you to choose whether you want to require *or* disallow something.
+Most rules require *or* disallow something.
 
 For example, whether numbers *must* or *must not* have a leading zero:
 
 -   `number-leading-zero`: `string -   "always"|"never"`
-    -   `"always"` -   there *must always* be a leading zero.
-    -   `"never"` -   there *must never* be a leading zero.
+    -   `"always"` -   there *must always* be a leading zero
+    -   `"never"` -   there *must never* be a leading zero
 
 ```css
 a { line-height: 0.5; }
@@ -44,11 +50,11 @@ a { line-height: 0.5; }
  * This leading zero */
 ```
 
-However, some rules *just disallow* something. `*-no-*` is used to identify these rules.
+However, some rules *just disallow* something. These rules include `*-no-*` in their name.
 
 For example, whether empty blocks should be disallowed:
 
--   `block-no-empty` -   blocks *must not* be empty.
+-   `block-no-empty` -   blocks *must not* be empty
 
 ```css
 a {   }
@@ -60,7 +66,7 @@ Notice how, for a rule like this, it does not make sense to have an option to en
 
 ### Max and min rules
 
-`*-max-*` and `*-min-*` rules are used when a rule is *setting a limit* to something.
+`*-max-*` and `*-min-*` rules are used to *set a limit* to something.
 
 For example, specifying the maximum number of digits after the "." in a number:
 
@@ -78,8 +84,8 @@ Whitespace rules allow you to specify whether an empty line, a single space, a n
 
 The whitespace rules combine two sets of keywords:
 
-1.  `before`, `after` and `inside` are used to specify where the whitespace (if any) is expected.
-2.  `empty-line`, `space` and `newline` are used to specify whether a single empty line, a single space, a single newline or no space is expected there.
+-   `before`, `after` and `inside` are used to specify where the whitespace (if any) is expected
+-   `empty-line`, `space` and `newline` are used to specify whether a single empty line, a single space, a single newline or no space is expected there
 
 For example, specifying if a single empty line or no space must come before all the comments in a stylesheet:
 
@@ -96,7 +102,7 @@ a {}
 
 Additionally, some whitespace rule make use of another set of keywords:
 
-1.  `comma`, `colon`, `semicolon`, `opening-brace`, `closing-brace`, `opening-parenthesis`, `closing-parenthesis`, `operator` or `range-operator` are used if a specific piece of punctuation in the *thing* is being targetted.
+-   `comma`, `colon`, `semicolon`, `opening-brace`, `closing-brace`, `opening-parenthesis`, `closing-parenthesis`, `operator` or `range-operator` are used if a specific piece of punctuation in the *thing* is being targetted
 
 For example, specifying if a single space or no space must come after a comma in a function:
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -5,7 +5,7 @@
 stylelint is an [npm package](https://www.npmjs.com/package/stylelint). Install it using:
 
 ```shell
-npm install -g stylelint
+npm install stylelint --save-dev
 ```
 
 <!-- TOC -->

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -24,7 +24,7 @@ The configuration object can have the following properties.
 
 ### `rules`
 
-Rules determine what the linter looks for and complains about. There are [over 150](rules.md) built into stylelint. *No rules are turned on by default*, so this is where you turn on everything you want to check. All the rules must be explicitly configured as *there are no default values*.
+Rules determine what the linter looks for and complains about. There are [over 160](rules.md) built into stylelint. *No rules are turned on by default*, so this is where you turn on everything you want to check. All the rules must be explicitly configured as *there are no default values*.
 
 The `rules` property is *an object whose keys are rule names and values are rule configurations*. Each rule configuration fits one of the following formats:
 

--- a/docs/user-guide/semantic-versioning-policy.md
+++ b/docs/user-guide/semantic-versioning-policy.md
@@ -1,0 +1,26 @@
+# Semantic versioning policy
+
+We follow [semantic versioning](http://semver.org). However, due to the nature of stylelint as a code quality tool, we've defined the following policy for stylelint:
+
+-   patch release (intended to not break your lint build)
+    -   a bug fix in a rule that results in stylelint reporting fewer errors
+    -   a bug fix to the CLI or core (including formatters)
+    -   improvements to documentation.
+    -   non-user-facing changes such as refactoring code or modifying tests
+    -   re-releasing after a failed release (i.e., publishing a release that doesn't work for anyone)
+
+-   minor release (might break your lint build)
+    -   a bug fix in a rule that results in stylelint reporting more errors
+    -   a new rule is created
+    -   a new option to an existing rule that does not result in stylelint reporting more errors by default
+    -   an existing rule is deprecated
+    -   a new CLI capability is created
+    -   a new public API capability is created
+    -   a new formatter is created
+
+-   major release (likely to break your lint build)
+    -   a change in the documented behaviour of an existing rule results in stylelint reporting more errors by default
+    -   an existing rule is removed
+    -   an existing formatter is removed
+    -   part of the a CLI is removed or changed in an incompatible way
+    -   part of the public API is removed or changed in an incompatible way


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix

> Is there anything in the PR that needs further explanation?

A lot of stylelint's users are not native English speakers. This PR tries to simplify the structure and the the language of the README (and one or two other pages). The British Government has good [research and guidance](https://www.gov.uk/guidance/content-design/writing-for-gov-uk) on writing for the web, and I've tried to incorporate it into this PR.

I had a cursory look through the other pages, but I decided to focus on main README for now as it has the high information density.
