### PR TITLE
Fix TypeError with benchmark-rule script

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -283,10 +283,6 @@ npm run benchmark-rule -- selector-combinator-space-after always
 ```
 
 ```shell
-npm run benchmark-rule -- selector-no-combinator true
-```
-
-```shell
 npm run benchmark-rule -- block-opening-brace-space-before "[\"always\", {\"ignoreAtRules\": [\"else\"]}]"
 ```
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -269,10 +269,10 @@ Deprecating rules doesn't happen very often. However, these two steps are import
 There's a simple way to run benchmarks on any given rule with any valid config for it:
 
 ```shell
-npm run benchmark-rule -- [rule-name] [config]
+npm run benchmark-rule -- ruleName ruleOptions [ruleContext]
 ```
 
-If the `config` argument is anything other than a string or a boolean, it must be valid JSON wrapped in quotation marks.
+If the `ruleOptions` argument is anything other than a string or a boolean, it must be valid JSON wrapped in quotation marks.
 
 ```shell
 npm run benchmark-rule -- selector-combinator-space-after never
@@ -284,6 +284,12 @@ npm run benchmark-rule -- selector-combinator-space-after always
 
 ```shell
 npm run benchmark-rule -- block-opening-brace-space-before "[\"always\", {\"ignoreAtRules\": [\"else\"]}]"
+```
+
+If the `ruleContext` argument is specified, the sames procedure would apply:
+
+```shell
+npm run benchmark-rule -- block-opening-brace-space-before "[\"always\", {\"ignoreAtRules\": [\"else\"]}]" "{\"fix\": \"true\"}"
 ```
 
 The script loads Bootstrap's CSS (from its CDN) and runs it through the configured rule.

--- a/scripts/benchmark-rule.js
+++ b/scripts/benchmark-rule.js
@@ -69,7 +69,7 @@ let firstTime = true;
 
 function benchFn(css, done) {
   processor
-    .process(css)
+    .process(css, { from: undefined })
     .then(result => {
       if (firstTime) {
         firstTime = false;

--- a/scripts/benchmark-rule.js
+++ b/scripts/benchmark-rule.js
@@ -7,13 +7,14 @@ const normalizeRuleSettings = require("../lib/normalizeRuleSettings");
 const postcss = require("postcss");
 const request = require("request");
 const requireRule = require("../lib/requireRule");
-const rules = require("../lib/rules");
 
 const ruleName = process.argv[2];
 const ruleOptions = process.argv[3];
 const ruleContext = process.argv[4];
 
-if (!rules.includes(ruleName)) {
+const ruleFunc = requireRule(ruleName);
+
+if (!ruleFunc) {
   throw new Error("You must specify a valid rule name");
 }
 
@@ -43,7 +44,7 @@ const primary = ruleSettings[0];
 const secondary = ruleSettings[1] || null;
 const context = ruleContext ? JSON.parse(ruleContext) : {};
 
-const rule = requireRule(ruleName).apply(null, [primary, secondary, context]);
+const rule = ruleFunc.apply(null, [primary, secondary, context]);
 
 const processor = postcss().use(rule);
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Fixes #3804 

> Is there anything in the PR that needs further explanation?

Not specifically. Addresses issue with current benchmark script throwing a TypeError - which looks like it was caused by a refactor here: https://github.com/stylelint/stylelint/commit/973e07b81244eb359cfe5ee8cdf63a2ab4fba72c#diff-1b5afd6b670c8bdd40102c599cbc9697

PR contains code fixes and updates to documentation for the benchmarking script.
