### PR TITLE
Remove unused TOC markers

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -4,8 +4,6 @@ Plugins are rules and sets of rules built by the community.
 
 We recommend familiarising yourself and adhering to stylelint's [conventions for writing rules](rules.md), including those for names, options, messages, tests and docs.
 
-<!-- TOC -->
-
 ## The anatomy of a plugin
 
 ```js

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -2,8 +2,6 @@
 
 Please help us create, enhance, and debug stylelint rules!
 
-<!-- TOC -->
-
 ## Creating a new rule
 
 First, open [an issue](https://github.com/stylelint/stylelint/issues/new) with your idea for the new rule.

--- a/docs/user-guide/about-rules.md
+++ b/docs/user-guide/about-rules.md
@@ -4,8 +4,6 @@ We have taken great care to consistently name rules.
 
 The rules have been designed to work together to enforce strict conventions.
 
-<!-- TOC -->
-
 ## About rule names
 
 Rule names are:

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -8,8 +8,6 @@ stylelint is an [npm package](https://www.npmjs.com/package/stylelint). Install 
 npm install stylelint --save-dev
 ```
 
-<!-- TOC -->
-
 ## Usage
 
 `stylelint --help` prints the CLI documentation.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -2,8 +2,6 @@
 
 The linter *expects a configuration object*. You can either craft your own config or extend an existing one.
 
-<!-- TOC -->
-
 ## Loading the configuration object
 
 Finding and loading of your configuration object is done with [cosmiconfig](https://github.com/davidtheclark/cosmiconfig). Starting from the current working directory, it will look for the following possible sources, in this order:

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,7 +1,5 @@
 # FAQ
 
-<!-- TOC -->
-
 ## How do I turn off, disable or ignore a rule?
 
 You can turn off a rule by setting its config value to `null`.

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -7,8 +7,6 @@ stylelint.lint(options)
   .then(function(resultObject) { .. });
 ```
 
-<!-- TOC -->
-
 ## Installation
 
 stylelint is an [npm package](https://www.npmjs.com/package/stylelint). Install it using:

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -4,8 +4,6 @@ As with any other [PostCSS plugin](https://github.com/postcss/postcss#plugins), 
 
 *However, if a dedicated stylelint task runner plugin [is available](complementary-tools.md) (e.g. [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) or [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint)) we recommend you use that rather than this plugin, as they provide better reporting.*
 
-<!-- TOC -->
-
 ## Installation
 
 stylelint is an [npm package](https://www.npmjs.com/package/stylelint). Install it using:


### PR DESCRIPTION
We had these markers so previous version of our website knew where to put Table of Content. Now Table of Content renders separate from content area, in a sidebar.