### PR TITLE
Fix failed tests when a `.stylelintrc` file exists in the home directory

### DIFF
--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -8,6 +8,10 @@ const getConfigForFile = require("./getConfigForFile");
 const getPostcssResult = require("./getPostcssResult");
 const isPathIgnored = require("./isPathIgnored");
 const lintSource = require("./lintSource");
+const path = require("path");
+
+const IS_TEST = process.env.NODE_ENV === "test";
+const STOP_DIR = IS_TEST ? path.resolve(__dirname, "..") : undefined;
 
 // The stylelint "internal API" is passed among functions
 // so that methods on a stylelint instance can invoke
@@ -21,10 +25,12 @@ module.exports = function(
   // Two separate explorers so they can each have their own transform
   // function whose results are cached by cosmiconfig
   stylelint._fullExplorer = cosmiconfig("stylelint", {
-    transform: _.partial(augmentConfig.augmentConfigFull, stylelint)
+    transform: _.partial(augmentConfig.augmentConfigFull, stylelint),
+    stopDir: STOP_DIR
   });
   stylelint._extendExplorer = cosmiconfig(null, {
-    transform: _.partial(augmentConfig.augmentConfigExtended, stylelint)
+    transform: _.partial(augmentConfig.augmentConfigExtended, stylelint),
+    stopDir: STOP_DIR
   });
 
   stylelint._specifiedConfigCache = new Map();


### PR DESCRIPTION
Summary
-------

By default `cosmiconfig` search a `.stylelintrc` file up to the home directory.
Thus, in test environments which include `.stylelintrc` in their home directory, some tests fail.

This commit fixes the failed tests, by setting project root to `stopDir` option of `cosmiconfig` on test only.
About `stopDir` option, please see <https://github.com/davidtheclark/cosmiconfig#stopdir>.

Reproduction
------------

1. Create following `Dockerfile`

    ```Dockerfile
    FROM node:6

    RUN git clone --depth=1 https://github.com/stylelint/stylelint.git /root/stylelint

    WORKDIR /root/stylelint

    RUN npm install

    # Failed when "${HOME}/.stylelintrc" exists
    RUN echo '{"rules":{}}' > /root/.stylelintrc && \
        $(npm bin)/jest lib/__tests__/standalone.test.js

    # Passed when "${HOME}/.stylelintrc" doesn't exists
    RUN $(npm bin)/jest lib/__tests__/standalone.test.js
    ```

2. Run `docker build .` command

    ```
    ...
    ● standalone with config locatable from process.cwd not file › two warning

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 0

      323 |
      324 |   it("two warning", () => {
    > 325 |     expect(results[0].warnings.length).toBe(2);
          |                                        ^
      326 |   });
      327 |
      328 |   it("first correct warning", () => {

      at Object.it (lib/__tests__/standalone.test.js:325:40)

    ● standalone with config locatable from process.cwd not file › first correct warning

    TypeError: Cannot read property 'text' of undefined

      328 |   it("first correct warning", () => {
      329 |     expect(
    > 330 |       results[0].warnings[0].text.indexOf("Unexpected empty block")
          |       ^
      331 |     ).not.toBe(-1);
      332 |   });
      333 |

      at Object.it (lib/__tests__/standalone.test.js:330:7)

    ● standalone with config locatable from process.cwd not file › second correct warning

    TypeError: Cannot read property 'text' of undefined

      333 |
      334 |   it("second correct warning", () => {
    > 335 |     expect(results[0].warnings[1].text.indexOf("foo")).not.toBe(-1);
          |            ^
      336 |   });
      337 | });
      338 |

      at Object.it (lib/__tests__/standalone.test.js:335:12)

    Test Suites: 1 failed, 1 total
    Tests:       3 failed, 31 passed, 34 total
    Snapshots:   0 total
    Time:        2.629s
    Ran all test suites matching /lib\/__tests__\/standalone.test.js/i.
    ```

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

I put `.stylelintrc` in my home directory to use `stylelint` globally installed.
When I clone `stylelint/stylelint` repository and run tests, I wonder that some tests fail always.
I hope that this PR help people such me. 😄 💪 