### PR TITLE
Add autofix to media-feature-range-operator-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -324,7 +324,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`media-feature-name-case`](../../lib/rules/media-feature-name-case/README.md): Specify lowercase or uppercase for media feature names.
 -   [`media-feature-parentheses-space-inside`](../../lib/rules/media-feature-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within media features.
 -   [`media-feature-range-operator-space-after`](../../lib/rules/media-feature-range-operator-space-after/README.md): Require a single space or disallow whitespace after the range operator in media features.
--   [`media-feature-range-operator-space-before`](../../lib/rules/media-feature-range-operator-space-before/README.md): Require a single space or disallow whitespace before the range operator in media features.
+-   [`media-feature-range-operator-space-before`](../../lib/rules/media-feature-range-operator-space-before/README.md): Require a single space or disallow whitespace before the range operator in media features (Autofixable).
 
 #### Media query list
 

--- a/lib/rules/findMediaOperator.js
+++ b/lib/rules/findMediaOperator.js
@@ -1,15 +1,20 @@
 "use strict";
 
-const rangeOperatorRegex = /[^><](>=?|<=?|=)/g;
+const rangeOperators = [">=", "<=", ">", "<", "="];
+const styleSearch = require("style-search");
 
 module.exports = function(atRule, cb) {
   if (atRule.name.toLowerCase() !== "media") {
     return;
   }
 
-  const params = atRule.params;
-  let match;
-  while ((match = rangeOperatorRegex.exec(params)) !== null) {
+  const params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
+
+  styleSearch({ source: params, target: rangeOperators }, match => {
+    const before = params[match.startIndex - 1];
+    if (before === ">" || before === "<") {
+      return;
+    }
     cb(match, params, atRule);
-  }
+  });
 };

--- a/lib/rules/media-feature-range-operator-space-after/__tests__/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/__tests__/index.js
@@ -22,6 +22,15 @@ testRule(rule, {
     },
     {
       code: "@media (width>= 600px) and (width<= 3em) {}"
+    },
+    {
+      code: "@media /*(width>=600px) and*/ (width <= 3em) {}"
+    },
+    {
+      code: "@media (width >= 600px) /*and (width<3em)*/ {}"
+    },
+    {
+      code: "@media (width >= /*>*/ 600px) {}"
     }
   ],
 
@@ -103,6 +112,15 @@ testRule(rule, {
     },
     {
       code: "@media (width >=600px) and (width <=3em) {}"
+    },
+    {
+      code: "@media /*(width >= 600px) and*/ (width<=3em) {}"
+    },
+    {
+      code: "@media (width>=600px) /*and (width < 3em)*/ {}"
+    },
+    {
+      code: "@media (width>=/* > */ 600px) {}"
     }
   ],
 

--- a/lib/rules/media-feature-range-operator-space-after/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/index.js
@@ -30,7 +30,7 @@ const rule = function(expectation) {
     });
 
     function checkAfterOperator(match, params, node) {
-      const endIndex = match.index + match[1].length;
+      const endIndex = match.startIndex + match.target.length - 1;
 
       checker.after({
         source: params,

--- a/lib/rules/media-feature-range-operator-space-before/README.md
+++ b/lib/rules/media-feature-range-operator-space-before/README.md
@@ -8,6 +8,8 @@ Require a single space or disallow whitespace before the range operator in media
  * The space before this */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/media-feature-range-operator-space-before/__tests__/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -22,48 +23,64 @@ testRule(rule, {
     },
     {
       code: "@media (width >= 600px) and (width <= 3em) {}"
+    },
+    {
+      code: "@media /*(width>=600px) and*/ (width <= 3em) {}"
+    },
+    {
+      code: "@media (width >= 600px) /*and (width<=3em)*/ {}"
+    },
+    {
+      code: "@media (width >= /*>*/ 600px) {}"
     }
   ],
 
   reject: [
     {
       code: "@media (width< 600px) {}",
+      fixed: "@media (width < 600px) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 13
     },
     {
       code: "@mEdIa (width< 600px) {}",
+      fixed: "@mEdIa (width < 600px) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 13
     },
     {
       code: "@MEDIA (width< 600px) {}",
+      fixed: "@MEDIA (width < 600px) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 13
     },
     {
       code: "@media (width  <= 600px) {}",
+      fixed: "@media (width <= 600px) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 15
     },
     {
       code: "@media (width\t= 600px) {}",
+      fixed: "@media (width = 600px) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 14
     },
     {
       code: "@media (width\n> 600px) {}",
+      fixed: "@media (width > 600px) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 14
     },
     {
       code: "@media (width\r\n> 600px) {}",
+      fixed: "@media (width > 600px) {}",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 1,
@@ -71,15 +88,31 @@ testRule(rule, {
     },
     {
       code: "@media (width>= 600px) and (width < 3em) {}",
+      fixed: "@media (width >= 600px) and (width < 3em) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 13
     },
     {
       code: "@media (width > 600px) and (width= 3em) {}",
+      fixed: "@media (width > 600px) and (width = 3em) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 33
+    },
+    {
+      code: "@media (width> 600px) and (width= 3em) {}",
+      fixed: "@media (width > 600px) and (width = 3em) {}",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 13
+    },
+    {
+      code: "@media (width/**/< 600px) {}",
+      fixed: "@media (width/**/ < 600px) {}",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 17
     }
   ]
 });
@@ -87,6 +120,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -103,48 +137,64 @@ testRule(rule, {
     },
     {
       code: "@media (width>= 600px) and (width<= 3em) {}"
+    },
+    {
+      code: "@media /*(width >= 600px) and*/ (width<= 3em) {}"
+    },
+    {
+      code: "@media (width>= 600px) /*and (width <= 3em)*/ {}"
+    },
+    {
+      code: "@media (width>= /* > */ 600px) {}"
     }
   ],
 
   reject: [
     {
       code: "@media (width < 600px) {}",
+      fixed: "@media (width< 600px) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 14
     },
     {
       code: "@mEdIa (width < 600px) {}",
+      fixed: "@mEdIa (width< 600px) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 14
     },
     {
       code: "@MEDIA (width < 600px) {}",
+      fixed: "@MEDIA (width< 600px) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 14
     },
     {
       code: "@media (width  <= 600px) {}",
+      fixed: "@media (width<= 600px) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 15
     },
     {
       code: "@media (width\t= 600px) {}",
+      fixed: "@media (width= 600px) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 14
     },
     {
       code: "@media (width\n> 600px) {}",
+      fixed: "@media (width> 600px) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 14
     },
     {
       code: "@media (width\r\n> 600px) {}",
+      fixed: "@media (width> 600px) {}",
       description: "CRLF",
       message: messages.rejectedBefore(),
       line: 1,
@@ -152,15 +202,31 @@ testRule(rule, {
     },
     {
       code: "@media (width>= 600px) and (width < 3em) {}",
+      fixed: "@media (width>= 600px) and (width< 3em) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 34
     },
     {
       code: "@media (width > 600px) and (width= 3em) {}",
+      fixed: "@media (width> 600px) and (width= 3em) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 14
+    },
+    {
+      code: "@media (width >= 600px) and (width < 3em) {}",
+      fixed: "@media (width>= 600px) and (width< 3em) {}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 14
+    },
+    {
+      code: "@media (width /**/ = 600px) {}",
+      fixed: "@media (width /**/= 600px) {}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 19
     }
   ]
 });

--- a/lib/rules/media-feature-range-operator-space-before/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/index.js
@@ -27,53 +27,53 @@ const rule = function(expectation, options, context) {
 
     root.walkAtRules(/^media$/i, atRule => {
       const fixOperatorIndices = [];
-      findMediaOperator(atRule, checkBeforeOperator);
+      const fix = context.fix ? index => fixOperatorIndices.push(index) : null;
+      findMediaOperator(atRule, (match, params, node) => {
+        checkBeforeOperator(match, params, node, fix);
+      });
 
       if (fixOperatorIndices.length) {
         let params = atRule.raws.params
           ? atRule.raws.params.raw
           : atRule.params;
-        fixOperatorIndices
-          .sort((a, b) => a - b)
-          .reverse()
-          .forEach(index => {
-            const beforeOperator = params.slice(0, index);
-            const afterOperator = params.slice(index);
-            if (expectation === "always") {
-              params = beforeOperator.replace(/\s*$/, " ") + afterOperator;
-            } else if (expectation === "never") {
-              params = beforeOperator.replace(/\s*$/, "") + afterOperator;
-            }
-          });
+        fixOperatorIndices.sort((a, b) => b - a).forEach(index => {
+          const beforeOperator = params.slice(0, index);
+          const afterOperator = params.slice(index);
+          if (expectation === "always") {
+            params = beforeOperator.replace(/\s*$/, " ") + afterOperator;
+          } else if (expectation === "never") {
+            params = beforeOperator.replace(/\s*$/, "") + afterOperator;
+          }
+        });
         if (atRule.raws.params) {
           atRule.raws.params.raw = params;
         } else {
           atRule.params = params;
         }
       }
-
-      function checkBeforeOperator(match, params, node) {
-        // The extra `+ 1` is because the match itself contains
-        // the character before the operator
-        checker.before({
-          source: params,
-          index: match.startIndex,
-          err: m => {
-            if (context.fix) {
-              fixOperatorIndices.push(match.startIndex);
-              return;
-            }
-            report({
-              message: m,
-              node,
-              index: match.startIndex - 1 + atRuleParamIndex(node),
-              result,
-              ruleName
-            });
-          }
-        });
-      }
     });
+
+    function checkBeforeOperator(match, params, node, fix) {
+      // The extra `+ 1` is because the match itself contains
+      // the character before the operator
+      checker.before({
+        source: params,
+        index: match.startIndex,
+        err: m => {
+          if (fix) {
+            fix(match.startIndex);
+            return;
+          }
+          report({
+            message: m,
+            node,
+            index: match.startIndex - 1 + atRuleParamIndex(node),
+            result,
+            ruleName
+          });
+        }
+      });
+    }
   };
 };
 

--- a/lib/rules/media-feature-range-operator-space-before/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
   rejectedBefore: () => "Unexpected whitespace before range operator"
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -26,26 +26,54 @@ const rule = function(expectation) {
     }
 
     root.walkAtRules(/^media$/i, atRule => {
+      const fixOperatorIndices = [];
       findMediaOperator(atRule, checkBeforeOperator);
-    });
 
-    function checkBeforeOperator(match, params, node) {
-      // The extra `+ 1` is because the match itself contains
-      // the character before the operator
-      checker.before({
-        source: params,
-        index: match.index + 1,
-        err: m => {
-          report({
-            message: m,
-            node,
-            index: match.index + atRuleParamIndex(node),
-            result,
-            ruleName
+      if (fixOperatorIndices.length) {
+        let params = atRule.raws.params
+          ? atRule.raws.params.raw
+          : atRule.params;
+        fixOperatorIndices
+          .sort((a, b) => a - b)
+          .reverse()
+          .forEach(index => {
+            const beforeOperator = params.slice(0, index);
+            const afterOperator = params.slice(index);
+            if (expectation === "always") {
+              params = beforeOperator.replace(/\s*$/, " ") + afterOperator;
+            } else if (expectation === "never") {
+              params = beforeOperator.replace(/\s*$/, "") + afterOperator;
+            }
           });
+        if (atRule.raws.params) {
+          atRule.raws.params.raw = params;
+        } else {
+          atRule.params = params;
         }
-      });
-    }
+      }
+
+      function checkBeforeOperator(match, params, node) {
+        // The extra `+ 1` is because the match itself contains
+        // the character before the operator
+        checker.before({
+          source: params,
+          index: match.startIndex,
+          err: m => {
+            if (context.fix) {
+              fixOperatorIndices.push(match.startIndex);
+              return;
+            }
+            report({
+              message: m,
+              node,
+              index: match.startIndex - 1 + atRuleParamIndex(node),
+              result,
+              ruleName
+            });
+          }
+        });
+      }
+    });
   };
 };
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3580

> Is there anything in the PR that needs further explanation?

if use the `--fix` option, to remove whitespace at the end of each line.

ex.

* option: `always`

    code:
    ```css
    @media (width<600px) {}
    ```
    fixed:
    ```css
    @media (width <600px) {}
    ```

* option: `never`

    code:
    ```css
    @media (width < 600px) {}
    ```

    fixed:
    ```css
    @media (width< 600px) {}
    ```