### PR TITLE
Fix error in tests

### DIFF
--- a/lib/__tests__/printConfig.test.js
+++ b/lib/__tests__/printConfig.test.js
@@ -9,7 +9,7 @@ it("printConfig uses getConfigForFile to retrieve the config", () => {
     __dirname,
     "fixtures/getConfigForFile/a/b/foo.css"
   );
-  printConfig({
+  return printConfig({
     files: [filepath]
   }).then(result => {
     expect(result).toEqual({

--- a/lib/__tests__/standalone-deprecations.test.js
+++ b/lib/__tests__/standalone-deprecations.test.js
@@ -16,7 +16,7 @@ blockNoEmpty.mockImplementation(() => {
 
 describe("standalone with deprecations", () => {
   it("works", () => {
-    standalone({
+    return standalone({
       code: "a {}",
       config: configBlockNoEmpty
     }).then(data => {

--- a/lib/__tests__/standalone-parseErrors.test.js
+++ b/lib/__tests__/standalone-parseErrors.test.js
@@ -16,7 +16,7 @@ blockNoEmpty.mockImplementation(() => {
 
 describe("standalone with deprecations", () => {
   it("works", () => {
-    standalone({
+    return standalone({
       code: "a {}",
       config: configBlockNoEmpty
     }).then(data => {


### PR DESCRIPTION
We have this error for two months in tests:

```
PASS lib/utils/__tests__/isStandardSyntaxValue.test.js
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.
      244 | ) /*: stylelint$config*/ {
      245 |   if (!config.plugins) return config;
    > 246 | 
          | ^
      247 |   const normalizedPlugins = Array.isArray(config.plugins)
      248 |     ? config.plugins
      249 |     : [config.plugins];
      at lazy (node_modules/import-lazy/index.js:2:51)
      at Object.get (node_modules/import-lazy/index.js:10:11)
      at baseGet (node_modules/lodash/lodash.js:3041:24)
      at Function.get (node_modules/lodash/lodash.js:13128:49)
      at Object.keys.forEach.ruleName (lib/augmentConfig.js:246:84)
          at Array.forEach (<anonymous>)
      at normalizeAllRuleSettings (lib/augmentConfig.js:238:29)
PASS lib/utils/__tests__/hasEmptyLine.test.js
```

It doesn't break tests but looks bad.

I spent three hours trying to find what the problem is. And eventually, it was a problem in `printConfig.test.js`. A promise in a test wasn't returned. We could find this problem earlier if we had [`jest/valid-expect-in-promise`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect-in-promise.md) enabled. That's why two other tests are fixed now as well. I've [created a PR](https://github.com/stylelint/eslint-config-stylelint/pull/56) to enable this rule.