### PR TITLE
Fix false positives for dollar variables in function-linear-gradient-no-nonstandard-direction

### DIFF
--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -266,3 +266,34 @@ testRule(rule, {
     }
   ]
 });
+
+// SCSS tests
+testRule(rule, {
+  ruleName,
+  config: [true],
+  syntax: "scss",
+
+  accept: [
+    {
+      code:
+        ".foo { background: linear-gradient($purple-top, $purple-bottom); }",
+      description: "scss: ignore variable names"
+    },
+    {
+      code:
+        ".foo { background: linear-gradient(    $purple-top, $purple-bottom); }"
+    },
+    {
+      code: ".foo { background: linear-gradient($to-top, $purple-bottom); }"
+    }
+  ],
+
+  reject: [
+    {
+      code: ".foo { background: linear-gradient(top, $purple-bottom); }",
+      message: messages.rejected,
+      line: 1,
+      column: 36
+    }
+  ]
+});

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -2,6 +2,7 @@
 
 const declarationValueIndex = require("../../utils/declarationValueIndex");
 const functionArgumentsSearch = require("../../utils/functionArgumentsSearch");
+const isStandardSyntaxValue = require("../../utils/isStandardSyntaxValue");
 const postcss = require("postcss");
 const report = require("../../utils/report");
 const ruleMessages = require("../../utils/ruleMessages");
@@ -56,6 +57,11 @@ const rule = function(actual) {
           "linear-gradient",
           (expression, expressionIndex) => {
             const firstArg = expression.split(",")[0].trim();
+
+            // If the first arg is not standard, return early
+            if (!isStandardSyntaxValue(firstArg)) {
+              return;
+            }
 
             // If the first character is a number, we can assume the user intends an angle
             if (/[\d.]/.test(firstArg[0])) {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #4014 

> Is there anything in the PR that needs further explanation?

Returns early if the first value is non-standard syntax.
