### PR TITLE
Add autofix to no-eol-whitespace

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -353,5 +353,5 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`linebreaks`](../../lib/rules/linebreaks/README.md): Specify unix or windows linebreaks (Autofixable).
 -   [`max-empty-lines`](../../lib/rules/max-empty-lines/README.md): Limit the number of adjacent empty lines.
 -   [`max-line-length`](../../lib/rules/max-line-length/README.md): Limit the length of a line.
--   [`no-eol-whitespace`](../../lib/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace.
+-   [`no-eol-whitespace`](../../lib/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace (Autofixable).
 -   [`no-missing-end-of-source-newline`](../../lib/rules/no-missing-end-of-source-newline/README.md): Disallow missing end-of-source newlines (Autofixable).

--- a/lib/rules/no-eol-whitespace/README.md
+++ b/lib/rules/no-eol-whitespace/README.md
@@ -8,6 +8,8 @@ a { color: pink; }···
  *  This whitespace */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix most of the problems reported by this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-eol-whitespace/__tests__/index.js
+++ b/lib/rules/no-eol-whitespace/__tests__/index.js
@@ -7,6 +7,7 @@ testRule(rule, {
   ruleName,
   config: [true],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [
     {
@@ -85,6 +86,7 @@ testRule(rule, {
   reject: [
     {
       code: " \n",
+      fixed: "\n",
       description: "no nodes with space before newline",
       message: messages.rejected,
       line: 1,
@@ -92,13 +94,23 @@ testRule(rule, {
     },
     {
       code: "/* foo  \nbar */ a { color: pink; }",
+      fixed: "/* foo\nbar */ a { color: pink; }",
       description: "eol-whitespace within a comment",
       message: messages.rejected,
       line: 1,
       column: 8
     },
     {
+      code: "/* \nfoo */ a { color: pink; }",
+      fixed: "/*\nfoo */ a { color: pink; }",
+      description: "eol-whitespace within a comment left",
+      message: messages.rejected,
+      line: 1,
+      column: 3
+    },
+    {
       code: "a, \nb {}",
+      fixed: "a,\nb {}",
       description: "selector delimiter with space before newline",
       message: messages.rejected,
       line: 1,
@@ -106,6 +118,7 @@ testRule(rule, {
     },
     {
       code: "a\t\n{}",
+      fixed: "a\n{}",
       description: "before opening brace with tab before newline",
       message: messages.rejected,
       line: 1,
@@ -113,6 +126,7 @@ testRule(rule, {
     },
     {
       code: "a { \n  color: pink; }",
+      fixed: "a {\n  color: pink; }",
       description: "after opening brace with space before and after newline",
       message: messages.rejected,
       line: 1,
@@ -120,6 +134,7 @@ testRule(rule, {
     },
     {
       code: "a { color: pink; \n}",
+      fixed: "a { color: pink;\n}",
       description: "before closing brace with space before newline",
       message: messages.rejected,
       line: 1,
@@ -127,6 +142,7 @@ testRule(rule, {
     },
     {
       code: "a { color: pink; }\t\nb { color: orange; }",
+      fixed: "a { color: pink; }\nb { color: orange; }",
       description: "after closing brace with tab before newline",
       message: messages.rejected,
       line: 1,
@@ -134,24 +150,28 @@ testRule(rule, {
     },
     {
       code: "a { color: pink; } \n\n\nb { color: orange; }",
+      fixed: "a { color: pink; }\n\n\nb { color: orange; }",
       message: messages.rejected,
       line: 1,
       column: 19
     },
     {
       code: "a { color: pink; }\n \n\nb { color: orange; }",
+      fixed: "a { color: pink; }\n\n\nb { color: orange; }",
       message: messages.rejected,
       line: 2,
       column: 1
     },
     {
       code: "a { color: pink; }\n\n \nb { color: orange; }",
+      fixed: "a { color: pink; }\n\n\nb { color: orange; }",
       message: messages.rejected,
       line: 3,
       column: 1
     },
     {
       code: "a { color: pink; \n  top: 0; }",
+      fixed: "a { color: pink;\n  top: 0; }",
       description:
         "between declarations with space before and two after newline",
       message: messages.rejected,
@@ -160,6 +180,7 @@ testRule(rule, {
     },
     {
       code: "a { color:\t\n\tpink; }",
+      fixed: "a { color:\n\tpink; }",
       description:
         "between properties and values with tab before and after newline",
       message: messages.rejected,
@@ -168,6 +189,7 @@ testRule(rule, {
     },
     {
       code: "a { background-position: top left, \ntop right; }",
+      fixed: "a { background-position: top left,\ntop right; }",
       description: "within values with space before newline",
       message: messages.rejected,
       line: 1,
@@ -175,6 +197,7 @@ testRule(rule, {
     },
     {
       code: "@media print, \nscreen {}",
+      fixed: "@media print,\nscreen {}",
       description: "within media query list with space before newline",
       message: messages.rejected,
       line: 1,
@@ -182,6 +205,7 @@ testRule(rule, {
     },
     {
       code: "@media print { \n  a { color: pink; } }",
+      fixed: "@media print {\n  a { color: pink; } }",
       description:
         "after opening brace of media query with space before and after newline",
       message: messages.rejected,
@@ -190,6 +214,7 @@ testRule(rule, {
     },
     {
       code: "a\t\r{}",
+      fixed: "a\r{}",
       description: "tab before carriage return before opening brace",
       message: messages.rejected,
       line: 1,
@@ -197,24 +222,28 @@ testRule(rule, {
     },
     {
       code: "a \n{\n\tcolor: pink;\n\ttop: 0;\n}",
+      fixed: "a\n{\n\tcolor: pink;\n\ttop: 0;\n}",
       message: messages.rejected,
       line: 1,
       column: 2
     },
     {
       code: "a\n{\t\n\tcolor: pink;\n\ttop: 0;\n}",
+      fixed: "a\n{\n\tcolor: pink;\n\ttop: 0;\n}",
       message: messages.rejected,
       line: 2,
       column: 2
     },
     {
       code: "a\n{\n\tcolor: pink; \n\ttop: 0;\n}",
+      fixed: "a\n{\n\tcolor: pink;\n\ttop: 0;\n}",
       message: messages.rejected,
       line: 3,
       column: 14
     },
     {
       code: "a\n{\n\tcolor: pink;\n\ttop: 0;  \n}",
+      fixed: "a\n{\n\tcolor: pink;\n\ttop: 0;\n}",
       message: messages.rejected,
       line: 4,
       column: 10
@@ -222,6 +251,8 @@ testRule(rule, {
     {
       code:
         "@media print { \n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 1,
       column: 15
@@ -229,6 +260,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n  a { \n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 2,
       column: 6
@@ -236,6 +269,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n  a {\n  color: pink; \n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 3,
       column: 15
@@ -243,6 +278,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n  a {\n  color: pink;\n  } \n}\n\n@media screen {\n  b { color: orange; }\n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 4,
       column: 4
@@ -250,6 +287,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n  a {\n  color: pink;\n  }\n} \n\n@media screen {\n  b { color: orange; }\n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 5,
       column: 2
@@ -257,6 +296,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n  a {\n  color: pink;\n  }\n}\n \n@media screen {\n  b { color: orange; }\n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 6,
       column: 1
@@ -264,6 +305,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen { \n  b { color: orange; }\n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 7,
       column: 16
@@ -271,9 +314,75 @@ testRule(rule, {
     {
       code:
         "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; } \n}",
+      fixed:
+        "@media print {\n  a {\n  color: pink;\n  }\n}\n\n@media screen {\n  b { color: orange; }\n}",
       message: messages.rejected,
       line: 8,
       column: 23
+    },
+    {
+      code: "a { color \n: \npink; }",
+      fixed: "a { color\n:\npink; }",
+      description: "between before and after newline",
+      message: messages.rejected,
+      line: 1,
+      column: 10
+    },
+    {
+      code: "a { padding: 0 \n0 \n0 \n0 \n; }",
+      fixed: "a { padding: 0\n0\n0\n0\n; }",
+      description: "values newline",
+      message: messages.rejected,
+      line: 1,
+      column: 15
+    },
+    {
+      code: "a { padding: 0 /* \n \n*/0 0 0; }",
+      fixed: "a { padding: 0 /*\n\n*/0 0 0; }",
+      description: "values comment newline",
+      message: messages.rejected,
+      line: 1,
+      column: 18
+    },
+    {
+      code: "a/* \n*/ \n.b { }",
+      fixed: "a/*\n*/\n.b { }",
+      description: "raws selector",
+      message: messages.rejected,
+      line: 1,
+      column: 4
+    },
+    {
+      code: "@media \n print {}",
+      fixed: "@media\n print {}",
+      description: "afterName",
+      message: messages.rejected,
+      line: 1,
+      column: 7
+    },
+    {
+      code: "@media/* \n*/ print {}",
+      fixed: "@media/*\n*/ print {}",
+      description: "afterName",
+      message: messages.rejected,
+      line: 1,
+      column: 9
+    },
+    {
+      code: "@media print, \nscreen {}",
+      fixed: "@media print,\nscreen {}",
+      description: "params",
+      message: messages.rejected,
+      line: 1,
+      column: 14
+    },
+    {
+      code: "@media print,/* \n*/screen {}",
+      fixed: "@media print,/*\n*/screen {}",
+      description: "raws params",
+      message: messages.rejected,
+      line: 1,
+      column: 16
     }
   ]
 });
@@ -282,6 +391,7 @@ testRule(rule, {
   ruleName,
   config: [true],
   syntax: "html",
+  fix: true,
 
   accept: [
     {
@@ -306,6 +416,14 @@ a {
 </style>
 
 </div>`,
+      fixed: `<div>
+<style>
+a {
+  color: red;
+}
+</style>
+
+</div>`,
       message: messages.rejected,
       line: 4,
       column: 14
@@ -317,6 +435,7 @@ testRule(rule, {
   ruleName,
   config: [true, { ignore: ["empty-lines"] }],
   skipBasicChecks: true,
+  fix: true,
 
   accept: [
     {
@@ -340,6 +459,7 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; \n}",
+      fixed: "a { color: pink;\n}",
       description: "typical rejection #1",
       message: messages.rejected,
       line: 1,
@@ -347,6 +467,7 @@ testRule(rule, {
     },
     {
       code: "a { color: pink; }\t\n",
+      fixed: "a { color: pink; }\n",
       description: "typical rejection #2",
       message: messages.rejected,
       line: 1,

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const whitespacesToReject = new Set([" ", "\t"]);
 
-const rule = function(on, options) {
+const rule = function(on, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(
       result,
@@ -39,41 +39,166 @@ const rule = function(on, options) {
     eachRoot(root, checkRoot);
 
     function checkRoot(root) {
-      const rootString = root.source.input.css;
+      if (context.fix) {
+        fix(root);
+      }
 
+      const rootString = context.fix ? root.toString() : root.source.input.css;
+
+      eachEolWhitespace(
+        rootString,
+        index => {
+          report({
+            message: messages.rejected,
+            node: root,
+            index,
+            result,
+            ruleName
+          });
+        },
+        true
+      );
+    }
+
+    /**
+     * Iterate each whitespace at the end of each line of the given string.
+     * @param {string} string the source code string
+     * @param {Function} callback callback the whitespace index at the end of each line.
+     * @param {boolean} isRootFirst set `true` if the given string is the first token of the root.
+     * @returns {void}
+     */
+    function eachEolWhitespace(string, callback, isRootFirst) {
       styleSearch(
         {
-          source: rootString,
+          source: string,
           target: ["\n", "\r"],
           comments: "check"
         },
         match => {
+          const eolWhitespaceIndex = match.startIndex - 1;
           // If the character before newline is not whitespace, ignore
-          if (!whitespacesToReject.has(rootString[match.startIndex - 1])) {
+          if (!whitespacesToReject.has(string[eolWhitespaceIndex])) {
             return;
           }
 
           if (optionsMatches(options, "ignore", "empty-lines")) {
             // If there is only whitespace between the previous newline and
             // this newline, ignore
-            const lineBefore = rootString.substring(
-              match.startIndex + 1,
-              rootString.lastIndexOf("\n", match.startIndex - 1)
+            const beforeNewlineIndex = string.lastIndexOf(
+              "\n",
+              eolWhitespaceIndex
             );
-            if (isOnlyWhitespace(lineBefore)) {
-              return;
+            if (beforeNewlineIndex >= 0 || isRootFirst) {
+              const line = string.substring(
+                beforeNewlineIndex,
+                eolWhitespaceIndex
+              );
+
+              if (isOnlyWhitespace(line)) {
+                return;
+              }
             }
           }
-
-          report({
-            message: messages.rejected,
-            node: root,
-            index: match.startIndex - 1,
-            result,
-            ruleName
-          });
+          callback(eolWhitespaceIndex);
         }
       );
+    }
+
+    function fix(root) {
+      let isRootFirst = true;
+      root.walk(node => {
+        fixText(
+          node.raws.before,
+          fixed => {
+            node.raws.before = fixed;
+          },
+          isRootFirst
+        );
+        isRootFirst = false;
+
+        // AtRule
+        fixText(node.raws.afterName, fixed => {
+          node.raws.afterName = fixed;
+        });
+        if (node.raws.params) {
+          fixText(node.raws.params.raw, fixed => {
+            node.raws.params.raw = fixed;
+          });
+        } else {
+          fixText(node.params, fixed => {
+            node.params = fixed;
+          });
+        }
+
+        // Rule
+        if (node.raws.selector) {
+          fixText(node.raws.selector.raw, fixed => {
+            node.raws.selector.raw = fixed;
+          });
+        } else {
+          fixText(node.selector, fixed => {
+            node.selector = fixed;
+          });
+        }
+
+        // AtRule or Rule or Decl
+        fixText(node.raws.between, fixed => {
+          node.raws.between = fixed;
+        });
+
+        // Decl
+        if (node.raws.value) {
+          fixText(node.raws.value.raw, fixed => {
+            node.raws.value.raw = fixed;
+          });
+        } else {
+          fixText(node.value, fixed => {
+            node.value = fixed;
+          });
+        }
+
+        // Comment
+        fixText(node.raws.left, fixed => {
+          node.raws.left = fixed;
+        });
+        fixText(node.text, fixed => {
+          node.text = fixed;
+        });
+
+        //
+        fixText(node.raws.after, fixed => {
+          node.raws.after = fixed;
+        });
+      });
+
+      fixText(
+        root.raws.after,
+        fixed => {
+          root.raws.after = fixed;
+        },
+        isRootFirst
+      );
+    }
+
+    function fixText(value, fix, isRootFirst) {
+      if (!value) {
+        return;
+      }
+      let fixed = "";
+      let lastIndex = 0;
+      eachEolWhitespace(
+        value,
+        index => {
+          const newlineIndex = index + 1;
+          fixed += value.slice(lastIndex, newlineIndex).replace(/[ \t]+$/, "");
+          lastIndex = newlineIndex;
+        },
+        isRootFirst
+      );
+      if (lastIndex) {
+        fixed += value.slice(lastIndex);
+        fix(fixed);
+      }
     }
   };
 };


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3608

> Is there anything in the PR that needs further explanation?

if use the `--fix` option, to remove whitespace at the end of each line.

ex.

code:
```css
a { color: pink; }····
```
fixed:
```css
a { color: pink; }
```
