### PR TITLE
Fix markup issue for the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stylelint
 
-[![NPM version](https://img.shields.io/npm/v/stylelint.svg)](https://www.npmjs.org/package/stylelint) ![Build Status](https://github.com/stylelint/stylelint/workflows/CI/badge.svg) [![NPM Downloads](https://img.shields.io/npm/dm/stylelint.svg)](https://npmcharts.com/compare/stylelint?minimal=true) [![Backers on Open Collective](https://opencollective.com/stylelint/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/stylelint/sponsors/badge.svg)](#sponsors)
+[![NPM version](https://img.shields.io/npm/v/stylelint.svg)](https://www.npmjs.org/package/stylelint) [![Build Status](https://github.com/stylelint/stylelint/workflows/CI/badge.svg)](https://github.com/stylelint/stylelint/actions) [![NPM Downloads](https://img.shields.io/npm/dm/stylelint.svg)](https://npmcharts.com/compare/stylelint?minimal=true) [![Backers on Open Collective](https://opencollective.com/stylelint/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/stylelint/sponsors/badge.svg)](#sponsors)
 
 A mighty, modern linter that helps you avoid errors and enforce conventions in your styles.
 


### PR DESCRIPTION
This will fix following problem:

<img width="697" alt="Screenshot 2019-10-12 at 23 25 08" src="https://user-images.githubusercontent.com/654597/66707847-b2383600-ed47-11e9-8af5-67e50d702ad9.png">

It will be fix after we release new stylelint version, though. Because content is generated from stylelint package.