### PR TITLE
Fix crash in block-no-empty

### DIFF
--- a/lib/rules/block-no-empty/__tests__/index.js
+++ b/lib/rules/block-no-empty/__tests__/index.js
@@ -133,6 +133,9 @@ testRule(rule, {
     },
     {
       code: "a {\n/* foo */\ncolor: pink;\n}"
+    },
+    {
+      code: '@import "foo.css";'
     }
   ],
 

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -2,6 +2,7 @@
 
 const _ = require("lodash");
 const beforeBlockString = require("../../utils/beforeBlockString");
+const hasBlock = require("../../utils/hasBlock");
 const hasEmptyBlock = require("../../utils/hasEmptyBlock");
 const optionsMatches = require("../../utils/optionsMatches");
 const report = require("../../utils/report");
@@ -47,9 +48,13 @@ const rule = function(primary, options = {}) {
         return;
       }
 
-      const hasCommentsOnly =
-        statement.nodes &&
-        statement.nodes.every(node => node.type === "comment");
+      if (!hasBlock(statement)) {
+        return;
+      }
+
+      const hasCommentsOnly = statement.nodes.every(
+        node => node.type === "comment"
+      );
 
       if (!hasCommentsOnly) {
         return;

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -47,9 +47,9 @@ const rule = function(primary, options = {}) {
         return;
       }
 
-      const hasCommentsOnly = statement.nodes.every(
-        node => node.type === "comment"
-      );
+      const hasCommentsOnly =
+        statement.nodes &&
+        statement.nodes.every(node => node.type === "comment");
 
       if (!hasCommentsOnly) {
         return;


### PR DESCRIPTION
`block-no-empty` should allow `@import` statements, but it's currently crashing with error "Cannot read property 'every' of undefined"

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

Closes #4109 
