### PR TITLE
Add missing `css` to syntax list on Node API doc

### DIFF
--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -139,7 +139,7 @@ A path to a file containing patterns describing files to ignore. The path can be
 
 ### `syntax`
 
-Options: `"css-in-js"|"html"|"less"|"markdown"|"sass"|"scss"|"sugarss"`
+Options: `"css"|"css-in-js"|"html"|"less"|"markdown"|"sass"|"scss"|"sugarss"`
 
 Force a specific non-standard syntax that should be used to parse source stylesheets.
 


### PR DESCRIPTION
The `css` syntax has been added since [v11.1.0](https://github.com/stylelint/stylelint/blob/11.1.0/CHANGELOG.md#1110).

See also:

https://github.com/stylelint/stylelint/blob/334f615149fe7b35aaf8b884097bbaf7d92837ad/lib/getPostcssResult.js#L95

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
