### PR TITLE
Add autofix to selector-list-comma-newline-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -309,7 +309,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 #### Selector list
 
 -   [`selector-list-comma-newline-after`](../../lib/rules/selector-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of selector lists.
--   [`selector-list-comma-newline-before`](../../lib/rules/selector-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of selector lists.
+-   [`selector-list-comma-newline-before`](../../lib/rules/selector-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of selector lists (Autofixable).
 -   [`selector-list-comma-space-after`](../../lib/rules/selector-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of selector lists.
 -   [`selector-list-comma-space-before`](../../lib/rules/selector-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of selector lists (Autofixable).
 

--- a/lib/rules/selector-list-comma-newline-before/README.md
+++ b/lib/rules/selector-list-comma-newline-before/README.md
@@ -9,6 +9,8 @@ Require a newline or disallow whitespace before the commas of selector lists.
  * The newline before this comma */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/lib/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -87,36 +88,42 @@ testRule(rule, {
   reject: [
     {
       code: "a,b {}",
+      fixed: "a\n,b {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 2
     },
     {
       code: "a ,b {}",
+      fixed: "a\n ,b {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 3
     },
     {
       code: "a  ,b {}",
+      fixed: "a\n  ,b {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 4
     },
     {
       code: "a\t,b {}",
+      fixed: "a\n\t,b {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 3
     },
     {
       code: "a\n,b,c {}",
+      fixed: "a\n,b\n,c {}",
       message: messages.expectedBefore(),
       line: 2,
       column: 3
     },
     {
       code: "a\r\n,b,c {}",
+      fixed: "a\r\n,b\r\n,c {}",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 2,
@@ -124,6 +131,7 @@ testRule(rule, {
     },
     {
       code: "a/*comment*/,/*comment*/b {}",
+      fixed: "a/*comment*/\n,/*comment*/b {}",
       description: "comment",
       message: messages.expectedBefore(),
       line: 1,
@@ -135,6 +143,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -161,12 +170,14 @@ testRule(rule, {
   reject: [
     {
       code: "a\n,b, c {}",
+      fixed: "a\n,b\n, c {}",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 3
     },
     {
       code: "a\r\n,b, c {}",
+      fixed: "a\r\n,b\r\n, c {}",
       description: "CRLF",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
@@ -174,6 +185,7 @@ testRule(rule, {
     },
     {
       code: "a\n,b, c {\n}",
+      fixed: "a\n,b\n, c {\n}",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 3
@@ -184,6 +196,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -219,18 +232,21 @@ testRule(rule, {
   reject: [
     {
       code: "a,\nb , c {}",
+      fixed: "a,\nb, c {}",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 3
     },
     {
       code: "a,\nb , c {\n}",
+      fixed: "a,\nb, c {\n}",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 3
     },
     {
       code: "a,\r\nb , c {\r\n}",
+      fixed: "a,\r\nb, c {\r\n}",
       description: "CRLF",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
@@ -238,6 +254,7 @@ testRule(rule, {
     },
     {
       code: "a/*comment*/\n,/*comment*/b {\n}",
+      fixed: "a/*comment*/,/*comment*/b {\n}",
       description: "comment",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before "," in a multi-line list'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("newline", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -26,12 +26,56 @@ const rule = function(expectation) {
       return;
     }
 
+    let fixData;
+
     selectorListCommaWhitespaceChecker({
       root,
       result,
       locationChecker: checker.beforeAllowingIndentation,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (ruleNode, index) => {
+            fixData = fixData || new Map();
+            const commaIndices = fixData.get(ruleNode) || [];
+            commaIndices.push(index);
+            fixData.set(ruleNode, commaIndices);
+            return true;
+          }
+        : null
     });
+    if (fixData) {
+      fixData.forEach((commaIndices, ruleNode) => {
+        let selector = ruleNode.raws.selector
+          ? ruleNode.raws.selector.raw
+          : ruleNode.selector;
+        commaIndices
+          .sort()
+          .reverse()
+          .forEach(index => {
+            let beforeSelector = selector.slice(0, index);
+            const afterSelector = selector.slice(index);
+            if (expectation.indexOf("always") === 0) {
+              const spaceIndex = beforeSelector.search(/\s+$/);
+              if (spaceIndex >= 0) {
+                beforeSelector =
+                  beforeSelector.slice(0, spaceIndex) +
+                  context.newline +
+                  beforeSelector.slice(spaceIndex);
+              } else {
+                beforeSelector = beforeSelector + context.newline;
+              }
+            } else if (expectation === "never-multi-line") {
+              beforeSelector = beforeSelector.replace(/\s*$/, "");
+            }
+            selector = beforeSelector + afterSelector;
+          });
+        if (ruleNode.raws.selector) {
+          ruleNode.raws.selector.raw = selector;
+        } else {
+          ruleNode.selector = selector;
+        }
+      });
+    }
   };
 };
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

`selector-list-comma-newline-before` in #2829

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    a,b {}
    ```
    fixed:
    ```css
    a
    ,b {}
    ```

* option: `never-multi-line`

    code:
    ```css
    a
    ,b {\n}
    ```

    fixed:
    ```css
    a,b {\n}
    ```
