### PR TITLE
Use function declarations instead of function expressions

### DIFF
--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -120,7 +120,7 @@ function formatter(messages, source) {
 	 * @param {[string, string, string, string, string]} columns
 	 * @return {[string, string, string, string, string]}
 	 */
-	const calculateWidths = function(columns) {
+	function calculateWidths(columns) {
 		for (const [key, value] of Object.entries(columns)) {
 			const normalisedValue = value ? value.toString() : value;
 
@@ -128,7 +128,7 @@ function formatter(messages, source) {
 		}
 
 		return columns;
-	};
+	}
 
 	let output = '\n';
 

--- a/lib/rules/at-rule-blacklist/index.js
+++ b/lib/rules/at-rule-blacklist/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected at-rule "${name}"`,
 });
 
-const rule = function(blacklistInput) {
+function rule(blacklistInput) {
 	// To allow for just a string as a parameter (not only arrays of strings)
 	const blacklist = [].concat(blacklistInput);
 
@@ -46,7 +46,7 @@ const rule = function(blacklistInput) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -23,7 +23,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before at-rule',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -146,7 +146,7 @@ const rule = function(expectation, options, context) {
 			report({ message, node: atRule, result, ruleName });
 		});
 	};
-};
+}
 
 function isAtRuleAfterSameNameAtRule(atRule) {
 	const previousNode = getPreviousNonSharedLineCommentNode(atRule);

--- a/lib/rules/at-rule-name-case/index.js
+++ b/lib/rules/at-rule-name-case/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -49,7 +49,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-name-newline-after/index.js
+++ b/lib/rules/at-rule-name-newline-after/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	expectedAfter: (name) => `Expected newline after at-rule name "${name}"`,
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -31,7 +31,7 @@ const rule = function(expectation) {
 			checkedRuleName: ruleName,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-name-space-after/index.js
+++ b/lib/rules/at-rule-name-space-after/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	expectedAfter: (name) => `Expected single space after at-rule name "${name}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -36,7 +36,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-no-unknown/index.js
+++ b/lib/rules/at-rule-no-unknown/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (atRule) => `Unexpected unknown at-rule "${atRule}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -58,7 +58,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-no-vendor-prefix/index.js
+++ b/lib/rules/at-rule-no-vendor-prefix/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (p) => `Unexpected vendor-prefixed at-rule "@${p}"`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return function(root, result) {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -43,7 +43,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-property-requirelist/index.js
+++ b/lib/rules/at-rule-property-requirelist/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (property, atRule) => `Expected property "${property}" for at-rule "${atRule}"`,
 });
 
-const rule = function(primary) {
+function rule(primary) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -53,7 +53,7 @@ const rule = function(primary) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-semicolon-newline-after/index.js
+++ b/lib/rules/at-rule-semicolon-newline-after/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	expectedAfter: () => 'Expected newline after ";"',
 });
 
-const rule = function(actual, secondary, context) {
+function rule(actual, secondary, context) {
 	const checker = whitespaceChecker('newline', actual, messages);
 
 	return (root, result) => {
@@ -69,7 +69,7 @@ const rule = function(actual, secondary, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-semicolon-space-before/index.js
+++ b/lib/rules/at-rule-semicolon-space-before/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ";"',
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -54,7 +54,7 @@ const rule = function(expectation) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/at-rule-whitelist/index.js
+++ b/lib/rules/at-rule-whitelist/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected at-rule "${name}"`,
 });
 
-const rule = function(whitelistInput) {
+function rule(whitelistInput) {
 	// To allow for just a string as a parameter (not only arrays of strings)
 	const whitelist = [].concat(whitelistInput);
 
@@ -46,7 +46,7 @@ const rule = function(whitelistInput) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before closing brace',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -109,7 +109,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -20,7 +20,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "}" of a multi-line block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -128,7 +128,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-newline-before/index.js
+++ b/lib/rules/block-closing-brace-newline-before/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: 'Unexpected whitespace before "}" of a multi-line block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -108,7 +108,7 @@ const rule = function(expectation, options, context) {
 			}
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-space-after/index.js
+++ b/lib/rules/block-closing-brace-space-after/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "}" of a multi-line block',
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return function(root, result) {
@@ -79,7 +79,7 @@ const rule = function(expectation) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-space-before/index.js
+++ b/lib/rules/block-closing-brace-space-before/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "}" of a multi-line block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -87,7 +87,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty block',
 });
 
