### PR TITLE
scripts/benchmark-rule.js: Switch to Bootstrap 4.4.1

### DIFF
--- a/scripts/benchmark-rule.js
+++ b/scripts/benchmark-rule.js
@@ -22,7 +22,7 @@ if (!ruleOptions) {
 	throw new Error('You must specify rule options');
 }
 
-const CSS_URL = 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.css';
+const CSS_URL = 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.css';
 
 let parsedOptions = ruleOptions;
 

--- a/scripts/benchmark-rule.js
+++ b/scripts/benchmark-rule.js
@@ -22,7 +22,7 @@ if (!ruleOptions) {
 	throw new Error('You must specify rule options');
 }
 
-const CSS_URL = 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.css';
+const CSS_URL = 'https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.css';
 
 let parsedOptions = ruleOptions;
 


### PR DESCRIPTION
I didn't switch to v4.x here, but let me know if you want to