### PR TITLE
Add Node.js 12 to CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
     - node_js: '8'
       script: npm run jest -- --maxWorkers=2
       env: CI=tests 8
+    - node_js: '12'
+      script: npm run jest -- --maxWorkers=2
+      env: CI=tests 12
 
 before_install:
   - npm install -g npm@latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   matrix:
     - nodejs_version: 8
     - nodejs_version: 10
+    - nodejs_version: 12
 
 clone_depth: 10
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,13 @@ branches:
     only:
       - master
 
+platform:
+  - x86
+
 install:
-  - ps: Install-Product node $env:nodejs_version
+  # Workaround from https://github.com/appveyor/ci/issues/2921#issuecomment-486727727
+  # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - npm install
 
 cache:


### PR DESCRIPTION
Node.js 12 was released on 2019-04-23, which is the **Current Release** version.
See <https://github.com/nodejs/Release#release-schedule>.

![image](https://user-images.githubusercontent.com/473530/57235902-ea33a280-705e-11e9-9825-14e735af1e22.png)

> Which issue, if any, is this issue related to?

Related to #3299.

> Is there anything in the PR that needs further explanation?

See [Node.js 12 changelog](https://github.com/nodejs/node/blob/v12.1.0/doc/changelogs/CHANGELOG_V12.md).

