### PR TITLE
Add info about invalid syntax in FAQ

### DIFF
--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -170,3 +170,7 @@ The `extends` mechanism is [detailed within the configuration docs](configuratio
 > When one configuration extends another, it starts with the other's properties then adds to and overrides what's there.
 
 The reason for this design is documented in [#1646](https://github.com/stylelint/stylelint/issues/1646#issuecomment-232779957).
+
+## Why doesn't stylelint report any warnings about invalid syntax in my CSS/Sass/Less/etc. files?
+
+The main aim of stylelint is to help you avoid frequently repeated errors and enforce conventions in your styles. But it's out of stylelint scope to check CSS/Sass/Less/etc. syntax validity. For such purposes please use validator instead.


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's additional info in documentation FAQ section.

> Is there anything in the PR that needs further explanation?

For the past 2 months I've met several issues about not reporting invalid syntax. May be it's good to add such info in the doc.
If it's completely irrelevant info feel free to close this PR.