### PR TITLE
Add autofix to media-query-list-comma-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -331,7 +331,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`media-query-list-comma-newline-after`](../../lib/rules/media-query-list-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of media query lists.
 -   [`media-query-list-comma-newline-before`](../../lib/rules/media-query-list-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of media query lists.
 -   [`media-query-list-comma-space-after`](../../lib/rules/media-query-list-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of media query lists (Autofixable).
--   [`media-query-list-comma-space-before`](../../lib/rules/media-query-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of media query lists.
+-   [`media-query-list-comma-space-before`](../../lib/rules/media-query-list-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of media query lists (Autofixable).
 
 #### At-rule
 

--- a/lib/rules/media-query-list-comma-space-before/README.md
+++ b/lib/rules/media-query-list-comma-space-before/README.md
@@ -8,6 +8,8 @@ Require a single space or disallow whitespace before the commas of media query l
  *             These commas */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"`

--- a/lib/rules/media-query-list-comma-space-before/__tests__/index.js
+++ b/lib/rules/media-query-list-comma-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -46,36 +47,42 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color), projection and (color) {}",
+      fixed: "@media screen and (color) , projection and (color) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 26
     },
     {
       code: "@mEdIa screen and (color), projection and (color) {}",
+      fixed: "@mEdIa screen and (color) , projection and (color) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 26
     },
     {
       code: "@MEDIA screen and (color), projection and (color) {}",
+      fixed: "@MEDIA screen and (color) , projection and (color) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color)  , projection and (color) {}",
+      fixed: "@media screen and (color) , projection and (color) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "@media screen and (color)\n, projection and (color) {}",
+      fixed: "@media screen and (color) , projection and (color) {}",
       message: messages.expectedBefore(),
       line: 2,
       column: 1
     },
     {
       code: "@media screen and (color)\r\n, projection and (color) {}",
+      fixed: "@media screen and (color) , projection and (color) {}",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 2,
@@ -83,9 +90,24 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color)\t, projection and (color) {}",
+      fixed: "@media screen and (color) , projection and (color) {}",
       message: messages.expectedBefore(),
       line: 1,
       column: 27
+    },
+    {
+      code: "@media screen and (color)/*comment*/, projection and (color) {}",
+      fixed: "@media screen and (color)/*comment*/ , projection and (color) {}",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 37
+    },
+    {
+      code: "@media " + "tv,".repeat(50) + "print {}",
+      fixed: "@media " + "tv ,".repeat(50) + "print {}",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 10
     }
   ]
 });
@@ -93,6 +115,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -133,36 +156,42 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color) , projection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 27
     },
     {
       code: "@mEdIa screen and (color) , projection and (color) {}",
+      fixed: "@mEdIa screen and (color), projection and (color) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 27
     },
     {
       code: "@MEDIA screen and (color) , projection and (color) {}",
+      fixed: "@MEDIA screen and (color), projection and (color) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 27
     },
     {
       code: "@media screen and (color)  , projection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "@media screen and (color)\n, projection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       message: messages.rejectedBefore(),
       line: 2,
       column: 1
     },
     {
       code: "@media screen and (color)\r\n, projection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       description: "CRLF",
       message: messages.rejectedBefore(),
       line: 2,
@@ -170,9 +199,24 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color)\t, projection and (color) {}",
+      fixed: "@media screen and (color), projection and (color) {}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 27
+    },
+    {
+      code: "@media screen and (color) /*comment*/ , projection and (color) {}",
+      fixed: "@media screen and (color) /*comment*/, projection and (color) {}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 39
+    },
+    {
+      code: "@media " + "tv ,".repeat(50) + "print {}",
+      fixed: "@media " + "tv,".repeat(50) + "print {}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 11
     }
   ]
 });
