### PR TITLE
Add autofix to block-opening-brace-space-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -288,7 +288,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`block-closing-brace-space-before`](../../lib/rules/block-closing-brace-space-before/README.md): Require a single space or disallow whitespace before the closing brace of blocks.
 -   [`block-opening-brace-newline-after`](../../lib/rules/block-opening-brace-newline-after/README.md): Require a newline after the opening brace of blocks.
 -   [`block-opening-brace-newline-before`](../../lib/rules/block-opening-brace-newline-before/README.md): Require a newline or disallow whitespace before the opening brace of blocks.
--   [`block-opening-brace-space-after`](../../lib/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks.
+-   [`block-opening-brace-space-after`](../../lib/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks (Autofixable).
 -   [`block-opening-brace-space-before`](../../lib/rules/block-opening-brace-space-before/README.md): Require a single space or disallow whitespace before the opening brace of blocks (Autofixable).
 
 #### Selector

--- a/lib/rules/block-opening-brace-space-after/README.md
+++ b/lib/rules/block-opening-brace-space-after/README.md
@@ -8,6 +8,8 @@ Require a single space or disallow whitespace after the opening brace of blocks.
  * The space after this brace */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/block-opening-brace-space-after/__tests__/index.js
+++ b/lib/rules/block-opening-brace-space-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -22,30 +23,35 @@ testRule(rule, {
   reject: [
     {
       code: "a {color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {  color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {\tcolor: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {\ncolor: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {\r\ncolor: pink; }",
+      fixed: "a { color: pink; }",
       description: "CRLF",
       message: messages.expectedAfter(),
       line: 1,
@@ -53,22 +59,32 @@ testRule(rule, {
     },
     {
       code: "@media print {\na { color: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedAfter(),
       line: 1,
       column: 15
     },
     {
       code: "@media print { a {\ncolor: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
     },
     {
       code: "@media print { a {\r\ncolor: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       description: "CRLF",
       message: messages.expectedAfter(),
       line: 1,
       column: 19
+    },
+    {
+      code: "a {/*comment*/ color: pink; }",
+      fixed: "a { /*comment*/ color: pink; }",
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 4
     }
   ]
 });
@@ -76,6 +92,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -89,30 +106,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a {color: pink; }",
       message: messages.rejectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {  color: pink; }",
+      fixed: "a {color: pink; }",
       message: messages.rejectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {\tcolor: pink; }",
+      fixed: "a {color: pink; }",
       message: messages.rejectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {\ncolor: pink; }",
+      fixed: "a {color: pink; }",
       message: messages.rejectedAfter(),
       line: 1,
       column: 4
     },
     {
       code: "a {\r\ncolor: pink; }",
+      fixed: "a {color: pink; }",
       description: "CRLF",
       message: messages.rejectedAfter(),
       line: 1,
@@ -120,15 +142,24 @@ testRule(rule, {
     },
     {
       code: "@media print {\na {color: pink; } }",
+      fixed: "@media print {a {color: pink; } }",
       message: messages.rejectedAfter(),
       line: 1,
       column: 15
     },
     {
       code: "@media print {a {\ncolor: pink; } }",
+      fixed: "@media print {a {color: pink; } }",
       message: messages.rejectedAfter(),
       line: 1,
       column: 18
+    },
+    {
+      code: "a { /*comment*/ color: pink; }",
+      fixed: "a {/*comment*/ color: pink; }",
+      message: messages.rejectedAfter(),
+      line: 1,
+      column: 4
     }
   ]
 });
@@ -136,6 +167,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -165,30 +197,35 @@ testRule(rule, {
   reject: [
     {
       code: "a {color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {  color: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {\tcolor: pink; }",
+      fixed: "a { color: pink; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 4
     },
     {
       code: "@media print {\ta { color: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 15
     },
     {
       code: "@media print { a {\tcolor: pink; } }",
+      fixed: "@media print { a { color: pink; } }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 19
@@ -199,6 +236,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -225,30 +263,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a {color: pink; }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {  color: pink; }",
+      fixed: "a {color: pink; }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {\tcolor: pink; }",
+      fixed: "a {color: pink; }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 4
     },
     {
       code: "@media print { a {color: pink; } }",
+      fixed: "@media print {a {color: pink; } }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 15
     },
     {
       code: "@media print {a { color: pink; } }",
+      fixed: "@media print {a {color: pink; } }",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 18
@@ -259,6 +302,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -287,30 +331,35 @@ testRule(rule, {
   reject: [
     {
       code: "a {color: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {  color: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {\tcolor: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {\ncolor: pink;\nbackground: orange; }",
+      fixed: "a { color: pink;\nbackground: orange; }",
       message: messages.expectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {\r\ncolor: pink;\r\nbackground: orange; }",
+      fixed: "a { color: pink;\r\nbackground: orange; }",
       description: "CRLF",
       message: messages.expectedAfterMultiLine(),
       line: 1,
@@ -318,12 +367,14 @@ testRule(rule, {
     },
     {
       code: "@media print\n{a { color: pink;\nbackground: orange; } }",
+      fixed: "@media print\n{ a { color: pink;\nbackground: orange; } }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 2
     },
     {
       code: "@media print { a\n{color: pink;\nbackground: orange; } }",
+      fixed: "@media print { a\n{ color: pink;\nbackground: orange; } }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 2
@@ -334,6 +385,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -366,24 +418,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\nbackground: orange; }",
+      fixed: "a {color: pink;\nbackground: orange; }",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {  color: pink;\nbackground: orange; }",
+      fixed: "a {color: pink;\nbackground: orange; }",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {\tcolor: pink;\nbackground: orange; }",
+      fixed: "a {color: pink;\nbackground: orange; }",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "a {\tcolor: pink;\r\nbackground: orange; }",
+      fixed: "a {color: pink;\r\nbackground: orange; }",
       description: "CRLF",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
@@ -391,18 +447,21 @@ testRule(rule, {
     },
     {
       code: "a {\ncolor: pink;\nbackground: orange; }",
+      fixed: "a {color: pink;\nbackground: orange; }",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
       column: 4
     },
     {
       code: "@media print\n{ a {color: pink;\nbackground: orange; } }",
+      fixed: "@media print\n{a {color: pink;\nbackground: orange; } }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 2
     },
     {
       code: "@media print{a\n{ color: pink;\nbackground: orange; } }",
+      fixed: "@media print{a\n{color: pink;\nbackground: orange; } }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 2

--- a/lib/rules/block-opening-brace-space-after/index.js
+++ b/lib/rules/block-opening-brace-space-after/index.js
@@ -24,7 +24,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace after "{" of a multi-line block'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -56,6 +56,15 @@ const rule = function(expectation) {
         source: blockString(statement),
         index: 0,
         err: m => {
+          if (context.fix) {
+            if (expectation.indexOf("always") === 0) {
+              statement.first.raws.before = " ";
+              return;
+            } else if (expectation.indexOf("never") === 0) {
+              statement.first.raws.before = "";
+              return;
+            }
+          }
           report({
             message: m,
             node: statement,


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

`block-opening-brace-space-after` in #2829

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    a {color: pink; }
    ```
    fixed:
    ```css
    a { color: pink; }
    ```

* option: `never***`

    code:
    ```css
    a { color: pink; }
    ```

    fixed:
    ```css
    a {color: pink; }
    ```
