### PR TITLE
Add baseIndentLevel to indentation

### DIFF
--- a/lib/rules/indentation/README.md
+++ b/lib/rules/indentation/README.md
@@ -135,6 +135,25 @@ a {
 
 ## Optional secondary options
 
+### `baseIndentLevel: int|"auto"`
+
+By default, the indent level of the CSS code block in non-CSS-like files is determined by the shortest indent of non-empty line. The setting `baseIndentLevel` allows you to define a relative indent level based on CSS code block opening or closing line.
+
+For example, with `[ 2, { baseIndentLevel: 1 } ]`, CSS should be indented 1 levels higher than `<style>` tag:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <style>
+    a {
+      display: block;
+    }
+  </style>
+</head>
+</html>
+```
+
 ### `indentInsideParens: "twice"|"once-at-root-twice-in-block"`
 
 By default, *one extra* indentation (of your specified type) is expected after newlines inside parentheses, and the closing parenthesis is expected to have no extra indentation.

--- a/lib/rules/indentation/__tests__/html.js
+++ b/lib/rules/indentation/__tests__/html.js
@@ -25,6 +25,16 @@ a {
 \tdisplay:block;
 }
 </style>`
+    },
+    {
+      code: `
+<style>a {
+\tdisplay:block;
+}
+</style>`
+    },
+    {
+      code: '<a style="display:block; color:red;"></a>'
     }
   ],
 
