### PR TITLE
Add autofix to media-query-list-comma-space-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -330,7 +330,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 -   [`media-query-list-comma-newline-after`](../../lib/rules/media-query-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of media query lists.
 -   [`media-query-list-comma-newline-before`](../../lib/rules/media-query-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of media query lists.
--   [`media-query-list-comma-space-after`](../../lib/rules/media-query-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of media query lists.
+-   [`media-query-list-comma-space-after`](../../lib/rules/media-query-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of media query lists (Autofixable).
 -   [`media-query-list-comma-space-before`](../../lib/rules/media-query-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of media query lists.
 
 #### At-rule

--- a/lib/rules/media-query-list-comma-space-after/README.md
+++ b/lib/rules/media-query-list-comma-space-after/README.md
@@ -8,6 +8,8 @@ Require a single space or disallow whitespace after the commas of media query li
  *            These commas */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"`

--- a/lib/rules/media-query-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/media-query-list-comma-space-after/__tests__/index.js
@@ -101,6 +101,13 @@ testRule(rule, {
       message: messages.expectedAfter(),
       line: 1,
       column: 26
+    },
+    {
+      code: "@media " + "tv,".repeat(50) + ",print {}",
+      fixed: "@media " + "tv, ".repeat(50) + ", print {}",
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 10
     }
   ]
 });

--- a/lib/rules/media-query-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/media-query-list-comma-space-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -46,36 +47,42 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color),projection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       message: messages.expectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@mEdIa screen and (color),projection and (color) {}",
+      fixed: "@mEdIa screen and (color), projection and (color) {}",
       message: messages.expectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@MEDIA screen and (color),projection and (color) {}",
+      fixed: "@MEDIA screen and (color), projection and (color) {}",
       message: messages.expectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color),  projection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       message: messages.expectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color),\nprojection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       message: messages.expectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color),\r\nprojection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       description: "CRLF",
       message: messages.expectedAfter(),
       line: 1,
@@ -83,6 +90,14 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color),\tprojection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 26
+    },
+    {
+      code: "@media screen and (color),/*comment*/projection and (color) {}",
+      fixed: "@media screen and (color), /*comment*/projection and (color) {}",
       message: messages.expectedAfter(),
       line: 1,
       column: 26
@@ -93,6 +108,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -133,36 +149,42 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color), projection and (color) {}",
+      fixed: "@media screen and (color),projection and (color) {}",
       message: messages.rejectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@mEdIa screen and (color), projection and (color) {}",
+      fixed: "@mEdIa screen and (color),projection and (color) {}",
       message: messages.rejectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@MEDIA screen and (color), projection and (color) {}",
+      fixed: "@MEDIA screen and (color),projection and (color) {}",
       message: messages.rejectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color),  projection and (color) {}",
+      fixed: "@media screen and (color),projection and (color) {}",
       message: messages.rejectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color),\nprojection and (color) {}",
+      fixed: "@media screen and (color),projection and (color) {}",
       message: messages.rejectedAfter(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color),\r\nprojection and (color) {}",
+      fixed: "@media screen and (color),projection and (color) {}",
       description: "CRLF",
       message: messages.rejectedAfter(),
       line: 1,
@@ -170,6 +192,14 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color),\tprojection and (color) {}",
+      fixed: "@media screen and (color),projection and (color) {}",
+      message: messages.rejectedAfter(),
+      line: 1,
+      column: 26
+    },
+    {
+      code: "@media screen and (color), /*comment*/ projection and (color) {}",
+      fixed: "@media screen and (color),/*comment*/ projection and (color) {}",
       message: messages.rejectedAfter(),
       line: 1,
       column: 26
@@ -180,6 +210,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -220,24 +251,28 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color) ,projection and (color) {}",
+      fixed: "@media screen and (color) , projection and (color) {}",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 27
     },
     {
       code: "@mEdIa screen and (color) ,projection and (color) {}",
+      fixed: "@mEdIa screen and (color) , projection and (color) {}",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 27
     },
     {
       code: "@MEDIA screen and (color) ,projection and (color) {}",
+      fixed: "@MEDIA screen and (color) , projection and (color) {}",
       message: messages.expectedAfterSingleLine(),
       line: 1,
       column: 27
     },
     {
       code: "@media screen and (color) ,projection and (color) {\n}",
+      fixed: "@media screen and (color) , projection and (color) {\n}",
       description: "single-line list, multi-line block",
       message: messages.expectedAfterSingleLine(),
       line: 1,
@@ -245,6 +280,7 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color) ,projection and (color) {\r\n}",
+      fixed: "@media screen and (color) , projection and (color) {\r\n}",
       description: "single-line list, multi-line block and CRLF",
       message: messages.expectedAfterSingleLine(),
       line: 1,
@@ -256,6 +292,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -296,24 +333,28 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color), projection and (color) {}",
+      fixed: "@media screen and (color),projection and (color) {}",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 26
     },
     {
       code: "@mEdIa screen and (color), projection and (color) {}",
+      fixed: "@mEdIa screen and (color),projection and (color) {}",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 26
     },
     {
       code: "@MEDIA screen and (color), projection and (color) {}",
+      fixed: "@MEDIA screen and (color),projection and (color) {}",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color), projection and (color) {\n}",
+      fixed: "@media screen and (color),projection and (color) {\n}",
       description: "single-line list, multi-line block",
       message: messages.rejectedAfterSingleLine(),
       line: 1,
