### PR TITLE
Fix failing appveyor test

### DIFF
--- a/lib/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -70,8 +70,8 @@ testRule(rule, {
       column: 7
     },
     {
-      code: "input:-moz-placeholder, input::placeholder { color: pink; }",
-      message: messages.rejected(":-moz-placeholder"),
+      code: "input::-moz-placeholder, input::placeholder { color: pink; }",
+      message: messages.rejected("::-moz-placeholder"),
       line: 1,
       column: 6
     },


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/3712

> Is there anything in the PR that needs further explanation?

It was an odd test as I believe that `moz-placeholder` is a pseudo _element_, rather than a class. It is used as an element in the subsequent test, so I just updated the failing test to match.
