### PR TITLE
Add autofix to declaration-block-semicolon-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -276,7 +276,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`declaration-block-semicolon-newline-after`](../../lib/rules/declaration-block-semicolon-newline-after/README.md): Require a newline or disallow whitespace after the semicolons of declaration blocks.
 -   [`declaration-block-semicolon-newline-before`](../../lib/rules/declaration-block-semicolon-newline-before/README.md): Require a newline or disallow whitespace before the semicolons of declaration blocks.
 -   [`declaration-block-semicolon-space-after`](../../lib/rules/declaration-block-semicolon-space-after/README.md): Require a single space or disallow whitespace after the semicolons of declaration blocks.
--   [`declaration-block-semicolon-space-before`](../../lib/rules/declaration-block-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of declaration blocks.
+-   [`declaration-block-semicolon-space-before`](../../lib/rules/declaration-block-semicolon-space-before/README.md): Require a single space or disallow whitespace before the semicolons of declaration blocks (Autofixable).
 -   [`declaration-block-trailing-semicolon`](../../lib/rules/declaration-block-trailing-semicolon/README.md): Require or disallow a trailing semicolon within declaration blocks (Autofixable).
 
 #### Block

--- a/lib/rules/declaration-block-semicolon-space-before/README.md
+++ b/lib/rules/declaration-block-semicolon-space-before/README.md
@@ -10,6 +10,8 @@ a { color: pink; }
 
 This rule ignores semicolons that are preceded by Less mixins.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"`

--- a/lib/rules/declaration-block-semicolon-space-before/__tests__/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -29,30 +30,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a { color: pink ; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 15
     },
     {
       code: "a { color: pink  ; }",
+      fixed: "a { color: pink ; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink\t; }",
+      fixed: "a { color: pink ; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink\n; }",
+      fixed: "a { color: pink ; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink\r\n; }",
+      fixed: "a { color: pink ; }",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 1,
@@ -60,9 +66,26 @@ testRule(rule, {
     },
     {
       code: "a { color: pink ; top: 0; }",
+      fixed: "a { color: pink ; top: 0 ; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 24
+    },
+    {
+      code: "a { color: pink/*comment*/; }",
+      fixed: "a { color: pink/*comment*/ ; }",
+      description: "comment",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 26
+    },
+    {
+      code: "a { color: pink /*comment*/; }",
+      fixed: "a { color: pink /*comment*/ ; }",
+      description: "comment",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 27
     }
   ]
 });
@@ -70,6 +93,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -90,30 +114,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink ; }",
+      fixed: "a { color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink  ; }",
+      fixed: "a { color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink\t; }",
+      fixed: "a { color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink\n; }",
+      fixed: "a { color: pink; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink\r\n; }",
+      fixed: "a { color: pink; }",
       description: "CRLF",
       message: messages.rejectedBefore(),
       line: 1,
@@ -121,9 +150,26 @@ testRule(rule, {
     },
     {
       code: "a { color: pink; top: 0 ; }",
+      fixed: "a { color: pink; top: 0; }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 24
+    },
+    {
+      code: "a { color: pink/*comment*/ ; }",
+      fixed: "a { color: pink/*comment*/; }",
+      description: "comment",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 27
+    },
+    {
+      code: "a { color: pink /*comment*/ ; }",
+      fixed: "a { color: pink /*comment*/; }",
+      description: "comment",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 28
     }
   ]
 });
@@ -131,6 +177,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -162,18 +209,21 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a { color: pink ; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 15
     },
     {
       code: "a,\nb { color: pink; }",
+      fixed: "a,\nb { color: pink ; }",
       message: messages.expectedBeforeSingleLine(),
       line: 2,
       column: 15
     },
     {
       code: "a,\r\nb { color: pink; }",
+      fixed: "a,\r\nb { color: pink ; }",
       description: "CRLF",
       message: messages.expectedBeforeSingleLine(),
       line: 2,
@@ -181,18 +231,21 @@ testRule(rule, {
     },
     {
       code: "a { color: pink  ; }",
+      fixed: "a { color: pink ; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink\t; }",
+      fixed: "a { color: pink ; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink ; top: 0; }",
+      fixed: "a { color: pink ; top: 0 ; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 24
@@ -203,6 +256,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -230,18 +284,21 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink ; }",
+      fixed: "a { color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 16
     },
     {
       code: "a,\nb { color: pink ; }",
+      fixed: "a,\nb { color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 2,
       column: 16
     },
     {
       code: "a,\r\nb { color: pink ; }",
+      fixed: "a,\r\nb { color: pink; }",
       description: "CRLF",
       message: messages.rejectedBeforeSingleLine(),
       line: 2,
@@ -249,18 +306,21 @@ testRule(rule, {
     },
     {
       code: "a { color: pink  ; }",
+      fixed: "a { color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink\t; }",
+      fixed: "a { color: pink; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink; top: 0 ; }",
+      fixed: "a { color: pink; top: 0; }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 24

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before ";" in a single-line declaration block'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
 
   return (root, result) => {
@@ -43,6 +43,26 @@ const rule = function(expectation) {
         index: declString.length,
         lineCheckStr: blockString(parentRule),
         err: m => {
+          if (context.fix) {
+            const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+            if (expectation.indexOf("always") === 0) {
+              const fixedValue = value.replace(/\s*$/, " ");
+              if (decl.raws.value) {
+                decl.raws.value.raw = fixedValue;
+              } else {
+                decl.value = fixedValue;
+              }
+              return;
+            } else if (expectation.indexOf("never") === 0) {
+              const fixedValue = value.replace(/\s*$/, "");
+              if (decl.raws.value) {
+                decl.raws.value.raw = fixedValue;
+              } else {
+                decl.value = fixedValue;
+              }
+              return;
+            }
+          }
           report({
             message: m,
             node: decl,


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3546

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    a { color: pink; }
    ```
    fixed:
    ```css
    a { color: pink ; }
    ```

* option: `never***`

    code:
    ```css
    a { color: pink ; }
    ```

    fixed:
    ```css
    a { color: pink; }
    ```
