### PR TITLE
Update micromatch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ cache:
 test_script:
   - node --version
   - npm --version
-  - cmd: "npm run jest -- --testPathPattern \\lib"
+  - cmd: "npm run jest"

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -3,6 +3,7 @@
 
 const micromatch = require("micromatch");
 const path = require("path");
+const slash = require("slash");
 
 // To find out if a path is ignored, we need to load the config,
 // which may have an ignoreFiles property. We then check the path
@@ -18,12 +19,14 @@ module.exports = function(
   }
 
   return stylelint.getConfigForFile(filePath).then(result => {
-    const config = result.config;
+    // Glob patterns for micromatch should be in POSIX-style
+    const ignoreFiles = (result.config.ignoreFiles || []).map(slash);
+
     const absoluteFilePath = path.isAbsolute(filePath)
       ? filePath
       : path.resolve(process.cwd(), filePath);
 
-    if (micromatch(absoluteFilePath, config.ignoreFiles).length) {
+    if (micromatch(absoluteFilePath, ignoreFiles).length) {
       return true;
     }
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "log-symbols": "^2.0.0",
     "mathml-tag-names": "^2.0.1",
     "meow": "^5.0.0",
-    "micromatch": "^2.3.11",
+    "micromatch": "^3.1.10",
     "normalize-selector": "^0.2.0",
     "pify": "^4.0.0",
     "postcss": "^7.0.0",
@@ -80,6 +80,7 @@
     "postcss-value-parser": "^3.3.0",
     "resolve-from": "^4.0.0",
     "signal-exit": "^3.0.2",
+    "slash": "^2.0.0",
     "specificity": "^0.4.1",
     "string-width": "^2.1.0",
     "style-search": "^0.1.0",
@@ -180,11 +181,6 @@
       "system-tests"
     ],
     "testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "micromatch"
-    ]
   },
   "remarkConfig": {
     "plugins": [


### PR DESCRIPTION
Behold! It's serious this time.

It's been almost a year and a half since last major micromatch version released https://github.com/stylelint/stylelint/pull/2597. Finally, I had time and possibility to tackle this thing. And the solution is so simple — convert all patterns from Windows to Unix paths. [`augmentConfig.js` converts](https://github.com/stylelint/stylelint/blob/5fd5905e9614da4725eb2e9c16351e4aa76fd1d4/lib/augmentConfig.js#L113-L119) all patterns to patterns with absolute paths, and new micromatch supports only Unix paths in patterns.

Also, allow Appveyor to run all tests.

Supersedes #2888.