### PR TITLE
Add flow-type annotations

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -469,23 +469,12 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
       return standalone(options)
         .then(linted => {
           if (reportNeedlessDisables) {
-            const hasReportNeedlessDisable =
-              !!linted.needlessDisables &&
-              linted.needlessDisables.some(sourceReport => {
-                if (!sourceReport.ranges || sourceReport.ranges.length === 0) {
-                  return false;
-                }
+            const report = needlessDisablesStringFormatter(linted.needlessDisables)
 
-                return true;
-              });
-
-            if (hasReportNeedlessDisable) {
-              process.stdout.write(
-                needlessDisablesStringFormatter(linted.needlessDisables)
-              );
+            process.stdout.write(report);
+            if (report) {
               process.exitCode = 2;
             }
-
             return;
           }
 

--- a/lib/formatters/needlessDisablesStringFormatter.js
+++ b/lib/formatters/needlessDisablesStringFormatter.js
@@ -1,9 +1,13 @@
+/* @flow */
+
 "use strict";
 
 const chalk = require("chalk");
 const path = require("path");
 
-function logFrom(fromValue) {
+function logFrom(
+  fromValue /*: string */
+) /*: string */ {
   if (fromValue.charAt(0) === "<") return fromValue;
   return path
     .relative(process.cwd(), fromValue)
@@ -11,7 +15,11 @@ function logFrom(fromValue) {
     .join("/");
 }
 
-module.exports = function(report) {
+module.exports = function(
+  report /*:: ?: stylelint$needlessDisablesReport */
+) /*: string */ {
+  if (!report) return "";
+
   let output = "";
 
   report.forEach(sourceReport => {

--- a/lib/utils/getCacheFile.js
+++ b/lib/utils/getCacheFile.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 "use strict";
 
 const fs = require("fs");
@@ -14,7 +16,10 @@ const path = require("path");
  * @param {string} cwd - Current working directory. Used for tests
  * @returns {string} Resolved path to the cache file
  */
-module.exports = function getCacheFile(cacheFile, cwd) {
+module.exports = function getCacheFile(
+  cacheFile /*: string */,
+  cwd /*: string */
+) /*: string */ {
   /*
    * Make sure path separators are normalized for environment/os.
    * Also, keep trailing path separator if present.

--- a/lib/utils/hash.js
+++ b/lib/utils/hash.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 "use strict";
 const murmur = require("imurmurhash");
 
@@ -6,7 +8,9 @@ const murmur = require("imurmurhash");
  * @param  {string} str the string to hash
  * @returns {string}    the hash
  */
-module.exports = function hash(str) {
+module.exports = function hash(
+  str /*: string */
+) /*: string */ {
   return murmur(str)
     .result()
     .toString(36);

--- a/lib/utils/isAfterSingleLineComment.js
+++ b/lib/utils/isAfterSingleLineComment.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 "use strict";
 
 const isSharedLineComment = require("./isSharedLineComment");

--- a/lib/utils/whitespaceChecker.js
+++ b/lib/utils/whitespaceChecker.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 "use strict";
 
 const configurationError = require("./configurationError");
@@ -184,11 +186,10 @@ module.exports = function(
     before(Object.assign({}, obj, { allowIndentation: true }));
   }
 
-  function expectBefore() {
-    const messageFunc =
-      arguments.length > 0 && arguments[0] !== undefined
-        ? arguments[0]
-        : messages.expectedBefore;
+  function expectBefore(
+    messageFunc /*:: ?: Function*/
+  ) {
+    messageFunc = messageFunc || messages.expectedBefore;
 
     if (activeArgs.allowIndentation) {
       expectBeforeAllowingIndentation(messageFunc);
@@ -217,11 +218,10 @@ module.exports = function(
     );
   }
 
-  function expectBeforeAllowingIndentation() {
-    const messageFunc =
-      arguments.length > 0 && arguments[0] !== undefined
-        ? arguments[0]
-        : messages.expectedBefore;
+  function expectBeforeAllowingIndentation(
+    messageFunc /*:: ?: Function*/
+  ) {
+    messageFunc = messageFunc || messages.expectedBefore;
     const _activeArgs2 = activeArgs;
     const source = _activeArgs2.source;
     const index = _activeArgs2.index;
@@ -245,11 +245,10 @@ module.exports = function(
     }
   }
 
-  function rejectBefore() {
-    const messageFunc =
-      arguments.length > 0 && arguments[0] !== undefined
-        ? arguments[0]
-        : messages.rejectedBefore;
+  function rejectBefore(
+    messageFunc /*:: ?: Function*/
+  ) {
+    messageFunc = messageFunc || messages.rejectedBefore;
     const _activeArgs3 = activeArgs;
     const source = _activeArgs3.source;
     const index = _activeArgs3.index;
@@ -267,11 +266,10 @@ module.exports = function(
     after(Object.assign({}, obj, { onlyOneChar: true }));
   }
 
-  function expectAfter() {
-    const messageFunc =
-      arguments.length > 0 && arguments[0] !== undefined
-        ? arguments[0]
-        : messages.expectedAfter;
+  function expectAfter(
+    messageFunc /*:: ?: Function*/
+  ) {
+    messageFunc = messageFunc || messages.expectedAfter;
     const _activeArgs4 = activeArgs;
     const source = _activeArgs4.source;
     const index = _activeArgs4.index;
@@ -310,11 +308,10 @@ module.exports = function(
     );
   }
 
-  function rejectAfter() {
-    const messageFunc =
-      arguments.length > 0 && arguments[0] !== undefined
-        ? arguments[0]
-        : messages.rejectedAfter;
+  function rejectAfter(
+    messageFunc /*:: ?: Function*/
+  ) {
+    messageFunc = messageFunc || messages.rejectedAfter;
     const _activeArgs5 = activeArgs;
     const source = _activeArgs5.source;
     const index = _activeArgs5.index;

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint-config-stylelint": "~8.1.0",
     "file-exists-promise": "^1.0.2",
     "flow-bin": "^0.77.0",
-    "flow-typed": "^2.3.0",
+    "flow-typed": "^2.5.1",
     "husky": "^0.14.3",
     "jest": "^23.4.1",
     "lint-staged": "^7.0.0",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

#2935 

> Is there anything in the PR that needs further explanation?

Add flow-type annotations into the files mentioned in #2935 except src/formatting/stringFormatter.js, which is blocked by an error in the libdefs for Lodash. (https://github.com/flow-typed/flow-typed/issues/2463)

It also updates flow-typed to the latest version, since atm `npm run flow-defs` just errors.
