### PR TITLE
Remove unused error option from --rd docs

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -253,8 +253,7 @@ const meowOptions /*: meowOptionsType*/ = {
       --report-needless-disables, --rd
 
         Report stylelint-disable comments that are not blocking a lint warning.
-        If you provide the argument "error", the process will exit with code 2
-        if needless disables are found.
+        The process will exit with code 2 if needless disables are found.
 
       --max-warnings, --mw
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

The `error` option to `--report-needless-disables, --rd` was removed in https://github.com/stylelint/stylelint/pull/2341 but the CLI output still references it.
