### PR TITLE
Add --print-config CLI flag (fixes #3127)

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -104,6 +104,10 @@ If you're using both these special comments and autofixing, please run stylelint
 
 For CSS with standard syntax, stylelint will use [postcss-safe-parser](https://github.com/postcss/postcss-safe-parser) to fix syntax errors.
 
+### Troubleshooting configurations
+
+With the `--print-config` option, stylelint outputs the configuration to be used for the file passed. When present, no linting is performed and only config-related options are valid.
+
 ## Syntax errors
 
 The CLI informs you about syntax errors in your CSS.

--- a/flow-typed/stylelint.js
+++ b/flow-typed/stylelint.js
@@ -137,6 +137,7 @@ export type stylelint$standaloneOptions = {
   configFile?: string,
   configBasedir?: string,
   configOverrides?: Object,
+  printConfig?: string,
   ignoreDisables?: boolean,
   ignorePath?: string,
   ignorePattern?: RegExp,

--- a/lib/__tests__/printConfig.test.js
+++ b/lib/__tests__/printConfig.test.js
@@ -31,7 +31,7 @@ it("printConfig with input css should throw", () => {
       code: "a {}"
     })
   ).rejects.toThrow(
-    "The --print-config option is not available for piped-in code."
+    "The --print-config option must be used with exactly one file path."
   );
 });
 

--- a/lib/__tests__/printConfig.test.js
+++ b/lib/__tests__/printConfig.test.js
@@ -26,37 +26,39 @@ it("printConfig uses getConfigForFile to retrieve the config", () => {
 });
 
 it("printConfig with input css should throw", () => {
-  expect(() => {
+  expect(
     printConfig({
       code: "a {}"
-    });
-  }).toThrow("The --print-config option is not available for piped-in code.");
+    })
+  ).rejects.toThrow(
+    "The --print-config option is not available for piped-in code."
+  );
 });
 
 it("printConfig with no path should throw", () => {
-  expect(() => {
+  expect(
     printConfig({
       files: []
-    });
-  }).toThrow(
+    })
+  ).rejects.toThrow(
     "The --print-config option must be used with exactly one file path."
   );
 });
 
 it("printConfig with multiple paths should throw", () => {
-  expect(() => {
+  expect(
     printConfig({
       files: ["./first-path.css", "./second-path.css"]
-    });
-  }).toThrow(
+    })
+  ).rejects.toThrow(
     "The --print-config option must be used with exactly one file path."
   );
 });
 
 it("printConfig with globs should throw", () => {
-  expect(() => {
+  expect(
     printConfig({
       files: ["./*.css"]
-    });
-  }).toThrow("The --print-config option does not support globs.");
+    })
+  ).rejects.toThrow("The --print-config option does not support globs.");
 });

