### PR TITLE
types: use default export from chalk

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,6 @@
 /* @flow */
 'use strict';
 
-const chalk = require('chalk');
 const checkInvalidCLIOptions = require('./utils/checkInvalidCLIOptions');
 const disableOptionsReportStringFormatter = require('./formatters/disableOptionsReportStringFormatter');
 const dynamicRequire = require('./dynamicRequire');
@@ -15,6 +14,8 @@ const printConfig = require('./printConfig');
 const resolveFrom = require('resolve-from');
 const standalone = require('./standalone');
 const writeOutputFile = require('./writeOutputFile');
+// $FlowFixMe default export exists, please see ~/node_modules/chalk/index.js
+const { default: chalk } = require('chalk');
 
 const EXIT_CODE_ERROR = 2;
 

--- a/lib/formatters/disableOptionsReportStringFormatter.js
+++ b/lib/formatters/disableOptionsReportStringFormatter.js
@@ -2,8 +2,9 @@
 
 'use strict';
 
-const chalk = require('chalk');
 const path = require('path');
+// $FlowFixMe default export exists, please see ~/node_modules/chalk/index.js
+const { default: chalk } = require('chalk');
 
 function logFrom(fromValue /*: string */) /*: string */ {
 	if (fromValue.charAt(0) === '<') return fromValue;

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const _ = require('lodash');
-const chalk = require('chalk');
 const path = require('path');
 const stringWidth = require('string-width');
 const symbols = require('log-symbols');
 const utils = require('postcss-reporter/lib/util');
+const { default: chalk } = require('chalk');
+
 let table;
 
 const MARGIN_WIDTHS = 9;

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
-const chalk = require('chalk');
 const stringFormatter = require('./stringFormatter');
+const { default: chalk } = require('chalk');
 
 module.exports = function(results) {
 	let output = stringFormatter(results);

--- a/lib/utils/__tests__/checkInvalidCLIOptions.test.js
+++ b/lib/utils/__tests__/checkInvalidCLIOptions.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const chalk = require('chalk');
 const checkInvalidCLIOptions = require('../checkInvalidCLIOptions');
 const EOL = require('os').EOL;
+const { default: chalk } = require('chalk');
 
 describe('checkInvalidCLIOptions', () => {
 	const allowedOptions = {

--- a/lib/utils/checkInvalidCLIOptions.js
+++ b/lib/utils/checkInvalidCLIOptions.js
@@ -2,9 +2,10 @@
 'use strict';
 
 const _ = require('lodash');
-const chalk = require('chalk');
 const EOL = require('os').EOL;
 const leven = require('leven');
+// $FlowFixMe default export exists, please see ~/node_modules/chalk/index.js
+const { default: chalk } = require('chalk');
 
 /*:: type allowedOptionsType = { [key: string]: { alias?: string } }*/
 


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

chalk types

> Is there anything in the PR that needs further explanation?
 
chalk flow types using `module.exports` instead of `default` exports, so I have used flowfixme in some places to prevent errors

> How to check that TS work correctly?

<img width="888" alt="Снимок экрана 2019-10-15 в 21 14 46" src="https://user-images.githubusercontent.com/10380560/66858163-64af0980-ef91-11e9-9db3-c23ccfacb0c6.png">

