### PR TITLE
Fix SyntaxError when an empty string is used for a rule's custom message

### DIFF
--- a/lib/formatters/__tests__/stringFormatter.test.js
+++ b/lib/formatters/__tests__/stringFormatter.test.js
@@ -182,4 +182,30 @@ describe("stringFormatter", () => {
 
     expect(output).toBe("");
   });
+
+  it("handles empty messages", () => {
+    const results = [
+      {
+        source: "path/to/file.css",
+        errored: true,
+        warnings: [
+          {
+            line: 1,
+            column: 1,
+            rule: "bar",
+            severity: "error",
+            text: ""
+          }
+        ],
+        deprecations: [],
+        invalidOptionWarnings: []
+      }
+    ];
+
+    const output = prepareFormatterOutput(results, stringFormatter);
+
+    expect(output).toBe(stripIndent`
+      path/to/file.css
+       1:1  ×     bar`);
+  });
 });

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -145,7 +145,7 @@ function formatter(messages, source) {
         3: {
           alignment: "left",
           width: getMessageWidth(columnWidths),
-          wrapWord: true
+          wrapWord: getMessageWidth(columnWidths) > 1
         },
         4: { alignment: "left", width: columnWidths[4], paddingRight: 0 }
       },


### PR DESCRIPTION
Closes #3718

No, it's self explanatory.
