### PR TITLE
Allow comments after commas in value lists when requiring newlines. F…

### DIFF
--- a/lib/rules/value-list-comma-newline-after/__tests__/index.js
+++ b/lib/rules/value-list-comma-newline-after/__tests__/index.js
@@ -38,6 +38,14 @@ testRule(rule, {
 			code: '$grid-breakpoints: (\n(xs),\n(sm, 768px)\n) !default;',
 			description: 'ignores scss maps',
 		},
+		{
+			code: 'a { background-size: 0, //\n0; }',
+			description: 'ignores single line comments',
+		},
+		{
+			code: 'a { background-size: 0, /**/\n0; }',
+			description: 'ignores multi line comments',
+		},
 	],
 
 	reject: [
@@ -62,6 +70,14 @@ testRule(rule, {
 			line: 1,
 			column: 23,
 		},
+		{
+			code: 'a { background-size: 0, /**/0; }',
+			fixed: 'a { background-size: 0, /**/\n0; }',
+			message: messages.expectedAfter(),
+			description: 'ignores multi line comments',
+			line: 1,
+			column: 28,
+		},
 	],
 });
 
@@ -73,6 +89,10 @@ testRule(rule, {
 	accept: [
 		{
 			code: 'a { background-size: 0,\n0,\n0; }',
+		},
+		{
+			code: 'a { background-size: 0, //\n0, /**/\n0; }',
+			description: 'with comments',
 		},
 		{
 			code: 'a { background-size: 0 ,\n  0,\n0; }',
@@ -93,6 +113,10 @@ testRule(rule, {
 			code: 'a { background-size: 0, 0;\r\n}',
 			description: 'ignores single-line list, multi-line block with CRLF',
 		},
+		{
+			code: 'a { background-size: 0, /**/ 0; }',
+			description: 'ignores single-line list, multi-line block with comment',
+		},
 	],
 
 	reject: [
@@ -102,6 +126,14 @@ testRule(rule, {
 			message: messages.expectedAfterMultiLine(),
 			line: 2,
 			column: 2,
+		},
+		{
+			code: 'a { background-size: 0, //\n0, /**/0; }',
+			fixed: 'a { background-size: 0, //\n0, /**/\n0; }',
+			description: 'with comments',
+			message: messages.expectedAfterMultiLine(),
+			line: 2,
+			column: 7,
 		},
 		{
 			code: 'a { background-size: 0,\n0,  0; }',
@@ -136,6 +168,10 @@ testRule(rule, {
 	accept: [
 		{
 			code: 'a { background-size: 0\n,0\n,0; }',
+		},
+		{
+			code: 'a { background-size: 0 //\n,0 /**/\n,0; }',
+			description: 'with comments',
 		},
 		{
 			code: 'a { background-size: 0\r\n,0\r\n,0; }',

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -51,6 +51,20 @@ const rule = function(expectation, options, context) {
 						return true;
 				  }
 				: null,
+			determineIndex: (declString, match) => {
+				const nextChars = declString.substr(match.endIndex, declString.length - match.endIndex);
+
+				// If there's a // comment, that means there has to be a newline
+				// ending the comment so we're fine
+				if (nextChars.match(/^[ \t]*\/\//)) {
+					return false;
+				}
+
+				// If there are spaces and then a comment begins, look for the newline
+				return nextChars.match(/^[ \t]*\/\*/)
+					? declString.indexOf('*/', match.endIndex) + 1
+					: match.startIndex;
+			},
 		});
 
 		if (fixData) {

--- a/lib/rules/valueListCommaWhitespaceChecker.js
+++ b/lib/rules/valueListCommaWhitespaceChecker.js
@@ -11,14 +11,24 @@ module.exports = function(opts) {
 			return;
 		}
 
+		const declString = decl.toString();
+
 		styleSearch(
 			{
-				source: decl.toString(),
+				source: declString,
 				target: ',',
 				functionArguments: 'skip',
 			},
 			(match) => {
-				checkComma(decl.toString(), match.startIndex, decl);
+				const indexToCheckAfter = opts.determineIndex
+					? opts.determineIndex(declString, match)
+					: match.startIndex;
+
+				if (indexToCheckAfter === false) {
+					return;
+				}
+
+				checkComma(declString, indexToCheckAfter, decl);
 			},
 		);
 	});


### PR DESCRIPTION
…ixes #2906.

<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #2906 

> Is there anything in the PR that needs further explanation?

I used `selector-list-comma-newline-after` as inspiration for the approach with a couple of minor tweaks.