### PR TITLE
Jest enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 matrix:
   include:
     - node_js: '8'
-      script: npm run pretest
+      script: npm run static-analysis
       env: CI=pretest
     - node_js: '8'
       script: npm run jest -- --maxWorkers=2 --coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 matrix:
   include:
     - node_js: '8'
-      script: npm run static-analysis
+      script: npm run pretest
       env: CI=pretest
     - node_js: '8'
       script: npm run jest -- --maxWorkers=2 --coverage

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "flow-typed": "^2.5.1",
     "husky": "^1.1.0",
     "jest": "^23.4.1",
+    "jest-watch-typeahead": "^0.2.0",
     "lint-staged": "^8.0.0",
     "npm-run-all": "^4.0.2",
     "npmpub": "^4.1.0",
@@ -180,7 +181,11 @@
       "lib",
       "system-tests"
     ],
-    "testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$"
+    "testRegex": ".*\\.test\\.js$|rules/.*/__tests__/.*\\.js$",
+    "watchPlugins": [
+      "jest-watch-typeahead/filename",
+      "jest-watch-typeahead/testname"
+    ]
   },
   "remarkConfig": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "flow-bin": "^0.83.0",
     "flow-typed": "^2.5.1",
     "husky": "^1.1.0",
-    "is-ci-cli": "^1.1.1",
     "jest": "^23.4.1",
     "jest-watch-typeahead": "^0.2.0",
     "lint-staged": "^8.0.0",
@@ -128,13 +127,11 @@
     "lint:js": "eslint . --cache",
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",
-    "static-analysis": "npm-run-all --serial lint flow",
+    "pretest": "npm-run-all --serial lint flow",
     "prettier:check": "prettier '**/*.js' --list-different",
     "prettier:fix": "prettier '**/*.js' --write",
     "release": "npmpub",
-    "test:coverage": "jest --coverage",
-    "test:full": "npm run static-analysis && npm run test:coverage",
-    "test": "is-ci test:full watch",
+    "test": "jest --coverage",
     "watch": "jest --watch"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "flow-bin": "^0.83.0",
     "flow-typed": "^2.5.1",
     "husky": "^1.1.0",
+    "is-ci-cli": "^1.1.1",
     "jest": "^23.4.1",
     "jest-watch-typeahead": "^0.2.0",
     "lint-staged": "^8.0.0",
@@ -127,11 +128,13 @@
     "lint:js": "eslint . --cache",
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",
-    "pretest": "npm-run-all --serial lint flow",
+    "static-analysis": "npm-run-all --serial lint flow",
     "prettier:check": "prettier '**/*.js' --list-different",
     "prettier:fix": "prettier '**/*.js' --write",
     "release": "npmpub",
-    "test": "jest --coverage",
+    "test:coverage": "jest --coverage",
+    "test:full": "npm run static-analysis && npm run test:coverage",
+    "test": "is-ci test:full watch",
     "watch": "jest --watch"
   },
   "husky": {


### PR DESCRIPTION
1\. Added much needed [jest-watch-typeahead](https://github.com/jest-community/jest-watch-typeahead). Very useful with our amount of tests.

~~2\. When developing locally we most likely use `npm run watch` (`jest --watch`), rather running full test suite all the time. With https://github.com/stylelint/stylelint/commit/67ad0e750e6bc1ad59d9d6ddbfbd650702d3a481 we can use `npm test` locally to run watch mode, but on CI it will run all tests and linters we have. What do you think, @stylelint/contributors?~~

P. S. Little known fact: `npm test` has an alias `npm t` ;)