### PR TITLE
add double quotes to prettier glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
     "lint:md": "remark . --quiet --frail",
     "lint": "npm-run-all --parallel lint:*",
     "pretest": "npm-run-all --serial lint flow prettier:check",
-    "prettier:check": "prettier '**/*.js' --list-different",
-    "prettier:fix": "prettier '**/*.js' --write",
+    "prettier:check": "prettier \"**/*.js\" --list-different",
+    "prettier:fix": "prettier \"**/*.js\" --write",
     "release": "np",
     "test": "jest --coverage",
     "watch": "jest --watch"


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #4322

> Is there anything in the PR that needs further explanation?

I was trying to run tests (`npm test`) on Windows and it wouldn't finish. `npm run jest` worked, but did not include any prettier checks/fixes.

I tested this on WSL Bash (Ubuntu 19.04) and macOS 14.0 (also bash).
