### PR TITLE
Add autofix to function-whitespace-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -223,7 +223,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`function-parentheses-newline-inside`](../../lib/rules/function-parentheses-newline-inside/README.md): Require a newline or disallow whitespace on the inside of the parentheses of functions (Autofixable).
 -   [`function-parentheses-space-inside`](../../lib/rules/function-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses of functions (Autofixable).
 -   [`function-url-quotes`](../../lib/rules/function-url-quotes/README.md): Require or disallow quotes for urls.
--   [`function-whitespace-after`](../../lib/rules/function-whitespace-after/README.md): Require or disallow whitespace after functions.
+-   [`function-whitespace-after`](../../lib/rules/function-whitespace-after/README.md): Require or disallow whitespace after functions (Autofixable).
 
 #### Number
 

--- a/lib/rules/function-whitespace-after/README.md
+++ b/lib/rules/function-whitespace-after/README.md
@@ -10,6 +10,8 @@ a { transform: translate(1, 1) scale(3); }
 
 This rule does not check for space immediately after `)` if the very next character is `,`, `)`, `/` or `}`, allowing some of the patterns exemplified below.
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/function-whitespace-after/__tests__/index.js
+++ b/lib/rules/function-whitespace-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -85,21 +86,45 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: translate(1, 1)scale(3); }",
+      fixed: "a { transform: translate(1, 1) scale(3); }",
       message: messages.expected,
       line: 1,
       column: 31
     },
     {
       code: "a { color: color(rgb(0,0,0)lightness(50%)) };",
+      fixed: "a { color: color(rgb(0,0,0) lightness(50%)) };",
       message: messages.expected,
       line: 1,
       column: 28
     },
     {
       code: "@import url(example.css)screen;",
+      fixed: "@import url(example.css) screen;",
       message: messages.expected,
       line: 1,
       column: 25
+    },
+    {
+      code: "a { transform: translateX(1)translateY(1)scale(3); }",
+      fixed: "a { transform: translateX(1) translateY(1) scale(3); }",
+      message: messages.expected,
+      line: 1,
+      column: 29
+    },
+    {
+      code: "@import url(example.css)scree/**/n;",
+      fixed: "@import url(example.css) scree/**/n;",
+      message: messages.expected,
+      line: 1,
+      column: 25
+    },
+    {
+      code: "a { transform: translate(1/**/, 1)scale(3); }",
+      fixed: "a { transform: translate(1/**/, 1) scale(3); }",
+      message: messages.expected,
+      line: 1,
+      column: 35
     }
   ]
 });
@@ -107,6 +132,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -142,24 +168,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: translate(1, 1) scale(3); }",
+      fixed: "a { transform: translate(1, 1)scale(3); }",
       message: messages.rejected,
       line: 1,
       column: 31
     },
     {
       code: "a { transform: translate(1, 1)  scale(3); }",
+      fixed: "a { transform: translate(1, 1)scale(3); }",
       message: messages.rejected,
       line: 1,
       column: 31
     },
     {
       code: "a { transform: translate(1, 1)\nscale(3); }",
+      fixed: "a { transform: translate(1, 1)scale(3); }",
       message: messages.rejected,
       line: 1,
       column: 31
     },
     {
       code: "a { transform: translate(1, 1)\r\nscale(3); }",
+      fixed: "a { transform: translate(1, 1)scale(3); }",
       description: "CRLF",
       message: messages.rejected,
       line: 1,
@@ -167,21 +197,54 @@ testRule(rule, {
     },
     {
       code: "a { color: color(rgb(0,0,0) lightness(50%)) };",
+      fixed: "a { color: color(rgb(0,0,0)lightness(50%)) };",
       message: messages.rejected,
       line: 1,
       column: 28
     },
     {
       code: "a { color: color(rgb(0,0,0)  lightness(50%)) };",
+      fixed: "a { color: color(rgb(0,0,0)lightness(50%)) };",
       message: messages.rejected,
       line: 1,
       column: 28
     },
     {
       code: "a { color: color(rgb(0,0,0)\nlightness(50%)) };",
+      fixed: "a { color: color(rgb(0,0,0)lightness(50%)) };",
       message: messages.rejected,
       line: 1,
       column: 28
+    },
+    {
+      code: "a { transform: translateX(1) translateY(1) scale(3); }",
+      fixed: "a { transform: translateX(1)translateY(1)scale(3); }",
+      message: messages.rejected,
+      line: 1,
+      column: 29
+    },
+    {
+      code:
+        "a { transform: /**/ translateX(1) /**/ translateY(1) /**/ scale(3); }",
+      fixed:
+        "a { transform: /**/ translateX(1)/**/ translateY(1)/**/ scale(3); }",
+      message: messages.rejected,
+      line: 1,
+      column: 34
+    },
+    {
+      code: "@import url(example.css) screen;",
+      fixed: "@import url(example.css)screen;",
+      message: messages.rejected,
+      line: 1,
+      column: 25
+    },
+    {
+      code: "@import url(example.css) /**/ screen;",
+      fixed: "@import url(example.css)/**/ screen;",
+      message: messages.rejected,
+      line: 1,
+      column: 25
     }
   ]
 });
