### PR TITLE
Fix TypeError in indentation regression

### DIFF
--- a/lib/rules/indentation/__tests__/rules.js
+++ b/lib/rules/indentation/__tests__/rules.js
@@ -421,6 +421,27 @@ testRule(rule, {
 
 testRule(rule, {
 	ruleName,
+	config: [2, null],
+
+	accept: [
+		{
+			code: 'a {\n' + '  color: pink;\n' + '}',
+		},
+	],
+	reject: [
+		{
+			code: '\ta {\n' + '  color: pink;\n' + '}',
+			fixed: 'a {\n' + '  color: pink;\n' + '}',
+
+			message: messages.expected('0 spaces'),
+			line: 1,
+			column: 2,
+		},
+	],
+});
+
+testRule(rule, {
+	ruleName,
 	config: ['tab'],
 	fix: true,
 
@@ -508,14 +529,6 @@ testRule(rule, {
 			column: 1,
 		},
 	],
-});
-
-testRule(rule, {
-	ruleName,
-	config: [2, null],
-
-	accept: [],
-	reject: [],
 });
 
 testRule(rule, {

--- a/lib/rules/indentation/__tests__/rules.js
+++ b/lib/rules/indentation/__tests__/rules.js
@@ -512,6 +512,14 @@ testRule(rule, {
 
 testRule(rule, {
 	ruleName,
+	config: [2, null],
+
+	accept: [],
+	reject: [],
+});
+
+testRule(rule, {
+	ruleName,
 	config: [2, { except: ['value'] }],
 	fix: true,
 

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -19,7 +19,9 @@ const messages = ruleMessages(ruleName, {
  *   keyword "tab" for single `\t`
  * @param {object} [options]
  */
-function rule(space, options = {}, context) {
+function rule(space, options, context) {
+	options = options || {};
+
 	const isTab = space === 'tab';
 	const indentChar = isTab ? '\t' : ' '.repeat(space);
 	const warningWord = isTab ? 'tab' : 'space';


### PR DESCRIPTION
This was introduced in v13.0.0 and happens because `options` is `null`, thus not falling back to `{}`

Fixes #4563 

We still need to make sure we are not hitting any other similar cases after #4458.

PS. tests didn't catch this :/