@@ -321,6 +362,7 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color), projection and (color) {\r\n}",
+      fixed: "@media screen and (color),projection and (color) {\r\n}",
       description: "single-line list, multi-line block and CRLF",
       message: messages.rejectedAfterSingleLine(),
       line: 1,

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const atRuleParamIndex = require("../../utils/atRuleParamIndex");
 const mediaQueryListCommaWhitespaceChecker = require("../mediaQueryListCommaWhitespaceChecker");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -16,7 +17,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace after "," in a single-line list'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -26,12 +27,48 @@ const rule = function(expectation) {
     if (!validOptions) {
       return;
     }
+
+    let fixData;
     mediaQueryListCommaWhitespaceChecker({
       root,
       result,
       locationChecker: checker.after,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (atRule, index) => {
+            const paramCommaIndex = index - atRuleParamIndex(atRule);
+            fixData = fixData || new Map();
+            const commaIndices = fixData.get(atRule) || [];
+            commaIndices.push(paramCommaIndex);
+            fixData.set(atRule, commaIndices);
+            return true;
+          }
+        : null
     });
+    if (fixData) {
+      fixData.forEach((commaIndices, atRule) => {
+        let params = atRule.raws.params
+          ? atRule.raws.params.raw
+          : atRule.params;
+        commaIndices
+          .sort()
+          .reverse()
+          .forEach(index => {
+            const beforeComma = params.slice(0, index + 1);
+            const afterComma = params.slice(index + 1);
+            if (expectation.indexOf("always") === 0) {
+              params = beforeComma + afterComma.replace(/^\s*/, " ");
+            } else if (expectation.indexOf("never") === 0) {
+              params = beforeComma + afterComma.replace(/^\s*/, "");
+            }
+          });
+        if (atRule.raws.params) {
+          atRule.raws.params.raw = params;
+        } else {
+          atRule.params = params;
+        }
+      });
+    }
   };
 };
 

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -50,18 +50,15 @@ const rule = function(expectation, options, context) {
         let params = atRule.raws.params
           ? atRule.raws.params.raw
           : atRule.params;
-        commaIndices
-          .sort((a, b) => a - b)
-          .reverse()
-          .forEach(index => {
-            const beforeComma = params.slice(0, index + 1);
-            const afterComma = params.slice(index + 1);
-            if (expectation.indexOf("always") === 0) {
-              params = beforeComma + afterComma.replace(/^\s*/, " ");
-            } else if (expectation.indexOf("never") === 0) {
-              params = beforeComma + afterComma.replace(/^\s*/, "");
-            }
-          });
+        commaIndices.sort((a, b) => b - a).forEach(index => {
+          const beforeComma = params.slice(0, index + 1);
+          const afterComma = params.slice(index + 1);
+          if (expectation.indexOf("always") === 0) {
+            params = beforeComma + afterComma.replace(/^\s*/, " ");
+          } else if (expectation.indexOf("never") === 0) {
+            params = beforeComma + afterComma.replace(/^\s*/, "");
+          }
+        });
         if (atRule.raws.params) {
           atRule.raws.params.raw = params;
         } else {

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -51,7 +51,7 @@ const rule = function(expectation, options, context) {
           ? atRule.raws.params.raw
           : atRule.params;
         commaIndices
-          .sort()
+          .sort((a, b) => a - b)
           .reverse()
           .forEach(index => {
             const beforeComma = params.slice(0, index + 1);

--- a/lib/rules/mediaQueryListCommaWhitespaceChecker.js
+++ b/lib/rules/mediaQueryListCommaWhitespaceChecker.js
@@ -6,7 +6,7 @@ const styleSearch = require("style-search");
 
 module.exports = function(opts) {
   opts.root.walkAtRules(/^media$/i, atRule => {
-    const params = atRule.params;
+    const params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
     styleSearch({ source: params, target: "," }, match => {
       checkComma(params, match.startIndex, atRule);
     });
@@ -16,14 +16,19 @@ module.exports = function(opts) {
     opts.locationChecker({
       source,
       index,
-      err: m =>
+      err: m => {
+        const commaIndex = index + atRuleParamIndex(node);
+        if (opts.fix && opts.fix(node, commaIndex)) {
+          return;
+        }
         report({
           message: m,
           node,
-          index: index + atRuleParamIndex(node),
+          index: commaIndex,
           result: opts.result,
           ruleName: opts.checkedRuleName
-        })
+        });
+      }
     });
   }
 };


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3570

> Is there anything in the PR that needs further explanation?

ex.

* option: `always`

    code:
    ```css
    @media screen and (color),projection and (color) {}
    ```
    fixed:
    ```css
    @media screen and (color), projection and (color) {}
    ```

* option: `never`

    code:
    ```css
    @media screen and (color), projection and (color) {}
    ```

    fixed:
    ```css
    @media screen and (color),projection and (color) {}
    ```