@@ -191,6 +254,7 @@ testRule(rule, {
   config: ["always"],
   skipBasicChecks: true,
   syntax: "scss",
+  fix: true,
 
   accept: [
     {
@@ -202,7 +266,29 @@ testRule(rule, {
   reject: [
     {
       code:
+        "a { padding:\n  10px\n  /* comment one*/\n  /* comment two*/\n  var(--boo)orange}",
+      fixed:
+        "a { padding:\n  10px\n  /* comment one*/\n  /* comment two*/\n  var(--boo) orange}",
+      message: messages.expected,
+      line: 5,
+      column: 13
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  reject: [
+    {
+      code:
         "a { padding:\n  10px\n  // comment one\n  // comment two\n  var(--boo)orange}",
+      // can't fix on scss
+      // fixed:
+      //   "a { padding:\n  10px\n  // comment one\n  // comment two\n  var(--boo) orange}",
       message: messages.expected,
       line: 5,
       column: 13
@@ -215,6 +301,7 @@ testRule(rule, {
   config: ["always"],
   skipBasicChecks: true,
   syntax: "less",
+  fix: true,
 
   accept: [
     // temporarily disable this test until this is fully supported in stylelint
@@ -228,6 +315,8 @@ testRule(rule, {
     {
       code:
         "a { padding:\n  10px\n  // comment one\n  // comment two\n  var(--boo)orange}",
+      fixed:
+        "a { padding:\n  10px\n  // comment one\n  // comment two\n  var(--boo) orange}",
       message: messages.expected,
       line: 5,
       column: 13
@@ -240,6 +329,7 @@ testRule(rule, {
   config: ["always"],
   skipBasicChecks: true,
   syntax: "jsx",
+  fix: true,
 
   accept: [
     {
@@ -251,6 +341,8 @@ testRule(rule, {
     {
       code:
         "export default <img style={{ ['transform']: 'translate(1, 1)scale(3)' }} />;",
+      fixed:
+        "export default <img style={{ ['transform']: 'translate(1, 1) scale(3)' }} />;",
       message: messages.expected,
       line: 1,
       column: 60

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -25,7 +25,7 @@ const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([
   undefined
 ]);
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual: expectation,
@@ -35,7 +35,7 @@ const rule = function(expectation) {
       return;
     }
 
-    function check(node, value, getIndex) {
+    function check(node, value, getIndex, fix) {
       styleSearch(
         {
           source: value,
@@ -43,12 +43,12 @@ const rule = function(expectation) {
           functionArguments: "only"
         },
         match => {
-          checkClosingParen(value, match.startIndex + 1, node, getIndex);
+          checkClosingParen(value, match.startIndex + 1, node, getIndex, fix);
         }
       );
     }
 
-    function checkClosingParen(source, index, node, getIndex) {
+    function checkClosingParen(source, index, node, getIndex, fix) {
       const nextChar = source[index];
       if (expectation === "always") {
         // Allow for the next character to be a single empty space,
@@ -65,6 +65,10 @@ const rule = function(expectation) {
         if (ACCEPTABLE_AFTER_CLOSING_PAREN.has(nextChar)) {
           return;
         }
+        if (fix) {
+          fix(index);
+          return;
+        }
         report({
           message: messages.expected,
           node,
@@ -74,6 +78,10 @@ const rule = function(expectation) {
         });
       } else if (expectation === "never") {
         if (isWhitespace(nextChar)) {
+          if (fix) {
+            fix(index);
+            return;
+          }
           report({
             message: messages.rejected,
             node,
@@ -85,16 +93,67 @@ const rule = function(expectation) {
       }
     }
 
-    root.walkAtRules(/^import$/i, atRule =>
-      check(atRule, atRule.params, atRuleParamIndex)
-    );
-    root.walkDecls(decl =>
-      check(
-        decl,
-        _.get(decl, "raws.value.raw", decl.value),
-        declarationValueIndex
-      )
-    );
+    function createFixer(value) {
+      let fixed = "";
+      let lastIndex = 0;
+      let applyFix;
+      if (expectation === "always") {
+        applyFix = index => {
+          fixed += value.slice(lastIndex, index) + " ";
+          lastIndex = index;
+        };
+      } else if (expectation === "never") {
+        applyFix = index => {
+          let whitespaceEndIndex = index + 1;
+          while (
+            whitespaceEndIndex < value.length &&
+            isWhitespace(value[whitespaceEndIndex])
+          ) {
+            whitespaceEndIndex++;
+          }
+          fixed += value.slice(lastIndex, index);
+          lastIndex = whitespaceEndIndex;
+        };
+      }
+      return {
+        applyFix,
+        get hasFixed() {
+          return !!lastIndex;
+        },
+        get fixed() {
+          return fixed + value.slice(lastIndex);
+        }
+      };
+    }
+
+    root.walkAtRules(/^import$/i, atRule => {
+      const param = _.get(atRule, "raws.params.raw", atRule.params);
+      const fixer = context.fix && createFixer(param);
+
+      check(atRule, param, atRuleParamIndex, fixer && fixer.applyFix);
+
+      if (fixer && fixer.hasFixed) {
+        if (atRule.raws.params) {
+          atRule.raws.params.raw = fixer.fixed;
+        } else {
+          atRule.params = fixer.fixed;
+        }
+      }
+    });
+    root.walkDecls(decl => {
+      const value = _.get(decl, "raws.value.raw", decl.value);
+      const fixer = context.fix && createFixer(value);
+
+      check(decl, value, declarationValueIndex, fixer && fixer.applyFix);
+
+      if (fixer && fixer.hasFixed) {
+        if (decl.raws.value) {
+          decl.raws.value.raw = fixer.fixed;
+        } else {
+          decl.value = fixer.fixed;
+        }
+      }
+    });
   };
 };
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3582

> Is there anything in the PR that needs further explanation?

ex.

* option: `always`

    code:
    ```css
    a { transform: translate(1, 1)scale(3); }
    ```
    fixed:
    ```css
    a { transform: translate(1, 1) scale(3); }
    ```

* option: `never`

    code:
    ```css
    a { transform: translate(1, 1) scale(3); }
    ```

    fixed:
    ```css
    a { transform: translate(1, 1)scale(3); }
    ```