### PR TITLE
fix: lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,18 +137,13 @@
     }
   },
   "lint-staged": {
-    "linters": {
-      "*.js": [
-        "prettier --write",
-        "eslint --max-warnings=0 --fix",
-        "git add"
-      ],
-      "*.md": [
-        "remark --quiet --frail"
-      ]
-    },
-    "ignore": [
-      "lib/utils/parseCalcExpression/parser.js"
+    "*.js": [
+      "prettier --write",
+      "eslint --max-warnings=0 --fix",
+      "git add"
+    ],
+    "*.md": [
+      "remark --quiet --frail"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Related discussion in #4163 

> Is there anything in the PR that needs further explanation?

Quoted from #4163:

> I noticed that lint-staged changed the way how it's configured. From [their document](https://github.com/okonet/lint-staged/blob/master/README.md#ignoring-files), they encourage to use ignore configuration of each linter. And since this file is already in `.eslintignore` and `.prettierignore`, I believe it's safe to remote corresponding line in lint-staged config.
