### PR TITLE
Fix false positives for selector-descendant-combinator-no-non-space

### DIFF
--- a/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
@@ -52,6 +52,9 @@ testRule(rule, {
     {
       code: "html { --custom-property-set: {} }",
       description: "custom property set in selector"
+    },
+    {
+      code: "div > :nth-child(2n + 1) {}"
     }
   ],
 
@@ -82,6 +85,18 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  accept: [
+    {
+      code: "div > :nth-child(#{$i + ($column - 1)}) {}"
+    }
+  ]
+})
 
 testRule(rule, {
   ruleName,

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const isStandardSyntaxCombinator = require("../../utils/isStandardSyntaxCombinator");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const parseSelector = require("../../utils/parseSelector");
 const punctuationSets = require("../../reference/punctuationSets");

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const isStandardSyntaxCombinator = require("../../utils/isStandardSyntaxCombinator");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const parseSelector = require("../../utils/parseSelector");
 const punctuationSets = require("../../reference/punctuationSets");
@@ -34,17 +35,22 @@ const rule = function(actual) {
           if (punctuationSets.nonSpaceCombinators.has(value)) {
             return;
           }
-          if (value === " ") {
-            return;
+
+          if (
+            value.includes('  ') ||
+            value.includes('\t') ||
+            value.includes('\n') ||
+            value.includes('\r')
+          ) {
+            report({
+              result,
+              ruleName,
+              message: messages.rejected(value),
+              node: rule,
+              index: combinatorNode.sourceIndex
+            });
           }
 
-          report({
-            result,
-            ruleName,
-            message: messages.rejected(value),
-            node: rule,
-            index: combinatorNode.sourceIndex
-          });
         });
       });
     });


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

fixes #3449 

> Is there anything in the PR that needs further explanation?

This rule is a little bit strange in that a descendent combinator is always whitespace, it's just not always a _single_ space. In fact the logic of the rule checks that the combinator is not one of the standard "non-space" combinators (+, >) and _passes_ if that is the case.

For this particular bug, PostCSS apparently determined that `+($column - 1)` is a combinator, which is odd, and it is not a non-space combinator nor is it a single space.

Anyway, since what are _really_ looking is whitespace combinators that are not single spaces, I changed the logic to do that instead. It's a bit of a work-around but it covers the case in question and most importantly does not regress.
