### PR TITLE
chore(deps): remove unused postcss-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "postcss-html": "^0.36.0",
     "postcss-jsx": "^0.36.3",
     "postcss-less": "^3.1.4",
-    "postcss-markdown": "^0.36.0",
     "postcss-media-query-parser": "^0.2.3",
     "postcss-reporter": "^6.0.1",
     "postcss-resolve-nested-selector": "^0.1.1",


### PR DESCRIPTION
I discovered that postcss-markdown was not used in the codebase. I might be wrong and it is used somewhere or is required for other reason.