### PR TITLE
Add ignoreSelectors option to property-no-unknown

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -304,7 +304,7 @@ Deviation: 16.63969674310928 ms
 
 What can you do with this? **When writing new rules or refactoring existing rules, use these measurements to determine the efficiency of your code.**
 
-A stylelint rule can repeat it's core logic many, many times (e.g. checking every value node of every declaration in a vast CSS codebase). So it's worth paying attention to performance and doing what we can to improve it!
+A stylelint rule can repeat its core logic many, many times (e.g. checking every value node of every declaration in a vast CSS codebase). So it's worth paying attention to performance and doing what we can to improve it!
 
 **This is a great way to contribute if you just want a quick little project.** Try picking a rule and seeing if there's anything you can do to speed it up.
 

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -130,3 +130,25 @@ a {
   -moz-overflow-scrolling: center;
 }
 ```
+
+### `ignorePropertiesOf: ["/regex/", /regex/, "string"]`
+
+Some CSS extensions allow arbitrary child properties of certain selectors and pseudo-classes, which shouldn't be checked against this rule. One such example is [ICSS](https://github.com/css-modules/icss), which defines the `:export` and `:import` pseudo-classes, where the property names can be any valid CSS declaration value.
+
+Given:
+
+```js
+[":export", "/^:import/"]
+```
+
+The following patterns are *not* considered violations:
+
+```css
+:export {
+  myProperty: blue;
+}
+
+:import("path/to/file.css") {
+  localAlias: keyFromDep;
+}
+```

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -131,11 +131,11 @@ a {
 }
 ```
 
-### `ignorePropertiesOf: ["/regex/", /regex/, "string"]`
+### `ignoreSelectors: ["/regex/", /regex/, "string"]`
 
-Some CSS extensions allow arbitrary child properties of certain selectors and pseudo-classes, which shouldn't be checked against this rule. One such example is [ICSS](https://github.com/css-modules/icss), which defines the `:export` and `:import` pseudo-classes, where the property names can be any valid CSS declaration value.
+Some CSS extensions allow arbitrary child properties of certain selectors and pseudo-classes, which shouldn't be checked against a whitelist of known properties. One such example is [ICSS](https://github.com/css-modules/icss), which defines `:export` and `:import` pseudo-classes allowing any valid CSS property name to be nested in their declaration blocks.
 
-Given:
+Given a config with `ignoreSelectors` set to:
 
 ```js
 [":export", "/^:import/"]

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -97,6 +97,24 @@ a {
 }
 ```
 
+### `ignoreSelectors: ["/regex/", /regex/, "string"]`
+
+Skips checking properties of the given selectors against this rule.
+
+Given:
+
+```js
+[":root"]
+```
+
+The following patterns are *not* considered violations:
+
+```css
+:root {
+  my-property: blue;
+}
+```
+
 ### `checkPrefixed: true | false` (default: `false`)
 
 If `true`, this rule will check vendor-prefixed properties.
