### PR TITLE
Ignore non-standard syntax in function-calc-no-invalid

### DIFF
--- a/lib/rules/function-calc-no-invalid/__tests__/index.js
+++ b/lib/rules/function-calc-no-invalid/__tests__/index.js
@@ -285,70 +285,52 @@ testRule(rule, {
 		},
 		{
 			code: `
-      a {
-        width: calc(
-          #{$min-value} +
-          #{strip-unit($max-value - $min-value)} *
-          (100vw - #{$min-vw})
-        );
-      }
-      `,
+				a {
+					width: calc(
+						#{$min-value} +
+						#{strip-unit($max-value - $min-value)} *
+						(100vw - #{$min-vw})
+					);
+				}
+			`,
 		},
 		{
 			code: `
-      a {
-        width: calc(#{$min-value} + #{$max-value}*(100vw - #{$min-vw}));
-      }
-      `,
+				a {
+					width: calc(#{$min-value} + #{$max-value}*(100vw - #{$min-vw}));
+				}
+     		 `,
+		},
+		{
+			code: 'a { top: calc(100% -#{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100% -$foo); }',
+		},
+		{
+			code: '.foo {width: calc(100% - -#{$foo});}',
+		},
+		{
+			code: '.foo {width: calc(-#{$foo});}',
+		},
+		{
+			code: '.foo {width: calc(100% - - -#{$foo});}',
+		},
+		{
+			code: `
+				a {
+					width: calc(#{$min-value} + #{$max-value}*(100vw -#{$min-vw}));
+				}
+			`,
 		},
 	],
 
 	reject: [
 		{
-			code: 'a { top: calc(100% -#{$foo}); }',
-			message: messages.expectedSpaceAfterOperator('-'),
-			line: 1,
-			column: 21,
-		},
-		{
-			code: 'a { top: calc(100% -$foo); }',
-			message: messages.expectedSpaceAfterOperator('-'),
-			line: 1,
-			column: 21,
-		},
-		{
 			code: 'a { top: calc(100% -foo()); }',
 			message: messages.expectedSpaceAfterOperator('-'),
 			line: 1,
 			column: 21,
-		},
-		{
-			code: '.foo {width: calc(100% - -#{$foo});}',
-			message: messages.expectedExpression(),
-			line: 1,
-			column: 27,
-		},
-		{
-			code: '.foo {width: calc(-#{$foo});}',
-			message: messages.expectedExpression(),
-			line: 1,
-			column: 20,
-		},
-		{
-			code: '.foo {width: calc(100% - - -#{$foo});}',
-			message: messages.expectedExpression(),
-			line: 1,
-			column: 29,
-		},
-		{
-			code: `
-      a {
-        width: calc(#{$min-value} + #{$max-value}*(100vw -#{$min-vw}));
-      }
-      `,
-			message: messages.expectedSpaceAfterOperator('-'),
-			line: 3,
-			column: 59,
 		},
 	],
 });
