### PR TITLE
Add autofix to function-comma-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -217,7 +217,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`function-comma-newline-after`](../../lib/rules/function-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of functions.
 -   [`function-comma-newline-before`](../../lib/rules/function-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of functions.
 -   [`function-comma-space-after`](../../lib/rules/function-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of functions (Autofixable).
--   [`function-comma-space-before`](../../lib/rules/function-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of functions.
+-   [`function-comma-space-before`](../../lib/rules/function-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of functions (Autofixable).
 -   [`function-max-empty-lines`](../../lib/rules/function-max-empty-lines/README.md): Limit the number of adjacent empty lines within functions.
 -   [`function-name-case`](../../lib/rules/function-name-case/README.md): Specify lowercase or uppercase for function names.
 -   [`function-parentheses-newline-inside`](../../lib/rules/function-parentheses-newline-inside/README.md): Require a newline or disallow whitespace on the inside of the parentheses of functions.

--- a/lib/rules/function-comma-space-before/README.md
+++ b/lib/rules/function-comma-space-before/README.md
@@ -8,6 +8,8 @@ a { transform: translate(1 ,1) }
  * The space before these commas */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"`

--- a/lib/rules/function-comma-space-before/__tests__/index.js
+++ b/lib/rules/function-comma-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -36,24 +37,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: translate(1, 1); }",
+      fixed: "a { transform: translate(1 , 1); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 27
     },
     {
       code: "a { transform: translate(1  , 1); }",
+      fixed: "a { transform: translate(1 , 1); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 29
     },
     {
       code: "a { transform: translate(1\n, 1); }",
+      fixed: "a { transform: translate(1 , 1); }",
       message: messages.expectedBefore(),
       line: 2,
       column: 1
     },
     {
       code: "a { transform: translate(1\r\n, 1); }",
+      fixed: "a { transform: translate(1 , 1); }",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 2,
@@ -61,18 +66,21 @@ testRule(rule, {
     },
     {
       code: "a { transform: translate(1\t, 1); }",
+      fixed: "a { transform: translate(1 , 1); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: color(rgb(0 , 0, 0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0 , 0 , 0) lightness(50%)); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 31
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0 , 0, 0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0 , 0 , 0)); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 46
@@ -83,6 +91,13 @@ testRule(rule, {
         transform: translate(
           1px /* comment */
           ,1px
+        );
+      }
+    `,
+      fixed: `
+      a {
+        transform: translate(
+          1px /* comment */ ,1px
         );
       }
     `,
@@ -112,6 +127,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -137,24 +153,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: translate(1 , 1); }",
+      fixed: "a { transform: translate(1, 1); }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: translate(1  , 1); }",
+      fixed: "a { transform: translate(1, 1); }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 29
     },
     {
       code: "a { transform: translate(1\n, 1); }",
+      fixed: "a { transform: translate(1, 1); }",
       message: messages.rejectedBefore(),
       line: 2,
       column: 1
     },
     {
       code: "a { transform: translate(1\r\n, 1); }",
+      fixed: "a { transform: translate(1, 1); }",
       description: "CRLF",
       message: messages.rejectedBefore(),
       line: 2,
@@ -162,21 +182,38 @@ testRule(rule, {
     },
     {
       code: "a { transform: translate(1\t, 1); }",
+      fixed: "a { transform: translate(1, 1); }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: color(rgb(0, 0 , 0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0, 0, 0) lightness(50%)); }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 31
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0, 0 , 0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0, 0, 0)); }",
       message: messages.rejectedBefore(),
       line: 1,
       column: 46
+    },
+    {
+      code: "a { transform: translate(1 /*comment*/ , 1); }",
+      fixed: "a { transform: translate(1 /*comment*/, 1); }",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 40
+    },
+    {
+      code: "a { transform: translate(1 /*c*/ /*c*/ , 1); }",
+      fixed: "a { transform: translate(1 /*c*/ /*c*/, 1); }",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 40
     }
   ]
 });
@@ -197,6 +234,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -242,18 +280,22 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: color(rgb(0 , 0, 0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0 , 0 , 0) lightness(50%)); }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 31
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0 , 0, 0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0 , 0 , 0)); }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 46
     },
     {
       code: "a { background: linear-gradient(45deg,\nrgba(0 , 0,0 ,1),red); }",
+      fixed:
+        "a { background: linear-gradient(45deg,\nrgba(0 , 0 ,0 ,1),red); }",
       message: messages.expectedBeforeSingleLine(),
       line: 2,
       column: 11
@@ -277,6 +319,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -318,12 +361,14 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: color(rgb(0, 0 , 0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0, 0, 0) lightness(50%)); }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 31
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0, 0 , 0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0, 0, 0)); }",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 46

--- a/lib/rules/function-comma-space-before/index.js
+++ b/lib/rules/function-comma-space-before/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before "," in a single-line function'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -31,7 +31,18 @@ const rule = function(expectation) {
       root,
       result,
       locationChecker: checker.before,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? div => {
+            if (expectation.indexOf("always") === 0) {
+              div.before = " ";
+              return true;
+            } else if (expectation.indexOf("never") === 0) {
+              div.before = "";
+              return true;
+            }
+          }
+        : null
     });
   };
 };


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3548

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    a { transform: translate(1, 1); }
    ```
    fixed:
    ```css
    a { transform: translate(1 , 1); }
    ```

* option: `never***`

    code:
    ```css
    a { transform: translate(1 , 1); }
    ```

    fixed:
    ```css
    a { transform: translate(1, 1); }
    ```
