### PR TITLE
Use arrow functions consistently

### DIFF
--- a/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
+++ b/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
@@ -4,7 +4,7 @@ const stylelint = require('../../');
 
 const ruleName = 'plugin/conditionally-check-color-hex-case';
 
-module.exports = stylelint.createPlugin(ruleName, function(expectation, options, context) {
+module.exports = stylelint.createPlugin(ruleName, (expectation, options, context) => {
 	const colorHexCaseRule = stylelint.rules['color-hex-case'](expectation, options, context);
 
 	return (root, result) => {

--- a/lib/__tests__/fixtures/plugin-slashless-warn-about-foo.js
+++ b/lib/__tests__/fixtures/plugin-slashless-warn-about-foo.js
@@ -8,7 +8,7 @@ const warnAboutFooMessages = stylelint.utils.ruleMessages('slashless-warn-about-
 	found: 'found .foo',
 });
 
-module.exports = stylelint.createPlugin(ruleName, function(expectation) {
+module.exports = stylelint.createPlugin(ruleName, (expectation) => {
 	return (root, result) => {
 		root.walkRules((rule) => {
 			if (rule.selector === '.foo') {

--- a/lib/__tests__/fixtures/plugin-warn-about-bar.js
+++ b/lib/__tests__/fixtures/plugin-warn-about-bar.js
@@ -8,7 +8,7 @@ const warnAboutBarMessages = stylelint.utils.ruleMessages('plugin/warn-about-bar
 	found: 'found .bar',
 });
 
-module.exports = stylelint.createPlugin(ruleName, function(expectation) {
+module.exports = stylelint.createPlugin(ruleName, (expectation) => {
 	return (root, result) => {
 		root.walkRules((rule) => {
 			if (rule.selector === '.bar') {

--- a/lib/__tests__/fixtures/plugin-warn-about-foo.js
+++ b/lib/__tests__/fixtures/plugin-warn-about-foo.js
@@ -8,7 +8,7 @@ const warnAboutFooMessages = stylelint.utils.ruleMessages('plugin/warn-about-foo
 	found: 'found .foo',
 });
 
-module.exports = stylelint.createPlugin(ruleName, function(expectation) {
+module.exports = stylelint.createPlugin(ruleName, (expectation) => {
 	return (root, result) => {
 		root.walkRules((rule) => {
 			if (rule.selector === '.foo') {

--- a/lib/postcssPlugin.js
+++ b/lib/postcssPlugin.js
@@ -6,7 +6,7 @@ const path = require('path');
 const postcss = require('postcss');
 //'block-no-empty': bool || Array
 
-module.exports = postcss.plugin('stylelint', function(options = {}) {
+module.exports = postcss.plugin('stylelint', (options = {}) => {
 	const tailoredOptions = options.rules ? { config: options } : options;
 	const stylelint = createStylelint(tailoredOptions);
 

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -66,7 +66,7 @@ function rule(expectation, options, context) {
 				const declProp = decl.prop;
 				const declBetween = decl.raws.between;
 
-				fixPositions.forEach(function(fixPosition) {
+				fixPositions.forEach((fixPosition) => {
 					// 1 — it's a # length
 					decl.value = replaceHex(
 						decl.value,

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -70,7 +70,7 @@ function rule(expectation, _, context) {
 				const declProp = decl.prop;
 				const declBetween = decl.raws.between;
 
-				fixPositions.forEach(function(fixPosition) {
+				fixPositions.forEach((fixPosition) => {
 					// 1 — it's a # length
 					decl.value = replaceHex(
 						decl.value,

--- a/lib/rules/color-named/generateColorFuncs.js
+++ b/lib/rules/color-named/generateColorFuncs.js
@@ -6,7 +6,7 @@ function lin_sRGB(RGB) {
 	// convert an array of sRGB values in the range 0.0 - 1.0
 	// to linear light (un-companded) form.
 	// https://en.wikipedia.org/wiki/SRGB
-	return RGB.map(function(val) {
+	return RGB.map((val) => {
 		if (val < 0.04045) {
 			return val / 12.92;
 		}

--- a/lib/rules/comment-whitespace-inside/index.js
+++ b/lib/rules/comment-whitespace-inside/index.js
@@ -27,7 +27,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		root.walkComments(function(comment) {
+		root.walkComments((comment) => {
 			if (comment.raws.inline || comment.inline) {
 				return;
 			}

--- a/lib/rules/declaration-block-semicolon-newline-before/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.js
@@ -28,7 +28,7 @@ function rule(expectation) {
 			return;
 		}
 
-		root.walkDecls(function(decl) {
+		root.walkDecls((decl) => {
 			const parentRule = decl.parent;
 
 			if (!parentRule.raws.semicolon && parentRule.last === decl) {

--- a/lib/rules/declaration-block-semicolon-space-after/index.js
+++ b/lib/rules/declaration-block-semicolon-space-after/index.js
@@ -31,7 +31,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		root.walkDecls(function(decl) {
+		root.walkDecls((decl) => {
 			// Ignore last declaration if there's no trailing semicolon
 			const parentRule = decl.parent;
 

--- a/lib/rules/declaration-property-unit-blacklist/index.js
+++ b/lib/rules/declaration-property-unit-blacklist/index.js
@@ -41,7 +41,7 @@ function rule(blacklist) {
 				return;
 			}
 
-			valueParser(value).walk(function(node) {
+			valueParser(value).walk((node) => {
 				// Ignore wrong units within `url` function
 				if (node.type === 'function' && node.value.toLowerCase() === 'url') {
 					return false;

--- a/lib/rules/declaration-property-unit-whitelist/index.js
+++ b/lib/rules/declaration-property-unit-whitelist/index.js
@@ -41,7 +41,7 @@ function rule(whitelist) {
 				return;
 			}
 
-			valueParser(value).walk(function(node) {
+			valueParser(value).walk((node) => {
 				// Ignore wrong units within `url` function
 				if (node.type === 'function' && node.value.toLowerCase() === 'url') {
 					return false;

--- a/lib/rules/declarationBangSpaceChecker.js
+++ b/lib/rules/declarationBangSpaceChecker.js
@@ -5,7 +5,7 @@ const report = require('../utils/report');
 const styleSearch = require('style-search');
 
 module.exports = function(opts) {
-	opts.root.walkDecls(function(decl) {
+	opts.root.walkDecls((decl) => {
 		const indexOffset = declarationValueIndex(decl);
 		const declString = decl.toString();
 		const valueString = decl.toString().slice(indexOffset);

--- a/lib/rules/function-blacklist/index.js
+++ b/lib/rules/function-blacklist/index.js
@@ -30,7 +30,7 @@ function rule(blacklist) {
 		root.walkDecls((decl) => {
 			const value = decl.value;
 
-			valueParser(value).walk(function(node) {
+			valueParser(value).walk((node) => {
 				if (node.type !== 'function') {
 					return;
 				}

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -48,7 +48,7 @@ function rule(expectation, options, context) {
 			let needFix = false;
 			const parsed = valueParser(decl.raws.value ? decl.raws.value.raw : decl.value);
 
-			parsed.walk(function(node) {
+			parsed.walk((node) => {
 				if (node.type !== 'function' || !isStandardSyntaxFunction(node)) {
 					return;
 				}

--- a/lib/rules/function-url-no-scheme-relative/index.js
+++ b/lib/rules/function-url-no-scheme-relative/index.js
@@ -21,7 +21,7 @@ function rule(actual) {
 			return;
 		}
 
-		root.walkDecls(function(decl) {
+		root.walkDecls((decl) => {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
 				const url = _.trim(args, ' \'"');
 

--- a/lib/rules/function-url-scheme-blacklist/index.js
+++ b/lib/rules/function-url-scheme-blacklist/index.js
@@ -26,7 +26,7 @@ function rule(blacklist) {
 			return;
 		}
 
-		root.walkDecls(function(decl) {
+		root.walkDecls((decl) => {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
 				const unspacedUrlString = _.trim(args, ' ');
 

--- a/lib/rules/function-url-scheme-whitelist/index.js
+++ b/lib/rules/function-url-scheme-whitelist/index.js
@@ -26,7 +26,7 @@ function rule(whitelist) {
 			return;
 		}
 
-		root.walkDecls(function(decl) {
+		root.walkDecls((decl) => {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
 				const unspacedUrlString = _.trim(args, ' ');
 

--- a/lib/rules/function-whitelist/index.js
+++ b/lib/rules/function-whitelist/index.js
@@ -32,7 +32,7 @@ function rule(whitelistInput) {
 		root.walkDecls((decl) => {
 			const value = decl.value;
 
-			valueParser(value).walk(function(node) {
+			valueParser(value).walk((node) => {
 				if (node.type !== 'function') {
 					return;
 				}

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -340,7 +340,7 @@ function rule(space, options = {}, context) {
 
 			if (fixPositions.length) {
 				if (node.type === 'rule') {
-					fixPositions.forEach(function(fixPosition) {
+					fixPositions.forEach((fixPosition) => {
 						node.selector = replaceIndentation(
 							node.selector,
 							fixPosition.currentIndentation,
@@ -354,7 +354,7 @@ function rule(space, options = {}, context) {
 					const declProp = node.prop;
 					const declBetween = node.raws.between;
 
-					fixPositions.forEach(function(fixPosition) {
+					fixPositions.forEach((fixPosition) => {
 						if (fixPosition.startIndex < declProp.length + declBetween.length) {
 							node.raws.between = replaceIndentation(
 								declBetween,
@@ -378,7 +378,7 @@ function rule(space, options = {}, context) {
 					const atRuleAfterName = node.raws.afterName;
 					const atRuleParams = node.params;
 
-					fixPositions.forEach(function(fixPosition) {
+					fixPositions.forEach((fixPosition) => {
 						// 1 — it's a @ length
 						if (fixPosition.startIndex < 1 + atRuleName.length + atRuleAfterName.length) {
 							node.raws.afterName = replaceIndentation(

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -168,7 +168,7 @@ function rule(actual, secondary, context) {
 			});
 
 			if (fixPositions.length) {
-				fixPositions.forEach(function(fixPosition) {
+				fixPositions.forEach((fixPosition) => {
 					if (node.type === 'atrule') {
 						// Use `-1` for `@` character before each at rule
 						const realIndex =

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -110,7 +110,7 @@ function rule(expectation, secondary, context) {
 			});
 
 			if (alwaysFixPositions.length) {
-				alwaysFixPositions.forEach(function(fixPosition) {
+				alwaysFixPositions.forEach((fixPosition) => {
 					const index = fixPosition.index;
 
 					if (node.type === 'atrule') {
@@ -122,7 +122,7 @@ function rule(expectation, secondary, context) {
 			}
 
 			if (neverFixPositions.length) {
-				neverFixPositions.forEach(function(fixPosition) {
+				neverFixPositions.forEach((fixPosition) => {
 					const startIndex = fixPosition.startIndex;
 					const endIndex = fixPosition.endIndex;
 

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -93,7 +93,7 @@ function rule(actual, secondary, context) {
 			});
 
 			if (fixPositions.length) {
-				fixPositions.forEach(function(fixPosition) {
+				fixPositions.forEach((fixPosition) => {
 					const startIndex = fixPosition.startIndex;
 					const endIndex = fixPosition.endIndex;
 

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -76,7 +76,7 @@ function rule(expectation, options, context) {
 				const offset = expectedSingle ? 1 : 0;
 				const extraColon = expectedSingle ? '' : ':';
 
-				fixPositions.forEach(function(fixPosition) {
+				fixPositions.forEach((fixPosition) => {
 					rule.selector =
 						rule.selector.substring(0, fixPosition.startIndex - offset) +
 						extraColon +

--- a/lib/rules/unit-blacklist/index.js
+++ b/lib/rules/unit-blacklist/index.js
@@ -78,7 +78,7 @@ function rule(blacklistInput, options) {
 				const mediaName = getMediaFeatureName(mediaFeatureNode);
 				const parentValue = mediaFeatureNode.parent.value;
 
-				valueParser(value).walk(function(valueNode) {
+				valueParser(value).walk((valueNode) => {
 					// Ignore all non-word valueNode and
 					// the values not included in the parentValue string
 					if (valueNode.type !== 'word' || !parentValue.includes(valueNode.value)) {
@@ -101,7 +101,7 @@ function rule(blacklistInput, options) {
 			// by postcss-value-parser
 			value = value.replace(/\*/g, ',');
 
-			valueParser(value).walk(function(valueNode) {
+			valueParser(value).walk((valueNode) => {
 				// Ignore wrong units within `url` function
 				if (valueNode.type === 'function' && valueNode.value.toLowerCase() === 'url') {
 					return false;

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -50,7 +50,7 @@ function rule(actual, options) {
 			const parsedValue = valueParser(value);
 			const ignoredMapProperties = [];
 
-			parsedValue.walk(function(valueNode) {
+			parsedValue.walk((valueNode) => {
 				// Ignore wrong units within `url` function
 				// and within functions listed in the `ignoreFunctions` option
 				if (

--- a/lib/rules/unit-whitelist/index.js
+++ b/lib/rules/unit-whitelist/index.js
@@ -45,7 +45,7 @@ function rule(whitelistInput, options) {
 			// make sure multiplication operations (*) are divided - not handled
 			// by postcss-value-parser
 			value = value.replace(/\*/g, ',');
-			valueParser(value).walk(function(valueNode) {
+			valueParser(value).walk((valueNode) => {
 				// Ignore wrong units within `url` function
 				if (valueNode.type === 'function' && valueNode.value.toLowerCase() === 'url') {
 					return false;

--- a/lib/utils/__tests__/isMap.test.js
+++ b/lib/utils/__tests__/isMap.test.js
@@ -30,7 +30,7 @@ describe('isMap', () => {
 		runTests(css, (decl) => {
 			const parsedValue = valueParser(decl.value);
 
-			parsedValue.walk(function(valueNode) {
+			parsedValue.walk((valueNode) => {
 				if (expected.includes(valueNode.sourceIndex)) {
 					expect(isMap(valueNode)).toBeTruthy();
 				} else {

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
         }
       ],
       "operator-assignment": "error",
+      "prefer-arrow-callback": "error",
       "prefer-object-spread": "error",
       "prefer-regex-literals": "error",
       "prefer-rest-params": "error",

--- a/system-tests/004/004.test.js
+++ b/system-tests/004/004.test.js
@@ -16,7 +16,7 @@ it('004', (done) => {
 		cwd: localPath,
 	});
 
-	cliProcess.on('error', function(error) {
+	cliProcess.on('error', (error) => {
 		console.log('error running cli:', error); // eslint-disable-line no-console
 	});
 
@@ -24,7 +24,7 @@ it('004', (done) => {
 
 	cliProcess.stdout.on('data', (data) => (stdout += data));
 
-	cliProcess.on('close', function(code) {
+	cliProcess.on('close', (code) => {
 		expect(stdout.includes('Cannot find module')).toBeTruthy();
 		expect(code).not.toEqual(0);
 		done();

--- a/system-tests/outputFile/outputFile.test.js
+++ b/system-tests/outputFile/outputFile.test.js
@@ -46,7 +46,7 @@ describe('outputFile', () => {
 
 		childProcess.stdout.on('data', (data) => (stdout += data));
 
-		childProcess.on('close', function() {
+		childProcess.on('close', () => {
 			return readFileAsync(directionPath, 'utf-8').then((content) => {
 				expect(content).toEqual(systemTestUtils.stripColors(stdout));
 				expect(content.replace('×', '✖')).toMatchSnapshot();


### PR DESCRIPTION
Draft because if we agree on these, we need to enforce arrow, rest arguments, rest spread, etc via ESLint. Also, the types need fixing :)

PS. I tested this on [Node.js 8.7.0](https://github.com/XhmikosR/stylelint/runs/324788583) which is what's listed as the minimum Node.js version in engines and it passes (minus linting).