### PR TITLE
Fix an example

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -47,7 +47,7 @@ stylelint "foo/*.css" --config bar/mySpecialConfig.json > myTestReport.txt
 Using `bar/mySpecialConfig.json` as config, with quiet mode on, to lint all `.css` files in the `foo` directory and any of its subdirectories and also all `.css` files in the `bar directory`:
 
 ```shell
-stylelint "foo/**/*.css bar/*.css" -q -f json --config bar/mySpecialConfig.json
+stylelint "foo/**/*.css" "bar/*.css" -q -f json --config bar/mySpecialConfig.json
 ```
 
 Linting all `.css` files except those within `docker` subfolders, using negation in the input glob:


### PR DESCRIPTION
In my testing, this does not work as expected:

```shell
stylelint "foo/**/*.css bar/*.css" -q -f json --config bar/mySpecialConfig.json
```

Whereas this does:
```shell
stylelint "foo/**/*.css" "bar/*.css" -q -f json --config bar/mySpecialConfig.json
```

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
