### PR TITLE
Fix false positives for Less variables and mixins in at-rule-* 

### DIFF
--- a/lib/rules/at-rule-semicolon-newline-after/__tests__/index.js
+++ b/lib/rules/at-rule-semicolon-newline-after/__tests__/index.js
@@ -125,3 +125,25 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: ["always"],
+  accept: [
+    {
+      code: `
+        .someMixin() { margin: 0; }
+        span { .someMixin(); }
+      `,
+      description: "ignore Less mixin"
+    },
+    {
+      code: `
+        @myVariable: #f7f8f9;
+        span { background-color: @myVariable; }
+      `,
+      description: "ignore Less variable"
+    }
+  ]
+});

--- a/lib/rules/at-rule-semicolon-newline-after/index.js
+++ b/lib/rules/at-rule-semicolon-newline-after/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const hasBlock = require("../../utils/hasBlock");
+const isStandardSyntaxAtRule = require("../../utils/isStandardSyntaxAtRule");
 const nextNonCommentNode = require("../../utils/nextNonCommentNode");
 const rawNodeString = require("../../utils/rawNodeString");
 const report = require("../../utils/report");
@@ -35,6 +36,10 @@ const rule = function(actual, secondary, context) {
       }
 
       if (hasBlock(atRule)) {
+        return;
+      }
+
+      if (!isStandardSyntaxAtRule(atRule)) {
         return;
       }
 

--- a/lib/rules/at-rule-semicolon-space-before/__tests__/index.js
+++ b/lib/rules/at-rule-semicolon-space-before/__tests__/index.js
@@ -151,3 +151,27 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: ["always"],
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: `
+        .someMixin() { margin: 0; }
+        span { .someMixin(); }
+      `,
+      description: "ignore Less mixin"
+    },
+    {
+      code: `
+        @myVariable: #f7f8f9;
+        span { background-color: @myVariable; }
+      `,
+      description: "ignore Less variable"
+    }
+  ]
+});

--- a/lib/rules/at-rule-semicolon-space-before/index.js
+++ b/lib/rules/at-rule-semicolon-space-before/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const hasBlock = require("../../utils/hasBlock");
+const isStandardSyntaxAtRule = require("../../utils/isStandardSyntaxAtRule");
 const rawNodeString = require("../../utils/rawNodeString");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -29,6 +30,10 @@ const rule = function(expectation) {
 
     root.walkAtRules(atRule => {
       if (hasBlock(atRule)) {
+        return;
+      }
+
+      if (!isStandardSyntaxAtRule(atRule)) {
         return;
       }
 

--- a/lib/rules/at-rule-whitelist/__tests__/index.js
+++ b/lib/rules/at-rule-whitelist/__tests__/index.js
@@ -152,3 +152,21 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  syntax: "less",
+  config: ["keyframes"],
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: `
+        .mixin() { margin: 0; }
+
+        span { .mixin(); }
+      `,
+      description: "ignore Less mixin which are treated as at-rule"
+    }
+  ]
+});

--- a/lib/rules/at-rule-whitelist/index.js
+++ b/lib/rules/at-rule-whitelist/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const isStandardSyntaxAtRule = require("../../utils/isStandardSyntaxAtRule");
 const postcss = require("postcss");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -28,6 +29,10 @@ const rule = function(whitelistInput) {
 
     root.walkAtRules(atRule => {
       const name = atRule.name;
+
+      if (!isStandardSyntaxAtRule(atRule)) {
+        return;
+      }
 
       if (
         whitelist.indexOf(postcss.vendor.unprefixed(name).toLowerCase()) !== -1


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3764.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

With this PR all `at-rule-*` rules should be ignoring Less mixins/variables.
