### PR TITLE
Ignore ERB template tags in selectors

### DIFF
--- a/lib/rules/string-no-newline/__tests__/index.js
+++ b/lib/rules/string-no-newline/__tests__/index.js
@@ -109,5 +109,21 @@ testRule(rule, {
       <div style="ttt: auto">actual issues are still reported</div>`,
 			description: 'single quotes',
 		},
+		{
+			// https://github.com/stylelint/stylelint/issues/4489
+			code: `<style>
+				.highlight {
+					padding: 2px;
+				}
+				<%- SEVERITY_COLORS.each do |severity, color| %>
+				.severity.<%= severity %> {
+					color: <%= color %>;
+				}
+				.highlight.<%= severity %> {
+					background-color: <%= color.fade_out(0.4) %>;
+				}
+				</style>`,
+			description: 'ERB templates are ignored',
+		},
 	],
 });

--- a/lib/rules/string-no-newline/index.js
+++ b/lib/rules/string-no-newline/index.js
@@ -2,6 +2,7 @@
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -40,6 +41,10 @@ const rule = function(actual) {
 		function checkRule(rule) {
 			// Get out quickly if there are no new line
 			if (!reNewLine.test(rule.selector)) {
+				return;
+			}
+
+			if (!isStandardSyntaxSelector(rule.selector)) {
 				return;
 			}
 

--- a/lib/utils/__tests__/isStandardSyntaxSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxSelector.test.js
@@ -69,4 +69,10 @@ describe('isStandardSyntaxSelector', () => {
 		expect(isStandardSyntaxSelector('.foo()[bar]')).toBeFalsy();
 		expect(isStandardSyntaxSelector(".foo()[bar='baz']")).toBeFalsy();
 	});
+
+	it('ERB templates', () => {
+		// E. g. like in https://github.com/stylelint/stylelint/issues/4489
+		expect(isStandardSyntaxSelector('<% COLORS.each do |color| %>\na')).toBe(false);
+		expect(isStandardSyntaxSelector('<% eng %>\na')).toBe(false);
+	});
 });

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -29,5 +29,10 @@ module.exports = function(selector) {
 		return false;
 	}
 
+	// ERB template tags
+	if (selector.includes('<%') || selector.includes('%>')) {
+		return false;
+	}
+
 	return true;
 };


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Fixes #4489.

> Is there anything in the PR that needs further explanation?

Problem lies in many places. We are passing selector `<% COLORS.each do |color| %>\na` to `postcss-selector-parser`, and the later falls into endless loop. Which is understandable. This case might be fixed in `postcss-selector-parser`, but it won't happen any time soon. Currently, we're using `postcss-selector-parser@3.1.0`, while the latest version is `6.0.2`. We can't [upgrade](https://github.com/stylelint/stylelint/pull/3988), because there are still some issues in new version of a parser which needs to be resolved in a parser.

So, the only choice we have is to fix problem in stylelint. My solution is not universal, but if will fix the problem. It might create false negatives for `isStandardSyntaxSelector`, when selector like `[data-something="<%"]` is used. I think it's very unlikely to have a selector with `<%` or `%>` in it.

---

There is also a question when to release the fix. The next version of stylelint should be major, because we have some breaking changes in `master`. On the other hand we want to drop Node.js 8 from January 1. Which will require to release new major version. I don't want to release two major versions, as it's bad UX for our users have to update two major versions.

If this fix has to be release as soon as possible, we can create a new branch from latest release tag and cherry pick this PR there, and release patch version from that branch.