### PR TITLE
Remove ignoring bower_components folder by default

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -172,7 +172,7 @@ Ignore `styleline-disable` comments.
 
 ### `--disable-default-ignores, --di`
 
-Allow linting of `node_modules` and `bower_components`.
+Allow linting of `node_modules`.
 
 ### `--cache`
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -290,7 +290,7 @@ If the globs are absolute paths, they are used as is. If they are relative, they
 -   the config's filepath, if the config is a file that stylelint found a loaded;
 -   or `process.cwd()`.
 
-By default, all `node_modules` and `bower_components` are ignored. Default values will be overridden if `ignoreFiles` is set.
+By default, all `node_modules` are ignored. Default values will be overridden if `ignoreFiles` is set.
 
 The `ignoreFiles` property is stripped from extended configs: only the root-level config can ignore files.
 

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -66,7 +66,7 @@ A file glob, or array of file globs. Ultimately passed to [globby](https://githu
 
 Relative globs are considered relative to `globbyOptions.cwd`.
 
-By default, all `node_modules` and `bower_components` are ignored.
+By default, all `node_modules` are ignored.
 
 ### `globbyOptions`
 
@@ -92,7 +92,7 @@ You can use this option to see what your linting results would be like without t
 
 ### `disableDefaultIgnores`
 
-If `true`, stylelint will not automatically ignore the contents of `node_modules` and `bower_components`. (By default, these directories are automatically ignored.)
+If `true`, stylelint will not automatically ignore the contents of `node_modules`. (By default, this directory are automatically ignored.)
 
 ### `cache`
 

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -323,8 +323,7 @@ test('disableDefaultIgnores allows paths in node_modules', () => {
 		},
 	}).then(({ results }) => {
 		// They are not ignored
-		expect(results).toHaveLength(2);
+		expect(results).toHaveLength(1);
 		expect(results[0].warnings).toHaveLength(1);
-		expect(results[1].warnings).toHaveLength(1);
 	});
 });

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -312,25 +312,9 @@ test('file in node_modules is ignored', () => {
 	});
 });
 
-test('file in bower_components is ignored', () => {
-	const files = [`${fixturesPath}/bower_components/test.css`];
-	const noFilesErrorMessage = new NoFilesFoundError(files);
-
+test('disableDefaultIgnores allows paths in node_modules', () => {
 	return standalone({
-		files,
-		config: {
-			rules: {
-				'block-no-empty': true,
-			},
-		},
-	}).catch((actualError) => {
-		expect(actualError).toEqual(noFilesErrorMessage);
-	});
-});
-
-test('disableDefaultIgnores allows paths in node_modules and bower_components', () => {
-	return standalone({
-		files: [`${fixturesPath}/bower_components/test.css`, `${fixturesPath}/node_modules/test.css`],
+		files: [`${fixturesPath}/node_modules/test.css`],
 		disableDefaultIgnores: true,
 		config: {
 			rules: {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -242,9 +242,8 @@ const meowOptions /*: meowOptionsType*/ = {
     Input: Files(s), glob(s), or nothing to use stdin.
 
       If an input argument is wrapped in quotation marks, it will be passed to
-      globby for cross-platform glob support. node_modules and
-      bower_components are always ignored. You can also pass no input and use
-      stdin, instead.
+	  globby for cross-platform glob support. node_modules are always ignored.
+	  You can also pass no input and use stdin, instead.
 
     Options:
 
@@ -306,7 +305,7 @@ const meowOptions /*: meowOptionsType*/ = {
 
       --disable-default-ignores, --di
 
-        Allow linting of node_modules and bower_components.
+        Allow linting of node_modules.
 
       --cache                       [default: false]
 

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -20,7 +20,7 @@ const pkg = require('../package.json');
 const { default: ignore } = require('ignore');
 const DEFAULT_IGNORE_FILENAME = '.stylelintignore';
 const FILE_NOT_FOUND_ERROR_CODE = 'ENOENT';
-const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**', '**/bower_components/**'];
+const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 const writeFileAtomic = require('write-file-atomic');
 
 /** @typedef {import('stylelint').StylelintStandaloneOptions} StylelintOptions */


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/4383
