### PR TITLE
Add codacy as an analysis platform engine

### DIFF
--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -4,6 +4,7 @@ A list of complementary tools built and maintained by the community.
 
 ## Analysis platform engines
 
+-   [codacy-stylelint](https://github.com/codacy/codacy-stylelint): [Codacy](https://www.codacy.com/) engine for stylelint
 -   [codeclimate-stylelint](https://github.com/gilbarbara/codeclimate-stylelint): Code Climate engine for stylelint
 
 ## Command Line Tools


### PR DESCRIPTION
Thank you for the great tool! 
I am adding Codacy to the docs as a analysis platform engine section.
This way, more people can use stylelint analysis out of the box, for free.