--- a/lib/__tests__/printConfig.test.js
+++ b/lib/__tests__/printConfig.test.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const path = require("path");
+const pluginWarnAboutFoo = require("./fixtures/plugin-warn-about-foo");
+const printConfig = require("../printConfig");
+
+it("printConfig uses getConfigForFile to retrieve the config", () => {
+  const filepath = path.join(
+    __dirname,
+    "fixtures/getConfigForFile/a/b/foo.css"
+  );
+  printConfig({
+    files: [filepath]
+  }).then(result => {
+    expect(result).toEqual({
+      plugins: [path.join(__dirname, "/fixtures/plugin-warn-about-foo.js")],
+      rules: {
+        "block-no-empty": [true],
+        "plugin/warn-about-foo": ["always"]
+      },
+      pluginFunctions: {
+        "plugin/warn-about-foo": pluginWarnAboutFoo.rule
+      }
+    });
+  });
+});
+
+it("printConfig with input css should throw", () => {
+  expect(() => {
+    printConfig({
+      code: "a {}"
+    });
+  }).toThrow("The --print-config option is not available for piped-in code.");
+});
+
+it("printConfig with no path should throw", () => {
+  expect(() => {
+    printConfig({
+      files: []
+    });
+  }).toThrow(
+    "The --print-config option must be used with exactly one file path."
+  );
+});
+
+it("printConfig with multiple paths should throw", () => {
+  expect(() => {
+    printConfig({
+      files: ["./first-path.css", "./second-path.css"]
+    });
+  }).toThrow(
+    "The --print-config option must be used with exactly one file path."
+  );
+});
+
+it("printConfig with globs should throw", () => {
+  expect(() => {
+    printConfig({
+      files: ["./*.css"]
+    });
+  }).toThrow("The --print-config option does not support globs.");
+});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -475,9 +475,15 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
     })
     .then(options => {
       if (cli.flags.printConfig) {
-        return printConfig(options).then(config => {
-          process.stdout.write(JSON.stringify(config, null, "  "));
-        });
+        return printConfig(options)
+          .then(config => {
+            process.stdout.write(JSON.stringify(config, null, "  "));
+          })
+          .catch((err /*: { stack: any, code: any }*/) => {
+            console.log(err.stack); // eslint-disable-line no-console
+            const exitCode = typeof err.code === "number" ? err.code : 1;
+            process.exit(exitCode); // eslint-disable-line no-process-exit
+          });
       }
 
       if (!options.files && !options.code) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -475,7 +475,9 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
     })
     .then(options => {
       if (cli.flags.printConfig) {
-        return printConfig(options);
+        return printConfig(options).then(config => {
+          process.stdout.write(JSON.stringify(config, null, "  "));
+        });
       }
 
       if (!options.files && !options.code) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,7 @@ const getStdin = require("get-stdin");
 const meow = require("meow");
 const needlessDisablesStringFormatter = require("./formatters/needlessDisablesStringFormatter");
 const path = require("path");
+const printConfig = require("./printConfig");
 const resolveFrom = require("resolve-from");
 const standalone = require("./standalone");
 
@@ -29,6 +30,9 @@ const standalone = require("./standalone");
       type: string
     },
     "config-basedir": {
+      type: string
+    },
+    "print-config": {
       type: string
     },
     color: {
@@ -100,6 +104,7 @@ const standalone = require("./standalone");
     cacheLocation: any,
     config: any,
     configBasedir: any,
+    printConfig: boolean,
     customFormatter: any,
     customSyntax: any,
     disableDefaultIgnores: boolean,
@@ -135,6 +140,7 @@ const standalone = require("./standalone");
   configOverrides: {
     quiet?: any,
   },
+  printConfig?: any,
   customSyntax?: any,
   fix?: any,
   ignoreDisables?: any,
@@ -179,6 +185,10 @@ const meowOptions /*: meowOptionsType*/ = {
         An absolute path to the directory that relative paths defining "extends"
         and "plugins" are *relative to*. Only necessary if these values are
         relative paths.
+
+      --print-config
+
+        Print the configuration for the given path.
 
       --ignore-path, -i
 
@@ -278,6 +288,9 @@ const meowOptions /*: meowOptionsType*/ = {
     },
     "config-basedir": {
       type: "string"
+    },
+    "print-config": {
+      type: "boolean"
     },
     color: {
       type: "boolean"
@@ -461,6 +474,10 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
       );
     })
     .then(options => {
+      if (cli.flags.printConfig) {
+        return printConfig(options);
+      }
+
       if (!options.files && !options.code) {
         cli.showHelp();
         return;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -479,11 +479,7 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
           .then(config => {
             process.stdout.write(JSON.stringify(config, null, "  "));
           })
-          .catch((err /*: { stack: any, code: any }*/) => {
-            console.log(err.stack); // eslint-disable-line no-console
-            const exitCode = typeof err.code === "number" ? err.code : 1;
-            process.exit(exitCode); // eslint-disable-line no-process-exit
-          });
+          .catch(handleError);
       }
 
       if (!options.files && !options.code) {
@@ -524,10 +520,12 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
             process.exitCode = 2;
           }
         })
-        .catch((err /*: { stack: any, code: any }*/) => {
-          console.log(err.stack); // eslint-disable-line no-console
-          const exitCode = typeof err.code === "number" ? err.code : 1;
-          process.exit(exitCode); // eslint-disable-line no-process-exit
-        });
+        .catch(handleError);
     });
 };
