### PR TITLE
Add rule block-opening-brace-empty-line-after

### DIFF
--- a/lib/rules/block-opening-brace-empty-line-after/README.md
+++ b/lib/rules/block-opening-brace-empty-line-after/README.md
@@ -1,0 +1,66 @@
+# block-opening-brace-empty-line-before
+
+Require or disallow an empty line after the opening brace of blocks.
+
+```css
+
+/** This line
+     ↓ */
+a /* ↓ */
+{ /* ↓ */
+  /* ← */
+  color: pink;
+}
+```
+
+The `--fix` option on the [command line](../../../docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+
+## Options
+
+`string`: `"always-multi-line"|"never"`
+
+### `always-multi-line`
+
+The following patterns are considered violations:
+
+```css
+a {
+  color: pink;
+}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+a {
+
+  color: pink;
+}
+```
+
+```css
+a { color: pink; }
+```
+
+### `never`
+
+The following patterns are considered violations:
+
+```css
+a {
+
+  color: pink;
+}
+```
+
+The following patterns are *not* considered violations:
+
+```css
+a {
+  color: pink;
+}
+```
+
+```css
+a { color: pink; }
+```

--- a/lib/rules/block-opening-brace-empty-line-after/__tests__/index.js
+++ b/lib/rules/block-opening-brace-empty-line-after/__tests__/index.js
@@ -1,0 +1,232 @@
+'use strict';
+
+const rule = require('..');
+const { messages, ruleName } = rule;
+
+testRule(rule, {
+	ruleName,
+	config: ['always-multi-line'],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { color: pink; }',
+		},
+		{
+			code: 'a {\n\ncolor: pink; }',
+		},
+		{
+			code: 'a {\r\n\r\ncolor: pink;}',
+		},
+		{
+			code: 'a {\n\ncolor: pink;\n}',
+		},
+		{
+			code: 'a {\r\n\r\ncolor: pink;\r\n}',
+		},
+		{
+			code: 'a {\n\ncolor: pink; }b {\n\ncolor: red;}',
+		},
+		{
+			code: 'a {\n\n\n\ncolor: pink;\n}',
+			description: 'one *or more* empty lines are allowed',
+		},
+		{
+			code: '@media print {\n\n  a {\n\n     color: pink;\n  }\n}',
+			description: 'indentation after the newline before the closing braces',
+		},
+		{
+			code:
+				'@media print {\n\n\ta {\n\n\t\tcolor: pink;\n\t\t&:hover{\n\n\t\t\tcolor: red;\n\t\t\t}\n\t\t}\n}',
+			description:
+				'3 level deep nesting with indentation after the newline before the closing braces',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a {\ncolor: pink; }',
+			fixed: 'a {\n\ncolor: pink; }',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\r\ncolor: pink; }',
+			fixed: 'a {\r\n\r\ncolor: pink; }',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\n color: pink;\n }',
+			fixed: 'a {\n\n color: pink;\n }',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\n\tcolor: pink; }',
+			fixed: 'a {\n\n\tcolor: pink; }',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\r\n  color: pink; }',
+			fixed: 'a {\r\n\r\n  color: pink; }',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\ncolor: pink;\n\n}',
+			fixed: 'a {\n\ncolor: pink;\n\n}',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\n/* comment here*/\n\ncolor: pink; }',
+			fixed: 'a {\n\n/* comment here*/\n\ncolor: pink; }',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\r\n/* comment here*/\r\n\r\ncolor: pink; }',
+			fixed: 'a {\r\n\r\n/* comment here*/\r\n\r\ncolor: pink; }',
+			message: messages.expected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: '@media print {\n  a {\n/* comment here*/\ncolor: pink; }\n}',
+			fixed: '@media print {\n\n  a {\n\n/* comment here*/\ncolor: pink; }\n}',
+			warnings: [
+				{
+					message: messages.expected,
+					line: 2,
+					column: 6,
+				},
+				{
+					message: messages.expected,
+					line: 1,
+					column: 15,
+				},
+			],
+		},
+	],
+});
+
+testRule(rule, {
+	ruleName,
+	config: ['never'],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { color: pink; }',
+		},
+		{
+			code: 'a {\ncolor: pink; }',
+		},
+		{
+			code: 'a {\r\ncolor: pink;}',
+		},
+		{
+			code: 'a {\ncolor: pink;\n}',
+		},
+		{
+			code: 'a {\r\ncolor: pink;\r\n}',
+		},
+		{
+			code: 'a {\ncolor: pink; }b {\ncolor: red; }',
+		},
+		{
+			code: '@media print {\n  a {\n     color: pink;\n  }\n}',
+			description: 'indentation after the newline before the closing braces',
+		},
+		{
+			code:
+				'@media print {\n\ta {\n\t\tcolor: pink;\n\t\t&:hover{\n\t\t\tcolor: red;\n\t\t\t}\n\t\t}\n}',
+			description:
+				'3 level deep nesting with indentation after the newline before the closing braces',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a {\n\ncolor: pink; }',
+			fixed: 'a {\ncolor: pink; }',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\r\n\r\ncolor: pink; }',
+			fixed: 'a {\r\ncolor: pink; }',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\n\n color: pink; }',
+			fixed: 'a {\n color: pink; }',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\n\n\tcolor: pink; }',
+			fixed: 'a {\n\tcolor: pink; }',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\r\n\r\n  color: pink; }',
+			fixed: 'a {\r\n  color: pink; }',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\n\ncolor: pink;\n}',
+			fixed: 'a {\ncolor: pink;\n}',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: 'a {\n\ncolor: pink;\n\n}',
+			fixed: 'a {\ncolor: pink;\n\n}',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+		{
+			code: '@media print {\n\n  a {\n\n     color: pink;\n  }\n}',
+			fixed: '@media print {\n  a {\n     color: pink;\n  }\n}',
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 3,
+					column: 6,
+				},
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 15,
+				},
+			],
+		},
+		{
+			code: 'a {\n\ncolor: pink;\n\n/* comment here */\n\n}',
+			fixed: 'a {\ncolor: pink;\n\n/* comment here */\n\n}',
+			message: messages.rejected,
+			line: 1,
+			column: 4,
+		},
+	],
+});

