### PR TITLE
Pass returnValue to formatter with needlessDisables + invalidScopeDisables

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -3,8 +3,8 @@
 A formatter is a function with the following signature:
 
 ```js
-formatter(results, returnValue) {
-  return 'a string of formatted results'
+function formatter(results, returnValue) {
+  return "a string of formatted results";
 }
 ```
 
@@ -44,31 +44,30 @@ And the second argument (`returnValue`) is an object with one or more of the fol
 
 ```js
 {
-  // true if there were any warnings with "error" severity
-  errored: false,
-
-  // set if stylelint was configured with {reportNeedlessDisables: true}
-  needlessDisables: [
+  errored: false, // `true` if there were any warnings with "error" severity
+  needlessDisables: [ // Present if stylelint was configured with `reportNeedlessDisables: true`
     {
-      source: "path/to/filename.css",
+      source: "path/to/file.css",
       ranges: [
-        {start: 10, unusedRule: 'indentation'}
+        {
+		      start: 10,
+          unusedRule: "indentation"
+        }
       ]
     }
   ],
-  
-  // set if stylelint was configured with {reportInvalidScopeDisables: true}
-  invalidScopeDisables: [
+  invalidScopeDisables: [ // Present if stylelint was configured with `reportInvalidScopeDisables: true`
     {
-      source: "path/to/filename.css",
+      source: "path/to/file.css",
       ranges: [
-        {start: 1, unusedRule: 'color-named'}
+        {
+          start: 1,
+          unusedRule: "color-named"
+        }
       ]
     }
   ],
-
-  // set if stylelint was configured with a maxWarnings count, e.g. {maxWarnings: 10}
-  maxWarningsExceeded: {
+  maxWarningsExceeded: { // Present if stylelint was configured with a `maxWarnings` count
     maxWarnings: 10,
     foundWarnings: 15
   }

--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -3,7 +3,9 @@
 A formatter is a function with the following signature:
 
 ```js
-formatter(results, returnValue)
+formatter(results, returnValue) {
+  return 'a string of formatted results'
+}
 ```
 
 Where the first argument (`results`) is an array of stylelint result objects in the form:

--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -1,6 +1,12 @@
 # Writing formatters
 
-A formatter is a function that accepts *an array of these stylelint result objects* and outputs a string:
+A formatter is a function with the following signature:
+
+```js
+formatter(results, returnValue)
+```
+
+Where the first argument (`results`) is an array of stylelint result objects in the form:
 
 ```js
 // A stylelint result object
@@ -29,6 +35,41 @@ A formatter is a function that accepts *an array of these stylelint result objec
     }
   ],
   ignored: false // This is `true` if the file's path matches a provided ignore pattern
+}
+```
+
+And the second argument (`returnValue`) is an object with one or more of the following keys:
+
+```js
+{
+  // true if there were any warnings with "error" severity
+  errored: false,
+
+  // set if stylelint was configured with {reportNeedlessDisables: true}
+  needlessDisables: [
+    {
+      source: "path/to/filename.css",
+      ranges: [
+        {start: 10, unusedRule: 'indentation'}
+      ]
+    }
+  ],
+  
+  // set if stylelint was configured with {reportInvalidScopeDisables: true}
+  invalidScopeDisables: [
+    {
+      source: "path/to/filename.css",
+      ranges: [
+        {start: 1, unusedRule: 'color-named'}
+      ]
+    }
+  ],
+
+  // set if stylelint was configured with a maxWarnings count, e.g. {maxWarnings: 10}
+  maxWarningsExceeded: {
+    maxWarnings: 10,
+    foundWarnings: 15
+  }
 }
 ```
 

--- a/lib/__tests__/standalone-formatter.test.js
+++ b/lib/__tests__/standalone-formatter.test.js
@@ -50,3 +50,53 @@ it('standalone with invalid formatter option', () => {
 		);
 	});
 });
+
+it('standalone formatter receives {needlessDisables} as second argument', () => {
+	const formatter = jest.fn((results, { needlessDisables }) => {
+		return JSON.stringify({ results, needlessDisables }, null, 2);
+	});
+
+	return standalone({
+		code: `
+			// stylelint-disable yo
+			a {}
+		`,
+		config: configBlockNoEmpty,
+		reportNeedlessDisables: true,
+		formatter,
+	}).then((linted) => {
+		const { output, results, needlessDisables } = linted;
+
+		expect(needlessDisables).not.toBeUndefined();
+		expect(needlessDisables).toHaveLength(1);
+
+		expect(typeof output).toBe('string');
+		expect(formatter).toHaveBeenCalledTimes(1);
+		expect(output).toBe(JSON.stringify({ results, needlessDisables }, null, 2));
+	});
+});
+
+it('standalone formatter receives {invalidScopeDisables} as second argument', () => {
+	const formatter = jest.fn((results, { invalidScopeDisables }) => {
+		return JSON.stringify({ results, invalidScopeDisables }, null, 2);
+	});
+
+	return standalone({
+		code: `
+			/* stylelint-disable indentation */
+			a { color: red; }
+		`,
+		config: configBlockNoEmpty,
+		reportInvalidScopeDisables: true,
+		formatter,
+	}).then((linted) => {
+		const { output, results, invalidScopeDisables } = linted;
+
+		expect(invalidScopeDisables).not.toBeUndefined();
+		expect(invalidScopeDisables).toHaveLength(1);
+
+		expect(typeof output).toBe('string');
+		expect(formatter).toHaveBeenCalledTimes(1);
+		expect(output).toBe(JSON.stringify({ results, invalidScopeDisables }, null, 2));
+	});
+});

--- a/lib/__tests__/standalone-formatter.test.js
+++ b/lib/__tests__/standalone-formatter.test.js
@@ -58,7 +58,7 @@ it('standalone formatter receives {needlessDisables} as second argument', () => 
 
 	return standalone({
 		code: `
