### PR TITLE
Deemphasize processors and syntax option in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,12 @@ This is the quickest way to get started. We suggest you extend either:
 
 The recommended config turns on just the [possible error](docs/user-guide/rules.md#possible-errors) rules. The standard config extends it by turning on 60 [stylistic rules](docs/user-guide/rules.md#stylistic-issues). We suggest you extend the:
 
-- recommended config if you use a pretty printer like [prettier](https://prettier.io/)
-- standard config if you want stylelint to enforce stylistic conventions
+-   recommended config if you use a pretty printer like [prettier](https://prettier.io/)
+-   standard config if you want stylelint to enforce stylistic conventions
 
 You may want to add rules to your config that [limit language features](docs/user-guide/rules.md#limit-language-features) as these will be specific to your team and/or project.
 
-_If you use language extensions, for example `@if` and `@extends`, you can use a community config like [`stylelint-config-recommended-scss`](https://github.com/kristerkari/stylelint-config-recommended-scss) instead._
-
+*If you use language extensions, for example `@if` and `@extends`, you can use a community config like [`stylelint-config-recommended-scss`](https://github.com/kristerkari/stylelint-config-recommended-scss) instead.*
 
 ### Craft your own config
 
@@ -76,8 +75,8 @@ If the answer to your problem isn't there, then post it on [stackoverflow](https
 
 Create a [new issue](https://github.com/stylelint/stylelint/issues/new/choose) if:
 
-- you think you've found a bug
-- you have a feature request
+-   you think you've found a bug
+-   you have a feature request
 
 If you're upgrading, read our [CHANGELOG](CHANGELOG.md) to learn what changes to expect in the latest version.
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ It's mighty because it:
 
 It's easy to get started.
 
-First, decide if you want to use stylelint:
+First, decide how you want to use stylelint:
 
 -   [on the command line](docs/user-guide/cli.md)
 -   [in your text editor](docs/user-guide/complementary-tools.md#editor-plugins), for example in VS Code
--   [in for your build tool](docs/user-guide/complementary-tools.md#build-tool-plugins), for example in Webpack
+-   [in for your build tool](docs/user-guide/complementary-tools.md#build-tool-plugins), for example in webpack
 -   [via the Node API](docs/user-guide/node-api.md)
 -   [as a PostCSS plugin](docs/user-guide/postcss-plugin.md)
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ It's mighty because it:
 
 -   has over **160 built-in rules** to catch errors, apply limits and enforce stylistic conventions
 -   understands the **latest CSS syntax** including custom properties and level 4 selectors
--   parses **CSS-like syntaxes** like SCSS, Sass, Less and SugarSS
 -   extracts **embedded styles** from HTML, markdown and CSS-in-JS object & template literals
--   automatically **fixes** some violations (*experimental feature*)
+-   parses **CSS-like syntaxes** like SCSS, Sass, Less and SugarSS
 -   supports **plugins** so you can create your own rules or make use of plugins written by the community
+-   automatically **fixes** some violations (*experimental feature*)
 -   is **well tested** with over 10000 unit tests
 -   supports **shareable configs** that you can extend or create your own of
 -   is **unopinionated** so you can tailor the linter to your exact needs
@@ -27,30 +27,32 @@ It's mighty because it:
 
 It's easy to get started.
 
-First, decide how you want to use stylelint:
+First, decide if you want to use stylelint:
 
 -   [on the command line](docs/user-guide/cli.md)
 -   [in your text editor](docs/user-guide/complementary-tools.md#editor-plugins), for example in VS Code
--   [in for your build tool](docs/user-guide/complementary-tools.md#build-tool-plugins), for example in webpack
+-   [in for your build tool](docs/user-guide/complementary-tools.md#build-tool-plugins), for example in Webpack
 -   [via the Node API](docs/user-guide/node-api.md)
 -   [as a PostCSS plugin](docs/user-guide/postcss-plugin.md)
 
-Then, create your [configuration object](docs/user-guide/configuration.md).
-
-You can either extend a shared configuration or craft your own.
+Then create your [configuration object](docs/user-guide/configuration.md). You can either extend a shared configuration or craft your own.
 
 ### Extend a shared configuration
 
-It's the quickest way to get started. We suggest extending either:
+This is the quickest way to get started. We suggest you extend either:
 
 -   [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended)
 -   [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard)
 
-The recommended one turns on the [possible error](docs/user-guide/rules.md#possible-errors) rules. The standard config builds on it by turning on over 60 of the [stylistic rules](docs/user-guide/rules.md#stylistic-issues) with sensible defaults. We update these configs with each release of stylelint, so it's easy to stay up to date.
+The recommended config turns on just the [possible error](docs/user-guide/rules.md#possible-errors) rules. The standard config extends it by turning on 60 [stylistic rules](docs/user-guide/rules.md#stylistic-issues). We suggest you extend the:
 
-However, you can use a community config, for example [`stylelint-config-recommended-scss`](https://github.com/kristerkari/stylelint-config-recommended-scss), if you use non-standard syntax like `@if`, `@extends` etc.
+- recommended config if you use a pretty printer like [prettier](https://prettier.io/)
+- standard config if you want stylelint to enforce stylistic conventions
 
-You can always override rules after extending any config. You may also want to add some rules that [limit language features](docs/user-guide/rules.md#limit-language-features) as these will be specific to your team and/or project.
+You may want to add rules to your config that [limit language features](docs/user-guide/rules.md#limit-language-features) as these will be specific to your team and/or project.
+
+_If you use language extensions, for example `@if` and `@extends`, you can use a community config like [`stylelint-config-recommended-scss`](https://github.com/kristerkari/stylelint-config-recommended-scss) instead._
+
 
 ### Craft your own config
 
@@ -68,15 +70,20 @@ You'll find detailed information on customising stylelint in our guides:
 
 ## Need help?
 
-Read our [FAQ](docs/user-guide/faq.md) first. If the answer to your problem isn't there, then post it on [stackoverflow](https://stackoverflow.com/questions/tagged/stylelint).
+Read our [FAQ](docs/user-guide/faq.md) first.
 
-Please create a [new issue](https://github.com/stylelint/stylelint/issues/new/choose) if you think you've found a bug or if you have feature request.
+If the answer to your problem isn't there, then post it on [stackoverflow](https://stackoverflow.com/questions/tagged/stylelint).
+
+Create a [new issue](https://github.com/stylelint/stylelint/issues/new/choose) if:
+
+- you think you've found a bug
+- you have a feature request
 
 If you're upgrading, read our [CHANGELOG](CHANGELOG.md) to learn what changes to expect in the latest version.
 
 ## Help out
 
-There is a lot of work to do. Please help out in any way. You can:
+To help out, you can:
 
 -   get involved in any open [issue](https://github.com/stylelint/stylelint/issues) or [pull request](https://github.com/stylelint/stylelint/pulls)
 -   create, enhance and debug rules using our [working on rules](docs/developer-guide/rules.md) guide
@@ -87,7 +94,7 @@ There is a lot of work to do. Please help out in any way. You can:
 -   open [a pull request](https://github.com/stylelint/stylelint/compare) to show us how your idea works
 -   create or contribute to [ecosystem tools](docs/user-guide/complementary-tools.md), for example the plugin for [VS Code](https://github.com/shinnn/vscode-stylelint)
 
-If you're interested in the project vision, you can read our [VISION document](VISION.md).
+Our [VISION document](VISION.md) guides our work.
 
 ## Semantic Versioning Policy
 

--- a/docs/developer-guide/issues.md
+++ b/docs/developer-guide/issues.md
@@ -1,34 +1,36 @@
 # Managing issues
 
--   Use [labels](https://github.com/stylelint/stylelint/labels):
-    -   Add _one_ of the `status: *` labels (or the `help wanted` label when ready-to-go).
-    -   Add _zero or one_ of the `type: *` labels.
-    -   Add _zero, one or more_ of the `non-standard syntax: *` labels.
-    -   Optionally, add the `good first issue` label.
--   Rename the title into a consistent format:
-    -   Lead with the [CHANGELOG group names](pull-requests.md), but in the present tense:
-        -   "Remove y" e.g. "Remove unit-blacklist".
-        -   "Deprecate x in y" e.g. "Deprecate resolvedNested option in selector-class-pattern".
-        -   "Add y" e.g. "Add unit-blacklist".
-        -   "Add x to y" e.g. "Add ignoreProperties: [] to property-blacklist".
-        -   "Fix false positives/negatives for x in y" e.g. "Fix false positives for Less mixins in color-no-hex".
-    -   Use `*` if the issue applies to a group of rules e.g. "Fix false negatives for SCSS variables in selector-*-pattern"
--   Provide a link to the relevant section of the [Developer Guide](../developer-guide.md) when:
-    -   Adding the `help wanted` label to encourage the original poster to contribute., e.g. [adding an option to an existing rule](../developer-guide/rules.md#adding-an-option-to-an-existing-rule) or [fixing a bug in an existing rule](../developer-guide/rules.md#fixing-a-bug-in-an-existing-rule).
-    -   Closing an issue because the feature is best part of ecosystem e.g. [a plugin](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/plugins.md) or [processor](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/processors.md).
--   Use milestones only on issues and not on pull requests:
-    -   Use the `future-major` milestone for issues that introduce breaking changes.
-    -   Optionally, create version milestones (e.g. `8.x`) to manage upcoming releases.
--   Use the following saved reply to close any issue that do not use the template:
+You should:
+
+-   use [labels](https://github.com/stylelint/stylelint/labels) and:
+    -   add _one_ of the `status: *` labels (or the `help wanted` label when ready-to-go)
+    -   add _zero or one_ of the `type: *` labels
+    -   add _zero, one or more_ of the `non-standard syntax: *` labels
+    -   optionally, add the `good first issue` label
+-   rename the title into a consistent format and:
+    -   lead with the [CHANGELOG group names](pull-requests.md), but in the present tense:
+        -   "Remove y" e.g. "Remove unit-blacklist"
+        -   "Deprecate x in y" e.g. "Deprecate resolvedNested option in selector-class-pattern"
+        -   "Add y" e.g. "Add unit-blacklist"
+        -   "Add x to y" e.g. "Add ignoreProperties: [] to property-blacklist"
+        -   "Fix false positives/negatives for x in y" e.g. "Fix false positives for Less mixins in color-no-hex"
+    -   use `*` if the issue applies to a group of rules e.g. "Fix false negatives for SCSS variables in selector-*-pattern"
+-   provide a link to the relevant section of the [Developer Guide](../developer-guide.md) when:
+    -   adding the `help wanted` label to encourage the original poster to contribute, e.g. [adding an option to an existing rule](../developer-guide/rules.md#adding-an-option-to-an-existing-rule) or [fixing a bug in an existing rule](../developer-guide/rules.md#fixing-a-bug-in-an-existing-rule)
+    -   closing an issue because the feature is best part of ecosystem e.g. [a plugin](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/plugins.md) or [processor](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/processors.md)
+-   use milestones only on issues and not on pull requests and:
+    -   use the `future-major` milestone for issues that introduce breaking changes
+    -   optionally, create version milestones (e.g. `8.x`) to manage upcoming releases
+-   use the following saved reply to close any issue that do not use the template:
 
 ```md
-Thanks for creating this issue but we are closing it as issues need to follow our issue template, so that we can clearly understand your particular circumstances.
+Thanks for creating this issue but we're closing it as issues need to follow one of our templates, so that we can clearly understand your particular circumstances.
 
-Please help us to help you by [recreating the issue](https://github.com/stylelint/stylelint/issues/new) using the template.
+Please help us to help you by [recreating the issue](https://github.com/stylelint/stylelint/issues/new/choose) using one of our templates.
 ```
 
-General rules of thumb:
+There are three rules of thumb. You should use the:
 
--   Use the `status: discussion`, `status: needs clarification` or `status: needs investigation` label when first triaging an issue.
--   Use the `help wanted`, a `type` (and `non-standard syntax: *` and `good first issue`) labels when a course of action is agreed.
--   Use the `status: wip` label when your are, or someone has said they are, about to start working on an issue.
+-   `status: discussion`, `status: needs clarification` or `status: needs investigation` label when first triaging an issue
+-   `help wanted`, a `type` (and `non-standard syntax: *` and `good first issue`) labels when a course of action is agreed
+-   `status: wip` label when your are, or someone has said they are, about to start working on an issue

--- a/docs/developer-guide/processors.md
+++ b/docs/developer-guide/processors.md
@@ -25,11 +25,7 @@ module.exports = function(options) {
 }
 ```
 
-Processors can enable stylelint to lint the CSS within non-stylesheet files. For example, let's say you want to lint the CSS within `<style>` tags in HTML. If you just feed stylelint your HTML code, you'll run into problems, because PostCSS does not parse HTML by default. Instead, you can create a processor that does the following:
-
--   In the `code` processor function, extract CSS from the `<style>` tags in the HTML code. Return a CSS string containing all that extracted CSS, which is what stylelint will inspect.
--   Build a sourcemap while performing the extraction, so warning positions can be tailored to match the original source HTML.
--   In the `result` processor function, modify the line/column position of each warning using your sourcemap.
+Processors can enable stylelint to lint the CSS within non-stylesheet files.
 
 *Processor options must be JSON-friendly*, because users will need to include them in `.stylelintrc` files.
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -44,10 +44,10 @@ Using `bar/mySpecialConfig.json` as config to lint all `.css` files in the `foo`
 stylelint "foo/*.css" --config bar/mySpecialConfig.json > myTestReport.txt
 ```
 
-Using `bar/mySpecialConfig.json` as config, with quiet mode on, to lint all `.css` files in the `foo` directory and any of its subdirectories and also all `.css` files in the `bar directory`, then writing the JSON-formatted output to `myJsonReport.json`:
+Using `bar/mySpecialConfig.json` as config, with quiet mode on, to lint all `.css` files in the `foo` directory and any of its subdirectories and also all `.css` files in the `bar directory`:
 
 ```shell
-stylelint "foo/**/*.css bar/*.css" -q -f json --config bar/mySpecialConfig.json > myJsonReport.json
+stylelint "foo/**/*.css bar/*.css" -q -f json --config bar/mySpecialConfig.json
 ```
 
 Linting all `.css` files except those within `docker` subfolders, using negation in the input glob:
@@ -62,21 +62,13 @@ Caching processed `.scss` files in order to operate only on changed ones in the 
 stylelint "foo/**/*.scss" --cache --cache-location "/Users/user/.stylelintcache/"
 ```
 
-Linting all the `.css` files in the `foo` directory, using the `syntax` option:
+stylelint will [automatically infer the syntax](css-processors.md##parsing-non-standard-syntax). You can, however, force a specific syntax using the  `--syntax` option. For example, linting all the `.css` files in the `foo` directory _as Scss_:
 
 ```shell
 stylelint "foo/**/*.css" --syntax scss
 ```
 
-In addition to `--syntax scss`, stylelint supports `--syntax sass`, `--syntax less`, and `--syntax sugarss` by default. If you're using one of the default syntaxes, you may not need to provide a `--syntax` option as non-standard syntaxes can be automatically inferred from the following:
-
--   The following file extensions: `.sass`, `.scss`, `.less`, and `.sss`.
--   The following values for the `lang` or `type` attribute on `<style>` tags (e.g. `lang="scss"`, `type="text/scss"`): `scss`, `less` and `sugarss`.
--   The following Markdown code fencing markers (e.g. ```` ```scss ````): `scss`, `less` and `sugarss`.
-
-Additionally, stylelint can accept a custom [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes). To use a custom syntax, supply a syntax module name or path to the syntax file: `--custom-syntax custom-syntax` or `--custom-syntax ./path/to/custom-syntax`.
-
-Note, however, that stylelint can provide no guarantee that core rules will work with syntaxes other than the defaults listed above.
+stylelint can also accept a custom [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes). To use a custom syntax, supply a syntax module name or path to the syntax file: `--custom-syntax custom-syntax` or `--custom-syntax ./path/to/custom-syntax`.
 
 ### Recursively linting a directory
 
@@ -86,7 +78,7 @@ To recursively lint a directory, using the `**` globstar:
 stylelint "foo/**/*.scss"
 ```
 
-The quotation marks around the glob are important because they will allow stylelint to interpret the glob, using node-glob, instead of your shell, which might not support all the same features.
+The quotation marks around the glob are important because they will allow stylelint to interpret the glob, using globby, instead of your shell, which might not support all the same features.
 
 ### Autofixing errors
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -62,7 +62,7 @@ Caching processed `.scss` files in order to operate only on changed ones in the 
 stylelint "foo/**/*.scss" --cache --cache-location "/Users/user/.stylelintcache/"
 ```
 
-stylelint will [automatically infer the syntax](css-processors.md##parsing-non-standard-syntax). You can, however, force a specific syntax using the  `--syntax` option. For example, linting all the `.css` files in the `foo` directory _as Scss_:
+stylelint will [automatically infer the syntax](css-processors.md#parsing-non-standard-syntax). You can, however, force a specific syntax using the  `--syntax` option. For example, linting all the `.css` files in the `foo` directory _as Scss_:
 
 ```shell
 stylelint "foo/**/*.css" --syntax scss

--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -6,10 +6,6 @@ A list of complementary tools built and maintained by the community.
 
 -   [codeclimate-stylelint](https://github.com/gilbarbara/codeclimate-stylelint): Code Climate engine for stylelint
 
-## Autocorrect
-
--   [stylefmt](https://github.com/morishitter/stylefmt): Automatically formats CSS and SCSS source code based on your stylelint configuration.
-
 ## Command Line Tools
 
 -   [stylelint-find-rules](https://github.com/alexilyaev/stylelint-find-rules): Find Stylelint rules that you don't have in your config.

--- a/docs/user-guide/css-processors.md
+++ b/docs/user-guide/css-processors.md
@@ -1,6 +1,6 @@
 # CSS processors
 
-The linter supports current and future CSS syntax. This includes all standard CSS but also special features that use standard CSS syntactic structures, e.g. special at-rules, special properties, and special functions. Some CSS-*like* language extensions --   features that use non-standard syntactic structures --   are, as such, supported; however, since there are infinite processing possibilities, the linter cannot support everything.
+The linter supports current and future CSS syntax. This includes all standard CSS but also special features that use standard CSS syntactic structures, e.g. special at-rules, special properties, and special functions. Some CSS-*like* language extensions -- features that use non-standard syntactic structures -- are, as such, supported; however, since there are infinite processing possibilities, the linter cannot support everything.
 
 You can run the linter before or after your css processors. Depending on which processors you use, each approach has caveats:
 
@@ -11,29 +11,26 @@ You can run the linter before or after your css processors. Depending on which p
 
 ## Parsing non-standard syntax
 
-By default, the linter can *parse* any the following non-standard syntaxes by using special PostCSS parsers:
+stylelint will automatically infer the syntax from the:
 
--   Sass (using [`postcss-sass`](https://github.com/AleshaOleg/postcss-sass))
--   SCSS (using [`postcss-scss`](https://github.com/postcss/postcss-scss))
--   Less (using [`postcss-less`](https://github.com/shellscape/postcss-less))
--   SugarSS (using [`sugarss`](https://github.com/postcss/sugarss))
+-   file extension
+-   value of the `lang` or `type` attribute on a `<style>` tag
+-   marker on Markdown code fence
 
-*Non-standard syntaxes can automatically be inferred from the following file extensions, values for the `lang` or `type` attribute on `<style>` tags, and markers for Markdown code fences: `css`, `less`, `scss`, and `sss`.* If you would need to specify your non-standard syntax, though, both the [CLI](cli.md) and the [Node API](node-api.md) expose a `syntax` option.
+You can force a specific syntax, though. Both the [CLI](cli.md) and the [Node API](node-api.md) expose a `syntax` option.
 
 -   If you're using the CLI, use the `syntax` flag like so:  `stylelint ... --syntax scss`.
 -   If you're using the Node API, pass in the `syntax` option like so: `stylelint.lint({ syntax: "sugarss", ... })`.
 
-Additionally, stylelint can accept a custom [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes) when using the CLI or Node API. For custom syntaxes, please use the `custom-syntax` and `customSyntax` options, respectively.
+stylelint can also accept a custom [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes) when using the CLI or Node API. For custom syntaxes, use the `custom-syntax` and `customSyntax` options, respectively.
 
 -   If you're using the CLI, use the `custom-syntax` flag like so:  `stylelint ... --custom-syntax custom-syntax-module` or `stylelint ... --custom-syntax ./path/to/custom-syntax-module`.
 -   If you're using the Node API, pass in the `customSyntax` option like so: `stylelint.lint({ customSyntax: path.join(process.cwd(), './path/to/custom-syntax-module') , ... })`.
 
-If you're using the linter as a [PostCSS Plugin](postcss-plugin.md), you'll need to use the special parser directly with PostCSS's `syntax` option like so:
+If you're using the linter as a [PostCSS Plugin](postcss-plugin.md), you should use the special `postcss-syntax` directly with PostCSS's `syntax` option like so:
 
 ```js
 var postcss = require("postcss")
-// "postcss-syntax" can automatically switch PostCSS syntax by file extensions
-// or use "postcss-less", "sugarss", "postcss-scss", or any PostCSS-compatible syntax
 var syntax = require("postcss-syntax")
 
 postcss([

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -128,11 +128,11 @@ A path to a file containing patterns describing files to ignore. The path can be
 
 ### `syntax`
 
-Options: `"sass"|"scss"|"less"|"sugarss"`
+Options: `"sass"|"scss"|"less"|"sugarss"|"html"|"styled"|"jsx"`
 
-Specify a non-standard syntax that should be used to parse source stylesheets.
+Force a specific non-standard syntax that should be used to parse source stylesheets.
 
-If you do not specify a syntax, non-standard syntaxes will be automatically inferred by the file extensions `.sass`, `.scss`, `.less`, and `.sss`.
+If you do not specify a syntax, non-standard syntaxes will be automatically inferred.
 
 See the [`customSyntax`](#customsyntax) option below if you would like to use stylelint with a custom syntax.
 

--- a/docs/user-guide/processors.md
+++ b/docs/user-guide/processors.md
@@ -1,10 +1,13 @@
 # Processors
 
-Processors are community packages that enable stylelint to lint the CSS within non-stylesheet files. For example, you could lint the CSS within `<style>` tags in HTML, code blocks in Markdown, or strings in JavaScript.
+Processors are community packages that enable stylelint to extract styles from within non-stylesheet files.
 
 *These processors can only be used with the CLI and the Node API, not with the PostCSS plugin.* (The PostCSS plugin will ignore them.)
 
 -   [stylelint-processor-arbitrary-tags](https://github.com/mapbox/stylelint-processor-arbitrary-tags): Lint within user-specified tags.
+
+stylelint now has built-in support for many common non-stylesheet files. You may no longer need to use the following processors:
+
 -   [stylelint-processor-glamorous](https://github.com/zabute/stylelint-processor-glamorous): Lint [glamorous](https://github.com/paypal/glamorous) and related css-in-js libraries using object literals.
 -   [stylelint-processor-markdown](https://github.com/mapbox/stylelint-processor-markdown): Lint within Markdown's [fenced code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/).
 -   [stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components): Lint [styled-components](https://styled-components.com) and related CSS-in-JS libraries using tagged template literals.


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/issues/3587

> Is there anything in the PR that needs further explanation?

This PR deemphasizes processors and syntax option in the docs (and emphasizes stylelint's built-in support for inferring syntax and extracting styles). It also continues to roll-out the simplified writing styled we started using on the homepage.
