### PR TITLE
Fix CSS syntax configuration when `--syntax css` is used

### DIFF
--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -9,6 +9,27 @@ const { promisify } = require('util');
 
 const fixturesPath = path.join(__dirname, 'fixtures');
 
+it('standalone with css syntax', () => {
+	const config = {
+		rules: {
+			'block-no-empty': true,
+		},
+	};
+
+	return standalone({
+		config,
+		code: 'a {}',
+		syntax: 'css',
+		formatter: stringFormatter,
+	}).then((linted) => {
+		const strippedOutput = stripAnsi(linted.output);
+
+		expect(typeof linted.output).toBe('string');
+		expect(strippedOutput).toContain('1:3');
+		expect(strippedOutput).toContain('block-no-empty');
+	});
+});
+
 it('standalone with scss syntax', () => {
 	const config = {
 		rules: {

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -58,9 +58,10 @@ module.exports = function(stylelint /*: stylelint$internalApi*/) /*: Promise<?Ob
 						stringify: postcss.stringify,
 					};
 				}
+			} else if (syntax === 'css') {
+				syntax = cssSyntax(stylelint);
 			} else if (syntax) {
 				const syntaxes = {
-					css: 'postcss-safe-parser',
 					'css-in-js': 'postcss-jsx',
 					html: 'postcss-html',
 					less: 'postcss-less',
@@ -88,10 +89,7 @@ module.exports = function(stylelint /*: stylelint$internalApi*/) /*: Promise<?Ob
 				}
 
 				syntax = autoSyntax({
-					css: {
-						parse: stylelint._options.fix ? dynamicRequire('postcss-safe-parser') : postcss.parse,
-						stringify: postcss.stringify,
-					},
+					css: cssSyntax(stylelint),
 				});
 			}
 
@@ -138,4 +136,11 @@ function readFile(filePath /*: string*/) /*: Promise<string>*/ {
 			resolve(content);
 		});
 	});
+}
+
+function cssSyntax(stylelint) {
+	return {
+		parse: stylelint._options.fix ? dynamicRequire('postcss-safe-parser') : postcss.parse,
+		stringify: postcss.stringify,
+	};
 }


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Fixing my mistakes https://github.com/stylelint/stylelint-demo/pull/177#issuecomment-540594505

> Is there anything in the PR that needs further explanation?

postcss-safe-parser is just a parser, so it needs a stringifier.
