### PR TITLE
Remove vscode extension from release template

### DIFF
--- a/docs/maintainer-guide/releases.md
+++ b/docs/maintainer-guide/releases.md
@@ -41,7 +41,6 @@
 - [ ] stylelint-config-standard update/release
 - [ ] stylelint-demo update
 - [ ] stylelint.io update
-- [ ] vscode-stylelint update
 - [ ] tweet
 
 cc @stylelint/core


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

We should remove vscode extension from release template now that the vscode extension [is no longer tied](https://github.com/stylelint/vscode-stylelint/pull/26) to a particular release.
