### PR TITLE
add :is to pseudo-class list. fixes #4236.

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -247,6 +247,7 @@ keywordSets.otherPseudoClasses = new Set([
 	'indeterminate',
 	'in-range',
 	'invalid',
+	'is',
 	'last-child',
 	'last-of-type',
 	'link',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -110,6 +110,11 @@ testRule(rule, {
 			description:
 				'represents any element that has been defined; includes any standard element built in to the browser, and custom elements that have been successfully defined (i.e. with the CustomElementRegistry.define() method).',
 		},
+		{
+			code: '*:is(*) { }',
+			description:
+				'takes a selector list as its argument, and selects any element that can be selected by one of the selectors in that list',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #4236 

> Is there anything in the PR that needs further explanation?

:is is still an experimental technology, but issue #4236 asked for a PR.

https://developer.mozilla.org/en-US/docs/Web/CSS/:is

