### PR TITLE
CI: stop installing the latest npm.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,9 +31,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Install latest npm
-      run: npm install --global npm@latest
-
     - name: Install dependencies
       run: npm ci
 
@@ -47,7 +44,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8, 10, 12]
+        # change `8.16.2` to `8` when https://github.com/actions/setup-node/issues/27 is fixed
+        node-version: [8.16.2, 10, 12]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: ubuntu-latest
@@ -60,9 +58,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Install latest npm
-      run: npm install --global npm@latest
 
     - name: Install dependencies
       run: npm ci
@@ -96,9 +91,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-
-    - name: Install latest npm
-      run: npm install --global npm@latest
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
This way we match real user conditions.

Notes:

1. I went with Node.js 8.16.2 which is the latest 8.x at the moment. In reality we need >= 8.10.0 for `npm ci` to work. After the issue is fixed this can be reverted back
2. This should speed up CI a bit

Maybe I'm missing something else regarding the npm update, so let me know if that's the case :)