### PR TITLE
Add autofix to function-comma-newline-after

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -214,8 +214,8 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 
 #### Function
 
--   [`function-comma-newline-after`](../../lib/rules/function-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of functions.
--   [`function-comma-newline-before`](../../lib/rules/function-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of functions.
+-   [`function-comma-newline-after`](../../lib/rules/function-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of functions (Autofixable).
+-   [`function-comma-newline-before`](../../lib/rules/function-comma-newline-before/README.md): Require a newline or disallow whitespace before the commas of functions (Autofixable).
 -   [`function-comma-space-after`](../../lib/rules/function-comma-space-after/README.md): Require a single space or disallow whitespace after the commas of functions (Autofixable).
 -   [`function-comma-space-before`](../../lib/rules/function-comma-space-before/README.md): Require a single space or disallow whitespace before the commas of functions (Autofixable).
 -   [`function-max-empty-lines`](../../lib/rules/function-max-empty-lines/README.md): Limit the number of adjacent empty lines within functions (Autofixable).

--- a/lib/rules/function-comma-newline-after/README.md
+++ b/lib/rules/function-comma-newline-after/README.md
@@ -9,6 +9,8 @@ a { transform: translate(1,
  *             These commas */
 ```
 
+The --fix option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/function-comma-newline-after/__tests__/index.js
+++ b/lib/rules/function-comma-newline-after/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -57,36 +58,42 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: translate(1,1); }",
+      fixed: "a { transform: translate(1,\n1); }",
       message: messages.expectedAfter(),
       line: 1,
       column: 27
     },
     {
       code: "a { transform: translate(1,  1); }",
+      fixed: "a { transform: translate(1,\n1); }",
       message: messages.expectedAfter(),
       line: 1,
       column: 27
     },
     {
       code: "a { transform: translate(1, 1); }",
+      fixed: "a { transform: translate(1,\n1); }",
       message: messages.expectedAfter(),
       line: 1,
       column: 27
     },
     {
       code: "a { transform: translate(1,\t1); }",
+      fixed: "a { transform: translate(1,\n1); }",
       message: messages.expectedAfter(),
       line: 1,
       column: 27
     },
     {
       code: "a { transform: color(rgb(0 , 0 ,\n0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0 ,\n0 ,\n0) lightness(50%)); }",
       message: messages.expectedAfter(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0 ,\n 0 ,0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0 ,\n 0 ,\n0)); }",
       message: messages.expectedAfter(),
       line: 2,
       column: 4
@@ -94,12 +101,15 @@ testRule(rule, {
     {
       code:
         "a { background: linear-gradient(45deg,\n rgba(0,\n 0, 0,\n 1),\n red); }",
+      fixed:
+        "a { background: linear-gradient(45deg,\n rgba(0,\n 0,\n0,\n 1),\n red); }",
       message: messages.expectedAfter(),
       line: 3,
       column: 3
     },
     {
       code: "a { transform: translate(\n  1,1\n); }",
+      fixed: "a { transform: translate(\n  1,\n1\n); }",
       message: messages.expectedAfter(),
       line: 2,
       column: 4
@@ -107,6 +117,9 @@ testRule(rule, {
     {
       code:
         "a {\n  transform: translate(\n    1px,  /* comment (with trailing space) */  \n" +
+        "    1px\n  );\n}",
+      fixed:
+        "a {\n  transform: translate(\n    1px,\n/* comment (with trailing space) */  \n" +
         "    1px\n  );\n}",
       description: "eol comments",
       message: messages.expectedAfter()
@@ -145,6 +158,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -219,12 +233,14 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: color(rgb(0 , 0 ,\n0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0 ,\n0 ,\n0) lightness(50%)); }",
       message: messages.expectedAfterMultiLine(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0 ,\n 0 ,0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0 ,\n 0 ,\n0)); }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 4
@@ -232,18 +248,23 @@ testRule(rule, {
     {
       code:
         "a { background-image: repeating-linear-gradient(\n-45deg,\ntransparent, rgba(0, 0, 0, 1) 5px\n);}",
+      fixed:
+        "a { background-image: repeating-linear-gradient(\n-45deg,\ntransparent,\nrgba(0, 0, 0, 1) 5px\n);}",
       message: messages.expectedAfterMultiLine(),
       line: 3,
       column: 12
     },
     {
       code: "a { background: linear-gradient(45deg,rgba(0,\n0 ,\n 0 ,\n 1)); }",
+      fixed:
+        "a { background: linear-gradient(45deg,\nrgba(0,\n0 ,\n 0 ,\n 1)); }",
       message: messages.expectedAfterMultiLine(),
       line: 1,
       column: 38
     },
     {
       code: "a { transform: translate(\n  1,1\n); }",
+      fixed: "a { transform: translate(\n  1,\n1\n); }",
       message: messages.expectedAfterMultiLine(),
       line: 2,
       column: 4
@@ -251,6 +272,9 @@ testRule(rule, {
     {
       code:
         "a {\n  transform: translate(\n    1px,  /* comment (with trailing space) */  \n" +
+        "    1px\n  );\n}",
+      fixed:
+        "a {\n  transform: translate(\n    1px,\n/* comment (with trailing space) */  \n" +
         "    1px\n  );\n}",
       description: "eol comments",
       message: messages.expectedAfterMultiLine()
@@ -285,6 +309,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -331,30 +356,35 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: color(rgb(0 ,0 ,\n0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0 ,0 ,0) lightness(50%)); }",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
       column: 31
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0 ,\n 0 ,0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0 ,0 ,0)); }",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
       column: 43
     },
     {
       code: "a { transform: color(rgb(0\n,0 ,\n0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0\n,0 ,0) lightness(50%)); }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 4
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0 ,\n 0\n,0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0 ,0\n,0)); }",
       message: messages.rejectedAfterMultiLine(),
       line: 1,
       column: 43
     },
     {
       code: "a { background: linear-gradient(45deg\n,rgba(0,0 , 0, 1), red); }",
+      fixed: "a { background: linear-gradient(45deg\n,rgba(0,0 , 0, 1),red); }",
       message: messages.rejectedAfterMultiLine(),
       line: 2,
       column: 18

--- a/lib/rules/function-comma-newline-after/index.js
+++ b/lib/rules/function-comma-newline-after/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fixer = require("../functionCommaSpaceFix");
 const functionCommaSpaceChecker = require("../functionCommaSpaceChecker");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -15,7 +16,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace after "," in a multi-line function'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("newline", expectation, messages);
 
   return (root, result) => {
@@ -32,7 +33,19 @@ const rule = function(expectation) {
       root,
       result,
       locationChecker: checker.afterOneOnly,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (div, index, nodes) => {
+            return fixer({
+              div,
+              index,
+              nodes,
+              expectation,
+              position: "after",
+              symb: "\n"
+            });
+          }
+        : null
     });
   };
 };

--- a/lib/rules/function-comma-newline-before/README.md
+++ b/lib/rules/function-comma-newline-before/README.md
@@ -9,6 +9,8 @@ Require a newline or disallow whitespace before the commas of functions.
  * These commas */
 ```
 
+The --fix option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"always-multi-line"|"never-multi-line"`

--- a/lib/rules/function-comma-newline-before/__tests__/index.js
+++ b/lib/rules/function-comma-newline-before/__tests__/index.js
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule(rule, {
   ruleName,
   config: ["always"],
+  fix: true,
 
   accept: [
     {
@@ -53,36 +54,42 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: translate(1,1); }",
+      fixed: "a { transform: translate(1\n,1); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 27
     },
     {
       code: "a { transform: translate(1  ,1); }",
+      fixed: "a { transform: translate(1\n,1); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 29
     },
     {
       code: "a { transform: translate(1 ,1); }",
+      fixed: "a { transform: translate(1\n,1); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: translate(1\t,1); }",
+      fixed: "a { transform: translate(1\n,1); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: color(rgb(0 , 0 \n,0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0\n, 0 \n,0) lightness(50%)); }",
       message: messages.expectedBefore(),
       line: 1,
       column: 28
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0\n, 0,0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0\n, 0\n,0)); }",
       message: messages.expectedBefore(),
       line: 2,
       column: 4
@@ -110,6 +117,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["always-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -166,12 +174,14 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: color(rgb(0\n, 0, 0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0\n, 0\n, 0) lightness(50%)); }",
       message: messages.expectedBeforeMultiLine(),
       line: 2,
       column: 4
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0,0\n,0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0\n,0\n,0)); }",
       message: messages.expectedBeforeMultiLine(),
       line: 1,
       column: 42
@@ -179,6 +189,8 @@ testRule(rule, {
     {
       code:
         "a { background: linear-gradient(45deg\n, rgba(0\n, 0, 0\n, 1)\n, red); }",
+      fixed:
+        "a { background: linear-gradient(45deg\n, rgba(0\n, 0\n, 0\n, 1)\n, red); }",
       message: messages.expectedBeforeMultiLine(),
       line: 3,
       column: 4
@@ -202,6 +214,7 @@ testRule(rule, {
 testRule(rule, {
   ruleName,
   config: ["never-multi-line"],
+  fix: true,
 
   accept: [
     {
@@ -227,37 +240,48 @@ testRule(rule, {
   reject: [
     {
       code: "a { transform: color(rgb(0,0\n,0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0,0,0) lightness(50%)); }",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 1
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0\n, 0, 0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0, 0, 0)); }",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 1
     },
     {
       code: "a { transform: color(rgb(0\n,0,\n0) lightness(50%)); }",
+      fixed: "a { transform: color(rgb(0,0,\n0) lightness(50%)); }",
       message: messages.rejectedBeforeMultiLine(),
       line: 2,
       column: 1
     },
     {
       code: "a { transform: color(lightness(50%) rgb(0,\n 0\n,0)); }",
+      fixed: "a { transform: color(lightness(50%) rgb(0,\n 0,0)); }",
       message: messages.rejectedBeforeMultiLine(),
       line: 3,
       column: 1
     },
     {
       code: `
-      a {
-        transform: translate(
-          1px /* comment */
-          , 1px
-        );
-      }
-    `,
+        a {
+          transform: translate(
+            1px /* comment */
+            , 1px
+          );
+        }
+      `,
+      fixed: `
+        a {
+          transform: translate(
+            1px /* comment */, 1px
+          );
+        }
+      `,
       description: "eol comments",
       message: messages.rejectedBeforeMultiLine()
     }

--- a/lib/rules/function-comma-newline-before/index.js
+++ b/lib/rules/function-comma-newline-before/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fixer = require("../functionCommaSpaceFix");
 const functionCommaSpaceChecker = require("../functionCommaSpaceChecker");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -15,7 +16,7 @@ const messages = ruleMessages(ruleName, {
     'Unexpected whitespace before "," in a multi-line function'
 });
 
-const rule = function(expectation) {
+const rule = function(expectation, options, context) {
   const checker = whitespaceChecker("newline", expectation, messages);
 
   return (root, result) => {
@@ -32,7 +33,19 @@ const rule = function(expectation) {
       root,
       result,
       locationChecker: checker.beforeAllowingIndentation,
-      checkedRuleName: ruleName
+      checkedRuleName: ruleName,
+      fix: context.fix
+        ? (div, index, nodes) => {
+            return fixer({
+              div,
+              index,
+              nodes,
+              expectation,
+              position: "before",
+              symb: "\n"
+            });
+          }
+        : null
     });
   };
 };

--- a/lib/rules/function-comma-space-after/index.js
+++ b/lib/rules/function-comma-space-after/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fixer = require("../functionCommaSpaceFix");
 const functionCommaSpaceChecker = require("../functionCommaSpaceChecker");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -36,30 +37,14 @@ const rule = function(expectation, options, context) {
       checkedRuleName: ruleName,
       fix: context.fix
         ? (div, index, nodes) => {
-            if (expectation.indexOf("always") === 0) {
-              div.after = " ";
-
-              return true;
-            } else if (expectation.indexOf("never") === 0) {
-              div.after = "";
-
-              for (let i = index + 1; i < nodes.length; i++) {
-                const node = nodes[i];
-
-                if (node.type === "comment") {
-                  continue;
-                }
-
-                if (node.type === "space") {
-                  node.value = "";
-                  continue;
-                }
-
-                break;
-              }
-
-              return true;
-            }
+            return fixer({
+              div,
+              index,
+              nodes,
+              expectation,
+              position: "after",
+              symb: " "
+            });
           }
         : null
     });

--- a/lib/rules/function-comma-space-before/index.js
+++ b/lib/rules/function-comma-space-before/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fixer = require("../functionCommaSpaceFix");
 const functionCommaSpaceChecker = require("../functionCommaSpaceChecker");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -35,16 +36,15 @@ const rule = function(expectation, options, context) {
       locationChecker: checker.before,
       checkedRuleName: ruleName,
       fix: context.fix
-        ? div => {
-            if (expectation.indexOf("always") === 0) {
-              div.before = " ";
-
-              return true;
-            } else if (expectation.indexOf("never") === 0) {
-              div.before = "";
-
-              return true;
-            }
+        ? (div, index, nodes) => {
+            return fixer({
+              div,
+              index,
+              nodes,
+              expectation,
+              position: "before",
+              symb: " "
+            });
           }
         : null
     });

--- a/lib/rules/functionCommaSpaceFix.js
+++ b/lib/rules/functionCommaSpaceFix.js
@@ -1,0 +1,30 @@
+"use strict";
+
+module.exports = function(params) {
+  const { div, index, nodes, expectation, position, symb } = params;
+
+  if (expectation.indexOf("always") === 0) {
+    div[position] = symb;
+
+    return true;
+  } else if (expectation.indexOf("never") === 0) {
+    div[position] = "";
+
+    for (let i = index + 1; i < nodes.length; i++) {
+      const node = nodes[i];
+
+      if (node.type === "comment") {
+        continue;
+      }
+
+      if (node.type === "space") {
+        node.value = "";
+        continue;
+      }
+
+      break;
+    }
+
+    return true;
+  }
+};


### PR DESCRIPTION

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3752 Added autofix to function-comma-newline-before;
Closes #3594 Add autofix to function-comma-newline-after 

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
