### PR TITLE
Add autofix to block-closing-brace-empty-line-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -281,7 +281,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 #### Block
 
--   [`block-closing-brace-empty-line-before`](../../lib/rules/block-closing-brace-empty-line-before/README.md): Require or disallow an empty line before the closing brace of blocks.
+-   [`block-closing-brace-empty-line-before`](../../lib/rules/block-closing-brace-empty-line-before/README.md): Require or disallow an empty line before the closing brace of blocks (Autofixable).
 -   [`block-closing-brace-newline-after`](../../lib/rules/block-closing-brace-newline-after/README.md): Require a newline or disallow whitespace after the closing brace of blocks (Autofixable).
 -   [`block-closing-brace-newline-before`](../../lib/rules/block-closing-brace-newline-before/README.md): Require a newline or disallow whitespace before the closing brace of blocks (Autofixable).
 -   [`block-closing-brace-space-after`](../../lib/rules/block-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of blocks.

--- a/lib/rules/block-closing-brace-empty-line-before/README.md
+++ b/lib/rules/block-closing-brace-empty-line-before/README.md
@@ -11,6 +11,8 @@ a {
  * This line */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always-multi-line"|"never"`

--- a/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -51,51 +52,82 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\n}",
+      fixed: "a { color: pink;\n\n}",
       message: messages.expected,
       line: 2,
       column: 1
     },
     {
       code: "a { color: pink;\r\n}",
+      fixed: "a { color: pink;\r\n\r\n}",
       message: messages.expected,
       line: 2,
       column: 1
     },
     {
       code: "a { color: pink;\n }",
+      fixed: "a { color: pink;\n\n }",
       message: messages.expected,
       line: 2,
       column: 2
     },
     {
       code: "a { color: pink;\n\t}",
+      fixed: "a { color: pink;\n\n\t}",
       message: messages.expected,
       line: 2,
       column: 2
     },
     {
       code: "a { color: pink;\r\n  }",
+      fixed: "a { color: pink;\r\n\r\n  }",
       message: messages.expected,
       line: 2,
       column: 3
     },
     {
       code: "a { color: pink;\n;}",
+      fixed: "a { color: pink;\n;\n\n}",
       message: messages.expected,
       line: 2,
       column: 2
     },
     {
       code: "a {\ncolor: pink;\n}",
+      fixed: "a {\ncolor: pink;\n\n}",
       message: messages.expected,
       line: 3,
       column: 1
     },
     {
       code: "a {\n\ncolor: pink;\n}",
+      fixed: "a {\n\ncolor: pink;\n\n}",
       message: messages.expected,
       line: 4,
       column: 1
+    },
+    {
+      code: "a { color: pink;\n\n/* comment here*/\n}",
+      fixed: "a { color: pink;\n\n/* comment here*/\n\n}",
+      message: messages.expected,
+      line: 4,
+      column: 1
+    },
+    {
+      code: "a { color: pink;\r\n\r\n/* comment here*/\r\n}",
+      fixed: "a { color: pink;\r\n\r\n/* comment here*/\r\n\r\n}",
+      message: messages.expected,
+      line: 4,
+      column: 1
+    },
+    {
+      code:
+        "@media print {\n  a {\n     color: pink;\n/* comment here*/\n  }\n}",
+      fixed:
+        "@media print {\n  a {\n     color: pink;\n/* comment here*/\n\n  }\n\n}",
+      message: messages.expected,
+      line: 5,
+      column: 3
     }
   ]
 });
