### PR TITLE
Missing: function-calc-no-invalid

### DIFF
--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -64,6 +64,7 @@ You might want to learn a little about [how rules are named and how they work to
     "font-family-no-missing-generic-family-keyword": true,
     "font-weight-notation": "numeric"|"named",
     "function-blacklist": string|[],
+    "function-calc-no-invalid": true,
     "function-calc-no-unspaced-operator": true,
     "function-comma-newline-after": "always"|"always-multi-line"|"never-multi-line",
     "function-comma-newline-before": "always"|"always-multi-line"|"never-multi-line",


### PR DESCRIPTION
Need to add: function-calc-no-invalid  -  https://stylelint.io/user-guide/rules/function-calc-no-invalid/

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
