### PR TITLE
Fix SVG tags whitelist in selector-type-no-unknown rule (#4472)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 *.log
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 node_modules
 *.log
 .coverage

--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -86,8 +86,8 @@ testRule(rule, {
 			description: 'svg tags',
 		},
 		{
-			code: '.test foreignObject { color: white }',
-			description: 'svg tags',
+			code: 'foreignObject {}',
+			description: 'case-sensitive svg tags',
 		},
 		{
 			code: '@media keyframes { 0.0% {} 49.1% {} 100% {} }',

--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -86,6 +86,10 @@ testRule(rule, {
 			description: 'svg tags',
 		},
 		{
+			code: '.test foreignObject { color: white }',
+			description: 'svg tags',
+		},
+		{
 			code: '@media keyframes { 0.0% {} 49.1% {} 100% {} }',
 			description: 'standard usage of keyframe selectors',
 		},

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -9,19 +9,11 @@ const isStandardSyntaxTypeSelector = require('../../utils/isStandardSyntaxTypeSe
 const keywordSets = require('../../reference/keywordSets');
 const mathMLTags = require('mathml-tag-names');
 const optionsMatches = require('../../utils/optionsMatches');
-const originSvgTags = require('svg-tags');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const svgTags = require('svg-tags');
 const validateOptions = require('../../utils/validateOptions');
-
-/**
- * @description Normalize SVG tags.
- *  'svg-tags' module exports tags in camelCase format while other tags modules
- *  (e.g. 'html-tags', 'mathml-tag-names') contain only lower-cased strings
- * @type {string[]}
- */
-const svgTags = originSvgTags.map((tag) => tag.toLowerCase());
 
 const ruleName = 'selector-type-no-unknown';
 
@@ -95,7 +87,8 @@ const rule = function(actual, options) {
 
 					if (
 						htmlTags.includes(tagNameLowerCase) ||
-						svgTags.includes(tagNameLowerCase) ||
+						// SVG tags are case-sensitive
+						svgTags.includes(tagName) ||
 						keywordSets.nonStandardHtmlTags.has(tagNameLowerCase) ||
 						mathMLTags.includes(tagNameLowerCase)
 					) {

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -9,11 +9,19 @@ const isStandardSyntaxTypeSelector = require('../../utils/isStandardSyntaxTypeSe
 const keywordSets = require('../../reference/keywordSets');
 const mathMLTags = require('mathml-tag-names');
 const optionsMatches = require('../../utils/optionsMatches');
+const originSvgTags = require('svg-tags');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
-const svgTags = require('svg-tags');
 const validateOptions = require('../../utils/validateOptions');
+
+/**
+ * @description Normalize SVG tags.
+ *  'svg-tags' module exports tags in camelCase format while other tags modules
+ *  (e.g. 'html-tags', 'mathml-tag-names') contain only lower-cased strings
+ * @type {string[]}
+ */
+const svgTags = originSvgTags.map((tag) => tag.toLowerCase());
 
 const ruleName = 'selector-type-no-unknown';
 


### PR DESCRIPTION
Fix for `selector-type-no-unknown` rule

Closes #4472