@@ -103,6 +135,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -144,50 +177,72 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\n\n}",
+      fixed: "a { color: pink;\n}",
       message: messages.rejected,
       line: 3,
       column: 1
     },
     {
       code: "a { color: pink;\r\n\r\n}",
+      fixed: "a { color: pink;\r\n}",
       message: messages.rejected,
       line: 3,
       column: 1
     },
     {
       code: "a { color: pink;\n\n }",
+      fixed: "a { color: pink;\n }",
       message: messages.rejected,
       line: 3,
       column: 2
     },
     {
       code: "a { color: pink;\n\n\t}",
+      fixed: "a { color: pink;\n\t}",
       message: messages.rejected,
       line: 3,
       column: 2
     },
     {
       code: "a { color: pink;\r\n\r\n  }",
+      fixed: "a { color: pink;\r\n  }",
       message: messages.rejected,
       line: 3,
       column: 3
     },
     {
       code: "a { color: pink;\n\n;}",
+      fixed: "a { color: pink;\n;}",
       message: messages.rejected,
       line: 3,
       column: 2
     },
     {
       code: "a {\ncolor: pink;\n\n}",
+      fixed: "a {\ncolor: pink;\n}",
       message: messages.rejected,
       line: 4,
       column: 1
     },
     {
       code: "a {\n\ncolor: pink;\n\n}",
+      fixed: "a {\n\ncolor: pink;\n}",
       message: messages.rejected,
       line: 5,
+      column: 1
+    },
+    {
+      code: "@media print {\n  a {\n     color: pink;\n\n  }\n\n}",
+      fixed: "@media print {\n  a {\n     color: pink;\n  }\n}",
+      message: messages.rejected,
+      line: 5,
+      column: 3
+    },
+    {
+      code: "a {\n\ncolor: pink;\n\n/* comment here */\n\n}",
+      fixed: "a {\n\ncolor: pink;\n\n/* comment here */\n}",
+      message: messages.rejected,
+      line: 7,
       column: 1
     }
   ]
@@ -196,6 +251,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never", { except: ["after-closing-brace"] }],
+  fix: true,
 
   accept: [
     {
@@ -220,12 +276,14 @@ testRule(rule, {
   reject: [
     {
       code: "a {\n\tcolor: aquamarine;\n\n}",
+      fixed: "a {\n\tcolor: aquamarine;\n}",
       message: messages.rejected,
       line: 4,
       column: 1
     },
     {
       code: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n}",
+      fixed: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n}",
       message: messages.expected,
       line: 6,
       column: 1
@@ -233,6 +291,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n}",
+      fixed:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n\n}",
       message: messages.expected,
       line: 10,
       column: 1
@@ -240,6 +300,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n}",
+      fixed:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n\n}",
       message: messages.rejected,
       line: 10,
       column: 2
@@ -247,12 +309,15 @@ testRule(rule, {
     {
       code:
         "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n}",
+      fixed:
+        "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n}",
       message: messages.expected,
       line: 6,
       column: 1
     },
     {
       code: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\t}\n}",
+      fixed: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\t}\n\n}",
       message: messages.expected,
       line: 6,
       column: 1
