### PR TITLE
Remove org-level community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.md
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.md
@@ -13,7 +13,7 @@ e.g. "There are false positives for two leading zeros when ..."
 
 e.g. `number-leading-zero`
 
-> What CSS is needed to reproduce the bug?
+> What code is needed to reproduce the bug?
 
 e.g.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-# Code of conduct
-
-You should adhere to GitHub's [Acceptable Use](https://help.github.com/articles/github-terms-of-service/#c-acceptable-use) policy.
-
-You can use GitHub's [grievance process](https://github.com/contact/report-abuse) to report breaches of this policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,0 @@
-# Reporting security issues
-
-Please send an email to stylelint@gmail.com if you discover a security issue.
-
-We can then assess the risk, and make a fix available before we add a bug report to the GitHub repository.
-
-Thank you for making stylelint safe for everyone!


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Following on from https://github.com/stylelint/stylelint/pull/4606.

> Is there anything in the PR that needs further explanation?

These are [organisation-wide](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) community health files and live [in the `.github` repo](https://github.com/stylelint/.github).
