### PR TITLE
Don't parse ignored files

### DIFF
--- a/lib/__tests__/stylelintignore-test/.stylelintignore
+++ b/lib/__tests__/stylelintignore-test/.stylelintignore
@@ -2,3 +2,5 @@
 
 fixtures/*.css
 !fixtures/invalid-hex.css
+
+badsyntax.css

--- a/lib/__tests__/stylelintignore-test/.stylelintignore2
+++ b/lib/__tests__/stylelintignore-test/.stylelintignore2
@@ -1,0 +1,3 @@
+# Paths are resolved absolutely to this directory
+
+/**

--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.js
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.js
@@ -86,5 +86,36 @@ describe("stylelintignore", () => {
         });
       });
     });
+
+    it("ignored file with syntax error is ignored", () => {
+      return standalone({
+        code: "var a = {",
+        codeFilename: `test.js`,
+        ignorePath: path.join(__dirname, ".stylelintignore2"),
+        config: {
+          extends: `${fixturesPath}/config-block-no-empty`
+        }
+      }).then(data => {
+        expect(data).toEqual({
+          errored: false,
+          output: "[]",
+          results: []
+        });
+      });
+    });
+
+    it("ignored file with syntax error is ignored and there is no config", () => {
+      return standalone({
+        code: "var a = {",
+        codeFilename: `test.js`,
+        ignorePath: path.join(__dirname, ".stylelintignore2")
+      }).then(data => {
+        expect(data).toEqual({
+          errored: false,
+          output: "[]",
+          results: []
+        });
+      });
+    });
   });
 });

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -109,6 +109,16 @@ module.exports = function(
         ? path.join(process.cwd(), codeFilename)
         : codeFilename;
 
+    // if file is ignored, return nothing
+    if (
+      absoluteCodeFilename &&
+      !filterFilePaths(ignorer, [
+        path.relative(process.cwd(), absoluteCodeFilename)
+      ]).length
+    ) {
+      return Promise.resolve(prepareReturnValue([]));
+    }
+
     return stylelint
       ._lintSource({
         code,
@@ -143,16 +153,6 @@ module.exports = function(
       })
       .catch(_.partial(handleError, stylelint))
       .then(stylelintResult => {
-        // if file is ignored, return nothing
-        if (
-          absoluteCodeFilename &&
-          !filterFilePaths(ignorer, [
-            path.relative(process.cwd(), absoluteCodeFilename)
-          ]).length
-        ) {
-          return prepareReturnValue([]);
-        }
-
         const postcssResult = stylelintResult._postcssResult;
         const returnValue = prepareReturnValue([stylelintResult]);
 


### PR DESCRIPTION
… in these files.

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

A replacement for https://github.com/stylelint/stylelint/pull/3778.

now, below codes will throw a parse error even the .stylelintignore has pattern /**

const stylelint = require('stylelint');

stylelint.lint({
  code: 'var a = {',
  codeFilename: 'test.js',
}).then(data => console.log(data));

because lintsource throw parse error even the file is ignored.

this PR ignore files before lint, so avoid that errors.

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
