### PR TITLE
Add autofix to block-closing-brace-space-before

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -285,7 +285,7 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`block-closing-brace-newline-after`](../../lib/rules/block-closing-brace-newline-after/README.md): Require a newline or disallow whitespace after the closing brace of blocks (Autofixable).
 -   [`block-closing-brace-newline-before`](../../lib/rules/block-closing-brace-newline-before/README.md): Require a newline or disallow whitespace before the closing brace of blocks (Autofixable).
 -   [`block-closing-brace-space-after`](../../lib/rules/block-closing-brace-space-after/README.md): Require a single space or disallow whitespace after the closing brace of blocks.
--   [`block-closing-brace-space-before`](../../lib/rules/block-closing-brace-space-before/README.md): Require a single space or disallow whitespace before the closing brace of blocks.
+-   [`block-closing-brace-space-before`](../../lib/rules/block-closing-brace-space-before/README.md): Require a single space or disallow whitespace before the closing brace of blocks (Autofixable).
 -   [`block-opening-brace-newline-after`](../../lib/rules/block-opening-brace-newline-after/README.md): Require a newline after the opening brace of blocks (Autofixable).
 -   [`block-opening-brace-newline-before`](../../lib/rules/block-opening-brace-newline-before/README.md): Require a newline or disallow whitespace before the opening brace of blocks (Autofixable).
 -   [`block-opening-brace-space-after`](../../lib/rules/block-opening-brace-space-after/README.md): Require a single space or disallow whitespace after the opening brace of blocks (Autofixable).

