### PR TITLE
Fix stylelint config usage

### DIFF
--- a/lib/__tests__/invalidScopeDisables.test.js
+++ b/lib/__tests__/invalidScopeDisables.test.js
@@ -93,26 +93,13 @@ it('invalidScopeDisables ignored case', () => {
 });
 
 it('invalidScopeDisables without config', () => {
-	const config = {
-		rules: {
-			'color-named': 'never',
-		},
-	};
-
 	return standalone({
-		config,
-		files: [fixture('disabled-ranges-1.css'), fixture('ignored-file.css')],
+		config: {
+			rules: {},
+		},
+		code: 'a {}',
 		ignoreDisables: true,
-		ignorePath: fixture('.stylelintignore'),
 	}).then((linted) => {
-		expect(invalidScopeDisables(linted.results)).toEqual([
-			{
-				source: fixture('disabled-ranges-1.css'),
-				ranges: [
-					{ start: 1, end: 3, unusedRule: 'color-named' },
-					{ start: 5, end: 7, unusedRule: 'block-no-empty' },
-				],
-			},
-		]);
+		expect(invalidScopeDisables(linted.results)).toEqual([]);
 	});
 });

--- a/lib/__tests__/invalidScopeDisables.test.js
+++ b/lib/__tests__/invalidScopeDisables.test.js
@@ -91,3 +91,28 @@ it('invalidScopeDisables ignored case', () => {
 		]);
 	});
 });
+
+it('invalidScopeDisables without config', () => {
+	const config = {
+		rules: {
+			'color-named': 'never',
+		},
+	};
+
+	return standalone({
+		config,
+		files: [fixture('disabled-ranges-1.css'), fixture('ignored-file.css')],
+		ignoreDisables: true,
+		ignorePath: fixture('.stylelintignore'),
+	}).then((linted) => {
+		expect(invalidScopeDisables(linted.results)).toEqual([
+			{
+				source: fixture('disabled-ranges-1.css'),
+				ranges: [
+					{ start: 1, end: 3, unusedRule: 'color-named' },
+					{ start: 5, end: 7, unusedRule: 'block-no-empty' },
+				],
+			},
+		]);
+	});
+});

--- a/lib/invalidScopeDisables.js
+++ b/lib/invalidScopeDisables.js
@@ -6,10 +6,10 @@
 
 /**
  * @param {import('stylelint').StylelintResult[]} results
- * @param {import('stylelint').StylelintConfig} config
+ * @param {import('stylelint').StylelintConfig|undefined} config
  * @returns {StylelintDisableOptionsReport}
  */
-module.exports = function(results, config) {
+module.exports = function(results, config = {}) {
 	/** @type {StylelintDisableOptionsReport} */
 	const report = [];
 	const usedRules = new Set(Object.keys(config.rules || {}));

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -306,8 +306,7 @@ module.exports = function(options) {
 		if (reportInvalidScopeDisables) {
 			returnValue.invalidScopeDisables = invalidScopeDisables(
 				stylelintResults,
-				// TODO TYPES possible undefined
-				/** @type {import('stylelint').StylelintConfig} */ (stylelint._options.config),
+				stylelint._options.config,
 			);
 		}
 


### PR DESCRIPTION
There was a comment in `lib/standalone.js:312` that `stylelint._options.config` might be `undefined`, but 
`invalidScopeDisables.js` function always expected an object as 2nd parameter.

For me there were 2 ways to fix that:
* adding  a conditional expression to `stylelint._options.config  || {}` for `invalidScopeDisables` call, or
* changing`invalidScopeDisables` interface to accept `undefined` as 2nd parameter.

I've chosen 2nd option, to prevent adding more conditions in the future in we need to call `invalidScopeDisables` somewhere else with the optional config param.

Closes #4479
