### PR TITLE
Fix Less test for function-calc-no-invalid

### DIFF
--- a/lib/rules/function-calc-no-invalid/__tests__/index.js
+++ b/lib/rules/function-calc-no-invalid/__tests__/index.js
@@ -377,7 +377,7 @@ testRule(rule, {
 		{
 			code: `
       a {
-        width: calc(@{min-value} + @{max-value}*(100vw - @{min-vw}));
+        width: calc(@min-value + @max-value*(100vw - @min-vw));
       }
       `,
 		},
@@ -423,12 +423,12 @@ testRule(rule, {
 		{
 			code: `
       a {
-        width: calc(@{min-value} + @{max-value}*(100vw -@{min-vw}));
+        width: calc(@min-value + @max-value*(100vw -@min-vw));
       }
       `,
 			message: messages.expectedSpaceAfterOperator('-'),
 			line: 3,
-			column: 57,
+			column: 53,
 		},
 	],
 });


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

This changes 2 test cases to highlight the issues explained on #4533 

> Is there anything in the PR that needs further explanation?

The syntax which was replaced and is now gone I don't think has any value inside of that test file.
It's not related to that rule at all.

The syntax that was being allowed was actually just plain wrong, but not for the reason being reported.
The issue is more along the lines of "You cannot directly do variable interpolations in the value section of CSS properties"

See LESS docs... http://lesscss.org/features/#variables-feature

allowed to interpolate in properties: 
```less
@{my-var}: 10px
```
allowed to interpolate in class names: 
```less
.@{my-var} { 
  width: 10px 
}
```
allowed to interpolate in strings: 
```less
background: url("@{base-url}-red.png");
```