### PR TITLE
Fix false positive for part pseudo-element in selector-pseudo-element-no-unknown

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -173,6 +173,8 @@ keywordSets.levelThreePseudoElements = new Set([
 	'content',
 ]);
 
+keywordSets.shadowTreePseudoElements = new Set(['part']);
+
 keywordSets.vendorSpecificPseudoElements = new Set([
 	'-moz-progress-bar',
 	'-moz-range-progress',
@@ -202,6 +204,7 @@ keywordSets.pseudoElements = uniteSets(
 	keywordSets.levelOneAndTwoPseudoElements,
 	keywordSets.levelThreePseudoElements,
 	keywordSets.vendorSpecificPseudoElements,
+	keywordSets.shadowTreePseudoElements,
 );
 
 keywordSets.aNPlusBNotationPseudoClasses = new Set([

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
@@ -105,6 +105,9 @@ testRule(rule, {
 			code: 'html { --custom-property-set: {} }',
 			description: 'custom property set in selector',
 		},
+		{
+			code: 'a::part(shadow-part) { }',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION


<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

fixes #4589

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
