### PR TITLE
Remove condescending language in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ It's mighty because it:
 
 ## Getting started
 
-It's easy to get started.
-
 First, decide how you want to use stylelint:
 
 -   [on the command line](docs/user-guide/cli.md)

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -30,7 +30,7 @@ module.exports.ruleName = ruleName
 module.exports.messages = messages
 ```
 
-Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`. If your plugin provides only a single rule or you can't think of a good namespace, you can simply use `plugin/my-rule`. This namespace ensures that plugin rules will never clash with core rules. *Make sure you document your plugin's rule name (and namespace) for users, because they will need to use it in their config.*
+Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`. If your plugin provides only a single rule or you can't think of a good namespace, you can use `plugin/my-rule`. This namespace ensures that plugin rules will never clash with core rules. *Make sure you document your plugin's rule name (and namespace) for users, because they will need to use it in their config.*
 
 `stylelint.createPlugin(ruleName, ruleFunction)` ensures that your plugin will be setup properly alongside other rules.
 
@@ -140,7 +140,7 @@ A typical use-case is to build in more complex conditionals that the rule's opti
 
 All rules share a common signature. They are a function that accepts two arguments: a primary option and a secondary options object. And that functions returns a function that has the signature of a PostCSS plugin, expecting a PostCSS root and result as its arguments.
 
-Here's a simple example of a plugin that runs `color-hex-case` only if there is a special directive `@@check-color-hex-case` somewhere in the stylesheet:
+Here's an example of a plugin that runs `color-hex-case` only if there is a special directive `@@check-color-hex-case` somewhere in the stylesheet:
 
 ```js
 export default stylelint.createPlugin(ruleName, function (expectation) {
@@ -186,7 +186,7 @@ For testing your plugin, you might consider using the same rule-testing function
 
 ## Plugin packs
 
-To make a single module provide multiple rules, simply export an array of plugin objects (rather than a single object).
+To make a single module provide multiple rules, export an array of plugin objects (rather than a single object).
 
 ## Sharing plugins and plugin packs
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -51,7 +51,7 @@ export default rule
 // or, for plugins: stylelint.createPlugin(ruleName, rule)
 ```
 
-There is one caveat here: If your rule accepts a primary option array, it cannot also accept a primary option object. Whenever possible, if you want your rule to accept a primary option array, you should just make an array the only possibility, instead of allowing for various data structures.
+There is one caveat here: If your rule accepts a primary option array, it cannot also accept a primary option object. Whenever possible, if you want your rule to accept a primary option array, you should make an array the only possibility, instead of allowing for various data structures.
 
 #### Secondary
 
@@ -68,7 +68,7 @@ A rule's secondary option can be anything if you're not ignoring or making excep
 
 `"ignore"` and `"except"` accept an array of predefined keyword options e.g. `["relative", "first-nested", "descendant"]`.
 
--   Use `"ignore"` when you want the rule to simply skip-over a particular pattern.
+-   Use `"ignore"` when you want the rule to skip-over a particular pattern.
 -   Use `"except"` when you want to invert the primary option for a particular pattern.
 
 ##### User-defined `"ignore*"`
@@ -88,7 +88,7 @@ Look at the messages of other rules to glean more conventions and patterns.
 
 *When writing the rule, always look to other similar rules for conventions and patterns to start from and mimic.*
 
-You will use the simple [PostCSS API](https://api.postcss.org/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes.
+You will use the [PostCSS API](https://api.postcss.org/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes.
 
 Depending on the rule, we also recommend using [postcss-value-parser](https://github.com/TrySound/postcss-value-parser) and [postcss-selector-parser](https://github.com/postcss/postcss-selector-parser). There are significant benefits to using these parsers instead of regular expressions or `indexOf` searches (even if they aren't always the most performant method).
 
@@ -135,7 +135,7 @@ Each rule must be accompanied by tests that contain:
 -   All patterns that are considered violations.
 -   All patterns that should *not* be considered violations.
 
-It is easy to write stylelint tests, so *write as many as you can stand to*.
+Write as many as you can stand to.
 
 #### Checklist
 
@@ -248,7 +248,7 @@ Once we've agreed on the direction, you can work on a pull request. Here are the
 
 ## Fixing a bug in an existing rule
 
-Fixing bugs is usually very easy. Here is a process that works:
+Here is a process that usually works:
 
 1.  Run `npm run watch` to start the interactive testing prompt.
 2.  Use the `p` command to filter the active tests to just the rule you're working on.
@@ -266,7 +266,7 @@ Deprecating rules doesn't happen very often. However, these two steps are import
 
 ## Improving the performance of a rule
 
-There's a simple way to run benchmarks on any given rule with any valid config for it:
+There's a way to run benchmarks on any given rule with any valid config for it:
 
 ```shell
 npm run benchmark-rule -- ruleName ruleOptions [ruleContext]

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -234,7 +234,7 @@ Once the plugin is declared, within your `"rules"` object *you'll need to add op
 }
 ```
 
-A "plugin" can provide a single rule or a set of rules. If the plugin you use provides a set, just invoke the module in your `"plugins"` configuration value, and use the rules it provides in `"rules"`. For example:
+A "plugin" can provide a single rule or a set of rules. If the plugin you use provides a set, invoke the module in your `"plugins"` configuration value, and use the rules it provides in `"rules"`. For example:
 
 ```json
 {

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -71,8 +71,6 @@ A rule must meet the [criteria](../developer-guide/rules.md) set out in the deve
 
 For example, we've found that rules to enforce property order, property groupings, etc., work better as plugins, because there are so many different opinions about what to enforce, and how. When you write or use a plugin, you can make sure to enforce your own particular preferences, exactly; but a rule that tries to address too many divergent use-cases becomes a mess.
 
-Plugins are easy to incorporate into your configuration.
-
 ## Can I customise stylelint's messages?
 
 Yes, you can either use the [`message` secondary option](configuration.md#custom-messages) or [write your own formatter](../developer-guide/formatters.md).


### PR DESCRIPTION
Inspired by [How to remove condescending language from documentation](https://dev.to/meeshkan/how-to-remove-condescending-language-from-documentation-4a5p).