### PR TITLE
Fix case when raws.after/before could be undefined or null

### DIFF
--- a/lib/rules/no-eol-whitespace/__tests__/index.js
+++ b/lib/rules/no-eol-whitespace/__tests__/index.js
@@ -668,3 +668,28 @@ testRule(rule, {
 		},
 	],
 });
+
+testRule(rule, {
+	ruleName,
+	syntax: 'css-in-js',
+	config: [true],
+
+	accept: [
+		{
+			code: `
+        export const a = styled.div\`
+          a {}
+\`;
+
+        export const b = styled.div\`
+          a {}
+\`;
+      `,
+		},
+		{
+			code: `export default <a style={{
+width: 'calc(100% - 80px)'
+}} />;`,
+		},
+	],
+});

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -212,14 +212,16 @@ const rule = function(on, options, context) {
 				isRootFirst,
 			);
 
-			const lastEOL = Math.max(
-				root.raws.after.lastIndexOf('\n'),
-				root.raws.after.lastIndexOf('\r'),
-			);
+			if (typeof root.raws.after === 'string') {
+				const lastEOL = Math.max(
+					root.raws.after.lastIndexOf('\n'),
+					root.raws.after.lastIndexOf('\r'),
+				);
 
-			if (lastEOL !== root.raws.after.length - 1) {
-				root.raws.after =
-					root.raws.after.slice(0, lastEOL + 1) + fixString(root.raws.after.slice(lastEOL + 1));
+				if (lastEOL !== root.raws.after.length - 1) {
+					root.raws.after =
+						root.raws.after.slice(0, lastEOL + 1) + fixString(root.raws.after.slice(lastEOL + 1));
+				}
 			}
 		}
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

fix https://github.com/stylelint/stylelint/issues/4309

> Is there anything in the PR that needs further explanation?

Nothing