@@ -180,6 +224,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -220,24 +265,28 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color), projection and (color) {}",
+      fixed: "@media screen and (color) , projection and (color) {}",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 26
     },
     {
       code: "@mEdIa screen and (color), projection and (color) {}",
+      fixed: "@mEdIa screen and (color) , projection and (color) {}",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 26
     },
     {
       code: "@MEDIA screen and (color), projection and (color) {}",
+      fixed: "@MEDIA screen and (color) , projection and (color) {}",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 26
     },
     {
       code: "@media screen and (color), projection and (color) {\n}",
+      fixed: "@media screen and (color) , projection and (color) {\n}",
       description: "single-line list, multi-line block",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
@@ -245,6 +294,7 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color), projection and (color) {\r\n}",
+      fixed: "@media screen and (color) , projection and (color) {\r\n}",
       description: "single-line list, multi-line block and CRLF",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
@@ -256,6 +306,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -296,24 +347,28 @@ testRule(rule, {
   reject: [
     {
       code: "@media screen and (color) ,projection and (color) {}",
+      fixed: "@media screen and (color),projection and (color) {}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 27
     },
     {
       code: "@mEdIa screen and (color) ,projection and (color) {}",
+      fixed: "@mEdIa screen and (color),projection and (color) {}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 27
     },
     {
       code: "@MEDIA screen and (color) ,projection and (color) {}",
+      fixed: "@MEDIA screen and (color),projection and (color) {}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 27
     },
     {
       code: "@media screen and (color) ,projection and (color) {\n}",
+      fixed: "@media screen and (color),projection and (color) {\n}",
       description: "single-line list, multi-line block",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
@@ -321,6 +376,7 @@ testRule(rule, {
     },
     {
       code: "@media screen and (color) ,projection and (color) {\r\n}",
+      fixed: "@media screen and (color),projection and (color) {\r\n}",
       description: "single-line list, multi-line block and CRLF",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,

--- a/lib/rules/media-query-list-comma-space-before/index.js
+++ b/lib/rules/media-query-list-comma-space-before/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const atRuleParamIndex = require("../../utils/atRuleParamIndex");
 const mediaQueryListCommaWhitespaceChecker = require("../mediaQueryListCommaWhitespaceChecker");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -16,7 +17,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before "," in a single-line list'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -27,12 +28,45 @@ const rule = function(expectation) {
       return;
     }
 
+    let fixData;
     mediaQueryListCommaWhitespaceChecker({
       root,
       result,
       locationChecker: checker.before,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (atRule, index) => {
+            const paramCommaIndex = index - atRuleParamIndex(atRule);
+            fixData = fixData || new Map();
+            const commaIndices = fixData.get(atRule) || [];
+            commaIndices.push(paramCommaIndex);
+            fixData.set(atRule, commaIndices);
+            return true;
+          }
+        : null
     });
+
+    if (fixData) {
+      fixData.forEach((commaIndices, atRule) => {
+        let params = atRule.raws.params
+          ? atRule.raws.params.raw
+          : atRule.params;
+        commaIndices.sort((a, b) => b - a).forEach(index => {
+          const beforeComma = params.slice(0, index);
+          const afterComma = params.slice(index);
+          if (expectation.indexOf("always") === 0) {
+            params = beforeComma.replace(/\s*$/, " ") + afterComma;
+          } else if (expectation.indexOf("never") === 0) {
+            params = beforeComma.replace(/\s*$/, "") + afterComma;
+          }
+        });
+        if (atRule.raws.params) {
+          atRule.raws.params.raw = params;
+        } else {
+          atRule.params = params;
+        }
+      });
+    }
   };
 };
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3571

> Is there anything in the PR that needs further explanation?

ex.

* option: `always***`

    code:
    ```css
    @media screen and (color),projection and (color) {}
    ```
    fixed:
    ```css
    @media screen and (color) ,projection and (color) {}
    ```

* option: `never***`

    code:
    ```css
    @media screen and (color) , projection and (color) {}
    ```

    fixed:
    ```css
    @media screen and (color), projection and (color) {}
    ```