### PR TITLE
Use consistent code style for JavaScript examples

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -4,7 +4,7 @@ A formatter is a function with the following signature:
 
 ```js
 function formatter(results, returnValue) {
-  return "a string of formatted results";
+    return 'a string of formatted results';
 }
 ```
 
@@ -13,30 +13,29 @@ Where the first argument (`results`) is an array of stylelint result objects in 
 ```js
 // A stylelint result object
 {
-  source:  "path/to/file.css", // The filepath or PostCSS identifier like <input css 1>
-  errored: true, // This is `true` if at least one rule with an "error"-level severity triggered a warning
-  warnings: [ // Array of rule violation warning objects, each like the following ...
-    {
-      line: 3,
-      column: 12,
-      rule: "block-no-empty",
-      severity: "error",
-      text: "You should not have an empty block (block-no-empty)"
-    },
-    ..
-  ],
-  deprecations: [ // Array of deprecation warning objects, each like the following ...
-    {
-      text: "Feature X has been deprecated and will be removed in the next major version.",
-      reference: "https://stylelint.io/docs/feature-x.md"
-    }
-  ],
-  invalidOptionWarnings: [ // Array of invalid option warning objects, each like the following ...
-    {
-      text: "Invalid option X for rule Y",
-    }
-  ],
-  ignored: false // This is `true` if the file's path matches a provided ignore pattern
+    source: 'path/to/file.css', // The filepath or PostCSS identifier like <input css 1>
+    errored: true, // This is `true` if at least one rule with an "error"-level severity triggered a warning
+    warnings: [ // Array of rule violation warning objects, each like the following ...
+        {
+            line: 3,
+            column: 12,
+            rule: 'block-no-empty',
+            severity: 'error',
+            text: 'You should not have an empty block (block-no-empty)',
+        },
+    ],
+    deprecations: [ // Array of deprecation warning objects, each like the following ...
+        {
+            text: 'Feature X has been deprecated and will be removed in the next major version.',
+            reference: 'https://stylelint.io/docs/feature-x.md',
+        },
+    ],
+    invalidOptionWarnings: [ // Array of invalid option warning objects, each like the following ...
+        {
+            text: 'Invalid option X for rule Y',
+        },
+    ],
+    ignored: false, // This is `true` if the file's path matches a provided ignore pattern
 }
 ```
 
@@ -44,33 +43,33 @@ And the second argument (`returnValue`) is an object with one or more of the fol
 
 ```js
 {
-  errored: false, // `true` if there were any warnings with "error" severity
-  needlessDisables: [ // Present if stylelint was configured with `reportNeedlessDisables: true`
-    {
-      source: "path/to/file.css",
-      ranges: [
+    errored: false, // `true` if there were any warnings with "error" severity
+    needlessDisables: [ // Present if stylelint was configured with `reportNeedlessDisables: true`
         {
-		      start: 10,
-          unusedRule: "indentation"
-        }
-      ]
-    }
-  ],
-  invalidScopeDisables: [ // Present if stylelint was configured with `reportInvalidScopeDisables: true`
-    {
-      source: "path/to/file.css",
-      ranges: [
+            source: 'path/to/file.css',
+            ranges: [
+                {
+                    start: 10,
+                    unusedRule: 'indentation',
+                },
+            ],
+        },
+    ],
+    invalidScopeDisables: [ // Present if stylelint was configured with `reportInvalidScopeDisables: true`
         {
-          start: 1,
-          unusedRule: "color-named"
-        }
-      ]
-    }
-  ],
-  maxWarningsExceeded: { // Present if stylelint was configured with a `maxWarnings` count
-    maxWarnings: 10,
-    foundWarnings: 15
-  }
+            source: 'path/to/file.css',
+            ranges: [
+                {
+                    start: 1,
+                    unusedRule: 'color-named',
+                },
+            ],
+        },
+    ],
+    maxWarningsExceeded: { // Present if stylelint was configured with a `maxWarnings` count
+        maxWarnings: 10,
+        foundWarnings: 15,
+    },
 }
 ```
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -10,24 +10,35 @@ We recommend familiarising yourself and adhering to stylelint's [conventions for
 
 ```js
 // Abbreviated example
-var stylelint = require("stylelint")
+const stylelint = require('stylelint');
 
-var ruleName = "plugin/foo-bar"
-var messages =  stylelint.utils.ruleMessages(ruleName, {
-  expected: "Expected ...",
-})
+const ruleName = 'plugin/foo-bar';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+    expected: 'Expected ...',
+});
 
-module.exports = stylelint.createPlugin(ruleName, function(primaryOption, secondaryOptionObject) {
-  return function(postcssRoot, postcssResult) {
-    var validOptions = stylelint.utils.validateOptions(postcssResult, ruleName, { .. })
-    if (!validOptions) { return }
-    // ... some logic ...
-    stylelint.utils.report({ .. })
-  }
-})
+module.exports = stylelint.createPlugin(ruleName, function(
+    primaryOption,
+    secondaryOptionObject
+) {
+    return function(postcssRoot, postcssResult) {
+        const validOptions = stylelint.utils.validateOptions(
+            postcssResult,
+            ruleName,
+            { /* .. */ }
+        );
 
-module.exports.ruleName = ruleName
-module.exports.messages = messages
+        if (!validOptions) {
+            return;
+        }
+
+        // ... some logic ...
+        stylelint.utils.report({ /* .. */ });
+    };
+});
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;
 ```
 
 Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`. If your plugin provides only a single rule or you can't think of a good namespace, you can simply use `plugin/my-rule`. This namespace ensures that plugin rules will never clash with core rules. *Make sure you document your plugin's rule name (and namespace) for users, because they will need to use it in their config.*
@@ -46,31 +57,41 @@ Rules with asynchronous PostCSS plugins are also possible! All you need to do is
 
 ```js
 // Abbreviated asynchronous example
