### PR TITLE
Tighten ESLint rules. 

### DIFF
--- a/lib/__tests__/fixtures/processor-fenced-blocks.js
+++ b/lib/__tests__/fixtures/processor-fenced-blocks.js
@@ -13,7 +13,7 @@ module.exports = function(options = {}) {
 			return toLint;
 		},
 		result(stylelintResult) {
-			return Object.assign({}, stylelintResult, { specialMessage });
+			return { ...stylelintResult, specialMessage };
 		},
 	};
 };

--- a/lib/__tests__/fixtures/processor-triple-question-marks.js
+++ b/lib/__tests__/fixtures/processor-triple-question-marks.js
@@ -17,9 +17,7 @@ module.exports = function() {
 			return toLint;
 		},
 		result(stylelintResult) {
-			return Object.assign({}, stylelintResult, {
-				tripleQuestionMarkBlocksFound: found,
-			});
+			return { ...stylelintResult, tripleQuestionMarkBlocksFound: found };
 		},
 	};
 };

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -57,7 +57,7 @@ describe('standalone cache', () => {
 	it('cache file is created at $CWD/.stylelintcache', () => {
 		// Ensure cache file exists
 		return fileExists(expectedCacheFilePath).then((isFileExist) => {
-			expect(!!isFileExist).toBe(true);
+			expect(Boolean(isFileExist)).toBe(true);
 
 			const fileCache = fCache.createFromFile(expectedCacheFilePath);
 			const { cache } = fileCache;
@@ -77,8 +77,8 @@ describe('standalone cache', () => {
 			})
 			.then((output) => {
 				// Ensure only changed files are linted
-				const isValidFileLinted = !!output.results.find((file) => file.source === validFile);
-				const isNewFileLinted = !!output.results.find((file) => file.source === newFileDest);
+				const isValidFileLinted = Boolean(output.results.find((file) => file.source === validFile));
+				const isNewFileLinted = Boolean(output.results.find((file) => file.source === newFileDest));
 
 				expect(isValidFileLinted).toBe(false);
 				expect(isNewFileLinted).toBe(true);
@@ -103,8 +103,8 @@ describe('standalone cache', () => {
 			})
 			.then((output) => {
 				// Ensure all files are re-linted
-				const isValidFileLinted = !!output.results.find((file) => file.source === validFile);
-				const isNewFileLinted = !!output.results.find((file) => file.source === newFileDest);
+				const isValidFileLinted = Boolean(output.results.find((file) => file.source === validFile));
+				const isNewFileLinted = Boolean(output.results.find((file) => file.source === newFileDest));
 
 				expect(isValidFileLinted).toBe(true);
 				expect(isNewFileLinted).toBe(true);
@@ -120,8 +120,10 @@ describe('standalone cache', () => {
 			.then((output) => {
 				expect(output.errored).toBe(true);
 				// Ensure only changed files are linted
-				const isValidFileLinted = !!output.results.find((file) => file.source === validFile);
-				const isInvalidFileLinted = !!output.results.find((file) => file.source === newFileDest);
+				const isValidFileLinted = Boolean(output.results.find((file) => file.source === validFile));
+				const isInvalidFileLinted = Boolean(
+					output.results.find((file) => file.source === newFileDest),
+				);
 
 				expect(isValidFileLinted).toBe(false);
 				expect(isInvalidFileLinted).toBe(true);
@@ -224,7 +226,7 @@ describe('standalone cache uses cacheLocation', () => {
 				return fileExists(cacheLocationFile);
 			})
 			.then((fileStats) => {
-				expect(!!fileStats).toBe(true);
+				expect(Boolean(fileStats)).toBe(true);
 
 				const fileCache = fCache.createFromFile(cacheLocationFile);
 				const { cache } = fileCache;
@@ -243,7 +245,7 @@ describe('standalone cache uses cacheLocation', () => {
 			})
 			.then((cacheFileStats) => {
 				// Ensure cache file is created
-				expect(!!cacheFileStats).toBe(true);
+				expect(Boolean(cacheFileStats)).toBe(true);
 
 				const fileCache = fCache.createFromFile(expectedCacheFilePath);
 				const { cache } = fileCache;

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -249,9 +249,25 @@ it('standalone with postcss-safe-parser', () => {
 
 		expect(results).toHaveLength(6);
 
+		const safeParserExtensionsTest = /\.(css|pcss|postcss)$/i;
+
+		results
+			.filter((result) => !safeParserExtensionsTest.test(result.source))
+			.forEach((result) => {
+				expect(result.warnings).toHaveLength(1);
+
+				const error = result.warnings[0];
+
+				expect(error.line).toBe(1);
+				expect(error.column).toBe(1);
+				expect(error.rule).toBe('CssSyntaxError');
+				expect(error.severity).toBe('error');
+			});
+
 		return Promise.all(
-			results.map((result) => {
-				if (/\.(css|pcss|postcss)$/i.test(result.source)) {
+			results
+				.filter((result) => safeParserExtensionsTest.test(result.source))
+				.map((result) => {
 					const root = result._postcssResult.root;
 
 					expect(result.errored).toBeFalsy();
@@ -259,16 +275,7 @@ it('standalone with postcss-safe-parser', () => {
 					expect(root.toString()).not.toBe(root.source.input.css);
 
 					return promisify(fs.writeFile)(root.source.input.file, root.source.input.css);
-				}
-
-				expect(result.warnings).toHaveLength(1);
-				const error = result.warnings[0];
-
-				expect(error.line).toBe(1);
-				expect(error.column).toBe(1);
-				expect(error.rule).toBe('CssSyntaxError');
-				expect(error.severity).toBe('error');
-			}),
+				}),
 		);
 	});
 });

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -259,15 +259,15 @@ it('standalone with postcss-safe-parser', () => {
 					expect(root.toString()).not.toBe(root.source.input.css);
 
 					return promisify(fs.writeFile)(root.source.input.file, root.source.input.css);
-				} else {
-					expect(result.warnings).toHaveLength(1);
-					const error = result.warnings[0];
-
-					expect(error.line).toBe(1);
-					expect(error.column).toBe(1);
-					expect(error.rule).toBe('CssSyntaxError');
-					expect(error.severity).toBe('error');
 				}
+
+				expect(result.warnings).toHaveLength(1);
+				const error = result.warnings[0];
+
+				expect(error.line).toBe(1);
+				expect(error.column).toBe(1);
+				expect(error.rule).toBe('CssSyntaxError');
+				expect(error.severity).toBe('error');
 			}),
 		);
 	});

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -158,8 +158,8 @@ module.exports = function(root, result) {
 
 			if (ruleToEnable === ALL_RULES) {
 				if (
-					// @ts-ignore https://github.com/stylelint/stylelint/issues/4328
 					Object.values(disabledRanges).every(
+						// @ts-ignore https://github.com/stylelint/stylelint/issues/4328
 						(ranges) => _.isEmpty(ranges) || Boolean(_.last(ranges.end)),
 					)
 				) {
@@ -184,10 +184,10 @@ module.exports = function(root, result) {
 						createDisableRange(start, false, end, false),
 					);
 				} else {
-					const range = { ..._.last(disabledRanges[ALL_RULES]) };
+					const range = _.last(disabledRanges[ALL_RULES]);
 
 					if (range) {
-						disabledRanges[ruleToEnable].push(range);
+						disabledRanges[ruleToEnable].push({ ...range });
 					}
 				}
 

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -159,7 +159,9 @@ module.exports = function(root, result) {
 			if (ruleToEnable === ALL_RULES) {
 				if (
 					// @ts-ignore https://github.com/stylelint/stylelint/issues/4328
-					Object.values(disabledRanges).every((ranges) => _.isEmpty(ranges) || !!_.last(ranges.end))
+					Object.values(disabledRanges).every(
+						(ranges) => _.isEmpty(ranges) || Boolean(_.last(ranges.end)),
+					)
 				) {
 					throw comment.error('No rules have been disabled', {
 						plugin: 'stylelint',
@@ -182,7 +184,7 @@ module.exports = function(root, result) {
 						createDisableRange(start, false, end, false),
 					);
 				} else {
-					const range = Object.assign({}, _.last(disabledRanges[ALL_RULES]));
+					const range = { ..._.last(disabledRanges[ALL_RULES]) };
 
 					if (range) {
 						disabledRanges[ruleToEnable].push(range);

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -53,7 +53,6 @@ function augmentConfigExtended(stylelint, cosmiconfigResult) {
 	if (!cosmiconfigResult) return Promise.resolve(null);
 
 	const configDir = path.dirname(cosmiconfigResult.filepath || '');
-	// eslint-disable-next-line no-unused-vars
 	const { ignoreFiles, ...cleanedConfig } = cosmiconfigResult.config;
 
 	return augmentConfigBasic(stylelint, cleanedConfig, configDir).then((augmentedConfig) => {
@@ -162,9 +161,8 @@ function extendConfig(stylelint, config, configDir) {
 	if (config.extends === undefined) return Promise.resolve(config);
 
 	const normalizedExtends = Array.isArray(config.extends) ? config.extends : [config.extends];
-
-	// eslint-disable-next-line no-unused-vars
 	const { extends: configExtends, ...originalWithoutExtends } = config;
+
 	const loadExtends = normalizedExtends.reduce((resultPromise, extendLookup) => {
 		return resultPromise.then((resultConfig) => {
 			return loadExtendedConfig(stylelint, resultConfig, configDir, extendLookup).then(

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -240,10 +240,10 @@ function mergeConfigs(a, b) {
 	const rulesMerger = {};
 
 	if (a.rules || b.rules) {
-		rulesMerger.rules = Object.assign({}, a.rules, b.rules);
+		rulesMerger.rules = { ...a.rules, ...b.rules };
 	}
 
-	const result = Object.assign({}, a, b, processorMerger, pluginMerger, rulesMerger);
+	const result = { ...a, ...b, ...processorMerger, ...pluginMerger, ...rulesMerger };
 
 	return result;
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -454,18 +454,10 @@ module.exports = (argv) => {
 			() => {
 				// Add input/code into options
 				if (cli.input.length) {
-					return Promise.resolve(
-						Object.assign({}, optionsBase, {
-							files: /** @type {string} */ (cli.input),
-						}),
-					);
+					return Promise.resolve({ ...optionsBase, files: /** @type {string} */ (cli.input) });
 				}
 
-				return getStdin().then((stdin) =>
-					Object.assign({}, optionsBase, {
-						code: stdin,
-					}),
-				);
+				return getStdin().then((stdin) => ({ ...optionsBase, code: stdin }));
 			},
 		)
 		.then((options) => {

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -14,12 +14,11 @@ const postcssProcessor = postcss();
 
 /**
  * @param {StylelintInternalApi} stylelint
+ * @param {import('stylelint').GetPostcssOptions} options
+ *
  * @returns {Promise<import('postcss').Result>}
  */
-module.exports = function(stylelint) {
-	/** @type {import('stylelint').GetPostcssOptions} */
-	const options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-
+module.exports = function(stylelint, options = {}) {
 	const cached = options.filePath ? stylelint._postcssResultCache.get(options.filePath) : undefined;
 
 	if (cached) return Promise.resolve(cached);

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -32,9 +32,9 @@ module.exports = function lintSource(stylelint, options = {}) {
 	if (inputFilePath !== undefined && !path.isAbsolute(inputFilePath)) {
 		if (isCodeNotFile) {
 			return Promise.reject(new Error('codeFilename must be an absolute path'));
-		} else {
-			return Promise.reject(new Error('filePath must be an absolute path'));
 		}
+
+		return Promise.reject(new Error('filePath must be an absolute path'));
 	}
 
 	const getIsIgnored = stylelint.isPathIgnored(inputFilePath).catch((err) => {

--- a/lib/requireRule.js
+++ b/lib/requireRule.js
@@ -10,7 +10,7 @@ const rules = require('./rules');
 module.exports = function(ruleName) {
 	if (rules.includes(ruleName)) {
 		return importLazy(`./rules/${ruleName}`);
-	} else {
-		return false;
 	}
+
+	return false;
 };

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -109,7 +109,7 @@ const rule = function(expectation, options, context) {
 			}
 
 			const hasEmptyLineBefore = hasEmptyLine(atRule.raws.before);
-			let expectEmptyLineBefore = expectation === 'always' ? true : false;
+			let expectEmptyLineBefore = expectation === 'always';
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -72,12 +72,12 @@ const rule = function(expectation, options, context) {
 					statement.type === 'atrule' &&
 					!childNodeTypes.includes('decl')
 				) {
-					return expectation === 'never' ? true : false;
+					return expectation === 'never';
 				}
 
-				return expectation === 'always-multi-line' && !isSingleLineString(blockString(statement))
-					? true
-					: false;
+				return Boolean(
+					expectation === 'always-multi-line' && !isSingleLineString(blockString(statement)),
+				);
 			})();
 
 			// Check for at least one empty line

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -108,7 +108,9 @@ const rule = function(expectation, options, context) {
 							}
 
 							return;
-						} else if (expectation.startsWith('never')) {
+						}
+
+						if (expectation.startsWith('never')) {
 							nodeToCheck.raws.before = '';
 
 							return;

--- a/lib/rules/block-closing-brace-newline-before/index.js
+++ b/lib/rules/block-closing-brace-newline-before/index.js
@@ -89,7 +89,9 @@ const rule = function(expectation, options, context) {
 						}
 
 						return;
-					} else if (expectation === 'never-multi-line') {
+					}
+
+					if (expectation === 'never-multi-line') {
 						statement.raws.after = statement.raws.after.replace(/\s/g, '');
 
 						return;

--- a/lib/rules/block-closing-brace-space-before/index.js
+++ b/lib/rules/block-closing-brace-space-before/index.js
@@ -67,7 +67,9 @@ const rule = function(expectation, options, context) {
 							statement.raws.after = statement.raws.after.replace(/\s*$/, ' ');
 
 							return;
-						} else if (expectation.startsWith('never')) {
+						}
+
+						if (expectation.startsWith('never')) {
 							statement.raws.after = statement.raws.after.replace(/\s*$/, '');
 
 							return;

--- a/lib/rules/block-opening-brace-newline-after/index.js
+++ b/lib/rules/block-opening-brace-newline-after/index.js
@@ -89,7 +89,9 @@ const rule = function(expectation, options, context) {
 							backupCommentNextBefores.delete(nodeToCheck);
 
 							return;
-						} else if (expectation === 'never-multi-line') {
+						}
+
+						if (expectation === 'never-multi-line') {
 							// Restore the `before` of the node next to the comment node.
 							backupCommentNextBefores.forEach((before, node) => {
 								node.raws.before = before;

--- a/lib/rules/block-opening-brace-newline-before/index.js
+++ b/lib/rules/block-opening-brace-newline-before/index.js
@@ -74,7 +74,7 @@ const rule = function(expectation, options, context) {
 									context.newline +
 									statement.raws.between.slice(spaceIndex);
 							} else {
-								statement.raws.between = statement.raws.between + context.newline;
+								statement.raws.between += context.newline;
 							}
 
 							return;

--- a/lib/rules/block-opening-brace-newline-before/index.js
+++ b/lib/rules/block-opening-brace-newline-before/index.js
@@ -78,7 +78,9 @@ const rule = function(expectation, options, context) {
 							}
 
 							return;
-						} else if (expectation.startsWith('never')) {
+						}
+
+						if (expectation.startsWith('never')) {
 							statement.raws.between = statement.raws.between.replace(/\s*$/, '');
 
 							return;

--- a/lib/rules/block-opening-brace-space-after/index.js
+++ b/lib/rules/block-opening-brace-space-after/index.js
@@ -59,7 +59,9 @@ const rule = function(expectation, options, context) {
 							statement.first.raws.before = ' ';
 
 							return;
-						} else if (expectation.startsWith('never')) {
+						}
+
+						if (expectation.startsWith('never')) {
 							statement.first.raws.before = '';
 
 							return;

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -89,7 +89,9 @@ const rule = function(expectation, options, context) {
 							statement.raws.between = ' ';
 
 							return;
-						} else if (expectation.startsWith('never')) {
+						}
+
+						if (expectation.startsWith('never')) {
 							statement.raws.between = '';
 
 							return;

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -98,7 +98,7 @@ function canShrink(hex) {
 function shorter(hex) {
 	let hexVariant = '#';
 
-	for (let i = 1; i < hex.length; i = i + 2) {
+	for (let i = 1; i < hex.length; i += 2) {
 		hexVariant += hex[i];
 	}
 

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -75,7 +75,7 @@ const rule = function(expectation, options, context) {
 				return;
 			}
 
-			let expectEmptyLineBefore = expectation === 'always' ? true : false;
+			let expectEmptyLineBefore = expectation === 'always';
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (

--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -64,7 +64,9 @@ const rule = function(expectation, options, context) {
 							setFixed(targetBefore + targetAfter.replace(/^\s*/, ' '));
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							setFixed(targetBefore + targetAfter.replace(/^\s*/, ''));
 
 							return true;

--- a/lib/rules/declaration-bang-space-before/index.js
+++ b/lib/rules/declaration-bang-space-before/index.js
@@ -64,7 +64,9 @@ const rule = function(expectation, options, context) {
 							setFixed(targetBefore.replace(/\s*$/, '') + ' ' + targetAfter);
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							setFixed(targetBefore.replace(/\s*$/, '') + targetAfter);
 
 							return true;

--- a/lib/rules/declaration-block-semicolon-newline-after/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.js
@@ -66,7 +66,9 @@ const rule = function(expectation, options, context) {
 							}
 
 							return;
-						} else if (expectation === 'never-multi-line') {
+						}
+
+						if (expectation === 'never-multi-line') {
 							nodeToCheck.raws.before = '';
 
 							return;

--- a/lib/rules/declaration-block-semicolon-space-after/index.js
+++ b/lib/rules/declaration-block-semicolon-space-after/index.js
@@ -55,7 +55,9 @@ const rule = function(expectation, options, context) {
 							nextDecl.raws.before = ' ';
 
 							return;
-						} else if (expectation.startsWith('never')) {
+						}
+
+						if (expectation.startsWith('never')) {
 							nextDecl.raws.before = '';
 
 							return;

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -58,7 +58,9 @@ const rule = function(expectation, options, context) {
 							}
 
 							return;
-						} else if (expectation.startsWith('never')) {
+						}
+
+						if (expectation.startsWith('never')) {
 							if (decl.important) {
 								decl.raws.important = decl.raws.important.replace(/\s*$/, '');
 							} else if (decl.raws.value) {

--- a/lib/rules/declaration-colon-space-after/index.js
+++ b/lib/rules/declaration-colon-space-after/index.js
@@ -42,7 +42,9 @@ const rule = function(expectation, options, context) {
 								between.slice(0, colonIndex) + between.slice(colonIndex).replace(/^:\s*/, ': ');
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							decl.raws.between =
 								between.slice(0, colonIndex) + between.slice(colonIndex).replace(/^:\s*/, ':');
 

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -41,7 +41,9 @@ const rule = function(expectation, options, context) {
 								between.slice(0, colonIndex).replace(/\s*$/, ' ') + between.slice(colonIndex);
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							decl.raws.between =
 								between.slice(0, colonIndex).replace(/\s*$/, '') + between.slice(colonIndex);
 

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -88,7 +88,7 @@ const rule = function(expectation, options, context) {
 				return;
 			}
 
-			let expectEmptyLineBefore = expectation === 'always' ? true : false;
+			let expectEmptyLineBefore = expectation === 'always';
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -125,8 +125,6 @@ const rule = function(expectation) {
 					if (required && !hasQuotes) {
 						return complain(messages.expected(family), family, decl);
 					}
-
-					return;
 			}
 		}
 

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -132,8 +132,6 @@ const rule = function(expectation, options) {
 				) {
 					return complain(messages.invalidNamed(weightValue));
 				}
-
-				return;
 			}
 
 			function complain(message) {

--- a/lib/rules/function-calc-no-invalid/index.js
+++ b/lib/rules/function-calc-no-invalid/index.js
@@ -51,9 +51,9 @@ const rule = function(actual) {
 						complain(messages.expectedExpression(), node.sourceIndex + e.hash.loc.range[0]);
 
 						return;
-					} else {
-						throw e;
 					}
+
+					throw e;
 				}
 
 				verifyMathExpressions(ast, node);

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -85,8 +85,6 @@ const rule = function(actual) {
 
 						if (!isStandardDirection(firstArg, withToPrefix)) {
 							complain();
-
-							return;
 						}
 
 						function complain() {

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -121,7 +121,7 @@ const rule = function(expectation, options, context) {
 			return {
 				applyFix,
 				get hasFixed() {
-					return !!lastIndex;
+					return Boolean(lastIndex);
 				},
 				get fixed() {
 					return fixed + value.slice(lastIndex);

--- a/lib/rules/functionCommaSpaceFix.js
+++ b/lib/rules/functionCommaSpaceFix.js
@@ -7,7 +7,9 @@ module.exports = function(params) {
 		div[position] = symb;
 
 		return true;
-	} else if (expectation.startsWith('never')) {
+	}
+
+	if (expectation.startsWith('never')) {
 		div[position] = '';
 
 		for (let i = index + 1; i < nodes.length; i++) {

--- a/lib/rules/indentation/__tests__/rules.js
+++ b/lib/rules/indentation/__tests__/rules.js
@@ -10,7 +10,7 @@ testRule(rule, {
 
 	accept: [
 		{
-			code: String('/* anything\n' + '    goes\n' + '\t\t\twithin a comment */\n'),
+			code: '/* anything\n' + '    goes\n' + '\t\t\twithin a comment */\n',
 		},
 		{
 			code: 'a { top: 0; } b { top: 1px; }',
@@ -86,7 +86,7 @@ testRule(rule, {
 			code: 'a {\n' + '  @media print { color: pink; }\n' + '}',
 		},
 		{
-			code: String('/* anything\r\n' + '    goes\r\n' + '\t\t\twithin a comment */\r\n'),
+			code: '/* anything\r\n' + '    goes\r\n' + '\t\t\twithin a comment */\r\n',
 		},
 		{
 			code: 'a {\r\n' + '  top: 0;\r\n' + '}\r\n' + 'b { top: 1px; bottom: 4px; }',

--- a/lib/rules/indentation/__tests__/rules.js
+++ b/lib/rules/indentation/__tests__/rules.js
@@ -10,7 +10,7 @@ testRule(rule, {
 
 	accept: [
 		{
-			code: '/* anything\n' + '    goes\n' + '\t\t\twithin a comment */\n' + '',
+			code: String('/* anything\n' + '    goes\n' + '\t\t\twithin a comment */\n'),
 		},
 		{
 			code: 'a { top: 0; } b { top: 1px; }',
@@ -86,7 +86,7 @@ testRule(rule, {
 			code: 'a {\n' + '  @media print { color: pink; }\n' + '}',
 		},
 		{
-			code: '/* anything\r\n' + '    goes\r\n' + '\t\t\twithin a comment */\r\n' + '',
+			code: String('/* anything\r\n' + '    goes\r\n' + '\t\t\twithin a comment */\r\n'),
 		},
 		{
 			code: 'a {\r\n' + '  top: 0;\r\n' + '}\r\n' + 'b { top: 1px; bottom: 4px; }',

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -465,16 +465,18 @@ function inferDocIndentSize(document, space) {
 		let bestScore = 0;
 
 		for (const indentSizeDate in scores) {
-			const score = scores[indentSizeDate];
+			if (Object.prototype.hasOwnProperty.call(scores, indentSizeDate)) {
+				const score = scores[indentSizeDate];
 
-			if (score > bestScore) {
-				bestScore = score;
-				indentSize = indentSizeDate;
+				if (score > bestScore) {
+					bestScore = score;
+					indentSize = indentSizeDate;
+				}
 			}
 		}
 	}
 
-	indentSize = +indentSize || (indents && indents[0].length) || +space || 2;
+	indentSize = Number(indentSize) || (indents && indents[0].length) || Number(space) || 2;
 	document.source.indentSize = indentSize;
 
 	return indentSize;
@@ -503,9 +505,9 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 
 		if (indents) {
 			return Math.min(...indents.map(getIndentLevel));
-		} else {
-			baseIndentLevel = 1;
 		}
+
+		baseIndentLevel = 1;
 	}
 
 	const indents = [];

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -83,11 +83,9 @@ const rule = function(max, options, context) {
 					// when max setted 0, should be treated as 1 in this situation.
 					_.set(root, 'raws.after', replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter, true));
 				}
-			} else {
+			} else if (rootRawsAfter) {
 				// `css in js` or `html`
-				if (rootRawsAfter) {
-					_.set(root, 'raws.after', replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter));
-				}
+				_.set(root, 'raws.after', replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter));
 			}
 
 			return;
@@ -109,7 +107,7 @@ const rule = function(max, options, context) {
 		);
 
 		function checkMatch(source, matchStartIndex, matchEndIndex, node) {
-			const eof = matchEndIndex === source.length ? true : false;
+			const eof = matchEndIndex === source.length;
 			let violation = false;
 
 			// Additional check for beginning of file
@@ -207,7 +205,7 @@ function isEofNode(document, root) {
 		after = _.get(document.nodes[rootIndex + 1], 'raws.beforeStart');
 	}
 
-	return !(after + '').trim();
+	return !String(after).trim();
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -76,9 +76,9 @@ const rule = function(expectation, secondary, context) {
 						});
 
 						return;
-					} else {
-						complain(messages.expected, node, getIndex(node) + index);
 					}
+
+					complain(messages.expected, node, getIndex(node) + index);
 				}
 
 				if (expectation === 'never') {
@@ -103,9 +103,9 @@ const rule = function(expectation, secondary, context) {
 						});
 
 						return;
-					} else {
-						complain(messages.rejected, node, getIndex(node) + index);
 					}
+
+					complain(messages.rejected, node, getIndex(node) + index);
 				}
 			});
 

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -80,16 +80,16 @@ const rule = function(actual, secondary, context) {
 					});
 
 					return;
-				} else {
-					report({
-						message: messages.rejected,
-						node,
-						// this is the index of the _first_ trailing zero
-						index: getIndex(node) + index,
-						result,
-						ruleName,
-					});
 				}
+
+				report({
+					message: messages.rejected,
+					node,
+					// this is the index of the _first_ trailing zero
+					index: getIndex(node) + index,
+					result,
+					ruleName,
+				});
 			});
 
 			if (fixPositions.length) {

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -86,7 +86,7 @@ const rule = function(expectation, options, context) {
 				return;
 			}
 
-			let expectEmptyLineBefore = expectation.includes('always') ? true : false;
+			let expectEmptyLineBefore = Boolean(expectation.includes('always'));
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (

--- a/lib/rules/selector-attribute-operator-space-after/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/index.js
@@ -71,7 +71,9 @@ const rule = function(expectation, options, context) {
 							setOperatorAfter(operatorAfter.replace(/^\s*/, ' '));
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							setOperatorAfter(operatorAfter.replace(/^\s*/, ''));
 
 							return true;

--- a/lib/rules/selector-attribute-operator-space-before/index.js
+++ b/lib/rules/selector-attribute-operator-space-before/index.js
@@ -53,7 +53,9 @@ const rule = function(expectation, options, context) {
 							setAttrAfter(attrAfter.replace(/\s*$/, ' '));
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							setAttrAfter(attrAfter.replace(/\s*$/, ''));
 
 							return true;

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -37,7 +37,9 @@ const rule = function(expectation, options, context) {
 							combinator.spaces.after = ' ';
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							combinator.spaces.after = '';
 
 							return true;

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -37,7 +37,9 @@ const rule = function(expectation, options, context) {
 							combinator.spaces.before = ' ';
 
 							return true;
-						} else if (expectation === 'never') {
+						}
+
+						if (expectation === 'never') {
 							combinator.spaces.before = '';
 
 							return true;

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -65,7 +65,7 @@ const rule = function(expectation, options, context) {
 									context.newline +
 									beforeSelector.slice(spaceIndex);
 							} else {
-								beforeSelector = beforeSelector + context.newline;
+								beforeSelector += context.newline;
 							}
 						} else if (expectation === 'never-multi-line') {
 							beforeSelector = beforeSelector.replace(/\s*$/, '');

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -45,9 +45,7 @@ const rule = function(max, options) {
 				possible: [
 					function(max) {
 						// Check that the max specificity is in the form "a,b,c"
-						const pattern = new RegExp('^\\d+,\\d+,\\d+$');
-
-						return pattern.test(max);
+						return /^\d+,\d+,\d+$/.test(max);
 					},
 				],
 			},

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -35,10 +35,7 @@ function isShorthandProperty(property) {
 	return propertiesWithShorthandNotation.has(property);
 }
 
-function canCondense(top, right) {
-	const bottom = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : null;
-	const left = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
-
+function canCondense(top, right, bottom, left) {
 	const lowerTop = top.toLowerCase();
 	const lowerRight = right.toLowerCase();
 	const lowerBottom = bottom && bottom.toLowerCase();

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -46,13 +46,17 @@ function canCondense(top, right) {
 
 	if (canCondenseToOneValue(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
 		return [top];
-	} else if (canCondenseToTwoValues(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
-		return [top, right];
-	} else if (canCondenseToThreeValues(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
-		return [top, right, bottom];
-	} else {
-		return [top, right, bottom, left];
 	}
+
+	if (canCondenseToTwoValues(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
+		return [top, right];
+	}
+
+	if (canCondenseToThreeValues(lowerTop, lowerRight, lowerBottom, lowerLeft)) {
+		return [top, right, bottom];
+	}
+
+	return [top, right, bottom, left];
 }
 
 function canCondenseToOneValue(top, right, bottom, left) {

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -125,7 +125,9 @@ const rule = function(expectation, secondary, context) {
 			// Get out quickly if there are no erroneous quotes
 			if (!value.includes(erroneousQuote)) {
 				return;
-			} else if (node.type === 'atrule' && node.name === 'charset') {
+			}
+
+			if (node.type === 'atrule' && node.name === 'charset') {
 				// allow @charset rules to have double quotes, in spite of the configuration
 				// TODO: @charset should always use double-quotes, see https://github.com/stylelint/stylelint/issues/2788
 				return;

--- a/lib/rules/unit-blacklist/index.js
+++ b/lib/rules/unit-blacklist/index.js
@@ -93,8 +93,6 @@ const rule = function(blacklistInput, options) {
 						options ? options.ignoreMediaFeatureNames : {},
 					);
 				});
-
-				return;
 			});
 		}
 

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -60,12 +60,11 @@ const rule = function(expectation, options, context) {
 
 				if (value.includes('*')) {
 					value.split('*').some((val) => {
-						return processValue(
-							Object.assign({}, valueNode, {
-								sourceIndex: value.indexOf(val) + val.length + 1,
-								value: val,
-							}),
-						);
+						return processValue({
+							...valueNode,
+							sourceIndex: value.indexOf(val) + val.length + 1,
+							value: val,
+						});
 					});
 				}
 

--- a/lib/rules/unit-whitelist/index.js
+++ b/lib/rules/unit-whitelist/index.js
@@ -57,7 +57,7 @@ const rule = function(whitelistInput, options) {
 					return;
 				}
 
-				if (options && optionsMatches(options['ignoreProperties'], unit.toLowerCase(), node.prop)) {
+				if (options && optionsMatches(options.ignoreProperties, unit.toLowerCase(), node.prop)) {
 					return;
 				}
 

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -339,7 +339,7 @@ module.exports = function(options) {
 function handleError(stylelint, error, filePath = undefined) {
 	if (error.name === 'CssSyntaxError') {
 		return createStylelintResult(stylelint, undefined, filePath, error);
-	} else {
-		throw error;
 	}
+
+	throw error;
 }

--- a/lib/utils/__tests__/validateOptions.test.js
+++ b/lib/utils/__tests__/validateOptions.test.js
@@ -257,7 +257,7 @@ describe("validateOptions with a function for 'possible'", () => {
 			return false;
 		}
 
-		if (x.every((item) => typeof item === 'string' || !!item.properties)) {
+		if (x.every((item) => typeof item === 'string' || Boolean(item.properties))) {
 			return true;
 		}
 

--- a/lib/utils/addEmptyLineAfter.js
+++ b/lib/utils/addEmptyLineAfter.js
@@ -19,7 +19,7 @@ function addEmptyLineAfter(node, newline) {
 	const after = _.last(node.raws.after.split(';')) || '';
 
 	if (!/\r?\n/.test(after)) {
-		node.raws.after = node.raws.after + newline.repeat(2);
+		node.raws.after += newline.repeat(2);
 	} else {
 		node.raws.after = node.raws.after.replace(/(\r?\n)/, `${newline}$1`);
 	}

--- a/lib/utils/eachDeclarationBlock.js
+++ b/lib/utils/eachDeclarationBlock.js
@@ -41,9 +41,9 @@ module.exports = function(root, cb /* Function */) {
 			const decls = statement.nodes.filter((node) => {
 				if (node.type === 'decl') {
 					return true;
-				} else {
-					each(node);
 				}
+
+				each(node);
 			});
 
 			if (decls.length) {

--- a/lib/utils/eachDeclarationBlock.js
+++ b/lib/utils/eachDeclarationBlock.js
@@ -28,7 +28,7 @@ function isContainerNode(node) {
  *
  * @returns {void}
  */
-module.exports = function(root, cb /* Function */) {
+module.exports = function(root, cb) {
 	/**
 	 * @param {PostcssNode} statement
 	 *
@@ -38,9 +38,12 @@ module.exports = function(root, cb /* Function */) {
 		if (!isContainerNode(statement)) return;
 
 		if (statement.nodes && statement.nodes.length) {
-			const decls = statement.nodes.filter((node) => {
+			/** @type {PostcssNode[]} */
+			const decls = [];
+
+			statement.nodes.forEach((node) => {
 				if (node.type === 'decl') {
-					return true;
+					decls.push(node);
 				}
 
 				each(node);

--- a/lib/utils/findFontFamily.js
+++ b/lib/utils/findFontFamily.js
@@ -107,7 +107,9 @@ module.exports = function findFontFamily(value) {
 			mergeCharacters = valueNode.value;
 
 			return;
-		} else if (valueNode.type === 'space' || valueNode.type === 'div') {
+		}
+
+		if (valueNode.type === 'space' || valueNode.type === 'div') {
 			return;
 		}
 

--- a/lib/utils/isAutoprefixable.js
+++ b/lib/utils/isAutoprefixable.js
@@ -28,7 +28,7 @@ module.exports = {
 	 * @returns {boolean}
 	 */
 	atRuleName(identifier) {
-		return !!prefixes.remove[`@${identifier.toLowerCase()}`];
+		return Boolean(prefixes.remove[`@${identifier.toLowerCase()}`]);
 	},
 
 	/**
@@ -54,7 +54,7 @@ module.exports = {
 	 * @returns {boolean}
 	 */
 	property(identifier) {
-		return !!autoprefixer.data.prefixes[prefixes.unprefixed(identifier.toLowerCase())];
+		return Boolean(autoprefixer.data.prefixes[prefixes.unprefixed(identifier.toLowerCase())]);
 	},
 
 	/**

--- a/lib/utils/nodeContextLookup.js
+++ b/lib/utils/nodeContextLookup.js
@@ -17,11 +17,10 @@ module.exports = function() {
 		/**
 		 * @param {import('postcss').Node} node
 		 */
-		getContext(node) {
+		getContext(node, /** @type {any[]} */ ...subContexts) {
 			// TODO TYPES node.source possible undefined
 			const nodeSource = /** @type {import('postcss').NodeSource} */ (node.source).input.from;
 			const baseContext = creativeGetMap(contextMap, nodeSource);
-			const subContexts = Array.from(arguments).slice(1);
 
 			return subContexts.reduce((result, context) => {
 				return creativeGetMap(result, context);

--- a/lib/utils/optionsMatches.js
+++ b/lib/utils/optionsMatches.js
@@ -13,10 +13,10 @@ const matchesStringOrRegExp = require('./matchesStringOrRegExp');
  * @returns {boolean}
  */
 module.exports = function optionsMatches(options, propertyName, input) {
-	return !!(
+	return Boolean(
 		options &&
-		options[propertyName] &&
-		typeof input === 'string' &&
-		matchesStringOrRegExp(input, options[propertyName])
+			options[propertyName] &&
+			typeof input === 'string' &&
+			matchesStringOrRegExp(input, options[propertyName]),
 	);
 };

--- a/lib/utils/ruleMessages.js
+++ b/lib/utils/ruleMessages.js
@@ -23,8 +23,8 @@ module.exports = function(ruleName, messages) {
 			if (typeof messageText === 'string') {
 				newMessages[messageId] = `${messageText} (${ruleName})`;
 			} else {
-				newMessages[messageId] = function() {
-					return `${messageText(...arguments)} (${ruleName})`;
+				newMessages[messageId] = (...args) => {
+					return `${messageText(...args)} (${ruleName})`;
 				};
 			}
 

--- a/lib/utils/ruleMessages.js
+++ b/lib/utils/ruleMessages.js
@@ -23,7 +23,7 @@ module.exports = function(ruleName, messages) {
 			if (typeof messageText === 'string') {
 				newMessages[messageId] = `${messageText} (${ruleName})`;
 			} else {
-				newMessages[messageId] = (...args) => {
+				newMessages[messageId] = (/** @type {any[]} */ ...args) => {
 					return `${messageText(...args)} (${ruleName})`;
 				};
 			}

--- a/lib/utils/typeGuards.js
+++ b/lib/utils/typeGuards.js
@@ -39,6 +39,6 @@ module.exports.isComment = function isComment(node) {
  * @param {Node} node
  * @returns {node is (Node & {source: NodeSource})}
  */
-module.exports.hasSource = function isComment(node) {
-	return !!node.source;
+module.exports.hasSource = function hasSource(node) {
+	return Boolean(node.source);
 };

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -77,7 +77,9 @@ function validate(opts, ruleName, complain) {
 		complain(`Expected option value for rule "${ruleName}"`);
 
 		return;
-	} else if (nothingPossible) {
+	}
+
+	if (nothingPossible) {
 		if (optional) {
 			complain(
 				`Incorrect configuration for rule "${ruleName}". Rule should have "possible" values for options validation`,

--- a/lib/utils/whitespaceChecker.js
+++ b/lib/utils/whitespaceChecker.js
@@ -191,7 +191,7 @@ module.exports = function(targetWhitespace, expectation, messages) {
 	 * @param {Object} obj
 	 */
 	function beforeAllowingIndentation(obj) {
-		before(Object.assign({}, obj, { allowIndentation: true }));
+		before({ ...obj, allowIndentation: true });
 	}
 
 	/**
@@ -271,7 +271,7 @@ module.exports = function(targetWhitespace, expectation, messages) {
 	 * @param {Object} obj
 	 */
 	function afterOneOnly(obj) {
-		after(Object.assign({}, obj, { onlyOneChar: true }));
+		after({ ...obj, onlyOneChar: true });
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -177,6 +177,12 @@
       "no-mixed-spaces-and-tabs": "off",
       "no-unneeded-ternary": "error",
       "no-useless-return": "error",
+      "no-unused-vars": [
+        "error",
+        {
+          "ignoreRestSiblings": true
+        }
+      ],
       "operator-assignment": "error",
       "prefer-object-spread": "error",
       "prefer-regex-literals": "error",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,24 @@
       "testRule": true
     },
     "rules": {
-      "no-mixed-spaces-and-tabs": 0
+      "array-callback-return": "error",
+      "dot-notation": "error",
+      "func-name-matching": "error",
+      "guard-for-in": "error",
+      "no-else-return": [
+        "error",
+        {
+          "allowElseIf": false
+        }
+      ],
+      "no-implicit-coercion": "error",
+      "no-lonely-if": "error",
+      "no-mixed-spaces-and-tabs": "off",
+      "no-unneeded-ternary": "error",
+      "prefer-object-spread": "error",
+      "prefer-regex-literals": "error",
+      "prefer-rest-params": "error",
+      "prefer-spread": "error"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -176,6 +176,8 @@
       "no-lonely-if": "error",
       "no-mixed-spaces-and-tabs": "off",
       "no-unneeded-ternary": "error",
+      "no-useless-return": "error",
+      "operator-assignment": "error",
       "prefer-object-spread": "error",
       "prefer-regex-literals": "error",
       "prefer-rest-params": "error",

--- a/system-tests/cli/cli.test.js
+++ b/system-tests/cli/cli.test.js
@@ -12,8 +12,8 @@ describe('CLI', () => {
 	let logRestore;
 
 	beforeAll(() => {
-		processRestore = Object.assign({}, process);
-		logRestore = Object.assign({}, console);
+		processRestore = { ...process };
+		logRestore = { ...console };
 		process.exit = (exitCode) => (process.exitCode = exitCode);
 	});
 

--- a/system-tests/fix/fix.test.js
+++ b/system-tests/fix/fix.test.js
@@ -36,9 +36,7 @@ describe('fix', () => {
 			})
 			.then((output) => {
 				// Remove the path to tmpDir
-				const cleanedResults = output.results.map((r) =>
-					Object.assign({}, r, { source: 'stylesheet.css' }),
-				);
+				const cleanedResults = output.results.map((r) => ({ ...r, source: 'stylesheet.css' }));
 
 				expect(systemTestUtils.prepResults(cleanedResults)).toMatchSnapshot();
 			});

--- a/system-tests/systemTestUtils.js
+++ b/system-tests/systemTestUtils.js
@@ -18,7 +18,6 @@ function caseConfig(caseNumber, ext = 'json') {
 function prepResults(results) {
 	return results.map((result) => {
 		// The _postcssResult object is not part of our API and is huge
-		// eslint-disable-next-line no-unused-vars
 		const { _postcssResult, source, ...preppedResult } = result;
 
 		// The `source` of each file will not be the same on different machines or platforms


### PR DESCRIPTION
I open this for discussion. Most of these rules, if not all, should be made to the upstream eslint config.

Notes:

* I haven't enabled some of the rules on purpose
* prefer-rest-params needs further changes but IMHO it's totally worth it
* prefer-spread same as above, but we need to test if everything will still work with Node.js 8.7.0; we might need >= 8.10.0