### PR TITLE
Reset whole return value when ignoring stdin. Fix #3590

### DIFF
--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.js
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.js
@@ -3,7 +3,7 @@
 const path = require("path");
 const standalone = require("../../standalone");
 
-describe("standalone with .stylelintignore file ignoring one file", () => {
+describe("stylelintignore", () => {
   let actualCwd;
   let results;
   const fixturesPath = path.join(__dirname, "../fixtures");
@@ -17,34 +17,74 @@ describe("standalone with .stylelintignore file ignoring one file", () => {
     process.chdir(actualCwd);
   });
 
-  beforeEach(() => {
-    return standalone({
-      files: [
-        `${fixturesPath}/empty-block.css`,
-        `${fixturesPath}/invalid-hex.css`
-      ],
-      config: {
-        extends: [
-          `${fixturesPath}/config-block-no-empty`,
-          `${fixturesPath}/config-color-no-invalid-hex`
-        ]
-      }
-    }).then(data => (results = data.results));
+  describe("standalone with .stylelintignore file ignoring one file", () => {
+    beforeEach(() => {
+      return standalone({
+        files: [
+          `${fixturesPath}/empty-block.css`,
+          `${fixturesPath}/invalid-hex.css`
+        ],
+        config: {
+          extends: [
+            `${fixturesPath}/config-block-no-empty`,
+            `${fixturesPath}/config-color-no-invalid-hex`
+          ]
+        }
+      }).then(data => (results = data.results));
+    });
+
+    it("one file read", () => {
+      expect(results.length).toBe(1);
+    });
+
+    it("empty-block.css not read", () => {
+      expect(/empty-block\.css/.test(results[0].source)).toBe(false);
+    });
+
+    it("color-no-invalid-hex.css read", () => {
+      expect(/invalid-hex\.css/.test(results[0].source)).toBe(true);
+    });
+
+    it("color-no-invalid-hex.css linted", () => {
+      expect(results[0].warnings.length).toBe(1);
+    });
   });
 
-  it("one file read", () => {
-    expect(results.length).toBe(1);
-  });
+  describe("standalone with .stylelintignore file ignoring codeFilename", () => {
+    it("ignored file is ignored", () => {
+      return standalone({
+        code: ".bar {}",
+        codeFilename: `${fixturesPath}/empty-block.css`,
+        ignorePath: path.join(__dirname, ".stylelintignore"),
+        config: {
+          extends: `${fixturesPath}/config-block-no-empty`
+        }
+      }).then(data => {
+        expect(data).toEqual({
+          errored: false,
+          output: "[]",
+          results: []
+        });
+      });
+    });
 
-  it("empty-block.css not read", () => {
-    expect(/empty-block\.css/.test(results[0].source)).toBe(false);
-  });
-
-  it("color-no-invalid-hex.css read", () => {
-    expect(/invalid-hex\.css/.test(results[0].source)).toBe(true);
-  });
-
-  it("color-no-invalid-hex.css linted", () => {
-    expect(results[0].warnings.length).toBe(1);
+    it("not ignored file is linted", () => {
+      return standalone({
+        code: ".bar {}",
+        codeFilename: `${fixturesPath}/empty-block.css`,
+        ignorePath: path.join(__dirname, ".stylelintignore-empty"),
+        config: {
+          extends: `${fixturesPath}/config-block-no-empty`
+        }
+      }).then(data => {
+        expect(data).toMatchObject({
+          errored: true,
+          output: expect.stringContaining(
+            "Unexpected empty block (block-no-empty)"
+          ),
+          results: expect.any(Array)
+        });
+      });
+    });
   });
 });

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -133,20 +133,19 @@ module.exports = function(
       })
       .catch(_.partial(handleError, stylelint))
       .then(stylelintResult => {
-        const returnValue = prepareReturnValue([stylelintResult]);
-        const postcssResult = stylelintResult._postcssResult;
         // if file is ignored, return nothing
         if (
           absoluteCodeFilename &&
           !ignorer.filter(path.relative(process.cwd(), absoluteCodeFilename))
             .length
         ) {
-          returnValue.output = "";
-        } else if (
-          options.fix &&
-          postcssResult &&
-          !postcssResult.stylelint.ignored
-        ) {
+          return prepareReturnValue([]);
+        }
+
+        const postcssResult = stylelintResult._postcssResult;
+        const returnValue = prepareReturnValue([stylelintResult]);
+
+        if (options.fix && postcssResult && !postcssResult.stylelint.ignored) {
           // If we're fixing, the output should be the fixed code
           returnValue.output = postcssResult.root.toString(
             postcssResult.opts.syntax


### PR DESCRIPTION
~Fixes #2833, and it also~ Fixes #3590 ~which is the same issue~.

Edit: my bad, #2833 is about `isPathIgnored`. This fixes the ignoring for the `lint()` API only, so #3590.

My tests showed everything working as expected, while the repro in #3590 did not. The difference between the two is that I was only checking `output` from the stylelint results… which is the only thing that (half) works.

For inputs via stdin, the results are ignored **after** linting, and it was only resetting [`output`](https://stylelint.io/user-guide/node-api/#output), not all other return values (`errored`, etc):

https://github.com/stylelint/stylelint/blob/2584d15e514fc99fb473e8d24175012c20627ff3/lib/standalone.js#L135-L156

…so all is well if you're using the CLI, or only look at `output` in your API integration (like I did in https://github.com/thibaudcolas/stylelint-repro), but for API usage relying on other return values it fails.

It also doesn't respect the formatter – with the default formatter, if there are no errors, `output` should be `"[]"` not `""`.

---

I went for the simplest fix. If there is no reason to lint files that are ignored (right?), then it would be better to ignore files before linting, over here: https://github.com/stylelint/stylelint/blob/2584d15e514fc99fb473e8d24175012c20627ff3/lib/standalone.js#L98-L104

That's a separate issue though.