### PR TITLE
Make docs titles more consistent

### DIFF
--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -1,4 +1,4 @@
-# The stylelint Node.js API
+# Node.js API
 
 The stylelint module includes a `lint()` function that provides the Node.js API.
 

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -1,4 +1,4 @@
-# The stylelint PostCSS plugin
+# PostCSS plugin
 
 As with any other [PostCSS plugin](https://github.com/postcss/postcss#plugins), you can use stylelint's PostCSS plugin either with a [PostCSS runner](https://github.com/postcss/postcss#runners) or with the PostCSS JS API directly.
 


### PR DESCRIPTION
“The stylelint” part looks redundant. Screenshot from our website:

<img width="235" alt="Screen Shot 2019-11-24 at 00 45 31" src="https://user-images.githubusercontent.com/654597/69487433-0d3a6e00-0e5a-11ea-94e5-0dcc3bde0605.png">
