### PR TITLE
Documentation Fix -- Removing extra line of copy

### DIFF
--- a/lib/rules/selector-max-type/README.md
+++ b/lib/rules/selector-max-type/README.md
@@ -75,8 +75,6 @@ a span {}
 div a .foo:not(span) {}
 ```
 
-The following patterns are _not_ considered violations:
-
 ## Optional secondary options
 
 ### `ignore: ["child", "compounded", "descendant", "next-sibling"]`


### PR DESCRIPTION
Currently at https://stylelint.io/user-guide/rules/selector-max-type, under the patterns that are not considered as violations, there is an extra `The following patterns are not considered violations:`

This PR removes that extra line of copy.

**Before:**
![image](https://user-images.githubusercontent.com/2349702/76554184-aa91d000-6452-11ea-8191-4712330372f7.png)

---- 
**After:**
![image](https://user-images.githubusercontent.com/2349702/76554145-9c43b400-6452-11ea-95c3-2b3ae00ebe24.png)


> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
