### PR TITLE
Add "css" option to --syntax parameter

### DIFF
--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -227,7 +227,7 @@ it('unknown syntax option', () => {
 		})
 		.catch((err) => {
 			expect(err.message).toBe(
-				'You must use a valid syntax option, either: css-in-js, html, less, markdown, sass, scss, or sugarss',
+				'You must use a valid syntax option, either: css, css-in-js, html, less, markdown, sass, scss, or sugarss',
 			);
 		});
 });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -216,9 +216,10 @@ const meowOptions /*: meowOptionsType*/ = {
 
       --syntax, -s
 
-        Specify a non-standard syntax. Options: "scss", "sass", "less", "sugarss".
-        If you do not specify a syntax, non-standard syntaxes will be
-        automatically inferred by the file extensions .scss, .sass, .less, and .sss.
+        Specify a syntax. Options: "css", "css-in-js", "html", "less",
+        "markdown", "sass", "scss", "sugarss". If you do not specify a syntax,
+        syntaxes will be automatically inferred by the file extensions
+        and file content.
 
       --fix
 
@@ -301,7 +302,7 @@ const meowOptions /*: meowOptionsType*/ = {
       --allow-empty-input, --aei
 
         When glob pattern matches no files, the process will exit without throwing an error.
-  `,
+	`,
 	flags: {
 		'allow-empty-input': {
 			alias: 'aei',

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -60,6 +60,7 @@ module.exports = function(stylelint /*: stylelint$internalApi*/) /*: Promise<?Ob
 				}
 			} else if (syntax) {
 				const syntaxes = {
+					css: 'postcss-safe-parser',
 					'css-in-js': 'postcss-jsx',
 					html: 'postcss-html',
 					less: 'postcss-less',
@@ -73,7 +74,7 @@ module.exports = function(stylelint /*: stylelint$internalApi*/) /*: Promise<?Ob
 
 				if (!syntax) {
 					throw new Error(
-						'You must use a valid syntax option, either: css-in-js, html, less, markdown, sass, scss, or sugarss',
+						'You must use a valid syntax option, either: css, css-in-js, html, less, markdown, sass, scss, or sugarss',
 					);
 				}
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Needed to fix https://github.com/stylelint/stylelint-demo/issues/155.

> Is there anything in the PR that needs further explanation?

Currently there is no way to specify “css” syntax.
