### PR TITLE
Config overrides function

### DIFF
--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -60,7 +60,9 @@ A partial stylelint configuration object whose properties will override the exis
 
 The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to *both* load a `.stylelintrc` file *and* override specific parts of it, `configOverrides` does just that.
 
-You may also provide a function for `configOverrides` that takes the loaded config object and either returns a new one and/or modifies the existing one in place:
+#### `configOverrides` as a function
+
+The `configOverrides` option can be passed as a function that takes the loaded config object and returns a new one and/or modifies the existing object in place:
 
 ```js
 const {pickBy} = require('lodash')

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -60,6 +60,19 @@ A partial stylelint configuration object whose properties will override the exis
 
 The difference between the `configOverrides` and `config` options is this: If any `config` object is passed, stylelint does not bother looking for a `.stylelintrc` file and instead just uses whatever `config` object you've passed; but if you want to *both* load a `.stylelintrc` file *and* override specific parts of it, `configOverrides` does just that.
 
+You may also provide a function for `configOverrides` that takes the loaded config object and either returns a new one and/or modifies the existing one in place:
+
+```js
+const {pickBy} = require('lodash')
+const rules = ['only/this-rule', 'and/that-rule']
+stylelint.lint({
+  files: "all/my/stylesheets/*.css",
+  configOverrides: config => {
+    config.rules = pickBy(config.rules, key => rules.includes(key))
+  }
+})
+```
+
 ### `files`
 
 A file glob, or array of file globs. Ultimately passed to [globby](https://github.com/sindresorhus/globby) to figure out what files you want to lint.

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -352,6 +352,45 @@ describe('configOverrides', () => {
 		});
 	});
 
+	it('Accepts a function that returns a new config', () => {
+		return standalone({
+			code: '.bar {}',
+			configBasedir: __dirname,
+			config: {
+				plugins: [],
+				rules: {
+					'plugin/warn-about-bar': 'always',
+				},
+			},
+			configOverrides: ({ rules }) => ({
+				plugins: ['./fixtures/plugin-warn-about-bar'],
+				rules,
+			}),
+		}).then((linted) => {
+			expect(linted.results[0].warnings).toHaveLength(1);
+			expect(linted.results[0].warnings[0].text).toBe('found .bar (plugin/warn-about-bar)');
+		});
+	});
+
+	it('Accepts a function that modifies the config (without returning it)', () => {
+		return standalone({
+			code: '.bar {}',
+			configBasedir: __dirname,
+			config: {
+				plugins: [],
+				rules: {
+					'plugin/warn-about-bar': 'always',
+				},
+			},
+			configOverrides: (config) => {
+				config.plugins.push('./fixtures/plugin-warn-about-bar');
+			},
+		}).then((linted) => {
+			expect(linted.results[0].warnings).toHaveLength(1);
+			expect(linted.results[0].warnings[0].text).toBe('found .bar (plugin/warn-about-bar)');
+		});
+	});
+
 	it('Setting `extends` inside `configOverrides` object should override the ones set in `config` object', () => {
 		return standalone({
 			code: '.bar {}',

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -33,21 +33,25 @@ function augmentConfigBasic(
 	configDir /*: string*/,
 	allowOverrides /*:: ?: boolean*/,
 ) /*: Promise<stylelint$config>*/ {
+	const configOverrides = stylelint._options.configOverrides;
+	const extendAndAbsolutize = (config) =>
+		Promise.resolve()
+			.then(() => extendConfig(stylelint, config, configDir))
+			.then((extended) => absolutizePaths(extended, configDir));
+
 	return Promise.resolve()
 		.then(() => {
 			if (!allowOverrides) return config;
 
-			const configOverrides = stylelint._options.configOverrides;
+			return configOverrides instanceof Object ? _.merge(config, configOverrides) : config;
+		})
+		.then(extendAndAbsolutize)
+		.then((augmentedConfig) => {
+			if (!allowOverrides) return augmentedConfig;
 
 			return typeof configOverrides === 'function'
-				? configOverrides(config) || config
-				: _.merge(config, stylelint._options.configOverrides);
-		})
-		.then((augmentedConfig) => {
-			return extendConfig(stylelint, augmentedConfig, configDir);
-		})
-		.then((augmentedConfig) => {
-			return absolutizePaths(augmentedConfig, configDir);
+				? extendAndAbsolutize(configOverrides(augmentedConfig) || augmentedConfig)
+				: augmentedConfig;
 		});
 }
 

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -37,7 +37,11 @@ function augmentConfigBasic(
 		.then(() => {
 			if (!allowOverrides) return config;
 
-			return _.merge(config, stylelint._options.configOverrides);
+			const configOverrides = stylelint._options.configOverrides;
+
+			return typeof configOverrides === 'function'
+				? configOverrides(config) || config
+				: _.merge(config, stylelint._options.configOverrides);
 		})
 		.then((augmentedConfig) => {
 			return extendConfig(stylelint, augmentedConfig, configDir);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,6 @@ const printConfig = require('./printConfig');
 const resolveFrom = require('resolve-from');
 const standalone = require('./standalone');
 const writeOutputFile = require('./writeOutputFile');
-const { pickBy } = require('lodash');
 // $FlowFixMe default export exists, please see ~/node_modules/chalk/index.js
 const { default: chalk } = require('chalk');
 
@@ -442,9 +441,13 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
 		const ruleNames = new Set(cli.flags.rules.split(','));
 
 		optionsBase.configOverrides = (config) => {
-			return Object.assign(config, overrides, {
-				rules: pickBy(config.rules, (ruleName) => ruleNames.has(ruleName)),
-			});
+			for (const ruleName of Object.keys(config.rules)) {
+				if (!ruleNames.has(ruleName)) {
+					delete config.rules[ruleName];
+				}
+			}
+
+			return Object.assign(config, overrides);
 		};
 	}
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,7 @@ const printConfig = require('./printConfig');
 const resolveFrom = require('resolve-from');
 const standalone = require('./standalone');
 const writeOutputFile = require('./writeOutputFile');
+const { pickBy } = require('lodash');
 // $FlowFixMe default export exists, please see ~/node_modules/chalk/index.js
 const { default: chalk } = require('chalk');
 
@@ -226,6 +227,11 @@ const meowOptions /*: meowOptionsType*/ = {
 
         Automatically fix violations of certain rules.
 
+      --rules, -r
+
+        Only apply the named rule(s) in the loaded configuration. Multiple rules
+        may be separated with commas, as in: --rules one,two,ns/three
+
       --custom-syntax
 
         Module name or path to a JS file exporting a PostCSS-compatible syntax.
@@ -381,6 +387,10 @@ const meowOptions /*: meowOptionsType*/ = {
 		'stdin-filename': {
 			type: 'string',
 		},
+		rules: {
+			alias: 'r',
+			type: 'string',
+		},
 		quiet: {
 			alias: 'q',
 			type: 'boolean',
@@ -425,6 +435,17 @@ module.exports = (argv /*: string[]*/) /*: Promise<void>|void*/ => {
 
 	if (cli.flags.quiet) {
 		optionsBase.configOverrides.quiet = cli.flags.quiet;
+	}
+
+	if (cli.flags.rules) {
+		const overrides = optionsBase.configOverrides;
+		const ruleNames = new Set(cli.flags.rules.split(','));
+
+		optionsBase.configOverrides = (config) => {
+			return Object.assign(config, overrides, {
+				rules: pickBy(config.rules, (ruleName) => ruleNames.has(ruleName)),
+			});
+		};
 	}
 
 	if (cli.flags.syntax) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -129,6 +129,7 @@ const EXIT_CODE_ERROR = 2;
     quiet: any,
     reportNeedlessDisables: boolean,
     reportInvalidScopeDisables: boolean,
+    rules: string,
     stdinFilename: any,
     syntax: any,
     v: string,


### PR DESCRIPTION
This implements the proposal in #4374. TL;DR: `configOverrides` can be a function that takes a fully resolved config and either modifies it in place and/or returns a new one:

```js
const anymatch = require('anymatch')
module.exports = {
  extends: ['some-other-config'],
  configOverrides: config => {
    // modify, add, or remove plugins config.rules and config.plugins
  }
}
```

### `--rules` CLI option
As a demonstration of how this works, I've also implemented a fix for #4331 with a new CLI flag: `--rules <comma-separated-list>` adds an config override that filters the configuration's `rules` object to include only the named rules in the list.

I haven't added docs for this yet, but I wanted to be sure that this change was welcome before doing so. I think it's super useful and would love not to have to maintain [stylelint-only](https://github.com/shawnbot/stylelint-only). 😁 

### File filters?
This _might_ pave the way for a solution to #3128, but I'm honestly not sure where in stylelint's configuration "lifecycle" the configuration is augmented, and it's entirely possible that this happens before the config is applied to individual files. If so, a follow-up would need to be necessary to either:

1. Apply `configOverrides()` for each file, and pass the file information to it; or
2. Use this function under the hood to implement one of the declarative file override patterns proposed in #3128.

Either way, this mechanism is only available in JS configs, and won't work in JSON or YAML.