### PR TITLE
Add jest-runner-stylelint to build tool plugins

### DIFF
--- a/docs/user-guide/complementary-tools.md
+++ b/docs/user-guide/complementary-tools.md
@@ -17,6 +17,7 @@ A list of complementary tools built and maintained by the community.
 -   [ember-cli-stylelint](https://github.com/billybonks/ember-cli-stylelint): An Ember CLI plugin for stylelint.
 -   [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint): A Grunt plugin for stylelint.
 -   [gulp-stylelint](https://github.com/olegskl/gulp-stylelint): A gulp plugin for stylelint.
+-   [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint): A Jest plugin for stylelint.
 -   [stylelint-webpack-plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin): A webpack plugin for stylelint.
 
 ## Editor plugins


### PR DESCRIPTION
A while ago I created a [Jest runner](https://jestjs.io/docs/en/configuration#runner-string) that runs stylelint. I've been using it in several of my projects, have it well tested, and use dependabot to keep it up to date. Since I've found using Jest to run my projects' unit tests and ensure code style to be very convenient, I'd love to have [`jest-runner-stylelint`](https://github.com/keplersj/jest-runner-stylelint) listed in the documentation to better share this with other stylelint users.