### PR TITLE
use Set instead of Array in property-no-unknown

### DIFF
--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -18,6 +18,8 @@ const messages = ruleMessages(ruleName, {
 });
 
 const rule = function(actual, options) {
+  const allValidProperties = new Set(properties);
+
   return (root, result) => {
     const validOptions = validateOptions(
       result,
@@ -62,7 +64,7 @@ const rule = function(actual, options) {
         return;
       }
 
-      if (properties.indexOf(prop.toLowerCase()) !== -1) {
+      if (allValidProperties.has(prop.toLowerCase())) {
         return;
       }
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

minor rule performance fix

> Is there anything in the PR that needs further explanation?

nothing
