### PR TITLE
Refactor standalone-cache.test.js to avoid relying on 'flatted'

### DIFF
--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -6,14 +6,11 @@ const standalone = require("../standalone");
 const fixturesPath = path.join(__dirname, "fixtures");
 const fs = require("fs");
 const pify = require("pify");
-const readFile = pify(fs.readFile);
 const unlink = pify(fs.unlink);
 const cpFile = require("cp-file");
 const fileExists = require("file-exists-promise");
-// As 'file-entry-cache' use 'flatted' to create the cache,
-// need use this package to parse the content
-// eslint-disable-next-line node/no-extraneous-require
-const { parse } = require("flatted/cjs");
+
+const fCache = require("file-entry-cache");
 
 const cwd = process.cwd();
 const invalidFile = path.join(fixturesPath, "empty-block.css");
@@ -58,20 +55,16 @@ describe("standalone cache", () => {
 
   it("cache file is created at $CWD/.stylelintcache", () => {
     // Ensure cache file exists
-    return fileExists(expectedCacheFilePath)
-      .then(isFileExist => {
-        expect(!!isFileExist).toBe(true);
+    return fileExists(expectedCacheFilePath).then(isFileExist => {
+      expect(!!isFileExist).toBe(true);
 
-        return readFile(expectedCacheFilePath, "utf8");
-      })
-      .then(fileContents => {
-        return parse(fileContents);
-      })
-      .then(cacheFile => {
-        // Ensure cache file contains only linted css file
-        expect(typeof cacheFile[validFile] === "object").toBe(true);
-        expect(typeof cacheFile[newFileDest] === "undefined").toBe(true);
-      });
+      const fileCache = fCache.createFromFile(expectedCacheFilePath);
+      const { cache } = fileCache;
+
+      // Ensure cache file contains only linted css file
+      expect(typeof cache.getKey(validFile) === "object").toBe(true);
+      expect(typeof cache.getKey(newFileDest) === "undefined").toBe(true);
+    });
   });
 
   it("only changed files are linted", () => {
@@ -93,15 +86,11 @@ describe("standalone cache", () => {
         expect(isValidFileLinted).toBe(false);
         expect(isNewFileLinted).toBe(true);
 
-        // Ensure cache file contains linted css files
-        return readFile(expectedCacheFilePath, "utf8");
-      })
-      .then(fileContents => {
-        return parse(fileContents);
-      })
-      .then(cachedFiles => {
-        expect(typeof cachedFiles[validFile] === "object").toBe(true);
-        expect(typeof cachedFiles[newFileDest] === "object").toBe(true);
+        const fileCache = fCache.createFromFile(expectedCacheFilePath);
+        const { cache } = fileCache;
+
+        expect(typeof cache.getKey(validFile) === "object").toBe(true);
+        expect(typeof cache.getKey(newFileDest) === "object").toBe(true);
       });
   });
 
@@ -148,15 +137,11 @@ describe("standalone cache", () => {
         expect(isValidFileLinted).toBe(false);
         expect(isInvalidFileLinted).toBe(true);
 
-        // Ensure cache file doesn't contain invalid file
-        return readFile(expectedCacheFilePath, "utf8");
-      })
-      .then(fileContents => {
-        return parse(fileContents);
-      })
-      .then(cachedFiles => {
-        expect(typeof cachedFiles[validFile] === "object").toBe(true);
-        expect(typeof cachedFiles[newFileDest] === "undefined").toBe(true);
+        const fileCache = fCache.createFromFile(expectedCacheFilePath);
+        const { cache } = fileCache;
+
+        expect(typeof cache.getKey(validFile) === "object").toBe(true);
+        expect(typeof cache.getKey(newFileDest) === "undefined").toBe(true);
       });
   });
   it("files with syntax errors are not cached", () => {
@@ -166,13 +151,11 @@ describe("standalone cache", () => {
         return standalone(getConfig());
       })
       .then(() => {
-        return readFile(expectedCacheFilePath, "utf8");
-      })
-      .then(fileContents => {
-        const cachedFiles = parse(fileContents);
+        const fileCache = fCache.createFromFile(expectedCacheFilePath);
+        const { cache } = fileCache;
 
-        expect(typeof cachedFiles[validFile] === "object").toBe(true);
-        expect(typeof cachedFiles[newFileDest] === "undefined").toBe(true);
+        expect(typeof cache.getKey(validFile) === "object").toBe(true);
+        expect(typeof cache.getKey(newFileDest) === "undefined").toBe(true);
       });
   });
   it("cache file is removed when cache is disabled", () => {
@@ -257,14 +240,10 @@ describe("standalone cache uses cacheLocation", () => {
       .then(fileStats => {
         expect(!!fileStats).toBe(true);
 
-        // Ensure cache file contains cached entity
-        return readFile(cacheLocationFile, "utf8");
-      })
-      .then(fileContents => {
-        return parse(fileContents);
-      })
-      .then(cacheFile => {
-        expect(typeof cacheFile[validFile] === "object").toBe(true);
+        const fileCache = fCache.createFromFile(cacheLocationFile);
+        const { cache } = fileCache;
+
+        expect(typeof cache.getKey(validFile) === "object").toBe(true);
       });
   });
   it("cacheLocation is a directory", () => {
@@ -280,14 +259,10 @@ describe("standalone cache uses cacheLocation", () => {
         // Ensure cache file is created
         expect(!!cacheFileStats).toBe(true);
 
-        // Ensure cache file contains cached entity
-        return readFile(expectedCacheFilePath, "utf8");
-      })
-      .then(fileContents => {
-        return parse(fileContents);
-      })
-      .then(cacheFile => {
-        expect(typeof cacheFile[validFile] === "object").toBe(true);
+        const fileCache = fCache.createFromFile(expectedCacheFilePath);
+        const { cache } = fileCache;
+
+        expect(typeof cache.getKey(validFile) === "object").toBe(true);
       });
   });
 });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cosmiconfig": "^5.0.0",
     "debug": "^4.0.0",
     "execall": "^1.0.0",
-    "file-entry-cache": "^4.0.0",
+    "file-entry-cache": "^5.0.1",
     "get-stdin": "^6.0.0",
     "global-modules": "^2.0.0",
     "globby": "^9.0.0",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3786

> Is there anything in the PR that needs further explanation?

Use `file-entry-cache#createFromFile` to create another instance of the cache, so that we can access to the cache without relying on the `flatted` which is the dependency of `file-entry-cache`
