### PR TITLE
Add “sans-serif” to tail of font shortcut

### DIFF
--- a/lib/rules/font-weight-notation/README.md
+++ b/lib/rules/font-weight-notation/README.md
@@ -31,7 +31,7 @@ a { font-weight: bold; }
 ```
 
 ```css
-a { font: italic normal 20px; }
+a { font: italic normal 20px sans-serif; }
 ```
 
 The following patterns are *not* considered violations:
@@ -41,7 +41,7 @@ a { font-weight: 700; }
 ```
 
 ```css
-a { font: italic 900 20px; }
+a { font: italic 900 20px sans-serif; }
 ```
 
 ### `"named-where-possible"`
@@ -57,7 +57,7 @@ a { font-weight: 700; }
 ```
 
 ```css
-a { font: italic 400 20px; }
+a { font: italic 400 20px sans-serif; }
 ```
 
 The following patterns are *not* considered violations:
@@ -67,7 +67,7 @@ a { font-weight: bold; }
 ```
 
 ```css
-a { font: italic normal 20px; }
+a { font: italic normal 20px sans-serif; }
 ```
 
 ## Optional secondary options


### PR DESCRIPTION
This pull request, if successful, closes #3812 and is a documentation fix. As noted in the issue, the `font` shortcut lacks the `font-family` property in the tail of the shortcut.
