### PR TITLE
enable strict warnings count check

### DIFF
--- a/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/__tests__/index.js
@@ -125,9 +125,18 @@ testRule(rule, {
         "@media print {\n  a {\n     color: pink;\n/* comment here*/\n  }\n}",
       fixed:
         "@media print {\n  a {\n     color: pink;\n/* comment here*/\n\n  }\n\n}",
-      message: messages.expected,
-      line: 5,
-      column: 3
+      warnings: [
+        {
+          message: messages.expected,
+          line: 5,
+          column: 3
+        },
+        {
+          message: messages.expected,
+          line: 6,
+          column: 1
+        }
+      ]
     }
   ]
 });
@@ -234,9 +243,18 @@ testRule(rule, {
     {
       code: "@media print {\n  a {\n     color: pink;\n\n  }\n\n}",
       fixed: "@media print {\n  a {\n     color: pink;\n  }\n}",
-      message: messages.rejected,
-      line: 5,
-      column: 3
+      warnings: [
+        {
+          message: messages.rejected,
+          line: 5,
+          column: 3
+        },
+        {
+          message: messages.rejected,
+          line: 7,
+          column: 1
+        }
+      ]
     },
     {
       code: "a {\n\ncolor: pink;\n\n/* comment here */\n\n}",
@@ -293,18 +311,31 @@ testRule(rule, {
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n}",
       fixed:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n\n}",
-      message: messages.expected,
-      line: 10,
-      column: 1
+      warnings: [
+        {
+          message: messages.expected,
+          line: 10,
+          column: 1
+        }
+      ]
     },
     {
       code:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\n\t}\n}",
       fixed:
         "@media print {\n\n\ta {\n\t\tcolor: aquamarine;\n\t}\n\n\tb {\n\t\tcolor: hotpink;\n\t}\n\n}",
-      message: messages.rejected,
-      line: 10,
-      column: 2
+      warnings: [
+        {
+          message: messages.rejected,
+          line: 10,
+          column: 2
+        },
+        {
+          message: messages.expected,
+          line: 11,
+          column: 1
+        }
+      ]
     },
     {
       code:

--- a/lib/rules/block-opening-brace-newline-after/__tests__/index.js
+++ b/lib/rules/block-opening-brace-newline-after/__tests__/index.js
@@ -159,9 +159,18 @@ testRule(rule, {
       fixed: ".a {/*.b*/\n.c {\n color: pink; } }",
       description:
         "next node is quasi-qualified selector without newline after",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 5
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 5
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 15
+        }
+      ]
     },
     {
       code: ".a {/*.b*/\n.c { color: pink; } }",

--- a/lib/rules/media-feature-colon-space-after/__tests__/index.js
+++ b/lib/rules/media-feature-colon-space-after/__tests__/index.js
@@ -97,16 +97,34 @@ testRule(rule, {
     {
       code: "@media (max-width:600px) and (min-width:3em) {}",
       fixed: "@media (max-width: 600px) and (min-width: 3em) {}",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 18
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 18
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 40
+        }
+      ]
     },
     {
       code: "@media(p:600px) and (prop:600px) {}",
       fixed: "@media(p: 600px) and (prop: 600px) {}",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 9
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 9
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 26
+        }
+      ]
     },
     {
       code: "@media (max-width:/*comment*/600px) {}",
@@ -209,9 +227,18 @@ testRule(rule, {
     {
       code: "@media (max-width: 600px) and (min-width: 3em) {}",
       fixed: "@media (max-width:600px) and (min-width:3em) {}",
-      message: messages.rejectedAfter(),
-      line: 1,
-      column: 18
+      warnings: [
+        {
+          message: messages.rejectedAfter(),
+          line: 1,
+          column: 18
+        },
+        {
+          message: messages.rejectedAfter(),
+          line: 1,
+          column: 41
+        }
+      ]
     },
     {
       code: "@media (max-width: /*comment*/ 600px) {}",

--- a/lib/rules/media-feature-colon-space-before/__tests__/index.js
+++ b/lib/rules/media-feature-colon-space-before/__tests__/index.js
@@ -97,9 +97,18 @@ testRule(rule, {
     {
       code: "@media (max-width:600px) and (min-width:3em) {}",
       fixed: "@media (max-width :600px) and (min-width :3em) {}",
-      message: messages.expectedBefore(),
-      line: 1,
-      column: 18
+      warnings: [
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 18
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 40
+        }
+      ]
     },
     {
       code: "@media (max-width/*comment*/:600px) {}",
@@ -205,9 +214,18 @@ testRule(rule, {
     {
       code: "@media (max-width :600px) and (min-width :3em) {}",
       fixed: "@media (max-width:600px) and (min-width:3em) {}",
-      message: messages.rejectedBefore(),
-      line: 1,
-      column: 19
+      warnings: [
+        {
+          message: messages.rejectedBefore(),
+          line: 1,
+          column: 19
+        },
+        {
+          message: messages.rejectedBefore(),
+          line: 1,
+          column: 42
+        }
+      ]
     },
     {
       code: "@media (max-width /*comment*/ :600px) {}",

--- a/lib/rules/media-feature-range-operator-space-after/__tests__/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/__tests__/index.js
@@ -103,9 +103,18 @@ testRule(rule, {
     {
       code: "@media (width>=600px) and (width<3em) {}",
       fixed: "@media (width>= 600px) and (width< 3em) {}",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 16
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 16
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 34
+        }
+      ]
     },
     {
       code: "@media (width</**/600px) {}",
@@ -217,9 +226,18 @@ testRule(rule, {
     {
       code: "@media (width >= 600px) and (width < 3em) {}",
       fixed: "@media (width >=600px) and (width <3em) {}",
-      message: messages.rejectedAfter(),
-      line: 1,
-      column: 17
+      warnings: [
+        {
+          message: messages.rejectedAfter(),
+          line: 1,
+          column: 17
+        },
+        {
+          message: messages.rejectedAfter(),
+          line: 1,
+          column: 37
+        }
+      ]
     },
     {
       code: "@media (width = /**/ 600px) {}",

--- a/lib/rules/media-feature-range-operator-space-before/__tests__/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/__tests__/index.js
@@ -103,9 +103,18 @@ testRule(rule, {
     {
       code: "@media (width> 600px) and (width= 3em) {}",
       fixed: "@media (width > 600px) and (width = 3em) {}",
-      message: messages.expectedBefore(),
-      line: 1,
-      column: 13
+      warnings: [
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 32
+        }
+      ]
     },
     {
       code: "@media (width/**/< 600px) {}",
@@ -217,9 +226,18 @@ testRule(rule, {
     {
       code: "@media (width >= 600px) and (width < 3em) {}",
       fixed: "@media (width>= 600px) and (width< 3em) {}",
-      message: messages.rejectedBefore(),
-      line: 1,
-      column: 14
+      warnings: [
+        {
+          message: messages.rejectedBefore(),
+          line: 1,
+          column: 14
+        },
+        {
+          message: messages.rejectedBefore(),
+          line: 1,
+          column: 35
+        }
+      ]
     },
     {
       code: "@media (width /**/ = 600px) {}",

--- a/lib/rules/media-query-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/media-query-list-comma-space-after/__tests__/index.js
@@ -103,11 +103,25 @@ testRule(rule, {
       column: 26
     },
     {
-      code: "@media " + "tv,".repeat(50) + ",print {}",
-      fixed: "@media " + "tv, ".repeat(50) + ", print {}",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 10
+      code: "@media tv,tv,tv,, print {}",
+      fixed: "@media tv, tv, tv, , print {}",
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 10
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 16
+        }
+      ]
     }
   ]
 });

--- a/lib/rules/media-query-list-comma-space-before/__tests__/index.js
+++ b/lib/rules/media-query-list-comma-space-before/__tests__/index.js
@@ -103,11 +103,25 @@ testRule(rule, {
       column: 37
     },
     {
-      code: "@media " + "tv,".repeat(50) + "print {}",
-      fixed: "@media " + "tv ,".repeat(50) + "print {}",
-      message: messages.expectedBefore(),
-      line: 1,
-      column: 10
+      code: "@media tv,tv,tv,print {}",
+      fixed: "@media tv ,tv ,tv ,print {}",
+      warnings: [
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 10
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 16
+        }
+      ]
     }
   ]
 });
@@ -212,11 +226,25 @@ testRule(rule, {
       column: 39
     },
     {
-      code: "@media " + "tv ,".repeat(50) + "print {}",
-      fixed: "@media " + "tv,".repeat(50) + "print {}",
-      message: messages.rejectedBefore(),
-      line: 1,
-      column: 11
+      code: "@media tv ,tv ,tv ,print {}",
+      fixed: "@media tv,tv,tv,print {}",
+      warnings: [
+        {
+          message: messages.rejectedBefore(),
+          line: 1,
+          column: 11
+        },
+        {
+          message: messages.rejectedBefore(),
+          line: 1,
+          column: 15
+        },
+        {
+          message: messages.rejectedBefore(),
+          line: 1,
+          column: 19
+        }
+      ]
     }
   ]
 });

--- a/lib/rules/number-leading-zero/__tests__/index.js
+++ b/lib/rules/number-leading-zero/__tests__/index.js
@@ -161,9 +161,18 @@ testRule(rule, {
       fixed: "a { transform: translate(0.4px, 0.8px); }",
       description:
         "multiple fractional values without leading zeros in a function",
-      message: messages.expected,
-      line: 1,
-      column: 26
+      warnings: [
+        {
+          message: messages.expected,
+          line: 1,
+          column: 26
+        },
+        {
+          message: messages.expected,
+          line: 1,
+          column: 32
+        }
+      ]
     },
     {
       code: "@media (min-width: .01em)",
@@ -318,9 +327,18 @@ testRule(rule, {
       fixed: "a { transform: translate(.4px, .8px); }",
       description:
         "multiple fractional values with leading zeros in a function",
-      message: messages.rejected,
-      line: 1,
-      column: 26
+      warnings: [
+        {
+          message: messages.rejected,
+          line: 1,
+          column: 26
+        },
+        {
+          message: messages.rejected,
+          line: 1,
+          column: 33
+        }
+      ]
     },
     {
       code: "a { line-height: 000.5; }",

--- a/lib/rules/selector-list-comma-newline-before/__tests__/index.js
+++ b/lib/rules/selector-list-comma-newline-before/__tests__/index.js
@@ -140,9 +140,38 @@ testRule(rule, {
     {
       code: "a,b,c,d,e,f,g {}",
       fixed: "a\n,b\n,c\n,d\n,e\n,f\n,g {}",
-      message: messages.expectedBefore(),
-      line: 1,
-      column: 2
+      warnings: [
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 2
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 4
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 6
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 8
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 10
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 12
+        }
+      ]
     }
   ]
 });

--- a/lib/rules/selector-max-id/__tests__/index.js
+++ b/lib/rules/selector-max-id/__tests__/index.js
@@ -212,9 +212,18 @@ testRule(rule, {
       code: "#foo #bar #baz { @media print { #bar {} } }",
       description:
         "compound selector: greater than max ID selectors, nested @media query",
-      message: messages.expected("#foo #bar #baz", 2),
-      line: 1,
-      column: 1
+      warnings: [
+        {
+          message: messages.expected("#foo #bar #baz", 2),
+          line: 1,
+          column: 1
+        },
+        {
+          message: messages.expected("#foo #bar #baz #bar", 2),
+          line: 1,
+          column: 33
+        }
+      ]
     },
     {
       code: ".foo { @media print { #bar #baz #foo {} } }",
@@ -227,9 +236,18 @@ testRule(rule, {
     {
       code: "#foo #bar { #baz { #quux {} } }",
       description: "nested compound selector: greater than max ID selectors",
-      message: messages.expected("#foo #bar #baz", 2),
-      line: 1,
-      column: 13
+      warnings: [
+        {
+          message: messages.expected("#foo #bar #baz", 2),
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expected("#foo #bar #baz #quux", 2),
+          line: 1,
+          column: 20
+        }
+      ]
     },
     {
       code: "#foo { #baz { #quux {} } }",
@@ -431,9 +449,18 @@ testRule(rule, {
       code: "#foo #bar #baz { @if ($p == 1) { #bar {} } }",
       description:
         "compound selector: greater than max ID selectors, nested @if statement",
-      message: messages.expected("#foo #bar #baz", 2),
-      line: 1,
-      column: 1
+      warnings: [
+        {
+          message: messages.expected("#foo #bar #baz", 2),
+          line: 1,
+          column: 1
+        },
+        {
+          message: messages.expected("#foo #bar #baz #bar", 2),
+          line: 1,
+          column: 34
+        }
+      ]
     },
     {
       code: ".foo { @if ($p == 1) { #bar #baz #foo {} } }",

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -193,9 +193,18 @@ testRule(rule, {
     },
     {
       code: ":horizontal:decrement {}",
-      message: messages.rejected(":horizontal"),
-      line: 1,
-      column: 1
+      warnings: [
+        {
+          message: messages.rejected(":horizontal"),
+          line: 1,
+          column: 1
+        },
+        {
+          message: messages.rejected(":decrement"),
+          line: 1,
+          column: 12
+        }
+      ]
     }
   ]
 });

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/__tests__/index.js
@@ -122,9 +122,28 @@ testRule(rule, {
     {
       code: "section:not(:has(h1, h2)) { }",
       fixed: "section:not( :has( h1, h2 ) ) { }",
-      message: messages.expectedOpening,
-      line: 1,
-      column: 13
+      warnings: [
+        {
+          message: messages.expectedOpening,
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expectedClosing,
+          line: 1,
+          column: 24
+        },
+        {
+          message: messages.expectedOpening,
+          line: 1,
+          column: 18
+        },
+        {
+          message: messages.expectedClosing,
+          line: 1,
+          column: 23
+        }
+      ]
     },
     {
       code: "input:not([type='radio'] ):not( [type='checkbox'] ) { }",
@@ -171,9 +190,28 @@ testRule(rule, {
     {
       code: "section:not(/**/:has(/**/h1, h2/**/)/**/) { }",
       fixed: "section:not( /**/:has( /**/h1, h2/**/ )/**/ ) { }",
-      message: messages.expectedOpening,
-      line: 1,
-      column: 13
+      warnings: [
+        {
+          message: messages.expectedOpening,
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expectedClosing,
+          line: 1,
+          column: 40
+        },
+        {
+          message: messages.expectedOpening,
+          line: 1,
+          column: 22
+        },
+        {
+          message: messages.expectedClosing,
+          line: 1,
+          column: 35
+        }
+      ]
     }
   ]
 });
@@ -277,9 +315,28 @@ testRule(rule, {
     {
       code: "section:not( :has( h1, h2 ) ) { }",
       fixed: "section:not(:has(h1, h2)) { }",
-      message: messages.rejectedOpening,
-      line: 1,
-      column: 13
+      warnings: [
+        {
+          message: messages.rejectedOpening,
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.rejectedClosing,
+          line: 1,
+          column: 28
+        },
+        {
+          message: messages.rejectedOpening,
+          line: 1,
+          column: 19
+        },
+        {
+          message: messages.rejectedClosing,
+          line: 1,
+          column: 26
+        }
+      ]
     },
     {
       code: "input:not( [type='radio']):not([type='checkbox']) { }",
@@ -326,9 +383,28 @@ testRule(rule, {
     {
       code: "section:not( /**/ :has( /**/ h1, h2 /**/ ) /**/ ) { }",
       fixed: "section:not(/**/ :has(/**/ h1, h2 /**/) /**/) { }",
-      message: messages.rejectedOpening,
-      line: 1,
-      column: 13
+      warnings: [
+        {
+          message: messages.rejectedOpening,
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.rejectedClosing,
+          line: 1,
+          column: 48
+        },
+        {
+          message: messages.rejectedOpening,
+          line: 1,
+          column: 24
+        },
+        {
+          message: messages.rejectedClosing,
+          line: 1,
+          column: 41
+        }
+      ]
     }
   ]
 });

--- a/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.js
@@ -106,9 +106,23 @@ testRule(rule, {
     {
       code: "a::before, a::after, a::first-letter { color: pink; }",
       fixed: "a:before, a:after, a:first-letter { color: pink; }",
-      message: messages.expected("single"),
-      line: 1,
-      column: 3
+      warnings: [
+        {
+          message: messages.expected("single"),
+          line: 1,
+          column: 3
+        },
+        {
+          message: messages.expected("single"),
+          line: 1,
+          column: 14
+        },
+        {
+          message: messages.expected("single"),
+          line: 1,
+          column: 24
+        }
+      ]
     }
   ]
 });
@@ -186,9 +200,23 @@ testRule(rule, {
     {
       code: "a:before, a:after, a:first-letter { color: pink; }",
       fixed: "a::before, a::after, a::first-letter { color: pink; }",
-      message: messages.expected("double"),
-      line: 1,
-      column: 2
+      warnings: [
+        {
+          message: messages.expected("double"),
+          line: 1,
+          column: 2
+        },
+        {
+          message: messages.expected("double"),
+          line: 1,
+          column: 12
+        },
+        {
+          message: messages.expected("double"),
+          line: 1,
+          column: 21
+        }
+      ]
     }
   ]
 });

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -543,7 +543,18 @@ testRule(rule, {
   reject: [
     {
       code: "a { margin: calc(10pixels + 1pixels); }",
-      message: messages.rejected("pixels")
+      warnings: [
+        {
+          message: messages.rejected("pixels"),
+          line: 1,
+          column: 18
+        },
+        {
+          message: messages.rejected("pixels"),
+          line: 1,
+          column: 29
+        }
+      ]
     }
   ]
 });
@@ -562,7 +573,18 @@ testRule(rule, {
   reject: [
     {
       code: "a { margin: calc(10pixels + 1pixels); }",
-      message: messages.rejected("pixels")
+      warnings: [
+        {
+          message: messages.rejected("pixels"),
+          line: 1,
+          column: 18
+        },
+        {
+          message: messages.rejected("pixels"),
+          line: 1,
+          column: 29
+        }
+      ]
     }
   ]
 });

--- a/lib/rules/value-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/value-list-comma-space-after/__tests__/index.js
@@ -72,9 +72,23 @@ testRule(rule, {
     {
       code: "a { background-size: 0,0,0,0; }",
       fixed: "a { background-size: 0, 0, 0, 0; }",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 23
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 23
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 25
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 27
+        }
+      ]
     },
     {
       code: ":root { --variable: 0,0; }",
@@ -87,16 +101,59 @@ testRule(rule, {
       code: "a { pr,op: 0,0; }",
       fixed: "a { pr,op: 0, 0; }",
       description: "edge case",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 7
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 7
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 13
+        }
+      ]
     },
     {
       code: "a{b: 0,0,0,0,0,0,0,0; }",
       fixed: "a{b: 0, 0, 0, 0, 0, 0, 0, 0; }",
-      message: messages.expectedAfter(),
-      line: 1,
-      column: 7
+      warnings: [
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 7
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 9
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 11
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 15
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 17
+        },
+        {
+          message: messages.expectedAfter(),
+          line: 1,
+          column: 19
+        }
+      ]
     }
   ]
 });
@@ -170,9 +227,23 @@ testRule(rule, {
     {
       code: "a { background-size: 0, 0, 0, 0 ; }",
       fixed: "a { background-size: 0,0,0,0 ; }",
-      message: messages.rejectedAfter(),
-      line: 1,
-      column: 23
+      warnings: [
+        {
+          message: messages.rejectedAfter(),
+          line: 1,
+          column: 23
+        },
+        {
+          message: messages.rejectedAfter(),
+          line: 1,
+          column: 26
+        },
+        {
+          message: messages.rejectedAfter(),
+          line: 1,
+          column: 29
+        }
+      ]
     },
     {
       code: ":root { --variable: 0, 0; }",

--- a/lib/rules/value-list-comma-space-before/__tests__/index.js
+++ b/lib/rules/value-list-comma-space-before/__tests__/index.js
@@ -73,9 +73,43 @@ testRule(rule, {
     {
       code: "a{b: 0,0,0,0,0,0,0,0; }",
       fixed: "a{b: 0 ,0 ,0 ,0 ,0 ,0 ,0 ,0; }",
-      message: messages.expectedBefore(),
-      line: 1,
-      column: 7
+      warnings: [
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 7
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 9
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 11
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 13
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 15
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 17
+        },
+        {
+          message: messages.expectedBefore(),
+          line: 1,
+          column: 19
+        }
+      ]
     }
   ]
 });


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

fix tests for:
* block-closing-brace-empty-line-before
* block-opening-brace-newline-after
* media-feature-colon-space-after
* media-feature-colon-space-before
* media-feature-range-operator-space-after
* media-feature-range-operator-space-before
* media-query-list-comma-space-after
* media-query-list-comma-space-before
* number-leading-zero
* selector-max-id
* selector-list-comma-newline-before
* selector-pseudo-class-no-unknown
* selector-pseudo-class-parentheses-space-inside
* selector-pseudo-element-colon-notation
* unit-no-unknown
* value-list-comma-space-after
* value-list-comma-space-before

> Is there anything in the PR that needs further explanation?

nothing
