### PR TITLE
Add ignore: ["comments"] to block-no-empty

### DIFF
--- a/lib/__tests__/disableRanges-integration.test.js
+++ b/lib/__tests__/disableRanges-integration.test.js
@@ -8,7 +8,7 @@ const stringQuotes = require("../rules/string-quotes");
 // disabling all rules
 testRule(blockNoEmpty, {
   ruleName: blockNoEmpty.ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
 
   accept: [
@@ -76,7 +76,7 @@ testRule(selectorCombinatorSpaceBefore, {
 
 testRule(blockNoEmpty, {
   ruleName: blockNoEmpty.ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
 
   accept: [
@@ -146,7 +146,7 @@ testRule(selectorCombinatorSpaceBefore, {
 
 testRule(blockNoEmpty, {
   ruleName: blockNoEmpty.ruleName,
-  config: [undefined],
+  config: [true],
   skipBasicChecks: true,
 
   accept: [

--- a/lib/rules/block-no-empty/README.md
+++ b/lib/rules/block-no-empty/README.md
@@ -23,15 +23,45 @@ a { }
 ```
 
 ```css
-@media print { a {} }
+@media print {
+  a {}
+}
 ```
 
 The following patterns are *not* considered violations:
 
 ```css
-a { color: pink; }
+a {
+  /* foo */
+}
 ```
 
 ```css
-@media print { a { color: pink; } }
+@media print {
+  a {
+    color: pink;
+  }
+}
+```
+
+## Optional secondary options
+
+### `ignore: ["comments"]`
+
+Exclude comments from being treated as content inside of a block.
+
+The following patterns are considered violations:
+
+```css
+a {
+  /* foo */
+}
+```
+
+```css
+@media print {
+  a {
+    /* foo */
+  }
+}
 ```

--- a/lib/rules/block-no-empty/__tests__/index.js
+++ b/lib/rules/block-no-empty/__tests__/index.js
@@ -19,7 +19,22 @@ testRule(rule, {
       code: "a { color: pink; }"
     },
     {
+      code: "a { /* foo */ }"
+    },
+    {
+      code: "a {\n/* foo */\n}"
+    },
+    {
+      code: "a {\n/* foo */\n/* bar */\n}"
+    },
+    {
+      code: "a {\n/*\nfoo\nbar\n*/\n}"
+    },
+    {
       code: "@media print { a { color: pink; } }"
+    },
+    {
+      code: "@media print { a { /* foo */ } }"
     },
     {
       code: "@import url(x.css)"
@@ -104,6 +119,59 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
+  config: [
+    true,
+    {
+      ignore: ["comments"]
+    }
+  ],
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: "a { /* foo */ color: pink; }"
+    },
+    {
+      code: "a {\n/* foo */\ncolor: pink;\n}"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a { /* foo */ }",
+      message: messages.rejected,
+      line: 1,
+      column: 3
+    },
+    {
+      code: "a {\n/* foo */\n}",
+      message: messages.rejected,
+      line: 1,
+      column: 3
+    },
+    {
+      code: "a {\n/* foo */\n/* bar */\n}",
+      message: messages.rejected,
+      line: 1,
+      column: 3
+    },
+    {
+      code: "a {\n/*\nfoo\nbar\n*/\n}",
+      message: messages.rejected,
+      line: 1,
+      column: 3
+    },
+    {
+      code: "@media print { a { /* foo */ } }",
+      message: messages.rejected,
+      line: 1,
+      column: 18
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
   config: [true],
   skipBasicChecks: true,
   syntax: "sugarss",
@@ -120,6 +188,64 @@ testRule(rule, {
       message: messages.rejected,
       line: 3,
       column: 4
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [
+    {
+      code: "a {\n// foo\n}"
+    },
+    {
+      code: "a {\n// foo\n// bar\n}"
+    },
+    {
+      code: "@media print { a {\n// foo\n} }"
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [
+    true,
+    {
+      ignore: ["comments"]
+    }
+  ],
+  skipBasicChecks: true,
+  syntax: "scss",
+
+  accept: [
+    {
+      code: "a {\n// foo\ncolor: pink;\n}"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a {\n// foo\n}",
+      message: messages.rejected,
+      line: 1,
+      column: 3
+    },
+    {
+      code: "a {\n// foo\n// bar\n}",
+      message: messages.rejected,
+      line: 1,
+      column: 3
+    },
+    {
+      code: "@media print { a {\n// foo\n} }",
+      message: messages.rejected,
+      line: 1,
+      column: 18
     }
   ]
 });

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -1,7 +1,9 @@
 "use strict";
 
+const _ = require("lodash");
 const beforeBlockString = require("../../utils/beforeBlockString");
 const hasEmptyBlock = require("../../utils/hasEmptyBlock");
+const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
 const validateOptions = require("../../utils/validateOptions");
@@ -12,20 +14,44 @@ const messages = ruleMessages(ruleName, {
   rejected: "Unexpected empty block"
 });
 
-const rule = function(actual) {
+const rule = function(primary, options = {}) {
   return (root, result) => {
-    const validOptions = validateOptions(result, ruleName, { actual });
+    const validOptions = validateOptions(
+      result,
+      ruleName,
+      {
+        actual: primary,
+        possible: _.isBoolean
+      },
+      {
+        actual: options,
+        possible: {
+          ignore: ["comments"]
+        },
+        optional: true
+      }
+    );
 
     if (!validOptions) {
       return;
     }
+
+    const ignoreComments = optionsMatches(options, "ignore", "comments");
 
     // Check both kinds of statements: rules and at-rules
     root.walkRules(check);
     root.walkAtRules(check);
 
     function check(statement) {
-      if (!hasEmptyBlock(statement)) {
+      if (!hasEmptyBlock(statement) && !ignoreComments) {
+        return;
+      }
+
+      const hasCommentsOnly = statement.nodes.every(
+        node => node.type === "comment"
+      );
+
+      if (!hasCommentsOnly) {
         return;
       }
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #3925. 

Adds secondary option of `ignore: ["comments"]` to rule `block-no-empty`

> Is there anything in the PR that needs further explanation?

Not really. If there's any issues with it, let me know :+1:
