### PR TITLE
Fix false negatives for nested at-rules in selector-max-*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .eslintcache
 package-lock.json
 yarn.lock
+**/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 .eslintcache
 package-lock.json
 yarn.lock
-**/.idea/

--- a/lib/rules/selector-max-attribute/__tests__/index.js
+++ b/lib/rules/selector-max-attribute/__tests__/index.js
@@ -66,6 +66,13 @@ testRule(rule, {
       message: messages.expected("a[rel='external']", 0),
       line: 1,
       column: 1
+    },
+    {
+      code: "@include test { a[rel='external'] {} }",
+      message: messages.expected("a[rel='external']", 0),
+      description: "nested in at-rule",
+      line: 1,
+      column: 17
     }
   ]
 });
@@ -258,6 +265,16 @@ testRule(rule, {
     {
       code: '[type="text"]#{$interpolation} { margin: { left: 0; top: 0; }; }',
       description: "scss: nested properties"
+    }
+  ],
+
+  reject: [
+    {
+      code: '@include test { [type="text"][name="message"] {} }',
+      description: "scss: mixin at-rule",
+      message: messages.expected('[type="text"][name="message"]', 0),
+      line: 1,
+      column: 17
     }
   ]
 });

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const hasUnresolvedNestedSelector = require("../../utils/hasUnresolvedNestedSelector");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector");
 const optionsMatches = require("../../utils/optionsMatches");
@@ -89,11 +90,7 @@ function rule(max, options) {
         return;
       }
 
-      if (
-        ruleNode.nodes.some(
-          node => ["rule", "atrule"].indexOf(node.type) !== -1
-        )
-      ) {
+      if (hasUnresolvedNestedSelector(ruleNode)) {
         // Skip unresolved nested selectors
         return;
       }

--- a/lib/rules/selector-max-class/__tests__/index.js
+++ b/lib/rules/selector-max-class/__tests__/index.js
@@ -136,6 +136,13 @@ testRule(rule, {
       message: messages.expected(".ab:hover > .ef.gh", 2),
       line: 1,
       column: 7
+    },
+    {
+      code: ".ab { @include test { .ef { &:hover .gh {} } } }",
+      description: "nested selectors: inside at-rule",
+      message: messages.expected(".ab .ef:hover .gh", 2),
+      line: 1,
+      column: 29
     }
   ]
 });
@@ -158,6 +165,16 @@ testRule(rule, {
     {
       code: ".foo { margin: { left: 0; top: 0; }; }",
       description: "scss: nested properties"
+    }
+  ],
+
+  reject: [
+    {
+      code: "@include test { .foo {} }",
+      description: "scss: mixin @include",
+      message: messages.expected(".foo", 0),
+      line: 1,
+      column: 17
     }
   ]
 });

--- a/lib/rules/selector-max-combinators/__tests__/index.js
+++ b/lib/rules/selector-max-combinators/__tests__/index.js
@@ -187,7 +187,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [true],
+  config: [0],
   skipBasicChecks: true,
   syntax: "scss",
 
