### PR TITLE
Improve documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing
 
-Thank you for wanting to contribute. stylelint _needs_ community contributions to continue to improve.
-
-If you like stylelint and open-source software (since you're reading this, you almost certainly do), please consider taking some time to pitch in. Not only will you help stylelint thrive, but you may learn a thing or two — about CSS, PostCSS, Node, ES2015, unit testing, open-source software, and more.
+Thank you for wanting to contribute.
 
 To help out, you can:
 
@@ -10,16 +8,14 @@ To help out, you can:
 - improve our [support for non-standard syntaxes](docs/about/syntaxes.md)
 - create, enhance and debug rules using [our guide](docs/developer-guide/rules.md)
 - improve the [documentation](docs/)
-- add new tests to _absolutely anything_
+- add [new tests](https://github.com/stylelint/stylelint/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+tests%22) to _absolutely anything_
 - improve the [performance of rules](docs/developer-guide/rules.md#improve-the-performance-of-a-rule)
 - open [new issues](https://github.com/stylelint/stylelint/issues/new/choose) about your ideas for making stylelint better
 - create or contribute to [integrations](docs/user-guide/integrations/editor.md), like our plugin for [VS Code](https://github.com/stylelint/vscode-stylelint)
 
-**We want to do everything we can to encourage contributions!** So if you want to participate but don't end up doing it for one reason or another, please [file an issue](https://github.com/stylelint/stylelint/issues/new) and give us feedback about what we could do to encourage you better.
+Not only will you help stylelint thrive, but you may learn a thing or two — about CSS, PostCSS, Node, ES2015, unit testing, open-source software, and more. We want to encourage contributions! If you want to participate but couldn't, please [give us feedback](https://github.com/stylelint/stylelint/issues/new) about what we could do better.
 
 ## Code contributions
-
-You should first [create a new issue](https://github.com/stylelint/stylelint/issues/new/choose) so that we can discuss your new feature, bug fix or change.
 
 To start coding, you'll need:
 
@@ -37,17 +33,26 @@ Next, you'll want to run the tests using `npm test`.
 
 However, this runs all 25,000+ unit tests and also linting.
 
-You can use interactive testing prompt to run tests for just a chosen set of files (which you'll want to do during development). For example, to run the tests for just the `color-hex-case` and `color-hex-length` rules:
+You can use the interactive testing prompt to run tests for just a chosen set of files (which you'll want to do during development). For example, to run the tests for just the `color-hex-case` and `color-hex-length` rules:
 
 1. Run `npm run watch` to start the interactive testing prompt.
 2. Press `p` to filter by a filename regex pattern.
-3. Enter `color-hex-case|color-hex-length` i.e. each rule name separated by the pipe symbol (`|`).
+3. Enter `color-hex-case|color-hex-length`, i.e. each rule name separated by the pipe symbol (`|`).
 
 You can find more information about testing on the [Jest website](https://jestjs.io/).
 
 ### Write code
 
-With the interactive testing prompt running, you can write the code to fix the bug or add the new feature confident that things are working as expected. You'll find more guidance on how we write code in the [Developer guide](docs/developer-guide/rules.md).
+With the interactive testing prompt running, you can write code confident that things are working as expected.
+
+You can write code to:
+
+- [add a rule](docs/developer-guide/rules.md#add-a-rule)
+- [add an option to a rule](docs/developer-guide/rules.md#add-an-option-to-a-rule)
+- [fix a bug in a rule](docs/developer-guide/rules.md#fix-a-bug-in-a-rule)
+- [improve the performance of a rule](docs/developer-guide/rules.md#improve-the-performance-of-a-rule)
+
+And many more things, including [writing system tests](docs/developer-guide/system-tests.md) and improving the [documentation](docs/).
 
 ### Format code
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's mighty as it:
 - parses **CSS-like syntaxes** like SCSS, Sass, Less and SugarSS
 - has over **170 built-in rules** to catch errors, apply limits and enforce stylistic conventions
 - supports **plugins** so you can create your own rules or make use of plugins written by the community
-- automatically **fixes** some violations (_experimental feature_)
+- automatically **fixes** the majority of stylistic violations (_experimental feature_)
 - is **well tested** with over 15000 unit tests
 - supports **shareable configs** that you can extend or create
 - is **unopinionated** so that you can customize it to your exact needs
@@ -25,7 +25,7 @@ It's mighty as it:
 
 ## Getting started
 
-You'll find steps to [get started with stylelint in our User guide](docs/user-guide/get-started.md).
+You'll find steps to [get started in our User guide](docs/user-guide/get-started.md).
 
 ## Contributors
 

--- a/docs/about/linting.md
+++ b/docs/about/linting.md
@@ -11,9 +11,7 @@ There are two approaches to enforcing stylistic conventions:
 - a machine algorithmically pretty prints the code (usually based on a maximum line length)
 - a human initially formats the code, and a machine fixes-up/warns-about any mistakes
 
-The former is handled by pretty printers, like [prettier](https://github.com/prettier/prettier), whereas the latter is catered for by the built-in stylistic rules.
-
-If you use a pretty printer, you'll want to use [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended), which only turns on [possible error](../user-guide/rules/list.md#possible-errors) rules.
+The former is handled by pretty printers, like [prettier](https://github.com/prettier/prettier), whereas the latter is catered for by the built-in [stylistic rules](../user-guide/rules/list.md#stylistic-issues). If you use a pretty printer, you'll want to use [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended), which only turns on [possible error](../user-guide/rules/list.md#possible-errors) rules.
 
 Additionally, the built-in stylistic rules and plugins are configurable to support a diverse range of stylistic conventions. For example, ordering properties within declaration blocks is a divisive topic, where there isn't a dominant convention. The [`stylelint-order`](https://www.npmjs.com/package/stylelint-order) plugin can be configured to lint and fix a diverse range of ordering conventions.
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -67,7 +67,7 @@ If your plugin rule supports [autofixing](rules.md#add-autofix), then `ruleFunct
 
 You'll have to [learn about the PostCSS API](https://api.postcss.org/).
 
-## Asynchronous rules
+### Asynchronous rules
 
 You can return a `Promise` instance from your plugin function to create an asynchronous rule.
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -4,18 +4,30 @@ Please help us create, enhance, and debug our rules!
 
 ## Add a rule
 
-_When writing a rule, always look to other similar rules for [conventions and patterns](../user-guide/rules/about.md) to start from and mimic._
+You should:
 
-The rule should:
+1. Get yourself ready to [contribute code](../../CONTRIBUTING.md#code-contributions).
+2. Familiarize yourself with the [conventions and patterns](../user-guide/rules/about.md) for rules.
 
-- not include code for methodologies or language extensions
-- be strict by default
+### Write the rule
 
-### PostCSS API
+When writing the rule, you should:
 
-Use the [PostCSS API](https://api.postcss.org/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes. Use `node.raws` instead of `node.raw()` when accessing raw strings from the PostCSS AST.
+- make the rule strict by default
+- add secondary `ignore` options to make the rule more permissive
+- not include code specific to language extensions, e.g. SCSS
 
-### Construct-specific parsers
+You should make use of the:
+
+- PostCSS API
+- construct-specific parsers
+- utility functions
+
+#### PostCSS API
+
+Use the [PostCSS API](https://api.postcss.org/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes. Use `node.raws` instead of `node.raw()` when accessing raw strings from the [PostCSS AST](https://astexplorer.net/#/gist/ef718daf3e03f1d200b03dc5a550ec60/c8cbe9c6809a85894cebf3fb66de46215c377f1a).
+
+#### Construct-specific parsers
 
 Depending on the rule, we also recommend using:
 
@@ -24,7 +36,7 @@ Depending on the rule, we also recommend using:
 
 There are significant benefits to using these parsers instead of regular expressions or `indexOf` searches (even if they aren't always the most performant method).
 
-### Utility functions
+#### Utility functions
 
 stylelint has [utility functions](https://github.com/stylelint/stylelint/tree/master/lib/utils) that are used in existing rules and might prove useful to you, as well. Please look through those so that you know what's available. (And if you have a new function that you think might prove generally helpful, let's add it to the list!).
 
@@ -33,9 +45,7 @@ Use the:
 - `validateOptions()` utility to warn users about invalid options
 - `isStandardSyntax*` utilities to ignore non-standard syntax
 
-### Options
-
-Provide secondary options so that the user can ignore non-standard syntax at the _configuration level_. For example, when dealing with specificity, a rule should not account for the `:global` and `:local` pseudo-classes (introduced in the CSS Modules language extension), instead the rule should provide a `ignorePseudoClasses: []` secondary option. Methodologies come and go quickly, and this approach ensures the codebase does not become littered with code for obsolete things.
+### Add options
 
 Only add an option to a rule if it addresses a _requested_ use case to avoid polluting the tool with unused features.
 
@@ -118,9 +128,9 @@ You should ask yourself how does your rule handle:
 
 You should:
 
+- only use standard CSS syntax in example code and options
 - use `<!-- prettier-ignore-->` before `css` code fences
-- avoid `scss` and `less` code fences
-- use "this rule" to refer to the rule e.g. "This rule ignores ..."
+- use "this rule" to refer to the rule, e.g. "This rule ignores ..."
 - align the arrows within the prototypical code example with the beginning of the highlighted construct
 - align the text within the prototypical code example as far to the left as possible
 
@@ -133,20 +143,17 @@ For example:
   *       These names and values */
 ```
 
-Look at the READMEs of other rules to glean more conventional patterns.
-
-#### Example patterns
-
-You should use:
+When writing examples, you should use:
 
 - complete CSS patterns i.e. avoid ellipses (`...`)
-- standard CSS syntax (and `css` [GFM fenced code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/)) by default
 - the minimum amount of code possible to communicate the pattern, e.g. if the rule targets selectors then use an empty rule, e.g. `{}`
 - `{}`, rather than `{ }` for empty rules
 - the `a` type selector by default
 - the `@media` at-rules by default
 - the `color` property by default
 - _foo_, _bar_ and _baz_ for names, e.g. `.foo`, `#bar`, `--baz`
+
+Look at the READMEs of other rules to glean more conventional patterns.
 
 ### Wire up the rule
 
@@ -159,21 +166,19 @@ The final step is to add references to the new rule in the following places:
 
 You should:
 
-1. Run `npm run watch` to start the interactive testing prompt.
-2. Use the `p` command to filter the active tests to just the rule you're working on.
-3. Change the rule's validation to allow for the new option.
-4. Add new unit tests to test the option.
-5. Add (as little as possible) logic to the rule to make the tests pass.
-6. Add documentation about the new option.
+1. Get ready to [contribute code](../../CONTRIBUTING.md#code-contributions).
+2. Change the rule's validation to allow for the new option.
+3. Add new unit tests to test the option.
+4. Add (as little as possible) logic to the rule to make the tests pass.
+5. Add documentation about the new option.
 
 ## Fix a bug in a rule
 
 You should:
 
-1. Run `npm run watch` to start the interactive testing prompt.
-2. Use the `p` command to filter the active tests to just the rule you're working on.
-3. Write failing unit tests that exemplify the bug.
-4. Fiddle with the rule until those new tests pass.
+1. Get ready to [contribute code](../../CONTRIBUTING.md#code-contributions).
+2. Write failing unit tests that exemplify the bug.
+3. Fiddle with the rule until those new tests pass.
 
 ## Deprecate a rule
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -129,7 +129,7 @@ You should ask yourself how does your rule handle:
 You should:
 
 - only use standard CSS syntax in example code and options
-- use `<!-- prettier-ignore-->` before `css` code fences
+- use `<!-- prettier-ignore -->` before `css` code fences
 - use "this rule" to refer to the rule, e.g. "This rule ignores ..."
 - align the arrows within the prototypical code example with the beginning of the highlighted construct
 - align the text within the prototypical code example as far to the left as possible

--- a/docs/maintainer-guide/issues.md
+++ b/docs/maintainer-guide/issues.md
@@ -47,48 +47,48 @@ You should use [saved replies](https://help.github.com/en/github/writing-on-gith
 
 ### Close an issue
 
-That does not use one of the templates:
+That doesn't use a template:
 
 ```md
 Thank you for creating this issue. However, issues need to follow one of our templates so that we can clearly understand your particular circumstances.
 
-Please help us to help you by [recreating the issue](https://github.com/stylelint/stylelint/issues/new/choose) using one of our templates.
+Please help us help you by [recreating the issue](https://github.com/stylelint/stylelint/issues/new/choose) using one of our templates.
 ```
 
 That is best-suited as a plugin:
 
 ```md
-Thank you for your suggestion. I think this is an ideal [a plugin](https://github.com/stylelint/stylelint/blob/master/developer-guide/plugins.md).
+Thank you for your suggestion. I think this is best-suited as a [plugin](https://stylelint.io/developer-guide/plugins).
 ```
 
 ### Label as ready to implement
 
-That adds a new rule:
+That fixes a bug in a rule:
 
 ```md
-I've labeled the issue as ready to implement. Please consider [contributing](https://github.com/stylelint/stylelint/blob/master/CONTRIBUTING.md) if you have time.
+I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 
-There are [steps on how to add a new rule](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#add-a-rule) in the Developer guide.
+There are [steps on how to fix a bug in a rule](https://stylelint.io/developer-guide/rules#fix-a-bug-in-a-rule) in the Developer guide.
 ```
 
 That adds a new option to a rule:
 
 ```md
-I've labeled the issue as ready to implement. Please consider [contributing](https://github.com/stylelint/stylelint/blob/master/CONTRIBUTING.md) if you have time.
+I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 
-There are [steps on how to add a new option](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#add-an-option-to-a-rule) in the Developer guide.
+There are [steps on how to add a new option](https://stylelint.io/developer-guide/rules#add-an-option-to-a-rule) in the Developer guide.
 ```
 
-That adds a bug in a rule:
+That adds a new rule:
 
 ```md
-I've labeled the issue as ready to implement. Please consider [contributing](https://github.com/stylelint/stylelint/blob/master/CONTRIBUTING.md) if you have time.
+I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 
-There are [steps on how to fix a bug in a rule](https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fix-a-bug-in-a-rule) in the Developer guide.
+There are [steps on how to add a new rule](https://stylelint.io/developer-guide/rules#add-a-rule) in the Developer guide.
 ```
 
 That is another type of improvement:
 
 ```md
-I've labeled the issue as ready to implement. Please consider [contributing](https://github.com/stylelint/stylelint/blob/master/CONTRIBUTING.md) if you have time.
+I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 ```

--- a/docs/maintainer-guide/pull-requests.md
+++ b/docs/maintainer-guide/pull-requests.md
@@ -2,7 +2,7 @@
 
 You should:
 
-- use the [GitHub reviews](https://help.github.com/articles/about-pull-request-reviews/)
+- use [GitHub reviews](https://help.github.com/articles/about-pull-request-reviews/)
 - review against the [Developer guide criteria](../developer-guide/rules.md)
 - resolve conflicts by [rebasing](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase)
 - assign _one or more_ [`pr: needs *`](https://github.com/stylelint/stylelint/labels) labels when requesting a change

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -8,7 +8,7 @@ stylelint uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to fi
 - a `.stylelintrc` file
 - a `stylelint.config.js` file exporting a JS object
 
-The search stops when one of these is found, and stylelint uses that object. You can use the [`--config` or `configFile` option](usage/options.md) to short-circuit the search.
+The search stops when one of these is found, and stylelint uses that object. You can use the [`--config` or `configFile` option](usage/options.md#configfile) to short-circuit the search.
 
 The `.stylelintrc` file (without extension) can be in JSON or YAML format. You can add a filename extension to help your text editor provide syntax checking and highlighting:
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -8,15 +8,13 @@ stylelint uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to fi
 - a `.stylelintrc` file
 - a `stylelint.config.js` file exporting a JS object
 
-The search stops when one of these is found, and stylelint uses that object.
+The search stops when one of these is found, and stylelint uses that object. You can use the [`--config` or `configFile` option](usage/options.md) to short-circuit the search.
 
 The `.stylelintrc` file (without extension) can be in JSON or YAML format. You can add a filename extension to help your text editor provide syntax checking and highlighting:
 
 - `.stylelintrc.json`
 - `.stylelintrc.yaml` / `.stylelintrc.yml`
 - `.stylelintrc.js`
-
-You can use the [`--config` or `configFile` option](usage/options.md) to short-circuit the configuration search.
 
 The configuration object has the following properties:
 
@@ -26,7 +24,17 @@ Rules determine what the linter looks for and complains about. There are [over 1
 
 _No rules are turned on by default and there are no default values. You must explicitly configure each rule to turn it on._
 
-The `rules` property is _an object whose keys are rule names and values are rule configurations_. Each rule configuration fits one of the following formats:
+The `rules` property is _an object whose keys are rule names and values are rule configurations_. For example:
+
+```json
+{
+  "rules": {
+    "color-no-invalid-hex": true
+  }
+}
+```
+
+Each rule configuration fits one of the following formats:
 
 - `null` (to turn the rule off)
 - a single value (the primary option)
@@ -34,21 +42,31 @@ The `rules` property is _an object whose keys are rule names and values are rule
 
 Specifying a primary option turns on a rule.
 
-Many rules provide secondary options for further customization. To set secondary options, use a two-member array:
+Many rules provide secondary options for further customization. To set secondary options, use a two-member array. For example:
 
-```js
-"selector-pseudo-class-no-unknown": [true, {
-  "ignorePseudoClasses": ["global"]
-}]
+```json
+{
+  "rules": {
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": ["global"]
+      }
+    ]
+  }
+}
 ```
 
-For example, you can turn off `block-no-empty`, turn on `color-no-invalid-hex`, `max-empty-lines` and `unit-whitelist` with primary options and turn on `comment-empty-line-before` with a primary and secondary option:
+You can add any number of keys in the object. For example, you can:
+
+- turn off `block-no-empty`
+- turn on `comment-empty-line-before` with a primary and secondary option
+- turn on `max-empty-lines` and `unit-whitelist` with primary options
 
 ```json
 {
   "rules": {
     "block-no-empty": null,
-    "color-no-invalid-hex": true,
     "comment-empty-line-before": [
       "always",
       {
@@ -61,7 +79,7 @@ For example, you can turn off `block-no-empty`, turn on `color-no-invalid-hex`, 
 }
 ```
 
-### Custom Messages
+### `message`
 
 You can use the `message` secondary option to deliver a custom message when a rule is violated.
 
@@ -79,7 +97,7 @@ For example, the following rule configuration would substitute in custom message
     2,
     {
       "except": ["block"],
-      "message": "Please use 2 spaces for indentation. Tabs make The Architect grumpy.",
+      "message": "Please use 2 spaces for indentation.",
       "severity": "warning"
     }
   ]
@@ -88,7 +106,7 @@ For example, the following rule configuration would substitute in custom message
 
 Alternately, you can write a [custom formatter](../developer-guide/formatters.md) for maximum control if you need serious customization.
 
-### Severities: error & warning
+### `severity`
 
 You can use the `severity` secondary option to adjust any specific rule's severity.
 
@@ -101,13 +119,15 @@ For example:
 
 ```json
 {
-  "indentation": [
-    2,
-    {
-      "except": ["value"],
-      "severity": "warning"
-    }
-  ]
+  "rules": {
+    "indentation": [
+      2,
+      {
+        "except": ["value"],
+        "severity": "warning"
+      }
+    ]
+  }
 }
 ```
 
@@ -129,10 +149,10 @@ You can _extend_ an existing configuration (whether your own or a third-party on
 
 Popular configurations include:
 
-- [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended): turns on just [possible error rules](rules/list.md#possible-errors)
-- [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard): extends recommended one by turning on 60 [stylistic rules](rules/list.md#stylistic-issues)
+- [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended) - turns on just [possible error rules](rules/list.md#possible-errors)
+- [`stylelint-config-standard`](https://github.com/stylelint/stylelint-config-standard) - extends recommended one by turning on 60 [stylistic rules](rules/list.md#stylistic-issues)
 
-You'll find more in [awesome stylelint](https://github.com/ntwb/awesome-stylelint#configs).
+You'll find more in [awesome stylelint](https://github.com/stylelint/awesome-stylelint#configs).
 
 When one configuration extends another, it starts with the other's properties then adds to and overrides what's there.
 
@@ -173,10 +193,10 @@ Plugins are rules or sets of rules built by the community that support methodolo
 
 Popular plugin packs include:
 
-- [`stylelint-order`](https://github.com/hudochenkov/stylelint-order): specify the ordering of things, e.g. properties within declaration blocks
-- [`stylelint-scss`](https://github.com/kristerkari/stylelint-scss): enforce a wide variety of SCSS-syntax specific linting rules
+- [`stylelint-order`](https://github.com/hudochenkov/stylelint-order) - specify the ordering of things, e.g. properties within declaration blocks
+- [`stylelint-scss`](https://github.com/kristerkari/stylelint-scss) - enforce a wide variety of linting rules for SCSS-like syntax
 
-You'll find more in [awesome stylelint](https://github.com/ntwb/awesome-stylelint#plugins).
+You'll find more in [awesome stylelint](https://github.com/stylelint/awesome-stylelint#plugins).
 
 To use one, add a `"plugins"` array to your config, containing "locaters" identifying the plugins you want to use. As with `extends`, above, a "locater" can be either a:
 
@@ -190,7 +210,7 @@ Once the plugin is declared, within your `"rules"` object _you'll need to add op
 {
   "plugins": ["../special-rule.js"],
   "rules": {
-    "plugin/special-rule": "everything"
+    "plugin-namespace/special-rule": "everything"
   }
 }
 ```
@@ -212,7 +232,7 @@ A "plugin" can provide a single rule or a set of rules. If the plugin you use pr
 
 Processors are functions built by the community that hook into stylelint's pipeline, modifying code on its way into stylelint and modifying results on their way out.
 
-**We discourage their use in favor of [PostCSS syntaxes](https://github.com/postcss/postcss#syntaxes). stylelint uses some of these syntaxes to support autofix for common non-stylesheet files. Processors can also only be used with the CLI and the Node.js API, not with the PostCSS plugin. (The PostCSS plugin ignores them.)**
+**We discourage their use in favor of using the built-in [syntaxes](../about/syntaxes.md) as processors are incompatible with the [autofix feature](usage/options.md#fix).**
 
 To use one, add a `"processors"` array to your config, containing "locaters" identifying the processors you want to use. As with `extends`, above, a "locater" can be either an npm module name, an absolute path, or a path relative to the invoking configuration file.
 
@@ -234,6 +254,8 @@ If your processor has options, make that item an array whose first item is the "
   "rules": {}
 }
 ```
+
+Processors can also only be used with the CLI and the Node.js API, not with the PostCSS plugin. (The PostCSS plugin ignores them.)
 
 ## `ignoreFiles`
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -87,20 +87,22 @@ For example, the following rule configuration would substitute in custom message
 
 ```json
 {
-  "color-hex-case": [
-    "lower",
-    {
-      "message": "Lowercase letters are easier to distinguish from numbers"
-    }
-  ],
-  "indentation": [
-    2,
-    {
-      "except": ["block"],
-      "message": "Please use 2 spaces for indentation.",
-      "severity": "warning"
-    }
-  ]
+  "rules": {
+    "color-hex-case": [
+      "lower",
+      {
+        "message": "Lowercase letters are easier to distinguish from numbers"
+      }
+    ],
+    "indentation": [
+      2,
+      {
+        "except": ["block"],
+        "message": "Please use 2 spaces for indentation.",
+        "severity": "warning"
+      }
+    ]
+  }
 }
 ```
 

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -30,12 +30,12 @@ Now that you're up and running, you'll likely want to customize stylelint to mee
 
 You'll want to customize your configuration.
 
-For example, you may want to use the:
+For example, you may want to use the popular:
 
 - [`stylelint-config-sass-guidelines` config](https://github.com/bjankord/stylelint-config-sass-guidelines) if you write SCSS
 - [`stylelint-order` plugin](https://github.com/hudochenkov/stylelint-order) if you want to order things like properties
 
-You'll find more [configs](https://github.com/ntwb/awesome-stylelint#configs) and [plugins](https://github.com/ntwb/awesome-stylelint#plugins) listed in [awesome stylelint](https://github.com/ntwb/awesome-stylelint).
+You'll find more [configs](https://github.com/stylelint/awesome-stylelint#configs) and [plugins](https://github.com/stylelint/awesome-stylelint#plugins) listed in [awesome stylelint](https://github.com/stylelint/awesome-stylelint).
 
 To further customize your stylelint configuration, you can adapt your:
 

--- a/docs/user-guide/ignore-code.md
+++ b/docs/user-guide/ignore-code.md
@@ -1,8 +1,11 @@
 # Ignoring code
 
-You can ignore sections within files or files entirely.
+You can ignore:
 
-## Sections within files
+- within files
+- files entirely
+
+## Within files
 
 You can temporarily turn off rules using special comments in your CSS. For example, you can either turn all the rules off:
 
@@ -61,7 +64,12 @@ stylelint supports complex, overlapping disabling & enabling patterns:
 
 ## Files entirely
 
-You can use a `.stylelintignore` file to ignore specific files.
+You can use a `.stylelintignore` file to ignore specific files. For example:
+
+```
+**/*.js
+vendor/**/*.css
+```
 
 The patterns in your `.stylelintignore` file must match [`.gitignore` syntax](https://git-scm.com/docs/gitignore). (Behind the scenes, [`node-ignore`](https://github.com/kaelzhang/node-ignore) parses your patterns.) _Your patterns in `.stylelintignore` are always analyzed relative to `process.cwd()`._
 

--- a/docs/user-guide/integrations/editor.md
+++ b/docs/user-guide/integrations/editor.md
@@ -2,10 +2,10 @@
 
 Editor integrations built and maintained by the community.
 
-- [Ale](https://github.com/dense-analysis/ale): A Vim plugin that supports stylelint.
-- [Flycheck](https://github.com/flycheck/flycheck): An Emacs extension that supports stylelint.
-- [linter-stylelint](https://github.com/AtomLinter/linter-stylelint): An Atom plugin for stylelint.
-- [SublimeLinter-stylelint](https://github.com/SublimeLinter/SublimeLinter-stylelint): A Sublime Text plugin for stylelint.
-- [SublimeLinter-contrib-stylelint_d](https://github.com/jo-sm/SublimeLinter-contrib-stylelint_d): A Sublime Text plugin for stylelint that run's on daemon.
-- [WebStorm](https://blog.jetbrains.com/webstorm/2016/09/webstorm-2016-3-eap-163-4830-stylelint-usages-for-default-exports-and-more/): Version 2016.3 onwards has built-in support for stylelint.
-- [vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint): A VS Code extension for stylelint.
+- [Ale](https://github.com/dense-analysis/ale) - A Vim plugin that supports stylelint.
+- [Flycheck](https://github.com/flycheck/flycheck) - An Emacs extension that supports stylelint.
+- [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - An Atom plugin for stylelint.
+- [SublimeLinter-stylelint](https://github.com/SublimeLinter/SublimeLinter-stylelint) - A Sublime Text plugin for stylelint.
+- [SublimeLinter-contrib-stylelint_d](https://github.com/jo-sm/SublimeLinter-contrib-stylelint_d) - A Sublime Text plugin for stylelint that run's on daemon.
+- [WebStorm](https://blog.jetbrains.com/webstorm/2016/09/webstorm-2016-3-eap-163-4830-stylelint-usages-for-default-exports-and-more/) - Version 2016.3 onwards has built-in support for stylelint.
+- [vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) - A VS Code extension for stylelint.

--- a/docs/user-guide/integrations/editor.md
+++ b/docs/user-guide/integrations/editor.md
@@ -2,10 +2,10 @@
 
 Editor integrations built and maintained by the community.
 
-- [Ale](https://github.com/dense-analysis/ale) - A Vim plugin that supports stylelint.
-- [Flycheck](https://github.com/flycheck/flycheck) - An Emacs extension that supports stylelint.
-- [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - An Atom plugin for stylelint.
-- [SublimeLinter-stylelint](https://github.com/SublimeLinter/SublimeLinter-stylelint) - A Sublime Text plugin for stylelint.
-- [SublimeLinter-contrib-stylelint_d](https://github.com/jo-sm/SublimeLinter-contrib-stylelint_d) - A Sublime Text plugin for stylelint that run's on daemon.
-- [WebStorm](https://blog.jetbrains.com/webstorm/2016/09/webstorm-2016-3-eap-163-4830-stylelint-usages-for-default-exports-and-more/) - Version 2016.3 onwards has built-in support for stylelint.
-- [vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) - A VS Code extension for stylelint.
+- [Ale](https://github.com/dense-analysis/ale) - Vim plugin that supports stylelint.
+- [Flycheck](https://github.com/flycheck/flycheck) - Emacs extension that supports stylelint.
+- [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - Atom plugin for stylelint.
+- [SublimeLinter-stylelint](https://github.com/SublimeLinter/SublimeLinter-stylelint) - Sublime Text plugin for stylelint.
+- [SublimeLinter-contrib-stylelint_d](https://github.com/jo-sm/SublimeLinter-contrib-stylelint_d) - Sublime Text plugin for stylelint that run's on daemon.
+- [WebStorm](https://blog.jetbrains.com/webstorm/2016/09/webstorm-2016-3-eap-163-4830-stylelint-usages-for-default-exports-and-more/) - version 2016.3 onwards has built-in support for stylelint.
+- [vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) - VS Code extension for stylelint.

--- a/docs/user-guide/integrations/other.md
+++ b/docs/user-guide/integrations/other.md
@@ -10,8 +10,8 @@ Other integrations built and maintained by the community.
 
 ## Version Control
 
-- [Pre-commit](https://github.com/awebdeveloper/pre-commit-stylelint) A git pre-commit hook for stylelint
+- [Pre-commit](https://github.com/awebdeveloper/pre-commit-stylelint) - Git pre-commit hook for stylelint
 
 ## Command Line Tools
 
-- [stylelint-find-rules](https://github.com/alexilyaev/stylelint-find-rules) - Find Stylelint rules that you don't have in your config.
+- [stylelint-find-rules](https://github.com/alexilyaev/stylelint-find-rules) - find Stylelint rules that you don't have in your config.

--- a/docs/user-guide/integrations/other.md
+++ b/docs/user-guide/integrations/other.md
@@ -4,9 +4,9 @@ Other integrations built and maintained by the community.
 
 ## Analysis platform engines
 
-- [codacy-stylelint](https://github.com/codacy/codacy-stylelint): [Codacy](https://www.codacy.com/) engine for stylelint
-- [codeclimate-stylelint](https://github.com/gilbarbara/codeclimate-stylelint): Code Climate engine for stylelint
-- [reviewdog/action-stylelint](https://github.com/reviewdog/action-stylelint): GitHub Action to run stylelint with [reviewdog](https://github.com/reviewdog/reviewdog)
+- [codacy-stylelint](https://github.com/codacy/codacy-stylelint) - [Codacy](https://www.codacy.com/) engine for stylelint
+- [codeclimate-stylelint](https://github.com/gilbarbara/codeclimate-stylelint) - Code Climate engine for stylelint
+- [reviewdog/action-stylelint](https://github.com/reviewdog/action-stylelint) - GitHub Action to run stylelint with [reviewdog](https://github.com/reviewdog/reviewdog)
 
 ## Version Control
 
@@ -14,4 +14,4 @@ Other integrations built and maintained by the community.
 
 ## Command Line Tools
 
-- [stylelint-find-rules](https://github.com/alexilyaev/stylelint-find-rules): Find Stylelint rules that you don't have in your config.
+- [stylelint-find-rules](https://github.com/alexilyaev/stylelint-find-rules) - Find Stylelint rules that you don't have in your config.

--- a/docs/user-guide/integrations/task-runner.md
+++ b/docs/user-guide/integrations/task-runner.md
@@ -2,9 +2,9 @@
 
 Task runner integrations built and maintained by the community.
 
-- [broccoli-stylelint](https://github.com/billybonks/broccoli-stylelint): A Broccoli plugin for stylelint.
-- [ember-cli-stylelint](https://github.com/billybonks/ember-cli-stylelint): An Ember CLI plugin for stylelint.
-- [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint): A Grunt plugin for stylelint.
-- [gulp-stylelint](https://github.com/olegskl/gulp-stylelint): A gulp plugin for stylelint.
-- [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint): A Jest plugin for stylelint.
-- [stylelint-webpack-plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin): A webpack plugin for stylelint.
+- [broccoli-stylelint](https://github.com/billybonks/broccoli-stylelint) - A Broccoli plugin for stylelint.
+- [ember-cli-stylelint](https://github.com/billybonks/ember-cli-stylelint) - An Ember CLI plugin for stylelint.
+- [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint) - A Grunt plugin for stylelint.
+- [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - A gulp plugin for stylelint.
+- [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint) - A Jest plugin for stylelint.
+- [stylelint-webpack-plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin) - A webpack plugin for stylelint.

--- a/docs/user-guide/integrations/task-runner.md
+++ b/docs/user-guide/integrations/task-runner.md
@@ -2,9 +2,9 @@
 
 Task runner integrations built and maintained by the community.
 
-- [broccoli-stylelint](https://github.com/billybonks/broccoli-stylelint) - A Broccoli plugin for stylelint.
-- [ember-cli-stylelint](https://github.com/billybonks/ember-cli-stylelint) - An Ember CLI plugin for stylelint.
-- [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint) - A Grunt plugin for stylelint.
-- [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - A gulp plugin for stylelint.
-- [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint) - A Jest plugin for stylelint.
-- [stylelint-webpack-plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin) - A webpack plugin for stylelint.
+- [broccoli-stylelint](https://github.com/billybonks/broccoli-stylelint) - Broccoli plugin for stylelint.
+- [ember-cli-stylelint](https://github.com/billybonks/ember-cli-stylelint) - Ember CLI plugin for stylelint.
+- [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint) - Grunt plugin for stylelint.
+- [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) - gulp plugin for stylelint.
+- [jest-runner-stylelint](https://github.com/keplersj/jest-runner-stylelint) - Jest plugin for stylelint.
+- [stylelint-webpack-plugin](https://github.com/webpack-contrib/stylelint-webpack-plugin) - webpack plugin for stylelint.

--- a/docs/user-guide/rules/about.md
+++ b/docs/user-guide/rules/about.md
@@ -17,21 +17,19 @@ Each rule accepts a primary and an optional secondary option.
 
 ### Primary
 
-Every rule _must have_ a **primary option**. For example:
+Every rule _must have_ a primary option. For example, in:
 
-- in `"color-hex-case": "upper"`, the primary option is `"upper"`
-- in `"indentation": [2, { "except": ["block"] }]`, the primary option is `2`
+- `"color-hex-case": "upper"`, the primary option is `"upper"`
+- `"indentation": [2, { "except": ["block"] }]`, the primary option is `2`
 
 ### Secondary
 
-Some rules require extra flexibility to address edge cases. These can use an **optional secondary options object**. For example:
+Some rules require extra flexibility to address edge cases. These can use an optional secondary options object. For example, in:
 
-- in `"color-hex-case": "upper"` there is no secondary options object
-- in `"indentation": [2, { "except": ["block"] }]`, the secondary options object is `{ "except": ["block"] }`
+- `"color-hex-case": "upper"` there is no secondary options object
+- `"indentation": [2, { "except": ["block"] }]`, the secondary options object is `{ "except": ["block"] }`
 
 The most typical secondary options are `"ignore": []` and `"except": []`.
-
-A rule's secondary option can be anything if it doesn't ignore or make exceptions. As an example, `resolveNestedSelectors: true|false` is used within some `selector-*` rules to change how the rule processes nested selectors.
 
 #### Keyword `"ignore"` and `"except"`
 
@@ -42,7 +40,14 @@ The `"ignore"` and `"except"` options accept an array of predefined keyword opti
 
 #### User-defined `"ignore*"`
 
-Some rules accept a _user-defined_ list of things to ignore. This takes the form of `"ignore<Things>": []`, e.g. `"ignoreAtRules": []` is used if a rule checks at-rules.
+Some rules accept a _user-defined_ list of things to ignore. This takes the form of `"ignore<Things>": []`, e.g. `"ignoreAtRules": []`.
+
+The `ignore*` options let users ignore non-standard syntax at the _configuration level_. For example, the:
+
+- `:global` and `:local` pseudo-classes introduced in CSS Modules
+- `@debug` and `@extend` at-rules introduced in SCSS
+
+Methodologies and language extensions come and go quickly, and this approach ensures our codebase does not become littered with code for obsolete things.
 
 ## Names
 

--- a/docs/user-guide/usage/cli.md
+++ b/docs/user-guide/usage/cli.md
@@ -1,12 +1,12 @@
 # Command Line Interface (CLI)
 
-You can use stylelint on the command line.
+You can use stylelint on the command line. For example:
 
 ```shell
-stylelint "**/*.css"
+npx stylelint "**/*.css"
 ```
 
-Use `stylelint --help` to print the CLI documentation.
+Use `npx stylelint --help` to print the CLI documentation.
 
 ## Options
 
@@ -42,9 +42,9 @@ Show the currently installed version of stylelint.
 
 ## Usage examples
 
-The CLI expects an input as either a [file glob](https://github.com/sindresorhus/globby) or `process.stdin`. It outputs formatted results into `process.stdout`.
+The CLI expects input as either a [file glob](https://github.com/sindresorhus/globby) or `process.stdin`. It outputs formatted results into `process.stdout`.
 
-Be sure to include quotation marks around file globs.
+_Be sure to include quotation marks around file globs._
 
 ### Example A - recursive
 
@@ -83,15 +83,15 @@ stylelint "foo/**/*.scss" --cache --cache-location "/Users/user/.stylelintcache/
 Linting all `.css` files in the `foo` directory, then writing the output to `myTestReport.txt`:
 
 ```shell
-stylelint "foo/*.css" --config bar/mySpecialConfig.json --output-file myTestReport.txt
+stylelint "foo/*.css" --output-file myTestReport.txt
 ```
 
-### Example F - multiple globs and specifying a config
+### Example F - specifying a config
 
-Using `bar/mySpecialConfig.json` as config to lint all `.css` files in the `foo` directory and any of its subdirectories and also all `.css` files in the `bar directory`:
+Using `bar/mySpecialConfig.json` as config to lint all `.css` files in the `foo` directory and any of its subdirectories:
 
 ```shell
-stylelint "foo/**/*.css" "bar/*.css" --config bar/mySpecialConfig.json
+stylelint "foo/**/*.css" --config bar/mySpecialConfig.json
 ```
 
 ## Exit codes

--- a/docs/user-guide/usage/node-api.md
+++ b/docs/user-guide/usage/node-api.md
@@ -72,7 +72,7 @@ An array of objects, one for each source, with tells you which stylelint-disable
 
 ### `invalidScopeDisables`
 
-an array of objects, one for each source, with tells you which rule in `stylelint-disable <rule>` comment don't exist within the configuration object.
+An array of objects, one for each source, with tells you which rule in `stylelint-disable <rule>` comment don't exist within the configuration object.
 
 ## Syntax errors
 

--- a/docs/user-guide/usage/node-api.md
+++ b/docs/user-guide/usage/node-api.md
@@ -24,7 +24,7 @@ A partial stylelint configuration object whose properties override the existing 
 
 ### `code`
 
-A CSS string to lint.
+A string to lint.
 
 ### `files`
 
@@ -62,6 +62,18 @@ An array containing all the accumulated [PostCSS LazyResults](https://api.postcs
 
 An array containing all the stylelint result objects (the objects that formatters consume).
 
+### `maxWarningsExceeded`
+
+An object containing the maximum number of warnings and the amount found, e.g. `{ maxWarnings: 0, foundWarnings: 12 }`.
+
+### `needlessDisables`
+
+An array of objects, one for each source, with tells you which stylelint-disable comments are not blocking a lint violation
+
+### `invalidScopeDisables`
+
+an array of objects, one for each source, with tells you which rule in `stylelint-disable <rule>` comment don't exist within the configuration object.
+
 ## Syntax errors
 
 `stylelint.lint()` does not reject the Promise when your CSS contains syntax errors.
@@ -71,12 +83,12 @@ It resolves with an object (see [The returned promise](#the-returned-promise)) t
 
 ### Example A
 
-If `myConfig` contains no relative paths for `extends` or `plugins`, you do not have to use `configBasedir`:
+As `config` contains no relative paths for `extends` or `plugins`, you do not have to use `configBasedir`:
 
 ```js
 stylelint
   .lint({
-    config: myConfig,
+    config: { rules: "color-no-invalid-hex" },
     files: "all/my/stylesheets/*.css"
   })
   .then(function(data) {
@@ -107,14 +119,14 @@ stylelint
 
 ### Example C
 
-Using a CSS string instead of a file glob, and the string formatter instead of the default JSON:
+Using a string instead of a file glob, and the verbose formatter instead of the default JSON:
 
 ```js
 stylelint
   .lint({
     code: "a { color: pink; }",
     config: myConfig,
-    formatter: "string"
+    formatter: "verbose"
   })
   .then(function() {
     /* .. */
@@ -132,12 +144,9 @@ stylelint
     files: "all/my/stylesheets/*.scss",
     formatter: function(stylelintResults) {
       /* .. */
-    },
-    syntax: "scss"
+    }
   })
   .then(function() {
     /* .. */
   });
 ```
-
-The same pattern can be used to lint Less, SCSS or [SugarSS](https://github.com/postcss/sugarss) syntax.

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -46,17 +46,17 @@ Options are:
 - `unix`
 - `verbose`
 
-The `formatter` Node.js API option can also accept function, whereas the `--custom-formatter` CLI flag accepts a path to a JS file exporting one. The function in both cases must fit the signature described in the [Developer Guide](../../developer-guide/formatters.md).
+The `formatter` Node.js API option can also accept a function, whereas the `--custom-formatter` CLI flag accepts a path to a JS file exporting one. The function in both cases must fit the signature described in the [Developer Guide](../../developer-guide/formatters.md).
 
 ## `cache`
 
 CLI flag: `--cache`
 
-Store the info about processed files to only operate on the changed ones the next time you run stylelint. By default, the cache is stored in `./.stylelintcache` in `process.cwd()`.
+Store the results of processed files so that stylelint only operates on the changed ones. By default, the cache is stored in `./.stylelintcache` in `process.cwd()`.
 
 Enabling this option can dramatically improve stylelint's speed because only changed files are linted.
 
-**Note:** If you run stylelint with `cache` and then run stylelint without `cache`, stylelint deletes the `.stylelintcache` because we have to assume that that second command invalidated `.stylelintcache`.
+_If you run stylelint with `cache` and then run stylelint without `cache`, stylelint deletes the `.stylelintcache` because we have to assume that that second command invalidated `.stylelintcache`._
 
 ## `cacheLocation`
 
@@ -66,7 +66,7 @@ Path to a file or directory for the cache location.
 
 If a directory is specified, stylelint creates a cache file inside the specified folder. The name of the file is based on the hash of `process.cwd()` (e.g. `.cache_hashOfCWD`) so that stylelint can reuse a single location for a variety of caches from different projects.
 
-**Note:** If the directory of `cacheLocation` does not exist, make sure you add a trailing `/` on \*nix systems or `\` on Windows. Otherwise, stylelint assumes the path to be a file.
+_If the directory of `cacheLocation` does not exist, make sure you add a trailing `/` on \*nix systems or `\` on Windows. Otherwise, stylelint assumes the path to be a file._
 
 ## `maxWarnings`
 
@@ -74,11 +74,12 @@ CLI flags: `--max-warnings, --mw`
 
 Set a limit to the number of warnings accepted.
 
-It is useful when setting `defaultSeverity` to `"warning"` and expecting the process to fail on warnings (e.g. CI build).
+It is useful when setting [`defaultSeverity`](../configure.md#defaultseverity) to `"warning"` and expecting the process to fail on warnings (e.g. CI build).
 
-For the CLI, the process exits with code `2` if the number of warnings exceeds this value.
+If the number of warnings exceeds this value, the:
 
-For the Node.js API, the returned data contains a `maxWarningsExceeded` property if the number of found warnings exceeds the given limit. The value is an Object (e.g. `{ maxWarnings: 0, foundWarnings: 12 }`).
+- CLI process exits with code `2`
+- Node.js API adds a [`maxWarningsExceeded`](node-api.md#maxwarningsexceeded) property to the returned data
 
 ## `syntax`
 
@@ -107,6 +108,18 @@ Module name or path to a JS file exporting a [PostCSS-compatible syntax](https:/
 
 Note, however, that stylelint can provide no guarantee that core rules work with syntaxes other than the defaults listed for the `syntax` option above.
 
+## `disableDefaultIgnores`
+
+CLI flags: `--disable-default-ignores, --di`
+
+Disable the default ignores. stylelint will not automatically ignore the contents of `node_modules`.
+
+## `ignorePath`
+
+CLI flags: `--ignore-path, -i`
+
+A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, stylelint looks for `.stylelintignore` in `process.cwd()`.
+
 ## `ignoreDisables`
 
 CLI flags: `--ignore-disables, --id`
@@ -121,11 +134,10 @@ CLI flags: `--report-needless-disables, --rd`
 
 Produce a report to clean up your codebase, keeping only the stylelint-disable comments that serve a purpose.
 
-For the CLI, the process exits with code `2` if needless disables are found.
+If needless disables are found, the:
 
-For the Node.js API, `ignoreDisables` is also set to `true`, and the returned data contains a `needlessDisables` property, whose value is an array of objects, one for each source, with tells you which stylelint-disable comments are not blocking a lint violation.
-
-Also, report errors for stylelint-disable comments that are not blocking a lint warning.
+- CLI process exits with code `2`
+- Node.js API adds a [`needlessDisables`](node-api.md#needlessdisables) property to the returned data
 
 ## `reportInvalidScopeDisables`
 
@@ -133,21 +145,10 @@ CLI flags: `--report-invalid-scope-disables, --risd`
 
 Produce a report of the stylelint-disable comments that used for rules that don't exist within the configuration object.
 
-For the CLI, the process exits with code `2` if invalid scope disables are found.
+If invalid scope disables are found, the:
 
-For the Node.js API, the returned data contains a `invalidScopeDisables` property, whose value is an array of objects, one for each source, with tells you which rule in `stylelint-disable <rule>` comment don't exist within the configuration object.
-
-## `disableDefaultIgnores`
-
-CLI flags: `--disable-default-ignores, --di`
-
-Disable the default ignores. stylelint will not automatically ignore the contents of `node_modules`.
-
-## `ignorePath`
-
-CLI flags: `--ignore-path, -i`
-
-A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, stylelint looks for `.stylelintignore` in `process.cwd()`.
+- CLI process exits with code `2`
+- Node.js API adds a [`invalidScopeDisables`](node-api.md#invalidscopedisables) property to the returned data
 
 ## `codeFilename`
 

--- a/docs/user-guide/usage/postcss-plugin.md
+++ b/docs/user-guide/usage/postcss-plugin.md
@@ -2,7 +2,7 @@
 
 As with any other [PostCSS plugin](https://github.com/postcss/postcss#plugins), you can use stylelint's PostCSS plugin either with a [PostCSS runner](https://github.com/postcss/postcss#runners) or with the PostCSS JS API directly.
 
-_However, if a dedicated stylelint task runner plugin [is available](../integrations/task-runner.md) (e.g. [gulp-stylelint](https://github.com/olegskl/gulp-stylelint) or [grunt-stylelint](https://github.com/wikimedia/grunt-stylelint)) we recommend you use that rather than this plugin, as they provide better reporting._
+_However, if a dedicated stylelint task runner plugin [is available](../integrations/task-runner.md) (e.g. [gulp-stylelint](https://github.com/olegskl/gulp-stylelint)) we recommend you use that rather than this plugin, as they provide better reporting._
 
 ## Options
 
@@ -27,8 +27,8 @@ const fs = require("fs");
 const less = require("postcss-less");
 const postcss = require("postcss");
 
-// CSS to be processed
-const css = fs.readFileSync("input.css", "utf8");
+// Code to be processed
+const code = fs.readFileSync("input.less", "utf8");
 
 postcss([
   require("stylelint")({
@@ -36,8 +36,8 @@ postcss([
   }),
   require("postcss-reporter")({ clearReportedMessages: true })
 ])
-  .process(css, {
-    from: "input.css",
+  .process(code, {
+    from: "input.less",
     syntax: less
   })
   .then(() => {})
@@ -66,7 +66,7 @@ postcss([
       })
     ]
   }),
-  require("postcss-cssnext"),
+  require("postcss-preset-env"),
   require("postcss-reporter")({ clearReportedMessages: true })
 ])
   .process(css, {


### PR DESCRIPTION
(If time is short, please review https://github.com/stylelint/stylelint/pull/4592 over over this pull request so that we can address https://github.com/stylelint/stylelint/issues/3514.)

Follow up from https://github.com/stylelint/stylelint/pull/4561

I went through the overhauled docs again now that they are live on the website.

I want to make sure the:

- sidebars worked well
- content was a clear as it could be when view on the website

In this pull request I:

- updated [some code examples](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/user-guide/configure.md#rules) to be more complete
- removed duplication in the [steps we link to from the saved replies](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/developer-guide/rules.md#add-an-option-to-a-rule)
- updated [the saved replies](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/maintainer-guide/issues.md#saved-replies) to use stylelint.io
- added missing info to [Node.js API returned promise](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/user-guide/usage/node-api.md#maxwarningsexceeded)
- used lists to more [cleanly show the different effects](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/user-guide/usage/options.md#reportneedlessdisables) of some options on the CLI vs Node.js API
- standardised [list punctuation](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/user-guide/integrations/editor.md)
- fixed [links to awesome stylelint](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/user-guide/get-started.md#your-configuration)
- adding a couple of [extra examples](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/user-guide/ignore-code.md#files-entirely) here and there for better context
- finalised the division between what rule conventions [exist in the user guide](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/user-guide/rules/about.md#user-defined-ignore) and [which go in the developer guide](https://github.com/stylelint/stylelint/blob/3bc680e1c8c46942ff082da50966f36e4396d49f/docs/developer-guide/rules.md#add-options)
- fixed some heading hierarchies and their content to better support the website sidebar 
