### PR TITLE
Fix wrong openIndex calculation in string-quotes (#4395)

### DIFF
--- a/lib/rules/string-quotes/__tests__/index.js
+++ b/lib/rules/string-quotes/__tests__/index.js
@@ -79,6 +79,13 @@ testRule(rule, {
 			column: 6,
 		},
 		{
+			code: 'a[ id="foo" ] {}',
+			fixed: "a[ id='foo' ] {}",
+			message: messages.expected('single'),
+			line: 1,
+			column: 7,
+		},
+		{
 			code: 'a\n{ background: url("foo"); }',
 			fixed: "a\n{ background: url('foo'); }",
 			message: messages.expected('single'),

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -81,7 +81,14 @@ function rule(expectation, secondary, context) {
 							return;
 						}
 
+						// we have to count the space length before attribute if it exists
+						// otherwise we get the wrong openIndex calculation (see #4395)
+						const attributeNodeSpaceBeforeLength = attributeNode.spaces.attribute
+							? attributeNode.spaces.attribute.before.length
+							: 0;
+
 						const openIndex =
+							attributeNodeSpaceBeforeLength +
 							// index of the start of our attribute node in our source
 							attributeNode.sourceIndex +
 							// length of our attribute


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

It should close #4395 .

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self explanatory."