@@ -376,59 +358,41 @@ testRule(rule, {
 		},
 		{
 			code: `
-      a {
-        width: calc(@{min-value} + @{max-value}*(100vw - @{min-vw}));
-      }
-      `,
+				a {
+					width: calc(@min-value + @max-value*100vw - @min-vw));
+				}
+			`,
+		},
+		{
+			code: 'a { top: calc(100% -@foo); }',
+		},
+		{
+			code: 'a { top: calc(100% -@foo[bar]); }',
+		},
+		{
+			code: '.foo {width: calc(100% - -@foo);}',
+		},
+		{
+			code: '.foo {width: calc(-@foo);}',
+		},
+		{
+			code: '.foo {width: calc(100% - - -@foo);}',
+		},
+		{
+			code: `
+				a {
+					width: calc(@min-value + @max-value*(100vw -@min-vw));
+				}
+			`,
 		},
 	],
 
 	reject: [
 		{
-			code: 'a { top: calc(100% -@foo); }',
-			message: messages.expectedSpaceAfterOperator('-'),
-			line: 1,
-			column: 21,
-		},
-		{
-			code: 'a { top: calc(100% -@foo[bar]); }',
-			message: messages.expectedSpaceAfterOperator('-'),
-			line: 1,
-			column: 21,
-		},
-		{
 			code: 'a { top: calc(100% -foo()); }',
 			message: messages.expectedSpaceAfterOperator('-'),
 			line: 1,
 			column: 21,
-		},
-		{
-			code: '.foo {width: calc(100% - -@foo);}',
-			message: messages.expectedExpression(),
-			line: 1,
-			column: 27,
-		},
-		{
-			code: '.foo {width: calc(-@foo);}',
-			message: messages.expectedExpression(),
-			line: 1,
-			column: 20,
-		},
-		{
-			code: '.foo {width: calc(100% - - -@foo);}',
-			message: messages.expectedExpression(),
-			line: 1,
-			column: 29,
-		},
-		{
-			code: `
-      a {
-        width: calc(@{min-value} + @{max-value}*(100vw -@{min-vw}));
-      }
-      `,
-			message: messages.expectedSpaceAfterOperator('-'),
-			line: 3,
-			column: 57,
 		},
 	],
 });

--- a/lib/rules/function-calc-no-invalid/index.js
+++ b/lib/rules/function-calc-no-invalid/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const isStandardSyntaxMathFunction = require('../../utils/isStandardSyntaxMathFunction');
 const parseCalcExpression = require('../../utils/parseCalcExpression');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -34,6 +35,12 @@ function rule(actual) {
 					return;
 				}
 
+				const mathFunction = valueParser.stringify(node);
+
+				if (!isStandardSyntaxMathFunction(mathFunction)) {
+					return;
+				}
+
 				if (checked.includes(node)) {
 					return;
 				}
@@ -45,7 +52,7 @@ function rule(actual) {
 				let ast;
 
 				try {
-					ast = parseCalcExpression(valueParser.stringify(node));
+					ast = parseCalcExpression(mathFunction);
 				} catch (e) {
 					if (e.hash && e.hash.loc) {
 						complain(messages.expectedExpression(), node.sourceIndex + e.hash.loc.range[0]);

--- a/lib/utils/__tests__/isStandardSyntaxMathFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxMathFunction.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const isStandardSyntaxMathFunction = require('../isStandardSyntaxMathFunction');
+
+describe('isStandardSyntaxMathFunction', () => {
+	it('standard', () => {
+		const css = 'calc(10px + 10px)';
+
+		expect(isStandardSyntaxMathFunction(css)).toBe(true);
+	});
+
+	it('standard with custom property', () => {
+		const css = 'calc(10px + var(--hello))';
+
+		expect(isStandardSyntaxMathFunction(css)).toBe(true);
+	});
+
+	it('SCSS variable without dashes', () => {
+		const css = 'calc($var * 3)';
+
+		expect(isStandardSyntaxMathFunction(css)).toBe(false);
+	});
+
+	it('SCSS variable with dashes', () => {
+		const css = 'calc(3 + $my-var)';
+
+		expect(isStandardSyntaxMathFunction(css)).toBe(false);
+	});
+
+	it('SCSS interpolation', () => {
+		const css = 'calc(3 - ${$my-var})';
+
+		expect(isStandardSyntaxMathFunction(css)).toBe(false);
+	});
+
+	it('Less variable without dashes', () => {
+		const css = 'calc(@var * 3)';
+
+		expect(isStandardSyntaxMathFunction(css)).toBe(false);
+	});
+
+	it('Less variable with dashes', () => {
+		const css = 'calc(3 - @my-var)';
+
+		expect(isStandardSyntaxMathFunction(css)).toBe(false);
+	});
+});

--- a/lib/utils/isStandardSyntaxMathFunction.js
+++ b/lib/utils/isStandardSyntaxMathFunction.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Check whether a math function is standard
+ *
+ * @param {string} mathFunction
+ * @returns {boolean}
+ */
+module.exports = function isStandardSyntaxMathFunction(mathFunction) {
+	// SCSS variable
+	if (mathFunction.includes('$')) {
+		return false;
+	}
+
+	// Less variable
+	if (mathFunction.includes('@')) {
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Fixes #4114, #4533.
Closes #4534.

> Is there anything in the PR that needs further explanation?

@jeddy3 [said](https://github.com/stylelint/stylelint/issues/4114#issuecomment-573375622):

> Built-in rules ignore non-standard syntax. This rule should only check the validity of `calc` functions containing standard CSS syntax.

To be honest, I don't think this is a good approach for users. `function-calc-no-invalid` catches many cases of invalid `calc` for preprocessor users. But with this PR, we reduce usefulness of this rule for these users.