### PR TITLE
Fix allow-empty-input CLI flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -281,11 +281,15 @@ const meowOptions /*: meowOptionsType*/ = {
 
         Show the currently installed version of stylelint.
 
-      --allow-empty-input
+      --allow-empty-input, --aei
 
         When glob pattern matches no files, the process will exit without throwing an error.
   `,
   flags: {
+    "allow-empty-input": {
+      alias: "aei",
+      type: "boolean"
+    },
     cache: {
       type: "boolean"
     },


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #4028

> Is there anything in the PR that needs further explanation?

We forgot to add the flag to the available options.