-var stylelint = require("stylelint")
+const stylelint = require('stylelint');
 
-var ruleName = "plugin/foo-bar-async"
-var messages =  stylelint.utils.ruleMessages(ruleName, {
-  expected: "Expected ...",
-})
+const ruleName = 'plugin/foo-bar-async';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+    expected: 'Expected ...',
+});
 
-module.exports = stylelint.createPlugin(ruleName, function(primaryOption, secondaryOptionObject) {
-  return function(postcssRoot, postcssResult) {
-    var validOptions = stylelint.utils.validateOptions(postcssResult, ruleName, { .. })
-    if (!validOptions) { return }
+module.exports = stylelint.createPlugin(ruleName, function(
+    primaryOption,
+    secondaryOptionObject
+) {
+    return function(postcssRoot, postcssResult) {
+        const validOptions = stylelint.utils.validateOptions(
+            postcssResult,
+            ruleName,
+            { /* .. */ }
+        );
 
-    return new Promise(function(resolve) {
-      // some async operation
-      setTimeout(function() {
-        // ... some logic ...
-        stylelint.utils.report({ .. })
-        resolve()
-      }, 1)
-    })
-  }
-})
+        if (!validOptions) {
+            return;
+        }
 
-module.exports.ruleName = ruleName
-module.exports.messages = messages
+        return new Promise(function(resolve) {
+            // some async operation
+            setTimeout(function() {
+                // ... some logic ...
+                stylelint.utils.report({ /* .. */ });
+                resolve();
+            }, 1);
+        });
+    };
+});
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;
 ```
 
 ## `stylelint.utils`
@@ -106,29 +127,32 @@ Use the warning to create a *new* warning *from your plugin rule* that you repor
 For example, imagine you want to create a plugin that runs `at-rule-no-unknown` with a built-in list of exceptions for at-rules provided by your preprocessor-of-choice:
 
 ```js
-const allowableAtRules = [..]
+const allowableAtRules = [ /* .. */ ];
 