--- a/lib/rules/block-closing-brace-space-before/README.md
+++ b/lib/rules/block-closing-brace-space-before/README.md
@@ -8,6 +8,8 @@ a { color: pink; }
  * The space before this brace */
 ```
 
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"|"always-single-line"|"never-single-line"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/block-closing-brace-space-before/__tests__/index.js
+++ b/lib/rules/block-closing-brace-space-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -22,24 +23,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;}",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 16
     },
     {
       code: "a { color: pink;  }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 18
     },
     {
       code: "a { color: pink;\n}",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink;\r\n}",
+      fixed: "a { color: pink; }",
       description: "CRLF",
       message: messages.expectedBefore(),
       line: 1,
@@ -47,15 +52,38 @@ testRule(rule, {
     },
     {
       code: "a { color: pink;\t}",
+      fixed: "a { color: pink; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink; } b { color: red;}",
+      fixed: "a { color: pink; } b { color: red; }",
       message: messages.expectedBefore(),
       line: 1,
       column: 34
+    },
+    {
+      code: "a { color: pink;} b { color: red;}",
+      fixed: "a { color: pink; } b { color: red; }",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 16
+    },
+    {
+      code: "a { color: pink;/*comment*/}",
+      fixed: "a { color: pink;/*comment*/ }",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 27
+    },
+    {
+      code: "a { color: pink;;;}",
+      fixed: "a { color: pink;;; }",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 18
     }
   ]
 });
@@ -63,6 +91,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never"],
+  fix: true,
 
   accept: [
     {
@@ -79,24 +108,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a { color: pink;}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink;  }",
+      fixed: "a { color: pink;}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 18
     },
     {
       code: "a { color: pink;\n}",
+      fixed: "a { color: pink;}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink;\r\n}",
+      fixed: "a { color: pink;}",
       description: "CRLF",
       message: messages.rejectedBefore(),
       line: 1,
@@ -104,15 +137,38 @@ testRule(rule, {
     },
     {
       code: "a { color: pink;\t}",
+      fixed: "a { color: pink;}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink;} b { color: red; }",
+      fixed: "a { color: pink;} b { color: red;}",
       message: messages.rejectedBefore(),
       line: 1,
       column: 34
+    },
+    {
+      code: "a { color: pink; } b { color: red; }",
+      fixed: "a { color: pink;} b { color: red;}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 17
+    },
+    {
+      code: "a { color: pink; /*comment*/ }",
+      fixed: "a { color: pink; /*comment*/}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 29
+    },
+    {
+      code: "a { color: pink ; ; ; }",
+      fixed: "a { color: pink ; ; ;}",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 22
     }
   ]
 });
@@ -120,6 +176,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -153,18 +210,21 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;}",
+      fixed: "a { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 16
     },
     {
       code: "a,\nb { color: pink;}",
+      fixed: "a,\nb { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 2,
       column: 16
     },
     {
       code: "a,\r\nb { color: pink;}",
+      fixed: "a,\r\nb { color: pink; }",
       description: "CRLF",
       message: messages.expectedBeforeSingleLine(),
       line: 2,
@@ -172,18 +232,21 @@ testRule(rule, {
     },
     {
       code: "a { color: pink;  }",
+      fixed: "a { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 18
     },
     {
       code: "a { color: pink;\t}",
+      fixed: "a { color: pink; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink; } b { color: red;}",
+      fixed: "a { color: pink; } b { color: red; }",
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 34
@@ -194,6 +257,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-single-line"],
+  fix: true,
 
   accept: [
     {
@@ -227,18 +291,21 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink; }",
+      fixed: "a { color: pink;}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 17
     },
     {
       code: "a,\nb { color: pink; }",
+      fixed: "a,\nb { color: pink;}",
       message: messages.rejectedBeforeSingleLine(),
       line: 2,
       column: 17
     },
     {
       code: "a,\r\nb { color: pink; }",
+      fixed: "a,\r\nb { color: pink;}",
       description: "CRLF",
       message: messages.rejectedBeforeSingleLine(),
       line: 2,
@@ -246,24 +313,28 @@ testRule(rule, {
     },
     {
       code: "a { color: pink;  }",
+      fixed: "a { color: pink;}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 18
     },
     {
       code: "a { color: pink;\t}",
+      fixed: "a { color: pink;}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 17
     },
     {
       code: "a { color: pink;} b { color: red;\t}",
+      fixed: "a { color: pink;} b { color: red;}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 34
     },
     {
       code: "a { color: pink;  } b { color: red;}",
+      fixed: "a { color: pink;} b { color: red;}",
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 18
@@ -274,6 +345,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -303,36 +375,42 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\ntop: 0;}",
+      fixed: "a { color: pink;\ntop: 0; }",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 7
     },
     {
       code: "a { color: pink;\ntop: 0;  }",
+      fixed: "a { color: pink;\ntop: 0; }",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 9
     },
     {
       code: "a { color: pink;\ntop: 0;\t}",
+      fixed: "a { color: pink;\ntop: 0; }",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 8
     },
     {
       code: "a { color: pink; } b { color: red;\ntop: 0;}",
+      fixed: "a { color: pink; } b { color: red;\ntop: 0; }",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 7
     },
     {
       code: "a { color: pink;\ntop: 0;} b { color: red; }",
+      fixed: "a { color: pink;\ntop: 0; } b { color: red; }",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 7
     },
     {
       code: "a { color: pink;\r\ntop: 0;} b { color: red; }",
+      fixed: "a { color: pink;\r\ntop: 0; } b { color: red; }",
       description: "CRLF",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
@@ -344,6 +422,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -373,24 +452,28 @@ testRule(rule, {
   reject: [
     {
       code: "a { color: pink;\ntop: 0; }",
+      fixed: "a { color: pink;\ntop: 0;}",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 8
     },
     {
       code: "a { color: pink;\ntop: 0;  }",
+      fixed: "a { color: pink;\ntop: 0;}",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 9
     },
     {
       code: "a { color: pink;\ntop: 0;\t}",
+      fixed: "a { color: pink;\ntop: 0;}",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 8
     },
     {
       code: "a { color: pink;\r\ntop: 0;\t}",
+      fixed: "a { color: pink;\r\ntop: 0;}",
       description: "CRLF",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
@@ -398,12 +481,14 @@ testRule(rule, {
     },
     {
       code: "a { color: pink; } b { color: red;\ntop: 0; }",
+      fixed: "a { color: pink; } b { color: red;\ntop: 0;}",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 8
     },
     {
       code: "a { color: pink;\ntop: 0; } b { color: red; }",
+      fixed: "a { color: pink;\ntop: 0;} b { color: red; }",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 8

--- a/lib/rules/block-closing-brace-space-before/index.js
+++ b/lib/rules/block-closing-brace-space-before/index.js
@@ -23,7 +23,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before "}" of a multi-line block'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("space", expectation, messages);
 
   return (root, result) => {
@@ -64,6 +64,15 @@ const rule = function(expectation) {
         source,
         index: source.length - 1,
         err: msg => {
+          if (context.fix) {
+            if (expectation.indexOf("always") === 0) {
+              statement.raws.after = statement.raws.after.replace(/\s*$/, " ");
+              return;
+            } else if (expectation.indexOf("never") === 0) {
+              statement.raws.after = statement.raws.after.replace(/\s*$/, "");
+              return;
+            }
+          }
           report({
             message: msg,
             node: statement,


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

closes #3567

> Is there anything in the PR that needs further explanation?

ex.

* option: `always**`

    code:
    ```css
    a {color: pink;}
    ```
    fixed:
    ```css
    a {color: pink; }
    ```

* option: `never**`

    code:
    ```css
    a { color: pink; }
    ```

    fixed:
    ```css
    a { color: pink;}
    ```