@@ -128,27 +146,5 @@ a {
 ```css
 a {
   -moz-overflow-scrolling: center;
-}
-```
-
-### `ignoreSelectors: ["/regex/", /regex/, "string"]`
-
-Some CSS extensions allow arbitrary child properties of certain selectors and pseudo-classes, which shouldn't be checked against a whitelist of known properties. One such example is [ICSS](https://github.com/css-modules/icss), which defines `:export` and `:import` pseudo-classes allowing any valid CSS property name to be nested in their declaration blocks.
-
-Given a config with `ignoreSelectors` set to:
-
-```js
-[":export", "/^:import/"]
-```
-
-The following patterns are *not* considered violations:
-
-```css
-:export {
-  myProperty: blue;
-}
-
-:import("path/to/file.css") {
-  localAlias: keyFromDep;
 }
 ```

--- a/lib/rules/property-no-unknown/__tests__/index.js
+++ b/lib/rules/property-no-unknown/__tests__/index.js
@@ -221,7 +221,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [true, { ignorePropertiesOf: [":export", ":import"] }],
+  config: [true, { ignoreSelectors: [":export", ":import"] }],
 
   accept: [
     {
@@ -248,7 +248,7 @@ testRule(rule, {
 
 testRule(rule, {
   ruleName,
-  config: [true, { ignorePropertiesOf: ["/:export/", /^:import/] }],
+  config: [true, { ignoreSelectors: ["/:export/", /^:import/] }],
 
   accept: [
     {

--- a/lib/rules/property-no-unknown/__tests__/index.js
+++ b/lib/rules/property-no-unknown/__tests__/index.js
@@ -67,6 +67,12 @@ testRule(rule, {
       message: messages.rejected("colr"),
       line: 1,
       column: 33
+    },
+    {
+      code: ":export { my-property: red; }",
+      message: messages.rejected("my-property"),
+      line: 1,
+      column: 11
     }
   ]
 });
@@ -209,6 +215,56 @@ testRule(rule, {
       message: messages.rejected("-moz-align-self"),
       line: 1,
       column: 8
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true, { ignorePropertiesOf: [":export", ":import"] }],
+
+  accept: [
+    {
+      code: ":export { my-property: 1; }"
+    }
+  ],
+
+  reject: [
+    {
+      code: ":not-export { my-property: 1; }",
+      message: messages.rejected("my-property"),
+      line: 1,
+      column: 15
+    },
+    {
+      // Non-regex strings must exactly match the parent selector.
+      code: ':import("path/to/file.css") { my-property: 1; }',
+      message: messages.rejected("my-property"),
+      line: 1,
+      column: 31
+    }
+  ]
+});
+
+testRule(rule, {
+  ruleName,
+  config: [true, { ignorePropertiesOf: ["/:export/", /^:import/] }],
+
+  accept: [
+    {
+      code: ":export { my-property: 1; }"
+    },
+    {
+      code: ':import("path/to/file.css") { my-property: 1; }'
+    }
+  ],
+
+  reject: [
+    {
+      code: ":exprat { my-property: 1; }",
+      message: messages.rejected("my-property"),
+      line: 1,
+      column: 11
     }
   ]
 });

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -29,7 +29,8 @@ const rule = function(actual, options) {
         actual: options,
         possible: {
           ignoreProperties: [_.isString, _.isRegExp],
-          checkPrefixed: _.isBoolean
+          checkPrefixed: _.isBoolean,
+          ignorePropertiesOf: [_.isString, _.isRegExp]
         },
         optional: true
       }
@@ -65,6 +66,13 @@ const rule = function(actual, options) {
       }
 
       if (allValidProperties.has(prop.toLowerCase())) {
+        return;
+      }
+
+      // Is the property a child of an ignored selector?
+      const { selector } = decl.parent;
+
+      if (selector && optionsMatches(options, "ignorePropertiesOf", selector)) {
         return;
       }
 

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -30,7 +30,7 @@ const rule = function(actual, options) {
         possible: {
           ignoreProperties: [_.isString, _.isRegExp],
           checkPrefixed: _.isBoolean,
-          ignorePropertiesOf: [_.isString, _.isRegExp]
+          ignoreSelectors: [_.isString, _.isRegExp]
         },
         optional: true
       }
@@ -72,7 +72,7 @@ const rule = function(actual, options) {
       // Is the property a child of an ignored selector?
       const { selector } = decl.parent;
 
-      if (selector && optionsMatches(options, "ignorePropertiesOf", selector)) {
+      if (selector && optionsMatches(options, "ignoreSelectors", selector)) {
         return;
       }
 

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -65,14 +65,13 @@ const rule = function(actual, options) {
         return;
       }
 
-      if (allValidProperties.has(prop.toLowerCase())) {
-        return;
-      }
-
-      // Is the property a child of an ignored selector?
       const { selector } = decl.parent;
 
       if (selector && optionsMatches(options, "ignoreSelectors", selector)) {
+        return;
+      }
+
+      if (allValidProperties.has(prop.toLowerCase())) {
         return;
       }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #4270 

> Is there anything in the PR that needs further explanation?

I think it's okay as-is. It's implementing what was discussed on the issue, with docs and tests (and a small typo fix).