-const rule = function(primary, options = {}) {
+function rule(primary, options = {}) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -74,7 +74,7 @@ const rule = function(primary, options = {}) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-newline-after/index.js
+++ b/lib/rules/block-opening-brace-newline-after/index.js
@@ -18,7 +18,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "{" of a multi-line block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -135,7 +135,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-newline-before/index.js
+++ b/lib/rules/block-opening-brace-newline-before/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "{" of a multi-line block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -98,7 +98,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-space-after/index.js
+++ b/lib/rules/block-opening-brace-space-after/index.js
@@ -20,7 +20,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "{" of a multi-line block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -79,7 +79,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -22,7 +22,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "{" of a multi-line block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -109,7 +109,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -78,7 +78,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 function replaceHex(input, searchString, replaceString, startIndex) {
 	const offset = startIndex + 1;

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, _, context) {
+function rule(expectation, _, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -82,7 +82,7 @@ const rule = function(expectation, _, context) {
 			}
 		});
 	};
-};
+}
 
 function canShrink(hex) {
 	hex = hex.toLowerCase();

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -25,7 +25,7 @@ const messages = ruleMessages(ruleName, {
 // Todo tested on case insensivity
 const NODE_TYPES = ['word', 'function'];
 
-const rule = function(expectation, options) {
+function rule(expectation, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -160,7 +160,7 @@ const rule = function(expectation, options) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/color-no-hex/index.js
+++ b/lib/rules/color-no-hex/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (hex) => `Unexpected hex color "${hex}"`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -48,7 +48,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/color-no-invalid-hex/index.js
+++ b/lib/rules/color-no-invalid-hex/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (hex) => `Unexpected invalid hex color "${hex}"`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -45,7 +45,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -21,7 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const stylelintCommandPrefix = 'stylelint-';
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -110,7 +110,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/comment-no-empty/index.js
+++ b/lib/rules/comment-no-empty/index.js
@@ -10,7 +10,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty comment',
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -37,7 +37,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/comment-whitespace-inside/index.js
+++ b/lib/rules/comment-whitespace-inside/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before "*/"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return function(root, result) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -108,7 +108,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/comment-word-blacklist/index.js
+++ b/lib/rules/comment-word-blacklist/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (pattern) => `Unexpected word matching pattern "${pattern}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -48,7 +48,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/custom-media-pattern/index.js
+++ b/lib/rules/custom-media-pattern/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: 'Expected custom media query name to match specified pattern',
 });
 
-const rule = function(pattern) {
+function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
@@ -45,7 +45,7 @@ const rule = function(pattern) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -22,7 +22,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before custom property',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -114,7 +114,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 function isAfterCustomProperty(decl) {
 	const prevNode = getPreviousNonSharedLineCommentNode(decl);

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: 'Expected custom property name to match specified pattern',
 });
 
-const rule = function(pattern) {
+function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
@@ -44,7 +44,7 @@ const rule = function(pattern) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after "!"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -75,7 +75,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-bang-space-before/index.js
+++ b/lib/rules/declaration-bang-space-before/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before "!"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -76,7 +76,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-no-duplicate-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected duplicate "${property}"`,
 });
 
-const rule = function(on, options) {
+function rule(on, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -112,7 +112,7 @@ const rule = function(on, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (props) => `Expected shorthand property "${props}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -90,7 +90,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (shorthand, original) => `Unexpected shorthand "${shorthand}" after "${original}"`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -52,7 +52,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-newline-after/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected newline after ";" in a multi-line declaration block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -86,7 +86,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-newline-before/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace before ";" in a multi-line declaration block',
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return function(root, result) {
@@ -53,7 +53,7 @@ const rule = function(expectation) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-space-after/index.js
+++ b/lib/rules/declaration-block-semicolon-space-after/index.js
@@ -18,7 +18,7 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace after ";" in a single-line declaration block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return function(root, result) {
@@ -75,7 +75,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace before ";" in a single-line declaration block',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -84,7 +84,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-single-line-max-declarations/index.js
+++ b/lib/rules/declaration-block-single-line-max-declarations/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} ${max === 1 ? 'declaration' : 'declarations'}`,
 });
 
-const rule = function(quantity) {
+function rule(quantity) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: quantity,
@@ -49,7 +49,7 @@ const rule = function(quantity) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected trailing semicolon',
 });
 
-const rule = function(expectation, _, context) {
+function rule(expectation, _, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -92,7 +92,7 @@ const rule = function(expectation, _, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-colon-newline-after/index.js
+++ b/lib/rules/declaration-colon-newline-after/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	expectedAfterMultiLine: () => 'Expected newline after ":" with a multi-line declaration',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -81,7 +81,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-colon-space-after/index.js
+++ b/lib/rules/declaration-colon-space-after/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	expectedAfterSingleLine: () => 'Expected single space after ":" with a single-line declaration',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -54,7 +54,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ":"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -53,7 +53,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -22,7 +22,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before declaration',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -124,7 +124,7 @@ const rule = function(expectation, options, context) {
 			report({ message, node: decl, result, ruleName });
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-no-important/index.js
+++ b/lib/rules/declaration-no-important/index.js
@@ -10,7 +10,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected !important',
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -32,7 +32,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-unit-blacklist/index.js
+++ b/lib/rules/declaration-property-unit-blacklist/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -67,7 +67,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-unit-whitelist/index.js
+++ b/lib/rules/declaration-property-unit-whitelist/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -67,7 +67,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-value-blacklist/index.js
+++ b/lib/rules/declaration-property-value-blacklist/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -49,7 +49,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-value-whitelist/index.js
+++ b/lib/rules/declaration-property-value-whitelist/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -49,7 +49,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -42,7 +42,7 @@ function quotesRequired(family) {
 	});
 }
 
-const rule = function(expectation) {
+function rule(expectation) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -138,7 +138,7 @@ const rule = function(expectation) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/font-family-no-duplicate-names/index.js
+++ b/lib/rules/font-family-no-duplicate-names/index.js
@@ -18,7 +18,7 @@ const messages = ruleMessages(ruleName, {
 const isFamilyNameKeyword = (node) =>
 	!node.quote && keywordSets.fontFamilyKeywords.has(node.value.toLowerCase());
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -94,7 +94,7 @@ const rule = function(actual, options) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 const isFamilyNameKeyword = (node) =>
 	!node.quote && keywordSets.fontFamilyKeywords.has(node.value.toLowerCase());
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -57,7 +57,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -23,7 +23,7 @@ const INITIAL_KEYWORD = 'initial';
 const NORMAL_KEYWORD = 'normal';
 const WEIGHTS_WITH_KEYWORD_EQUIVALENTS = ['400', '700'];
 
-const rule = function(expectation, options) {
+function rule(expectation, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -145,7 +145,7 @@ const rule = function(expectation, options) {
 			}
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-blacklist/index.js
+++ b/lib/rules/function-blacklist/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected function "${name}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -53,7 +53,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/function-calc-no-invalid/index.js
+++ b/lib/rules/function-calc-no-invalid/index.js
@@ -18,7 +18,7 @@ const messages = ruleMessages(ruleName, {
 		`Expected to be compatible with the left and right argument types of "${operator}" operation.`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -119,7 +119,7 @@ const rule = function(actual) {
 			}
 		});
 	};
-};
+}
 
 function getCalcNodes(node) {
 	if (node.type !== 'function') {

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	expectedOperatorBeforeSign: (operator) => `Expected an operator before sign "${operator}"`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -107,7 +107,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 function blurVariables(source) {
 	return source.replace(/[$@][^)\s]+|#{.+?}/g, '0');

--- a/lib/rules/function-comma-newline-after/index.js
+++ b/lib/rules/function-comma-newline-after/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line function',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -46,7 +46,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-comma-newline-before/index.js
+++ b/lib/rules/function-comma-newline-before/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line function',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -46,7 +46,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-comma-space-after/index.js
+++ b/lib/rules/function-comma-space-after/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line function',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -47,7 +47,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-comma-space-before/index.js
+++ b/lib/rules/function-comma-space-before/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line function',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -47,7 +47,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -38,7 +38,7 @@ function isStandardDirection(source, withToPrefix) {
 	return false;
 }
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -101,7 +101,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-max-empty-lines/index.js
+++ b/lib/rules/function-max-empty-lines/index.js
@@ -16,7 +16,7 @@ function placeIndexOnValueStart(decl) {
 	return decl.prop.length + decl.raws.between.length - 1;
 }
 
-const rule = function(max, options, context) {
+function rule(max, options, context) {
 	const maxAdjacentNewlines = max + 1;
 
 	return (root, result) => {
@@ -94,7 +94,7 @@ const rule = function(max, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -22,7 +22,7 @@ keywordSets.camelCaseFunctionNames.forEach((func) => {
 	mapLowercaseFunctionNamesToCamelCase.set(func.toLowerCase(), func);
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -106,7 +106,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-parentheses-newline-inside/index.js
+++ b/lib/rules/function-parentheses-newline-inside/index.js
@@ -20,7 +20,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosingMultiLine: 'Unexpected whitespace before ")" in a multi-line function',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -140,7 +140,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 function getCheckBefore(valueNode) {
 	let before = valueNode.before;

--- a/lib/rules/function-parentheses-space-inside/index.js
+++ b/lib/rules/function-parentheses-space-inside/index.js
@@ -22,7 +22,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosingSingleLine: 'Unexpected whitespace before ")" in a single-line function',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -159,7 +159,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-url-no-scheme-relative/index.js
+++ b/lib/rules/function-url-no-scheme-relative/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected scheme-relative url',
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -39,7 +39,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: () => 'Unexpected quotes',
 });
 
-const rule = function(expectation, options) {
+function rule(expectation, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -104,7 +104,7 @@ const rule = function(expectation, options) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/function-url-scheme-blacklist/index.js
+++ b/lib/rules/function-url-scheme-blacklist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (scheme) => `Unexpected URL scheme "${scheme}:"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -55,7 +55,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/function-url-scheme-whitelist/index.js
+++ b/lib/rules/function-url-scheme-whitelist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (scheme) => `Unexpected URL scheme "${scheme}:"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -55,7 +55,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/function-whitelist/index.js
+++ b/lib/rules/function-whitelist/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected function "${name}"`,
 });
 
-const rule = function(whitelistInput) {
+function rule(whitelistInput) {
 	const whitelist = [].concat(whitelistInput);
 
 	return (root, result) => {
@@ -55,7 +55,7 @@ const rule = function(whitelistInput) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -18,7 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([')', ',', '}', ':', '/', undefined]);
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -159,7 +159,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
  *   keyword "tab" for single `\t`
  * @param {object} [options]
  */
-const rule = function(space, options = {}, context) {
+function rule(space, options = {}, context) {
 	const isTab = space === 'tab';
 	const indentChar = isTab ? '\t' : ' '.repeat(space);
 	const warningWord = isTab ? 'tab' : 'space';
@@ -405,7 +405,7 @@ const rule = function(space, options = {}, context) {
 
 		return `${count} ${quantifiedWarningWord}`;
 	}
-};
+}
 
 function getRootBaseIndentLevel(root, baseIndentLevel, space) {
 	const document = root.document;

--- a/lib/rules/keyframe-declaration-no-important/index.js
+++ b/lib/rules/keyframe-declaration-no-important/index.js
@@ -10,7 +10,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected !important',
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -34,7 +34,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/keyframes-name-pattern/index.js
+++ b/lib/rules/keyframes-name-pattern/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (keyframeName) => `Expected keyframe name "${keyframeName}" to match specified pattern`,
 });
 
-const rule = function(pattern) {
+function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
@@ -41,7 +41,7 @@ const rule = function(pattern) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -21,7 +21,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected unit',
 });
 
-const rule = function(actual, secondary, context) {
+function rule(actual, secondary, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -184,7 +184,7 @@ const rule = function(actual, secondary, context) {
 			}
 		}
 	};
-};
+}
 
 function replaceZero(input, startIndex, length) {
 	const stringStart = input.slice(0, startIndex);

--- a/lib/rules/linebreaks/index.js
+++ b/lib/rules/linebreaks/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (linebreak) => `Expected linebreak to be ${linebreak}`,
 });
 
-const rule = function(actual, secondary, context) {
+function rule(actual, secondary, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual,
@@ -100,7 +100,7 @@ const rule = function(actual, secondary, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
-const rule = function(max, options, context) {
+function rule(max, options, context) {
 	let emptyLines = 0;
 	let lastIndex = -1;
 
@@ -182,7 +182,7 @@ const rule = function(max, options, context) {
 			return result;
 		}
 	};
-};
+}
 
 /**
  * Checks whether the given node is the last node of file.

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 		`Expected line length to be no more than ${max} ${max === 1 ? 'character' : 'characters'}`,
 });
 
-const rule = function(maxLength, options, context) {
+function rule(maxLength, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -180,7 +180,7 @@ const rule = function(maxLength, options, context) {
 			return complain(complaintIndex, root);
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (depth) => `Expected nesting depth to be no more than ${depth}`,
 });
 
-const rule = function(max, options) {
+function rule(max, options) {
 	const isIgnoreAtRule = (node) =>
 		node.type === 'atrule' && optionsMatches(options, 'ignoreAtRules', node.name);
 
@@ -105,7 +105,7 @@ const rule = function(max, options) {
 		// until we hit the root node
 		return nestingDepth(parent, level + 1);
 	}
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-colon-space-after/index.js
+++ b/lib/rules/media-feature-colon-space-after/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after ":"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -73,7 +73,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-colon-space-before/index.js
+++ b/lib/rules/media-feature-colon-space-before/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ":"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -73,7 +73,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-name-blacklist/index.js
+++ b/lib/rules/media-feature-name-blacklist/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected media feature name "${name}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -56,7 +56,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -78,7 +78,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-name-no-unknown/index.js
+++ b/lib/rules/media-feature-name-no-unknown/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (mediaFeatureName) => `Unexpected unknown media feature name "${mediaFeatureName}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -73,7 +73,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected vendor-prefix',
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -43,7 +43,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-name-value-whitelist/index.js
+++ b/lib/rules/media-feature-name-value-whitelist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name, value) => `Unexpected value "${value}" for name "${name}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -61,7 +61,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-name-whitelist/index.js
+++ b/lib/rules/media-feature-name-whitelist/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected media feature name "${name}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -56,7 +56,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/media-feature-parentheses-space-inside/index.js
+++ b/lib/rules/media-feature-parentheses-space-inside/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before ")"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -97,7 +97,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-range-operator-space-after/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after range operator',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -83,7 +83,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-range-operator-space-before/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before range operator',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -83,7 +83,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-query-list-comma-newline-after/index.js
+++ b/lib/rules/media-query-list-comma-newline-after/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -81,7 +81,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-query-list-comma-newline-before/index.js
+++ b/lib/rules/media-query-list-comma-newline-before/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -33,7 +33,7 @@ const rule = function(expectation) {
 			checkedRuleName: ruleName,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -75,7 +75,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-query-list-comma-space-before/index.js
+++ b/lib/rules/media-query-list-comma-space-before/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -75,7 +75,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -21,7 +21,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (b, a) => `Expected selector "${b}" to come before selector "${a}"`,
 });
 
-const rule = function(on, options) {
+function rule(on, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -115,7 +115,7 @@ const rule = function(on, options) {
 			priorComparableSelectors.push(entry);
 		}
 	};
-};
+}
 
 function lastCompoundSelectorWithoutPseudoClasses(selectorNode) {
 	const nodesAfterLastCombinator = _.last(

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (atImport) => `Unexpected duplicate @import rule ${atImport}`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -59,7 +59,7 @@ const rule = function(actual) {
 			imports[uri] = imports[uri].concat(media);
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 		`Unexpected duplicate selector "${selector}", first used at line ${firstDuplicateLine}`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -129,7 +129,7 @@ const rule = function(actual, options) {
 			contextSelectorSet.set(sortedSelectorList, selectorLine);
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-empty-first-line/index.js
+++ b/lib/rules/no-empty-first-line/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line',
 });
 
-const rule = function(actual, _, context) {
+function rule(actual, _, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -40,7 +40,7 @@ const rule = function(actual, _, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-empty-source/index.js
+++ b/lib/rules/no-empty-source/index.js
@@ -10,7 +10,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty source',
 });
 
-const rule = function(actual, options, context) {
+function rule(actual, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -31,7 +31,7 @@ const rule = function(actual, options, context) {
 			ruleName,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -51,7 +51,7 @@ function findErrorStartIndex(
 	return eolWhitespaceIndex;
 }
 
-const rule = function(on, options, context) {
+function rule(on, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -250,7 +250,7 @@ const rule = function(on, options, context) {
 			}
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -43,7 +43,7 @@ function getOffsetByNode(node) {
 	return index;
 }
 
-const rule = function(actual, options, context) {
+function rule(actual, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -234,7 +234,7 @@ const rule = function(actual, options, context) {
 			return str;
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-invalid-double-slash-comments/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/index.js
@@ -10,7 +10,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected double-slash CSS comment',
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -41,7 +41,7 @@ const rule = function(actual) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-missing-end-of-source-newline/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/index.js
@@ -10,7 +10,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected missing end-of-source newline',
 });
 
-const rule = function(primary, _, context) {
+function rule(primary, _, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { primary });
 
@@ -43,7 +43,7 @@ const rule = function(primary, _, context) {
 			ruleName,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-unknown-animations/index.js
+++ b/lib/rules/no-unknown-animations/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (animationName) => `Unexpected unknown animation name "${animationName}"`,
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -55,7 +55,7 @@ const rule = function(actual) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected leading zero',
 });
 
-const rule = function(expectation, secondary, context) {
+function rule(expectation, secondary, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -145,7 +145,7 @@ const rule = function(expectation, secondary, context) {
 			});
 		}
 	};
-};
+}
 
 function addLeadingZero(input, index) {
 	// eslint-disable-next-line prefer-template

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (number, precision) => `Expected "${number}" to be "${number.toFixed(precision)}"`,
 });
 
-const rule = function(precision, options) {
+function rule(precision, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -92,7 +92,7 @@ const rule = function(precision, options) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected trailing zero(s)',
 });
 
-const rule = function(actual, secondary, context) {
+function rule(actual, secondary, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -106,7 +106,7 @@ const rule = function(actual, secondary, context) {
 			}
 		}
 	};
-};
+}
 
 function removeTrailingZeros(input, startIndex, endIndex) {
 	return input.slice(0, startIndex) + input.slice(endIndex);

--- a/lib/rules/property-blacklist/index.js
+++ b/lib/rules/property-blacklist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected property "${property}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -49,7 +49,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/property-case/index.js
+++ b/lib/rules/property-case/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -54,7 +54,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected unknown property "${property}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	const allValidProperties = new Set(properties);
 
 	return (root, result) => {
@@ -83,7 +83,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/property-no-vendor-prefix/index.js
+++ b/lib/rules/property-no-vendor-prefix/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected vendor-prefix "${property}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -61,7 +61,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/property-whitelist/index.js
+++ b/lib/rules/property-whitelist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected property "${property}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -49,7 +49,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -21,7 +21,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before rule',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -130,7 +130,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 function isAfterRule(rule) {
 	const prevNode = getPreviousNonSharedLineCommentNode(rule);

--- a/lib/rules/selector-attribute-brackets-space-inside/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before "]"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -177,7 +177,7 @@ const rule = function(expectation, options, context) {
 			setAfter(after.replace(/\s*$/, ''));
 		}
 	}
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-attribute-operator-blacklist/index.js
+++ b/lib/rules/selector-attribute-operator-blacklist/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (operator) => `Unexpected operator "${operator}"`,
 });
 
-const rule = function(blacklistInput) {
+function rule(blacklistInput) {
 	const blacklist = [].concat(blacklistInput);
 
 	return (root, result) => {
@@ -54,7 +54,7 @@ const rule = function(blacklistInput) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-attribute-operator-space-after/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: (operator) => `Unexpected whitespace after "${operator}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const checker = whitespaceChecker('space', expectation, messages);
 		const validOptions = validateOptions(result, ruleName, {
@@ -82,7 +82,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-attribute-operator-space-before/index.js
+++ b/lib/rules/selector-attribute-operator-space-before/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: (operator) => `Unexpected whitespace before "${operator}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -64,7 +64,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-attribute-operator-whitelist/index.js
+++ b/lib/rules/selector-attribute-operator-whitelist/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (operator) => `Unexpected operator "${operator}"`,
 });
 
-const rule = function(whitelistInput) {
+function rule(whitelistInput) {
 	const whitelist = [].concat(whitelistInput);
 
 	return (root, result) => {
@@ -54,7 +54,7 @@ const rule = function(whitelistInput) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (value) => `Unexpected quotes around "${value}"`,
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -68,7 +68,7 @@ const rule = function(expectation) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 		`Expected class selector ".${selectorValue}" to match specified pattern`,
 });
 
-const rule = function(pattern, options) {
+function rule(pattern, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -87,7 +87,7 @@ const rule = function(pattern, options) {
 			});
 		}
 	};
-};
+}
 
 // An "interpolating ampersand" means an "&" used to interpolate
 // within another simple selector, rather than an "&" that

--- a/lib/rules/selector-combinator-blacklist/index.js
+++ b/lib/rules/selector-combinator-blacklist/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -55,7 +55,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 function normalizeCombinator(value) {
 	return value.replace(/\s+/g, ' ');

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: (combinator) => `Unexpected whitespace after "${combinator}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -48,7 +48,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: (combinator) => `Unexpected whitespace before "${combinator}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -48,7 +48,7 @@ const rule = function(expectation, options, context) {
 				: null,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-combinator-whitelist/index.js
+++ b/lib/rules/selector-combinator-whitelist/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -55,7 +55,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 function normalizeCombinator(value) {
 	return value.replace(/\s+/g, ' ');

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (nonSpaceCharacter) => `Unexpected "${nonSpaceCharacter}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -76,7 +76,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 		`Expected ID selector "#${selectorValue}" to match specified pattern`,
 });
 
-const rule = function(pattern) {
+function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
@@ -58,7 +58,7 @@ const rule = function(pattern) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -108,7 +108,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -82,7 +82,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-list-comma-space-after/index.js
+++ b/lib/rules/selector-list-comma-space-after/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -74,7 +74,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -74,7 +74,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
-const rule = function(max) {
+function rule(max) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
@@ -73,7 +73,7 @@ const rule = function(max) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-empty-lines/index.js
+++ b/lib/rules/selector-max-empty-lines/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
-const rule = function(max, options, context) {
+function rule(max, options, context) {
 	const maxAdjacentNewlines = max + 1;
 
 	return (root, result) => {
@@ -56,7 +56,7 @@ const rule = function(max, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -35,7 +35,7 @@ const specificitySum = (specificities) => {
 	return sum;
 };
 
-const rule = function(max, options) {
+function rule(max, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -176,7 +176,7 @@ const rule = function(max, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-nested-pattern/index.js
+++ b/lib/rules/selector-nested-pattern/index.js
@@ -12,7 +12,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (selector) => `Expected nested selector "${selector}" to match specified pattern`,
 });
 
-const rule = function(pattern) {
+function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
@@ -48,7 +48,7 @@ const rule = function(pattern) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-no-qualifying-type/index.js
+++ b/lib/rules/selector-no-qualifying-type/index.js
@@ -41,7 +41,7 @@ function getRightNodes(node) {
 	return result;
 }
 
-const rule = function(enabled, options) {
+function rule(enabled, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -125,7 +125,7 @@ const rule = function(enabled, options) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-no-vendor-prefix/index.js
+++ b/lib/rules/selector-no-vendor-prefix/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected vendor-prefix "${selector}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -60,7 +60,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-pseudo-class-blacklist/index.js
+++ b/lib/rules/selector-pseudo-class-blacklist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-class "${selector}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -64,7 +64,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-pseudo-class-case/index.js
+++ b/lib/rules/selector-pseudo-class-case/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -88,7 +88,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -20,7 +20,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected unknown pseudo-class selector "${selector}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -148,7 +148,7 @@ const rule = function(actual, options) {
 			check(selector, result, node);
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before ")"',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -109,7 +109,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 function setFirstNodeSpaceBefore(node, value) {
 	const target = node.first;

--- a/lib/rules/selector-pseudo-class-whitelist/index.js
+++ b/lib/rules/selector-pseudo-class-whitelist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-class "${selector}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -63,7 +63,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-pseudo-element-blacklist/index.js
+++ b/lib/rules/selector-pseudo-element-blacklist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-element "${selector}"`,
 });
 
-const rule = function(blacklist) {
+function rule(blacklist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: blacklist,
@@ -63,7 +63,7 @@ const rule = function(blacklist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-pseudo-element-case/index.js
+++ b/lib/rules/selector-pseudo-element-case/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -75,7 +75,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (q) => `Expected ${q} colon pseudo-element notation`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -85,7 +85,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected unknown pseudo-element selector "${selector}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -83,7 +83,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-pseudo-element-whitelist/index.js
+++ b/lib/rules/selector-pseudo-element-whitelist/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-element "${selector}"`,
 });
 
-const rule = function(whitelist) {
+function rule(whitelist) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: whitelist,
@@ -63,7 +63,7 @@ const rule = function(whitelist) {
 			});
 		});
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -98,7 +98,7 @@ const rule = function(expectation, options, context) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -21,7 +21,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected unknown type selector "${selector}"`,
 });
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -106,7 +106,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -72,7 +72,7 @@ function canCondenseToThreeValues(top, right, bottom, left) {
 	return right === left;
 }
 
-const rule = function(actual, secondary, context) {
+function rule(actual, secondary, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -128,7 +128,7 @@ const rule = function(actual, secondary, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/string-no-newline/index.js
+++ b/lib/rules/string-no-newline/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected newline in string',
 });
 
-const rule = function(actual) {
+function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -106,7 +106,7 @@ const rule = function(actual) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 const singleQuote = `'`;
 const doubleQuote = `"`;
 
-const rule = function(expectation, secondary, context) {
+function rule(expectation, secondary, context) {
 	const correctQuote = expectation === 'single' ? singleQuote : doubleQuote;
 	const erroneousQuote = expectation === 'single' ? doubleQuote : singleQuote;
 
@@ -170,7 +170,7 @@ const rule = function(expectation, secondary, context) {
 			});
 		}
 	};
-};
+}
 
 function replaceQuote(string, index, replace) {
 	return string.substring(0, index) + replace + string.substring(index + replace.length);

--- a/lib/rules/time-min-milliseconds/index.js
+++ b/lib/rules/time-min-milliseconds/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (time) => `Expected a minimum of ${time} milliseconds`,
 });
 
-const rule = function(minimum) {
+function rule(minimum) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: minimum,
@@ -74,7 +74,7 @@ const rule = function(minimum) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/unicode-bom/index.js
+++ b/lib/rules/unicode-bom/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected Unicode BOM',
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -50,7 +50,7 @@ const rule = function(expectation) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/unit-blacklist/index.js
+++ b/lib/rules/unit-blacklist/index.js
@@ -26,7 +26,7 @@ const getMediaFeatureName = (mediaFeatureNode) => {
 	return /((-?\w*)*)/i.exec(value)[1];
 };
 
-const rule = function(blacklistInput, options) {
+function rule(blacklistInput, options) {
 	const blacklist = [].concat(blacklistInput);
 
 	return (root, result) => {
@@ -114,7 +114,7 @@ const rule = function(blacklistInput, options) {
 		root.walkAtRules(/^media$/i, (atRule) => checkMedia(atRule, atRule.params, atRuleParamIndex));
 		root.walkDecls((decl) => checkDecl(decl, decl.value, declarationValueIndex));
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -105,7 +105,7 @@ const rule = function(expectation, options, context) {
 		});
 		root.walkDecls((decl) => check(decl, decl.value, declarationValueIndex));
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -23,7 +23,7 @@ const messages = ruleMessages(ruleName, {
 // has index that being divided by 4 gives remainder equals 0
 const mapPropertyNameIndexOffset = 4;
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -146,7 +146,7 @@ const rule = function(actual, options) {
 		});
 		root.walkDecls((decl) => check(decl, decl.value, declarationValueIndex));
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/unit-whitelist/index.js
+++ b/lib/rules/unit-whitelist/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (unit) => `Unexpected unit "${unit}"`,
 });
 
-const rule = function(whitelistInput, options) {
+function rule(whitelistInput, options) {
 	const whitelist = [].concat(whitelistInput);
 
 	return (root, result) => {
@@ -74,7 +74,7 @@ const rule = function(whitelistInput, options) {
 		root.walkAtRules(/^media$/i, (atRule) => check(atRule, atRule.params, atRuleParamIndex));
 		root.walkDecls((decl) => check(decl, decl.value, declarationValueIndex));
 	};
-};
+}
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -28,7 +28,7 @@ keywordSets.camelCaseKeywords.forEach((func) => {
 	mapLowercaseKeywordsToCamelCase.set(func.toLowerCase(), func);
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -195,7 +195,7 @@ const rule = function(expectation, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -93,7 +93,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/value-list-comma-newline-before/index.js
+++ b/lib/rules/value-list-comma-newline-before/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
-const rule = function(expectation) {
+function rule(expectation) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
 	return (root, result) => {
@@ -33,7 +33,7 @@ const rule = function(expectation) {
 			checkedRuleName: ruleName,
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/value-list-comma-space-after/index.js
+++ b/lib/rules/value-list-comma-space-after/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -79,7 +79,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/value-list-comma-space-before/index.js
+++ b/lib/rules/value-list-comma-space-before/index.js
@@ -15,7 +15,7 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
-const rule = function(expectation, options, context) {
+function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
 	return (root, result) => {
@@ -79,7 +79,7 @@ const rule = function(expectation, options, context) {
 			});
 		}
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/value-list-max-empty-lines/index.js
+++ b/lib/rules/value-list-max-empty-lines/index.js
@@ -11,7 +11,7 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
-const rule = function(max, options, context) {
+function rule(max, options, context) {
 	const maxAdjacentNewlines = max + 1;
 
 	return (root, result) => {
@@ -53,7 +53,7 @@ const rule = function(max, options, context) {
 			}
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -19,7 +19,7 @@ const messages = ruleMessages(ruleName, {
 
 const valuePrefixes = ['-webkit-', '-moz-', '-ms-', '-o-'];
 
-const rule = function(actual, options) {
+function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -75,7 +75,7 @@ const rule = function(actual, options) {
 			});
 		});
 	};
-};
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
Use function declarations instead of function expressions for better readability.