### PR TITLE
Refactor CLI system test

### DIFF
--- a/system-tests/cli/cli.test.js
+++ b/system-tests/cli/cli.test.js
@@ -29,79 +29,79 @@ describe('CLI', () => {
 		process.stdout.write = jest.fn();
 	});
 
-	it('basic', () => {
-		return cli([]).then(() => {
-			expect(process.exitCode).toBe(2);
-			expect(console.log.mock.calls).toHaveLength(1);
-			const lastCallArgs = console.log.mock.calls.pop();
+	it('basic', async () => {
+		await cli([]);
 
-			expect(lastCallArgs).toHaveLength(1);
-			expect(lastCallArgs.pop()).toMatch('Usage: stylelint [input] [options]');
-		});
+		expect(process.exitCode).toBe(2);
+		expect(console.log.mock.calls).toHaveLength(1);
+		const lastCallArgs = console.log.mock.calls.pop();
+
+		expect(lastCallArgs).toHaveLength(1);
+		expect(lastCallArgs.pop()).toMatch('Usage: stylelint [input] [options]');
 	});
 
-	it('--help', () => {
-		return cli(['--help']).then(() => {
-			expect(process.exitCode).toBe(0);
-			expect(console.log.mock.calls).toHaveLength(1);
-			const lastCallArgs = console.log.mock.calls.pop();
+	it('--help', async () => {
+		await cli(['--help']);
 
-			expect(lastCallArgs).toHaveLength(1);
-			expect(lastCallArgs.pop()).toMatchSnapshot();
-		});
+		expect(process.exitCode).toBe(0);
+		expect(console.log.mock.calls).toHaveLength(1);
+		const lastCallArgs = console.log.mock.calls.pop();
+
+		expect(lastCallArgs).toHaveLength(1);
+		expect(lastCallArgs.pop()).toMatchSnapshot();
 	});
 
-	it('--version', () => {
-		return cli(['--version']).then(() => {
-			expect(process.exitCode).toBeUndefined();
-			expect(console.log.mock.calls).toHaveLength(1);
-			const lastCallArgs = console.log.mock.calls.pop();
+	it('--version', async () => {
+		await cli(['--version']);
 
-			expect(lastCallArgs).toHaveLength(1);
-			expect(lastCallArgs.pop()).toMatch(pkg.version);
-		});
+		expect(process.exitCode).toBeUndefined();
+		expect(console.log.mock.calls).toHaveLength(1);
+		const lastCallArgs = console.log.mock.calls.pop();
+
+		expect(lastCallArgs).toHaveLength(1);
+		expect(lastCallArgs.pop()).toMatch(pkg.version);
 	});
 
-	it('--print-config', () => {
-		return cli([
+	it('--print-config', async () => {
+		await cli([
 			'--print-config',
 			'--config',
 			path.join(__dirname, 'config.json'),
 			replaceBackslashes(path.join(__dirname, 'stylesheet.css')),
-		]).then(() => {
-			expect(process.exitCode).toBeUndefined();
-			expect(process.stdout.write).toHaveBeenCalledTimes(1);
-			expect(process.stdout.write).toHaveBeenLastCalledWith(
-				JSON.stringify(
-					{
-						rules: {
-							'block-no-empty': [true],
-						},
+		]);
+
+		expect(process.exitCode).toBeUndefined();
+		expect(process.stdout.write).toHaveBeenCalledTimes(1);
+		expect(process.stdout.write).toHaveBeenLastCalledWith(
+			JSON.stringify(
+				{
+					rules: {
+						'block-no-empty': [true],
 					},
-					null,
-					'  ',
-				),
-			);
-		});
+				},
+				null,
+				'  ',
+			),
+		);
 	});
 
-	it('--report-needless-disables', () => {
-		return cli([
+	it('--report-needless-disables', async () => {
+		await cli([
 			'--report-needless-disables',
 			'--config',
 			path.join(__dirname, 'config.json'),
 			replaceBackslashes(path.join(__dirname, 'stylesheet.css')),
-		]).then(() => {
-			expect(process.exitCode).toBe(2);
-			expect(process.stdout.write).toHaveBeenCalledTimes(2);
-			expect(process.stdout.write).toHaveBeenNthCalledWith(
-				1,
-				expect.stringContaining('unused rule: color-named'),
-			);
-			expect(process.stdout.write).toHaveBeenNthCalledWith(
-				2,
-				expect.stringContaining('Unexpected empty block'),
-			);
-		});
+		]);
+
+		expect(process.exitCode).toBe(2);
+		expect(process.stdout.write).toHaveBeenCalledTimes(2);
+		expect(process.stdout.write).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining('unused rule: color-named'),
+		);
+		expect(process.stdout.write).toHaveBeenNthCalledWith(
+			2,
+			expect.stringContaining('Unexpected empty block'),
+		);
 	});
 });

--- a/system-tests/cli/cli.test.js
+++ b/system-tests/cli/cli.test.js
@@ -23,17 +23,10 @@ describe('CLI', () => {
 		Object.assign(console, logRestore);
 	});
 
-	beforeEach(function() {
+	beforeEach(() => {
 		process.exitCode = undefined;
 		console.log = jest.fn();
 		process.stdout.write = jest.fn();
-
-		if (parseInt(process.versions.node) < 7) {
-			// https://github.com/sindresorhus/get-stdin/issues/13
-			process.nextTick(() => {
-				process.stdin.end();
-			});
-		}
 	});
 
 	it('basic', () => {
@@ -48,7 +41,7 @@ describe('CLI', () => {
 	});
 
 	it('--help', () => {
-		return Promise.resolve(cli(['--help'])).then(() => {
+		return cli(['--help']).then(() => {
 			expect(process.exitCode).toBe(0);
 			expect(console.log.mock.calls).toHaveLength(1);
 			const lastCallArgs = console.log.mock.calls.pop();
@@ -59,7 +52,7 @@ describe('CLI', () => {
 	});
 
 	it('--version', () => {
-		return Promise.resolve(cli(['--version'])).then(() => {
+		return cli(['--version']).then(() => {
 			expect(process.exitCode).toBeUndefined();
 			expect(console.log.mock.calls).toHaveLength(1);
 			const lastCallArgs = console.log.mock.calls.pop();
@@ -70,14 +63,12 @@ describe('CLI', () => {
 	});
 
 	it('--print-config', () => {
-		return Promise.resolve(
-			cli([
-				'--print-config',
-				'--config',
-				path.join(__dirname, 'config.json'),
-				replaceBackslashes(path.join(__dirname, 'stylesheet.css')),
-			]),
-		).then(() => {
+		return cli([
+			'--print-config',
+			'--config',
+			path.join(__dirname, 'config.json'),
+			replaceBackslashes(path.join(__dirname, 'stylesheet.css')),
+		]).then(() => {
 			expect(process.exitCode).toBeUndefined();
 			expect(process.stdout.write).toHaveBeenCalledTimes(1);
 			expect(process.stdout.write).toHaveBeenLastCalledWith(
@@ -95,14 +86,12 @@ describe('CLI', () => {
 	});
 
 	it('--report-needless-disables', () => {
-		return Promise.resolve(
-			cli([
-				'--report-needless-disables',
-				'--config',
-				path.join(__dirname, 'config.json'),
-				replaceBackslashes(path.join(__dirname, 'stylesheet.css')),
-			]),
-		).then(() => {
+		return cli([
+			'--report-needless-disables',
+			'--config',
+			path.join(__dirname, 'config.json'),
+			replaceBackslashes(path.join(__dirname, 'stylesheet.css')),
+		]).then(() => {
 			expect(process.exitCode).toBe(2);
 			expect(process.stdout.write).toHaveBeenCalledTimes(2);
 			expect(process.stdout.write).toHaveBeenNthCalledWith(


### PR DESCRIPTION
What does this do:

- Remove the workaround for Node < 7. Now, Node 10 is required.
- Inline unnecessary `Promise.resolve()`.
- Convert to an arrow function for consistency in a file.
- Convert to `async` functions for readability.

> Which issue, if any, is this issue related to?

None, as it's refactoring for the system test code.

> Is there anything in the PR that needs further explanation?

No, it's self explanatory.
