### PR TITLE
fix: autofix `!important` in `declaration-block-semicolon-space-before`

### DIFF
--- a/lib/rules/declaration-block-semicolon-space-before/__tests__/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/__tests__/index.js
@@ -24,6 +24,9 @@ testRule(rule, {
     },
     {
       code: "a { color: pink ; top: 0}"
+    },
+    {
+      code: "a { width: 50% !important ;}"
     }
   ],
 
@@ -86,6 +89,14 @@ testRule(rule, {
       message: messages.expectedBefore(),
       line: 1,
       column: 27
+    },
+    {
+      code: "a { width: 50% !important; }",
+      fixed: "a { width: 50% !important ; }",
+      description: "important",
+      message: messages.expectedBefore(),
+      line: 1,
+      column: 25
     }
   ]
 });
@@ -108,6 +119,9 @@ testRule(rule, {
     },
     {
       code: "a { color: pink; top: 0; }"
+    },
+    {
+      code: "a { width: 50% !important;}"
     }
   ],
 
@@ -170,6 +184,22 @@ testRule(rule, {
       message: messages.rejectedBefore(),
       line: 1,
       column: 28
+    },
+    {
+      code: "a { width: 50% !important ; }",
+      fixed: "a { width: 50% !important; }",
+      description: "important",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 26
+    },
+    {
+      code: "a { width: 50% !important     ; }",
+      fixed: "a { width: 50% !important; }",
+      description: "important",
+      message: messages.rejectedBefore(),
+      line: 1,
+      column: 30
     }
   ]
 });
@@ -203,6 +233,12 @@ testRule(rule, {
     {
       code: "a {\r\n  color: pink;\r\n  top: 0;\r\n}",
       description: "CRLF"
+    },
+    {
+      code: "a { width: 50% !important ; }"
+    },
+    {
+      code: "a {\n  width: 50% !important;\n}"
     }
   ],
 
@@ -249,6 +285,14 @@ testRule(rule, {
       message: messages.expectedBeforeSingleLine(),
       line: 1,
       column: 24
+    },
+    {
+      code: "a { width: 50% !important; }",
+      fixed: "a { width: 50% !important ; }",
+      description: "important",
+      message: messages.expectedBeforeSingleLine(),
+      line: 1,
+      column: 25
     }
   ]
 });
@@ -278,6 +322,12 @@ testRule(rule, {
     },
     {
       code: "a {\n  color: pink ;\n  top: 0 ;\n}"
+    },
+    {
+      code: "a { width: 50% !important; }"
+    },
+    {
+      code: "a {\n  width: 50% !important ;\n}"
     }
   ],
 
@@ -324,6 +374,22 @@ testRule(rule, {
       message: messages.rejectedBeforeSingleLine(),
       line: 1,
       column: 24
+    },
+    {
+      code: "a { width: 50% !important ; }",
+      fixed: "a { width: 50% !important; }",
+      description: "important",
+      message: messages.rejectedBeforeSingleLine(),
+      line: 1,
+      column: 26
+    },
+    {
+      code: "a { width: 50% !important     ; }",
+      fixed: "a { width: 50% !important; }",
+      description: "important",
+      message: messages.rejectedBeforeSingleLine(),
+      line: 1,
+      column: 30
     }
   ]
 });

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -49,22 +49,22 @@ const rule = function(expectation, options, context) {
             const value = decl.raws.value ? decl.raws.value.raw : decl.value;
 
             if (expectation.indexOf("always") === 0) {
-              const fixedValue = value.replace(/\s*$/, " ");
-
-              if (decl.raws.value) {
-                decl.raws.value.raw = fixedValue;
+              if (decl.important) {
+                decl.raws.important = " !important ";
+              } else if (decl.raws.value) {
+                decl.raws.value.raw = value.replace(/\s*$/, " ");
               } else {
-                decl.value = fixedValue;
+                decl.value = value.replace(/\s*$/, " ");
               }
 
               return;
             } else if (expectation.indexOf("never") === 0) {
-              const fixedValue = value.replace(/\s*$/, "");
-
-              if (decl.raws.value) {
-                decl.raws.value.raw = fixedValue;
+              if (decl.important) {
+                decl.raws.important = decl.raws.important.replace(/\s*$/, "");
+              } else if (decl.raws.value) {
+                decl.raws.value.raw = value.replace(/\s*$/, "");
               } else {
-                decl.value = fixedValue;
+                decl.value = value.replace(/\s*$/, "");
               }
 
               return;


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

fixes #4016 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
