### PR TITLE
Fix ESLint Jest warnings

### DIFF
--- a/lib/__tests__/defaultSeverity.test.js
+++ b/lib/__tests__/defaultSeverity.test.js
@@ -13,7 +13,7 @@ it("`defaultSeverity` option set to warning", () => {
     .process("a {}", { from: undefined }, config)
     .then(result => {
       const warnings = result.warnings();
-      expect(warnings.length).toBe(1);
+      expect(warnings).toHaveLength(1);
       expect(warnings[0].text.indexOf("block-no-empty")).not.toBe(-1);
       expect(warnings[0].severity).toBe("warning");
     });

--- a/lib/__tests__/extends.test.js
+++ b/lib/__tests__/extends.test.js
@@ -15,8 +15,8 @@ it("basic extending", () => {
     configBasedir: path.join(__dirname, "fixtures")
   }).then(linted => {
     expect(typeof linted.output).toBe("string");
-    expect(linted.results.length).toBe(1);
-    expect(linted.results[0].warnings.length).toBe(1);
+    expect(linted.results).toHaveLength(1);
+    expect(linted.results[0].warnings).toHaveLength(1);
     expect(linted.results[0].warnings[0].rule).toBe("block-no-empty");
   });
 });
@@ -28,8 +28,8 @@ it("recursive extending", () => {
     configBasedir: path.join(__dirname, "fixtures")
   }).then(linted => {
     expect(typeof linted.output).toBe("string");
-    expect(linted.results.length).toBe(1);
-    expect(linted.results[0].warnings.length).toBe(1);
+    expect(linted.results).toHaveLength(1);
+    expect(linted.results[0].warnings).toHaveLength(1);
     expect(linted.results[0].warnings[0].rule).toBe("block-no-empty");
   });
 });
@@ -40,7 +40,7 @@ it("extending with overrides", () => {
     config: configExtendingThreeWithOverride,
     configBasedir: path.join(__dirname, "fixtures")
   }).then(linted => {
-    expect(linted.results[0].warnings.length).toBe(0);
+    expect(linted.results[0].warnings).toHaveLength(0);
   });
 });
 
@@ -65,7 +65,7 @@ it("extending a config that is overridden", () => {
       rules: { "string-quotes": "double" }
     }
   }).then(linted => {
-    expect(linted.results[0].warnings.length).toBe(0);
+    expect(linted.results[0].warnings).toHaveLength(0);
   });
 });
 
