### PR TITLE
Upgrade micromatch because of vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "log-symbols": "^2.0.0",
     "mathml-tag-names": "^2.0.1",
     "meow": "^5.0.0",
-    "micromatch": "^2.3.11",
+    "micromatch": "^3.1.10",
     "normalize-selector": "^0.2.0",
     "pify": "^4.0.0",
     "postcss": "^7.0.0",


### PR DESCRIPTION
 Low severity vuln found in braces@1.8.5, introduced via stylelint@9.5.0
    Description: Regular Expression Denial of Service (ReDoS)
    Info: https://snyk.io/vuln/npm:braces:20180219
    From: stylelint@9.5.0 > micromatch@2.3.11 > braces@1.8.5

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