-function myPluginRule(primaryOption, secondaryOptions) {
-  return (root, result) => {
-    const defaultedOptions = Object.assign({}, secondaryOptions, {
-      ignoreAtRules: allowableAtRules.concat(options.ignoreAtRules || []),
-    })
+function myPluginRule(primaryOption, secondaryOptionObject) {
+    return function(postcssRoot, postcssResult) {
+        const defaultedOptions = Object.assign({}, secondaryOptionObject, {
+            ignoreAtRules: allowableAtRules.concat(options.ignoreAtRules || []),
+        });
 
-    stylelint.utils.checkAgainstRule({
-      ruleName: 'at-rule-no-unknown',
-      ruleSettings: [primaryOption, defaultedOptions],
-      root: root
-    }, (warning) => {
-      stylelint.utils.report({
-        message: myMessage,
-        ruleName: myRuleName,
-        result: result,
-        node: warning.node,
-        line: warning.line,
-        column: warning.column,
-      })
-    })
-  }
+        stylelint.utils.checkAgainstRule(
+            {
+                ruleName: 'at-rule-no-unknown',
+                ruleSettings: [primaryOption, defaultedOptions],
+                root: postcssRoot,
+            },
+            (warning) => {
+                stylelint.utils.report({
+                    message: myMessage,
+                    ruleName: myRuleName,
+                    result: postcssResult,
+                    node: warning.node,
+                    line: warning.line,
+                    column: warning.column,
+                });
+            }
+        );
+    };
 }
 ```
 
@@ -143,13 +167,17 @@ All rules share a common signature. They are a function that accepts two argumen
 Here's a simple example of a plugin that runs `color-hex-case` only if there is a special directive `@@check-color-hex-case` somewhere in the stylesheet:
 
 ```js
-export default stylelint.createPlugin(ruleName, function (expectation) {
-  const runColorHexCase = stylelint.rules["color-hex-case"](expectation)
-  return (root, result) => {
-    if (root.toString().indexOf("@@check-color-hex-case") === -1) return
-    runColorHexCase(root, result)
-  }
-})
+module.exports = stylelint.createPlugin(ruleName, function(expectation) {
+    const runColorHexCase = stylelint.rules['color-hex-case'](expectation);
+
+    return (root, result) => {
+        if (root.toString().indexOf('@@check-color-hex-case') === -1) {
+            return;
+        }
+
+        runColorHexCase(root, result);
+    };
+});
 ```
 
 ## Allow primary option arrays

--- a/docs/developer-guide/processors.md
+++ b/docs/developer-guide/processors.md
@@ -12,17 +12,18 @@ Processor modules are functions that accept an options object and return an obje
 ```js
 // my-processor.js
 module.exports = function(options) {
-  return {
-    code: function(input, filepath) {
-      // ...
-      return transformedCode;
-    },
-    result: function(stylelintResult, filepath) {
-      // ...
-      return transformedResult;
-    }
-  };
-}
+    return {
+        code: function(input, filepath) {
+            // ...
+            return transformedCode;
+        },
+        result: function(stylelintResult, filepath) {
+            // ...
+            return transformedResult;
+        },
+    };
+};
+
 ```
 
 Processors can enable stylelint to lint the CSS within non-stylesheet files.

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -44,11 +44,15 @@ If your rule can accept an array as its primary option, you must designate this 
 
 ```js
 function rule(primary, secondary) {
-  return (root, result) => {..}
+    return (root, result) => { /* .. */ };
 }
-rule.primaryOptionArray = true
-export default rule
-// or, for plugins: stylelint.createPlugin(ruleName, rule)
+
+rule.primaryOptionArray = true;
+
+module.exports = rule;
+
+// or, for plugins:
+// module.exports = stylelint.createPlugin(ruleName, rule);
 ```
 
 There is one caveat here: If your rule accepts a primary option array, it cannot also accept a primary option object. Whenever possible, if you want your rule to accept a primary option array, you should just make an array the only possibility, instead of allowing for various data structures.
@@ -108,7 +112,7 @@ Add `context` variable to rule parameters:
 
 ```js
 function rule(primary, secondary, context) {
-  return (root, result) => {..}
+    return (root, result) => { /* .. */ };
 }
 ```
 
@@ -121,11 +125,11 @@ If `context.fix` is `true`, then change `root` using PostCSS API and return earl
 
 ```js
 if (context.fix) {
-  // Apply fixes using PostCSS API
-  return // Return and don't report a problem
+    // Apply fixes using PostCSS API
+    return; // Return and don't report a problem
 }
 