@@ -45,6 +55,23 @@ a {
       message: messages.expected("2 tabs"),
       line: 4,
       column: 2
+    },
+    {
+      code: `
+<style>
+  a {
+      display:block;
+    }
+</style>`,
+      fixed: `
+<style>
+\ta {
+\t\tdisplay:block;
+\t}
+</style>`,
+      message: messages.expected("1 tab"),
+      line: 3,
+      column: 3
     },
     {
       code: `
@@ -83,23 +110,203 @@ a {
     {
       code: `
 \t<style>
-\t a {
-\t display:block;
-\t }
-\t</style>
-\t<style>
-\t b {
-\t display:block;
-\t }
+    a {
+        display:block;
+    }
+    b {
+      display:block;
+    }
 \t</style>`,
       fixed: `
 \t<style>
 \ta {
 \t\tdisplay:block;
 \t}
-\t</style>
-\t<style>
 \tb {
+\t\tdisplay:block;
+\t}
+\t</style>`,
+      message: messages.expected("1 tab"),
+      line: 3,
+      column: 5
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [2],
+  syntax: "html",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+<style>
+  a {
+    display:block;
+  }
+</style>`
+    },
+    {
+      code: `
+<style>
+a {
+  display:block;
+}
+</style>`
+    },
+    {
+      code: `
+<style>a {
+  display:block;
+}
+</style>`
+    }
+  ],
+  reject: [
+    {
+      code: `
+<style>a {
+ display:block;
+}
+</style>`,
+      fixed: `
+<style>a {
+  display:block;
+}
+</style>`,
+      message: messages.expected("2 spaces"),
+      line: 3,
+      column: 2
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [
+    "tab",
+    {
+      baseIndentLevel: 1
+    }
+  ],
+  syntax: "html",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+<style>
+\ta {
+\t\tdisplay:block;
+\t}
+</style>`
+    },
+    {
+      code: `
+\t<style>
+\t\ta {
+\t\t\tdisplay:block;
+\t\t}
+\t</style>`
+    }
+  ],
+  reject: [
+    {
+      code: `
+<style>
+a {
+\tdisplay:block;
+}
+</style>`,
+      fixed: `
+<style>
+\ta {
+\t\tdisplay:block;
+\t}
+</style>`,
+      message: messages.expected("1 tab"),
+      line: 3,
+      column: 1
+    },
+    {
+      code: `
+\t<style>
+\ta {
+\t\tdisplay:block;
+\t}
+\t</style>`,
+      fixed: `
+\t<style>
+\t\ta {
+\t\t\tdisplay:block;
+\t\t}
+\t</style>`,
+      message: messages.expected("2 tabs"),
+      line: 3,
+      column: 2
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [
+    "tab",
+    {
+      baseIndentLevel: 0
+    }
+  ],
+  syntax: "html",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+<style>
+a {
+\tdisplay:block;
+}
+</style>`
+    },
+    {
+      code: `
+\t<style>
+\ta {
+\t\tdisplay:block;
+\t}
+\t</style>`
+    }
+  ],
+  reject: [
+    {
+      code: `
+<style>
+\ta {
+\t\tdisplay:block;
+\t}
+</style>`,
+      fixed: `
+<style>
+a {
+\tdisplay:block;
+}
+</style>`,
+      message: messages.expected("0 tabs"),
+      line: 3,
+      column: 2
+    },
+    {
+      code: `
+\t<style>
+\t\ta {
+\t\t\tdisplay:block;
+\t\t}
+\t</style>`,
+      fixed: `
+\t<style>
+\ta {
 \t\tdisplay:block;
 \t}
 \t</style>`,

--- a/lib/rules/indentation/__tests__/javascript.js
+++ b/lib/rules/indentation/__tests__/javascript.js
@@ -1,0 +1,176 @@
+"use strict";
+
+const rule = require("..");
+const { messages, ruleName } = rule;
+
+testRule(rule, {
+  ruleName,
+  config: [2],
+  syntax: "jsx",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+export default <img style={{ transform: 'translate(1, 1)', display: 'block' }} />;
+`
+    },
+    {
+      code: `
+export default <img style={{
+  transform: 'translate(1, 1)'
+}} />;
+`
+    },
+    {
+      code: `
+export default <img style=
+  {
+    {
+      transform: 'translate(1, 1)'
+    }
+  }
+/>;
+`
+    }
+  ],
+  reject: [
+    {
+      code: `
+export default <img style={{
+    transform: 'translate(1, 1)'
+}} />;
+`,
+      fixed: `
+export default <img style={{
+  transform: 'translate(1, 1)'
+}} />;
+`,
+      message: messages.expected("2 spaces"),
+      line: 3,
+      column: 4
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [
+    "tab",
+    {
+      baseIndentLevel: 1
+    }
+  ],
+  syntax: "jsx",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+import styled from "styled-components";
+export default styled.div\`
+\tcolor: #00;
+\`;`
+    },
+    {
+      code: `
+\timport styled from "styled-components";
+\texport default styled.div\`
+\t\tcolor: #00;
+\t\`;`
+    }
+  ],
+  reject: [
+    {
+      code: `
+import styled from "styled-components";
+export default styled.div\`
+color: #00;
+\`;`,
+      fixed: `
+import styled from "styled-components";
+export default styled.div\`
+\tcolor: #00;
+\`;`,
+      message: messages.expected("1 tab"),
+      line: 4,
+      column: 1
+    },
+    {
+      code: `
+\timport styled from "styled-components";
+\texport default styled.div\`
+\tcolor: #00;
+\t\`;`,
+      fixed: `
+\timport styled from "styled-components";
+\texport default styled.div\`
+\t\tcolor: #00;
+\t\`;`,
+      message: messages.expected("2 tabs"),
+      line: 4,
+      column: 2
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [
+    "tab",
+    {
+      baseIndentLevel: 0
+    }
+  ],
+  syntax: "jsx",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+import styled from "styled-components";
+export default styled.div\`
+color: #00;
+\`;`
+    },
+    {
+      code: `
+\timport styled from "styled-components";
+\texport default styled.div\`
+\tcolor: #00;
+\t\`;`
+    }
+  ],
+  reject: [
+    {
+      code: `
+import styled from "styled-components";
+export default styled.div\`
+\tcolor: #00;
+\`;`,
+      fixed: `
+import styled from "styled-components";
+export default styled.div\`
+color: #00;
+\`;`,
+      message: messages.expected("0 tabs"),
+      line: 4,
+      column: 2
+    },
+    {
+      code: `
+\timport styled from "styled-components";
+\texport default styled.div\`
+\t\tcolor: #00;
+\t\`;`,
+      fixed: `
+\timport styled from "styled-components";
+\texport default styled.div\`
+\tcolor: #00;
+\t\`;`,
+      message: messages.expected("1 tab"),
+      line: 4,
+      column: 3
+    }
+  ]
+});

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -37,6 +37,7 @@ const rule = function(space, options, context) {
       {
         actual: options,
         possible: {
+          baseIndentLevel: [_.isNumber, "auto"],
           except: ["block", "value", "param"],
           ignore: ["value", "param", "inside-parens"],
           indentInsideParens: ["twice", "once-at-root-twice-in-block"],
@@ -52,39 +53,42 @@ const rule = function(space, options, context) {
     // Cycle through all nodes using walk.
     root.walk(node => {
       const nodeLevel = indentationLevel(node);
-      const expectedWhitespace = _.repeat(indentChar, nodeLevel);
 
-      let before = node.raws.before || "";
+      // Cut out any * and _ hacks from `before`
+      const before = (node.raws.before || "").replace(/[*_]$/, "");
       const after = node.raws.after || "";
+      const parent = node.parent;
+
+      const expectedOpeningBraceIndentation = _.repeat(indentChar, nodeLevel);
 
       // Only inspect the spaces before the node
       // if this is the first node in root
       // or there is a newline in the `before` string.
       // (If there is no newline before a node,
       // there is no "indentation" to check.)
-      const inspectBefore =
-        node.root().first === node || before.indexOf("\n") !== -1;
-
-      // Cut out any * and _ hacks from `before`
-      if (
-        before[before.length - 1] === "*" ||
-        before[before.length - 1] === "_"
-      ) {
-        before = before.slice(0, before.length - 1);
-      }
-
+      const isFirstChild = parent.type === "root" && parent.first === node;
+      const lastIndexOfNewline = before.lastIndexOf("\n");
       // Inspect whitespace in the `before` string that is
       // *after* the *last* newline character,
       // because anything besides that is not indentation for this node:
       // it is some other kind of separation, checked by some separate rule
       if (
-        inspectBefore &&
-        before.slice(before.lastIndexOf("\n") + 1) !== expectedWhitespace
+        (lastIndexOfNewline !== -1 ||
+          (isFirstChild &&
+            (!parent.document ||
+              parent.raws.beforeStart.slice(-1) === "\n"))) &&
+        before.slice(lastIndexOfNewline + 1) !== expectedOpeningBraceIndentation
       ) {
         if (context.fix) {
+          if (isFirstChild && _.isString(node.raws.before)) {
+            node.raws.before = node.raws.before.replace(
+              /^[ \t]*(?=\S|$)/,
+              expectedOpeningBraceIndentation
+            );
+          }
           node.raws.before = fixIndentation(
             node.raws.before,
-            expectedWhitespace
+            expectedOpeningBraceIndentation
           );
         } else {
           report({
@@ -150,7 +154,10 @@ const rule = function(space, options, context) {
       level = level || 0;
 
       if (node.parent.type === "root") {
-        return level + getRootBaseIndentLevel(node.parent);
+        return (
+          level +
+          getRootBaseIndentLevel(node.parent, options.baseIndentLevel, space)
+        );
       }
 
       let calculatedLevel;
@@ -424,16 +431,6 @@ const rule = function(space, options, context) {
         }
       }
     }
-
-    function getRootBaseIndentLevel(node) {
-      if (node === root) {
-        return 0;
-      }
-      if (isNaN(node.source.baseIndentLevel)) {
-        node.source.baseIndentLevel = getBaseIndentLevel(node, root, space);
-      }
-      return node.source.baseIndentLevel;
-    }
   };
 
   function legibleExpectation(level) {
@@ -444,44 +441,125 @@ const rule = function(space, options, context) {
   }
 };
 
-function getBaseIndentLength(indents) {
-  return Math.min.apply(Math, indents.map(indent => indent.length));
-}
-
-function getSoftIndentLevel(softIndentCount, space) {
-  return Math.round(softIndentCount / (parseInt(space) || 2));
-}
-
-function getBaseIndentLevel(node, root, space) {
-  const code = node.source.input.css;
-  if (/^\S+/m.test(code)) {
+function getRootBaseIndentLevel(root, baseIndentLevel, space) {
+  const document = root.document;
+  if (!document) {
     return 0;
   }
+  let indentLevel = root.source.baseIndentLevel;
+  if (!Number.isSafeInteger(indentLevel)) {
+    indentLevel = inferRootIndentLevel(root, baseIndentLevel, () =>
+      inferDocIndentSize(document, space)
+    );
+    root.source.baseIndentLevel = indentLevel;
+  }
+  return indentLevel;
+}
 
-  const softIndents = code.match(/^ +(?=\S+)/gm);
-  const hardIndents = code.match(/^\t+(?=\S+)/gm);
-  let softIndentCount = softIndents ? softIndents.length : 0;
-  let hardIndentCount = hardIndents ? hardIndents.length : 0;
+function inferDocIndentSize(document, space) {
+  let indentSize = document.source.indentSize;
+  if (Number.isSafeInteger(indentSize)) {
+    return indentSize;
+  }
+  const source = document.source.input.css;
+  const indents = source.match(/^ *(?=\S)/gm);
+  if (indents) {
+    const scores = {};
+    let lastIndentSize = 0;
+    let lastLeadingSpacesLength = 0;
+    const vote = leadingSpacesLength => {
+      if (leadingSpacesLength) {
+        lastIndentSize =
+          Math.abs(leadingSpacesLength - lastLeadingSpacesLength) ||
+          lastIndentSize;
+        if (lastIndentSize > 1) {
+          if (scores[lastIndentSize]) {
+            scores[lastIndentSize]++;
+          } else {
+            scores[lastIndentSize] = 1;
+          }
+        }
+      } else {
+        lastIndentSize = 0;
+      }
+      lastLeadingSpacesLength = leadingSpacesLength;
+    };
 
-  if (softIndentCount > hardIndentCount) {
-    return getSoftIndentLevel(getBaseIndentLength(softIndents), space);
-  } else if (hardIndentCount) {
-    return getBaseIndentLength(hardIndents);
+    indents.forEach(leadingSpaces => {
+      vote(leadingSpaces.length);
+    });
+
+    let bestScore = 0;
+
+    for (const indentSizeDate in scores) {
+      const score = scores[indentSizeDate];
+      if (score > bestScore) {
+        bestScore = score;
+        indentSize = indentSizeDate;
+      }
+    }
   }
 
-  let afterEnd = root.nodes[root.nodes.indexOf(node) + 1];
-  if (afterEnd) {
-    afterEnd = afterEnd.raws.beforeStart;
-  } else {
-    afterEnd = root.raws.afterEnd;
-  }
-  hardIndentCount = 0;
-  softIndentCount = afterEnd.match(/^\s*/)[0].replace(/\t/g, () => {
-    hardIndentCount++;
-    return "";
-  }).length;
+  indentSize = +indentSize || (indents && indents[0].length) || +space || 2;
+  document.source.indentSize = indentSize;
+  return indentSize;
+}
 
-  return hardIndentCount + getSoftIndentLevel(softIndentCount, space);
+function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
+  function getIndentLevel(indent) {
+    let tabCount = indent.match(/\t/g);
+    tabCount = tabCount ? tabCount.length : 0;
+    let spaceCount = indent.match(/ /g);
+    spaceCount = spaceCount ? Math.round(spaceCount.length / indentSize()) : 0;
+    return tabCount + spaceCount;
+  }
+
+  if (!Number.isSafeInteger(baseIndentLevel)) {
+    let source = root.source.input.css;
+    source = source.replace(
+      /^[^\r\n]+/,
+      firstLine =>
+        /(?:^|\n)([ \t]*)$/.test(root.raws.beforeStart)
+          ? RegExp.$1 + firstLine
+          : ""
+    );
+
+    const indents = source.match(/^[ \t]*(?=\S)/gm);
+    if (indents) {
+      return Math.min.apply(Math, indents.map(getIndentLevel));
+    } else {
+      baseIndentLevel = 1;
+    }
+  }
+
+  const indents = [];
+
+  if (/(?:^|\n)([ \t]*)\S[^\r\n]*(?:\r?\n\s*)*$/.test(root.raws.beforeStart)) {
+    indents.push(RegExp.$1);
+  }
+
+  const after = root.raws.after;
+  if (after) {
+    let afterEnd;
+    if (after.slice(-1) === "\n") {
+      const document = root.document;
+      afterEnd = document.nodes[root.nodes.indexOf(root) + 1];
+      if (afterEnd) {
+        afterEnd = afterEnd.raws.beforeStart;
+      } else {
+        afterEnd = document.raws.afterEnd;
+      }
+    } else {
+      afterEnd = after;
+    }
+    indents.push(afterEnd.match(/^[ \t]*/)[0]);
+  }
+
+  if (indents.length) {
+    return Math.max.apply(Math, indents.map(getIndentLevel)) + baseIndentLevel;
+  }
+
+  return baseIndentLevel;
 }
 
 function fixIndentation(str, whitespace) {
@@ -489,21 +567,7 @@ function fixIndentation(str, whitespace) {
     return str;
   }
 
-  const strLength = str.length;
-
-  if (!strLength) {
-    return str;
-  }
-
-  let stringEnd = str[strLength - 1];
-
-  if (stringEnd !== "*" && stringEnd !== "_") {
-    stringEnd = "";
-  }
-
-  const stringStart = str.slice(0, str.lastIndexOf("\n") + 1);
-
-  return stringStart + whitespace + stringEnd;
+  return str.replace(/\n[ \t]*(?=\S|$)/g, "\n" + whitespace);
 }
 
 function replaceIndentation(input, searchString, replaceString, startIndex) {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3427

> Is there anything in the PR that needs further explanation?

Add setting `baseIndentLevel` for `indentation` rule. See: lib/rules/indentation/README.md
