### PR TITLE
fix(docs): remove hypen from flex regex

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -62,7 +62,7 @@ This rule complains when the following shorthand properties can be used:
 
 **Please note** that properties are considered to be redundant if they may be written shorthand according to the specification, **regardless of the behavior of any individual browser**. For example, due to Internet Explorer's implementation of Flexbox, [it may not be possible to use the shorthand property `flex`](https://github.com/philipwalton/flexbugs#flexbug-8), but the longhand form is still considered a violation.
 
-Flexbox-related properties can be ignored using `ignoreShorthands: ["/flex-/"]` (see below).
+Flexbox-related properties can be ignored using `ignoreShorthands: ["/flex/"]` (see below).
 
 ## Options
 


### PR DESCRIPTION
The docs say:

> Flexbox-related properties can be ignored using `ignoreShorthands: ["/flex-/"]` (see below).

That doesn't work, however `ignoreShorthands: ["/flex/"]` does. This removes the hyphen in the documentation.