@@ -88,7 +88,7 @@ describe("extending a config from process.cwd", () => {
         extends: ["./fixtures/config-string-quotes-single"]
       }
     }).then(linted => {
-      expect(linted.results[0].warnings.length).toBe(1);
+      expect(linted.results[0].warnings).toHaveLength(1);
     });
   });
 });

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -23,7 +23,7 @@ describe("extending config and ignoreFiles glob ignoring single glob", () => {
   });
 
   it("two files found", () => {
-    expect(results.length).toBe(2);
+    expect(results).toHaveLength(2);
   });
 
   it("empty-block.css found", () => {
@@ -31,7 +31,7 @@ describe("extending config and ignoreFiles glob ignoring single glob", () => {
   });
 
   it("empty-block.css linted", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
   });
 
   it("invalid-hex.css found", () => {
@@ -39,7 +39,7 @@ describe("extending config and ignoreFiles glob ignoring single glob", () => {
   });
 
   it("invalid-hex.css not linted", () => {
-    expect(results[1].warnings.length).toBe(0);
+    expect(results[1].warnings).toHaveLength(0);
   });
 
   it("invalid-hex.css marked as ignored", () => {
@@ -77,7 +77,7 @@ describe("same as above with no configBasedir, ignore-files path relative to pro
   });
 
   it("two files found", () => {
-    expect(results.length).toBe(2);
+    expect(results).toHaveLength(2);
   });
 
   it("empty-block.css found", () => {
@@ -85,7 +85,7 @@ describe("same as above with no configBasedir, ignore-files path relative to pro
   });
 
   it("empty-block.css linted", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
   });
 
   it("invalid-hex.css found", () => {
@@ -93,7 +93,7 @@ describe("same as above with no configBasedir, ignore-files path relative to pro
   });
 
   it("invalid-hex.css not linted", () => {
-    expect(results[1].warnings.length).toBe(0);
+    expect(results[1].warnings).toHaveLength(0);
   });
 
   it("invalid-hex.css marked as ignored", () => {
@@ -121,11 +121,11 @@ describe("absolute ignoreFiles glob path", () => {
   });
 
   it("two files found", () => {
-    expect(results.length).toBe(2);
+    expect(results).toHaveLength(2);
   });
 
   it("first not linted", () => {
-    expect(results[0].warnings.length).toBe(0);
+    expect(results[0].warnings).toHaveLength(0);
   });
 
   it("first marked as ignored", () => {
@@ -133,7 +133,7 @@ describe("absolute ignoreFiles glob path", () => {
   });
 
   it("second has no warnings", () => {
-    expect(results[1].warnings.length).toBe(0);
+    expect(results[1].warnings).toHaveLength(0);
   });
 
   it("second not marked as ignored", () => {
@@ -162,7 +162,7 @@ describe("extending config with ignoreFiles glob ignoring one by negation", () =
   });
 
   it("two files found", () => {
-    expect(results.length).toBe(2);
+    expect(results).toHaveLength(2);
   });
 
   it("empty-block.css found", () => {
@@ -170,7 +170,7 @@ describe("extending config with ignoreFiles glob ignoring one by negation", () =
   });
 
   it("empty-block.css has no warnings", () => {
-    expect(results[0].warnings.length).toBe(0);
+    expect(results[0].warnings).toHaveLength(0);
   });
 
   it("empty-block.css was ignored", () => {
@@ -182,7 +182,7 @@ describe("extending config with ignoreFiles glob ignoring one by negation", () =
   });
 
   it("invalid-hex.css has warnings", () => {
-    expect(results[1].warnings.length).toBe(1);
+    expect(results[1].warnings).toHaveLength(1);
   });
 
   it("invalid-hex.css was not ignored", () => {
@@ -216,7 +216,7 @@ describe("specified `ignorePath` file ignoring one file", () => {
   });
 
   it("no files read", () => {
-    expect(results.length).toBe(0);
+    expect(results).toHaveLength(0);
   });
 });
 
@@ -246,7 +246,7 @@ describe("specified `ignorePattern` file ignoring one file", () => {
   });
 
   it("no files read", () => {
-    expect(results.length).toBe(0);
+    expect(results).toHaveLength(0);
   });
 });
 
@@ -282,7 +282,7 @@ describe("specified `ignorePattern` file ignoring two files", () => {
   });
 
   it("no files read", () => {
-    expect(results.length).toBe(0);
+    expect(results).toHaveLength(0);
   });
 });
 
@@ -302,7 +302,7 @@ describe("using ignoreFiles with input files that would cause a postcss syntax e
   });
 
   it("two files found", () => {
-    expect(results.length).toBe(2);
+    expect(results).toHaveLength(2);
   });
 
   it("no-syntax-error.css found", () => {
@@ -310,7 +310,7 @@ describe("using ignoreFiles with input files that would cause a postcss syntax e
   });
 
   it("no-syntax-error.css linted", () => {
-    expect(results[0].warnings.length).toBe(0);
+    expect(results[0].warnings).toHaveLength(0);
   });
 
   it("syntax-error-ignored.scss found", () => {
@@ -318,7 +318,7 @@ describe("using ignoreFiles with input files that would cause a postcss syntax e
   });
 
   it("syntax-error-ignored.scss not linted", () => {
-    expect(results[1].warnings.length).toBe(0);
+    expect(results[1].warnings).toHaveLength(0);
   });
 
   it("syntax-error-ignored.scss marked as ignored", () => {
@@ -343,7 +343,7 @@ describe("extending a config that ignores files", () => {
   });
 
   it("found correct files", () => {
-    expect(results.length).toBe(2);
+    expect(results).toHaveLength(2);
   });
 
   it("empty-block.css found", () => {
@@ -351,7 +351,7 @@ describe("extending a config that ignores files", () => {
   });
 
   it("empty-block.css linted", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
   });
 
   it("invalid-hex.css found", () => {
@@ -359,7 +359,7 @@ describe("extending a config that ignores files", () => {
   });
 
   it("invalid-hex.css not linted", () => {
-    expect(results[1].warnings.length).toBe(0);
+    expect(results[1].warnings).toHaveLength(0);
   });
 });
 
@@ -378,7 +378,7 @@ describe("using codeFilename and ignoreFiles together", () => {
   });
 
   it("no warnings", () => {
-    expect(results[0].warnings.length).toBe(0);
+    expect(results[0].warnings).toHaveLength(0);
   });
 
   it("ignored", () => {
@@ -402,7 +402,7 @@ describe("using codeFilename and ignoreFiles with configBasedir", () => {
   });
 
   it("no warnings", () => {
-    expect(results[0].warnings.length).toBe(0);
+    expect(results[0].warnings).toHaveLength(0);
   });
 
   it("ignored", () => {
@@ -423,7 +423,7 @@ describe("file in node_modules", () => {
 
   it("is ignored", () => {
     return lint().then(output => {
-      expect(output.results.length).toBe(0);
+      expect(output.results).toHaveLength(0);
     });
   });
 });
@@ -441,7 +441,7 @@ describe("file in bower_components", () => {
 
   it("is ignored", () => {
     return lint().then(output => {
-      expect(output.results.length).toBe(0);
+      expect(output.results).toHaveLength(0);
     });
   });
 });
@@ -464,9 +464,9 @@ describe("disableDefaultIgnores allows paths in node_modules and bower_component
 
     it("are not ignored", () => {
       return lint().then(output => {
-        expect(output.results.length).toBe(2);
-        expect(output.results[0].warnings.length).toBe(1);
-        expect(output.results[1].warnings.length).toBe(1);
+        expect(output.results).toHaveLength(2);
+        expect(output.results[0].warnings).toHaveLength(1);
+        expect(output.results[1].warnings).toHaveLength(1);
       });
     });
   });

--- a/lib/__tests__/ignoreDisables.test.js
+++ b/lib/__tests__/ignoreDisables.test.js
@@ -33,14 +33,14 @@ describe("ignoreDisables with postcssPlugins", () => {
   });
 
   it("expected number of warnings", () => {
-    expect(result.warnings().length).toBe(2);
+    expect(result.warnings()).toHaveLength(2);
   });
 
-  it("expected rule", () => {
+  it("expected rule 0", () => {
     expect(result.warnings()[0].text.indexOf("block-no-empty")).not.toBe(1);
   });
 
-  it("expected rule", () => {
+  it("expected rule 1", () => {
     expect(result.warnings()[1].text.indexOf("block-no-empty")).not.toBe(1);
   });
 });
@@ -57,14 +57,14 @@ describe("ignoreDisables with standalone", () => {
   });
 
   it("expected number of warnings", () => {
-    expect(results[0].warnings.length).toBe(2);
+    expect(results[0].warnings).toHaveLength(2);
   });
 
-  it("expected rule", () => {
+  it("expected rule 0", () => {
     expect(results[0].warnings[0].text.indexOf("block-no-empty")).not.toBe(1);
   });
 
-  it("expected rule", () => {
+  it("expected rule 1", () => {
     expect(results[0].warnings[1].text.indexOf("block-no-empty")).not.toBe(1);
   });
 });

--- a/lib/__tests__/integration.test.js
+++ b/lib/__tests__/integration.test.js
@@ -59,7 +59,7 @@ describe("integration test expecting warnings", () => {
   });
 
   it("number and type", () => {
-    expect(result.messages.length).toBe(5);
+    expect(result.messages).toHaveLength(5);
     expect(result.messages.every(m => m.type === "warning")).toBeTruthy();
     expect(result.messages.every(m => m.plugin === "stylelint")).toBeTruthy();
   });
@@ -103,7 +103,7 @@ it("Less integration test", () => {
     .use(stylelint({ rules: {} }))
     .process(less, { syntax: lessSyntax, from: undefined })
     .then(result => {
-      expect(result.messages.length).toBe(0);
+      expect(result.messages).toHaveLength(0);
     });
 });
 
@@ -115,7 +115,7 @@ it("Sass integration test", () => {
     .use(stylelint({ rules: {} }))
     .process(sass, { syntax: sassSyntax, from: undefined })
     .then(result => {
-      expect(result.messages.length).toBe(0);
+      expect(result.messages).toHaveLength(0);
     });
 });
 
@@ -129,7 +129,7 @@ it("Scss integration test", () => {
     .use(stylelint({ rules: {} }))
     .process(scss, { syntax: scssSyntax, from: undefined })
     .then(result => {
-      expect(result.messages.length).toBe(0);
+      expect(result.messages).toHaveLength(0);
     });
 });
 
@@ -151,11 +151,11 @@ describe("integration test null option", () => {
   });
 
   it("no invalid option warnings", () => {
-    expect(results[0].invalidOptionWarnings.length).toBe(0);
+    expect(results[0].invalidOptionWarnings).toHaveLength(0);
   });
 
   it("no warnings", () => {
-    expect(results[0].warnings.length).toBe(0);
+    expect(results[0].warnings).toHaveLength(0);
   });
 });
 
@@ -177,10 +177,10 @@ describe("integration test [null] option", () => {
   });
 
   it("no invalid option warnings", () => {
-    expect(results[0].invalidOptionWarnings.length).toBe(0);
+    expect(results[0].invalidOptionWarnings).toHaveLength(0);
   });
 
   it("no warnings", () => {
-    expect(results[0].warnings.length).toBe(0);
+    expect(results[0].warnings).toHaveLength(0);
   });
 });

--- a/lib/__tests__/message.test.js
+++ b/lib/__tests__/message.test.js
@@ -11,7 +11,7 @@ it("standalone loading YAML with custom message", () => {
       "fixtures/config-color-named-custom-message.yaml"
     )
   }).then(linted => {
-    expect(linted.results[0].warnings.length).toBe(1);
+    expect(linted.results[0].warnings).toHaveLength(1);
     expect(linted.results[0].warnings[0].text).toBe("Unacceptable");
   });
 });

--- a/lib/__tests__/needlessDisables.test.js
+++ b/lib/__tests__/needlessDisables.test.js
@@ -35,7 +35,7 @@ it("needlessDisables simple case", () => {
     ignoreDisables: true
   }).then(linted => {
     const report = needlessDisables(linted.results);
-    expect(report.length).toBe(1);
+    expect(report).toHaveLength(1);
     expect(report[0].ranges).toEqual([
       { start: 7, end: 9 },
       { start: 11, end: 11 }

--- a/lib/__tests__/normalizeRuleSettings-integration.test.js
+++ b/lib/__tests__/normalizeRuleSettings-integration.test.js
@@ -43,7 +43,7 @@ it("[normalized rule settings] no-array primary, primary option null", () => {
       }
     }
   }).then(linted => {
-    expect(linted.results[0].warnings.length).toBe(0);
+    expect(linted.results[0].warnings).toHaveLength(0);
   });
 });
 
@@ -57,7 +57,7 @@ it("[normalized rule settings] no-array primary, primary option null in array", 
       }
     }
   }).then(linted => {
-    expect(linted.results[0].warnings.length).toBe(0);
+    expect(linted.results[0].warnings).toHaveLength(0);
   });
 });
 
@@ -71,7 +71,7 @@ it("[normalized rule settings] array primary, primary option null", () => {
       }
     }
   }).then(linted => {
-    expect(linted.results[0].warnings.length).toBe(0);
+    expect(linted.results[0].warnings).toHaveLength(0);
   });
 });
 
@@ -85,6 +85,6 @@ it("[normalized rule settings] array primary, primary option null in array", () 
       }
     }
   }).then(linted => {
-    expect(linted.results[0].invalidOptionWarnings.length).toBe(0);
+    expect(linted.results[0].invalidOptionWarnings).toHaveLength(0);
   });
 });

