### PR TITLE
Fix missing `compact` formatter in CLI help

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -234,7 +234,7 @@ const meowOptions /*: meowOptionsType*/ = {
 
       --formatter, -f               [default: "string"]
 
-        The output formatter: "json", "string" or "verbose".
+        The output formatter: "compact", "json", "string" or "verbose".
 
       --custom-formatter
 
@@ -469,7 +469,9 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
       return standalone(options)
         .then(linted => {
           if (reportNeedlessDisables) {
-            const report = needlessDisablesStringFormatter(linted.needlessDisables)
+            const report = needlessDisablesStringFormatter(
+              linted.needlessDisables
+            );
 
             process.stdout.write(report);
             if (report) {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Related to #3488

> Is there anything in the PR that needs further explanation?

Following the order of formatters in [the stylelint Node API documentation](https://github.com/stylelint/stylelint/blob/9.4.0/docs/user-guide/node-api.md#formatter):

```
Options: "compact"|"json"|"string"|"verbose", or a function. Default is "json".
```



