### PR TITLE
Introduce unicode-bom rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 -   Added: `max-empty-lines` autofix ([#3667](https://github.com/stylelint/stylelint/pull/3667)).
 -   Added: `ignore: ["selectors-within-list"]` to `no-descending-specificity` ([#4176](https://github.com/stylelint/stylelint/pull/4176)).
 -   Added: `selector-*` support for all logical combinations (:matches, :has) ([#4179](https://github.com/stylelint/stylelint/pull/4179)).
+-   Added: `no-unicode-bom` rule ([#4225](https://github.com/stylelint/stylelint/pull/4225)).
 -   Fixed: `block-no-empty` crash for `@import` statements ([#4110](https://github.com/stylelint/stylelint/pull/4110)).
 -   Fixed: `indentation` false positives for <style> tag with multiline attributes ([#4177](https://github.com/stylelint/stylelint/pull/4177)).
 -   Fixed: `length-zero-no-unit` false positives for inside calc function ([#4175](https://github.com/stylelint/stylelint/pull/4175)).

--- a/docs/user-guide/example-config.md
+++ b/docs/user-guide/example-config.md
@@ -170,6 +170,7 @@ You might want to learn a little about [how rules are named and how they work to
     "string-no-newline": true,
     "string-quotes": "single"|"double",
     "time-min-milliseconds": int,
+    "unicode-bom": "always"|"never",
     "unit-blacklist": string|[],
     "unit-case": "lower"|"upper",
     "unit-no-unknown": true,

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -358,3 +358,4 @@ Here are all the rules within stylelint, grouped first [by category](../../VISIO
 -   [`no-eol-whitespace`](../../lib/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace (Autofixable).
 -   [`no-missing-end-of-source-newline`](../../lib/rules/no-missing-end-of-source-newline/README.md): Disallow missing end-of-source newlines (Autofixable).
 -   [`no-empty-first-line`](../../lib/rules/no-empty-first-line/README.md): Disallow empty first lines (Autofixable).
+-   [`unicode-bom`](../../lib/rules/unicode-bom/README.md): Require or disallow Unicode BOM.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -163,6 +163,7 @@ module.exports = [
   "string-no-newline",
   "string-quotes",
   "time-min-milliseconds",
+  "unicode-bom",
   "unit-blacklist",
   "unit-case",
   "unit-no-unknown",

--- a/lib/rules/unicode-bom/README.md
+++ b/lib/rules/unicode-bom/README.md
@@ -1,0 +1,37 @@
+# unicode-bom
+
+Require or disallow the Unicode Byte Order Mark.
+
+## Options
+
+`string`: `"always"|"never"`
+
+### `"always"`
+
+The following pattern is considered a violation:
+
+```css
+a {}
+```
+
+The following pattern is *not* considered a violation:
+
+```css
+U+FEFF
+a {}
+```
+
+### `"never"`
+
+The following pattern is considered a violation:
+
+```css
+U+FEFF
+a {}
+```
+
+The following pattern is *not* considered a violation:
+
+```css
+a {}
+```

--- a/lib/rules/unicode-bom/__tests__/index.js
+++ b/lib/rules/unicode-bom/__tests__/index.js
@@ -1,0 +1,152 @@
+"use strict";
+
+const rule = require("..");
+const { messages, ruleName } = rule;
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: "\uFEFF",
+      description: "empty with BOM"
+    },
+    {
+      code: "\uFEFFa{}",
+      description: "with BOM"
+    }
+  ],
+
+  reject: [
+    {
+      code: "",
+      description: "empty without BOM",
+      message: messages.expected
+    },
+    {
+      code: "a{}",
+      description: "without BOM",
+      message: messages.expected
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: "",
+      description: "empty without BOM"
+    },
+    {
+      code: "a{}",
+      description: "without BOM"
+    }
+  ],
+
+  reject: [
+    {
+      code: "\uFEFF",
+      description: "empty with BOM",
+      message: messages.rejected
+    },
+    {
+      code: "\uFEFFa{}",
+      description: "with BOM",
+      message: messages.rejected
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  syntax: "html",
+  config: ["always"],
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: '<a style="color: red;"></a>',
+      description: "without BOM"
+    },
+    {
+      code: '<a style="\uFEFFcolor: red;"></a>',
+      description: "with BOM"
+    },
+    {
+      code: `<style>a{}</style>`,
+      description: "without BOM"
+    },
+    {
+      code: `<style>\uFEFFa{}</style>`,
+      description: "with BOM"
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  syntax: "html",
+  config: ["never"],
+  skipBasicChecks: true,
+
+  accept: [
+    {
+      code: '<a style="color: red;"></a>',
+      description: "without BOM"
+    },
+    {
+      code: '<a style="\uFEFFcolor: red;"></a>',
+      description: "with BOM"
+    },
+    {
+      code: `<style>a{}</style>`,
+      description: "without BOM"
+    },
+    {
+      code: `<style>\uFEFFa{}</style>`,
+      description: "with BOM"
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["always"],
+  skipBasicChecks: true,
+  syntax: "css-in-js",
+
+  accept: [
+    {
+      code: `export default (
+        <button
+          style={{ color: "#fff" }}
+        >
+        </button>
+      );`
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: ["never"],
+  skipBasicChecks: true,
+  syntax: "css-in-js",
+
+  accept: [
+    {
+      code: `export default (
+        <button
+          style={{ color: "#fff" }}
+        >
+        </button>
+      );`
+    }
+  ]
+});

--- a/lib/rules/unicode-bom/index.js
+++ b/lib/rules/unicode-bom/index.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const report = require("../../utils/report");
+const ruleMessages = require("../../utils/ruleMessages");
+const validateOptions = require("../../utils/validateOptions");
+
+const ruleName = "unicode-bom";
+
+const messages = ruleMessages(ruleName, {
+  expected: "Expected Unicode BOM",
+  rejected: "Unexpected Unicode BOM"
+});
+
+const rule = function(expectation) {
+  return (root, result) => {
+    const validOptions = validateOptions(result, ruleName, {
+      actual: expectation,
+      possible: ["always", "never"]
+    });
+
+    if (
+      !validOptions ||
+      root.source.inline ||
+      root.source.lang === "object-literal" ||
+      // Ignore HTML documents
+      root.document !== undefined
+    ) {
+      return;
+    }
+
+    const { hasBOM } = root.source.input;
+
+    if (expectation === "always" && !hasBOM) {
+      report({
+        result,
+        ruleName,
+        message: messages.expected,
+        root,
+        line: 1
+      });
+    }
+
+    if (expectation === "never" && hasBOM) {
+      report({
+        result,
+        ruleName,
+        message: messages.rejected,
+        root,
+        line: 1
+      });
+    }
+  };
+};
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+module.exports = rule;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #3792.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.

I think it's better to add the auto-fix functionality separately, because first we need to fix the bug in stylelint that causes BOM to be cut out in any auto-fix run (https://github.com/stylelint/stylelint/issues/4228).