### PR TITLE
Fix false positives for prefers-color-scheme in media-feature-name-no-unknown

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -594,6 +594,7 @@ keywordSets.mediaFeatureNames = uniteSets(
     "overflow-block",
     "overflow-inline",
     "pointer",
+    "prefers-color-scheme",
     "prefers-reduced-motion",
     "prefers-reduced-transparency",
     "resolution",


### PR DESCRIPTION
This is a new media query added to CSS Media Queries Level 5 to utilize the dark mode preference operating systems provide.

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3950

> Is there anything in the PR that needs further explanation?

Please see issue #3950
