### PR TITLE
Add autofix to declaration-block-semicolon-newline-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -273,7 +273,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 #### Declaration block
 
--   [`declaration-block-semicolon-newline-after`](../../lib/rules/declaration-block-semicolon-newline-after/README.md): Require a newline or disallow whitespace after the semicolons of declaration blocks.
+-   [`declaration-block-semicolon-newline-after`](../../lib/rules/declaration-block-semicolon-newline-after/README.md): Require a newline or disallow whitespace after the semicolons of declaration blocks (Autofixable).
 -   [`declaration-block-semicolon-newline-before`](../../lib/rules/declaration-block-semicolon-newline-before/README.md): Require a newline or disallow whitespace before the semicolons of declaration blocks.
 -   [`declaration-block-semicolon-space-after`](../../lib/rules/declaration-block-semicolon-space-after/README.md): Require a single space or disallow whitespace after the semicolons of declaration blocks.
 -   [`declaration-block-semicolon-space-before`](../../lib/rules/declaration-block-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of declaration blocks.

--- a/lib/rules/declaration-block-semicolon-newline-after/README.md
+++ b/lib/rules/declaration-block-semicolon-newline-after/README.md
@@ -27,6 +27,8 @@ a {
 }
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/declaration-block-semicolon-newline-after/__tests__/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -83,30 +84,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;top: 0; }",
+      fixed: "a { color: pink;\ntop: 0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink; top: 0; }",
+      fixed: "a { color: pink;\n top: 0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink; top: 0; }",
+      fixed: "a { color: pink;\n top: 0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink;\ttop: 0; }",
+      fixed: "a { color: pink;\n\ttop: 0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 17
     },
     {
       code: "a {\n  color: pink; /* 1 */ top: 0\n}",
+      fixed: "a {\n  color: pink; /* 1 */\n top: 0\n}",
       description: "next node is comment without newline after",
       message: messages.expectedAfter(),
       line: 2,
@@ -114,7 +120,30 @@ testRule(rule, {
     },
     {
       code: "a {\r\n  color: pink; /* 1 */ top: 0\r\n}",
+      fixed: "a {\r\n  color: pink; /* 1 */\r\n top: 0\r\n}",
       description: "CRLF and next node is comment without newline after",
+      message: messages.expectedAfter(),
+      line: 2,
+      column: 15
+    },
+    {
+      code: "a { color: pink; \n top: 0; }",
+      fixed: "a { color: pink;\n top: 0; }",
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 17
+    },
+    {
+      code: "a {\n  color: pink; /* 1 */ /* 2 */ top: 0\n}",
+      fixed: "a {\n  color: pink; /* 1 */ /* 2 */\n top: 0\n}",
+      description: "next*2 node is comment",
+      message: messages.expectedAfter(),
+      line: 2,
+      column: 15
+    },
+    {
+      code: "a {\n  color: pink; /* 1 */ \n top: 0\n}",
+      fixed: "a {\n  color: pink; /* 1 */\n top: 0\n}",
       message: messages.expectedAfter(),
       line: 2,
       column: 15
@@ -125,6 +154,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -177,18 +207,21 @@ testRule(rule, {
   reject: [
     {
       code: "a {\ncolor: pink;top: 0;\n}",
+      fixed: "a {\ncolor: pink;\ntop: 0;\n}",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 13
     },
     {
       code: "a {\ncolor: pink; top: 0;\n}",
+      fixed: "a {\ncolor: pink;\n top: 0;\n}",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 13
     },
     {
       code: "a {\r\ncolor: pink; top: 0;\r\n}",
+      fixed: "a {\r\ncolor: pink;\r\n top: 0;\r\n}",
       description: "CRLF",
       message: messages.expectedAfterMultiLine(),
       line: 2,
@@ -196,18 +229,21 @@ testRule(rule, {
     },
     {
       code: "a {\ncolor: pink; top: 0;\n}",
+      fixed: "a {\ncolor: pink;\n top: 0;\n}",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 13
     },
     {
       code: "a {\ncolor: pink;\ttop: 0;\n}",
+      fixed: "a {\ncolor: pink;\n\ttop: 0;\n}",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 13
     },
     {
       code: "a {\r\ncolor: pink;\ttop: 0;\r\n}",
+      fixed: "a {\r\ncolor: pink;\r\n\ttop: 0;\r\n}",
       description: "CRLF",
       message: messages.expectedAfterMultiLine(),
       line: 2,
@@ -219,6 +255,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -251,24 +288,28 @@ testRule(rule, {
   reject: [
     {
       code: "a {\ncolor: pink; top: 0;\n}",
+      fixed: "a {\ncolor: pink;top: 0;\n}",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 13
     },
     {
       code: "a {\ncolor: pink;  top: 0;\n}",
+      fixed: "a {\ncolor: pink;top: 0;\n}",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 13
     },
     {
       code: "a {\ncolor: pink;\ntop: 0;\n}",
+      fixed: "a {\ncolor: pink;top: 0;\n}",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 13
     },
     {
       code: "a {\r\ncolor: pink;\r\ntop: 0;\r\n}",
+      fixed: "a {\r\ncolor: pink;top: 0;\r\n}",
       description: "CRLF",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
@@ -276,9 +317,32 @@ testRule(rule, {
     },
     {
       code: "a {\ncolor: pink;\ttop: 0;\n}",
+      fixed: "a {\ncolor: pink;top: 0;\n}",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 13
+    },
+    {
+      code: "a {\ncolor: pink; /*comment*/ top: 0;\n}",
+      fixed: "a {\ncolor: pink; /*comment*/top: 0;\n}",
+      message: messages.rejectedAfterMultiLine(),
+      line: 2,
+      column: 13
+    },
+    {
+      code: "a {\n  color: pink; /* 1 */ /* 2 */\ntop: 0\n}",
+      fixed: "a {\n  color: pink; /* 1 */ /* 2 */top: 0\n}",
+      description: "next*2 node is comment",
+      message: messages.rejectedAfterMultiLine(),
+      line: 2,
+      column: 15
+    },
+    {
+      code: "a {\n  color: pink; /* 1 */ \n top: 0\n}",
+      fixed: "a {\n  color: pink; /* 1 */top: 0\n}",
+      message: messages.rejectedAfterMultiLine(),
+      line: 2,
+      column: 15
     }
   ]
 });

--- a/lib/rules/declaration-block-semicolon-newline-after/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.js
@@ -18,7 +18,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected newline after ";" in a multi-line declaration block'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("newline", expectation, messages);
 
   return (root, result) => {
@@ -53,6 +53,22 @@ const rule = function(expectation) {
         index: -1,
         lineCheckStr: blockString(parentRule),
         err: m => {
+          if (context.fix) {
+            if (expectation.indexOf("always") === 0) {
+              const index = nodeToCheck.raws.before.search(/\r?\n/);
+              if (index >= 0) {
+                nodeToCheck.raws.before = nodeToCheck.raws.before.slice(index);
+              } else {
+                nodeToCheck.raws.before =
+                  context.newline + nodeToCheck.raws.before;
+              }
+              return;
+            } else if (expectation === "never-multi-line") {
+              nodeToCheck.raws.before = "";
+              return;
+            }
+          }
+
           report({
             message: m,
             node: decl,


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3544

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    a { color: pink;top: 0; }
    ```
    fixed:
    ```css
    a { color: pink;
    top: 0; }
    ```

* option: `never-multi-line`

    code:
    ```css
    a {
      color: pink;
      top: 0;
    }
    ```

    fixed:
    ```css
    a {
      color: pink;top: 0;
    }
    ```
