### PR TITLE
Revert adding Node.js 12 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - nodejs_version: 8
     - nodejs_version: 10
-    - nodejs_version: 12
 
 clone_depth: 10
 
@@ -16,13 +15,8 @@ branches:
     only:
       - master
 
-platform:
-  - x86
-
 install:
-  # Workaround from https://github.com/appveyor/ci/issues/2921#issuecomment-486727727
-  # https://www.appveyor.com/docs/lang/nodejs-iojs/#installing-any-version-of-nodejs-or-iojs
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
+  - ps: Install-Product node $env:nodejs_version
   - npm install
 
 cache:


### PR DESCRIPTION
Before [the change](https://github.com/stylelint/stylelint/pull/4072) AppVeyor took 5-7 minutes to complete.

https://ci.appveyor.com/project/stylelint/stylelint/builds/24925881
https://ci.appveyor.com/project/stylelint/stylelint/builds/24825609

After change it takes 13-23 minutes:

https://ci.appveyor.com/project/stylelint/stylelint/builds/24976236 13 minutes.
https://ci.appveyor.com/project/stylelint/stylelint/builds/25120885 23 minutes and false fail.