### PR TITLE
Use `includes` instead of `indexOf`.

### DIFF
--- a/lib/__tests__/defaultSeverity.test.js
+++ b/lib/__tests__/defaultSeverity.test.js
@@ -14,7 +14,7 @@ it('`defaultSeverity` option set to warning', () => {
 		const warnings = result.warnings();
 
 		expect(warnings).toHaveLength(1);
-		expect(warnings[0].text.indexOf('block-no-empty')).not.toBe(-1);
+		expect(warnings[0].text).toContain('block-no-empty');
 		expect(warnings[0].severity).toBe('warning');
 	});
 });

--- a/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
+++ b/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
@@ -8,7 +8,7 @@ module.exports = stylelint.createPlugin(ruleName, function(expectation, options,
 	const colorHexCaseRule = stylelint.rules['color-hex-case'](expectation, options, context);
 
 	return (root, result) => {
-		if (root.toString().indexOf('@@check-color-hex-case') === -1) return;
+		if (!root.toString().includes('@@check-color-hex-case')) return;
 
 		colorHexCaseRule(root, result);
 	};

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -19,13 +19,13 @@ test('extending config and ignoreFiles glob ignoring single glob', () => {
 		expect(results).toHaveLength(2);
 
 		// empty-block.css found
-		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
+		expect(results[0].source).toContain('empty-block.css');
 
 		// empty-block.css linted
 		expect(results[0].warnings).toHaveLength(1);
 
 		// invalid-hex.css found
-		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
+		expect(results[1].source).toContain('invalid-hex.css');
 
 		// invalid-hex.css not linted
 		expect(results[1].warnings).toHaveLength(0);
@@ -54,13 +54,13 @@ test('same as above with no configBasedir, ignore-files path relative to process
 		expect(results).toHaveLength(2);
 
 		// empty-block.css found
-		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
+		expect(results[0].source).toContain('empty-block.css');
 
 		// empty-block.css linted
 		expect(results[0].warnings).toHaveLength(1);
 
 		// invalid-hex.css found
-		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
+		expect(results[1].source).toContain('invalid-hex.css');
 
 		// invalid-hex.css not linted
 		expect(results[1].warnings).toHaveLength(0);
@@ -116,7 +116,7 @@ test('extending config with ignoreFiles glob ignoring one by negation', () => {
 		expect(results).toHaveLength(2);
 
 		// empty-block.css found
-		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
+		expect(results[0].source).toContain('empty-block.css');
 
 		// empty-block.css has no warnings
 		expect(results[0].warnings).toHaveLength(0);
@@ -125,7 +125,7 @@ test('extending config with ignoreFiles glob ignoring one by negation', () => {
 		expect(results[0].ignored).toBeTruthy();
 
 		// invalid-hex.css found
-		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
+		expect(results[1].source).toContain('invalid-hex.css');
 
 		// invalid-hex.css has warnings
 		expect(results[1].warnings).toHaveLength(1);
@@ -221,12 +221,12 @@ test('using ignoreFiles with input files that would cause a postcss syntax error
 		const two = results.find((result) => result.source.includes('syntax-error-ignored.scss'));
 
 		// no-syntax-error.css found
-		expect(one.source.indexOf('no-syntax-error.css')).not.toBe(-1);
+		expect(one.source).toContain('no-syntax-error.css');
 		// no-syntax-error.css linted
 		expect(one.warnings).toHaveLength(0);
 
 		// syntax-error-ignored.scss found
-		expect(two.source.indexOf('syntax-error-ignored.scss')).not.toBe(-1);
+		expect(two.source).toContain('syntax-error-ignored.scss');
 
 		// syntax-error-ignored.scss not linted
 		expect(two.warnings).toHaveLength(0);
@@ -248,13 +248,13 @@ test('extending a config that ignores files', () => {
 		expect(results).toHaveLength(2);
 
 		// empty-block.css found
-		expect(results[0].source.indexOf('empty-block.css')).not.toBe(-1);
+		expect(results[0].source).toContain('empty-block.css');
 
 		// empty-block.css linted
 		expect(results[0].warnings).toHaveLength(1);
 
 		// invalid-hex.css found
-		expect(results[1].source.indexOf('invalid-hex.css')).not.toBe(-1);
+		expect(results[1].source).toContain('invalid-hex.css');
 
 		// invalid-hex.css not linted
 		expect(results[1].warnings).toHaveLength(0);

--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -11,7 +11,7 @@ it('`config` option is `null`', () => {
 			throw new Error('should not have succeeded');
 		})
 		.catch((err) => {
-			expect(err.message.indexOf('No configuration provided')).not.toBe(-1);
+			expect(err.message).toContain('No configuration provided');
 		});
 });
 
@@ -24,7 +24,7 @@ it('`configFile` option with absolute path', () => {
 		const warnings = postcssResult.warnings();
 
 		expect(warnings).toHaveLength(1);
-		expect(warnings[0].text.indexOf('block-no-empty')).not.toBe(-1);
+		expect(warnings[0].text).toContain('block-no-empty');
 	});
 });
 

--- a/lib/__tests__/standalone-deprecations.test.js
+++ b/lib/__tests__/standalone-deprecations.test.js
@@ -20,7 +20,7 @@ describe('standalone with deprecations', () => {
 			code: 'a {}',
 			config: configBlockNoEmpty,
 		}).then((data) => {
-			expect(data.output.indexOf('Some deprecation')).not.toBe(-1);
+			expect(data.output).toContain('Some deprecation');
 			expect(data.results).toHaveLength(1);
 			expect(data.results[0].deprecations).toHaveLength(1);
 			expect(data.results[0].deprecations[0].text).toBe('Some deprecation');

--- a/lib/__tests__/standalone-formatter.test.js
+++ b/lib/__tests__/standalone-formatter.test.js
@@ -16,8 +16,8 @@ it('standalone with input css and alternate formatter specified by keyword', () 
 		const strippedOutput = stripAnsi(output);
 
 		expect(typeof output).toBe('string');
-		expect(strippedOutput.indexOf('1:3')).not.toBe(-1);
-		expect(strippedOutput.indexOf('block-no-empty')).not.toBe(-1);
+		expect(strippedOutput).toContain('1:3');
+		expect(strippedOutput).toContain('block-no-empty');
 	});
 });
 
@@ -32,8 +32,8 @@ it('standalone with input css and alternate formatter function', () => {
 		const strippedOutput = stripAnsi(output);
 
 		expect(typeof output).toBe('string');
-		expect(strippedOutput.indexOf('1:3')).not.toBe(-1);
-		expect(strippedOutput.indexOf('block-no-empty')).not.toBe(-1);
+		expect(strippedOutput).toContain('1:3');
+		expect(strippedOutput).toContain('block-no-empty');
 	});
 });
 

--- a/lib/__tests__/standalone-parseErrors.test.js
+++ b/lib/__tests__/standalone-parseErrors.test.js
@@ -21,7 +21,7 @@ test('standalone with deprecations', async () => {
 		config: configBlockNoEmpty,
 	});
 
-	expect(data.output.indexOf('Some parseError')).not.toBe(-1);
+	expect(data.output).toContain('Some parseError');
 	expect(data.results).toHaveLength(1);
 	expect(data.results[0].parseErrors).toHaveLength(1);
 	expect(data.results[0].parseErrors[0].text).toBe('Some parseError');

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -46,8 +46,8 @@ it('standalone with scss syntax', () => {
 		const strippedOutput = stripAnsi(linted.output);
 
 		expect(typeof linted.output).toBe('string');
-		expect(strippedOutput.indexOf('2:3')).not.toBe(-1);
-		expect(strippedOutput.indexOf('block-no-empty')).not.toBe(-1);
+		expect(strippedOutput).toContain('2:3');
+		expect(strippedOutput).toContain('block-no-empty');
 	});
 });
 
@@ -67,8 +67,8 @@ it('standalone with sugarss syntax', () => {
 		const strippedOutput = stripAnsi(linted.output);
 
 		expect(typeof linted.output).toBe('string');
-		expect(strippedOutput.indexOf('3:9')).not.toBe(-1);
-		expect(strippedOutput.indexOf('length-zero-no-unit')).not.toBe(-1);
+		expect(strippedOutput).toContain('3:9');
+		expect(strippedOutput).toContain('length-zero-no-unit');
 	});
 });
 
@@ -88,8 +88,8 @@ it('standalone with Less syntax', () => {
 		const strippedOutput = stripAnsi(linted.output);
 
 		expect(typeof linted.output).toBe('string');
-		expect(strippedOutput.indexOf('2:3')).not.toBe(-1);
-		expect(strippedOutput.indexOf('block-no-empty')).not.toBe(-1);
+		expect(strippedOutput).toContain('2:3');
+		expect(strippedOutput).toContain('block-no-empty');
 	});
 });
 

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -56,7 +56,7 @@ describe('standalone with two file-specific globs', () => {
 		expect(results[1].warnings).toHaveLength(1);
 
 		// Ordering of the files is non-deterministic, I believe
-		if (results[0].source.indexOf('empty-block') !== -1) {
+		if (results[0].source.includes('empty-block')) {
 			expect(results[0].warnings[0].rule).toBe('block-no-empty');
 			expect(results[1].warnings[0].rule).toBe('color-no-invalid-hex');
 		} else {
@@ -270,31 +270,31 @@ describe('standalone with different configs per file', () => {
 	});
 
 	it('no warnings for A', () => {
-		const resultA = results.find((result) => result.source.indexOf('a.css') !== -1);
+		const resultA = results.find((result) => result.source.includes('a.css'));
 
 		expect(resultA.warnings).toHaveLength(0);
 	});
 
 	it('one warning for B', () => {
-		const resultB = results.find((result) => result.source.indexOf('b.css') !== -1);
+		const resultB = results.find((result) => result.source.includes('b.css'));
 
 		expect(resultB.warnings).toHaveLength(1);
 	});
 
 	it('correct warning for B', () => {
-		const resultB = results.find((result) => result.source.indexOf('b.css') !== -1);
+		const resultB = results.find((result) => result.source.includes('b.css'));
 
 		expect(resultB.warnings[0].text.indexOf('Unexpected empty block')).not.toBe(-1);
 	});
 
 	it('no warnings for C', () => {
-		const resultC = results.find((result) => result.source.indexOf('c.css') !== -1);
+		const resultC = results.find((result) => result.source.includes('c.css'));
 
 		expect(resultC.warnings).toHaveLength(0);
 	});
 
 	it('no warnings for D', () => {
-		const resultD = results.find((result) => result.source.indexOf('d.css') !== -1);
+		const resultD = results.find((result) => result.source.includes('d.css'));
 
 		expect(resultD.warnings).toHaveLength(0);
 	});

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -23,7 +23,7 @@ describe('standalone with one input file', () => {
 	});
 
 	it('triggers warning', () => {
-		expect(output.indexOf('block-no-empty')).not.toBe(-1);
+		expect(output).toContain('block-no-empty');
 		expect(results).toHaveLength(1);
 		expect(results[0].warnings).toHaveLength(1);
 		expect(results[0].warnings[0].rule).toBe('block-no-empty');
@@ -49,8 +49,8 @@ describe('standalone with two file-specific globs', () => {
 	});
 
 	it('triggers warnings', () => {
-		expect(output.indexOf('block-no-empty')).not.toBe(-1);
-		expect(output.indexOf('color-no-invalid-hex')).not.toBe(-1);
+		expect(output).toContain('block-no-empty');
+		expect(output).toContain('color-no-invalid-hex');
 		expect(results).toHaveLength(2);
 		expect(results[0].warnings).toHaveLength(1);
 		expect(results[1].warnings).toHaveLength(1);
@@ -83,7 +83,7 @@ describe('standalone with files and globbyOptions', () => {
 	});
 
 	it('triggers warning', () => {
-		expect(output.indexOf('block-no-empty')).not.toBe(-1);
+		expect(output).toContain('block-no-empty');
 		expect(results).toHaveLength(1);
 		expect(results[0].warnings).toHaveLength(1);
 		expect(results[0].warnings[0].rule).toBe('block-no-empty');
@@ -175,7 +175,7 @@ describe('standalone passing code with syntax error', () => {
 	});
 
 	it('(CssSyntaxError) in warning text', () => {
-		expect(results[0].warnings[0].text.indexOf(' (CssSyntaxError)')).not.toBe(-1);
+		expect(results[0].warnings[0].text).toContain(' (CssSyntaxError)');
 	});
 });
 
@@ -185,7 +185,7 @@ it('standalone passing file with syntax error', () => {
 		codeFilename: path.join(__dirname, 'syntax-error.css'),
 		config: { rules: { 'block-no-empty': true } },
 	}).then((linted) => {
-		expect(linted.results[0].source.indexOf('syntax-error.css')).not.toBe(-1);
+		expect(linted.results[0].source).toContain('syntax-error.css');
 	});
 });
 
@@ -284,7 +284,7 @@ describe('standalone with different configs per file', () => {
 	it('correct warning for B', () => {
 		const resultB = results.find((result) => result.source.includes('b.css'));
 
-		expect(resultB.warnings[0].text.indexOf('Unexpected empty block')).not.toBe(-1);
+		expect(resultB.warnings[0].text).toContain('Unexpected empty block');
 	});
 
 	it('no warnings for C', () => {

--- a/lib/rules/at-rule-blacklist/index.js
+++ b/lib/rules/at-rule-blacklist/index.js
@@ -34,7 +34,7 @@ const rule = function(blacklistInput) {
 				return;
 			}
 
-			if (blacklist.indexOf(postcss.vendor.unprefixed(name).toLowerCase()) === -1) {
+			if (!blacklist.includes(postcss.vendor.unprefixed(name).toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/at-rule-whitelist/index.js
+++ b/lib/rules/at-rule-whitelist/index.js
@@ -34,7 +34,7 @@ const rule = function(whitelistInput) {
 				return;
 			}
 
-			if (whitelist.indexOf(postcss.vendor.unprefixed(name).toLowerCase()) !== -1) {
+			if (whitelist.includes(postcss.vendor.unprefixed(name).toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -70,7 +70,7 @@ const rule = function(expectation, options, context) {
 				if (
 					optionsMatches(options, 'except', 'after-closing-brace') &&
 					statement.type === 'atrule' &&
-					childNodeTypes.indexOf('decl') === -1
+					!childNodeTypes.includes('decl')
 				) {
 					return expectation === 'never' ? true : false;
 				}

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -73,7 +73,7 @@ const rule = function(expectation, options, context) {
 			const nextNodeIsSingleLineComment =
 				nextNode.type === 'comment' &&
 				!/[^ ]/.test(nextNode.raws.before || '') &&
-				nextNode.toString().indexOf('\n') === -1;
+				!nextNode.toString().includes('\n');
 
 			const nodeToCheck = nextNodeIsSingleLineComment ? nextNode.next() : nextNode;
 

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -88,7 +88,7 @@ const rule = function(expectation, options) {
 				}
 
 				// Return early if neither a word nor a function
-				if (NODE_TYPES.indexOf(type) === -1) {
+				if (!NODE_TYPES.includes(type)) {
 					return;
 				}
 
@@ -96,7 +96,7 @@ const rule = function(expectation, options) {
 				if (
 					expectation === 'never' &&
 					type === 'word' &&
-					namedColors.indexOf(value.toLowerCase()) !== -1
+					namedColors.includes(value.toLowerCase())
 				) {
 					complain(messages.rejected(value), decl, declarationValueIndex(decl) + sourceIndex);
 
@@ -117,9 +117,7 @@ const rule = function(expectation, options) {
 					for (let i = 0, l = namedColors.length; i < l; i++) {
 						namedColor = namedColors[i];
 
-						if (
-							namedColorData[namedColor].func.indexOf(normalizedFunctionString.toLowerCase()) !== -1
-						) {
+						if (namedColorData[namedColor].func.includes(normalizedFunctionString.toLowerCase())) {
 							complain(
 								messages.expected(namedColor, normalizedFunctionString),
 								decl,
@@ -139,7 +137,7 @@ const rule = function(expectation, options) {
 				for (let i = 0, l = namedColors.length; i < l; i++) {
 					namedColor = namedColors[i];
 
-					if (namedColorData[namedColor].hex.indexOf(value.toLowerCase()) !== -1) {
+					if (namedColorData[namedColor].hex.includes(value.toLowerCase())) {
 						complain(
 							messages.expected(namedColor, value),
 							decl,

--- a/lib/rules/declaration-property-unit-blacklist/index.js
+++ b/lib/rules/declaration-property-unit-blacklist/index.js
@@ -53,7 +53,7 @@ const rule = function(blacklist) {
 
 				const unit = getUnitFromValueNode(node);
 
-				if (!unit || (unit && propBlacklist.indexOf(unit.toLowerCase()) === -1)) {
+				if (!unit || (unit && !propBlacklist.includes(unit.toLowerCase()))) {
 					return;
 				}
 

--- a/lib/rules/declarationBangSpaceChecker.js
+++ b/lib/rules/declarationBangSpaceChecker.js
@@ -10,7 +10,7 @@ module.exports = function(opts) {
 		const declString = decl.toString();
 		const valueString = decl.toString().slice(indexOffset);
 
-		if (valueString.indexOf('!') === -1) {
+		if (!valueString.includes('!')) {
 			return;
 		}
 

--- a/lib/rules/function-calc-no-invalid/index.js
+++ b/lib/rules/function-calc-no-invalid/index.js
@@ -35,7 +35,7 @@ const rule = function(actual) {
 					return;
 				}
 
-				if (checked.indexOf(node) >= 0) {
+				if (checked.includes(node)) {
 					return;
 				}
 

--- a/lib/rules/function-max-empty-lines/index.js
+++ b/lib/rules/function-max-empty-lines/index.js
@@ -35,7 +35,7 @@ const rule = function(max, options, context) {
 		const allowedCRLFNewLinesString = context.fix ? '\r\n'.repeat(maxAdjacentNewlines) : '';
 
 		root.walkDecls((decl) => {
-			if (decl.value.indexOf('(') === -1) {
+			if (!decl.value.includes('(')) {
 				return;
 			}
 

--- a/lib/rules/function-parentheses-newline-inside/index.js
+++ b/lib/rules/function-parentheses-newline-inside/index.js
@@ -32,7 +32,7 @@ const rule = function(expectation, options, context) {
 		}
 
 		root.walkDecls((decl) => {
-			if (decl.value.indexOf('(') === -1) {
+			if (!decl.value.includes('(')) {
 				return;
 			}
 
@@ -53,7 +53,7 @@ const rule = function(expectation, options, context) {
 				const isMultiLine = !isSingleLineString(functionString);
 
 				function containsNewline(str) {
-					return str.indexOf('\n') !== -1;
+					return str.includes('\n');
 				}
 
 				// Check opening ...

--- a/lib/rules/function-parentheses-space-inside/index.js
+++ b/lib/rules/function-parentheses-space-inside/index.js
@@ -34,7 +34,7 @@ const rule = function(expectation, options, context) {
 		}
 
 		root.walkDecls((decl) => {
-			if (decl.value.indexOf('(') === -1) {
+			if (!decl.value.includes('(')) {
 				return;
 			}
 

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -108,7 +108,7 @@ const rule = function(space, options, context) {
 			if (
 				hasBlock(node) &&
 				after &&
-				after.indexOf('\n') !== -1 &&
+				after.includes('\n') &&
 				after.slice(after.lastIndexOf('\n') + 1) !== expectedClosingBraceIndentation
 			) {
 				if (context.fix) {
@@ -169,7 +169,7 @@ const rule = function(space, options, context) {
 		}
 
 		function checkValue(decl, declLevel) {
-			if (decl.value.indexOf('\n') === -1) {
+			if (!decl.value.includes('\n')) {
 				return;
 			}
 
@@ -212,7 +212,7 @@ const rule = function(space, options, context) {
 		}
 
 		function checkMultilineBit(source, newlineIndentLevel, node) {
-			if (source.indexOf('\n') === -1) {
+			if (!source.includes('\n')) {
 				return;
 			}
 

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -106,7 +106,7 @@ const rule = function(actual, secondary, context) {
 				}
 
 				const prevValueBreakIndex = _.findLastIndex(value.substr(0, index), (char) => {
-					return [' ', ',', ')', '(', '#', ':', '\n', '\t'].indexOf(char) !== -1;
+					return [' ', ',', ')', '(', '#', ':', '\n', '\t'].includes(char);
 				});
 
 				// Ignore hex colors
@@ -118,7 +118,7 @@ const rule = function(actual, secondary, context) {
 				const valueWithZeroStart = prevValueBreakIndex === -1 ? 0 : prevValueBreakIndex + 1;
 
 				const nextValueBreakIndex = _.findIndex(value.substr(valueWithZeroStart), (char) => {
-					return [' ', ',', ')', '/'].indexOf(char) !== -1;
+					return [' ', ',', ')', '/'].includes(char);
 				});
 
 				// If no next break was found, this value ends at the end of the string

--- a/lib/rules/linebreaks/index.js
+++ b/lib/rules/linebreaks/index.js
@@ -43,7 +43,7 @@ const rule = function(actual, secondary, context) {
 			for (let i = 0; i < lines.length; i++) {
 				let line = lines[i];
 
-				if (i < lines.length - 1 && line.indexOf('\r') === -1) {
+				if (i < lines.length - 1 && !line.includes('\r')) {
 					line += '\n';
 				}
 

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -173,7 +173,7 @@ const rule = function(maxLength, options, context) {
 			// If there are no spaces besides initial (indent) spaces, ignore it
 			const lineString = rootString.slice(match.endIndex, nextNewlineIndex);
 
-			if (lineString.replace(/^\s+/, '').indexOf(' ') === -1) {
+			if (!lineString.replace(/^\s+/, '').includes(' ')) {
 				return;
 			}
 

--- a/lib/rules/media-feature-name-value-whitelist/index.js
+++ b/lib/rules/media-feature-name-value-whitelist/index.js
@@ -29,7 +29,7 @@ const rule = function(whitelist) {
 		root.walkAtRules(/^media$/i, (atRule) => {
 			mediaParser(atRule.params).walk(/^media-feature-expression$/i, (node) => {
 				// Ignore boolean and range context
-				if (node.value.indexOf(':') === -1) {
+				if (!node.value.includes(':')) {
 					return;
 				}
 

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -40,7 +40,7 @@ const rule = function(actual) {
 				.filter((n) => n.length);
 
 			const isDuplicate = media.length
-				? imports[uri] && media.some((q) => imports[uri].indexOf(q) !== -1)
+				? imports[uri] && media.some((q) => imports[uri].includes(q))
 				: imports[uri];
 
 			if (isDuplicate) {

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -40,7 +40,7 @@ const rule = function(expectation, secondary, context) {
 			const alwaysFixPositions = [];
 
 			// Get out quickly if there are no periods
-			if (value.indexOf('.') === -1) {
+			if (!value.includes('.')) {
 				return;
 			}
 

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -51,7 +51,7 @@ const rule = function(precision, options) {
 
 		function check(node, value, getIndex) {
 			// Get out quickly if there are no periods
-			if (value.indexOf('.') === -1) {
+			if (!value.includes('.')) {
 				return;
 			}
 

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -35,7 +35,7 @@ const rule = function(actual, secondary, context) {
 			const fixPositions = [];
 
 			// Get out quickly if there are no periods
-			if (value.indexOf('.') === -1) {
+			if (!value.includes('.')) {
 				return;
 			}
 

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -82,11 +82,11 @@ const rule = function(expectation, options, context) {
 			}
 
 			// Ignore if the expectation is for multiple and the rule is single-line
-			if (expectation.indexOf('multi-line') !== -1 && isSingleLineString(rule.toString())) {
+			if (expectation.includes('multi-line') && isSingleLineString(rule.toString())) {
 				return;
 			}
 
-			let expectEmptyLineBefore = expectation.indexOf('always') !== -1 ? true : false;
+			let expectEmptyLineBefore = expectation.includes('always') ? true : false;
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (

--- a/lib/rules/selector-attribute-brackets-space-inside/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.js
@@ -33,7 +33,7 @@ const rule = function(expectation, options, context) {
 				return;
 			}
 
-			if (rule.selector.indexOf('[') === -1) {
+			if (!rule.selector.includes('[')) {
 				return;
 			}
 

--- a/lib/rules/selector-attribute-operator-blacklist/index.js
+++ b/lib/rules/selector-attribute-operator-blacklist/index.js
@@ -31,7 +31,7 @@ const rule = function(blacklistInput) {
 				return;
 			}
 
-			if (rule.selector.indexOf('[') === -1 || rule.selector.indexOf('=') === -1) {
+			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
 				return;
 			}
 
@@ -39,7 +39,7 @@ const rule = function(blacklistInput) {
 				selectorTree.walkAttributes((attributeNode) => {
 					const operator = attributeNode.operator;
 
-					if (!operator || (operator && blacklist.indexOf(operator) === -1)) {
+					if (!operator || (operator && !blacklist.includes(operator))) {
 						return;
 					}
 

--- a/lib/rules/selector-attribute-operator-whitelist/index.js
+++ b/lib/rules/selector-attribute-operator-whitelist/index.js
@@ -31,7 +31,7 @@ const rule = function(whitelistInput) {
 				return;
 			}
 
-			if (rule.selector.indexOf('[') === -1 || rule.selector.indexOf('=') === -1) {
+			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
 				return;
 			}
 
@@ -39,7 +39,7 @@ const rule = function(whitelistInput) {
 				selectorTree.walkAttributes((attributeNode) => {
 					const operator = attributeNode.operator;
 
-					if (!operator || (operator && whitelist.indexOf(operator) !== -1)) {
+					if (!operator || (operator && whitelist.includes(operator))) {
 						return;
 					}
 

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -34,7 +34,7 @@ const rule = function(expectation) {
 				return;
 			}
 
-			if (rule.selector.indexOf('[') === -1 || rule.selector.indexOf('=') === -1) {
+			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
 				return;
 			}
 

--- a/lib/rules/selector-combinator-blacklist/index.js
+++ b/lib/rules/selector-combinator-blacklist/index.js
@@ -40,7 +40,7 @@ const rule = function(blacklist) {
 
 					const value = normalizeCombinator(combinatorNode.value);
 
-					if (blacklist.indexOf(value) === -1) {
+					if (!blacklist.includes(value)) {
 						return;
 					}
 

--- a/lib/rules/selector-combinator-whitelist/index.js
+++ b/lib/rules/selector-combinator-whitelist/index.js
@@ -40,7 +40,7 @@ const rule = function(whitelist) {
 
 					const value = normalizeCombinator(combinatorNode.value);
 
-					if (whitelist.indexOf(value) !== -1) {
+					if (whitelist.includes(value)) {
 						return;
 					}
 

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -57,9 +57,9 @@ const rule = function(expectation, options, context) {
 						let beforeSelector = selector.slice(0, index);
 						const afterSelector = selector.slice(index);
 
-						if (expectation.indexOf('always') >= 0) {
+						if (expectation.includes('always')) {
 							beforeSelector = beforeSelector.replace(/\s*$/, ' ');
-						} else if (expectation.indexOf('never') >= 0) {
+						} else if (expectation.includes('never')) {
 							beforeSelector = beforeSelector.replace(/\s*$/, '');
 						}
 

--- a/lib/rules/selector-max-pseudo-class/index.js
+++ b/lib/rules/selector-max-pseudo-class/index.js
@@ -42,7 +42,7 @@ function rule(max) {
 				// Exclude pseudo elements from the count
 				if (
 					childNode.type === 'pseudo' &&
-					(childNode.value.indexOf('::') !== -1 ||
+					(childNode.value.includes('::') ||
 						keywordSets.levelOneAndTwoPseudoElements.has(childNode.value.toLowerCase().slice(1)))
 				) {
 					return total;

--- a/lib/rules/selector-no-qualifying-type/index.js
+++ b/lib/rules/selector-no-qualifying-type/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 const selectorCharacters = ['#', '.', '['];
 
 function isSelectorCharacters(value) {
-	return selectorCharacters.some((char) => value.indexOf(char) !== -1);
+	return selectorCharacters.some((char) => value.includes(char));
 }
 
 function getRightNodes(node) {

--- a/lib/rules/selector-pseudo-class-blacklist/index.js
+++ b/lib/rules/selector-pseudo-class-blacklist/index.js
@@ -38,7 +38,7 @@ const rule = function(blacklist) {
 				return;
 			}
 
-			if (selector.indexOf(':') === -1) {
+			if (!selector.includes(':')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-class-case/index.js
+++ b/lib/rules/selector-pseudo-class-case/index.js
@@ -50,7 +50,7 @@ const rule = function(expectation, options, context) {
 						}
 
 						if (
-							pseudo.indexOf('::') !== -1 ||
+							pseudo.includes('::') ||
 							keywordSets.levelOneAndTwoPseudoElements.has(pseudo.toLowerCase().slice(1))
 						) {
 							return;

--- a/lib/rules/selector-pseudo-class-case/index.js
+++ b/lib/rules/selector-pseudo-class-case/index.js
@@ -31,9 +31,8 @@ const rule = function(expectation, options, context) {
 			}
 
 			const selector = rule.selector;
-			const startIndexPseudo = selector.indexOf(':');
 
-			if (startIndexPseudo === -1) {
+			if (!selector.includes(':')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -141,7 +141,7 @@ const rule = function(actual, options) {
 
 			// Return early before parse if no pseudos for performance
 
-			if (selector.indexOf(':') === -1) {
+			if (!selector.includes(':')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -31,7 +31,7 @@ const rule = function(expectation, options, context) {
 				return;
 			}
 
-			if (rule.selector.indexOf('(') === -1) {
+			if (!rule.selector.includes('(')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-class-whitelist/index.js
+++ b/lib/rules/selector-pseudo-class-whitelist/index.js
@@ -38,7 +38,7 @@ const rule = function(whitelist) {
 				return;
 			}
 
-			if (selector.indexOf(':') === -1) {
+			if (!selector.includes(':')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-element-blacklist/index.js
+++ b/lib/rules/selector-pseudo-element-blacklist/index.js
@@ -38,7 +38,7 @@ const rule = function(blacklist) {
 				return;
 			}
 
-			if (selector.indexOf('::') === -1) {
+			if (!selector.includes('::')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-element-case/index.js
+++ b/lib/rules/selector-pseudo-element-case/index.js
@@ -31,9 +31,8 @@ const rule = function(expectation, options, context) {
 			}
 
 			const selector = rule.selector;
-			const startIndexPseudoElement = selector.indexOf(':');
 
-			if (startIndexPseudoElement === -1) {
+			if (!selector.includes(':')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-element-case/index.js
+++ b/lib/rules/selector-pseudo-element-case/index.js
@@ -46,7 +46,7 @@ const rule = function(expectation, options, context) {
 					}
 
 					if (
-						pseudoElement.indexOf('::') === -1 &&
+						!pseudoElement.includes('::') &&
 						!keywordSets.levelOneAndTwoPseudoElements.has(pseudoElement.toLowerCase().slice(1))
 					) {
 						return;

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -32,7 +32,7 @@ const rule = function(expectation, options, context) {
 			const selector = rule.selector;
 
 			// get out early if no pseudo elements or classes
-			if (selector.indexOf(':') === -1) {
+			if (!selector.includes(':')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -45,7 +45,7 @@ const rule = function(actual, options) {
 
 			// Return early before parse if no pseudos for performance
 
-			if (selector.indexOf(':') === -1) {
+			if (!selector.includes(':')) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-element-whitelist/index.js
+++ b/lib/rules/selector-pseudo-element-whitelist/index.js
@@ -38,7 +38,7 @@ const rule = function(whitelist) {
 				return;
 			}
 
-			if (selector.indexOf('::') === -1) {
+			if (!selector.includes('::')) {
 				return;
 			}
 

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -91,10 +91,10 @@ const rule = function(actual, options) {
 					const tagNameLowerCase = tagName.toLowerCase();
 
 					if (
-						htmlTags.indexOf(tagNameLowerCase) !== -1 ||
-						svgTags.indexOf(tagNameLowerCase) !== -1 ||
+						htmlTags.includes(tagNameLowerCase) ||
+						svgTags.includes(tagNameLowerCase) ||
 						keywordSets.nonStandardHtmlTags.has(tagNameLowerCase) ||
-						mathMLTags.indexOf(tagNameLowerCase) !== -1
+						mathMLTags.includes(tagNameLowerCase)
 					) {
 						return;
 					}

--- a/lib/rules/selectorAttributeOperatorSpaceChecker.js
+++ b/lib/rules/selectorAttributeOperatorSpaceChecker.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
 			return;
 		}
 
-		if (rule.selector.indexOf('[') === -1 || rule.selector.indexOf('=') === -1) {
+		if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
 			return;
 		}
 

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -28,7 +28,7 @@ const propertiesWithShorthandNotation = new Set([
 const ignoredCharacters = ['+', '*', '/', '(', ')', '$', '@', '--', 'var('];
 
 function hasIgnoredCharacters(value) {
-	return ignoredCharacters.some((char) => value.indexOf(char) !== -1);
+	return ignoredCharacters.some((char) => value.includes(char));
 }
 
 function isShorthandProperty(property) {

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -65,7 +65,7 @@ const rule = function(expectation, secondary, context) {
 				return;
 			}
 
-			if (rule.selector.indexOf('[') === -1 || rule.selector.indexOf('=') === -1) {
+			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
 				return;
 			}
 
@@ -73,8 +73,8 @@ const rule = function(expectation, secondary, context) {
 
 			parseSelector(rule.selector, result, rule, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
-					if (attributeNode.quoted && attributeNode.value.indexOf(erroneousQuote) !== -1) {
-						const needsEscape = attributeNode.value.indexOf(correctQuote) !== -1;
+					if (attributeNode.quoted && attributeNode.value.includes(erroneousQuote)) {
+						const needsEscape = attributeNode.value.includes(correctQuote);
 
 						if (avoidEscape && needsEscape) {
 							// don't consider this an error
@@ -123,7 +123,7 @@ const rule = function(expectation, secondary, context) {
 			const fixPositions = [];
 
 			// Get out quickly if there are no erroneous quotes
-			if (value.indexOf(erroneousQuote) === -1) {
+			if (!value.includes(erroneousQuote)) {
 				return;
 			} else if (node.type === 'atrule' && node.name === 'charset') {
 				// allow @charset rules to have double quotes, in spite of the configuration
@@ -133,7 +133,7 @@ const rule = function(expectation, secondary, context) {
 
 			valueParser(value).walk((valueNode) => {
 				if (valueNode.type === 'string' && valueNode.quote === erroneousQuote) {
-					const needsEscape = valueNode.value.indexOf(correctQuote) !== -1;
+					const needsEscape = valueNode.value.includes(correctQuote);
 
 					if (avoidEscape && needsEscape) {
 						// don't consider this an error

--- a/lib/rules/unit-blacklist/index.js
+++ b/lib/rules/unit-blacklist/index.js
@@ -55,7 +55,7 @@ const rule = function(blacklistInput, options) {
 			const unit = getUnitFromValueNode(valueNode);
 
 			// There is not unit or it is not configured as a violation
-			if (!unit || (unit && blacklist.indexOf(unit.toLowerCase()) === -1)) {
+			if (!unit || (unit && !blacklist.includes(unit.toLowerCase()))) {
 				return;
 			}
 

--- a/lib/rules/unit-whitelist/index.js
+++ b/lib/rules/unit-whitelist/index.js
@@ -53,7 +53,7 @@ const rule = function(whitelistInput, options) {
 
 				const unit = getUnitFromValueNode(valueNode);
 
-				if (!unit || (unit && whitelist.indexOf(unit.toLowerCase()) !== -1)) {
+				if (!unit || (unit && whitelist.includes(unit.toLowerCase()))) {
 					return;
 				}
 

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -85,7 +85,7 @@ const rule = function(expectation, options, context) {
 				if (
 					node.type !== 'word' ||
 					!isStandardSyntaxValue(node.value) ||
-					value.indexOf('#') !== -1 ||
+					value.includes('#') ||
 					ignoredCharacters.has(keyword) ||
 					getUnitFromValueNode(node)
 				) {

--- a/lib/utils/containsString.js
+++ b/lib/utils/containsString.js
@@ -1,6 +1,8 @@
 /* @flow */
 'use strict';
 
+const _ = require('lodash');
+
 /**
  * Checks if a string contains a value. The comparison value can be a string or
  * an array of strings.
@@ -30,7 +32,9 @@ module.exports = function containsString(
 function testAgainstString(value, comparison) {
 	if (!comparison) return false;
 
-	if (comparison[0] === '/' && comparison[comparison.length - 1] === '/') {
+	if (!_.isString(comparison)) return false;
+
+	if (comparison.startsWith('/') && comparison.endsWith('/')) {
 		return false;
 	}
 

--- a/lib/utils/containsString.js
+++ b/lib/utils/containsString.js
@@ -34,7 +34,7 @@ function testAgainstString(value, comparison) {
 		return false;
 	}
 
-	if (value.indexOf(comparison) >= 0) {
+	if (value.includes(comparison)) {
 		return { match: value, pattern: comparison };
 	}
 

--- a/lib/utils/isAutoprefixable.js
+++ b/lib/utils/isAutoprefixable.js
@@ -35,7 +35,7 @@ module.exports = {
 	},
 
 	mediaFeatureName(identifier /*: string*/) /*: boolean*/ {
-		return identifier.toLowerCase().indexOf('device-pixel-ratio') !== -1;
+		return identifier.toLowerCase().includes('device-pixel-ratio');
 	},
 
 	property(identifier /*: string*/) /*: boolean*/ {

--- a/lib/utils/isCustomElement.js
+++ b/lib/utils/isCustomElement.js
@@ -14,7 +14,7 @@ module.exports = function(selector /*: string*/) /*: boolean*/ {
 		return false;
 	}
 
-	if (selector.indexOf('-') === -1) {
+	if (!selector.includes('-')) {
 		return false;
 	}
 
@@ -24,11 +24,11 @@ module.exports = function(selector /*: string*/) /*: boolean*/ {
 		return false;
 	}
 
-	if (svgTags.indexOf(selectorLowerCase) !== -1) {
+	if (svgTags.includes(selectorLowerCase)) {
 		return false;
 	}
 
-	if (htmlTags.indexOf(selectorLowerCase) !== -1) {
+	if (htmlTags.includes(selectorLowerCase)) {
 		return false;
 	}
 
@@ -36,7 +36,7 @@ module.exports = function(selector /*: string*/) /*: boolean*/ {
 		return false;
 	}
 
-	if (mathMLTags.indexOf(selectorLowerCase) !== -1) {
+	if (mathMLTags.includes(selectorLowerCase)) {
 		return false;
 	}
 

--- a/lib/utils/isRangeContextMediaFeature.js
+++ b/lib/utils/isRangeContextMediaFeature.js
@@ -8,9 +8,5 @@
  * @return {boolean} If `true`, media feature is a range context one
  */
 module.exports = function(mediaFeature /*: string*/) /*: boolean*/ {
-	return (
-		mediaFeature.indexOf('=') !== -1 ||
-		mediaFeature.indexOf('<') !== -1 ||
-		mediaFeature.indexOf('>') !== -1
-	);
+	return mediaFeature.includes('=') || mediaFeature.includes('<') || mediaFeature.includes('>');
 };

--- a/lib/utils/isStandardSyntaxMediaFeature.js
+++ b/lib/utils/isStandardSyntaxMediaFeature.js
@@ -11,7 +11,7 @@ module.exports = function(mediaFeature /*: string*/) /*: boolean*/ {
 	mediaFeature = mediaFeature.slice(1, -1);
 
 	// Parentheticals used for non-standard operations e.g. ($var - 10)
-	if (mediaFeature.indexOf('(') !== -1) {
+	if (mediaFeature.includes('(')) {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxUrl.js
+++ b/lib/utils/isStandardSyntaxUrl.js
@@ -38,7 +38,7 @@ module.exports = function(url /*: string*/) /*: boolean*/ {
 	// In url without quotes scss variable can be everywhere
 	// But in this case it is allowed to use only specific characters
 	// Also forbidden "/" at the end of url
-	if (url.indexOf('$') !== -1 && /^[$\sA-Za-z0-9+-/*_'"/]+$/.test(url) && !url.endsWith('/')) {
+	if (url.includes('$') && /^[$\sA-Za-z0-9+-/*_'"/]+$/.test(url) && !url.endsWith('/')) {
 		return false;
 	}
 

--- a/lib/utils/isWhitespace.js
+++ b/lib/utils/isWhitespace.js
@@ -5,5 +5,5 @@
  * Check if a character is whitespace.
  */
 module.exports = function(char /*: string*/) /*: boolean*/ {
-	return [' ', '\n', '\t', '\r', '\f'].indexOf(char) !== -1;
+	return [' ', '\n', '\t', '\r', '\f'].includes(char);
 };

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -66,7 +66,7 @@ module.exports = function(
 				// do not register a warning
 				range.start <= startLine &&
 				(range.end >= startLine || range.end === undefined) &&
-				(!range.rules || range.rules.indexOf(ruleName) !== -1)
+				(!range.rules || range.rules.includes(ruleName))
 			) {
 				return;
 			}

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -133,7 +133,7 @@ function validate(
 	}
 
 	Object.keys(actual).forEach((optionName) => {
-		if (ignoredOptions.indexOf(optionName) !== -1) {
+		if (ignoredOptions.includes(optionName)) {
 			return;
 		}
 


### PR DESCRIPTION
This now throws in one case, but I'm not sure if it's a test to blame or if `containsString()` should check for regex and return false explicitly.

Fixes #4414.