### PR TITLE
Drop support for Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,15 @@ cache:
 
 matrix:
   include:
-    - node_js: '8'
+    - node_js: '10'
       script: npm run pretest
       env: CI=pretest
-    - node_js: '8'
+    - node_js: '10'
       script: npm run jest -- --maxWorkers=2 --coverage
       env: CI=coverage
-    - node_js: '10'
+    - node_js: '8'
       script: npm run jest -- --maxWorkers=2
-      env: CI=tests 10
-    - node_js: '6'
-      script: npm run jest -- --maxWorkers=2
-      env: CI=tests 6
+      env: CI=tests 8
 
 before_install:
   - npm install -g npm@latest

--- a/docs/developer-guide/prerequisites.md
+++ b/docs/developer-guide/prerequisites.md
@@ -2,7 +2,7 @@
 
 ## Technical
 
--   [Node.js](https://nodejs.org/en/) 4.2.1+.
+-   [Node.js](https://nodejs.org/en/) 8.15.1+.
 -   Latest [npm](https://www.npmjs.com/).
 
 ## Rules of thumb

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "!flow-typed/npm"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8.15.1"
   },
   "dependencies": {
     "autoprefixer": "^9.0.0",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/4000.

> Is there anything in the PR that needs further explanation?

Node.js 8.15.1 is the latest 8.x version at the moment.

Changed Travis configuration to use Node.js 10 for pretest and coverage, as it theoretically should be faster. Also, it's recommended Node.js version for most users.
