### PR TITLE
Drop Node.js required version from 8.15.0 to 8.7.0

### DIFF
--- a/docs/developer-guide/prerequisites.md
+++ b/docs/developer-guide/prerequisites.md
@@ -2,7 +2,7 @@
 
 ## Technical
 
--   [Node.js](https://nodejs.org/en/) 8.15.1+.
+-   Minimum [Node.js](https://nodejs.org/en/) v8.0.0+, though we do recommend using the latest 8.x, 10.x, or 11.x Node.js release
 -   Latest [npm](https://www.npmjs.com/).
 
 ## Rules of thumb

--- a/docs/developer-guide/prerequisites.md
+++ b/docs/developer-guide/prerequisites.md
@@ -2,7 +2,7 @@
 
 ## Technical
 
--   Minimum [Node.js](https://nodejs.org/en/) v8.0.0+, though we do recommend using the latest 8.x, 10.x, or 11.x Node.js release
+-   Minimum [Node.js](https://nodejs.org/en/) v8.7.0+, though we do recommend using the latest 8.x, 10.x, or 11.x Node.js releases.
 -   Latest [npm](https://www.npmjs.com/).
 
 ## Rules of thumb

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "!flow-typed/npm"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=8.7.0"
   },
   "dependencies": {
     "autoprefixer": "^9.5.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "!flow-typed/npm"
   ],
   "engines": {
-    "node": ">=8.15.1"
+    "node": ">=8"
   },
   "dependencies": {
     "autoprefixer": "^9.5.1",


### PR DESCRIPTION
Via https://github.com/stylelint/stylelint/issues/4000#issuecomment-483020108

As AWS Labda currenty only supports Node.js 8.10, let's drop the required version down to 8.0.0

We can add this to the next _minor_ release 10.0.1