--- a/lib/__tests__/plugins.test.js
+++ b/lib/__tests__/plugins.test.js
@@ -56,7 +56,7 @@ it("one plugin runs", () => {
   return processorRelative
     .process(cssWithFoo, { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(2);
+      expect(result.warnings()).toHaveLength(2);
       expect(result.warnings()[0].text).toBe(
         "found .foo (plugin/warn-about-foo)"
       );
@@ -68,7 +68,7 @@ it("another plugin runs", () => {
   return processorRelative
     .process(cssWithoutFoo, { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(1);
+      expect(result.warnings()).toHaveLength(1);
       expect(result.warnings()[0].text).toBe(
         "Unexpected empty block (block-no-empty)"
       );
@@ -79,7 +79,7 @@ it("plugin with absolute path and no configBasedir", () => {
   return processorAbsolute
     .process(cssWithFoo, { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(2);
+      expect(result.warnings()).toHaveLength(2);
       expect(result.warnings()[0].text).toBe(
         "found .foo (plugin/warn-about-foo)"
       );
@@ -91,7 +91,7 @@ it("config extending another config that invokes a plugin with a relative path",
   return processorExtendRelative
     .process(cssWithFoo, { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(1);
+      expect(result.warnings()).toHaveLength(1);
       expect(result.warnings()[0].text).toBe(
         "found .foo (plugin/warn-about-foo)"
       );
@@ -103,7 +103,7 @@ it("config with its own plugins extending another config that invokes a plugin w
   return processorRelativeAndExtendRelative
     .process(cssWithFooAndBar, { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(2);
+      expect(result.warnings()).toHaveLength(2);
       expect(result.warnings()[0].text).toBe(
         "found .bar (plugin/warn-about-bar)"
       );
@@ -140,7 +140,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
       .use(stylelint(config("upper")))
       .process(cssWithDirectiveLower, { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(1);
+        expect(result.warnings()).toHaveLength(1);
         expect(result.warnings()[0].text).toBe(
           'Expected "#eee" to be "#EEE" (color-hex-case)'
         );
@@ -152,7 +152,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
       .use(stylelint(config("upper")))
       .process(cssWithDirectiveUpper, { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(0);
+        expect(result.warnings()).toHaveLength(0);
       });
   });
 
@@ -161,7 +161,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
       .use(stylelint(config("lower")))
       .process(cssWithDirectiveUpper, { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(1);
+        expect(result.warnings()).toHaveLength(1);
         expect(result.warnings()[0].text).toBe(
           'Expected "#EEE" to be "#eee" (color-hex-case)'
         );
@@ -173,7 +173,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
       .use(stylelint(config("lower")))
       .process(cssWithDirectiveLower, { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(0);
+        expect(result.warnings()).toHaveLength(0);
       });
   });
 
@@ -182,7 +182,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
       .use(stylelint(config("upper")))
       .process(cssWithoutDirectiveLower, { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(0);
+        expect(result.warnings()).toHaveLength(0);
       });
   });
 
@@ -191,7 +191,7 @@ describe("plugin using exposed rules via stylelint.rules", () => {
       .use(stylelint(config("lower")))
       .process(cssWithoutDirectiveUpper, { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(0);
+        expect(result.warnings()).toHaveLength(0);
       });
   });
 });
@@ -210,7 +210,7 @@ describe("module providing an array of plugins", () => {
       .use(stylelint(config))
       .process("@@check-color-hex-case a { color: #eee; }", { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(1);
+        expect(result.warnings()).toHaveLength(1);
         expect(result.warnings()[0].text).toBe(
           'Expected "#eee" to be "#EEE" (color-hex-case)'
         );
@@ -222,7 +222,7 @@ describe("module providing an array of plugins", () => {
       .use(stylelint(config))
       .process(".foo {}", { from: undefined })
       .then(result => {
-        expect(result.warnings().length).toBe(1);
+        expect(result.warnings()).toHaveLength(1);
         expect(result.warnings()[0].text).toBe(
           "found .foo (plugin/warn-about-foo)"
         );
@@ -264,7 +264,7 @@ it("plugin with primary option array", () => {
     .use(stylelint(config))
     .process("a {}", { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(0);
+      expect(result.warnings()).toHaveLength(0);
     });
 });
 
@@ -279,7 +279,7 @@ it("plugin with primary option array within options array", () => {
     .use(stylelint(config))
     .process("a {}", { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(0);
+      expect(result.warnings()).toHaveLength(0);
     });
 });
 
@@ -294,7 +294,7 @@ it("plugin with async rule", () => {
     .use(stylelint(config))
     .process("a {}", { from: undefined })
     .then(result => {
-      expect(result.warnings().length).toBe(1);
+      expect(result.warnings()).toHaveLength(1);
     });
 });
 
@@ -326,7 +326,7 @@ describe("loading a plugin from process.cwd", () => {
   });
 
   it("error is caught", () => {
-    expect(result.warnings().length).toBe(1);
+    expect(result.warnings()).toHaveLength(1);
   });
 
   it("error is correct", () => {

--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -23,7 +23,7 @@ it("`configFile` option with absolute path", () => {
     .process("a {}", { from: undefined }, config)
     .then(postcssResult => {
       const warnings = postcssResult.warnings();
-      expect(warnings.length).toBe(1);
+      expect(warnings).toHaveLength(1);
       expect(warnings[0].text.indexOf("block-no-empty")).not.toBe(-1);
     });
 });

--- a/lib/__tests__/processors.test.js
+++ b/lib/__tests__/processors.test.js
@@ -21,11 +21,11 @@ describe("processor transforms input and output", () => {
   });
 
   it("number of results", () => {
-    expect(results.length).toBe(1);
+    expect(results).toHaveLength(1);
   });
 
   it("number of warnings", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
   });
 
   it("warning rule", () => {
@@ -88,11 +88,11 @@ describe("multiple processors", () => {
   });
 
   it("number of results", () => {
-    expect(results.length).toBe(1);
+    expect(results).toHaveLength(1);
   });
 
   it("number of warnings", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
   });
 
   it("warning rule", () => {
@@ -150,11 +150,11 @@ describe("loading processors (and extend) from process.cwd", () => {
   });
 
   it("number of results", () => {
-    expect(results.length).toBe(1);
+    expect(results).toHaveLength(1);
   });
 
   it("number of warnings", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
   });
 
   it("special message", () => {
@@ -182,7 +182,7 @@ describe("processor gets to modify result on CssSyntaxError", () => {
   });
 
   it("CssSyntaxError occurred", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
     expect(results[0].warnings[0].rule).toBe("CssSyntaxError");
   });
 

--- a/lib/__tests__/standalone-deprecations.test.js
+++ b/lib/__tests__/standalone-deprecations.test.js
@@ -21,8 +21,8 @@ describe("standalone with deprecations", () => {
       config: configBlockNoEmpty
     }).then(data => {
       expect(data.output.indexOf("Some deprecation")).not.toBe(-1);
-      expect(data.results.length).toBe(1);
-      expect(data.results[0].deprecations.length).toBe(1);
+      expect(data.results).toHaveLength(1);
+      expect(data.results[0].deprecations).toHaveLength(1);
       expect(data.results[0].deprecations[0].text).toBe("Some deprecation");
     });
   });

--- a/lib/__tests__/standalone-needlessDisables.test.js
+++ b/lib/__tests__/standalone-needlessDisables.test.js
@@ -22,8 +22,8 @@ it("standalone with input css and `reportNeedlessDisables`", () => {
     const needlessDisables = linted.needlessDisables;
 
     expect(typeof needlessDisables).toBe("object");
-    expect(needlessDisables.length).toBe(1);
-    expect(needlessDisables[0].ranges.length).toBe(1);
+    expect(needlessDisables).toHaveLength(1);
+    expect(needlessDisables[0].ranges).toHaveLength(1);
     expect(needlessDisables[0].ranges[0]).toEqual({
       start: 1
     });
@@ -47,7 +47,7 @@ it("standalone with input file(s) and `reportNeedlessDisables`", () => {
     const needlessDisables = linted.needlessDisables;
 
     expect(typeof needlessDisables).toBe("object");
-    expect(needlessDisables.length).toBe(1);
+    expect(needlessDisables).toHaveLength(1);
     expect(needlessDisables[0].source).toBe(
       path.join(fixturesPath, "empty-block-with-disables.css")
     );

--- a/lib/__tests__/standalone-parseErrors.test.js
+++ b/lib/__tests__/standalone-parseErrors.test.js
@@ -21,8 +21,8 @@ describe("standalone with deprecations", () => {
       config: configBlockNoEmpty
     }).then(data => {
       expect(data.output.indexOf("Some parseError")).not.toBe(-1);
-      expect(data.results.length).toBe(1);
-      expect(data.results[0].parseErrors.length).toBe(1);
+      expect(data.results).toHaveLength(1);
+      expect(data.results[0].parseErrors).toHaveLength(1);
       expect(data.results[0].parseErrors[0].text).toBe("Some parseError");
     });
   });

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -101,31 +101,31 @@ it("standalone with postcss-html syntax", () => {
     formatter: stringFormatter
   }).then(linted => {
     const results = linted.results;
-    expect(results.length).toBe(4);
+    expect(results).toHaveLength(4);
 
     const atRuleEmptyLineBeforeResult = results.find(r =>
       /[/\\]at-rule-empty-line-before\.html$/.test(r.source)
     );
     expect(atRuleEmptyLineBeforeResult.errored).toBeFalsy();
-    expect(atRuleEmptyLineBeforeResult.warnings.length).toBe(0);
+    expect(atRuleEmptyLineBeforeResult.warnings).toHaveLength(0);
 
     const commentEmptyLineBeforeResult = results.find(r =>
       /[/\\]comment-empty-line-before\.html$/.test(r.source)
     );
     expect(commentEmptyLineBeforeResult.errored).toBeFalsy();
-    expect(commentEmptyLineBeforeResult.warnings.length).toBe(0);
+    expect(commentEmptyLineBeforeResult.warnings).toHaveLength(0);
 
     const noEmptySourceResult = results.find(r =>
       /[/\\]no-empty-source\.html$/.test(r.source)
     );
     expect(noEmptySourceResult.errored).toBeFalsy();
-    expect(noEmptySourceResult.warnings.length).toBe(0);
+    expect(noEmptySourceResult.warnings).toHaveLength(0);
 
     const ruleEmptyLineBeforeResult = results.find(r =>
       /[/\\]rule-empty-line-before\.html$/.test(r.source)
     );
     expect(ruleEmptyLineBeforeResult.errored).toBe(true);
-    expect(ruleEmptyLineBeforeResult.warnings.length).toBe(1);
+    expect(ruleEmptyLineBeforeResult.warnings).toHaveLength(1);
     expect(ruleEmptyLineBeforeResult.warnings[0].line).toBe(8);
     expect(ruleEmptyLineBeforeResult.warnings[0].rule).toBe(
       "rule-empty-line-before"
@@ -203,7 +203,7 @@ describe("standalone with syntax set by extension", () => {
     });
 
     it("correct number of files", () => {
-      expect(results.length).toBe(6);
+      expect(results).toHaveLength(6);
     });
 
     it("parsed each according to its extension", () => {
@@ -222,7 +222,7 @@ describe("standalone with syntax set by extension", () => {
       expect(jsResult._postcssResult.root.source.lang).toBe("jsx");
 
       results.forEach(result => {
-        expect(result.warnings.length).toBe(1);
+        expect(result.warnings).toHaveLength(1);
         expect(result.warnings[0].rule).toBe("color-no-invalid-hex");
       });
     });
@@ -272,7 +272,7 @@ it("standalone with automatic syntax inference", () => {
       expect(result._postcssResult.css).toEqual(
         result._postcssResult.root.source.input.css
       );
-      expect(result.warnings.length).toBe(1);
+      expect(result.warnings).toHaveLength(1);
       expect(result.warnings[0].rule).toBe("block-no-empty");
       expect(result.warnings[0].column).toBe(1);
     });
@@ -288,21 +288,21 @@ it("standalone with postcss-safe-parser", () => {
     fix: true
   }).then(data => {
     const results = data.results;
-    expect(results.length).toBe(6);
+    expect(results).toHaveLength(6);
 
     return Promise.all(
       results.map(result => {
         if (/\.(css|pcss|postcss)$/i.test(result.source)) {
           const root = result._postcssResult.root;
           expect(results[0].errored).toBeFalsy();
-          expect(results[0].warnings.length).toBe(0);
+          expect(results[0].warnings).toHaveLength(0);
           expect(root.toString()).not.toBe(root.source.input.css);
           return pify(fs.writeFile)(
             root.source.input.file,
             root.source.input.css
           );
         } else {
-          expect(result.warnings.length).toBe(1);
+          expect(result.warnings).toHaveLength(1);
           const error = result.warnings[0];
           expect(error.line).toBe(1);
           expect(error.column).toBe(1);
@@ -329,8 +329,8 @@ it("standalone with path to custom parser", () => {
   }).then(linted => {
     const results = linted.results;
 
-    expect(results.length).toBe(1);
-    expect(results[0].warnings.length).toBe(1);
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
     expect(results[0].warnings[0].line).toBe(2);
     expect(results[0].warnings[0].column).toBe(6);
     expect(results[0].warnings[0].rule).toBe("block-no-empty");
@@ -352,8 +352,8 @@ it("standalone with path to custom syntax", () => {
   }).then(linted => {
     const results = linted.results;
 
-    expect(results.length).toBe(1);
-    expect(results[0].warnings.length).toBe(1);
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
     expect(results[0].warnings[0].line).toBe(2);
     expect(results[0].warnings[0].column).toBe(3);
     expect(results[0].warnings[0].rule).toBe("block-no-empty");
@@ -376,8 +376,8 @@ it("standalone should use customSyntax when both customSyntax and syntax are set
   }).then(linted => {
     const results = linted.results;
 
-    expect(results.length).toBe(1);
-    expect(results[0].warnings.length).toBe(1);
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
     expect(results[0].warnings[0].line).toBe(2);
     expect(results[0].warnings[0].column).toBe(3);
     expect(results[0].warnings[0].rule).toBe("block-no-empty");

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -23,8 +23,8 @@ describe("standalone with one input file", () => {
 
   it("triggers warning", () => {
     expect(output.indexOf("block-no-empty")).not.toBe(-1);
-    expect(results.length).toBe(1);
-    expect(results[0].warnings.length).toBe(1);
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
     expect(results[0].warnings[0].rule).toBe("block-no-empty");
   });
 });
@@ -53,9 +53,9 @@ describe("standalone with two file-specific globs", () => {
   it("triggers warnings", () => {
     expect(output.indexOf("block-no-empty")).not.toBe(-1);
     expect(output.indexOf("color-no-invalid-hex")).not.toBe(-1);
-    expect(results.length).toBe(2);
-    expect(results[0].warnings.length).toBe(1);
-    expect(results[1].warnings.length).toBe(1);
+    expect(results).toHaveLength(2);
+    expect(results[0].warnings).toHaveLength(1);
+    expect(results[1].warnings).toHaveLength(1);
     // Ordering of the files is non-deterministic, I believe
     if (results[0].source.indexOf("empty-block") !== -1) {
       expect(results[0].warnings[0].rule).toBe("block-no-empty");
@@ -85,8 +85,8 @@ describe("standalone with files and globbyOptions", () => {
 
   it("triggers warning", () => {
     expect(output.indexOf("block-no-empty")).not.toBe(-1);
-    expect(results.length).toBe(1);
-    expect(results[0].warnings.length).toBe(1);
+    expect(results).toHaveLength(1);
+    expect(results[0].warnings).toHaveLength(1);
     expect(results[0].warnings[0].rule).toBe("block-no-empty");
   });
 });
@@ -97,8 +97,8 @@ it("standalone with input css", () => {
     config: configBlockNoEmpty
   }).then(linted => {
     expect(typeof linted.output).toBe("string");
-    expect(linted.results.length).toBe(1);
-    expect(linted.results[0].warnings.length).toBe(1);
+    expect(linted.results).toHaveLength(1);
+    expect(linted.results[0].warnings).toHaveLength(1);
     expect(linted.results[0].warnings[0].rule).toBe("block-no-empty");
   });
 });
@@ -118,7 +118,7 @@ it("standalone with non-existent-file quietly exits", () => {
     config: configBlockNoEmpty
   }).then(linted => {
     expect(typeof linted.output).toBe("string");
-    expect(linted.results.length).toBe(0);
+    expect(linted.results).toHaveLength(0);
     expect(linted.errored).toBe(false);
     expect(linted.output).toBe("[]");
   });
@@ -139,15 +139,15 @@ describe("standalone passing code with syntax error", () => {
   });
 
   it("empty deprecations", () => {
-    expect(results[0].deprecations.length).toBe(0);
+    expect(results[0].deprecations).toHaveLength(0);
   });
 
   it("empty invalidOptionWarnings", () => {
-    expect(results[0].invalidOptionWarnings.length).toBe(0);
+    expect(results[0].invalidOptionWarnings).toHaveLength(0);
   });
 
   it("empty parseError", () => {
-    expect(results[0].parseErrors.length).toBe(0);
+    expect(results[0].parseErrors).toHaveLength(0);
   });
 
   it("error registered", () => {
@@ -155,7 +155,7 @@ describe("standalone passing code with syntax error", () => {
   });
 
   it("syntax error rule is CssSyntaxError", () => {
-    expect(results[0].warnings.length).toBe(1);
+    expect(results[0].warnings).toHaveLength(1);
     expect(results[0].warnings[0].rule).toBe("CssSyntaxError");
   });
 
@@ -268,14 +268,14 @@ describe("standalone with different configs per file", () => {
     const resultA = results.find(
       result => result.source.indexOf("a.css") !== -1
     );
-    expect(resultA.warnings.length).toBe(0);
+    expect(resultA.warnings).toHaveLength(0);
   });
 
   it("one warning for B", () => {
     const resultB = results.find(
       result => result.source.indexOf("b.css") !== -1
     );
-    expect(resultB.warnings.length).toBe(1);
+    expect(resultB.warnings).toHaveLength(1);
   });
 
   it("correct warning for B", () => {
@@ -291,14 +291,14 @@ describe("standalone with different configs per file", () => {
     const resultC = results.find(
       result => result.source.indexOf("c.css") !== -1
     );
-    expect(resultC.warnings.length).toBe(0);
+    expect(resultC.warnings).toHaveLength(0);
   });
 
   it("no warnings for D", () => {
     const resultD = results.find(
       result => result.source.indexOf("d.css") !== -1
     );
-    expect(resultD.warnings.length).toBe(0);
+    expect(resultD.warnings).toHaveLength(0);
   });
 });
 
@@ -322,7 +322,7 @@ describe("standalone with config locatable from process.cwd not file", () => {
   });
 
   it("two warning", () => {
-    expect(results[0].warnings.length).toBe(2);
+    expect(results[0].warnings).toHaveLength(2);
   });
 
   it("first correct warning", () => {
@@ -351,7 +351,7 @@ describe("configOverrides", () => {
         plugins: ["./fixtures/plugin-warn-about-bar"]
       }
     }).then(linted => {
-      expect(linted.results[0].warnings.length).toBe(1);
+      expect(linted.results[0].warnings).toHaveLength(1);
       expect(linted.results[0].warnings[0].text).toBe(
         "found .bar (plugin/warn-about-bar)"
       );
@@ -369,7 +369,7 @@ describe("configOverrides", () => {
         extends: ["./fixtures/config-block-no-empty"]
       }
     }).then(linted => {
-      expect(linted.results[0].warnings.length).toBe(1);
+      expect(linted.results[0].warnings).toHaveLength(1);
       expect(linted.results[0].warnings[0].text).toContain("block-no-empty");
     });
   });
@@ -399,7 +399,7 @@ describe("nonexistent codeFilename with loaded config", () => {
       code: "a {}",
       codeFilename: "does-not-exist.css"
     }).then(linted => {
-      expect(linted.results[0].warnings.length).toBe(1);
+      expect(linted.results[0].warnings).toHaveLength(1);
     });
   });
 });
@@ -421,7 +421,7 @@ describe("existing codeFilename for nested config detection", () => {
       code: "a {}",
       codeFilename: "a/b/foo.css"
     }).then(linted => {
-      expect(linted.results[0].warnings.length).toBe(1);
+      expect(linted.results[0].warnings).toHaveLength(1);
     });
   });
 });

--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.js
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.js
@@ -34,7 +34,7 @@ describe("stylelintignore", () => {
     });
 
     it("one file read", () => {
-      expect(results.length).toBe(1);
+      expect(results).toHaveLength(1);
     });
 
     it("empty-block.css not read", () => {
@@ -46,7 +46,7 @@ describe("stylelintignore", () => {
     });
 
     it("color-no-invalid-hex.css linted", () => {
-      expect(results[0].warnings.length).toBe(1);
+      expect(results[0].warnings).toHaveLength(1);
     });
   });
 

--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -138,7 +138,7 @@ it("with postcss-import and duplicates within a file, a warning strikes", () => 
       from: path.join(__dirname, "test.css")
     })
     .then(result => {
-      expect(result.warnings().length).toBe(1);
+      expect(result.warnings()).toHaveLength(1);
     });
 });
 
@@ -151,6 +151,6 @@ it("with postcss-import and duplicates across files, no warnings", () => {
       }
     )
     .then(result => {
-      expect(result.warnings().length).toBe(0);
+      expect(result.warnings()).toHaveLength(0);
     });
 });

--- a/lib/utils/__tests__/checkAgainstRule.test.js
+++ b/lib/utils/__tests__/checkAgainstRule.test.js
@@ -18,7 +18,7 @@ describe("checkAgainstRule", () => {
       warning => warnings.push(warning)
     );
 
-    expect(warnings.length).toBe(0);
+    expect(warnings).toHaveLength(0);
   });
 
   it("handles non-array rule settings", () => {
@@ -34,7 +34,7 @@ describe("checkAgainstRule", () => {
       warning => warnings.push(warning)
     );
 
-    expect(warnings.length).toBe(1);
+    expect(warnings).toHaveLength(1);
     expect(warnings[0].rule).toBe("at-rule-name-case");
     expect(warnings[0].line).toBe(1);
     expect(warnings[0].column).toBe(6);
@@ -55,7 +55,7 @@ describe("checkAgainstRule", () => {
       warning => warnings.push(warning)
     );
 
-    expect(warnings.length).toBe(1);
+    expect(warnings).toHaveLength(1);
     expect(warnings[0].rule).toBe("at-rule-empty-line-before");
     expect(warnings[0].line).toBe(3);
     expect(warnings[0].column).toBe(1);

--- a/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
@@ -55,7 +55,7 @@ describe("isStandardSyntaxAtRule", () => {
     });
   });
 
-  it("nested at-rules with newline after name", () => {
+  it("nested at-rules with windows newline after name", () => {
     atRules("@media\r\n(min-width: 100px) {};", atRule => {
       expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
     });
@@ -67,7 +67,7 @@ describe("isStandardSyntaxAtRule", () => {
     });
   });
 
-  it("ignore `@content` inside mixins", () => {
+  it("ignore `@content` inside mixins newline", () => {
     const sass = "@mixin mixin()\n  @content";
     sassAtRules(sass, atRule => {
       if (atRule.name === "mixin") {
@@ -77,7 +77,7 @@ describe("isStandardSyntaxAtRule", () => {
     });
   });
 
-  it("ignore `@content` inside mixins", () => {
+  it("ignore `@content` inside mixins space", () => {
     const scss = "@mixin mixin() { @content; };";
     scssAtRules(scss, atRule => {
       if (atRule.name === "mixin") {

--- a/lib/utils/__tests__/isStandardSyntaxMediaFeatureName.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxMediaFeatureName.test.js
@@ -6,7 +6,7 @@ describe("isStandardSyntaxMediaFeatureName", () => {
   it("keyword", () => {
     expect(isStandardSyntaxMediaFeatureName("min-width")).toBeTruthy();
   });
-  it("keyword", () => {
+  it("vendor prefixed keyword", () => {
     expect(
       isStandardSyntaxMediaFeatureName("-webkit-min-device-pixel-ratio")
     ).toBeTruthy();
@@ -17,28 +17,28 @@ describe("isStandardSyntaxMediaFeatureName", () => {
   it("scss var", () => {
     expect(isStandardSyntaxMediaFeatureName("$sass-variable")).toBeFalsy();
   });
-  it("scss var", () => {
+  it("scss var addition", () => {
     expect(isStandardSyntaxMediaFeatureName("min-width + $value")).toBeFalsy();
   });
-  it("scss var", () => {
+  it("scss var added to", () => {
     expect(isStandardSyntaxMediaFeatureName("$value + min-width")).toBeFalsy();
   });
-  it("scss var", () => {
+  it("scss var single quoted addition", () => {
     expect(
       isStandardSyntaxMediaFeatureName("'min-width + $value'")
     ).toBeFalsy();
   });
-  it("scss var", () => {
+  it("scss var single quoted added to ", () => {
     expect(
       isStandardSyntaxMediaFeatureName("'$value + min-width'")
     ).toBeFalsy();
   });
-  it("scss var", () => {
+  it("scss var doubled quoted addition", () => {
     expect(
       isStandardSyntaxMediaFeatureName('"min-width + $value"')
     ).toBeFalsy();
   });
-  it("scss var", () => {
+  it("scss var doubled quoted added to", () => {
     expect(
       isStandardSyntaxMediaFeatureName('"$value + min-width"')
     ).toBeFalsy();
@@ -46,25 +46,25 @@ describe("isStandardSyntaxMediaFeatureName", () => {
   it("scss interpolation", () => {
     expect(isStandardSyntaxMediaFeatureName("min-width#{$value}")).toBeFalsy();
   });
-  it("scss interpolation", () => {
+  it("scss interpolation start", () => {
     expect(isStandardSyntaxMediaFeatureName("#{$value}min-width")).toBeFalsy();
   });
-  it("scss interpolation", () => {
+  it("scss interpolation single quoted", () => {
     expect(
       isStandardSyntaxMediaFeatureName("'min-width#{$value}'")
     ).toBeFalsy();
   });
-  it("scss interpolation", () => {
+  it("scss interpolation single quoted start", () => {
     expect(
       isStandardSyntaxMediaFeatureName("'#{$value}min-width'")
     ).toBeFalsy();
   });
-  it("scss interpolation", () => {
+  it("scss interpolation double quoted", () => {
     expect(
       isStandardSyntaxMediaFeatureName('"min-width#{$value}"')
     ).toBeFalsy();
   });
-  it("scss interpolation", () => {
+  it("scss interpolation doubled quoted start", () => {
     expect(
       isStandardSyntaxMediaFeatureName('"#{$value}min-width"')
     ).toBeFalsy();

--- a/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
@@ -60,7 +60,7 @@ describe("isStandardSyntaxTypeSelector", () => {
       expect(isStandardSyntaxTypeSelector(func)).toBeFalsy();
     });
   });
-  it("nesting selector", () => {
+  it("nesting selector underscores", () => {
     rules(".foo { &__bar {} }", func => {
       expect(isStandardSyntaxTypeSelector(func)).toBeFalsy();
     });

--- a/lib/utils/__tests__/isStandardSyntaxUrl.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxUrl.test.js
@@ -177,7 +177,7 @@ describe("isStandardSyntaxUrl", () => {
   it("sass variable and concatenation", () => {
     expect(isStandardSyntaxUrl("$sass-variable + foo")).toBeFalsy();
   });
-  it("sass variable and concatenation", () => {
+  it("sass variable and double concatenation", () => {
     expect(isStandardSyntaxUrl("test + $sass-variable + foo")).toBeFalsy();
   });
   it("sass interpolation and concatenation", () => {

--- a/lib/utils/__tests__/validateOptions.test.js
+++ b/lib/utils/__tests__/validateOptions.test.js
@@ -313,7 +313,7 @@ describe("validateOptions with a function for 'possible'", () => {
     expect(result.warn).toHaveBeenCalledTimes(0);
   });
 
-  it("array of mixed objects and strings passes", () => {
+  it("object of mixed objects and strings passes", () => {
     const invalidObject = validateOptions(result, "foo", {
       possible: schema,
       actual: { properties: ["one"] }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/issues/3638

> Is there anything in the PR that needs further explanation?

Fixes up the 150 or so ESLint warnings in `master`. The just plugin is useful as it caught these mistakes.

Warnings cames from:

- https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-have-length.md
- https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-identical-title.md
