### PR TITLE
Add `no-confusing-arrow` ESLint rule

### DIFF
--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -104,6 +104,7 @@ function formatter(messages, source) {
 
 	const orderedMessages = _.sortBy(
 		messages,
+		// eslint-disable-next-line no-confusing-arrow
 		(m) => (m.line ? 2 : 1), // positionless first
 		(m) => m.line,
 		(m) => m.column,

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -48,7 +48,11 @@ module.exports = function(options) {
 
 	const configSearchPath = stylelint._options.configFile || absoluteFilePath;
 
-	return stylelint
-		.getConfigForFile(configSearchPath)
-		.then((result) => (result === null ? null : result.config));
+	return stylelint.getConfigForFile(configSearchPath).then((result) => {
+		if (result === null) {
+			return result;
+		}
+
+		return result.config;
+	});
 };

--- a/lib/rules/color-named/generateColorFuncs.js
+++ b/lib/rules/color-named/generateColorFuncs.js
@@ -56,7 +56,13 @@ function xyz2lab(xyzIn) {
 	const xyz = xyzIn.map((value, i) => value / white[i]);
 
 	// now compute f
-	const f = xyz.map((value) => (value > ε ? Math.cbrt(value) : (κ * value + 16) / 116));
+	const f = xyz.map((value) => {
+		if (value > ε) {
+			return Math.cbrt(value);
+		}
+
+		return (κ * value + 16) / 116;
+	});
 
 	return [
 		116 * f[1] - 16, // L

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -497,9 +497,13 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 	if (!Number.isSafeInteger(baseIndentLevel)) {
 		let source = root.source.input.css;
 
-		source = source.replace(/^[^\r\n]+/, (firstLine) =>
-			/(?:^|\n)([ \t]*)$/.test(root.raws.beforeStart) ? RegExp.$1 + firstLine : '',
-		);
+		source = source.replace(/^[^\r\n]+/, (firstLine) => {
+			if (/(?:^|\n)([ \t]*)$/.test(root.raws.beforeStart)) {
+				return RegExp.$1 + firstLine;
+			}
+
+			return '';
+		});
 
 		const indents = source.match(/^[ \t]*(?=\S)/gm);
 

--- a/lib/utils/checkInvalidCLIOptions.js
+++ b/lib/utils/checkInvalidCLIOptions.js
@@ -49,7 +49,13 @@ const suggest = (all, invalid) => {
  * @param {string} opt
  * @return {string}
  */
-const cliOption = (opt) => (opt.length === 1 ? `"-${opt}"` : `"--${_.kebabCase(opt)}"`);
+const cliOption = (opt) => {
+	if (opt.length === 1) {
+		return `"-${opt}"`;
+	}
+
+	return `"--${_.kebabCase(opt)}"`;
+};
 
 /**
  * @param {string} invalid

--- a/lib/utils/declarationValueIndex.js
+++ b/lib/utils/declarationValueIndex.js
@@ -16,5 +16,11 @@ module.exports = function(decl) {
 		_.get(decl, 'raws.prop.suffix'),
 		_.get(decl, 'raws.between', ':'),
 		_.get(decl, 'raws.value.prefix'),
-	].reduce((count, str) => (str ? count + str.length : count), 0);
+	].reduce((count, str) => {
+		if (str) {
+			return count + str.length;
+		}
+
+		return count;
+	}, 0);
 };

--- a/package.json
+++ b/package.json
@@ -162,7 +162,12 @@
       "dot-notation": "error",
       "func-name-matching": "error",
       "guard-for-in": "error",
-      "no-confusing-arrow": "error",
+      "no-confusing-arrow": [
+        "error", 
+        { 
+          "allowParens": false 
+        }
+      ],
       "no-else-return": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
       "dot-notation": "error",
       "func-name-matching": "error",
       "guard-for-in": "error",
+      "no-confusing-arrow": "error",
       "no-else-return": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -163,9 +163,9 @@
       "func-name-matching": "error",
       "guard-for-in": "error",
       "no-confusing-arrow": [
-        "error", 
-        { 
-          "allowParens": false 
+        "error",
+        {
+          "allowParens": false
         }
       ],
       "no-else-return": [


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/pull/4453#issuecomment-570963865

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."

The issues detected by the addition of this rule will require updating 