--- a/lib/rules/block-opening-brace-empty-line-after/index.js
+++ b/lib/rules/block-opening-brace-empty-line-after/index.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const addEmptyLineBefore = require('../../utils/addEmptyLineBefore');
+const blockString = require('../../utils/blockString');
+const hasBlock = require('../../utils/hasBlock');
+const hasEmptyBlock = require('../../utils/hasEmptyBlock');
+const hasEmptyLine = require('../../utils/hasEmptyLine');
+const isSingleLineString = require('../../utils/isSingleLineString');
+const removeEmptyLinesBefore = require('../../utils/removeEmptyLinesBefore');
+const report = require('../../utils/report');
+const ruleMessages = require('../../utils/ruleMessages');
+const validateOptions = require('../../utils/validateOptions');
+
+const ruleName = 'block-opening-brace-empty-line-after';
+
+const messages = ruleMessages(ruleName, {
+	expected: 'Expected empty line after opening brace',
+	rejected: 'Unexpected empty line after opening brace',
+});
+
+const rule = function(expectation, options, context) {
+	return (root, result) => {
+		const validOptions = validateOptions(result, ruleName, {
+			actual: expectation,
+			possible: ['always-multi-line', 'never'],
+		});
+
+		if (!validOptions) {
+			return;
+		}
+
+		// Check both kinds of statements: rules and at-rules
+		root.walkRules(check);
+		root.walkAtRules(check);
+
+		function check(statement) {
+			// Return early if blockless or has empty block
+			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
+				return;
+			}
+
+			// Get whitespace after "{"
+			const after = statement.nodes[0].raws.before || '';
+
+			// Set expectation
+			const expectEmptyLineAfter =
+				expectation === 'always-multi-line' && !isSingleLineString(blockString(statement));
+
+			// Check for at least one empty line
+			const hasEmptyLineAfter = hasEmptyLine(after);
+
+			// Return if the expectation is met
+			if (expectEmptyLineAfter === hasEmptyLineAfter) {
+				return;
+			}
+
+			// Calculate index
+			const statementString = statement.toString();
+			const index = statementString.indexOf('{') + 1;
+
+			if (context.fix) {
+				if (expectEmptyLineAfter) {
+					addEmptyLineBefore(statement.nodes[0], context.newline);
+				} else {
+					removeEmptyLinesBefore(statement.nodes[0], context.newline);
+				}
+
+				return;
+			}
+
+			const message = expectEmptyLineAfter ? messages.expected : messages.rejected;
+
+			report({
+				message,
+				result,
+				ruleName,
+				node: statement,
+				index,
+			});
+		}
+	};
+};
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+module.exports = rule;

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -18,6 +18,7 @@ module.exports = [
 	'block-closing-brace-space-after',
 	'block-closing-brace-space-before',
 	'block-no-empty',
+	'block-opening-brace-empty-line-after',
 	'block-opening-brace-newline-after',
 	'block-opening-brace-newline-before',
 	'block-opening-brace-space-after',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #4366

> Is there anything in the PR that needs further explanation?

This is symmetric rule to `block-closing-brace-empty-line-before`.

`block-closing-brace-empty-line-before` checks empty line before closing brace.
New rule `block-opening-brace-empty-line-after` checks empty line after opening brace.
