### PR TITLE
Update ignore to version 5.0.3

### DIFF
--- a/lib/__tests__/stylelintignore-test/.stylelintignore
+++ b/lib/__tests__/stylelintignore-test/.stylelintignore
@@ -1,4 +1,4 @@
 # Paths are resolved absolutely to this directory
 
-../fixtures/*.css
-!../fixtures/invalid-hex.css
+fixtures/*.css
+!fixtures/invalid-hex.css

--- a/lib/__tests__/stylelintignore-test/fixtures/config-block-no-empty.json
+++ b/lib/__tests__/stylelintignore-test/fixtures/config-block-no-empty.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "block-no-empty": true
+  }
+}

--- a/lib/__tests__/stylelintignore-test/fixtures/config-color-no-invalid-hex.json
+++ b/lib/__tests__/stylelintignore-test/fixtures/config-color-no-invalid-hex.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "color-no-invalid-hex": true
+  }
+}

--- a/lib/__tests__/stylelintignore-test/fixtures/empty-block.css
+++ b/lib/__tests__/stylelintignore-test/fixtures/empty-block.css
@@ -1,0 +1,9 @@
+.foo {
+  color: pink;
+}
+
+.bar {}
+
+.baz {
+  background: orange;
+}

--- a/lib/__tests__/stylelintignore-test/fixtures/invalid-hex.css
+++ b/lib/__tests__/stylelintignore-test/fixtures/invalid-hex.css
@@ -1,0 +1,3 @@
+a {
+  color: #zzzzzz;
+}

--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.js
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.js
@@ -6,11 +6,11 @@ const standalone = require("../../standalone");
 describe("stylelintignore", () => {
   let actualCwd;
   let results;
-  const fixturesPath = path.join(__dirname, "../fixtures");
+  const fixturesPath = path.join(__dirname, "./fixtures");
 
   beforeEach(() => {
     actualCwd = process.cwd();
-    process.chdir(__dirname, "../fixtures");
+    process.chdir(__dirname);
   });
 
   afterEach(() => {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -6,6 +6,7 @@ const createStylelint = require("./createStylelint");
 const createStylelintResult = require("./createStylelintResult");
 const debug = require("debug")("stylelint:standalone");
 const FileCache = require("./utils/FileCache");
+const filterFilePaths = require("./utils/filterFilePaths");
 const formatters = require("./formatters");
 const fs = require("fs");
 const getFormatterOptionsText = require("./utils/getFormatterOptionsText");
@@ -145,8 +146,9 @@ module.exports = function(
         // if file is ignored, return nothing
         if (
           absoluteCodeFilename &&
-          !ignorer.filter(path.relative(process.cwd(), absoluteCodeFilename))
-            .length
+          !filterFilePaths(ignorer, [
+            path.relative(process.cwd(), absoluteCodeFilename)
+          ]).length
         ) {
           return prepareReturnValue([]);
         }
@@ -190,7 +192,8 @@ module.exports = function(
   return globby(fileList, globbyOptions)
     .then(filePaths => {
       // The ignorer filter needs to check paths relative to cwd
-      filePaths = ignorer.filter(
+      filePaths = filterFilePaths(
+        ignorer,
         filePaths.map(p => path.relative(process.cwd(), p))
       );
 

--- a/lib/utils/__tests__/filterFilePaths.test.js
+++ b/lib/utils/__tests__/filterFilePaths.test.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const filterFilePaths = require("../filterFilePaths");
+const ignore = require("ignore");
+
+describe("filterFilePaths", () => {
+  it("empty ignorefile", () => {
+    const ignorer = ignore().add("");
+    const files = ["a.css", "b/c/d.css", "e/f.css", "../w.css"];
+
+    expect(filterFilePaths(ignorer, files)).toEqual(files);
+  });
+
+  it("ignore some files", () => {
+    const ignorer = ignore().add("*.css\n!e/f.css");
+    const files = ["a.css", "b/c/d.css", "e/f.css", "../w.css"];
+
+    expect(filterFilePaths(ignorer, files)).toEqual(["e/f.css", "../w.css"]);
+  });
+});

--- a/lib/utils/filterFilePaths.js
+++ b/lib/utils/filterFilePaths.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const { isPathValid } = require("ignore").default;
+
+module.exports = function filterFilePaths(ignorer, filePaths) {
+  const validForIgnore = filePaths.filter(isPathValid);
+  // Paths which starts with `..` are not valid for `ignore`, e. g. `../style.css`
+  const notValidForIgnore = filePaths.filter(p => !validForIgnore.includes(p));
+
+  const filteredByIgnore = ignorer.filter(validForIgnore);
+
+  // Preserving files order, while removing paths which were filtered by `ignore`
+  return filePaths.filter(
+    p => notValidForIgnore.includes(p) || filteredByIgnore.includes(p)
+  );
+};

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "globby": "^8.0.0",
     "globjoin": "^0.1.4",
     "html-tags": "^2.0.0",
-    "ignore": "^4.0.0",
+    "ignore": "^5.0.3",
     "import-lazy": "^3.1.0",
     "imurmurhash": "^0.1.4",
     "known-css-properties": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "globby": "^8.0.0",
     "globjoin": "^0.1.4",
     "html-tags": "^2.0.0",
-    "ignore": "^5.0.3",
+    "ignore": "^5.0.4",
     "import-lazy": "^3.1.0",
     "imurmurhash": "^0.1.4",
     "known-css-properties": "^0.9.0",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/pull/3534.

> Is there anything in the PR that needs further explanation?

`ignore` doesn't support paths starting with `../`, which makes sense, because it follows .gitignore [spec](https://git-scm.com/docs/gitignore). In previous version `ignore` ignored invalid paths. We use paths like this, because any path could be given to linter.

Fixed `.stylelintignore` tests, because `.stylelintignore` was invalid.

P. S. Created separate PR, because I don't won't to share credit to my work with a bot.