### PR TITLE
Fix value-keyword-case in scss list

### DIFF
--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -692,6 +692,10 @@ testRule(rule, {
       description: "ignore unit within comments"
     },
     {
+      code: '$list: (\n key: "vAluE", // single quote comment\n );',
+      description: "ignore list single quote comment"
+    },
+    {
       code: "a { $display: block; }"
     },
     {

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -59,6 +59,8 @@ const rule = function(expectation, options, context) {
         decl.raws.value ? decl.raws.value.raw : decl.value
       );
 
+      let needFix = false;
+
       parsed.walk(node => {
         const valueLowerCase = node.value.toLowerCase();
 
@@ -210,6 +212,7 @@ const rule = function(expectation, options, context) {
         }
 
         if (context.fix) {
+          needFix = true;
           node.value = expectedKeyword;
 
           return;
@@ -224,7 +227,7 @@ const rule = function(expectation, options, context) {
         });
       });
 
-      if (context.fix) {
+      if (context.fix && needFix) {
         decl.value = parsed.toString();
       }
     });


### PR DESCRIPTION
The problem is that parsed.toString() converts `//` with `/*` I avoid this converting not calling the fixer in a expected case.

> Which issue, if any, is this issue related to?

Fixes #3847

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
