### PR TITLE
Resolve the ambiguity of the `Node.js` name

### DIFF
--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.md
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.md
@@ -39,7 +39,7 @@ e.g.
 
 e.g. `9.2.0`
 
-> How are you running stylelint: CLI, PostCSS plugin, Node API?
+> How are you running stylelint: CLI, PostCSS plugin, Node.js API?
 
 e.g. "CLI with `stylelint "**/*.css" --config myconfig.json`"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,7 @@
 
 # 9.0.0
 
--   Removed: Node.JS 4.x support. Node.js 6.x or greater is now required ([#3075](https://github.com/stylelint/stylelint/pull/3087)).
+-   Removed: Node.js 4.x support. Node.js 6.x or greater is now required ([#3075](https://github.com/stylelint/stylelint/pull/3087)).
 -   Added: (experimental) support for [SASS](http://sass-lang.com/) syntax ([#2503](https://github.com/stylelint/stylelint/pull/2503)).
 -   Added: allow processors to handle PostCSS errors ([#3063](https://github.com/stylelint/stylelint/pull/3063)).
 -   Added: `--max-warnings` CLI flag ([#2942](https://github.com/stylelint/stylelint/pull/2942)).
@@ -254,7 +254,7 @@
 
 -   Added: Allow specifying `codeFilename` to `createStylelintResult` for raw code linting standalone API ([#2450](https://github.com/stylelint/stylelint/issues/2450)).
 -   Added: `ignorePattern` option (`--ignore-pattern` in CLI), to allow patterns of files to ignored ([#2834](https://github.com/stylelint/stylelint/issues/2834)).
--   Added: More rules now support experimental autofixing. Use `--fix` CLI parameter or `fix: true` Node API options property. Newly supported rules:
+-   Added: More rules now support experimental autofixing. Use `--fix` CLI parameter or `fix: true` Node.js API options property. Newly supported rules:
     -   `color-hex-length` ([#2781](https://github.com/stylelint/stylelint/pull/2781)).
     -   `no-missing-end-of-source-newline` ([#2772](https://github.com/stylelint/stylelint/pull/2772)).
 -   Fixed: `*-empty-line-before` false positives shared-line comments and `"first-nested"` option ([#2827](https://github.com/stylelint/stylelint/issues/2827)).
@@ -352,7 +352,7 @@ Changes:
 
 # 7.11.0
 
--   Added: experimental autofixing ([#2467](https://github.com/stylelint/stylelint/pull/2467), [#2500](https://github.com/stylelint/stylelint/pull/2500), [#2529](https://github.com/stylelint/stylelint/pull/2529) and [#2577](https://github.com/stylelint/stylelint/pull/2577)). Use `--fix` CLI parameter or `fix: true` Node API options property. Supported rules:
+-   Added: experimental autofixing ([#2467](https://github.com/stylelint/stylelint/pull/2467), [#2500](https://github.com/stylelint/stylelint/pull/2500), [#2529](https://github.com/stylelint/stylelint/pull/2529) and [#2577](https://github.com/stylelint/stylelint/pull/2577)). Use `--fix` CLI parameter or `fix: true` Node.js API options property. Supported rules:
     -   `at-rule-empty-line-before`
     -   `at-rule-name-case`
     -   `color-hex-case`
@@ -445,14 +445,14 @@ Changes:
 
 # 7.7.0
 
--   Added: `stylelint.formatters` exposed in public Node API ([#2190](https://github.com/stylelint/stylelint/pull/2190)).
+-   Added: `stylelint.formatters` exposed in public Node.js API ([#2190](https://github.com/stylelint/stylelint/pull/2190)).
 -   Added: `stylelint.utils.checkAgainstRule` for checking CSS against a standard stylelint rule *within your own rule* ([#2173](https://github.com/stylelint/stylelint/pull/2173)).
 -   Added: `allow-empty-input` flag to CLI ([#2117](https://github.com/stylelint/stylelint/pull/2117)).
 -   Added: `except: ["after-rule"]` option to `rule-nested-empty-line-before` ([#2188](https://github.com/stylelint/stylelint/pull/2188)).
--   Fixed: regression causing `--stdin-filename` in CLI and `codeFilename` in Node API to error if a non-existent filename is provided ([#2128](https://github.com/stylelint/stylelint/pull/2128)).
+-   Fixed: regression causing `--stdin-filename` in CLI and `codeFilename` in Node.js API to error if a non-existent filename is provided ([#2128](https://github.com/stylelint/stylelint/pull/2128)).
 -   Fixed: a boolean CLI flag (e.g. `--quiet`) placed before an input glob no longer causes the input to be ignored ([#2186](https://github.com/stylelint/stylelint/pull/2186)).
 -   Fixed: the `node_modules` and `bower_components` directories are correctly ignored by default when stylelint is used as a PostCSS plugin ([#2171](https://github.com/stylelint/stylelint/pull/2171)).
--   Fixed: bug where some Node errors in special cases did not cause the CLI to exit with a non-zero code ([#2140](https://github.com/stylelint/stylelint/pull/2140))
+-   Fixed: bug where some Node.js errors in special cases did not cause the CLI to exit with a non-zero code ([#2140](https://github.com/stylelint/stylelint/pull/2140))
 -   Fixed: false positives related to LESS detached rulesets ([#2089](https://github.com/stylelint/stylelint/pull/2089)).
 -   Fixed: `color-named` now ignores SCSS maps, so map property names can be color names ([#2182](https://github.com/stylelint/stylelint/pull/2182)).
 -   Fixed: `comment-whitespace-inside` no longer complains about `/*!` comments with non-space whitespace (e.g. newlines) ([#2121](https://github.com/stylelint/stylelint/pull/2121)).
@@ -462,7 +462,7 @@ Changes:
 
 # 7.6.0
 
--   Added: option `customSyntax` (for Node API) and `--custom-syntax` (for CLI).
+-   Added: option `customSyntax` (for Node.js API) and `--custom-syntax` (for CLI).
 -   Added: `font-family-no-duplicate-names` rule.
 -   Fixed: CLI now understands absolute paths for the `--custom-formatter` option.
 -   Fixed: the `string` and `verbose` formatters now use `dim` instead of `gray` for greater compatibility with different terminal color schemes.
@@ -642,7 +642,7 @@ Changes:
 
 # 6.8.0
 
--   Deprecated: `-e` and `--extract` CLI flags, and the `extractStyleTagsFromHtml` node API option. If you use these flags or option, please consider creating a processor for the community.
+-   Deprecated: `-e` and `--extract` CLI flags, and the `extractStyleTagsFromHtml` Node.js API option. If you use these flags or option, please consider creating a processor for the community.
 -   Added: `at-rule-no-unknown` rule.
 -   Added: `no-empty-source` rule.
 -   Added: `except: ["after-single-line-comment"]` option for `rule-non-nested-empty-line-before`.
@@ -733,7 +733,7 @@ Changes:
 -   Fixed: `font-family-name-quotes`, `media-feature-no-missing-punctuation`, `media-query-list-comma-newline-after`, `media-query-list-comma-newline-before`, `media-query-list-comma-space-after` and `media-query-list-comma-space-before` rules now better ignore SCSS, Less variables and nonstandard at-rules.
 -   Fixed: `no-unknown-animations` now ignores `ease` value.
 -   Fixed: `unit-blacklist`, `unit-case`, `unit-no-unknown`, `unit-whitelist` now better accounts interpolation.
--   Fixed: `unit-no-unknown` no longer breaks Node 0.12 (because we've included the Babel polyfill).
+-   Fixed: `unit-no-unknown` no longer breaks Node.js 0.12 (because we've included the Babel polyfill).
 -   Fixed: `value-keyword-case` now ignores custom idents of properties `animation-name`, `counter-increment`, `font-family`, `grid-row`, `grid-column`, `grid-area`, `list-style-type`.
 -   Fixed: wrong example for `always-multi-line` in rule `block-opening-brace-newline-before` documentation.
 
@@ -1023,7 +1023,7 @@ Changes:
 -   Added: support for regular expression property identification in `property-blacklist`, `property-unit-blacklist`, `property-unit-whitelist`, `property-value-blacklist`, and `property-whitelist`.
 -   Added: better handling of vendor prefixes in `property-unit-blacklist` and `property-unit-whitelist`, e.g. if you enter `animation` it now also checks `-webkit-animation`.
 -   Added: support for using names of modules for the CLI's `--config` argument, not just paths.
--   Added: `codeFilename` option to Node API.
+-   Added: `codeFilename` option to Node.js API.
 -   Added: exposed rules at `stylelint.rules` to make stylelint even more extensible.
 -   Added: brought `stylelint-rule-tester` into this repo, and exposed it at `stylelint.utils.ruleTester`.
 -   Fixed: bug in `rule-properties-order` empty line detection when the two newlines were separated
@@ -1199,13 +1199,13 @@ Changes:
 
 -   Changed: plugins are now included and configured via a "locator", rather than either being `required` or being inserted directly into the configuration object as a function.
 -   Added: CLI.
--   Added: standalone Node API.
--   Added: quiet mode to CLI and Node API.
--   Added: support for formatters, including custom ones, to CLI and Node API.
+-   Added: standalone Node.js API.
+-   Added: quiet mode to CLI and Node.js API.
+-   Added: support for formatters, including custom ones, to CLI and Node.js API.
 -   Added: `string` and `json` formatters.
 -   Added: support for using `.stylelintrc` JSON file.
 -   Added: support for extending existing configs using the `extends` property.
--   Added: support for SCSS syntax parsing to CLI and Node API.
+-   Added: support for SCSS syntax parsing to CLI and Node.js API.
 -   Added: `function-comma-newline-after` rule.
 -   Added: `function-comma-newline-before` rule.
 -   Added: `"always-single-line"` and `"never-single-line"` options to `function-comma-space-after` rule.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ First, decide how you want to use stylelint:
 -   [on the command line](docs/user-guide/cli.md)
 -   [in your text editor](docs/user-guide/complementary-tools.md#editor-plugins), for example in VS Code
 -   [in for your build tool](docs/user-guide/complementary-tools.md#build-tool-plugins), for example in webpack
--   [via the Node API](docs/user-guide/node-api.md)
+-   [via the Node.js API](docs/user-guide/node-api.md)
 -   [as a PostCSS plugin](docs/user-guide/postcss-plugin.md)
 
 Then create your [configuration object](docs/user-guide/configuration.md). You can either extend a shared configuration or craft your own.

--- a/docs/developer-guide/processors.md
+++ b/docs/developer-guide/processors.md
@@ -2,7 +2,7 @@
 
 Processors are functions that hook into stylelint's pipeline, modifying code on its way into stylelint and modifying results on their way out.
 
-*Processors can only be used with the CLI and the Node API, not with the PostCSS plugin.*
+*Processors can only be used with the CLI and the Node.js API, not with the PostCSS plugin.*
 
 Processor modules are functions that accept an options object and return an object with the following the functions, which hook into the processing of each file:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -18,7 +18,7 @@
 ## Usage
 
 -   [The CLI](user-guide/cli.md): Examples and exit codes for using the CLI.
--   [The Node API](user-guide/node-api.md): Options and examples for using the Node API.
+-   [The Node.js API](user-guide/node-api.md): Options and examples for using the Node.js API.
 -   [The PostCSS plugin](user-guide/postcss-plugin.md): Options and examples for using the PostCSS plugin.
 -   [Complementary tools](user-guide/complementary-tools.md): List of community editor plugins, build tool plugins and other tools.
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -208,7 +208,7 @@ Or starting with `stylelint-config-standard`, then layering `myExtendableConfig`
 The value of `"extends"` is a "locater" (or an array of "locaters") that is ultimately `require()`d, so can fit whatever format works with Node's `require.resolve()` algorithm. That means a "locater" can be:
 
 -   The name of a module in `node_modules` (e.g. `stylelint-config-standard`; that module's `main` file must be a valid JSON configuration)
--   An absolute path to a file (which makes sense if you're creating a JS object in a Node context and passing it in) with a `.js` or `.json` extension.
+-   An absolute path to a file (which makes sense if you're creating a JS object in a Node.js context and passing it in) with a `.js` or `.json` extension.
 -   A relative path to a file with a `.js` or `.json` extension, relative to the referencing configuration (e.g. if configA has `extends: "../configB"`, we'll look for `configB` relative to configA).
 
 *Because of `extends`, you can create and use shareable stylelint configurations.* Use the `stylelint-config` keyword within your `package.json` if publishing your config to npm.
@@ -251,7 +251,7 @@ A "plugin" can provide a single rule or a set of rules. If the plugin you use pr
 
 Processors are functions that hook into stylelint's pipeline, modifying code on its way into stylelint and modifying results on their way out.
 
-*Processors can only be used with the CLI and the Node API, not with the PostCSS plugin.* (The PostCSS plugin will ignore them.)
+*Processors can only be used with the CLI and the Node.js API, not with the PostCSS plugin.* (The PostCSS plugin will ignore them.)
 
 Processors can enable stylelint to lint, but not autofix, the CSS within non-stylesheet files that aren't supported out-of-the-box by stylelint.
 

--- a/docs/user-guide/css-processors.md
+++ b/docs/user-guide/css-processors.md
@@ -17,15 +17,15 @@ stylelint will automatically infer the syntax from the:
 -   value of the `lang` or `type` attribute on a `<style>` tag
 -   marker on Markdown code fence
 
-You can force a specific syntax, though. Both the [CLI](cli.md) and the [Node API](node-api.md) expose a `syntax` option.
+You can force a specific syntax, though. Both the [CLI](cli.md) and the [Node.js API](node-api.md) expose a `syntax` option.
 
 -   If you're using the CLI, use the `syntax` flag like so:  `stylelint ... --syntax scss`.
--   If you're using the Node API, pass in the `syntax` option like so: `stylelint.lint({ syntax: "sugarss", ... })`.
+-   If you're using the Node.js API, pass in the `syntax` option like so: `stylelint.lint({ syntax: "sugarss", ... })`.
 
-stylelint can also accept a custom [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes) when using the CLI or Node API. For custom syntaxes, use the `custom-syntax` and `customSyntax` options, respectively.
+stylelint can also accept a custom [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes) when using the CLI or Node.js API. For custom syntaxes, use the `custom-syntax` and `customSyntax` options, respectively.
 
 -   If you're using the CLI, use the `custom-syntax` flag like so:  `stylelint ... --custom-syntax custom-syntax-module` or `stylelint ... --custom-syntax ./path/to/custom-syntax-module`.
--   If you're using the Node API, pass in the `customSyntax` option like so: `stylelint.lint({ customSyntax: path.join(process.cwd(), './path/to/custom-syntax-module') , ... })`.
+-   If you're using the Node.js API, pass in the `customSyntax` option like so: `stylelint.lint({ customSyntax: path.join(process.cwd(), './path/to/custom-syntax-module') , ... })`.
 
 If you're using the linter as a [PostCSS Plugin](postcss-plugin.md), you should use the special `postcss-syntax` directly with PostCSS's `syntax` option like so:
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -37,7 +37,7 @@ If there isn't a dedicated stylelint plugin for your task runner of choice, you 
 
 There are also examples of using the PostCSS plugin via the PostCSS JS API within the [docs](postcss-plugin.md).
 
-However, using stylelint as a PostCSS plugin limits your reporting options to [postcss-reporter](https://github.com/postcss/postcss-reporter/). We recommend using the stylelint CLI or Node API, instead, for better reporting.
+However, using stylelint as a PostCSS plugin limits your reporting options to [postcss-reporter](https://github.com/postcss/postcss-reporter/). We recommend using the stylelint CLI or Node.js API, instead, for better reporting.
 
 ## How do I lint within my text editor?
 
@@ -47,7 +47,7 @@ The stylelint community also maintains a [handful of plugins](complementary-tool
 
 stylelint can *parse* any the following non-standard syntaxes by default: Sass, Less and SugarSS. Non-standard syntaxes can automatically be inferred from the following file extensions `.sass`, `.scss`, `.less`, and `.sss`; or else you can specify the syntax yourself.
 
-Additionally, stylelint can accept any [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes) when using the CLI or Node API. Note, however, that stylelint can provide no guarantee that core rules will work with syntaxes other than the defaults listed above.
+Additionally, stylelint can accept any [PostCSS-compatible syntax](https://github.com/postcss/postcss#syntaxes) when using the CLI or Node.js API. Note, however, that stylelint can provide no guarantee that core rules will work with syntaxes other than the defaults listed above.
 
 Refer to the [docs](css-processors.md#parsing-non-standard-syntax) on how to configure stylelint to parse non-standard syntaxes.
 
@@ -57,7 +57,7 @@ We [recommend](css-processors.md) linting your source files before any transform
 
 ## How do I automatically fix stylistic violations?
 
-Use the `--fix` CLI flag or the `fix` Node API option to fix a number of stylistic violations with this *experimental* feature.
+Use the `--fix` CLI flag or the `fix` Node.js API option to fix a number of stylistic violations with this *experimental* feature.
 
 ## How do I manage conflicts between rules?
 

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -1,6 +1,6 @@
-# The stylelint Node API
+# The stylelint Node.js API
 
-The stylelint module includes a `lint()` function that provides the Node API.
+The stylelint module includes a `lint()` function that provides the Node.js API.
 
 ```js
 stylelint.lint(options)

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -69,7 +69,7 @@ You'll also need to use a reporter. *The stylelint plugin registers warnings via
 
 A separate lint task that uses the plugin via the PostCSS JS API to lint Less using [`postcss-less`](https://github.com/shellscape/postcss-less).
 
-*Note: the stylelint PostCSS plugin, unlike the stylelint CLI and node API, doesn't have a `syntax` option. Instead, the syntax must be set within the [PostCSS options](https://github.com/postcss/postcss#options) as there can only be one parser/syntax in a pipeline.*
+*Note: the stylelint PostCSS plugin, unlike the stylelint CLI and Node.js API, doesn't have a `syntax` option. Instead, the syntax must be set within the [PostCSS options](https://github.com/postcss/postcss#options) as there can only be one parser/syntax in a pipeline.*
 
 ```js
 var fs = require("fs")

--- a/docs/user-guide/processors.md
+++ b/docs/user-guide/processors.md
@@ -2,7 +2,7 @@
 
 Processors are community packages that enable stylelint to extract styles from within non-stylesheet files.
 
-*These processors can only be used with the CLI and the Node API, not with the PostCSS plugin.* (The PostCSS plugin will ignore them.)
+*These processors can only be used with the CLI and the Node.js API, not with the PostCSS plugin.* (The PostCSS plugin will ignore them.)
 
 -   [stylelint-processor-arbitrary-tags](https://github.com/mapbox/stylelint-processor-arbitrary-tags): Lint within user-specified tags.
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

`Node.js` is the official name. Also may be confused with the `Node` class in `PostCSS`