-report(...)
+report(...);
 ```
 
 ### Write tests

--- a/docs/user-guide/about-rules.md
+++ b/docs/user-guide/about-rules.md
@@ -280,19 +280,19 @@ You can do that with:
 
 ```js
 "at-rule-empty-line-before": ["always", {
-  "except": ["first-nested"]
+   "except": ["first-nested"]
 }],
 "custom-property-empty-line-before": [ "always", {
-  "except": [
-    "after-custom-property",
-    "first-nested"
-  ]
+    "except": [
+        "after-custom-property",
+        "first-nested"
+    ]
 }],
 "declaration-empty-line-before": ["always", {
-  "except": [
-    "after-declaration",
-    "first-nested"
-  ]
+    "except": [
+        "after-declaration",
+        "first-nested"
+    ]
 }],
 "block-closing-brace-empty-line-before": "never",
 "rule-empty-line-before": ["always-multi-line"]

--- a/docs/user-guide/css-processors.md
+++ b/docs/user-guide/css-processors.md
@@ -30,16 +30,15 @@ stylelint can also accept a custom [PostCSS-compatible syntax](https://github.co
 If you're using the linter as a [PostCSS Plugin](postcss-plugin.md), you should use the special `postcss-syntax` directly with PostCSS's `syntax` option like so:
 
 ```js
-var postcss = require("postcss")
-var syntax = require("postcss-syntax")
+const postcss = require('postcss');
+const syntax = require('postcss-syntax');
 
 postcss([
-  require("stylelint"),
-  require("reporter")
+  require('stylelint'),
+  require('reporter'),
 ])
   .process(css, {
-    from: "lib/app.css",
-    syntax: syntax
-  })
-})
+      from: 'lib/app.css',
+      syntax: syntax,
+  });
 ```

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -4,7 +4,7 @@ The stylelint module includes a `lint()` function that provides the Node.js API.
 
 ```js
 stylelint.lint(options)
-  .then(function(resultObject) { .. });
+    .then(function(resultObject) { /* .. */ });
 ```
 
 <!-- TOC -->
@@ -187,49 +187,56 @@ It resolves with an object (see [The returned promise](#the-returned-promise)) t
 If `myConfig` contains no relative paths for `extends` or `plugins`, you do not have to use `configBasedir`:
 
 ```js
-stylelint.lint({
-  config: myConfig,
-  files: "all/my/stylesheets/*.css"
-})
-  .then(function(data) {
-    // do things with data.output, data.errored,
-    // and data.results
-  })
-  .catch(function(err) {
-    // do things with err e.g.
-    console.error(err.stack);
-  });
+stylelint
+    .lint({
+        config: myConfig,
+        files: 'all/my/stylesheets/*.css',
+    })
+    .then(function(data) {
+        // do things with data.output, data.errored,
+        // and data.results
+    })
+    .catch(function(err) {
+        // do things with err e.g.
+        console.error(err.stack);
+    });
 ```
 
 If `myConfig` *does* contain relative paths for `extends` or `plugins`, you *do* have to use `configBasedir`:
 
 ```js
-stylelint.lint({
-  config: myConfig,
-  configBasedir: path.join(__dirname, "configs"),
-  files: "all/my/stylesheets/*.css"
-}).then(function() { .. });
+stylelint
+    .lint({
+        config: myConfig,
+        configBasedir: path.join(__dirname, 'configs'),
+        files: 'all/my/stylesheets/*.css',
+    })
+    .then(function() { /* .. */ });
 ```
 
 Maybe you want to use a CSS string instead of a file glob, and you want to use the string formatter instead of the default JSON:
 
 ```js
-stylelint.lint({
-  code: "a { color: pink; }",
-  config: myConfig,
-  formatter: "string"
-}).then(function() { .. });
+stylelint
+    .lint({
+        code: 'a { color: pink; }',
+        config: myConfig,
+        formatter: 'string',
+    })
+    .then(function() { /* .. */ });
 ```
 
 Maybe you want to use my own custom formatter function and parse `.scss` source files:
 
 ```js
-stylelint.lint({
-  config: myConfig,
-  files: "all/my/stylesheets/*.scss",
-  formatter: function(stylelintResults) { .. },
-  syntax: "scss"
-}).then(function() { .. });
+stylelint
+    .lint({
+        config: myConfig,
+        files: 'all/my/stylesheets/*.scss',
+        formatter: function(stylelintResults) { /* .. */ },
+        syntax: 'scss',
+    })
+    .then(function() { /* .. */ });
 ```
 
 The same pattern can be used to lint Less, SCSS or [SugarSS](https://github.com/postcss/sugarss) syntax.

--- a/docs/user-guide/postcss-plugin.md
+++ b/docs/user-guide/postcss-plugin.md
@@ -72,23 +72,25 @@ A separate lint task that uses the plugin via the PostCSS JS API to lint Less us
 *Note: the stylelint PostCSS plugin, unlike the stylelint CLI and Node.js API, doesn't have a `syntax` option. Instead, the syntax must be set within the [PostCSS options](https://github.com/postcss/postcss#options) as there can only be one parser/syntax in a pipeline.*
 
 ```js
-var fs = require("fs")
-var less = require("postcss-less")
-var postcss = require("postcss")
+const fs = require('fs');
+const less = require('postcss-less');
+const postcss = require('postcss');
 
 // CSS to be processed
-var css = fs.readFileSync("input.css", "utf8")
+const css = fs.readFileSync('input.css', 'utf8');
 
 postcss([
-  require("stylelint")({ /* your options */ }),
-  require("postcss-reporter")({ clearReportedMessages: true })
+    require('stylelint')({
+        /* your options */
+    }),
+    require('postcss-reporter')({ clearReportedMessages: true }),
 ])
-  .process(css, {
-    from: "input.css",
-    syntax: less
-  })
-  .then()
-  .catch(err => console.error(err.stack))
+    .process(css, {
+        from: 'input.css',
+        syntax: less,
+    })
+    .then(() => {})
+    .catch((err) => console.error(err.stack));
 ```
 
 The same pattern can be used to lint Less, SCSS or [SugarSS](https://github.com/postcss/sugarss) syntax.
@@ -98,28 +100,34 @@ The same pattern can be used to lint Less, SCSS or [SugarSS](https://github.com/
 A combined lint and build task where the plugin is used via the PostCSS JS API, but within [`postcss-import`](https://github.com/postcss/postcss-import) (using the its `plugins` option) so that the source files are linted before any transformations.
 
 ```js
-var fs = require("fs")
-var postcss = require("postcss")
-var stylelint = require("stylelint")
+const fs = require('fs');
+const postcss = require('postcss');
+const stylelint = require('stylelint');
 
 // CSS to be processed
-var css = fs.readFileSync("lib/app.css", "utf8")
+const css = fs.readFileSync('lib/app.css', 'utf8');
 
-postcss(
-  [
-    require("postcss-import")({
-      plugins: [
-        require("stylelint")({ /* your options */ })
-      ]
+postcss([
+    require('postcss-import')({
+        plugins: [
+            require('stylelint')({
+                /* your options */
+            }),
+        ],
     }),
-    require("postcss-cssnext"),
-    require("postcss-reporter")({ clearReportedMessages: true })
-  ]
-)
-  .process(css, { from: 'lib/app.css', to: 'app.css' })
-  .then(function (result) {
-    fs.writeFileSync('app.css', result.css);
-    if ( result.map ) fs.writeFileSync('app.css.map', result.map);
-  })
-  .catch(err => console.error(err.stack))
+    require('postcss-cssnext'),
+    require('postcss-reporter')({ clearReportedMessages: true }),
+])
+    .process(css, {
+        from: 'lib/app.css',
+        to: 'app.css',
+    })
+    .then((result) => {
+        fs.writeFileSync('app.css', result.css);
+
+        if (result.map) {
+            fs.writeFileSync('app.css.map', result.map);
+        }
+    })
+    .catch((err) => console.error(err.stack));
 ```


### PR DESCRIPTION
Tried to make all JavaScript examples in a consistent code style.