### PR TITLE
Update file-entry-cache to avoid the deprecated warning

### DIFF
--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -10,6 +10,10 @@ const readFile = pify(fs.readFile);
 const unlink = pify(fs.unlink);
 const cpFile = require("cp-file");
 const fileExists = require("file-exists-promise");
+// As 'file-entry-cache' use 'flatted' to create the cache,
+// need use this package to parse the content
+// eslint-disable-next-line node/no-extraneous-require
+const { parse } = require("flatted/cjs");
 
 const cwd = process.cwd();
 const invalidFile = path.join(fixturesPath, "empty-block.css");
@@ -61,7 +65,7 @@ describe("standalone cache", () => {
         return readFile(expectedCacheFilePath, "utf8");
       })
       .then(fileContents => {
-        return JSON.parse(fileContents);
+        return parse(fileContents);
       })
       .then(cacheFile => {
         // Ensure cache file contains only linted css file
@@ -93,7 +97,7 @@ describe("standalone cache", () => {
         return readFile(expectedCacheFilePath, "utf8");
       })
       .then(fileContents => {
-        return JSON.parse(fileContents);
+        return parse(fileContents);
       })
       .then(cachedFiles => {
         expect(typeof cachedFiles[validFile] === "object").toBe(true);
@@ -148,7 +152,7 @@ describe("standalone cache", () => {
         return readFile(expectedCacheFilePath, "utf8");
       })
       .then(fileContents => {
-        return JSON.parse(fileContents);
+        return parse(fileContents);
       })
       .then(cachedFiles => {
         expect(typeof cachedFiles[validFile] === "object").toBe(true);
@@ -165,7 +169,7 @@ describe("standalone cache", () => {
         return readFile(expectedCacheFilePath, "utf8");
       })
       .then(fileContents => {
-        const cachedFiles = JSON.parse(fileContents);
+        const cachedFiles = parse(fileContents);
 
         expect(typeof cachedFiles[validFile] === "object").toBe(true);
         expect(typeof cachedFiles[newFileDest] === "undefined").toBe(true);
@@ -257,7 +261,7 @@ describe("standalone cache uses cacheLocation", () => {
         return readFile(cacheLocationFile, "utf8");
       })
       .then(fileContents => {
-        return JSON.parse(fileContents);
+        return parse(fileContents);
       })
       .then(cacheFile => {
         expect(typeof cacheFile[validFile] === "object").toBe(true);
@@ -280,7 +284,7 @@ describe("standalone cache uses cacheLocation", () => {
         return readFile(expectedCacheFilePath, "utf8");
       })
       .then(fileContents => {
-        return JSON.parse(fileContents);
+        return parse(fileContents);
       })
       .then(cacheFile => {
         expect(typeof cacheFile[validFile] === "object").toBe(true);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cosmiconfig": "^5.0.0",
     "debug": "^4.0.0",
     "execall": "^1.0.0",
-    "file-entry-cache": "^2.0.0",
+    "file-entry-cache": "^4.0.0",
     "get-stdin": "^6.0.0",
     "global-modules": "^2.0.0",
     "globby": "^9.0.0",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3877

Update `file-entry-cache` to avoid the deprecated warning

> Is there anything in the PR that needs further explanation?

Just as the #3786 and #3779, the only thing to do is update the `standalone-cache.test.js`. Just use the `parse` method from the `flatted` which is used by `file-entry-cache` to create the cache to parse the content, then tests can pass. 
