### PR TITLE
Quiet error handling

### DIFF
--- a/lib/__tests__/standalone-quiet.test.js
+++ b/lib/__tests__/standalone-quiet.test.js
@@ -14,3 +14,18 @@ it("standalone with input css and quiet mode", () => {
     expect(linted.results[0].warnings).toEqual([]);
   });
 });
+
+it("standalone with input error css and quiet mode", () => {
+  const config = {
+    quiet: true,
+    rules: {
+      "block-no-empty": true
+    }
+  };
+
+  return standalone({ code: "a {}", config }).then(linted => {
+    expect(linted.results[0].warnings[0].rule).toBe("block-no-empty");
+    expect(linted.results[0].warnings[0].severity).toBe("warning");
+    expect(linted.results[0].errored).toBeUndefined();
+  });
+});

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -36,12 +36,13 @@ module.exports = function(
 
   result.stylelint = result.stylelint || {};
 
-  // In quiet mode, mere warnings are ignored
-  if (
-    result.stylelint.quiet &&
-    result.stylelint.ruleSeverities[ruleName] !== "error"
-  ) {
-    return;
+  // In quiet mode, mere warnings are ignored, errors are set to warnings
+  if (result.stylelint.quiet) {
+    if (result.stylelint.ruleSeverities[ruleName] === "error") {
+      result.stylelint.ruleSeverities[ruleName] = "warning";
+    } else {
+      return;
+    }
   }
 
   // If a line is not passed, use the node.positionBy method to get the


### PR DESCRIPTION
Closes https://github.com/stylelint/stylelint/issues/4156

fixes issue of errors still being set in quiet mode - should be set to warning which then allows for the CLI to exit quietly too. 
