### PR TITLE
Fix false positives for hashes in URLs in color-no-invalid-hex

### DIFF
--- a/lib/rules/color-no-invalid-hex/__tests__/index.js
+++ b/lib/rules/color-no-invalid-hex/__tests__/index.js
@@ -40,6 +40,18 @@ testRule(rule, {
       description: "ignore sass-like interpolation"
     },
     {
+      code: "a { background-image: svg-load('x.svg', fill=url(#a)); }",
+      description: "svg-load url with fill"
+    },
+    {
+      code: "a { background-image: url(#a); }",
+      description: "url standalone hash"
+    },
+    {
+      code: "a { background-image: url(x.svg#a); }",
+      description: "url with hash"
+    },
+    {
       code:
         "@font-face {\n" +
         "font-family: dashicons;\n" +

--- a/lib/rules/color-no-invalid-hex/index.js
+++ b/lib/rules/color-no-invalid-hex/index.js
@@ -23,6 +23,8 @@ const rule = function(actual) {
 
     root.walkDecls(decl => {
       valueParser(decl.value).walk(({ value, type, sourceIndex }) => {
+        if (type === "function" && value.endsWith("url")) return false;
+
         if (type !== "word") return;
 
         const hexMatch = /^#[0-9A-Za-z]+/.exec(value);


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #4034

> Is there anything in the PR that needs further explanation?

No, it's self explanatory
