### PR TITLE
Fix false positives for longhand grid-column/row-* properties in value-keyword-case

### DIFF
--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -669,6 +669,13 @@ testRule(rule, {
 			line: 1,
 			column: 24,
 		},
+		{
+			code: 'a { GRID-COLUMN-START: SPAN camelCaseArea; }',
+			fixed: 'a { GRID-COLUMN-START: span camelCaseArea; }',
+			message: messages.expected('SPAN', 'span'),
+			line: 1,
+			column: 24,
+		},
 	],
 });
 
@@ -1282,6 +1289,10 @@ testRule(rule, {
 		{
 			code: 'a { color: ThreeDShadow; }',
 			description: 'another system color',
+		},
+		{
+			code: 'a { GRID-COLUMN-START: SPAN camelCaseArea; }',
+			description: 'ignore property case',
 		},
 	],
 

--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -311,6 +311,10 @@ testRule(rule, {
 			code: 'a { color: ThreeDShadow; }',
 			description: 'another system color',
 		},
+		{
+			code: 'a { grid-column-start: span camelCaseArea; }',
+			description: 'ignore area case',
+		},
 	],
 
 	reject: [
@@ -657,6 +661,13 @@ testRule(rule, {
 			message: messages.expected('UPPER-ALPHA', 'upper-alpha'),
 			line: 1,
 			column: 23,
+		},
+		{
+			code: 'a { grid-column-start: sPan camelCaseArea; }',
+			fixed: 'a { grid-column-start: span camelCaseArea; }',
+			message: messages.expected('sPan', 'span'),
+			line: 1,
+			column: 24,
 		},
 	],
 });

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -21,6 +21,8 @@ const messages = ruleMessages(ruleName, {
 
 // Operators are interpreted as "words" by the value parser, so we want to make sure to ignore them.
 const ignoredCharacters = new Set(['+', '-', '/', '*', '%']);
+const gridRowProps = new Set(['grid-row', 'grid-row-start', 'grid-row-end']);
+const gridColumnProps = new Set(['grid-column', 'grid-column-start', 'grid-column-end']);
 
 const mapLowercaseKeywordsToCamelCase = new Map();
 
@@ -52,7 +54,7 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkDecls((decl) => {
-			const prop = decl.prop;
+			const prop = decl.prop.toLowerCase();
 			const value = decl.value;
 
 			const parsed = valueParser(decl.raws.value ? decl.raws.value.raw : decl.value);
@@ -124,11 +126,11 @@ function rule(expectation, options, context) {
 					return;
 				}
 
-				if (prop === 'grid-row' && !keywordSets.gridRowKeywords.has(valueLowerCase)) {
+				if (gridRowProps.has(prop) && !keywordSets.gridRowKeywords.has(valueLowerCase)) {
 					return;
 				}
 
-				if (prop === 'grid-column' && !keywordSets.gridColumnKeywords.has(valueLowerCase)) {
+				if (gridColumnProps.has(prop) && !keywordSets.gridColumnKeywords.has(valueLowerCase)) {
 					return;
 				}
 


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

It should close #4605 .

> Is there anything in the PR that needs further explanation?

I think its necessary to convert prop to lower case before any comparison can be done.
