### PR TITLE
Update default Node.js in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
         os: [ubuntu-latest]
 
     steps:
@@ -51,7 +51,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: ubuntu-latest
-            node-version: 10
+            node-version: 12
 
     steps:
     - uses: actions/checkout@v1
@@ -83,7 +83,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [12]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
[Node.js 12 is LTS now.](https://nodejs.org/en/blog/release/v12.13.0/)