### PR TITLE
fix no-duplicate-selectors

### DIFF
--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -74,7 +74,7 @@ testRule(rule, {
       column: 1
     },
     {
-      code: ".a, .b, .a, .c, .d, .a {}",
+      code: ".a, .a, .a {}",
       message: messages.rejected(".a", 1),
       line: 1,
       column: 1,

--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -74,6 +74,14 @@ testRule(rule, {
       column: 1
     },
     {
+      code: ".a, .b, .a, .c, .d, .a {}",
+      message: messages.rejected(".a", 1),
+      line: 1,
+      column: 1,
+      description:
+        "duplicated selectors within one rule's selector list. 3 duplicates"
+    },
+    {
       code: "a {} b {} a {}",
       description: "duplicate simple selectors with another rule between",
       message: messages.rejected("a", 1),

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -114,20 +114,27 @@ const rule = function(actual, options) {
         });
       }
 
+      const presentedSelectors = new Set();
+      const reportedSelectors = new Set();
+
       // Or complain if one selector list contains the same selector more than one
-      rule.selectors.forEach((selector, i) => {
-        if (
-          _.includes(
-            normalizedSelectorList.slice(0, i),
-            normalizeSelector(selector)
-          )
-        ) {
+      rule.selectors.forEach(selector => {
+        const normalized = normalizeSelector(selector);
+
+        if (presentedSelectors.has(normalized)) {
+          if (reportedSelectors.has(normalized)) {
+            return;
+          }
+
           report({
             result,
             ruleName,
             node: rule,
             message: messages.rejected(selector, selectorLine)
           });
+          reportedSelectors.add(normalized);
+        } else {
+          presentedSelectors.add(normalized);
         }
       });
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Fixes #4113 

> Is there anything in the PR that needs further explanation?

current test cases can not find this problem, to reproduce in current `master` branch commit ->`1178f2d2d4c7d83d12ad4ec55b686a7bf7e28995` add:
```expect(output.results[0].warnings).toHaveLength(1);```
here https://github.com/stylelint/stylelint/blob/master/jest-setup.js#L92

run `node node_modules/jest/bin/jest.js lib/rules/no-duplicate-selectors/__tests__/index.js`