+
+function handleError(err /*: { stack: any, code: any }*/) /*: void */ {
+  console.log(err.stack); // eslint-disable-line no-console
+  const exitCode = typeof err.code === "number" ? err.code : 1;
+  process.exit(exitCode); // eslint-disable-line no-process-exit
+}

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -7,25 +7,14 @@ const path = require("path");
 
 module.exports = function(
   options /*: stylelint$standaloneOptions */
-) /*: void*/ {
+) /*: Promise<stylelint$config>*/ {
   const code = options.code;
   const config = options.config;
   const configBasedir = options.configBasedir;
   const configFile = options.configFile;
   const configOverrides = options.configOverrides;
-  const customSyntax = options.customSyntax;
   const globbyOptions = options.globbyOptions;
   const files = options.files;
-  const fix = options.fix;
-  const ignoreDisables = options.ignoreDisables;
-  const reportNeedlessDisables = options.reportNeedlessDisables;
-  const syntax = options.syntax;
-
-  if (!files || files.length > 1) {
-    throw new Error(
-      "The --print-config option must be used with exactly one file path."
-    );
-  }
 
   const isCodeNotFile = code !== undefined;
   if (isCodeNotFile) {
@@ -34,28 +23,28 @@ module.exports = function(
     );
   }
 
+  if (!files || files.length !== 1) {
+    throw new Error(
+      "The --print-config option must be used with exactly one file path."
+    );
+  }
+
   const stylelint = createStylelint({
     config,
     configFile,
     configBasedir,
-    configOverrides,
-    ignoreDisables,
-    reportNeedlessDisables,
-    syntax,
-    customSyntax,
-    fix
+    configOverrides
   });
 
-  const cwd = _.get(globbyOptions, "cwd", process.cwd());
   const filePath = files[0];
+  const cwd = _.get(globbyOptions, "cwd", process.cwd());
   const absoluteFilePath = !path.isAbsolute(filePath)
     ? path.join(cwd, filePath)
     : path.normalize(filePath);
 
   const configSearchPath = stylelint._options.configFile || absoluteFilePath;
 
-  return stylelint.getConfigForFile(configSearchPath).then(result => {
-    const config /*: stylelint$config*/ = result.config;
-    process.stdout.write(JSON.stringify(config, null, "  "));
-  });
+  return stylelint
+    .getConfigForFile(configSearchPath)
+    .then(result => result.config);
 };

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -18,13 +18,7 @@ module.exports = function(
   const files = options.files;
 
   const isCodeNotFile = code !== undefined;
-  if (isCodeNotFile) {
-    return Promise.reject(
-      new Error("The --print-config option is not available for piped-in code.")
-    );
-  }
-
-  if (!files || files.length !== 1) {
+  if (!files || files.length !== 1 || isCodeNotFile) {
     return Promise.reject(
       new Error(
         "The --print-config option must be used with exactly one file path."

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -3,6 +3,7 @@
 
 const _ = require("lodash");
 const createStylelint = require("./createStylelint");
+const globby /*: Function*/ = require("globby");
 const path = require("path");
 
 module.exports = function(
@@ -29,6 +30,12 @@ module.exports = function(
     );
   }
 
+  const filePath = files[0];
+
+  if (globby.hasMagic(filePath)) {
+    throw new Error("The --print-config option does not support globs.");
+  }
+
   const stylelint = createStylelint({
     config,
     configFile,
@@ -36,7 +43,6 @@ module.exports = function(
     configOverrides
   });
 
-  const filePath = files[0];
   const cwd = _.get(globbyOptions, "cwd", process.cwd());
   const absoluteFilePath = !path.isAbsolute(filePath)
     ? path.join(cwd, filePath)

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -1,0 +1,61 @@
+/* @flow */
+"use strict";
+
+const _ = require("lodash");
+const createStylelint = require("./createStylelint");
+const path = require("path");
+
+module.exports = function(
+  options /*: stylelint$standaloneOptions */
+) /*: void*/ {
+  const code = options.code;
+  const config = options.config;
+  const configBasedir = options.configBasedir;
+  const configFile = options.configFile;
+  const configOverrides = options.configOverrides;
+  const customSyntax = options.customSyntax;
+  const globbyOptions = options.globbyOptions;
+  const files = options.files;
+  const fix = options.fix;
+  const ignoreDisables = options.ignoreDisables;
+  const reportNeedlessDisables = options.reportNeedlessDisables;
+  const syntax = options.syntax;
+
+  if (!files || files.length > 1) {
+    throw new Error(
+      "The --print-config option must be used with exactly one file path."
+    );
+  }
+
+  const isCodeNotFile = code !== undefined;
+  if (isCodeNotFile) {
+    throw new Error(
+      "The --print-config option is not available for piped-in code."
+    );
+  }
+
+  const stylelint = createStylelint({
+    config,
+    configFile,
+    configBasedir,
+    configOverrides,
+    ignoreDisables,
+    reportNeedlessDisables,
+    syntax,
+    customSyntax,
+    fix
+  });
+
+  const cwd = _.get(globbyOptions, "cwd", process.cwd());
+  const filePath = files[0];
+  const absoluteFilePath = !path.isAbsolute(filePath)
+    ? path.join(cwd, filePath)
+    : path.normalize(filePath);
+
+  const configSearchPath = stylelint._options.configFile || absoluteFilePath;
+
+  return stylelint.getConfigForFile(configSearchPath).then(result => {
+    const config /*: stylelint$config*/ = result.config;
+    process.stdout.write(JSON.stringify(config, null, "  "));
+  });
+};

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -19,21 +19,25 @@ module.exports = function(
 
   const isCodeNotFile = code !== undefined;
   if (isCodeNotFile) {
-    throw new Error(
-      "The --print-config option is not available for piped-in code."
+    return Promise.reject(
+      new Error("The --print-config option is not available for piped-in code.")
     );
   }
 
   if (!files || files.length !== 1) {
-    throw new Error(
-      "The --print-config option must be used with exactly one file path."
+    return Promise.reject(
+      new Error(
+        "The --print-config option must be used with exactly one file path."
+      )
     );
   }
 
   const filePath = files[0];
 
   if (globby.hasMagic(filePath)) {
-    throw new Error("The --print-config option does not support globs.");
+    return Promise.reject(
+      new Error("The --print-config option does not support globs.")
+    );
   }
 
   const stylelint = createStylelint({

--- a/system-tests/cli/cli.test.js
+++ b/system-tests/cli/cli.test.js
@@ -1,6 +1,7 @@
 /* eslint no-console: off */
 "use strict";
 const cli = require("../../lib/cli");
+const path = require("path");
 const pkg = require("../../package.json");
 
 jest.mock("get-stdin");
@@ -23,6 +24,7 @@ describe("CLI", () => {
   beforeEach(function() {
     process.exitCode = undefined;
     console.log = jest.fn();
+    process.stdout.write = jest.fn();
     if (parseInt(process.versions.node) < 7) {
       // https://github.com/sindresorhus/get-stdin/issues/13
       process.nextTick(() => {
@@ -58,6 +60,31 @@ describe("CLI", () => {
       const lastCallArgs = console.log.mock.calls.pop();
       expect(lastCallArgs).toHaveLength(1);
       expect(lastCallArgs.pop()).toMatch(pkg.version);
+    });
+  });
+
+  it("--print-config", () => {
+    return Promise.resolve(
+      cli([
+        "--print-config",
+        "--config",
+        path.join(__dirname, "config.json"),
+        path.join(__dirname, "stylesheet.css")
+      ])
+    ).then(() => {
+      expect(process.exitCode).toBe(undefined);
+      expect(process.stdout.write).toHaveBeenCalledTimes(1);
+      expect(process.stdout.write).toHaveBeenLastCalledWith(
+        JSON.stringify(
+          {
+            rules: {
+              "block-no-empty": [true]
+            }
+          },
+          null,
+          "  "
+        )
+      );
     });
   });
 });

--- a/system-tests/cli/config.json
+++ b/system-tests/cli/config.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "block-no-empty": true
+  }
+}


### PR DESCRIPTION
Resolves #3127.

> A nice feature of eslint's CLI is the option `--print-config` that will log to the console the parsed configuration object for a given configuration file, including all the extended rules. It's awesome for debugging configuration files.

This PR is largely inspired by the [ESLint implementation](https://github.com/eslint/eslint/blob/1e88170fa57656206a39d579fd0c176d414c275b/lib/cli.js#L156-L172). Also recycles its (succinct) [docs](https://eslint.org/docs/user-guide/command-line-interface#--print-config). Most of the functionality is taken care of by `getConfigForFile`, so what I added is mostly an integration of that into the CLI, replicating how `getConfigForFile` gets called [in `lintSource`](https://github.com/thibaudcolas/stylelint/blob/2584d15e514fc99fb473e8d24175012c20627ff3/lib/lintSource.js#L122:L123).

Here are useful commands to use while testing this that should cover the various scenarios:

```bash
# The canonical example: point to a file, there's a config with extends nearby, it resolves the full config.
./bin/stylelint.js --print-config lib/__tests__/fixtures/getConfigForFile/a/b/foo.css
# Needs to be given a path.
./bin/stylelint.js --print-config
# Globs are not supported.
./bin/stylelint.js --print-config 'lib/__tests__/fixtures/getConfigForFile/**/foo.css'
# Multiple paths isn't supported either.
./bin/stylelint.js --print-config lib/__tests__/fixtures/getConfigForFile/a/b/foo.css lib/__tests__/fixtures/empty-block.css
```

Sample output:

```
$ ./bin/stylelint.js --print-config lib/__tests__/fixtures/getConfigForFile/**/foo.css
{
  "rules": {
    "block-no-empty": [
      true
    ],
    "plugin/warn-about-foo": [
      "always"
    ]
  },
  "plugins": [
    "[...]/stylelint/lib/__tests__/fixtures/plugin-warn-about-foo.js"
  ],
  "pluginFunctions": {}
}
```

And the errors:

<details>

```
$ ./bin/stylelint.js --print-config 'lib/__tests__/fixtures/getConfigForFile/**/foo.css'
Error: The --print-config option does not support globs.
    at module.exports ([...]/stylelint/lib/printConfig.js:33:7)
    at Promise.resolve.then.then.options ([...]/stylelint/lib/cli.js:478:16)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
    at Function.Module.runMain (module.js:667:11)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:607:3

$ ./bin/stylelint.js --print-config lib/__tests__/fixtures/getConfigForFile/a/b/foo.css lib/__tests__/fixtures/empty-block.css
Error: The --print-config option must be used with exactly one file path.
    at module.exports ([...]/stylelint/lib/printConfig.js:23:7)
    at Promise.resolve.then.then.options ([...]/stylelint/lib/cli.js:478:16)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
    at Function.Module.runMain (module.js:667:11)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:607:3
```

</details>