### PR TITLE
Add ignoreFontFamilies option to `font-family-no-missing-generic-family-keyword`

### DIFF
--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -56,12 +56,12 @@ a { font: caption; }
 
 ## Optional secondary options
 
-### `ignoreFontFamilies: : ["/regex/", /regex/, "string"]`
+### `ignoreFontFamilies: ["/regex/", /regex/, "string"]`
 
 Given:
 
 ```
-["custom-icon-font"]
+["custom-font"]
 ```
 
 The following pattern is _not_ considered a violation:
@@ -69,4 +69,11 @@ The following pattern is _not_ considered a violation:
 <!-- prettier-ignore -->
 ```css
 a { font-family: custom-font; }
+```
+
+The following pattern is considered a violation:
+
+<!-- prettier-ignore -->
+```css
+a { font-family: invalid-custom-font; }
 ```

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -64,7 +64,7 @@ Given:
 ["custom-icon-font"]
 ```
 
-The following pattern is not considered a violation:
+The following pattern is _not_ considered a violation:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -56,9 +56,15 @@ a { font: caption; }
 
 ## Optional secondary options
 
-### `ignoreValues: ["custom-font"]`
+### `ignoreFontFamilies: : ["/regex/", /regex/, "string"]`
 
-Ignore this rule for specific font names that would not have an appropriate generic font family to fall back to. Commonly, this would be used for icon fonts.
+Given:
+
+```
+["custom-icon-font"]
+```
+
+The following pattern is not considered a violation:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -53,3 +53,14 @@ a { font: inherit; }
 ```css
 a { font: caption; }
 ```
+
+## Optional secondary options
+
+### `ignoreValues: ["custom-font"]`
+
+Ignore this rule for specific font names that would not have an appropriate generic font family to fall back to. Commonly, this would be used for icon fonts.
+
+<!-- prettier-ignore -->
+```css
+a { font-family: custom-font; }
+```

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
@@ -135,7 +135,7 @@ testRule(rule, {
 	config: [
 		true,
 		{
-			ignoreValues: ['custom-font'],
+			ignoreFontFamilies: ['custom-font'],
 		},
 	],
 	accept: [
@@ -144,20 +144,11 @@ testRule(rule, {
 		},
 		{
 			code: 'a { font: 1em Lucida Grande, Arial, custom-font }',
-			message: messages.rejected,
-			line: 1,
-			column: 37,
 		},
 	],
 	reject: [
 		{
 			code: 'a { font-family: Arial; }',
-			message: messages.rejected,
-			line: 1,
-			column: 18,
-		},
-		{
-			code: 'a { font-family: Times; }',
 			message: messages.rejected,
 			line: 1,
 			column: 18,

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
@@ -135,7 +135,7 @@ testRule(rule, {
 	config: [
 		true,
 		{
-			ignoreFontFamilies: ['custom-font'],
+			ignoreFontFamilies: ['custom-font', /foo/, '/baz[0-9]/'],
 		},
 	],
 	accept: [
@@ -144,6 +144,12 @@ testRule(rule, {
 		},
 		{
 			code: 'a { font: 1em Lucida Grande, Arial, custom-font }',
+		},
+		{
+			code: 'a { font: foo-font }',
+		},
+		{
+			code: 'a { font: baz7 }',
 		},
 	],
 	reject: [
@@ -158,6 +164,18 @@ testRule(rule, {
 			message: messages.rejected,
 			line: 1,
 			column: 37,
+		},
+		{
+			code: 'a { font: bar-font }',
+			message: messages.rejected,
+			line: 1,
+			column: 11,
+		},
+		{
+			code: 'a { font: baz-7 }',
+			message: messages.rejected,
+			line: 1,
+			column: 11,
 		},
 	],
 });

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
@@ -6,7 +6,6 @@ const { messages, ruleName } = rule;
 testRule(rule, {
 	ruleName,
 	config: [true],
-
 	accept: [
 		{
 			code: 'a { font-family: "Lucida Grande", "Arial", sans-serif; }',
@@ -121,6 +120,47 @@ testRule(rule, {
 			message: messages.rejected,
 			line: 1,
 			column: 43,
+		},
+		{
+			code: 'a { font: 1em Lucida Grande, Arial, "sans-serif" }',
+			message: messages.rejected,
+			line: 1,
+			column: 37,
+		},
+	],
+});
+
+testRule(rule, {
+	ruleName,
+	config: [
+		true,
+		{
+			ignoreValues: ['custom-font'],
+		},
+	],
+	accept: [
+		{
+			code: 'a { font-family: custom-font; }',
+		},
+		{
+			code: 'a { font: 1em Lucida Grande, Arial, custom-font }',
+			message: messages.rejected,
+			line: 1,
+			column: 37,
+		},
+	],
+	reject: [
+		{
+			code: 'a { font-family: Arial; }',
+			message: messages.rejected,
+			line: 1,
+			column: 18,
+		},
+		{
+			code: 'a { font-family: Times; }',
+			message: messages.rejected,
+			line: 1,
+			column: 18,
 		},
 		{
 			code: 'a { font: 1em Lucida Grande, Arial, "sans-serif" }',

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -62,11 +62,7 @@ function rule(actual, options) {
 				return;
 			}
 
-			if (
-				fontFamilies.some((node) =>
-					optionsMatches(options, 'ignoreFontFamilies', node.value.toLowerCase()),
-				)
-			) {
+			if (fontFamilies.some((node) => optionsMatches(options, 'ignoreFontFamilies', node.value))) {
 				return;
 			}
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -3,9 +3,12 @@
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const findFontFamily = require('../../utils/findFontFamily');
 const keywordSets = require('../../reference/keywordSets');
+const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+
+const _ = require('lodash');
 
 const ruleName = 'font-family-no-missing-generic-family-keyword';
 
@@ -16,9 +19,20 @@ const messages = ruleMessages(ruleName, {
 const isFamilyNameKeyword = (node) =>
 	!node.quote && keywordSets.fontFamilyKeywords.has(node.value.toLowerCase());
 
-function rule(actual, options = {}) {
+function rule(actual, options) {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{ actual },
+			{
+				actual: options,
+				possible: {
+					ignoreFontFamilies: [_.isString, _.isRegExp],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
 			return;
@@ -49,10 +63,9 @@ function rule(actual, options = {}) {
 			}
 
 			if (
-				options.ignoreValues &&
-				fontFamilies.some((node) => {
-					return !node.quote && options.ignoreValues.includes(node.value.toLowerCase());
-				})
+				fontFamilies.some((node) =>
+					optionsMatches(options, 'ignoreFontFamilies', node.value.toLowerCase()),
+				)
 			) {
 				return;
 			}

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -16,7 +16,7 @@ const messages = ruleMessages(ruleName, {
 const isFamilyNameKeyword = (node) =>
 	!node.quote && keywordSets.fontFamilyKeywords.has(node.value.toLowerCase());
 
-function rule(actual) {
+function rule(actual, options = {}) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
@@ -45,6 +45,15 @@ function rule(actual) {
 			}
 
 			if (fontFamilies.some(isFamilyNameKeyword)) {
+				return;
+			}
+
+			if (
+				options.ignoreValues &&
+				fontFamilies.some((node) => {
+					return !node.quote && options.ignoreValues.includes(node.value.toLowerCase());
+				})
+			) {
 				return;
 			}
 


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes #3288

> Is there anything in the PR that needs further explanation?

Seems to work alright so far. Something I'm struggling with is how a font family name in quotes should be written. I couldn't tell if that works and I'm just writing the test poorly or this doesn't work with quoted names.