### PR TITLE
Remove `_.trim`

### DIFF
--- a/lib/rules/function-url-no-scheme-relative/index.js
+++ b/lib/rules/function-url-no-scheme-relative/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const functionArgumentsSearch = require('../../utils/functionArgumentsSearch');
 const isStandardSyntaxUrl = require('../../utils/isStandardSyntaxUrl');
 const report = require('../../utils/report');
@@ -23,7 +22,7 @@ const rule = function(actual) {
 
 		root.walkDecls(function(decl) {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
-				const url = _.trim(args, ' \'"');
+				const url = args.trim().replace(/^['"]+|['"]+$/g, '');
 
 				if (!isStandardSyntaxUrl(url) || !url.startsWith('//')) {
 					return;

--- a/lib/rules/function-url-scheme-blacklist/index.js
+++ b/lib/rules/function-url-scheme-blacklist/index.js
@@ -28,13 +28,13 @@ const rule = function(blacklist) {
 
 		root.walkDecls(function(decl) {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
-				const unspacedUrlString = _.trim(args, ' ');
+				const unspacedUrlString = args.trim();
 
 				if (!isStandardSyntaxUrl(unspacedUrlString)) {
 					return;
 				}
 
-				const urlString = _.trim(unspacedUrlString, '\'"');
+				const urlString = unspacedUrlString.replace(/^['"]+|['"]+$/g, '');
 				const scheme = getSchemeFromUrl(urlString);
 
 				if (scheme === null) {

--- a/lib/rules/function-url-scheme-whitelist/index.js
+++ b/lib/rules/function-url-scheme-whitelist/index.js
@@ -28,13 +28,13 @@ const rule = function(whitelist) {
 
 		root.walkDecls(function(decl) {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
-				const unspacedUrlString = _.trim(args, ' ');
+				const unspacedUrlString = args.trim();
 
 				if (!isStandardSyntaxUrl(unspacedUrlString)) {
 					return;
 				}
 
-				const urlString = _.trim(unspacedUrlString, '\'"');
+				const urlString = unspacedUrlString.replace(/^['"]+|['"]+$/g, '');
 				const scheme = getSchemeFromUrl(urlString);
 
 				if (scheme === null) {


### PR DESCRIPTION
Use `String.trim()` and `String.replace()` instead.

Refs #4412 

What I'm not 100% sure about is if we want to do `trim()` after removing the quotes again. IIRC lodash.trim does this.