### PR TITLE
Stop skipping linting when --report-needless-disables CLI flag is used. Fix #4076

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -274,7 +274,7 @@ const meowOptions /*: meowOptionsType*/ = {
 
       --report-needless-disables, --rd
 
-        Report stylelint-disable comments that are not blocking a lint warning.
+        Also report errors for stylelint-disable comments that are not blocking a lint warning.
         The process will exit with code ${EXIT_CODE_ERROR} if needless disables are found.
 
       --max-warnings, --mw
@@ -282,9 +282,9 @@ const meowOptions /*: meowOptionsType*/ = {
         Number of warnings above which the process will exit with code ${EXIT_CODE_ERROR}.
         Useful when setting "defaultSeverity" to "warning" and expecting the
         process to fail on warnings (e.g. CI build).
-        
+
       --output-file, -o
-      
+
         Path of file to write report.
 
       --version, -v
@@ -552,8 +552,6 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
             if (report) {
               process.exitCode = EXIT_CODE_ERROR;
             }
-
-            return;
           }
 
           if (!linted.output) {

--- a/system-tests/cli/cli.test.js
+++ b/system-tests/cli/cli.test.js
@@ -92,4 +92,26 @@ describe("CLI", () => {
       );
     });
   });
+
+  it("--report-needless-disables", () => {
+    return Promise.resolve(
+      cli([
+        "--report-needless-disables",
+        "--config",
+        path.join(__dirname, "config.json"),
+        path.join(__dirname, "stylesheet.css")
+      ])
+    ).then(() => {
+      expect(process.exitCode).toBe(2);
+      expect(process.stdout.write).toHaveBeenCalledTimes(2);
+      expect(process.stdout.write).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("unused rule: color-named")
+      );
+      expect(process.stdout.write).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("Unexpected empty block")
+      );
+    });
+  });
 });

--- a/system-tests/cli/stylesheet.css
+++ b/system-tests/cli/stylesheet.css
@@ -1,0 +1,3 @@
+/* stylelint-disable-next-line color-named */
+body {
+}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes #4076, #2369, #4100. 

> Is there anything in the PR that needs further explanation?

This PR does the same change as #2731, which was closed for cleanup and never reopened. The current behavior can be a source of confusion for people used to ESLint’s [`--report-needless-disables`](https://eslint.org/docs/user-guide/command-line-interface#--report-unused-disable-directives). It also seems a bit wasteful to have to run linting twice just to get the extra reporting of unused disable comments.
