### PR TITLE
Fix false positives for interpolation in function-calc-no-invalid

### DIFF
--- a/lib/rules/function-calc-no-invalid/__tests__/index.js
+++ b/lib/rules/function-calc-no-invalid/__tests__/index.js
@@ -269,6 +269,13 @@ testRule(rule, {
     },
     {
       code: "a { top: calc(100% - foo()); }"
+    },
+    {
+      code: `
+      a {
+        width: calc(#{$min-value} + #{$max-value}*(100vw - #{$min-vw}));
+      }
+      `
     }
   ],
 
@@ -308,6 +315,16 @@ testRule(rule, {
       message: messages.expectedExpression(),
       line: 1,
       column: 29
+    },
+    {
+      code: `
+      a {
+        width: calc(#{$min-value} + #{$max-value}*(100vw -#{$min-vw}));
+      }
+      `,
+      message: messages.expectedSpaceAfterOperator("-"),
+      line: 3,
+      column: 59
     }
   ]
 });
@@ -332,6 +349,13 @@ testRule(rule, {
     },
     {
       code: "a { top: calc(100% - foo()); }"
+    },
+    {
+      code: `
+      a {
+        width: calc(@{min-value} + @{max-value}*(100vw - @{min-vw}));
+      }
+      `
     }
   ],
 
@@ -371,6 +395,16 @@ testRule(rule, {
       message: messages.expectedExpression(),
       line: 1,
       column: 29
+    },
+    {
+      code: `
+      a {
+        width: calc(@{min-value} + @{max-value}*(100vw -@{min-vw}));
+      }
+      `,
+      message: messages.expectedSpaceAfterOperator("-"),
+      line: 3,
+      column: 57
     }
   ]
 });

--- a/lib/rules/function-calc-no-invalid/__tests__/index.js
+++ b/lib/rules/function-calc-no-invalid/__tests__/index.js
@@ -273,6 +273,17 @@ testRule(rule, {
     {
       code: `
       a {
+        width: calc(
+          #{$min-value} +
+          #{strip-unit($max-value - $min-value)} *
+          (100vw - #{$min-vw})
+        );
+      }
+      `
+    },
+    {
+      code: `
+      a {
         width: calc(#{$min-value} + #{$max-value}*(100vw - #{$min-vw}));
       }
       `

--- a/lib/utils/parseCalcExpression/parser.jison
+++ b/lib/utils/parseCalcExpression/parser.jison
@@ -50,6 +50,9 @@
 "("                                                   return 'LPAREN';
 ")"                                                   return 'RPAREN';
 
+#\{([\s\S]*?)\}                                       return 'UNKNOWN'; // scss variable
+@\{([\s\S]*?)\}                                       return 'UNKNOWN'; // less variable
+
 \S[^\s()*/+-]*                                        return 'UNKNOWN';
 
 <<EOF>>                                               return 'EOF';

--- a/lib/utils/parseCalcExpression/parser.jison
+++ b/lib/utils/parseCalcExpression/parser.jison
@@ -50,8 +50,8 @@
 "("                                                   return 'LPAREN';
 ")"                                                   return 'RPAREN';
 
-#\{([\s\S]*?)\}                                       return 'UNKNOWN'; // scss variable
-@\{([\s\S]*?)\}                                       return 'UNKNOWN'; // less variable
+#\{([\s\S]*?)\}                                       return 'UNKNOWN'; // scss interpolation
+@\{([\s\S]*?)\}                                       return 'UNKNOWN'; // less interpolation
 
 \S[^\s()*/+-]*                                        return 'UNKNOWN';
 

--- a/lib/utils/parseCalcExpression/parser.js
+++ b/lib/utils/parseCalcExpression/parser.js
@@ -3731,6 +3731,20 @@ EOF: 1,
 
         break;
 
+      case 39:
+        /*! Conditions:: INITIAL */
+        /*! Rule::       #\{([\s\S]*?)\} */
+        return 18;  // scss variable  
+
+        break;
+
+      case 40:
+        /*! Conditions:: INITIAL */
+        /*! Rule::       @\{([\s\S]*?)\} */
+        return 18;  // less variable  
+
+        break;
+
       default:
         return this.simpleCaseActionClusters[yyrulenumber];
       }
@@ -3779,11 +3793,11 @@ EOF: 1,
 
       /*! Conditions:: INITIAL */
       /*! Rule::       \S[^\s()*\/+-]* */
-      39: 18,
+      41: 18,
 
       /*! Conditions:: INITIAL */
       /*! Rule::       $ */
-      40: 1
+      42: 1
     },
 
     rules: [
@@ -3826,8 +3840,10 @@ EOF: 1,
       /* 36: */  /^(?:(\d+(\.\d+)?|\.\d+)\b)/i,
       /* 37: */  /^(?:\()/i,
       /* 38: */  /^(?:\))/i,
-      /* 39: */  /^(?:\S[^\s()*\/+-]*)/i,
-      /* 40: */  /^(?:$)/i
+      /* 39: */  /^(?:#\{([\s\S]*?)\})/i,
+      /* 40: */  /^(?:@\{([\s\S]*?)\})/i,
+      /* 41: */  /^(?:\S[^\s()*\/+-]*)/i,
+      /* 42: */  /^(?:$)/i
     ],
 
     conditions: {
@@ -3873,7 +3889,9 @@ EOF: 1,
           37,
           38,
           39,
-          40
+          40,
+          41,
+          42
         ],
 
         inclusive: true


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3908

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
