### PR TITLE
Add workaround for failing Windows environment

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,7 +61,7 @@ jobs:
     # Workaround until https://github.com/stylelint/stylelint/issues/4337 is fixed
     - name: Change directory to uppercase drive letter
       if: matrix.os == 'windows-latest'
-      run: cd .. && cd D%cd:~1%
+      run: cd .. && cd D:\a\stylelint\stylelint
 
     - name: npm install, and test
       run: npm install && npm run jest -- --ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -59,11 +59,12 @@ jobs:
       run: npm install --global npm@latest
 
     # Workaround until https://github.com/stylelint/stylelint/issues/4337 is fixed
-    - name: Change directory to uppercase drive letter
+    - name: npm install, and test
       if: matrix.os == 'windows-latest'
-      run: cd .. && cd D:\a\stylelint\stylelint
+      run: cd .. && cd D:\a\stylelint\stylelint && npm install && npm run jest -- --ci
 
     - name: npm install, and test
+      if: matrix.os != 'windows-latest'
       run: npm install && npm run jest -- --ci
 
   coverage:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -59,11 +59,11 @@ jobs:
       run: npm install --global npm@latest
 
     # Workaround until https://github.com/stylelint/stylelint/issues/4337 is fixed
-    - name: npm install, and test
+    - name: npm install, and test (Windows)
       if: matrix.os == 'windows-latest'
       run: cd .. && cd D:\a\stylelint\stylelint && npm install && npm run jest -- --ci
 
-    - name: npm install, and test
+    - name: npm install, and test (Unix)
       if: matrix.os != 'windows-latest'
       run: npm install && npm run jest -- --ci
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,7 +61,7 @@ jobs:
     # Workaround until https://github.com/stylelint/stylelint/issues/4337 is fixed
     - name: Change directory to uppercase drive letter
       if: matrix.os == 'windows-latest'
-      run: cd .. && cd C%cd:~1%
+      run: cd .. && cd D%cd:~1%
 
     - name: npm install, and test
       run: npm install && npm run jest -- --ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,6 +58,11 @@ jobs:
     - name: Install latest npm
       run: npm install --global npm@latest
 
+    # Workaround until https://github.com/stylelint/stylelint/issues/4337 is fixed
+    - name: Change directory to uppercase drive letter
+      if: matrix.os == 'windows-latest'
+      run: cd .. && cd C%cd:~1%
+
     - name: npm install, and test
       run: npm install && npm run jest -- --ci
 

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -7,7 +7,7 @@ const stylelint = require('./lib/standalone');
 const util = require('util');
 
 jest.mock('./lib/utils/getOsEol', () => () => '\n');
-//
+
 global.testRule = (rule, schema) => {
 	expect.extend({
 		toHaveMessage(testCase) {

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -7,7 +7,7 @@ const stylelint = require('./lib/standalone');
 const util = require('util');
 
 jest.mock('./lib/utils/getOsEol', () => () => '\n');
-
+//
 global.testRule = (rule, schema) => {
 	expect.extend({
 		toHaveMessage(testCase) {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Temporary workaround for https://github.com/stylelint/stylelint/issues/4337.

> Is there anything in the PR that needs further explanation?

Used [this](https://github.com/Microsoft/vscode/issues/9448#issuecomment-245024153) idea. Because for Windows case in a path is not important.
