### PR TITLE
package.json: skip `testUtils` folder too.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lib",
     "VISION.md",
     "!**/__tests__",
+    "!lib/testUtils",
     "flow-typed",
     "!flow-typed/npm"
   ],


### PR DESCRIPTION
It seems these aren't needed in production