### PR TITLE
Improve test stability

### DIFF
--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -6,467 +6,338 @@ const standalone = require('../standalone');
 
 const fixturesPath = path.join(__dirname, 'fixtures');
 
-describe('extending config and ignoreFiles glob ignoring single glob', () => {
-	let results;
-
-	beforeEach(() => {
-		return standalone({
-			files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
-			config: {
-				ignoreFiles: '**/invalid-hex.css',
-				extends: ['./config-block-no-empty', './config-color-no-invalid-hex'],
-			},
-			configBasedir: path.join(__dirname, 'fixtures'),
-		}).then((data) => (results = data.results));
-	});
-
-	it('two files found', () => {
+test('extending config and ignoreFiles glob ignoring single glob', () => {
+	return standalone({
+		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+		config: {
+			ignoreFiles: '**/invalid-hex.css',
+			extends: ['./config-block-no-empty', './config-color-no-invalid-hex'],
+		},
+		configBasedir: path.join(__dirname, 'fixtures'),
+	}).then(({ results }) => {
+		// two files found
 		expect(results).toHaveLength(2);
-	});
 
-	it('empty-block.css found', () => {
+		// empty-block.css found
 		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
-	});
 
-	it('empty-block.css linted', () => {
+		// empty-block.css linted
 		expect(results[0].warnings).toHaveLength(1);
-	});
 
-	it('invalid-hex.css found', () => {
+		// invalid-hex.css found
 		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
-	});
 
-	it('invalid-hex.css not linted', () => {
+		// invalid-hex.css not linted
 		expect(results[1].warnings).toHaveLength(0);
-	});
 
-	it('invalid-hex.css marked as ignored', () => {
+		// invalid-hex.css marked as ignored
 		expect(results[1].ignored).toBeTruthy();
 	});
 });
 
-describe('same as above with no configBasedir, ignore-files path relative to process.cwd', () => {
-	let actualCwd;
-	let results;
+test('same as above with no configBasedir, ignore-files path relative to process.cwd', () => {
+	const actualCwd = process.cwd();
 
-	beforeAll(() => {
-		actualCwd = process.cwd();
-		process.chdir(__dirname);
-	});
+	process.chdir(__dirname);
 
-	afterAll(() => {
+	return standalone({
+		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+		config: {
+			ignoreFiles: 'fixtures/invalid-hex.css',
+			extends: [
+				`${fixturesPath}/config-block-no-empty.json`,
+				`${fixturesPath}/config-color-no-invalid-hex`,
+			],
+		},
+	}).then(({ results }) => {
+		// two files found
+		expect(results).toHaveLength(2);
+
+		// empty-block.css found
+		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
+
+		// empty-block.css linted
+		expect(results[0].warnings).toHaveLength(1);
+
+		// invalid-hex.css found
+		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
+
+		// invalid-hex.css not linted
+		expect(results[1].warnings).toHaveLength(0);
+
+		// invalid-hex.css marked as ignored
+		expect(results[1].ignored).toBeTruthy();
+
 		process.chdir(actualCwd);
 	});
-
-	beforeEach(() => {
-		return standalone({
-			files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
-			config: {
-				ignoreFiles: 'fixtures/invalid-hex.css',
-				extends: [
-					`${fixturesPath}/config-block-no-empty.json`,
-					`${fixturesPath}/config-color-no-invalid-hex`,
-				],
-			},
-		}).then((data) => (results = data.results));
-	});
-
-	it('two files found', () => {
-		expect(results).toHaveLength(2);
-	});
-
-	it('empty-block.css found', () => {
-		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
-	});
-
-	it('empty-block.css linted', () => {
-		expect(results[0].warnings).toHaveLength(1);
-	});
-
-	it('invalid-hex.css found', () => {
-		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
-	});
-
-	it('invalid-hex.css not linted', () => {
-		expect(results[1].warnings).toHaveLength(0);
-	});
-
-	it('invalid-hex.css marked as ignored', () => {
-		expect(results[1].ignored).toBeTruthy();
-	});
 });
 
-describe('absolute ignoreFiles glob path', () => {
-	let results;
-
-	beforeEach(() => {
-		return standalone({
-			files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
-			config: {
-				ignoreFiles: [`${fixturesPath}/empty-b*.css`],
-				rules: {
-					'block-no-empty': true,
-				},
+test('absolute ignoreFiles glob path', () => {
+	return standalone({
+		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+		config: {
+			ignoreFiles: [`${fixturesPath}/empty-b*.css`],
+			rules: {
+				'block-no-empty': true,
 			},
-			configBasedir: path.join(__dirname, 'fixtures'),
-		}).then((data) => (results = data.results));
-	});
-
-	it('two files found', () => {
+		},
+		configBasedir: path.join(__dirname, 'fixtures'),
+	}).then(({ results }) => {
+		// two files found
 		expect(results).toHaveLength(2);
-	});
 
-	it('first not linted', () => {
+		// first not linted
 		expect(results[0].warnings).toHaveLength(0);
-	});
 
-	it('first marked as ignored', () => {
+		// first marked as ignored
 		expect(results[0].ignored).toBeTruthy();
-	});
 
-	it('second has no warnings', () => {
+		// second has no warnings
 		expect(results[1].warnings).toHaveLength(0);
-	});
 
-	it('second not marked as ignored', () => {
+		// second not marked as ignored
 		expect(results[1].ignored).toBeFalsy();
 	});
 });
 
-describe('extending config with ignoreFiles glob ignoring one by negation', () => {
-	let results;
-
-	beforeEach(() => {
-		return standalone({
-			files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
-			config: {
-				ignoreFiles: ['**/*.css', '!**/invalid-hex.css'],
-				extends: [
-					`${fixturesPath}/config-block-no-empty`,
-					`${fixturesPath}/config-color-no-invalid-hex`,
-				],
-			},
-			configBasedir: path.join(__dirname, 'fixtures'),
-		}).then((data) => (results = data.results));
-	});
-
-	it('two files found', () => {
+test('extending config with ignoreFiles glob ignoring one by negation', () => {
+	return standalone({
+		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+		config: {
+			ignoreFiles: ['**/*.css', '!**/invalid-hex.css'],
+			extends: [
+				`${fixturesPath}/config-block-no-empty`,
+				`${fixturesPath}/config-color-no-invalid-hex`,
+			],
+		},
+		configBasedir: path.join(__dirname, 'fixtures'),
+	}).then(({ results }) => {
+		// two files found
 		expect(results).toHaveLength(2);
-	});
 
-	it('empty-block.css found', () => {
+		// empty-block.css found
 		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
-	});
 
-	it('empty-block.css has no warnings', () => {
+		// empty-block.css has no warnings
 		expect(results[0].warnings).toHaveLength(0);
-	});
 
-	it('empty-block.css was ignored', () => {
+		// empty-block.css was ignored
 		expect(results[0].ignored).toBeTruthy();
-	});
 
-	it('invalid-hex.css found', () => {
+		// invalid-hex.css found
 		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
-	});
 
-	it('invalid-hex.css has warnings', () => {
+		// invalid-hex.css has warnings
 		expect(results[1].warnings).toHaveLength(1);
-	});
 
-	it('invalid-hex.css was not ignored', () => {
+		// invalid-hex.css was not ignored
 		expect(results[1].ignored).toBeFalsy();
 	});
 });
 
-describe('specified `ignorePath` file ignoring one file', () => {
+test('specified `ignorePath` file ignoring one file', () => {
 	const files = [`${fixturesPath}/empty-block.css`];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
-	let actualCwd;
-	let errorMessage;
+	const actualCwd = process.cwd();
 
-	beforeAll(() => {
-		actualCwd = process.cwd();
-		process.chdir(__dirname);
-	});
+	process.chdir(__dirname);
 
-	afterAll(() => {
-		process.chdir(actualCwd);
-	});
-
-	beforeEach(() => {
-		return standalone({
-			files,
-			config: {
-				rules: {
-					'block-no-empty': true,
-				},
+	return standalone({
+		files,
+		config: {
+			rules: {
+				'block-no-empty': true,
 			},
-			ignorePath: path.join(__dirname, 'fixtures/ignore.txt'),
-		}).catch((actualError) => {
-			errorMessage = actualError;
-		});
-	});
+		},
+		ignorePath: path.join(__dirname, 'fixtures/ignore.txt'),
+	}).catch((actualError) => {
+		// no files read
+		expect(actualError).toEqual(noFilesErrorMessage);
 
-	it('no files read', () => {
-		expect(errorMessage).toEqual(noFilesErrorMessage);
+		process.chdir(actualCwd);
 	});
 });
 
-describe('specified `ignorePattern` file ignoring one file', () => {
+test('specified `ignorePattern` file ignoring one file', () => {
 	const files = [`${fixturesPath}/empty-block.css`];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
-	let actualCwd;
-	let errorMessage;
+	const actualCwd = process.cwd();
 
-	beforeAll(() => {
-		actualCwd = process.cwd();
-		process.chdir(__dirname);
-	});
+	process.chdir(__dirname);
 
-	afterAll(() => {
-		process.chdir(actualCwd);
-	});
-
-	beforeEach(() => {
-		return standalone({
-			files,
-			config: {
-				rules: {
-					'block-no-empty': true,
-				},
+	return standalone({
+		files,
+		config: {
+			rules: {
+				'block-no-empty': true,
 			},
-			ignorePattern: 'fixtures/empty-block.css',
-		}).catch((actualError) => {
-			errorMessage = actualError;
-		});
-	});
+		},
+		ignorePattern: 'fixtures/empty-block.css',
+	}).catch((actualError) => {
+		// no files read
+		expect(actualError).toEqual(noFilesErrorMessage);
 
-	it('no files read', () => {
-		expect(errorMessage).toEqual(noFilesErrorMessage);
+		process.chdir(actualCwd);
 	});
 });
 
-describe('specified `ignorePattern` file ignoring two files', () => {
+test('specified `ignorePattern` file ignoring two files', () => {
 	const files = [`${fixturesPath}/empty-block.css`, `${fixturesPath}/no-syntax-error.css`];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
-	let actualCwd;
-	let errorMessage;
+	const actualCwd = process.cwd();
 
-	beforeAll(() => {
-		actualCwd = process.cwd();
-		process.chdir(__dirname);
-	});
+	process.chdir(__dirname);
 
-	afterAll(() => {
-		process.chdir(actualCwd);
-	});
-
-	beforeEach(() => {
-		return standalone({
-			files,
-			config: {
-				rules: {
-					'block-no-empty': true,
-				},
+	return standalone({
+		files,
+		config: {
+			rules: {
+				'block-no-empty': true,
 			},
-			ignorePattern: ['fixtures/empty-block.css', 'fixtures/no-syntax-error.css'],
-		}).catch((actualError) => {
-			errorMessage = actualError;
-		});
-	});
+		},
+		ignorePattern: ['fixtures/empty-block.css', 'fixtures/no-syntax-error.css'],
+	}).catch((actualError) => {
+		// no files read
+		expect(actualError).toEqual(noFilesErrorMessage);
 
-	it('no files read', () => {
-		expect(errorMessage).toEqual(noFilesErrorMessage);
+		process.chdir(actualCwd);
 	});
 });
 
-describe('using ignoreFiles with input files that would cause a postcss syntax error', () => {
-	let results;
-
-	beforeEach(() => {
-		return standalone({
-			files: [`${fixturesPath}/standaloneNoParsing/*`],
-			config: {
-				ignoreFiles: ['**/*.scss'],
-				rules: {
-					'block-no-empty': true,
-				},
+test('using ignoreFiles with input files that would cause a postcss syntax error', () => {
+	return standalone({
+		files: [`${fixturesPath}/standaloneNoParsing/*`],
+		config: {
+			ignoreFiles: ['**/*.scss'],
+			rules: {
+				'block-no-empty': true,
 			},
-		}).then((data) => (results = data.results));
-	});
-
-	it('two files found', () => {
+		},
+	}).then(({ results }) => {
+		// two files found
 		expect(results).toHaveLength(2);
-	});
 
-	it('no-syntax-error.css found', () => {
+		// no-syntax-error.css found
 		expect(results[0].source.indexOf('no-syntax-error.css')).not.toBe(-1);
-	});
-
-	it('no-syntax-error.css linted', () => {
+		// no-syntax-error.css linted
 		expect(results[0].warnings).toHaveLength(0);
-	});
 
-	it('syntax-error-ignored.scss found', () => {
-		// For node 8 on Windows
-		const index = Number(results[1].source.indexOf('syntax-error-ignored.scss'));
+		// syntax-error-ignored.scss found
+		expect(results[1].source.indexOf('syntax-error-ignored.scss')).not.toBe(-1);
 
-		expect(index).not.toBe(-1);
-	});
-
-	it('syntax-error-ignored.scss not linted', () => {
+		// syntax-error-ignored.scss not linted
 		expect(results[1].warnings).toHaveLength(0);
-	});
 
-	it('syntax-error-ignored.scss marked as ignored', () => {
+		// syntax-error-ignored.scss marked as ignored
 		expect(results[1].ignored).toBeTruthy();
 	});
 });
 
-describe('extending a config that ignores files', () => {
-	let results;
-
-	beforeEach(() => {
-		return standalone({
-			files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
-			config: {
-				extends: [`${fixturesPath}/config-extending-and-ignoring`],
-			},
-			configBasedir: path.join(__dirname, 'fixtures'),
-		}).then((data) => (results = data.results));
-	});
-
-	it('found correct files', () => {
+test('extending a config that ignores files', () => {
+	return standalone({
+		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+		config: {
+			extends: [`${fixturesPath}/config-extending-and-ignoring`],
+		},
+		configBasedir: path.join(__dirname, 'fixtures'),
+	}).then(({ results }) => {
+		// found correct files
 		expect(results).toHaveLength(2);
-	});
 
-	it('empty-block.css found', () => {
+		// empty-block.css found
 		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
-	});
 
-	it('empty-block.css linted', () => {
+		// empty-block.css linted
 		expect(results[0].warnings).toHaveLength(1);
-	});
 
-	it('invalid-hex.css found', () => {
+		// invalid-hex.css found
 		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
-	});
 
-	it('invalid-hex.css not linted', () => {
+		// invalid-hex.css not linted
 		expect(results[1].warnings).toHaveLength(0);
 	});
 });
 
-describe('using codeFilename and ignoreFiles together', () => {
-	let results;
-
-	beforeEach(() => {
-		return standalone({
-			code: 'a {}',
-			codeFilename: path.join(__dirname, 'foo.css'),
-			config: {
-				ignoreFiles: ['**/foo.css'],
-				rules: { 'block-no-empty': true },
-			},
-		}).then((data) => (results = data.results));
-	});
-
-	it('no warnings', () => {
+test('using codeFilename and ignoreFiles together', () => {
+	return standalone({
+		code: 'a {}',
+		codeFilename: path.join(__dirname, 'foo.css'),
+		config: {
+			ignoreFiles: ['**/foo.css'],
+			rules: { 'block-no-empty': true },
+		},
+	}).then(({ results }) => {
+		// no warnings
 		expect(results[0].warnings).toHaveLength(0);
-	});
 
-	it('ignored', () => {
+		// ignored
 		expect(results[0].ignored).toBeTruthy();
 	});
 });
 
-describe('using codeFilename and ignoreFiles with configBasedir', () => {
-	let results;
-
-	beforeEach(() => {
-		return standalone({
-			code: 'a {}',
-			codeFilename: path.join(__dirname, 'foo.css'),
-			config: {
-				ignoreFiles: ['foo.css'],
-				rules: { 'block-no-empty': true },
-			},
-			configBasedir: __dirname,
-		}).then((data) => (results = data.results));
-	});
-
-	it('no warnings', () => {
+test('using codeFilename and ignoreFiles with configBasedir', () => {
+	return standalone({
+		code: 'a {}',
+		codeFilename: path.join(__dirname, 'foo.css'),
+		config: {
+			ignoreFiles: ['foo.css'],
+			rules: { 'block-no-empty': true },
+		},
+		configBasedir: __dirname,
+	}).then(({ results }) => {
+		// no warnings
 		expect(results[0].warnings).toHaveLength(0);
-	});
 
-	it('ignored', () => {
+		// ignored
 		expect(results[0].ignored).toBeTruthy();
 	});
 });
 
-describe('file in node_modules', () => {
+test('file in node_modules is ignored', () => {
 	const files = [`${fixturesPath}/node_modules/test.css`];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
-	const lint = () =>
-		standalone({
-			files,
-			config: {
-				rules: {
-					'block-no-empty': true,
-				},
-			},
-		});
 
-	it('is ignored', () => {
-		return lint().catch((actualError) => {
-			expect(actualError).toEqual(noFilesErrorMessage);
-		});
+	return standalone({
+		files,
+		config: {
+			rules: {
+				'block-no-empty': true,
+			},
+		},
+	}).catch((actualError) => {
+		expect(actualError).toEqual(noFilesErrorMessage);
 	});
 });
 
-describe('file in bower_components', () => {
+test('file in bower_components is ignored', () => {
 	const files = [`${fixturesPath}/bower_components/test.css`];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
-	const lint = () =>
-		standalone({
-			files,
-			config: {
-				rules: {
-					'block-no-empty': true,
-				},
-			},
-		});
 
-	it('is ignored', () => {
-		return lint().catch((actualError) => {
-			expect(actualError).toEqual(noFilesErrorMessage);
-		});
+	return standalone({
+		files,
+		config: {
+			rules: {
+				'block-no-empty': true,
+			},
+		},
+	}).catch((actualError) => {
+		expect(actualError).toEqual(noFilesErrorMessage);
 	});
 });
 
-describe('disableDefaultIgnores allows paths in node_modules and bower_components', () => {
-	describe('files in node_modules and bower_components', () => {
-		const lint = () =>
-			standalone({
-				files: [
-					`${fixturesPath}/bower_components/test.css`,
-					`${fixturesPath}/node_modules/test.css`,
-				],
-				disableDefaultIgnores: true,
-				config: {
-					rules: {
-						'block-no-empty': true,
-					},
-				},
-			});
-
-		it('are not ignored', () => {
-			return lint().then((output) => {
-				expect(output.results).toHaveLength(2);
-				expect(output.results[0].warnings).toHaveLength(1);
-				expect(output.results[1].warnings).toHaveLength(1);
-			});
-		});
+test('disableDefaultIgnores allows paths in node_modules and bower_components', () => {
+	return standalone({
+		files: [`${fixturesPath}/bower_components/test.css`, `${fixturesPath}/node_modules/test.css`],
+		disableDefaultIgnores: true,
+		config: {
+			rules: {
+				'block-no-empty': true,
+			},
+		},
+	}).then(({ results }) => {
+		// They are not ignored
+		expect(results).toHaveLength(2);
+		expect(results[0].warnings).toHaveLength(1);
+		expect(results[1].warnings).toHaveLength(1);
 	});
 });

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -217,19 +217,22 @@ test('using ignoreFiles with input files that would cause a postcss syntax error
 		// two files found
 		expect(results).toHaveLength(2);
 
+		const one = results.find((result) => result.source.includes('no-syntax-error.css'));
+		const two = results.find((result) => result.source.includes('syntax-error-ignored.scss'));
+
 		// no-syntax-error.css found
-		expect(results[0].source.indexOf('no-syntax-error.css')).not.toBe(-1);
+		expect(one.source.indexOf('no-syntax-error.css')).not.toBe(-1);
 		// no-syntax-error.css linted
-		expect(results[0].warnings).toHaveLength(0);
+		expect(one.warnings).toHaveLength(0);
 
 		// syntax-error-ignored.scss found
-		expect(results[1].source.indexOf('syntax-error-ignored.scss')).not.toBe(-1);
+		expect(two.source.indexOf('syntax-error-ignored.scss')).not.toBe(-1);
 
 		// syntax-error-ignored.scss not linted
-		expect(results[1].warnings).toHaveLength(0);
+		expect(two.warnings).toHaveLength(0);
 
 		// syntax-error-ignored.scss marked as ignored
-		expect(results[1].ignored).toBeTruthy();
+		expect(two.ignored).toBeTruthy();
 	});
 });
 

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -138,83 +138,15 @@ it('standalone with postcss-html syntax', () => {
 });
 
 describe('standalone with syntax set by extension', () => {
-	let results;
-
-	// The first tests here establish the meaningfulness of the last test
-
-	describe('SASS', () => {
-		beforeEach(() => {
-			return standalone({
-				files: `${fixturesPath}/extension-sensitive.*`,
-				config: { rules: { 'color-no-invalid-hex': true } },
-			}).then((data) => (results = data.results));
-		});
-
-		it('parsed as SASS', () => {
-			const sassResult = results.find((r) => path.extname(r.source) === '.sass');
-
-			expect(sassResult._postcssResult.root.source.lang).toBe('sass');
-		});
-	});
-
-	describe('SCSS', () => {
-		beforeEach(() => {
-			return standalone({
-				files: `${fixturesPath}/extension-sensitive.*`,
-				config: { rules: { 'block-no-empty': true } },
-			}).then((data) => (results = data.results));
-		});
-
-		it('parsed as SCSS', () => {
-			const scssResult = results.find((r) => path.extname(r.source) === '.scss');
-
-			expect(scssResult._postcssResult.root.source.lang).toBe('scss');
-		});
-	});
-
-	describe('Less', () => {
-		beforeEach(() => {
-			return standalone({
-				files: `${fixturesPath}/extension-sensitive.*`,
-				config: { rules: { 'block-no-empty': true } },
-			}).then((data) => (results = data.results));
-		});
-
-		it('parsed as Less', () => {
-			const lessResult = results.find((r) => path.extname(r.source) === '.less');
-
-			expect(lessResult._postcssResult.root.source.lang).toBe('less');
-		});
-	});
-
-	describe('SugarSS', () => {
-		beforeEach(() => {
-			return standalone({
-				files: `${fixturesPath}/extension-sensitive.*`,
-				config: { rules: { 'block-no-empty': true } },
-			}).then((data) => (results = data.results));
-		});
-
-		it('parsed as SugarSS', () => {
-			const sssResult = results.find((r) => path.extname(r.source) === '.sss');
-
-			expect(sssResult._postcssResult.root.source.lang).toBe('sugarss');
-		});
-	});
-
-	describe('By extension', () => {
-		beforeEach(() => {
-			return standalone({
-				files: `${fixturesPath}/extension-sensitive.*`,
-				config: { rules: { 'color-no-invalid-hex': true } },
-			}).then((data) => (results = data.results));
-		});
-
-		it('correct number of files', () => {
+	it('By extension', () => {
+		return standalone({
+			files: `${fixturesPath}/extension-sensitive.*`,
+			config: { rules: { 'color-no-invalid-hex': true } },
+		}).then(({ results }) => {
+			// correct number of files
 			expect(results).toHaveLength(6);
-		});
 
-		it('parsed each according to its extension', () => {
+			// parsed each according to its extension
 			const sssResult = results.find((r) => path.extname(r.source) === '.sss');
 			const lessResult = results.find((r) => path.extname(r.source) === '.less');
 			const sassResult = results.find((r) => path.extname(r.source) === '.sass');
@@ -236,18 +168,15 @@ describe('standalone with syntax set by extension', () => {
 		});
 	});
 
-	describe('By extension with config processors to a empty array', () => {
-		beforeEach(() => {
-			return standalone({
-				files: `${fixturesPath}/extension-sensitive.*`,
-				config: {
-					rules: { 'color-no-invalid-hex': true },
-					processors: [],
-				},
-			}).then((data) => (results = data.results));
-		});
-
-		it('parsed each according to its extension', () => {
+	it('By extension with config processors to a empty array', () => {
+		return standalone({
+			files: `${fixturesPath}/extension-sensitive.*`,
+			config: {
+				rules: { 'color-no-invalid-hex': true },
+				processors: [],
+			},
+		}).then(({ results }) => {
+			// parsed each according to its extension
 			const sssResult = results.find((r) => path.extname(r.source) === '.sss');
 			const lessResult = results.find((r) => path.extname(r.source) === '.less');
 			const sassResult = results.find((r) => path.extname(r.source) === '.sass');

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -233,8 +233,8 @@ it('standalone with postcss-safe-parser', () => {
 				if (/\.(css|pcss|postcss)$/i.test(result.source)) {
 					const root = result._postcssResult.root;
 
-					expect(results[0].errored).toBeFalsy();
-					expect(results[0].warnings).toHaveLength(0);
+					expect(result.errored).toBeFalsy();
+					expect(result.warnings).toHaveLength(0);
 					expect(root.toString()).not.toBe(root.source.input.css);
 
 					return promisify(fs.writeFile)(root.source.input.file, root.source.input.css);


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/4303.

> Is there anything in the PR that needs further explanation?

I rewrote tests to be less complex. Following common sense and inspired by [Avoid Nesting when you're Testing](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).

And I fixed stability issues. They were pretty simple as it turned out. When we use glob for `files` we can't guarantee what order of files we get. Therefore results we get from stylelint could be in different order between two runs. That's why it was failing on Windows a lot. And luckily it was failing for me on macOS, so I could find the problem :)