@@ -263,6 +328,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line", { except: ["after-closing-brace"] }],
+  fix: true,
 
   accept: [
     {
@@ -290,12 +356,14 @@ testRule(rule, {
   reject: [
     {
       code: "a {\n\tcolor: aquamarine;\n}",
+      fixed: "a {\n\tcolor: aquamarine;\n\n}",
       message: messages.expected,
       line: 3,
       column: 1
     },
     {
       code: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n}",
+      fixed: "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n}",
       message: messages.rejected,
       line: 8,
       column: 1
@@ -303,6 +371,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n\n}",
+      fixed:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n}",
       message: messages.rejected,
       line: 13,
       column: 1
@@ -310,6 +380,8 @@ testRule(rule, {
     {
       code:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n\n}",
+      fixed:
+        "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n}",
       message: messages.rejected,
       line: 13,
       column: 1
@@ -317,12 +389,15 @@ testRule(rule, {
     {
       code:
         "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n\n}",
+      fixed:
+        "@supports (animation-name: test) {\n\n\ta {\n\t\tcolor: aquamarine;\n\n\t}\n}",
       message: messages.rejected,
       line: 8,
       column: 1
     },
     {
       code: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\n\t}\n\n}",
+      fixed: "@keyframes test {\n\n\t100% {\n\t\tcolor: aquamarine;\n\n\t}\n}",
       message: messages.rejected,
       line: 8,
       column: 1

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -1,11 +1,13 @@
 "use strict";
 
+const addEmptyLineAfter = require("../../utils/addEmptyLineAfter");
 const blockString = require("../../utils/blockString");
 const hasBlock = require("../../utils/hasBlock");
 const hasEmptyBlock = require("../../utils/hasEmptyBlock");
 const hasEmptyLine = require("../../utils/hasEmptyLine");
 const isSingleLineString = require("../../utils/isSingleLineString");
 const optionsMatches = require("../../utils/optionsMatches");
+const removeEmptyLineAfter = require("../../utils/removeEmptyLinesAfter");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -17,7 +19,7 @@ const messages = ruleMessages(ruleName, {
   rejected: "Unexpected empty line before closing brace"
 });
 
-const rule = function(expectation, options) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(
       result,
@@ -84,6 +86,15 @@ const rule = function(expectation, options) {
 
       // Return if the expectation is met
       if (expectEmptyLineBefore === hasEmptyLineBefore) {
+        return;
+      }
+
+      if (context.fix) {
+        if (expectEmptyLineBefore) {
+          addEmptyLineAfter(statement, context.newline);
+        } else {
+          removeEmptyLineAfter(statement, context.newline);
+        }
         return;
       }
 

--- a/lib/utils/__tests__/addEmptyLineAfter.test.js
+++ b/lib/utils/__tests__/addEmptyLineAfter.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const addEmptyLineAfter = require("../addEmptyLineAfter");
+const postcss = require("postcss");
+
+describe("addEmptyLineBefore", () => {
+  it("adds single newline to the newline at the beginning", () => {
+    expect(run("a {\n}", "\n")).toBe("a {\n\n}");
+  });
+
+  it("adds single newline to newline at the beginning with CRLF", () => {
+    expect(run("a {\r\n}", "\r\n")).toBe("a {\r\n\r\n}");
+  });
+
+  it("adds single newline to newline at the end", () => {
+    expect(run("a {\t\n}", "\n")).toBe("a {\t\n\n}");
+  });
+
+  it("adds single newline to newline at the end with CRLF", () => {
+    expect(run("a {\t\r\n}", "\r\n")).toBe("a {\t\r\n\r\n}");
+  });
+
+  it("adds single newline to newline in the middle", () => {
+    expect(run("a {  \n\t}", "\n")).toBe("a {  \n\n\t}");
+  });
+
+  it("adds single newline to newline in the middle with CRLF", () => {
+    expect(run("a {  \r\n\t}", "\r\n")).toBe("a {  \r\n\r\n\t}");
+  });
+
+  it("adds two newlines if there aren't any existing newlines", () => {
+    expect(run("a {  }", "\n")).toBe("a {  \n\n}");
+  });
+
+  it("adds two newlines if there aren't any existing newlines with CRLF", () => {
+    expect(run("a {  }", "\r\n")).toBe("a {  \r\n\r\n}");
+  });
+
+  it("adds two newlines if there aren't any newlines after semicolon", () => {
+    expect(run("a {\n;}", "\n")).toBe("a {\n;\n\n}");
+  });
+
+  it("adds two newlines if there aren't any newlines after semicolon with CRLF", () => {
+    expect(run("a {\r\n;}", "\r\n")).toBe("a {\r\n;\r\n\r\n}");
+  });
+});
+
+function run(css, lineEnding) {
+  const root = postcss.parse(css);
+
+  addEmptyLineAfter(root.nodes[0], lineEnding);
+
+  return root.toString();
+}

--- a/lib/utils/__tests__/removeEmptyLineAfter.test.js
+++ b/lib/utils/__tests__/removeEmptyLineAfter.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const postcss = require("postcss");
+const removeEmptyLinesAfter = require("../removeEmptyLinesAfter");
+
+describe("removeEmptyLineBefore", () => {
+  it("removes single newline from the newline at the beginning", () => {
+    expect(run("a {\n\n  }", "\n")).toBe("a {\n  }");
+  });
+
+  it("removes single newline from newline at the beginning with CRLF", () => {
+    expect(run("a {\r\n\r\n  }", "\r\n")).toBe("a {\r\n  }");
+  });
+
+  it("removes single newline from newline at the end", () => {
+    expect(run("a {\t\n\n}", "\n")).toBe("a {\t\n}");
+  });
+
+  it("removes single newline from newline at the end with CRLF", () => {
+    expect(run("a {\t\r\n\r\n}", "\r\n")).toBe("a {\t\r\n}");
+  });
+
+  it("removes single newline from newline in the middle", () => {
+    expect(run("a {  \n\n\t}", "\n")).toBe("a {  \n\t}");
+  });
+
+  it("removes single newline to newline in the middle with CRLF", () => {
+    expect(run("a {  \r\n\r\n\t}", "\r\n")).toBe("a {  \r\n\t}");
+  });
+
+  it("removes two newlines if there are three newlines", () => {
+    expect(run("a {\n\n\n  }", "\n")).toBe("a {\n  }");
+  });
+
+  it("removes two newlines if there are three newlines with CRLF", () => {
+    expect(run("a {\r\n\r\n\r\n  }", "\r\n")).toBe("a {\r\n  }");
+  });
+
+  it("removes three newlines if there are four newlines", () => {
+    expect(run("a {\n\n\n\n  }", "\n")).toBe("a {\n  }");
+  });
+
+  it("removes three newlines if there are four newlines with CRLF", () => {
+    expect(run("a {\r\n\r\n\r\n\r\n  }", "\r\n")).toBe("a {\r\n  }");
+  });
+});
+
+function run(css, lineEnding) {
+  const root = postcss.parse(css);
+
+  removeEmptyLinesAfter(root.nodes[0], lineEnding);
+
+  return root.toString();
+}

--- a/lib/utils/addEmptyLineAfter.js
+++ b/lib/utils/addEmptyLineAfter.js
@@ -1,0 +1,20 @@
+/* @flow */
+"use strict";
+
+const _ = require("lodash");
+
+// Add an empty line after a node. Mutates the node.
+function addEmptyLineAfter(
+  node /*: postcss$node*/,
+  newline /*: '\n' | '\r\n'*/
+) /*: postcss$node*/ {
+  const after = _.last(node.raws.after.split(";"));
+  if (!/\r?\n/.test(after)) {
+    node.raws.after = node.raws.after + _.repeat(newline, 2);
+  } else {
+    node.raws.after = node.raws.after.replace(/(\r?\n)/, `${newline}$1`);
+  }
+  return node;
+}
+
+module.exports = addEmptyLineAfter;

--- a/lib/utils/addEmptyLineBefore.js
+++ b/lib/utils/addEmptyLineBefore.js
@@ -10,10 +10,6 @@ function addEmptyLineBefore(
 ) /*: postcss$node*/ {
   if (!/\r?\n/.test(node.raws.before)) {
     node.raws.before = _.repeat(newline, 2) + node.raws.before;
-  } else if (/^\r?\n/.test(node.raws.before)) {
-    node.raws.before = newline + node.raws.before;
-  } else if (/\r?\n$/.test(node.raws.before)) {
-    node.raws.before = node.raws.before + newline;
   } else {
     node.raws.before = node.raws.before.replace(/(\r?\n)/, `${newline}$1`);
   }

--- a/lib/utils/removeEmptyLinesAfter.js
+++ b/lib/utils/removeEmptyLinesAfter.js
@@ -1,0 +1,14 @@
+/* @flow */
+"use strict";
+
+// Remove empty lines before a node. Mutates the node.
+function removeEmptyLinesAfter(
+  node /*: postcss$node*/,
+  newline /*: '\n' | '\r\n'*/
+) /*: postcss$node*/ {
+  node.raws.after = node.raws.after.replace(/(\r?\n\s*\r?\n)+/g, newline);
+
+  return node;
+}
+
+module.exports = removeEmptyLinesAfter;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #3614 

> Is there anything in the PR that needs further explanation?

ex.
- option: `always-multi-line`  

   code:  
   ```css
   a {
     color: pink;
   }
   ```
   fixed:  
   ```css
   a {
     color: pink;
   
   }
   ```

- option: `never`  

   code:  
   ```css
   a {
     color: pink;

   }
   ```
   fixed:  
   ```css
   a {
     color: pink;   
   }
   ```

- option: `["never", { except: ["after-closing-brace"] }]`  

   code:  
   ```css
   @media print {

     a {
       color: aquamarine;
     }

     b {
       color: hotpink;
     }
   }
   ```
   fixed:  
   ```css
   @media print {

     a {
       color: aquamarine;
     }

     b {
       color: hotpink;
     }

   }
   ```

- option: `["always-multi-line", { except: ["after-closing-brace"] }]`  

   code:  
   ```css
   @media print {

     a {
       color: aquamarine;

     }

     b {
       color: hotpink;

     }

   }
   ```
   fixed:  
   ```css
   @media print {

     a {
       color: aquamarine;

     }

     b {
       color: hotpink;

     }
   }
   ```