### PR TITLE
Add autofix to declaration-colon-space-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -267,7 +267,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`declaration-bang-space-after`](../../lib/rules/declaration-bang-space-after/README.md): Require a single space or disallow whitespace after the bang of declarations.
 -   [`declaration-bang-space-before`](../../lib/rules/declaration-bang-space-before/README.md): Require a single space or disallow whitespace before the bang of declarations.
 -   [`declaration-colon-newline-after`](../../lib/rules/declaration-colon-newline-after/README.md): Require a newline or disallow whitespace after the colon of declarations.
--   [`declaration-colon-space-after`](../../lib/rules/declaration-colon-space-after/README.md): Require a single space or disallow whitespace after the colon of declarations.
+-   [`declaration-colon-space-after`](../../lib/rules/declaration-colon-space-after/README.md): Require a single space or disallow whitespace after the colon of declarations (Autofixable).
 -   [`declaration-colon-space-before`](../../lib/rules/declaration-colon-space-before/README.md): Require a single space or disallow whitespace before the colon of declarations (Autofixable).
 -   [`declaration-empty-line-before`](../../lib/rules/declaration-empty-line-before/README.md): Require or disallow an empty line before declarations (Autofixable).
 

--- a/lib/rules/declaration-colon-space-after/README.md
+++ b/lib/rules/declaration-colon-space-after/README.md
@@ -8,6 +8,8 @@ a { color: pink }
  * The space after this colon */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"`

--- a/lib/rules/declaration-colon-space-after/__tests__/index.js
+++ b/lib/rules/declaration-colon-space-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -41,6 +42,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color :pink; }",
+      fixed: "a { color : pink; }",
       description: "no space after",
       message: messages.expectedAfter(),
       line: 1,
@@ -48,6 +50,7 @@ testRule(rule, {
     },
     {
       code: "a { color :  pink; }",
+      fixed: "a { color : pink; }",
       description: "two spaces after",
       message: messages.expectedAfter(),
       line: 1,
@@ -55,6 +58,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\tpink; }",
+      fixed: "a { color : pink; }",
       description: "tab after",
       message: messages.expectedAfter(),
       line: 1,
@@ -62,6 +66,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\npink; }",
+      fixed: "a { color : pink; }",
       description: "newline after",
       message: messages.expectedAfter(),
       line: 1,
@@ -69,6 +74,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\r\npink; }",
+      fixed: "a { color : pink; }",
       description: "CRLF after",
       message: messages.expectedAfter(),
       line: 1,
@@ -76,7 +82,16 @@ testRule(rule, {
     },
     {
       code: "a { color:pink; }",
+      fixed: "a { color: pink; }",
       description: "no space after",
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 11
+    },
+    {
+      code: "a { color/*comment*/:/*comment*/pink; }",
+      fixed: "a { color/*comment*/: /*comment*/pink; }",
+      description: "comment",
       message: messages.expectedAfter(),
       line: 1,
       column: 11
@@ -87,6 +102,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -114,6 +130,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color : pink; }",
+      fixed: "a { color :pink; }",
       description: "space after",
       message: messages.rejectedAfter(),
       line: 1,
@@ -121,6 +138,7 @@ testRule(rule, {
     },
     {
       code: "a { color:  pink; }",
+      fixed: "a { color:pink; }",
       description: "two spaces after",
       message: messages.rejectedAfter(),
       line: 1,
@@ -128,6 +146,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\tpink; }",
+      fixed: "a { color :pink; }",
       description: "tab after",
       message: messages.rejectedAfter(),
       line: 1,
@@ -135,6 +154,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\npink; }",
+      fixed: "a { color :pink; }",
       description: "newline after",
       message: messages.rejectedAfter(),
       line: 1,
@@ -142,7 +162,16 @@ testRule(rule, {
     },
     {
       code: "a { color :\r\npink; }",
+      fixed: "a { color :pink; }",
       description: "CRLF after",
+      message: messages.rejectedAfter(),
+      line: 1,
+      column: 11
+    },
+    {
+      code: "a { color/*comment*/ : /*comment*/pink; }",
+      fixed: "a { color/*comment*/ :/*comment*/pink; }",
+      description: "comment",
       message: messages.rejectedAfter(),
       line: 1,
       column: 11
@@ -153,6 +182,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -180,6 +210,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color :pink; }",
+      fixed: "a { color : pink; }",
       description: "no space after single-line",
       message: messages.expectedAfterSingleLine(),
       line: 1,
@@ -187,6 +218,7 @@ testRule(rule, {
     },
     {
       code: "a { color :  pink; }",
+      fixed: "a { color : pink; }",
       description: "two spaces after single-line",
       message: messages.expectedAfterSingleLine(),
       line: 1,
@@ -194,6 +226,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\tpink; }",
+      fixed: "a { color : pink; }",
       description: "tab after single-line",
       message: messages.expectedAfterSingleLine(),
       line: 1,
@@ -201,6 +234,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\npink; }",
+      fixed: "a { color : pink; }",
       description: "newline after single-line",
       message: messages.expectedAfterSingleLine(),
       line: 1,
@@ -208,6 +242,7 @@ testRule(rule, {
     },
     {
       code: "a { color :\r\npink; }",
+      fixed: "a { color : pink; }",
       description: "CRLF after single-line",
       message: messages.expectedAfterSingleLine(),
       line: 1,
@@ -215,7 +250,16 @@ testRule(rule, {
     },
     {
       code: "a { color:pink; }",
+      fixed: "a { color: pink; }",
       description: "no space after",
+      message: messages.expectedAfterSingleLine(),
+      line: 1,
+      column: 11
+    },
+    {
+      code: "a { color/*comment*/:/*comment*/pink; }",
+      fixed: "a { color/*comment*/: /*comment*/pink; }",
+      description: "comment",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 11

--- a/lib/rules/declaration-colon-space-after/index.js
+++ b/lib/rules/declaration-colon-space-after/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const declarationColonSpaceChecker = require("../declarationColonSpaceChecker");
+const declarationValueIndex = require("../../utils/declarationValueIndex");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
 const whitespaceChecker = require("../../utils/whitespaceChecker");
@@ -14,7 +15,7 @@ const messages = ruleMessages(ruleName, {
     'Expected single space after ":" with a single-line declaration'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -29,7 +30,24 @@ const rule = function(expectation) {
       root,
       result,
       locationChecker: checker.after,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (decl, index) => {
+            const colonIndex = index - declarationValueIndex(decl);
+            const between = decl.raws.between;
+            if (expectation.indexOf("always") === 0) {
+              decl.raws.between =
+                between.slice(0, colonIndex) +
+                between.slice(colonIndex).replace(/^:\s*/, ": ");
+              return true;
+            } else if (expectation === "never") {
+              decl.raws.between =
+                between.slice(0, colonIndex) +
+                between.slice(colonIndex).replace(/^:\s*/, ":");
+              return true;
+            }
+          }
+        : null
     });
   };
 };


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

`declaration-colon-space-after` in #2829

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    a { color:pink; }
    ```
    fixed:
    ```css
    a { color: pink; }
    ```

* option: `never`

    code:
    ```css
    a { color: pink; }
    ```

    fixed:
    ```css
    a { color:pink; }
    ```
