### PR TITLE
remove pify in favor of node 8 util.promisify

### DIFF
--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -4,12 +4,11 @@ const hash = require("../utils/hash");
 const path = require("path");
 const standalone = require("../standalone");
 const fixturesPath = path.join(__dirname, "fixtures");
-const fs = require("fs");
-const pify = require("pify");
-const unlink = pify(fs.unlink);
 const cpFile = require("cp-file");
 const fileExists = require("file-exists-promise");
-
+const fs = require("fs");
+const { promisify } = require("util");
+const unlink = promisify(fs.unlink);
 const fCache = require("file-entry-cache");
 
 const cwd = process.cwd();

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -2,10 +2,10 @@
 
 const fs = require("fs");
 const path = require("path");
-const pify = require("pify");
 const standalone = require("../standalone");
 const stringFormatter = require("../formatters/stringFormatter");
 const stripAnsi = require("strip-ansi");
+const { promisify } = require("util");
 
 const fixturesPath = path.join(__dirname, "fixtures");
 
@@ -314,7 +314,7 @@ it("standalone with postcss-safe-parser", () => {
           expect(results[0].warnings).toHaveLength(0);
           expect(root.toString()).not.toBe(root.source.input.css);
 
-          return pify(fs.writeFile)(
+          return promisify(fs.writeFile)(
             root.source.input.file,
             root.source.input.css
           );

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -16,13 +16,13 @@ const ignore = require("ignore");
 const needlessDisables /*: Function*/ = require("./needlessDisables");
 const NoFilesFoundError = require("./utils/noFilesFoundError");
 const path = require("path");
-const pify = require("pify");
 const pkg = require("../package.json");
 const writeFileAtomic /*: Function*/ = require("./vendor/writeFileAtomic");
-
+const { promisify } = require("util");
 const DEFAULT_IGNORE_FILENAME = ".stylelintignore";
 const FILE_NOT_FOUND_ERROR_CODE = "ENOENT";
 const ALWAYS_IGNORED_GLOBS = ["**/node_modules/**", "**/bower_components/**"];
+const writeFileAtomicAsync = promisify(writeFileAtomic);
 
 module.exports = function(
   options /*: stylelint$standaloneOptions */
@@ -248,7 +248,7 @@ module.exports = function(
               );
 
               if (postcssResult.root.source.input.css !== fixedCss) {
-                fixFile = pify(writeFileAtomic)(absoluteFilepath, fixedCss);
+                fixFile = writeFileAtomicAsync(absoluteFilepath, fixedCss);
               }
             }
 

--- a/lib/vendor/writeFileAtomic.js
+++ b/lib/vendor/writeFileAtomic.js
@@ -35,10 +35,11 @@ function cleanupOnExit(tmpfile) {
 }
 
 function writeFile(filename, data, options, callback) {
-  if (options instanceof Function) {
+  if (typeof options === "function") {
     callback = options;
     options = null;
   }
+
   if (!options) options = {};
 
   var Promise = options.Promise || global.Promise;

--- a/lib/writeOutputFile.js
+++ b/lib/writeOutputFile.js
@@ -2,9 +2,10 @@
 "use strict";
 
 const path = require("path");
-const pify = require("pify");
 const stripAnsi = require("strip-ansi");
 const writeFileAtomic /*: Function*/ = require("./vendor/writeFileAtomic");
+const { promisify } = require("util");
+const writeFileAtomicAsync = promisify(writeFileAtomic);
 
 module.exports = (content /*: string*/, filePath /*: string*/) =>
-  pify(writeFileAtomic)(path.normalize(filePath), stripAnsi(content));
+  writeFileAtomicAsync(path.normalize(filePath), stripAnsi(content));

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "meow": "^5.0.0",
     "micromatch": "^4.0.0",
     "normalize-selector": "^0.2.0",
-    "pify": "^4.0.1",
     "postcss": "^7.0.14",
     "postcss-html": "^0.36.0",
     "postcss-jsx": "^0.36.3",

--- a/system-tests/fix/fix.test.js
+++ b/system-tests/fix/fix.test.js
@@ -6,9 +6,10 @@ const del = require("del");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const pify = require("pify");
 const stylelint = require("../../lib");
 const systemTestUtils = require("../systemTestUtils");
+const { promisify } = require("util");
+const readFileAsync = promisify(fs.readFile);
 
 describe("fix", () => {
   let tmpDir;
@@ -66,7 +67,7 @@ describe("fix", () => {
       .then(output => {
         const result = output.results[0]._postcssResult;
 
-        return pify(fs.readFile)(stylesheetPath, "utf8").then(fileContent => {
+        return readFileAsync(stylesheetPath, "utf8").then(fileContent => {
           expect(fileContent).toBe(result.root.toString(result.opts.syntax));
         });
       });
@@ -87,8 +88,8 @@ describe("fix", () => {
         fix: true
       })
       .then(() => {
-        return pify(fs.readFile)(stylesheetPath, "utf8").then(newFile => {
-          return pify(fs.readFile)(
+        return readFileAsync(stylesheetPath, "utf8").then(newFile => {
+          return readFileAsync(
             path.join(__dirname, "stylesheet.css"),
             "utf8"
           ).then(oldFile => {

--- a/system-tests/outputFile/outputFile.test.js
+++ b/system-tests/outputFile/outputFile.test.js
@@ -5,9 +5,10 @@ const del = require("del");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const pify = require("pify");
 const spawn = require("child_process").spawn;
 const systemTestUtils = require("../systemTestUtils");
+const { promisify } = require("util");
+const readFileAsync = promisify(fs.readFile);
 
 describe("outputFile", () => {
   let tmpDir;
@@ -45,7 +46,7 @@ describe("outputFile", () => {
     childProcess.stdout.on("data", data => (stdout += data));
 
     childProcess.on("close", function() {
-      return pify(fs.readFile)(directionPath, "utf-8").then(content => {
+      return readFileAsync(directionPath, "utf-8").then(content => {
         expect(content).toEqual(systemTestUtils.stripColors(stdout));
         expect(content).toMatchSnapshot();
         done();


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

remove [pify](https://github.com/sindresorhus/pify) in favor of node 8 [util.promisify](https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original)

> Is there anything in the PR that needs further explanation?

nothing
