### PR TITLE
Fix reports of errors with the --fix option in declaration-block-trailing-semicolon

### DIFF
--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -57,11 +57,11 @@ const rule = function(expectation, _, context) {
             node.raws.between = "";
             node.parent.raws.after = " ";
           }
+          return;
         }
 
         message = messages.expected;
-      }
-      if (expectation === "never") {
+      } else if (expectation === "never") {
         if (!node.parent.raws.semicolon) {
           return;
         }
@@ -69,6 +69,7 @@ const rule = function(expectation, _, context) {
         // auto-fix
         if (context.fix) {
           node.parent.raws.semicolon = false;
+          return;
         }
 
         message = messages.rejected;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #3492

> Is there anything in the PR that needs further explanation?

Fixed not to report errors `declaration-block-trailing-semicolon`, when using the `--fix` option.
