### PR TITLE
Fix typo in semantic versioning policy

### DIFF
--- a/docs/user-guide/semantic-versioning-policy.md
+++ b/docs/user-guide/semantic-versioning-policy.md
@@ -22,5 +22,5 @@ We follow [semantic versioning](http://semver.org). However, due to the nature o
     -   a change in the documented behaviour of an existing rule results in stylelint reporting more errors by default
     -   an existing rule is removed
     -   an existing formatter is removed
-    -   part of the a CLI is removed or changed in an incompatible way
+    -   part of the CLI is removed or changed in an incompatible way
     -   part of the public API is removed or changed in an incompatible way


### PR DESCRIPTION
Small typo I spotted while working on #4151.