### PR TITLE
Enhancemenet: add `:defined` pseudo class, fix #4080

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -252,6 +252,7 @@ keywordSets.otherPseudoClasses = new Set([
   "contains",
   "current",
   "default",
+  "defined",
   "disabled",
   "drop",
   "empty",

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -98,6 +98,11 @@ testRule(rule, {
     {
       code: ".test::-webkit-scrollbar-button:horizontal:decrement {}",
       description: "non-standalone webkit scrollbar multiple pseudo classes"
+    },
+    {
+      code: "a:defined { }",
+      description:
+        "represents any element that has been defined; includes any standard element built in to the browser, and custom elements that have been successfully defined (i.e. with the CustomElementRegistry.define() method)."
     }
   ],
 


### PR DESCRIPTION
Best practice for eliminating FOUC when using custom elements [1]

```css
app-drawer:not(:defined) {
  /* Pre-style, give layout, replicate app-drawer's eventual styles, etc. */
  display: inline-block;
  height: 100vh;
  opacity: 0;
  transition: opacity 0.3s ease-in-out;
}
```

[1]: https://developers.google.com/web/fundamentals/web-components/customelements#prestyle

> Which issue, if any, is this issue related to?

Closes #4080 

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
