### PR TITLE
Remove `_.forOwn`

### DIFF
--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -121,11 +121,11 @@ function formatter(messages, source) {
 	 * @return {[string, string, string, string, string]}
 	 */
 	const calculateWidths = function(columns) {
-		_.forOwn(columns, (value, key) => {
+		for (const [key, value] of Object.entries(columns)) {
 			const normalisedValue = value ? value.toString() : value;
 
 			columnWidths[key] = Math.max(columnWidths[key], stringWidth(normalisedValue));
-		});
+		}
 
 		return columns;
 	};

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -48,14 +48,15 @@ module.exports = function(results) {
 
 	output += chalk.underline(`\n${warnings.length} ${problemWord} found\n`);
 
-	_.forOwn(warningsBySeverity, (warningList, severityLevel) => {
+	for (const [severityLevel, warningList] of Object.entries(warningsBySeverity)) {
 		const warningsByRule = _.groupBy(warningList, 'rule');
 
 		output += ` severity level "${severityLevel}": ${warningList.length}\n`;
-		_.forOwn(warningsByRule, (list, rule) => {
+
+		for (const [rule, list] of Object.entries(warningsByRule)) {
 			output += chalk.dim(`  ${rule}: ${list.length}\n`);
-		});
-	});
+		}
+	}
 
 	return output + '\n';
 };


### PR DESCRIPTION
Refs #4412

@hudochenkov let's confirm the behavior is the same, i.e. we only want to loop through the object's own enumerable keys only and we don't care about the order