### PR TITLE
Add autofix to value-list-comma-newline-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -248,7 +248,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 #### Value list
 
--   [`value-list-comma-newline-after`](../../lib/rules/value-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of value lists.
+-   [`value-list-comma-newline-after`](../../lib/rules/value-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of value lists (Autofixable).
 -   [`value-list-comma-newline-before`](../../lib/rules/value-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of value lists.
 -   [`value-list-comma-space-after`](../../lib/rules/value-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of value lists (Autofixable).
 -   [`value-list-comma-space-before`](../../lib/rules/value-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of value lists (Autofixable).

--- a/lib/rules/value-list-comma-newline-after/README.md
+++ b/lib/rules/value-list-comma-newline-after/README.md
@@ -9,6 +9,8 @@ a { background-size: 0,
  * The newline after these commas */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix most of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/lib/rules/value-list-comma-newline-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -42,18 +43,21 @@ testRule(rule, {
   reject: [
     {
       code: "a { background-size: 0, 0; }",
+      fixed: "a { background-size: 0,\n0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 23
     },
     {
       code: "a { background-size: 0,  0; }",
+      fixed: "a { background-size: 0,\n 0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 23
     },
     {
       code: "a { background-size: 0,\t0; }",
+      fixed: "a { background-size: 0,\t\n0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 23
@@ -64,6 +68,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -93,24 +98,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { background-size: 0,\n0, 0; }",
+      fixed: "a { background-size: 0,\n0,\n0; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 2
     },
     {
       code: "a { background-size: 0,\n0,  0; }",
+      fixed: "a { background-size: 0,\n0,\n 0; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 2
     },
     {
       code: "a { background-size: 0,\n0,\t0; }",
+      fixed: "a { background-size: 0,\n0,\t\n0; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 2
     },
     {
       code: "a { background-size: 0,\r\n0,\t0; }",
+      fixed: "a { background-size: 0,\r\n0,\t\n0; }",
       description: "CRLF",
       message: messages.expectedAfterMultiLine(),
       line: 2,
@@ -122,6 +131,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -148,18 +158,21 @@ testRule(rule, {
   reject: [
     {
       code: "a { background-size: 0\n,0\n, 0; }",
+      fixed: "a { background-size: 0\n,0\n,0; }",
       message: messages.rejectedAfterMultiLine(),
       line: 3,
       column: 1
     },
     {
       code: "a { background-size: 0\n,0\n,  0; }",
+      fixed: "a { background-size: 0\n,0\n,0; }",
       message: messages.rejectedAfterMultiLine(),
       line: 3,
       column: 1
     },
     {
       code: "a { background-size: 0\r\n,0\r\n,  0; }",
+      fixed: "a { background-size: 0\r\n,0\r\n,0; }",
       description: "CRLF",
       message: messages.rejectedAfterMultiLine(),
       line: 3,
@@ -167,6 +180,7 @@ testRule(rule, {
     },
     {
       code: "a { background-size: 0\n,0\n,\t0; }",
+      fixed: "a { background-size: 0\n,0\n,0; }",
       message: messages.rejectedAfterMultiLine(),
       line: 3,
       column: 1

--- a/lib/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/lib/rules/value-list-comma-newline-after/__tests__/index.js
@@ -119,7 +119,7 @@ testRule(rule, {
     },
     {
       code: "a { background-size: 0,\r\n0,\t0; }",
-      fixed: "a { background-size: 0,\r\n0,\n\t0; }",
+      fixed: "a { background-size: 0,\r\n0,\r\n\t0; }",
       description: "CRLF",
       message: messages.expectedAfterMultiLine(),
       line: 2,

--- a/lib/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/lib/rules/value-list-comma-newline-after/__tests__/index.js
@@ -43,21 +43,21 @@ testRule(rule, {
   reject: [
     {
       code: "a { background-size: 0, 0; }",
-      fixed: "a { background-size: 0,\n0; }",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 23
-    },
-    {
-      code: "a { background-size: 0,  0; }",
       fixed: "a { background-size: 0,\n 0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 23
     },
     {
+      code: "a { background-size: 0,  0; }",
+      fixed: "a { background-size: 0,\n  0; }",
+      message: messages.expectedAfter(),
+      line: 1,
+      column: 23
+    },
+    {
       code: "a { background-size: 0,\t0; }",
-      fixed: "a { background-size: 0,\t\n0; }",
+      fixed: "a { background-size: 0,\n\t0; }",
       message: messages.expectedAfter(),
       line: 1,
       column: 23
@@ -98,28 +98,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { background-size: 0,\n0, 0; }",
-      fixed: "a { background-size: 0,\n0,\n0; }",
-      message: messages.expectedAfterMultiLine(),
-      line: 2,
-      column: 2
-    },
-    {
-      code: "a { background-size: 0,\n0,  0; }",
       fixed: "a { background-size: 0,\n0,\n 0; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 2
     },
     {
+      code: "a { background-size: 0,\n0,  0; }",
+      fixed: "a { background-size: 0,\n0,\n  0; }",
+      message: messages.expectedAfterMultiLine(),
+      line: 2,
+      column: 2
+    },
+    {
       code: "a { background-size: 0,\n0,\t0; }",
-      fixed: "a { background-size: 0,\n0,\t\n0; }",
+      fixed: "a { background-size: 0,\n0,\n\t0; }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 2
     },
     {
       code: "a { background-size: 0,\r\n0,\t0; }",
-      fixed: "a { background-size: 0,\r\n0,\t\n0; }",
+      fixed: "a { background-size: 0,\r\n0,\n\t0; }",
       description: "CRLF",
       message: messages.expectedAfterMultiLine(),
       line: 2,

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -58,7 +58,7 @@ const rule = function(expectation, options, context) {
             const beforeValue = value.slice(0, valueIndex + 1);
             let afterValue = value.slice(valueIndex + 1);
             if (expectation.indexOf("always") === 0) {
-              afterValue = afterValue.replace(/^\s*/, context.newline);
+              afterValue = context.newline + afterValue;
             } else if (expectation.indexOf("never-multi-line") === 0) {
               afterValue = afterValue.replace(/^\s*/, "");
             }

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -50,7 +50,7 @@ const rule = function(expectation, options, context) {
     if (fixData) {
       fixData.forEach((commaIndices, decl) => {
         commaIndices
-          .sort()
+          .sort((a, b) => a - b)
           .reverse()
           .forEach(index => {
             const value = decl.raws.value ? decl.raws.value.raw : decl.value;

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const declarationValueIndex = require("../../utils/declarationValueIndex");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
 const valueListCommaWhitespaceChecker = require("../valueListCommaWhitespaceChecker");
@@ -15,7 +16,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace after "," in a multi-line list'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("newline", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -26,12 +27,49 @@ const rule = function(expectation) {
       return;
     }
 
+    let fixData;
     valueListCommaWhitespaceChecker({
       root,
       result,
       locationChecker: checker.afterOneOnly,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (declNode, index) => {
+            const valueIndex = declarationValueIndex(declNode);
+            if (index <= valueIndex) {
+              return false;
+            }
+            fixData = fixData || new Map();
+            const commaIndices = fixData.get(declNode) || [];
+            commaIndices.push(index);
+            fixData.set(declNode, commaIndices);
+            return true;
+          }
+        : null
     });
+    if (fixData) {
+      fixData.forEach((commaIndices, decl) => {
+        commaIndices
+          .sort()
+          .reverse()
+          .forEach(index => {
+            const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+            const valueIndex = index - declarationValueIndex(decl);
+            const beforeValue = value.slice(0, valueIndex + 1);
+            let afterValue = value.slice(valueIndex + 1);
+            if (expectation.indexOf("always") === 0) {
+              afterValue = afterValue.replace(/^\s*/, context.newline);
+            } else if (expectation.indexOf("never-multi-line") === 0) {
+              afterValue = afterValue.replace(/^\s*/, "");
+            }
+            if (decl.raws.value) {
+              decl.raws.value.raw = beforeValue + afterValue;
+            } else {
+              decl.value = beforeValue + afterValue;
+            }
+          });
+      });
+    }
   };
 };
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #3595

> Is there anything in the PR that needs further explanation?

ex.


- option: always***

 code:

 ```css
 a { background-size: 0,0; }
 ```
 fixed:

 ```css
 a { background-size: 0,
      0; }
 ```
- option: never-multi-line

 code:
 ```css
 a { background-size: 0
       , 0; }
 ```

 fixed:
 ```css
 a { background-size: 0
      ,0; }
 ```