### PR TITLE
Make docs about turning rules off linkable

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -56,6 +56,16 @@ The `rules` property is *an object whose keys are rule names and values are rule
 
 Specifying a primary option will turn a rule on. A complete list of primary rule options can be found in the [example configuration](example-config.md).
 
+Many rules have secondary options which provide further customization. To set secondary options, a two-member array is used:
+
+```js
+"selector-pseudo-class-no-unknown": [true, {
+  "ignorePseudoClasses": ["global"]
+}]
+```
+
+#### Turning rules off
+
 To turn a rule off (when extending a configuration) you can set the value of the rule to `null`:
 
 ```json
@@ -67,15 +77,7 @@ To turn a rule off (when extending a configuration) you can set the value of the
 }
 ```
 
-Many rules have secondary options which provide further customization. To set secondary options, a two-member array is used:
-
-```js
-"selector-pseudo-class-no-unknown": [true, {
-  "ignorePseudoClasses": ["global"]
-}]
-```
-
-#### Turning rules off from within your CSS
+##### Turning rules off from within your CSS
 
 Rules can be temporarily turned off by using special comments in your CSS. For example, you can either turn all the rules off:
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

We quite often point people towards this section of the docs. It'll be easier if had a linkable heading.
