### PR TITLE
Deprecate createRuleTester API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 const checkAgainstRule = require("./utils/checkAgainstRule");
 const createPlugin = require("./createPlugin");
-const createRuleTester = require("./testUtils/createRuleTester");
 const createStylelint = require("./createStylelint");
 const formatters = require("./formatters");
 const postcssPlugin = require("./postcssPlugin");
@@ -32,7 +31,6 @@ api.lint = standalone;
 api.rules = requiredRules;
 api.formatters = formatters;
 api.createPlugin = createPlugin;
-api.createRuleTester = createRuleTester;
 api.createLinter = createStylelint;
 
 module.exports = api;

--- a/lib/testUtils/createRuleTester.js
+++ b/lib/testUtils/createRuleTester.js
@@ -9,6 +9,7 @@ const postcss = require("postcss");
 const sassSyntax = require("postcss-sass");
 const scssSyntax = require("postcss-scss");
 const sugarss = require("sugarss");
+const { deprecate } = require("util");
 
 /**
  * Create a stylelint rule testing function.
@@ -97,7 +98,7 @@ function checkCaseForOnly(caseType, testCase) {
   onlyTest = { case: testCase, type: caseType };
 }
 
-module.exports = function(equalityCheck) {
+function createRuleTester(equalityCheck) {
   return function(rule, schema) {
     const alreadyHadOnlyTest = !!onlyTest;
 
@@ -122,7 +123,7 @@ module.exports = function(equalityCheck) {
       });
     }
   };
-};
+}
 
 function processGroup(rule, schema, equalityCheck) {
   const ruleName = schema.ruleName;
@@ -305,3 +306,8 @@ function processGroup(rule, schema, equalityCheck) {
 function spaceJoin() {
   return _.compact(Array.from(arguments)).join(" ");
 }
+
+module.exports = deprecate(
+  createRuleTester,
+  "createRuleTester deprecated, please use https://github.com/stylelint/jest-preset-stylelint instead"
+);


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

related to https://github.com/stylelint/stylelint/issues/2454
loading this module cost to much https://gist.github.com/vankop/f83bdeda2cae617b4a801d8e210454ef

Suggest developers to load `~/lib/testUtils/createRuleTester` directly if needed

> Is there anything in the PR that needs further explanation?

nothing
