### PR TITLE
Fix dead "SMACSS book" link in a rule doc

### DIFF
--- a/lib/rules/selector-max-compound-selectors/README.md
+++ b/lib/rules/selector-max-compound-selectors/README.md
@@ -9,7 +9,7 @@ Limit the number of compound selectors in a selector.
   Lv1 Lv2              Lv3     Lv4     Lv5  -- these are compound selectors */
 ```
 
-A [compound selector](https://www.w3.org/TR/selectors4/#compound) is a chain of one or more simple (tag, class, ID, universal, attribute) selectors. If there is more than one compound selector in a complete selector, they will be separated by combinators (e.g. ` `, `+`, `>`). One reason why you might want to limit the number of compound selectors is described in the [SMACSS book](https://smacss.com/book/applicability).
+A [compound selector](https://www.w3.org/TR/selectors4/#compound) is a chain of one or more simple (tag, class, ID, universal, attribute) selectors. If there is more than one compound selector in a complete selector, they will be separated by combinators (e.g. ` `, `+`, `>`). One reason why you might want to limit the number of compound selectors is described in the [SMACSS book](http://smacss.com/book/applicability).
 
 This rule resolves nested selectors before counting the depth of a selector. Each selector in a [selector list](https://www.w3.org/TR/selectors4/#selector-list) is evaluated separately.
 


### PR DESCRIPTION
HTTPS -> HTTP

NG: <https://smacss.com/book/applicability>
OK: <http://smacss.com/book/applicability>

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
