### PR TITLE
Use spaces for *.md, *.css and package.json formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,11 @@ end_of_line = lf
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[package.json]
+indent_style = space
+indent_size = 2
+
+[*.{md,css}]
+indent_style = space
+indent_size = 2

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,4 +7,13 @@ module.exports = {
 	singleQuote: true,
 	trailingComma: 'all',
 	useTabs: true,
+	overrides: [
+		{
+			files: ['package.json', '*.md', '*.css'],
+			options: {
+				useTabs: false,
+				tabWidth: 2,
+			},
+		},
+	],
 };

--- a/package.json
+++ b/package.json
@@ -147,6 +147,9 @@
     ]
   },
   "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 2019
+    },
     "extends": [
       "stylelint"
     ],


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Follow-up to https://github.com/stylelint/stylelint/pull/4259.

> Is there anything in the PR that needs further explanation?

I've configured `*.md`, `*.css` and `package.json` to use spaces, so these files are not be broken by new configuration. They use spaces and in many places it's critical for alignment and/or correct test results (like system tests).

ESLint config change is to correct parsing trailing comma in function arguments.