### PR TITLE
Fix to ignore SCSS namespace

### DIFF
--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
@@ -75,6 +75,9 @@ testRule(rule, {
 			code: 'a { font: status-bar; }',
 		},
 		{
+			code: 'a { font: @font-family; }',
+		},
+		{
 			code: 'a { font: $font-family; }',
 		},
 		{

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
@@ -74,6 +74,12 @@ testRule(rule, {
 		{
 			code: 'a { font: status-bar; }',
 		},
+		{
+			code: 'a { font: $font-family; }',
+		},
+		{
+			code: 'a { font: namespace.$font-family; }',
+		},
 	],
 
 	reject: [

--- a/lib/utils/__tests__/isStandardSyntaxValue.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxValue.test.js
@@ -18,6 +18,9 @@ describe('isStandardSyntaxValue', () => {
 	it('scss var', () => {
 		expect(isStandardSyntaxValue('$sass-variable')).toBeFalsy();
 	});
+	it('scss namespace', () => {
+		expect(isStandardSyntaxValue('namespace.$sass-variable')).toBeFalsy();
+	});
 	it('negative scss var', () => {
 		expect(isStandardSyntaxValue('-$sass-variable')).toBeFalsy();
 	});

--- a/lib/utils/isStandardSyntaxValue.js
+++ b/lib/utils/isStandardSyntaxValue.js
@@ -14,8 +14,13 @@ module.exports = function(value /*: string*/) /*: boolean*/ {
 		normalizedValue = normalizedValue.slice(1);
 	}
 
-	// SCSS variable
+	// SCSS variable (example $color-primary)
 	if (normalizedValue[0] === '$') {
+		return false;
+	}
+
+	// SCSS namespace (example color.$primary)
+	if (/^.*\.\$/.test(value)) {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxValue.js
+++ b/lib/utils/isStandardSyntaxValue.js
@@ -14,12 +14,12 @@ module.exports = function(value /*: string*/) /*: boolean*/ {
 		normalizedValue = normalizedValue.slice(1);
 	}
 
-	// SCSS variable (example $color-primary)
+	// SCSS variable (example $variable)
 	if (normalizedValue[0] === '$') {
 		return false;
 	}
 
-	// SCSS namespace (example color.$primary)
+	// SCSS namespace (example namespace.$variable)
 	if (/^.*\.\$/.test(value)) {
 		return false;
 	}

--- a/lib/utils/isStandardSyntaxValue.js
+++ b/lib/utils/isStandardSyntaxValue.js
@@ -20,7 +20,7 @@ module.exports = function(value /*: string*/) /*: boolean*/ {
 	}
 
 	// SCSS namespace (example namespace.$variable)
-	if (/^.*\.\$/.test(value)) {
+	if (/^.+\.\$/.test(value)) {
 		return false;
 	}
 


### PR DESCRIPTION
Issue: Rules are not ignored when using SCSS namespace (https://github.com/stylelint/stylelint/issues/4378)

There is a rule to ignore SCSS variable in "lib/utils/isStandardSyntaxValue.js".
I added a rule there that also ignores the SCSS namespace.