### PR TITLE
Bump postcss-jsx version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pify": "^4.0.1",
     "postcss": "^7.0.14",
     "postcss-html": "^0.36.0",
-    "postcss-jsx": "^0.36.0",
+    "postcss-jsx": "^0.36.1",
     "postcss-less": "^3.1.4",
     "postcss-markdown": "^0.36.0",
     "postcss-media-query-parser": "^0.2.3",


### PR DESCRIPTION
Bumping `postcss-jsx` to include fix for template literal interpolation in CSS-in-JS. https://github.com/gucong3000/postcss-jsx/issues/49