### PR TITLE
Better error output for --report-needless-disables

### DIFF
--- a/flow-typed/stylelint.js
+++ b/flow-typed/stylelint.js
@@ -110,6 +110,7 @@ export type stylelint$cssSyntaxError = {
 export type stylelint$needlessDisablesReport = Array<{
   source: string,
   ranges: Array<{
+    unusedRule: string,
     start: number,
     end?: number
   }>

--- a/lib/__tests__/needlessDisables.test.js
+++ b/lib/__tests__/needlessDisables.test.js
@@ -38,8 +38,8 @@ it("needlessDisables simple case", () => {
 
     expect(report).toHaveLength(1);
     expect(report[0].ranges).toEqual([
-      { start: 7, end: 9 },
-      { start: 11, end: 11 }
+      { start: 7, end: 9, unusedRule: "all" },
+      { start: 11, end: 11, unusedRule: "block-no-empty" }
     ]);
   });
 });
@@ -66,14 +66,18 @@ it("needlessDisables complex case", () => {
       {
         source: fixture("disabled-ranges-1.css"),
         ranges: [
-          { start: 1, end: 3 },
-          { start: 5, end: 7 },
-          { start: 10, end: 10 }
+          { start: 1, end: 3, unusedRule: "color-named" },
+          { start: 5, end: 7, unusedRule: "block-no-empty" },
+          { start: 10, end: 10, unusedRule: "block-no-empty" }
         ]
       },
       {
         source: fixture("disabled-ranges-2.css"),
-        ranges: [{ start: 5, end: 5 }, { start: 6, end: 6 }, { start: 8 }]
+        ranges: [
+          { start: 5, end: 5, unusedRule: "color-named" },
+          { start: 6, end: 6, unusedRule: "block-no-empty" },
+          { start: 8, unusedRule: "block-no-empty" }
+        ]
       }
     ]);
   });
@@ -96,9 +100,9 @@ it("needlessDisables ignored case", () => {
       {
         source: fixture("disabled-ranges-1.css"),
         ranges: [
-          { start: 1, end: 3 },
-          { start: 5, end: 7 },
-          { start: 10, end: 10 }
+          { start: 1, end: 3, unusedRule: "color-named" },
+          { start: 5, end: 7, unusedRule: "block-no-empty" },
+          { start: 10, end: 10, unusedRule: "all" }
         ]
       }
     ]);

--- a/lib/__tests__/standalone-needlessDisables.test.js
+++ b/lib/__tests__/standalone-needlessDisables.test.js
@@ -25,7 +25,8 @@ it("standalone with input css and `reportNeedlessDisables`", () => {
     expect(needlessDisables).toHaveLength(1);
     expect(needlessDisables[0].ranges).toHaveLength(1);
     expect(needlessDisables[0].ranges[0]).toEqual({
-      start: 1
+      start: 1,
+      unusedRule: "color-named"
     });
   });
 });
@@ -52,7 +53,8 @@ it("standalone with input file(s) and `reportNeedlessDisables`", () => {
       path.join(fixturesPath, "empty-block-with-disables.css")
     );
     expect(needlessDisables[0].ranges[0]).toEqual({
-      start: 1
+      start: 1,
+      unusedRule: "color-named"
     });
   });
 });

--- a/lib/formatters/__tests__/needlessDisablesStringFormatter.test.js
+++ b/lib/formatters/__tests__/needlessDisablesStringFormatter.test.js
@@ -10,11 +10,17 @@ describe("needlessDisablesStringFormatter", () => {
       needlessDisablesStringFormatter([
         {
           source: "foo",
-          ranges: [{ start: 1, end: 3 }, { start: 7 }]
+          ranges: [
+            { start: 1, end: 3, unusedRule: "baz" },
+            { start: 7, unusedRule: "all" }
+          ]
         },
         {
           source: "bar",
-          ranges: [{ start: 19, end: 33 }, { start: 99, end: 102 }]
+          ranges: [
+            { start: 19, end: 33, unusedRule: "all" },
+            { start: 99, end: 102, unusedRule: "baz" }
+          ]
         },
         {
           sourc: "baz",
@@ -25,12 +31,12 @@ describe("needlessDisablesStringFormatter", () => {
 
     let expected = stripIndent`
       foo
-      start: 1, end: 3
-      start: 7
+      unused rule: baz, start line: 1, end line: 3
+      unused rule: all, start line: 7
 
       bar
-      start: 19, end: 33
-      start: 99, end: 102`;
+      unused rule: all, start line: 19, end line: 33
+      unused rule: baz, start line: 99, end line: 102`;
 
     expected = `\n${expected}\n`;
 

--- a/lib/formatters/needlessDisablesStringFormatter.js
+++ b/lib/formatters/needlessDisablesStringFormatter.js
@@ -29,10 +29,10 @@ module.exports = function(
     output += "\n";
     output += chalk.underline(logFrom(sourceReport.source)) + "\n";
     sourceReport.ranges.forEach(range => {
-      output += `start: ${range.start}`;
+      output += `unused rule: ${range.unusedRule}, start line: ${range.start}`;
 
       if (range.end !== undefined) {
-        output += `, end: ${range.end}`;
+        output += `, end line: ${range.end}`;
       }
 
       output += "\n";

--- a/lib/needlessDisables.js
+++ b/lib/needlessDisables.js
@@ -9,6 +9,7 @@ const _ = require("lodash");
 */
 
 /*:: type rangeType = {
+  unusedRule: string,
   end?: number,
   start: number,
   used?: boolean,
@@ -78,6 +79,7 @@ module.exports = function(
         // If this range is unused and no equivalent is marked,
         // mark this range as unused
         if (!range.used && !alreadyMarkedUnused) {
+          range.unusedRule = rule;
           unused.ranges.push(range);
         }
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #4066.

> Is there anything in the PR that needs further explanation?

When running `stylelint` CLI with `--report-needless-disables`, the output:

Before

```
assets/foo.css
start: 2
```

After 

```
assets/foo.css
unused rule: color-named, start line: 2, end line: 4
```
