### PR TITLE
Fix atypical rule README structure

### DIFF
--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -36,7 +36,7 @@ a { font-family: Helvetica, Arial, Verdana, Tahoma, sans-serif; }
 ```
 
 ```css
-a { font: 1em/1.3 Times, serif Apple Color Emoji; }
+a { font: 1em/1.3 Times, serif, Apple Color Emoji; }
 ```
 
 ```css

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -8,6 +8,11 @@ a { font-family: Arial, sans-serif; }
  * An example of generic family name */
 ```
 
+The generic font family can be:
+
+-   placed anywhere in the font family list
+-   omitted if a keyword related to property inheritance or a system font is used
+
 This rule checks the `font` and `font-family` properties.
 
 ## Options
@@ -31,20 +36,13 @@ a { font-family: Helvetica, Arial, Verdana, Tahoma, sans-serif; }
 ```
 
 ```css
-a { font: 1em/1.3 Times, serif; }
+a { font: 1em/1.3 Times, serif Apple Color Emoji; }
 ```
-
-It's also *not* a violation to use a keyword related to property inheritance or a system font value.
 
 ```css
 a { font: inherit; }
-b { font: initial; }
-i { font: unset; }
-input { font: caption; }
 ```
 
-It's also *not* a violation to use a generic font family anywhere in the list. In other words, the generic font name doesn't need to be the last.
-
 ```css
-a { font-family: Helvetica Neue, sans-serif, Apple Color Emoji; }
+a { font: caption; }
 ```


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint.io/issues/120

> Is there anything in the PR that needs further explanation?

The structure of the README was atypical as we [usually place these things](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#write-the-readme) in the expanded description. 


