### PR TITLE
Blockless pseudoclasses

### DIFF
--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -148,6 +148,65 @@ a {
 }
 ```
 
+### `ignore: ["blockless-pseudoclasses"]`
+
+Ignore pseudoclases that only wrap other rules, and do not themselves have declaration blocks.
+
+For example, with `1`:
+
+The following patterns are considered violations:
+
+As the pseudoclasses have a declarations blocks.
+
+```css
+a {
+  &:hover { /* 1 */
+    b { /* 2 */
+      top: 0;
+    }
+  }
+}
+```
+
+```css
+a {
+  &:nest { /* 1 */
+    &:nest-lvl2 { /* 1 */
+      top: 0;
+      .class { /* 2 */
+        bottom: 0;
+      }
+    }
+  }
+}
+```
+
+The following patterns are *not* considered violations:
+
+As all of the following pseudoclasses rules would have a nesting depth of just 1.
+
+```css
+a {
+  b { /* 1 */
+    &:hover { /* 1 */
+      color: pink;
+    }
+  }
+}
+```
+
+```css
+a {
+  b { /* 1 */
+    &:nest { /* 1 */
+      &:nest-lvl2 { /* 1 */
+        top: 0;
+      }
+    }
+  }
+}
+```
+
 ### `ignoreAtRules: ["/regex/", "string"]`
 
 Ignore the specified at-rules.

--- a/lib/rules/max-nesting-depth/__tests__/index.js
+++ b/lib/rules/max-nesting-depth/__tests__/index.js
@@ -112,6 +112,38 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [1, { ignore: ["blockless-pseudoclasses"] }],
+
+  accept: [
+    {
+      code: "a { b { top: 0; }}"
+    },
+    {
+      code: "a { b { &:hover { top: 0; }}}"
+    },
+    {
+      code: "a { b { &:nest { &:nest-lvl2 { top: 0; }}}}"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a { b { c { top: 0; }}}",
+      message: messages.expected(1)
+    },
+    {
+      code: "a { &:hover { b { top: 0; }}}",
+      message: messages.expected(1)
+    },
+    {
+      code: "a { &:nest { &:nest-lvl2 { top: 0; .class { bottom: 0; }}}}",
+      message: messages.expected(1)
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: [1, { ignoreAtRules: ["media", "/^my-/"] }],
 
   accept: [

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -31,7 +31,7 @@ const rule = function(max, options) {
         optional: true,
         actual: options,
         possible: {
-          ignore: ["blockless-at-rules"],
+          ignore: ["blockless-at-rules", "blockless-pseudoclasses"],
           ignoreAtRules: [_.isString]
         }
       }
@@ -82,9 +82,12 @@ const rule = function(max, options) {
     }
 
     if (
-      optionsMatches(options, "ignore", "blockless-at-rules") &&
-      node.type === "atrule" &&
-      node.every(child => child.type !== "decl")
+      (optionsMatches(options, "ignore", "blockless-at-rules") &&
+        node.type === "atrule" &&
+        node.every(child => child.type !== "decl")) ||
+      (optionsMatches(options, "ignore", "blockless-pseudoclasses") &&
+        node.type === "rule" &&
+        node.some(child => child.selector && child.selector.startsWith("&:")))
     ) {
       return nestingDepth(parent, level);
     }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?
https://github.com/stylelint/stylelint/issues/3723

> Is there anything in the PR that needs further explanation?
Having max-nesting-depth = 1, it could be useful adding a rule to ìgnore` like
```
'max-nesting-depth': [1, {
  ignore: ["blockless-pseudoelements"]
}],
```

Allowing for example this css code
```
a {
  b { /* 1 */
    &:nest { /* 1 */
      &:nest-lvl2 { /* 1 */
        top: 0;
      }
    }
  }
}
```