### PR TITLE
Fix false positives for focus-visible in selector-pseudo-class-no-unknown

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -235,6 +235,7 @@ keywordSets.otherPseudoClasses = new Set([
   "focus",
   "focus-ring",
   "focus-within",
+  "focus-visible",
   "fullscreen",
   "future",
   "has",

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -22,6 +22,9 @@ testRule(rule, {
       code: "a:HOVER { }"
     },
     {
+      code: "a:focus-visible { }"
+    },
+    {
       code: "a:before { }"
     },
     {


### PR DESCRIPTION
There is one known issue with this PR: the test passes even if the fix itself is reverted. Any ideas why?

Fixes: https://github.com/stylelint/stylelint/issues/3886