@@ -223,6 +223,64 @@ testRule(rule, {
     {
       code: "div:nth-child(#{map-get($foo, bar)}) {}",
       description: "ignore sass map-get interpolation"
+    }
+  ],
+
+  reject: [
+    {
+      code: "foo bar { @include test {} }",
+      message: messages.expected("foo bar", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "foo + bar { @include test { .aa {} } }",
+      message: messages.expected("foo + bar", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "foo > bar { @include test {} }",
+      description: "compound selector 3: nested at-rule",
+      message: messages.expected("foo > bar", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "foo ~ bar { @include test {} }",
+      message: messages.expected("foo ~ bar", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "foo bar, .baz { @include test {} }",
+      message: messages.expected("foo bar", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".foo, bar baz { @include test {} }",
+      message: messages.expected("bar baz", 0),
+      line: 1,
+      column: 7
+    },
+    {
+      code: "\t.foo,\n\tbar baz { @include test {} }",
+      message: messages.expected("bar baz", 0),
+      line: 2,
+      column: 2
+    },
+    {
+      code: "foo#bar ~ baz { @include test {} }",
+      message: messages.expected("foo#bar ~ baz", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "@include test { foo bar {} }",
+      message: messages.expected("foo bar", 0),
+      line: 1,
+      column: 17
     }
   ]
 });

--- a/lib/rules/selector-max-combinators/index.js
+++ b/lib/rules/selector-max-combinators/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const hasUnresolvedNestedSelector = require("../../utils/hasUnresolvedNestedSelector");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector");
 const parseSelector = require("../../utils/parseSelector");
@@ -66,11 +67,7 @@ function rule(max) {
         return;
       }
 
-      if (
-        ruleNode.nodes.some(
-          node => ["rule", "atrule"].indexOf(node.type) !== -1
-        )
-      ) {
+      if (hasUnresolvedNestedSelector(ruleNode)) {
         // Skip unresolved nested selectors
         return;
       }

--- a/lib/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/lib/rules/selector-max-compound-selectors/__tests__/index.js
@@ -267,6 +267,39 @@ testRule(rule, {
       code: ".foo { margin: { left: 5px; top: 10px; }; }",
       description: "nested properties"
     }
+  ],
+
+  reject: [
+    {
+      code: "a b { @include test {} top: 0; }",
+      message: messages.expected("a b", 1),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "#id > .cl + .cl2 { @include test {} top: 0; }",
+      message: messages.expected("#id > .cl + .cl2", 1),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "a c, d + e h { @include test{} top: 0; }",
+      message: messages.expected("a c", 1),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "a ~ h + d { @include test {} top: 0; }",
+      message: messages.expected("a ~ h + d", 1),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "@include test { a b { top: 0; } }",
+      message: messages.expected("a b", 1),
+      line: 1,
+      column: 17
+    }
   ]
 });
 

--- a/lib/rules/selector-max-id/__tests__/index.js
+++ b/lib/rules/selector-max-id/__tests__/index.js
@@ -284,6 +284,87 @@ testRule(rule, {
       code: "@for $n from 1 through 10 { .n-#{$n} #foo {} }",
       description: "ignore sass interpolation + ID inside @for"
     }
+  ],
+
+  reject: [
+    {
+      code: "#foo { @include test {} }",
+      message: messages.expected("#foo", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".bar #foo { @include test {} }",
+      message: messages.expected(".bar #foo", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".bar > #foo { @include test {} }",
+      message: messages.expected(".bar > #foo", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "#foo.bar { @include test {} }",
+      message: messages.expected("#foo.bar", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".foo, .bar, #foo.baz { @include test {} }",
+      message: messages.expected("#foo.baz", 0),
+      line: 1,
+      column: 13
+    },
+    {
+      code: "#foo [lang^=en] { @include test {} }",
+      message: messages.expected("#foo [lang^=en]", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "#foo[lang^=en] { @include test {} }",
+      message: messages.expected("#foo[lang^=en]", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "* #foo { @include test {} }",
+      message: messages.expected("* #foo", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "#foo * { @include test {} }",
+      message: messages.expected("#foo *", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "*#foo { @include test {} }",
+      message: messages.expected("*#foo", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "#foo:hover { @include test {} }",
+      message: messages.expected("#foo:hover", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":not(#foo) { @include test {} }",
+      message: messages.expected("#foo", 0),
+      line: 1,
+      column: 6
+    },
+    {
+      code: "@include test { #foo {} }",
+      message: messages.expected("#foo", 0),
+      line: 1,
+      column: 17
+    }
   ]
 });
 

--- a/lib/rules/selector-max-pseudo-class/__tests__/index.js
+++ b/lib/rules/selector-max-pseudo-class/__tests__/index.js
@@ -75,6 +75,30 @@ testRule(rule, {
       message: messages.expected("a:hover", 0),
       line: 1,
       column: 5
+    },
+    {
+      code: ":global { @include test {} }",
+      message: messages.expected(":global", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "a:first-child { @include test {} }",
+      message: messages.expected("a:first-child", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "a,\na:first-child { @include test {} }",
+      message: messages.expected("a:first-child", 0),
+      line: 2,
+      column: 1
+    },
+    {
+      code: "@include test { a { &:hover {}} }",
+      message: messages.expected("a:hover", 0),
+      line: 1,
+      column: 21
     }
   ]
 });

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -280,6 +280,57 @@ testRule(rule, {
       code: "@each $a in $b { .#{ map-get($a, b) } { c {} } }",
       description: "ignore nested rules with variable interpolation"
     }
+  ],
+
+  reject: [
+    {
+      code: ".ab .ab { @include test {} }",
+      message: messages.expected(".ab .ab", "0,1,1"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:not(.b) { @include test {} }",
+      message: messages.expected(".a:not(.b)", "0,1,1"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:not(.b, .c) { @include test {} }",
+      message: messages.expected(".a:not(.b, .c)", "0,1,1"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":not(.b, .c.d) { @include test {} }",
+      message: messages.expected(":not(.b, .c.d)", "0,1,1"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:matches(.b) { @include test {} }",
+      message: messages.expected(".a:matches(.b)", "0,1,1"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".a:matches(.b, .c) { @include test {} }",
+      message: messages.expected(".a:matches(.b, .c)", "0,1,1"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":matches(.b, .c.d) { @include test {} }",
+      message: messages.expected(":matches(.b, .c.d)", "0,1,1"),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "@include test { .ab .ab {} }",
+      message: messages.expected(".ab .ab", "0,1,1"),
+      line: 1,
+      column: 17
+    }
   ]
 });
 

--- a/lib/rules/selector-max-type/__tests__/index.js
+++ b/lib/rules/selector-max-type/__tests__/index.js
@@ -119,6 +119,14 @@ testRule(rule, {
       message: messages.expected(".foo div", 0),
       line: 1,
       column: 8
+    },
+    {
+      code:
+        "@supports (display: grid) { @media (min-width: 10rem) { div {} } }",
+      description: "nested rules within nested at-rule",
+      message: messages.expected("div", 0),
+      line: 1,
+      column: 57
     }
   ]
 });
@@ -227,6 +235,10 @@ testRule(rule, {
     {
       code: ".foo { div, a {} }",
       description: "nested selector list of descendants"
+    },
+    {
+      code: ".foo { @include test { div {} } }",
+      description: "nested at-rule in descendants"
     }
   ],
 
@@ -275,6 +287,20 @@ testRule(rule, {
       message: messages.expected(".foo ~ div", 0),
       line: 1,
       column: 1
+    },
+    {
+      code: "@media(min-width: 10rem) { div {} }",
+      description: "inside at-rule",
+      message: messages.expected("div", 0),
+      line: 1,
+      column: 28
+    },
+    {
+      code: "@include placeholder { div {} }",
+      description: "inside scss at-rule",
+      message: messages.expected("div", 0),
+      line: 1,
+      column: 24
     }
   ]
 });
@@ -489,6 +515,52 @@ testRule(rule, {
       code:
         '@for $n from 1 through 5 { .foo-#{$n} { div { content: "#{$n}"; } } }'
     }
+  ],
+
+  reject: [
+    {
+      code: ".foo { div { @include test-mixin {} } }",
+      description: "nested at-rule for valid SCSS syntax",
+      message: messages.expected(".foo div", 0),
+      line: 1,
+      column: 8
+    },
+    {
+      code: ".foo { .baz, div { @include test-mixin {} } }",
+      description:
+        "nested selector list of descendants with at-rule for valid SCSS syntax",
+      message: messages.expected(".foo div", 0),
+      line: 1,
+      column: 8
+    },
+    {
+      code: ".foo { .baz { @include test-mixin {} .nested { div {} } } }",
+      description: "nested at-rule in parent",
+      message: messages.expected(".foo .baz .nested div", 0),
+      line: 1,
+      column: 48
+    },
+    {
+      code: "@include test-mixin { div {} }",
+      description: "at-rule at top level",
+      message: messages.expected("div", 0),
+      line: 1,
+      column: 23
+    },
+    {
+      code: ".foo { @include test-mixin { div {} } }",
+      description: "at-rule inside class",
+      message: messages.expected(".foo div", 0),
+      line: 1,
+      column: 30
+    },
+    {
+      code: "a { @extend placeholder; }",
+      description: "at-rule inside type",
+      message: messages.expected("a", 0),
+      line: 1,
+      column: 1
+    }
   ]
 });
 
@@ -505,6 +577,16 @@ testRule(rule, {
     {
       code:
         '.for(@n: 1) when (@n <= 5) { .foo-@{n} { div { content: "@{n}"; } } .for (@n + 1); }'
+    }
+  ],
+
+  reject: [
+    {
+      code: "@foo: { div {} };",
+      description: "non-standard at-rule less",
+      message: messages.expected("div", 0),
+      line: 1,
+      column: 9
     }
   ]
 });

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const hasUnresolvedNestedSelector = require("../../utils/hasUnresolvedNestedSelector");
 const isKeyframeSelector = require("../../utils/isKeyframeSelector");
 const isOnlyWhitespace = require("../../utils/isOnlyWhitespace");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
@@ -112,11 +113,7 @@ function rule(max, options) {
         return;
       }
 
-      if (
-        ruleNode.nodes.some(
-          node => ["rule", "atrule"].indexOf(node.type) !== -1
-        )
-      ) {
+      if (hasUnresolvedNestedSelector(ruleNode)) {
         // Skip unresolved nested selectors
         return;
       }

--- a/lib/rules/selector-max-universal/__tests__/index.js
+++ b/lib/rules/selector-max-universal/__tests__/index.js
@@ -198,3 +198,85 @@ testRule(rule, {
     }
   ]
 });
+
+testRule(rule, {
+  ruleName,
+  config: [0],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  reject: [
+    {
+      code: "* { @include test {} }",
+      message: messages.expected("*", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".bar * { @include test {} }",
+      message: messages.expected(".bar *", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "*.bar { @include test {} }",
+      message: messages.expected("*.bar", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "* [lang^=en] { @include test {} }",
+      message: messages.expected("* [lang^=en]", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "*[lang^=en] { @include test {} }",
+      message: messages.expected("*[lang^=en]", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".foo, .bar, *.baz { @include test {} }",
+      message: messages.expected("*.baz", 0),
+      line: 1,
+      column: 13
+    },
+    {
+      code: "* #id { @include test {} }",
+      message: messages.expected("* #id", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "*#id { @include test {} }",
+      message: messages.expected("*#id", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ".foo* { @include test {} }",
+      message: messages.expected(".foo*", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: "*:hover { @include test {} }",
+      message: messages.expected("*:hover", 0),
+      line: 1,
+      column: 1
+    },
+    {
+      code: ":not(*) { @include test {} }",
+      message: messages.expected("*", 0),
+      line: 1,
+      column: 6
+    },
+    {
+      code: "@include test { * {} }",
+      message: messages.expected("*", 0),
+      line: 1,
+      column: 17
+    }
+  ]
+});

--- a/lib/rules/selector-max-universal/index.js
+++ b/lib/rules/selector-max-universal/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const hasUnresolvedNestedSelector = require("../../utils/hasUnresolvedNestedSelector");
 const isStandardSyntaxRule = require("../../utils/isStandardSyntaxRule");
 const isStandardSyntaxSelector = require("../../utils/isStandardSyntaxSelector");
 const parseSelector = require("../../utils/parseSelector");
@@ -67,11 +68,7 @@ function rule(max) {
         return;
       }
 
-      if (
-        ruleNode.nodes.some(
-          node => ["rule", "atrule"].indexOf(node.type) !== -1
-        )
-      ) {
+      if (hasUnresolvedNestedSelector(ruleNode)) {
         // Skip unresolved nested selectors
         return;
       }

--- a/lib/utils/__tests__/hasUnresolvedNestedSelector.test.js
+++ b/lib/utils/__tests__/hasUnresolvedNestedSelector.test.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const hasUnresolvedNestedSelector = require("../hasUnresolvedNestedSelector");
+const postcss = require("postcss");
+const scss = require("postcss-scss");
+
+describe("hasUnresolvedNestedSelector", () => {
+  it("type", () => {
+    expect.assertions(1);
+    rules("a {}", rule => {
+      expect(hasUnresolvedNestedSelector(rule)).toBeFalsy();
+    });
+  });
+  it("class", () => {
+    expect.assertions(1);
+    rules(".foo {}", rule => {
+      expect(hasUnresolvedNestedSelector(rule)).toBeFalsy();
+    });
+  });
+  it("nested type", () => {
+    expect.assertions(1);
+    const parsed = postcss.parse(".foo { a {} }");
+
+    expect(hasUnresolvedNestedSelector(parsed.first)).toBeTruthy();
+  });
+  it("nested selector", () => {
+    expect.assertions(1);
+    const parsed = postcss.parse(".foo { .bar {} }");
+
+    expect(hasUnresolvedNestedSelector(parsed.first)).toBeTruthy();
+  });
+  it("SCSS mixin", () => {
+    expect.assertions(1);
+    scssRules("@include test-mixin {}", rule => {
+      expect(hasUnresolvedNestedSelector(rule)).toBeFalsy();
+    });
+  });
+  it("SCSS nested mixin no children", () => {
+    expect.assertions(2);
+    scssRules(".foo { @include test-mixin; }", rule => {
+      expect(hasUnresolvedNestedSelector(rule)).toBeFalsy();
+    });
+  });
+  it("SCSS nested mixin children", () => {
+    expect.assertions(2);
+    scssRules(".foo { @include test-mixin {} }", rule => {
+      expect(hasUnresolvedNestedSelector(rule)).toBeFalsy();
+    });
+  });
+  it("SCSS multiple mixins", () => {
+    expect.assertions(2);
+    scssRules("@include test-mixin { @media (min-width: 10rem) {} }", rule => {
+      expect(hasUnresolvedNestedSelector(rule)).toBeFalsy();
+    });
+  });
+});
+
+function rules(css, cb) {
+  postcss.parse(css).walk(cb);
+}
+
+function scssRules(css, cb) {
+  scss.parse(css).walk(cb);
+}

--- a/lib/utils/hasUnresolvedNestedSelector.js
+++ b/lib/utils/hasUnresolvedNestedSelector.js
@@ -1,0 +1,9 @@
+/* @flow */
+"use strict";
+
+/**
+ * Check whether an array of nodes has some unresolved nested selector
+ */
+module.exports = function(rule /*: Object*/) /*: boolean*/ {
+  return (rule.nodes || []).some(node => ["rule"].indexOf(node.type) !== -1);
+};

--- a/system-tests/005/__snapshots__/005.test.js.snap
+++ b/system-tests/005/__snapshots__/005.test.js.snap
@@ -16540,6 +16540,13 @@ b\\" to have no more than 0 combinators (selector-max-combinators)",
       },
       Object {
         "column": 1,
+        "line": 1,
+        "rule": "selector-max-type",
+        "severity": "error",
+        "text": "Expected \\"a\\" to have no more than 0 type selectors (selector-max-type)",
+      },
+      Object {
+        "column": 1,
         "line": 2,
         "rule": "selector-max-type",
         "severity": "error",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3947

> Is there anything in the PR that needs further explanation?

This seems to solve the problem for selector-max-type, but I wanted to put up a POC before moving on to the other rules to see if I'm moving in the right direction. Feedback is appreciated.
