### PR TITLE
Remove unneeded `@types/meow` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -721,15 +721,6 @@
       "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
       "dev": true
     },
-    "@types/meow": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/meow/-/meow-5.0.0.tgz",
-      "integrity": "sha512-csdM22P8TFF5KwuHseifUBOzWiGtiLfYmQosrKPGpA/xdK3o3PNo3+4YOpiJ5BQBshwO2kuhdJ7NoAitQ6m/jg==",
-      "dev": true,
-      "requires": {
-        "@types/minimist-options": "*"
-      }
-    },
     "@types/micromatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-3.1.1.tgz",
@@ -748,15 +739,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
-    },
-    "@types/minimist-options": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/minimist-options/-/minimist-options-3.0.0.tgz",
-      "integrity": "sha512-FYeTlkAANOr9KR0mQL7X+v7MT7Nb/aWdNNHNKzJ8sPctpS2Ei8ucgMbvQRbLRjaYZH2OVN5AGDGGcHV5x8lSgQ==",
-      "dev": true,
-      "requires": {
-        "@types/minimist": "*"
-      }
     },
     "@types/node": {
       "version": "12.7.12",
@@ -8489,6 +8471,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
       "requires": {
         "pify": "^3.0.0"
       },
@@ -8496,7 +8479,8 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "@types/global-modules": "^2.0.0",
     "@types/globjoin": "^0.1.0",
     "@types/lodash": "^4.14.149",
-    "@types/meow": "^5.0.0",
     "@types/micromatch": "^3.1.1",
     "benchmark": "^2.1.4",
     "common-tags": "^1.8.0",


### PR DESCRIPTION
[meow v6](https://github.com/sindresorhus/meow/releases/tag/v6.0.0) has own built-in type definitions.
See <https://github.com/stylelint/stylelint/pull/4504#issuecomment-572354918>

~~Blocked by #4517~~