### PR TITLE
Add autofix to selector-pseudo-class-parentheses-space-inside

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -301,7 +301,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`selector-combinator-space-before`](../../lib/rules/selector-combinator-space-before/README.md): Require a single space or disallow whitespace before the combinators of selectors (Autofixable).
 -   [`selector-descendant-combinator-no-non-space`](../../lib/rules/selector-descendant-combinator-no-non-space/README.md): Disallow non-space characters for descendant combinators of selectors.
 -   [`selector-pseudo-class-case`](../../lib/rules/selector-pseudo-class-case/README.md): Specify lowercase or uppercase for pseudo-class selectors.
--   [`selector-pseudo-class-parentheses-space-inside`](../../lib/rules/selector-pseudo-class-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within pseudo-class selectors.
+-   [`selector-pseudo-class-parentheses-space-inside`](../../lib/rules/selector-pseudo-class-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within pseudo-class selectors (Autofixable).
 -   [`selector-pseudo-element-case`](../../lib/rules/selector-pseudo-element-case/README.md): Specify lowercase or uppercase for pseudo-element selectors.
 -   [`selector-pseudo-element-colon-notation`](../../lib/rules/selector-pseudo-element-colon-notation/README.md): Specify single or double colon notation for applicable pseudo-elements (Autofixable).
 -   [`selector-type-case`](../../lib/rules/selector-type-case/README.md): Specify lowercase or uppercase for type selector.

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/README.md
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/README.md
@@ -8,6 +8,8 @@ input:not( [type="submit"] ) {}
  * The space inside these two parentheses */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -50,93 +51,122 @@ testRule(rule, {
   reject: [
     {
       code: "input:not([type='submit'] ) { }",
+      fixed: "input:not( [type='submit'] ) { }",
       message: messages.expectedOpening,
       line: 1,
       column: 11
     },
     {
       code: "input:not( [type='submit']) { }",
+      fixed: "input:not( [type='submit'] ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 26
     },
     {
       code: "input:not([type='submit'], [type='text'] ) { }",
+      fixed: "input:not( [type='submit'], [type='text'] ) { }",
       message: messages.expectedOpening,
       line: 1,
       column: 11
     },
     {
       code: "input:not( [type='submit'], [type='text']) { }",
+      fixed: "input:not( [type='submit'], [type='text'] ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 41
     },
     {
       code: "input:not(  [type='submit']) { }",
+      fixed: "input:not(  [type='submit'] ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 27
     },
     {
       code: "section:not(:has( h1, h2 ) ) { }",
+      fixed: "section:not( :has( h1, h2 ) ) { }",
       message: messages.expectedOpening,
       line: 1,
       column: 13
     },
     {
       code: "section:not( :has( h1, h2 )) { }",
+      fixed: "section:not( :has( h1, h2 ) ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 27
     },
     {
       code: "section:not( :has(h1, h2 ) ) { }",
+      fixed: "section:not( :has( h1, h2 ) ) { }",
       message: messages.expectedOpening,
       line: 1,
       column: 19
     },
     {
       code: "section:not( :has( h1, h2) ) { }",
+      fixed: "section:not( :has( h1, h2 ) ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 25
     },
     {
+      code: "section:not(:has(h1, h2)) { }",
+      fixed: "section:not( :has( h1, h2 ) ) { }",
+      message: messages.expectedOpening,
+      line: 1,
+      column: 13
+    },
+    {
       code: "input:not([type='radio'] ):not( [type='checkbox'] ) { }",
+      fixed: "input:not( [type='radio'] ):not( [type='checkbox'] ) { }",
       message: messages.expectedOpening,
       line: 1,
       column: 11
     },
     {
       code: "input:not( [type='radio']):not( [type='checkbox'] ) { }",
+      fixed: "input:not( [type='radio'] ):not( [type='checkbox'] ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 25
     },
     {
       code: "input:not( [type='radio'] ):not([type='checkbox'] ) { }",
+      fixed: "input:not( [type='radio'] ):not( [type='checkbox'] ) { }",
       message: messages.expectedOpening,
       line: 1,
       column: 33
     },
     {
       code: "input:not( [type='radio'] ):not( [type='checkbox']) { }",
+      fixed: "input:not( [type='radio'] ):not( [type='checkbox'] ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 50
     },
     {
       code: "a:hover:not(.active ) { }",
+      fixed: "a:hover:not( .active ) { }",
       message: messages.expectedOpening,
       line: 1,
       column: 13
     },
     {
       code: "a:hover:not( .active) { }",
+      fixed: "a:hover:not( .active ) { }",
       message: messages.expectedClosing,
       line: 1,
       column: 20
+    },
+    {
+      code: "section:not(/**/:has(/**/h1, h2/**/)/**/) { }",
+      fixed: "section:not( /**/:has( /**/h1, h2/**/ )/**/ ) { }",
+      message: messages.expectedOpening,
+      line: 1,
+      column: 13
     }
   ]
 });
@@ -144,6 +174,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -172,93 +203,122 @@ testRule(rule, {
   reject: [
     {
       code: "input:not([type='submit'] ) { }",
+      fixed: "input:not([type='submit']) { }",
       message: messages.rejectedClosing,
       line: 1,
       column: 26
     },
     {
       code: "input:not( [type='submit']) { }",
+      fixed: "input:not([type='submit']) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 11
     },
     {
       code: "input:not([type='submit'], [type='text'] ) { }",
+      fixed: "input:not([type='submit'], [type='text']) { }",
       message: messages.rejectedClosing,
       line: 1,
       column: 41
     },
     {
       code: "input:not( [type='submit'], [type='text']) { }",
+      fixed: "input:not([type='submit'], [type='text']) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 11
     },
     {
       code: "input:not(  [type='submit']) { }",
+      fixed: "input:not([type='submit']) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 11
     },
     {
       code: "section:not( :has(h1, h2)) { }",
+      fixed: "section:not(:has(h1, h2)) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 13
     },
     {
       code: "section:not(:has( h1, h2)) { }",
+      fixed: "section:not(:has(h1, h2)) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 18
     },
     {
       code: "section:not(:has(h1, h2) ) { }",
+      fixed: "section:not(:has(h1, h2)) { }",
       message: messages.rejectedClosing,
       line: 1,
       column: 25
     },
     {
       code: "section:not(:has(h1, h2 )) { }",
+      fixed: "section:not(:has(h1, h2)) { }",
       message: messages.rejectedClosing,
       line: 1,
       column: 24
     },
     {
+      code: "section:not( :has( h1, h2 ) ) { }",
+      fixed: "section:not(:has(h1, h2)) { }",
+      message: messages.rejectedOpening,
+      line: 1,
+      column: 13
+    },
+    {
       code: "input:not( [type='radio']):not([type='checkbox']) { }",
+      fixed: "input:not([type='radio']):not([type='checkbox']) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 11
     },
     {
       code: "input:not([type='radio'] ):not([type='checkbox']) { }",
+      fixed: "input:not([type='radio']):not([type='checkbox']) { }",
       message: messages.rejectedClosing,
       line: 1,
       column: 25
     },
     {
       code: "input:not([type='radio']):not( [type='checkbox']) { }",
+      fixed: "input:not([type='radio']):not([type='checkbox']) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 31
     },
     {
       code: "input:not([type='radio']):not([type='checkbox'] ) { }",
+      fixed: "input:not([type='radio']):not([type='checkbox']) { }",
       message: messages.rejectedClosing,
       line: 1,
       column: 48
     },
     {
       code: "a:hover:not( .active) { }",
+      fixed: "a:hover:not(.active) { }",
       message: messages.rejectedOpening,
       line: 1,
       column: 13
     },
     {
       code: "a:hover:not(.active ) { }",
+      fixed: "a:hover:not(.active) { }",
       message: messages.rejectedClosing,
       line: 1,
       column: 20
+    },
+    {
+      code: "section:not( /**/ :has( /**/ h1, h2 /**/ ) /**/ ) { }",
+      fixed: "section:not(/**/ :has(/**/ h1, h2 /**/) /**/) { }",
+      message: messages.rejectedOpening,
+      line: 1,
+      column: 13
     }
   ]
 });

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -1,11 +1,9 @@
 "use strict";
 
-const _ = require("lodash");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const parseSelector = require("../../utils/parseSelector");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
-const styleSearch = require("style-search");
 const validateOptions = require("../../utils/validateOptions");
 
 const ruleName = "selector-pseudo-class-parentheses-space-inside";
@@ -17,7 +15,7 @@ const messages = ruleMessages(ruleName, {
   rejectedClosing: 'Unexpected whitespace before ")"'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -35,39 +33,71 @@ const rule = function(expectation) {
         return;
       }
 
-      parseSelector(rule.selector, result, rule, selectorTree => {
-        selectorTree.walkPseudos(pseudoNode => {
-          if (_.get(pseudoNode, "parent.parent.type") === "pseudo") {
-            return;
-          }
-
-          const pseudoSelectorString = pseudoNode.toString();
-
-          styleSearch({ source: pseudoSelectorString, target: "(" }, match => {
-            const nextCharIsSpace =
-              pseudoSelectorString[match.startIndex + 1] === " ";
-            const index = pseudoNode.sourceIndex + match.startIndex + 1;
+      let hasFixed = false;
+      const selector = rule.raws.selector
+        ? rule.raws.selector.raw
+        : rule.selector;
+      const fixedSelector = parseSelector(
+        selector,
+        result,
+        rule,
+        selectorTree => {
+          selectorTree.walkPseudos(pseudoNode => {
+            if (!pseudoNode.length) {
+              return;
+            }
+            const beforeString =
+              (pseudoNode.rawSpaceBefore || "") +
+              stringifyProperty(pseudoNode, "value");
+            const paramString = pseudoNode.map(String).join(",");
+            const nextCharIsSpace = paramString.startsWith(" ");
+            const openIndex = pseudoNode.sourceIndex + beforeString.length + 1;
             if (nextCharIsSpace && expectation === "never") {
-              complain(messages.rejectedOpening, index);
+              if (context.fix) {
+                hasFixed = true;
+                setFirstNodeSpaceBefore(pseudoNode, "");
+              } else {
+                complain(messages.rejectedOpening, openIndex);
+              }
             }
             if (!nextCharIsSpace && expectation === "always") {
-              complain(messages.expectedOpening, index);
+              if (context.fix) {
+                hasFixed = true;
+                setFirstNodeSpaceBefore(pseudoNode, " ");
+              } else {
+                complain(messages.expectedOpening, openIndex);
+              }
             }
-          });
 
-          styleSearch({ source: pseudoSelectorString, target: ")" }, match => {
-            const prevCharIsSpace =
-              pseudoSelectorString[match.startIndex - 1] === " ";
-            const index = pseudoNode.sourceIndex + match.startIndex - 1;
+            const prevCharIsSpace = paramString.endsWith(" ");
+            const closeIndex = openIndex + paramString.length - 1;
             if (prevCharIsSpace && expectation === "never") {
-              complain(messages.rejectedClosing, index);
+              if (context.fix) {
+                hasFixed = true;
+                setLastNodeSpaceAfter(pseudoNode, "");
+              } else {
+                complain(messages.rejectedClosing, closeIndex);
+              }
             }
             if (!prevCharIsSpace && expectation === "always") {
-              complain(messages.expectedClosing, index);
+              if (context.fix) {
+                hasFixed = true;
+                setLastNodeSpaceAfter(pseudoNode, " ");
+              } else {
+                complain(messages.expectedClosing, closeIndex);
+              }
             }
           });
-        });
-      });
+        }
+      );
+
+      if (hasFixed) {
+        if (!rule.raws.selector) {
+          rule.selector = fixedSelector;
+        } else {
+          rule.raws.selector.raw = fixedSelector;
+        }
+      }
 
       function complain(message, index) {
         report({
@@ -81,6 +111,27 @@ const rule = function(expectation) {
     });
   };
 };
+
+function setFirstNodeSpaceBefore(node, value) {
+  const target = node.first;
+  if (target.type === "selector") {
+    setFirstNodeSpaceBefore(target, value);
+  } else {
+    target.spaces.before = value;
+  }
+}
+function setLastNodeSpaceAfter(node, value) {
+  const target = node.last;
+  if (target.type === "selector") {
+    setLastNodeSpaceAfter(target, value);
+  } else {
+    target.spaces.after = value;
+  }
+}
+
+function stringifyProperty(node, propName) {
+  return (node.raws && node.raws[propName]) || node[propName];
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3584

> Is there anything in the PR that needs further explanation?

ex.

* option: `always`

    code:
    ```css
    input:not([type='submit']) { }
    ```
    fixed:
    ```css
    input:not( [type='submit'] ) { }
    ```

* option: `never`

    code:
    ```css
    input:not( [type='submit'] ) { }
    ```

    fixed:
    ```css
    input:not([type='submit']) { }
    ```