### PR TITLE
types: add types to writeOutputFile.js

### DIFF
--- a/lib/vendor/writeFileAtomic.js
+++ b/lib/vendor/writeFileAtomic.js
@@ -1,3 +1,4 @@
+//@ts-nocheck
 // This is a fork of https://github.com/npm/write-file-atomic v2.3.0
 // with graceful-fs replaced with fs to avoid memory leak during testing
 // See: https://github.com/stylelint/stylelint/pull/2992

--- a/lib/writeOutputFile.js
+++ b/lib/writeOutputFile.js
@@ -2,10 +2,32 @@
 'use strict';
 
 const path = require('path');
-const stripAnsi = require('strip-ansi');
 const writeFileAtomic /*: Function*/ = require('./vendor/writeFileAtomic');
+const { default: stripAnsi } = require('strip-ansi');
 const { promisify } = require('util');
+
+/**
+ * @typedef {Object} WriteFileAtomicOptions
+ * @property {{uid: number, gid: number}} chown
+ * @property {string | null} [encoding='utf8']
+ * @property {boolean} [fsync=true]
+ * @property {number} [mode]
+ * @property {Function} [tmpfileCreated]
+ */
+
+/**
+ * @type {((
+ *  filename: string,
+ *  data: string | Buffer,
+ *  options?: string | WriteFileAtomicOptions
+ *  ) => Promise<Error | undefined>)}
+ */
 const writeFileAtomicAsync = promisify(writeFileAtomic);
 
+/**
+ * @param {string} content
+ * @param {string} filePath
+ * @returns {Promise<Error | undefined>}
+ */
 module.exports = (content /*: string*/, filePath /*: string*/) =>
 	writeFileAtomicAsync(path.normalize(filePath), stripAnsi(content));


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

add types to writeOutputFile.js

> Is there anything in the PR that needs further explanation?

Since `writeFileAtomic` is a fork, I decided to skip it from type checking and use it as blackbox and just define output interface

> How to check that TS works?

run `npm run lint:types | grep writeOutputFile`
run `npm run lint:types | grep writeFileAtomic`