-			// stylelint-disable yo
+			/* stylelint-disable yo */
 			a {}
 		`,
 		config: configBlockNoEmpty,

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -297,6 +297,8 @@ module.exports = function(
 		/** @type {StylelintStandaloneReturnValue} */
 		const returnValue /*: stylelint$standaloneReturnValue*/ = {
 			errored,
+			results: [],
+			output: '',
 		};
 
 		if (reportNeedlessDisables) {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -293,24 +293,34 @@ module.exports = function(
 		const errored = stylelintResults.some(
 			(result) => result.errored || result.parseErrors.length > 0,
 		);
+
 		/** @type {StylelintStandaloneReturnValue} */
 		const returnValue /*: stylelint$standaloneReturnValue*/ = {
 			errored,
-			output: formatterFunction(stylelintResults),
 			results: stylelintResults,
 		};
 
+		const formatterExtras = {};
+
 		if (reportNeedlessDisables) {
-			returnValue.needlessDisables = needlessDisables(stylelintResults);
+			const foundNeedlessDisables = needlessDisables(stylelintResults);
+
+			returnValue.needlessDisables = foundNeedlessDisables;
+			formatterExtras.needlessDisables = foundNeedlessDisables;
 		}
 
 		if (reportInvalidScopeDisables) {
-			returnValue.invalidScopeDisables = invalidScopeDisables(
+			const foundInvalidScopeDisables = invalidScopeDisables(
 				stylelintResults,
 				// TODO TYPES possible undefined
 				/** @type {import('stylelint').StylelintConfig} */ (stylelint._options.config),
 			);
+
+			returnValue.invalidScopeDisables = foundInvalidScopeDisables;
+			formatterExtras.invalidScopeDisables = foundInvalidScopeDisables;
 		}
+
+		returnValue.output = formatterFunction(stylelintResults, formatterExtras);
 
 		if (maxWarnings !== undefined) {
 			const foundWarnings = stylelintResults.reduce((count, file) => {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -297,30 +297,19 @@ module.exports = function(
 		/** @type {StylelintStandaloneReturnValue} */
 		const returnValue /*: stylelint$standaloneReturnValue*/ = {
 			errored,
-			results: stylelintResults,
 		};
 
-		const formatterExtras = {};
-
 		if (reportNeedlessDisables) {
-			const foundNeedlessDisables = needlessDisables(stylelintResults);
-
-			returnValue.needlessDisables = foundNeedlessDisables;
-			formatterExtras.needlessDisables = foundNeedlessDisables;
+			returnValue.needlessDisables = needlessDisables(stylelintResults);
 		}
 
 		if (reportInvalidScopeDisables) {
-			const foundInvalidScopeDisables = invalidScopeDisables(
+			returnValue.invalidScopeDisables = invalidScopeDisables(
 				stylelintResults,
 				// TODO TYPES possible undefined
 				/** @type {import('stylelint').StylelintConfig} */ (stylelint._options.config),
 			);
-
-			returnValue.invalidScopeDisables = foundInvalidScopeDisables;
-			formatterExtras.invalidScopeDisables = foundInvalidScopeDisables;
 		}
-
-		returnValue.output = formatterFunction(stylelintResults, formatterExtras);
 
 		if (maxWarnings !== undefined) {
 			const foundWarnings = stylelintResults.reduce((count, file) => {
@@ -331,6 +320,9 @@ module.exports = function(
 				returnValue.maxWarningsExceeded = { maxWarnings, foundWarnings };
 			}
 		}
+
+		returnValue.output = formatterFunction(stylelintResults, returnValue);
+		returnValue.results = stylelintResults;
 
 		debug(`Linting complete in ${Date.now() - startTime}ms`);
 


### PR DESCRIPTION
Fixes #4136. I've shuffled things around in the standalone `prepareReturnValue()` function so that the `output` is set last and the formatting function gets the `returnValue` object as its second argument, so that needless disables can be accessed like so in a custom formatter:

```js
module.exports = function customFormatter(results, returnValue) {
  const errors = formatErrors(results)
  if (returnValue.needlessDisables) {
    errors.push(...formatNeedlessDisables(returnValue.needlessDisables))
  }
  return errors.join('\n')
}
```

The `returnValue` object includes:
- the `errored` flag
- a `needlessDisables` array if configured with `reportNeedlessDisables: true`
- an `invalidScopeDisables` array if configured with `reportInvalidScopeDisables: true`
- a `maxWarningsExceeded` object if configured with `maxWarnings`