### PR TITLE
Allow global installed configuration

### DIFF
--- a/lib/utils/getModulePath.js
+++ b/lib/utils/getModulePath.js
@@ -2,17 +2,24 @@
 "use strict";
 
 const configurationError = require("./configurationError");
+const resolve = require("path").resolve;
 const resolveFrom = require("resolve-from");
 
-module.exports = function(
+const GLOBAL_NODE_MODULES = resolve(__dirname, "../../../../node_modules/");
+
+module.exports = function getModulePath(
   basedir /*: string*/,
   lookup /*: string*/
 ) /*: string*/ {
-  // First try to resolve from the provided directory,
-  // then try to resolve from process.cwd.
+  // 1. Try to resolve from the provided directory
+  // 2. Try to resolve from `process.cwd`
+  // 3. Try to resolve from global `node_modules` directory
   let path = resolveFrom.silent(basedir, lookup);
   if (!path) {
     path = resolveFrom.silent(process.cwd(), lookup);
+  }
+  if (!path) {
+    path = resolveFrom.silent(GLOBAL_NODE_MODULES, lookup);
   }
   if (!path) {
     throw configurationError(

--- a/lib/utils/getModulePath.js
+++ b/lib/utils/getModulePath.js
@@ -2,10 +2,8 @@
 "use strict";
 
 const configurationError = require("./configurationError");
-const resolve = require("path").resolve;
+const globalModules = require("global-modules");
 const resolveFrom = require("resolve-from");
-
-const GLOBAL_NODE_MODULES = resolve(__dirname, "../../../../node_modules/");
 
 module.exports = function getModulePath(
   basedir /*: string*/,
@@ -19,7 +17,7 @@ module.exports = function getModulePath(
     path = resolveFrom.silent(process.cwd(), lookup);
   }
   if (!path) {
-    path = resolveFrom.silent(GLOBAL_NODE_MODULES, lookup);
+    path = resolveFrom.silent(globalModules, lookup);
   }
   if (!path) {
     throw configurationError(

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "execall": "^1.0.0",
     "file-entry-cache": "^2.0.0",
     "get-stdin": "^6.0.0",
+    "global-modules": "^1.0.0",
     "globby": "^8.0.0",
     "globjoin": "^0.1.4",
     "html-tags": "^2.0.0",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes #1973 

> Is there anything in the PR that needs further explanation?

This patch fixes the following situation.

```
$ npm ls -g --depth 0 | grep stylelint
├── stylelint@9.5.0
├── stylelint-config-standard@18.2.0

$ cat ~/.stylelintrc.js
module.exports = {
  extends: ['stylelint-config-standard'],
};

$ stylelint ~/tmp/*.css
Error: Could not find "stylelint-config-standard". Do you need a `configBasedir`?
    at module.exports (/usr/local/lib/node_modules/stylelint/lib/utils/configurationError.js:8:28)
    at module.exports (/usr/local/lib/node_modules/stylelint/lib/utils/getModulePath.js:18:11)
    at loadExtendedConfig (/usr/local/lib/node_modules/stylelint/lib/augmentConfig.js:186:22)
    at resultPromise.then.resultConfig (/usr/local/lib/node_modules/stylelint/lib/augmentConfig.js:161:16)
```

This patch is inspired by this code in ESLint:

https://github.com/eslint/eslint/blob/c5b688e5350d16b330222f13749ab8b6ead517f8/lib/config/config-file.js#L333

If stylelint is globally installed to `/usr/local/lib/node_modules/stylelint`, then global `node_modules` directory should be `/usr/local/lib/node_modules`.

In this case, `path.resolve(__dirname, "../../../../node_modules/")` in `lib/utils/getModulePath.js` should evaluate to `/usr/local/lib/node_modules`:

```
/usr/local/lib/node_modules/stylelint/lib/utils/getModulePath.js
/usr/local/lib/node_modules/stylelint/lib/utils/     # __dirname
/usr/local/lib/node_modules/stylelint/lib/           # ../
/usr/local/lib/node_modules/stylelint/               # ../../
/usr/local/lib/node_modules/                         # ../../../
/usr/local/lib/                                      # ../../../../
/usr/local/lib/node_modules/                         # ../../../../node_modules/
```

**NOTE: About testing**

I can't find a way to test this patch. 😞 
Please tell me if there is any good way. 🙇 
