### PR TITLE
Fix tests to account for new syntax errors in PostCSS

### DIFF
--- a/lib/rules/no-invalid-double-slash-comments/README.md
+++ b/lib/rules/no-invalid-double-slash-comments/README.md
@@ -3,7 +3,9 @@
 Disallow double-slash comments (`//...`) which are not supported by CSS and [could lead to unexpected results](https://stackoverflow.com/a/20192639/130652).
 
 ```css
-a { // color: pink; }
+a {
+  //color: pink;
+}
 /** ↑
  *  This comment */
 ```
@@ -17,19 +19,30 @@ If you are using a preprocessor that allows `//` single-line comments (e.g. Sass
 The following patterns are considered violations:
 
 ```css
-a { // color: pink; }
+a {
+  //color: pink;
+}
 ```
 
 ```css
-// a { color: pink; }
-```
-
-The following patterns are *not* considered violations:
-
-```css
-a { /* color: pink; */ }
+//a { color: pink; }
 ```
 
 ```css
-/* a { color: pink; } */
+// Comment {}
+a {
+  color: pink;
+}
+```
+
+The following patterns are _not_ considered violations:
+
+```css
+a {
+  /* color: pink; */
+}
+```
+
+```css
+/* a { color: pink;  } */
 ```

--- a/lib/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -24,28 +24,35 @@ testRule(rule, {
 
   reject: [
     {
-      code: "a { // color: pink; }",
-      description: "before declaration",
+      code: "// Invalid comment {}\na {}",
+      description: "line before",
       message: messages.rejected,
       line: 1,
-      column: 5
+      column: 1
     },
     {
-      code: "// a { color: pink; }",
+      code: "a {\n//color: pink;\n}",
+      description: "before declaration",
+      message: messages.rejected,
+      line: 2,
+      column: 1
+    },
+    {
+      code: "//a { color: pink; }",
       description: "before rule",
       message: messages.rejected,
       line: 1,
       column: 1
     },
     {
-      code: "a, // div { color: pink; }",
+      code: "a, //div { color: pink; }",
       description: "between rules",
       message: messages.rejected,
       line: 1,
       column: 1
     },
     {
-      code: "// @media { }",
+      code: "//@media { }",
       description: "before media rule",
       message: messages.rejected,
       line: 1,

--- a/lib/rules/value-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/value-list-comma-space-after/__tests__/index.js
@@ -180,14 +180,6 @@ testRule(rule, {
       message: messages.rejectedAfter(),
       line: 1,
       column: 22
-    },
-    {
-      code: "a { pr, op: 0, 0; }",
-      fixed: "a { pr, op: 0,0; }",
-      description: "edge case",
-      message: messages.rejectedAfter(),
-      line: 1,
-      column: 7
     }
   ]
 });


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/3891

> Is there anything in the PR that needs further explanation?

1. Looking again at https://www.xanthir.com/b4U10, I think our tests and examples were wrong because I don't think you can have a space after the slashes.

2. Remove an test of invalid CSS from `value-list-comma-space-after`
