### PR TITLE
Prettier 2.0 fixes

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,6 +3,7 @@
 // https://prettier.io/docs/en/options.html
 module.exports = {
 	arrowParens: 'always',
+	endOfLine: 'lf',
 	printWidth: 100,
 	singleQuote: true,
 	trailingComma: 'all',

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -21,11 +21,11 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
   expected: "Expected ..."
 });
 
-module.exports = stylelint.createPlugin(ruleName, function(
+module.exports = stylelint.createPlugin(ruleName, function (
   primaryOption,
   secondaryOptionObject
 ) {
-  return function(postcssRoot, postcssResult) {
+  return function (postcssRoot, postcssResult) {
     const validOptions = stylelint.utils.validateOptions(
       postcssResult,
       ruleName,
@@ -80,11 +80,11 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
   expected: "Expected ..."
 });
 
-module.exports = stylelint.createPlugin(ruleName, function(
+module.exports = stylelint.createPlugin(ruleName, function (
   primaryOption,
   secondaryOptionObject
 ) {
-  return function(postcssRoot, postcssResult) {
+  return function (postcssRoot, postcssResult) {
     const validOptions = stylelint.utils.validateOptions(
       postcssResult,
       ruleName,
@@ -97,9 +97,9 @@ module.exports = stylelint.createPlugin(ruleName, function(
       return;
     }
 
-    return new Promise(function(resolve) {
+    return new Promise(function (resolve) {
       // some async operation
-      setTimeout(function() {
+      setTimeout(function () {
         // ... some logic ...
         stylelint.utils.report({
           /* .. */
@@ -152,7 +152,7 @@ const allowableAtRules = [
 ];
 
 function myPluginRule(primaryOption, secondaryOptionObject) {
-  return function(postcssRoot, postcssResult) {
+  return function (postcssRoot, postcssResult) {
     const defaultedOptions = Object.assign({}, secondaryOptionObject, {
       ignoreAtRules: allowableAtRules.concat(options.ignoreAtRules || [])
     });
@@ -189,7 +189,7 @@ All rules share a common signature. They are a function that accepts two argumen
 Here's an example of a plugin that runs `color-hex-case` only if there is a special directive `@@check-color-hex-case` somewhere in the stylesheet:
 
 ```js
-module.exports = stylelint.createPlugin(ruleName, function(expectation) {
+module.exports = stylelint.createPlugin(ruleName, function (expectation) {
   const runColorHexCase = stylelint.rules["color-hex-case"](expectation);
 
   return (root, result) => {

--- a/docs/developer-guide/processors.md
+++ b/docs/developer-guide/processors.md
@@ -11,13 +11,13 @@ Processor modules are functions that accept an options object and return an obje
 
 ```js
 // my-processor.js
-module.exports = function(options) {
+module.exports = function (options) {
   return {
-    code: function(input, filepath) {
+    code: function (input, filepath) {
       // ...
       return transformedCode;
     },
-    result: function(stylelintResult, filepath) {
+    result: function (stylelintResult, filepath) {
       // ...
       return transformedResult;
     }

--- a/docs/user-guide/usage/node-api.md
+++ b/docs/user-guide/usage/node-api.md
@@ -3,7 +3,7 @@
 The stylelint module includes a `lint()` function that provides the Node.js API.
 
 ```js
-stylelint.lint(options).then(function(resultObject) {
+stylelint.lint(options).then(function (resultObject) {
   /* .. */
 });
 ```
@@ -91,11 +91,11 @@ stylelint
     config: { rules: "color-no-invalid-hex" },
     files: "all/my/stylesheets/*.css"
   })
-  .then(function(data) {
+  .then(function (data) {
     // do things with data.output, data.errored,
     // and data.results
   })
-  .catch(function(err) {
+  .catch(function (err) {
     // do things with err e.g.
     console.error(err.stack);
   });
@@ -112,7 +112,7 @@ stylelint
     configBasedir: path.join(__dirname, "configs"),
     files: "all/my/stylesheets/*.css"
   })
-  .then(function() {
+  .then(function () {
     /* .. */
   });
 ```
@@ -128,7 +128,7 @@ stylelint
     config: myConfig,
     formatter: "verbose"
   })
-  .then(function() {
+  .then(function () {
     /* .. */
   });
 ```
@@ -142,11 +142,11 @@ stylelint
   .lint({
     config: myConfig,
     files: "all/my/stylesheets/*.scss",
-    formatter: function(stylelintResults) {
+    formatter: function (stylelintResults) {
       /* .. */
     }
   })
-  .then(function() {
+  .then(function () {
     /* .. */
   });
 ```

--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -645,8 +645,5 @@ it('enable rule without disabling rule', () => {
 });
 
 function testDisableRanges(source, cb) {
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(source, { from: undefined })
-		.then(cb);
+	return postcss().use(assignDisabledRanges).process(source, { from: undefined }).then(cb);
 }

--- a/lib/__tests__/fixtures/processor-fenced-blocks.js
+++ b/lib/__tests__/fixtures/processor-fenced-blocks.js
@@ -2,7 +2,7 @@
 
 const execall = require('execall');
 
-module.exports = function(options = {}) {
+module.exports = function (options = {}) {
 	const specialMessage = options.specialMessage || 'was processed';
 
 	return {

--- a/lib/__tests__/fixtures/processor-triple-question-marks.js
+++ b/lib/__tests__/fixtures/processor-triple-question-marks.js
@@ -2,7 +2,7 @@
 
 const execall = require('execall');
 
-module.exports = function() {
+module.exports = function () {
 	let found = false;
 
 	return {

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -37,7 +37,7 @@ function createDisableRange(start, strictStart, end, strictEnd) {
  * @param {PostcssResult} result
  * @returns {PostcssResult}
  */
-module.exports = function(root, result) {
+module.exports = function (root, result) {
 	result.stylelint = result.stylelint || {
 		disabledRanges: {},
 		ruleSeverities: {},
@@ -155,8 +155,9 @@ module.exports = function(root, result) {
 		getCommandRules(enableCommand, comment.text).forEach((ruleToEnable) => {
 			// TODO TYPES
 			// need fallback if endLine will be undefined
-			const endLine =
-				/** @type {number} */ (comment.source && comment.source.end && comment.source.end.line);
+			const endLine = /** @type {number} */ (comment.source &&
+				comment.source.end &&
+				comment.source.end.line);
 
 			if (ruleToEnable === ALL_RULES) {
 				if (

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -256,42 +256,39 @@ function addPluginFunctions(config) {
 
 	const normalizedPlugins = Array.isArray(config.plugins) ? config.plugins : [config.plugins];
 
-	const pluginFunctions = normalizedPlugins.reduce(
-		(result, pluginLookup) => {
-			let pluginImport = dynamicRequire(pluginLookup);
+	const pluginFunctions = normalizedPlugins.reduce((result, pluginLookup) => {
+		let pluginImport = dynamicRequire(pluginLookup);
 
-			// Handle either ES6 or CommonJS modules
-			pluginImport = pluginImport.default || pluginImport;
+		// Handle either ES6 or CommonJS modules
+		pluginImport = pluginImport.default || pluginImport;
 
-			// A plugin can export either a single rule definition
-			// or an array of them
-			const normalizedPluginImport = Array.isArray(pluginImport) ? pluginImport : [pluginImport];
+		// A plugin can export either a single rule definition
+		// or an array of them
+		const normalizedPluginImport = Array.isArray(pluginImport) ? pluginImport : [pluginImport];
 
-			normalizedPluginImport.forEach((pluginRuleDefinition) => {
-				if (!pluginRuleDefinition.ruleName) {
-					throw configurationError(
-						'stylelint v3+ requires plugins to expose a ruleName. ' +
-							`The plugin "${pluginLookup}" is not doing this, so will not work ` +
-							'with stylelint v3+. Please file an issue with the plugin.',
-					);
-				}
+		normalizedPluginImport.forEach((pluginRuleDefinition) => {
+			if (!pluginRuleDefinition.ruleName) {
+				throw configurationError(
+					'stylelint v3+ requires plugins to expose a ruleName. ' +
+						`The plugin "${pluginLookup}" is not doing this, so will not work ` +
+						'with stylelint v3+. Please file an issue with the plugin.',
+				);
+			}
 
-				if (!pluginRuleDefinition.ruleName.includes('/')) {
-					throw configurationError(
-						'stylelint v7+ requires plugin rules to be namespaced, ' +
-							'i.e. only `plugin-namespace/plugin-rule-name` plugin rule names are supported. ' +
-							`The plugin rule "${pluginRuleDefinition.ruleName}" does not do this, so will not work. ` +
-							'Please file an issue with the plugin.',
-					);
-				}
+			if (!pluginRuleDefinition.ruleName.includes('/')) {
+				throw configurationError(
+					'stylelint v7+ requires plugin rules to be namespaced, ' +
+						'i.e. only `plugin-namespace/plugin-rule-name` plugin rule names are supported. ' +
+						`The plugin rule "${pluginRuleDefinition.ruleName}" does not do this, so will not work. ` +
+						'Please file an issue with the plugin.',
+				);
+			}
 
-				result[pluginRuleDefinition.ruleName] = pluginRuleDefinition.rule;
-			});
+			result[pluginRuleDefinition.ruleName] = pluginRuleDefinition.rule;
+		});
 
-			return result;
-		},
-		/** @type {{[k: string]: Function}} */ ({}),
-	);
+		return result;
+	}, /** @type {{[k: string]: Function}} */ ({}));
 
 	config.pluginFunctions = pluginFunctions;
 

--- a/lib/createPlugin.js
+++ b/lib/createPlugin.js
@@ -5,7 +5,7 @@
  * @param {Function} rule
  * @returns {{ruleName: string, rule: Function}}
  */
-module.exports = function(ruleName, rule) {
+module.exports = function (ruleName, rule) {
 	return {
 		ruleName,
 		rule,

--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -22,7 +22,7 @@ const STOP_DIR = IS_TEST ? path.resolve(__dirname, '..') : undefined;
  * @param {import('stylelint').StylelintStandaloneOptions} options
  * @returns {StylelintInternalApi}
  */
-module.exports = function(options = {}) {
+module.exports = function (options = {}) {
 	/** @type {Partial<StylelintInternalApi>} */
 	const stylelint = { _options: options };
 

--- a/lib/createStylelintResult.js
+++ b/lib/createStylelintResult.js
@@ -13,7 +13,7 @@ const _ = require('lodash');
  * @param {import('stylelint').StylelintCssSyntaxError} [cssSyntaxError]
  * @return {Promise<StylelintResult>}
  */
-module.exports = function(stylelint, postcssResult, filePath, cssSyntaxError) {
+module.exports = function (stylelint, postcssResult, filePath, cssSyntaxError) {
 	/** @type {StylelintResult} */
 	let stylelintResult;
 	/** @type {string | undefined} */
@@ -103,8 +103,8 @@ module.exports = function(stylelint, postcssResult, filePath, cssSyntaxError) {
 
 	return stylelint.getConfigForFile(filePath).then((configForFile) => {
 		// TODO TYPES handle possible null here
-		const config =
-			/** @type {{ config: import('stylelint').StylelintConfig, filepath: string }} */ (configForFile).config;
+		const config = /** @type {{ config: import('stylelint').StylelintConfig, filepath: string }} */ (configForFile)
+			.config;
 		const file = source || (cssSyntaxError && cssSyntaxError.file);
 
 		if (config.resultProcessors) {

--- a/lib/dynamicRequire.js
+++ b/lib/dynamicRequire.js
@@ -5,6 +5,6 @@
  * @param {string} name
  * @return {any} any module
  */
-module.exports = function(name) {
+module.exports = function (name) {
 	return require(name);
 };

--- a/lib/formatters/__tests__/prepareFormatterOutput.js
+++ b/lib/formatters/__tests__/prepareFormatterOutput.js
@@ -9,7 +9,7 @@ symbolConversions.set('✔', '√');
 symbolConversions.set('⚠', '‼');
 symbolConversions.set('✖', '×');
 
-module.exports = function(results, formatter) {
+module.exports = function (results, formatter) {
 	let output = stripAnsi(formatter(results)).trim();
 
 	symbolConversions.forEach((win, nix) => {

--- a/lib/formatters/disableOptionsReportStringFormatter.js
+++ b/lib/formatters/disableOptionsReportStringFormatter.js
@@ -10,17 +10,14 @@ const path = require('path');
 function logFrom(fromValue) {
 	if (fromValue.startsWith('<')) return fromValue;
 
-	return path
-		.relative(process.cwd(), fromValue)
-		.split(path.sep)
-		.join('/');
+	return path.relative(process.cwd(), fromValue).split(path.sep).join('/');
 }
 
 /**
  * @param {import('stylelint').StylelintDisableOptionsReport} report
  * @returns {string}
  */
-module.exports = function(report) {
+module.exports = function (report) {
 	if (!report) return '';
 
 	let output = '';

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -68,10 +68,7 @@ function invalidOptionsFormatter(results) {
 function logFrom(fromValue) {
 	if (fromValue.startsWith('<')) return fromValue;
 
-	return path
-		.relative(process.cwd(), fromValue)
-		.split(path.sep)
-		.join('/');
+	return path.relative(process.cwd(), fromValue).split(path.sep).join('/');
 }
 
 /**
@@ -200,7 +197,7 @@ function formatter(messages, source) {
  * @param {import('stylelint').StylelintResult[]} results
  * @returns {string}
  */
-module.exports = function(results) {
+module.exports = function (results) {
 	let output = invalidOptionsFormatter(results);
 
 	output += deprecationsFormatter(results);

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -8,7 +8,7 @@ const stringFormatter = require('./stringFormatter');
  * @param {import('stylelint').StylelintResult[]} results
  * @returns {string}
  */
-module.exports = function(results) {
+module.exports = function (results) {
 	let output = stringFormatter(results);
 
 	if (output === '') {

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -13,7 +13,7 @@ const path = require('path');
  * @param {string} [searchPath]
  * @returns {ConfigPromise}
  */
-module.exports = function(stylelint, searchPath = process.cwd()) {
+module.exports = function (stylelint, searchPath = process.cwd()) {
 	const optionsConfig = stylelint._options.config;
 
 	if (optionsConfig !== undefined) {

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -18,7 +18,7 @@ const postcssProcessor = postcss();
  *
  * @returns {Promise<import('postcss').Result>}
  */
-module.exports = function(stylelint, options = {}) {
+module.exports = function (stylelint, options = {}) {
 	const cached = options.filePath ? stylelint._postcssResultCache.get(options.filePath) : undefined;
 
 	if (cached) return Promise.resolve(cached);

--- a/lib/invalidScopeDisables.js
+++ b/lib/invalidScopeDisables.js
@@ -9,7 +9,7 @@
  * @param {import('stylelint').StylelintConfig|undefined} config
  * @returns {StylelintDisableOptionsReport}
  */
-module.exports = function(results, config = {}) {
+module.exports = function (results, config = {}) {
 	/** @type {StylelintDisableOptionsReport} */
 	const report = [];
 	const usedRules = new Set(Object.keys(config.rules || {}));

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -14,7 +14,7 @@ const slash = require('slash');
  * @param {string} [filePath]
  * @return {Promise<boolean>}
  */
-module.exports = function(stylelint, filePath) {
+module.exports = function (stylelint, filePath) {
 	if (!filePath) {
 		return Promise.resolve(false);
 	}

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -152,11 +152,10 @@ function lintPostcssResult(stylelint, postcssResult, config) {
 		postcssResult.stylelint.disableWritingFix = true;
 	}
 
-	const postcssRoots =
-		/** @type {import('postcss').Root[]} */ (postcssDoc &&
-		postcssDoc.constructor.name === 'Document'
-			? postcssDoc.nodes
-			: [postcssDoc]);
+	const postcssRoots = /** @type {import('postcss').Root[]} */ (postcssDoc &&
+	postcssDoc.constructor.name === 'Document'
+		? postcssDoc.nodes
+		: [postcssDoc]);
 
 	// Promises for the rules. Although the rule code runs synchronously now,
 	// the use of Promises makes it compatible with the possibility of async

--- a/lib/needlessDisables.js
+++ b/lib/needlessDisables.js
@@ -10,7 +10,7 @@ const _ = require('lodash');
  * @param {import('stylelint').StylelintResult[]} results
  * @returns {StylelintDisableOptionsReport}
  */
-module.exports = function(results) {
+module.exports = function (results) {
 	/** @type {StylelintDisableOptionsReport} */
 	const report = [];
 

--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -21,7 +21,7 @@ const requireRule = require('./requireRule');
  * @param {boolean} [primaryOptionArray] If primaryOptionArray is not provided, we try to get it from the, rules themselves, which will not work for plugins
  * @return {[any, Object] | Array<any | [any, Object]> | null}
  */
-module.exports = function(
+module.exports = function (
 	rawSettings,
 	ruleName,
 	// If primaryOptionArray is not provided, we try to get it from the

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -11,7 +11,7 @@ const path = require('path');
  * @param {import('stylelint').StylelintStandaloneOptions} options
  * @returns {Promise<StylelintConfig | null>}
  */
-module.exports = function(options) {
+module.exports = function (options) {
 	const code = options.code;
 	const config = options.config;
 	const configBasedir = options.configBasedir;

--- a/lib/requireRule.js
+++ b/lib/requireRule.js
@@ -7,7 +7,7 @@ const rules = require('./rules');
  * @param {string} ruleName
  * @returns {false|any}
  */
-module.exports = function(ruleName) {
+module.exports = function (ruleName) {
 	if (rules.includes(ruleName)) {
 		return importLazy(`./rules/${ruleName}`);
 	}

--- a/lib/rules/at-rule-no-vendor-prefix/index.js
+++ b/lib/rules/at-rule-no-vendor-prefix/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 });
 
 function rule(actual) {
-	return function(root, result) {
+	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, { actual });
 
 		if (!validOptions) {

--- a/lib/rules/atRuleNameSpaceChecker.js
+++ b/lib/rules/atRuleNameSpaceChecker.js
@@ -3,7 +3,7 @@
 const isStandardSyntaxAtRule = require('../utils/isStandardSyntaxAtRule');
 const report = require('../utils/report');
 
-module.exports = function(options) {
+module.exports = function (options) {
 	options.root.walkAtRules((atRule) => {
 		if (!isStandardSyntaxAtRule(atRule)) {
 			return;

--- a/lib/rules/block-closing-brace-space-after/index.js
+++ b/lib/rules/block-closing-brace-space-after/index.js
@@ -22,7 +22,7 @@ const messages = ruleMessages(ruleName, {
 function rule(expectation) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
-	return function(root, result) {
+	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
 			possible: [

--- a/lib/rules/comment-whitespace-inside/index.js
+++ b/lib/rules/comment-whitespace-inside/index.js
@@ -17,7 +17,7 @@ const messages = ruleMessages(ruleName, {
 });
 
 function rule(expectation, options, context) {
-	return function(root, result) {
+	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
 			possible: ['always', 'never'],

--- a/lib/rules/declaration-block-semicolon-newline-before/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.js
@@ -18,7 +18,7 @@ const messages = ruleMessages(ruleName, {
 function rule(expectation) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
-	return function(root, result) {
+	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],

--- a/lib/rules/declaration-block-semicolon-space-after/index.js
+++ b/lib/rules/declaration-block-semicolon-space-after/index.js
@@ -21,7 +21,7 @@ const messages = ruleMessages(ruleName, {
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
-	return function(root, result) {
+	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
 			possible: ['always', 'never', 'always-single-line', 'never-single-line'],

--- a/lib/rules/declarationBangSpaceChecker.js
+++ b/lib/rules/declarationBangSpaceChecker.js
@@ -4,7 +4,7 @@ const declarationValueIndex = require('../utils/declarationValueIndex');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts.root.walkDecls((decl) => {
 		const indexOffset = declarationValueIndex(decl);
 		const declString = decl.toString();

--- a/lib/rules/declarationColonSpaceChecker.js
+++ b/lib/rules/declarationColonSpaceChecker.js
@@ -4,7 +4,7 @@ const declarationValueIndex = require('../utils/declarationValueIndex');
 const isStandardSyntaxDeclaration = require('../utils/isStandardSyntaxDeclaration');
 const report = require('../utils/report');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts.root.walkDecls((decl) => {
 		if (!isStandardSyntaxDeclaration(decl)) {
 			return;

--- a/lib/rules/findMediaOperator.js
+++ b/lib/rules/findMediaOperator.js
@@ -3,7 +3,7 @@
 const rangeOperators = ['>=', '<=', '>', '<', '='];
 const styleSearch = require('style-search');
 
-module.exports = function(atRule, cb) {
+module.exports = function (atRule, cb) {
 	if (atRule.name.toLowerCase() !== 'media') {
 		return;
 	}

--- a/lib/rules/functionCommaSpaceChecker.js
+++ b/lib/rules/functionCommaSpaceChecker.js
@@ -6,7 +6,7 @@ const isStandardSyntaxFunction = require('../utils/isStandardSyntaxFunction');
 const report = require('../utils/report');
 const valueParser = require('postcss-value-parser');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts.root.walkDecls((decl) => {
 		const declValue = _.get(decl, 'raws.value.raw', decl.value);
 

--- a/lib/rules/functionCommaSpaceFix.js
+++ b/lib/rules/functionCommaSpaceFix.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(params) {
+module.exports = function (params) {
 	const { div, index, nodes, expectation, position, symb } = params;
 
 	if (expectation.startsWith('always')) {

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -140,10 +140,7 @@ function rule(maxLength, options, context) {
 				// This trimming business is to notice when the line starts a
 				// comment but that comment is indented, e.g.
 				//       /* something here */
-				const nextTwoChars = rootString
-					.slice(match.endIndex)
-					.trim()
-					.slice(0, 2);
+				const nextTwoChars = rootString.slice(match.endIndex).trim().slice(0, 2);
 
 				if (nextTwoChars === '/*' || nextTwoChars === '//') {
 					return;
@@ -158,10 +155,7 @@ function rule(maxLength, options, context) {
 				// This trimming business is to notice when the line starts a
 				// comment but that comment is indented, e.g.
 				//       /* something here */
-				const nextTwoChars = rootString
-					.slice(match.endIndex)
-					.trim()
-					.slice(0, 2);
+				const nextTwoChars = rootString.slice(match.endIndex).trim().slice(0, 2);
 
 				if (nextTwoChars !== '/*' && nextTwoChars !== '//') {
 					return;

--- a/lib/rules/mediaFeatureColonSpaceChecker.js
+++ b/lib/rules/mediaFeatureColonSpaceChecker.js
@@ -4,7 +4,7 @@ const atRuleParamIndex = require('../utils/atRuleParamIndex');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts.root.walkAtRules(/^media$/i, (atRule) => {
 		const params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 

--- a/lib/rules/mediaQueryListCommaWhitespaceChecker.js
+++ b/lib/rules/mediaQueryListCommaWhitespaceChecker.js
@@ -4,7 +4,7 @@ const atRuleParamIndex = require('../utils/atRuleParamIndex');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts.root.walkAtRules(/^media$/i, (atRule) => {
 		const params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -59,10 +59,7 @@ function rule(actual, options) {
 
 			// Sort the selectors list so that the order of the constituents
 			// doesn't matter
-			const sortedSelectorList = normalizedSelectorList
-				.slice()
-				.sort()
-				.join(',');
+			const sortedSelectorList = normalizedSelectorList.slice().sort().join(',');
 
 			const checkPreviousDuplicationPosition = (
 				selectorList,

--- a/lib/rules/rangeContextNodeParser.js
+++ b/lib/rules/rangeContextNodeParser.js
@@ -33,7 +33,7 @@ function getRangeContextName(parsedNode) {
 	return parsedNode.find((value) => value.match(/^(?!--)\D+/) || value.match(/^(--).+/));
 }
 
-module.exports = function(node) {
+module.exports = function (node) {
 	const nodeValue = node.value;
 
 	const operators = getRangeContextOperators(node);

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -27,7 +27,7 @@ function rule(max, options) {
 			{
 				actual: max,
 				possible: [
-					function(max) {
+					function (max) {
 						return typeof max === 'number' && max >= 0;
 					},
 				],

--- a/lib/rules/selector-max-class/index.js
+++ b/lib/rules/selector-max-class/index.js
@@ -20,7 +20,7 @@ function rule(max) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
 			possible: [
-				function(max) {
+				function (max) {
 					return typeof max === 'number' && max >= 0;
 				},
 			],

--- a/lib/rules/selector-max-combinators/index.js
+++ b/lib/rules/selector-max-combinators/index.js
@@ -21,7 +21,7 @@ function rule(max) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
 			possible: [
-				function(max) {
+				function (max) {
 					return typeof max === 'number' && max >= 0;
 				},
 			],

--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -22,7 +22,7 @@ function rule(max) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
 			possible: [
-				function(max) {
+				function (max) {
 					return typeof max === 'number' && max > 0;
 				},
 			],

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -20,7 +20,7 @@ function rule(max) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
 			possible: [
-				function(max) {
+				function (max) {
 					return typeof max === 'number' && max >= 0;
 				},
 			],

--- a/lib/rules/selector-max-pseudo-class/index.js
+++ b/lib/rules/selector-max-pseudo-class/index.js
@@ -21,7 +21,7 @@ function rule(max) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
 			possible: [
-				function(max) {
+				function (max) {
 					return typeof max === 'number' && max >= 0;
 				},
 			],

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -43,7 +43,7 @@ function rule(max, options) {
 			{
 				actual: max,
 				possible: [
-					function(max) {
+					function (max) {
 						// Check that the max specificity is in the form "a,b,c"
 						return /^\d+,\d+,\d+$/.test(max);
 					},

--- a/lib/rules/selector-max-universal/index.js
+++ b/lib/rules/selector-max-universal/index.js
@@ -22,7 +22,7 @@ function rule(max) {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
 			possible: [
-				function(max) {
+				function (max) {
 					return typeof max === 'number' && max >= 0;
 				},
 			],

--- a/lib/rules/selectorAttributeOperatorSpaceChecker.js
+++ b/lib/rules/selectorAttributeOperatorSpaceChecker.js
@@ -5,7 +5,7 @@ const parseSelector = require('../utils/parseSelector');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function(options) {
+module.exports = function (options) {
 	options.root.walkRules((rule) => {
 		if (!isStandardSyntaxRule(rule)) {
 			return;

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -4,7 +4,7 @@ const isStandardSyntaxRule = require('../utils/isStandardSyntaxRule');
 const parseSelector = require('../utils/parseSelector');
 const report = require('../utils/report');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	let hasFixed;
 
 	opts.root.walkRules((rule) => {

--- a/lib/rules/selectorListCommaWhitespaceChecker.js
+++ b/lib/rules/selectorListCommaWhitespaceChecker.js
@@ -4,7 +4,7 @@ const isStandardSyntaxRule = require('../utils/isStandardSyntaxRule');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts.root.walkRules((rule) => {
 		if (!isStandardSyntaxRule(rule)) {
 			return;

--- a/lib/rules/valueListCommaWhitespaceChecker.js
+++ b/lib/rules/valueListCommaWhitespaceChecker.js
@@ -5,7 +5,7 @@ const isStandardSyntaxProperty = require('../utils/isStandardSyntaxProperty');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function(opts) {
+module.exports = function (opts) {
 	opts.root.walkDecls((decl) => {
 		if (!isStandardSyntaxDeclaration(decl) || !isStandardSyntaxProperty(decl.prop)) {
 			return;

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -30,7 +30,7 @@ const writeFileAtomic = require('write-file-atomic');
  * @param {StylelintOptions} options
  * @returns {Promise<StylelintStandaloneReturnValue>}
  */
-module.exports = function(options) {
+module.exports = function (options) {
 	const cacheLocation = options.cacheLocation;
 	const code = options.code;
 	const codeFilename = options.codeFilename;
@@ -73,9 +73,7 @@ module.exports = function(options) {
 	 * @type {any}
 	 */
 	const ignorePattern = options.ignorePattern || [];
-	const ignorer = ignore()
-		.add(ignoreText)
-		.add(ignorePattern);
+	const ignorer = ignore().add(ignoreText).add(ignorePattern);
 
 	const isValidCode = typeof code === 'string';
 

--- a/lib/testUtils/mergeTestDescriptions.js
+++ b/lib/testUtils/mergeTestDescriptions.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 
-module.exports = function(...args) {
+module.exports = function (...args) {
 	const mergeWithArgs = [{}];
 
 	Array.from(args).forEach((arg) => mergeWithArgs.push(arg));

--- a/lib/utils/atRuleParamIndex.js
+++ b/lib/utils/atRuleParamIndex.js
@@ -4,7 +4,7 @@
  * @param {import('postcss').AtRule} atRule
  * @returns {number}
  */
-module.exports = function(atRule) {
+module.exports = function (atRule) {
 	// Initial 1 is for the `@`
 	let index = 1 + atRule.name.length;
 

--- a/lib/utils/beforeBlockString.js
+++ b/lib/utils/beforeBlockString.js
@@ -11,7 +11,7 @@
  *
  * @returns {string}
  */
-module.exports = function(statement, options = {}) {
+module.exports = function (statement, options = {}) {
 	let result = '';
 	/** @type {Rule | undefined} */
 	let rule; /*?: postcss$rule*/

--- a/lib/utils/blockString.js
+++ b/lib/utils/blockString.js
@@ -16,7 +16,7 @@ const rawNodeString = require('./rawNodeString');
  * @param {Rule | AtRule} statement - postcss rule or at-rule node
  * @return {string | boolean}
  */
-module.exports = function(statement) {
+module.exports = function (statement) {
 	if (!hasBlock(statement)) {
 		return false;
 	}

--- a/lib/utils/blurComments.js
+++ b/lib/utils/blurComments.js
@@ -5,6 +5,6 @@
  *
  * @returns {string}
  */
-module.exports = function(source, blurChar = '`') {
+module.exports = function (source, blurChar = '`') {
 	return source.replace(/\/\*.*\*\//g, blurChar);
 };

--- a/lib/utils/blurFunctionArguments.js
+++ b/lib/utils/blurFunctionArguments.js
@@ -17,7 +17,7 @@ const balancedMatch = require('balanced-match');
  * @param {string} functionName
  * @return {string} - The result string, with the function arguments "blurred"
  */
-module.exports = function(source, functionName, blurChar = '`') {
+module.exports = function (source, functionName, blurChar = '`') {
 	const nameWithParen = `${functionName.toLowerCase()}(`;
 	const lowerCaseSource = source.toLowerCase();
 

--- a/lib/utils/blurInterpolation.js
+++ b/lib/utils/blurInterpolation.js
@@ -5,6 +5,6 @@
  *
  * @returns {string}
  */
-module.exports = function(source, blurChar = ' ') {
+module.exports = function (source, blurChar = ' ') {
 	return source.replace(/[#@{}]+/g, blurChar);
 };

--- a/lib/utils/checkAgainstRule.js
+++ b/lib/utils/checkAgainstRule.js
@@ -16,7 +16,7 @@ const rules = require('../rules');
  * @param {Function} callback
  * @returns {void}
  */
-module.exports = function(options, callback) {
+module.exports = function (options, callback) {
 	if (!options)
 		throw new Error(
 			"checkAgainstRule requires an options object with 'ruleName', 'ruleSettings', and 'root' properties",

--- a/lib/utils/configurationError.js
+++ b/lib/utils/configurationError.js
@@ -5,7 +5,7 @@
  * @param {string} text
  * @returns {Object}
  */
-module.exports = function(text) /* Object */ {
+module.exports = function (text) /* Object */ {
 	/** @type {Error & {code?: number}} */
 	const err = new Error(text);
 

--- a/lib/utils/declarationValueIndex.js
+++ b/lib/utils/declarationValueIndex.js
@@ -9,7 +9,7 @@ const _ = require('lodash');
  *
  * @returns {number}
  */
-module.exports = function(decl) {
+module.exports = function (decl) {
 	return [
 		_.get(decl, 'raws.prop.prefix'),
 		_.get(decl, 'raws.prop.raw', decl.prop),

--- a/lib/utils/eachDeclarationBlock.js
+++ b/lib/utils/eachDeclarationBlock.js
@@ -28,7 +28,7 @@ function isContainerNode(node) {
  *
  * @returns {void}
  */
-module.exports = function(root, cb) {
+module.exports = function (root, cb) {
 	/**
 	 * @param {PostcssNode} statement
 	 *

--- a/lib/utils/functionArgumentsSearch.js
+++ b/lib/utils/functionArgumentsSearch.js
@@ -17,7 +17,7 @@ const styleSearch = require('style-search');
  * @param {string} functionName
  * @param {Function} callback
  */
-module.exports = function(source, functionName, callback) {
+module.exports = function (source, functionName, callback) {
 	styleSearch(
 		{
 			source,

--- a/lib/utils/getFileIgnorer.js
+++ b/lib/utils/getFileIgnorer.js
@@ -14,7 +14,7 @@ const FILE_NOT_FOUND_ERROR_CODE = 'ENOENT';
  * @param {StylelintOptions} options
  * @return {import('ignore').Ignore}
  */
-module.exports = function(options) {
+module.exports = function (options) {
 	const ignoreFilePath = options.ignorePath || DEFAULT_IGNORE_FILENAME;
 	const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
 		? ignoreFilePath
@@ -32,9 +32,7 @@ module.exports = function(options) {
 	 * @type {any}
 	 */
 	const ignorePattern = options.ignorePattern || [];
-	const ignorer = ignore()
-		.add(ignoreText)
-		.add(ignorePattern);
+	const ignorer = ignore().add(ignoreText).add(ignorePattern);
 
 	return ignorer;
 };

--- a/lib/utils/getSchemeFromUrl.js
+++ b/lib/utils/getSchemeFromUrl.js
@@ -9,7 +9,7 @@ const { URL } = require('url');
  *
  * @param {string} urlString
  */
-module.exports = function(urlString) {
+module.exports = function (urlString) {
 	let protocol = null;
 
 	try {

--- a/lib/utils/getUnitFromValueNode.js
+++ b/lib/utils/getUnitFromValueNode.js
@@ -13,7 +13,7 @@ const valueParser = require('postcss-value-parser');
  *
  * @returns {string | null}
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	if (!node || !node.value) {
 		return null;
 	}

--- a/lib/utils/hasBlock.js
+++ b/lib/utils/hasBlock.js
@@ -6,6 +6,6 @@
  * @param {import('postcss').Rule | import('postcss').AtRule} statement - postcss rule or at-rule node
  * @return {boolean} True if `statement` has a block (empty or otherwise)
  */
-module.exports = function(statement) {
+module.exports = function (statement) {
 	return statement.nodes !== undefined;
 };

--- a/lib/utils/hasEmptyBlock.js
+++ b/lib/utils/hasEmptyBlock.js
@@ -6,7 +6,7 @@
  * @param {import('postcss').Rule | import('postcss').AtRule} statement - postcss rule or at-rule node
  * @return {boolean} True if the statement has a block and it is empty
  */
-module.exports = function(statement) {
+module.exports = function (statement) {
 	return (
 		statement.nodes !== undefined && statement.nodes.length === 0 // has block
 	); // and is empty

--- a/lib/utils/hasEmptyLine.js
+++ b/lib/utils/hasEmptyLine.js
@@ -7,7 +7,7 @@
  *
  * @returns {boolean}
  */
-module.exports = function(string) {
+module.exports = function (string) {
 	if (string === '' || string === undefined) return false;
 
 	return /\n[\r\t ]*\n/.test(string);

--- a/lib/utils/hasInterpolation.js
+++ b/lib/utils/hasInterpolation.js
@@ -11,7 +11,7 @@ const hasTplInterpolation = require('../utils/hasTplInterpolation');
  * @param {string} string
  * @return {boolean} If `true`, a string has interpolation
  */
-module.exports = function(string) {
+module.exports = function (string) {
 	// SCSS or Less interpolation
 	if (
 		hasLessInterpolation(string) ||

--- a/lib/utils/hasLessInterpolation.js
+++ b/lib/utils/hasLessInterpolation.js
@@ -6,6 +6,6 @@
  * @param {string} string
  * @return {boolean} If `true`, a string has less interpolation
  */
-module.exports = function(string) {
+module.exports = function (string) {
 	return /@{.+?}/.test(string);
 };

--- a/lib/utils/hasPsvInterpolation.js
+++ b/lib/utils/hasPsvInterpolation.js
@@ -5,6 +5,6 @@
  *
  * @param {string} string
  */
-module.exports = function(string) {
+module.exports = function (string) {
 	return /\$\(.+?\)/.test(string);
 };

--- a/lib/utils/hasScssInterpolation.js
+++ b/lib/utils/hasScssInterpolation.js
@@ -5,6 +5,6 @@
  *
  * @param {string} string
  */
-module.exports = function(string) {
+module.exports = function (string) {
 	return /#{.+?}/.test(string);
 };

--- a/lib/utils/hasTplInterpolation.js
+++ b/lib/utils/hasTplInterpolation.js
@@ -6,6 +6,6 @@
  * @param {string} string
  * @return {boolean} If `true`, a string has template literal interpolation
  */
-module.exports = function(string) {
+module.exports = function (string) {
 	return /{.+?}/.test(string);
 };

--- a/lib/utils/hash.js
+++ b/lib/utils/hash.js
@@ -8,7 +8,5 @@ const murmur = require('imurmurhash');
  * @returns {string} the hash
  */
 module.exports = function hash(str) {
-	return murmur(str)
-		.result()
-		.toString(36);
+	return murmur(str).result().toString(36);
 };

--- a/lib/utils/isAfterComment.js
+++ b/lib/utils/isAfterComment.js
@@ -5,7 +5,7 @@ const isSharedLineComment = require('./isSharedLineComment');
 /**
  * @param {import('postcss').Node} node
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	const previousNode = node.prev();
 
 	if (!previousNode || previousNode.type !== 'comment') {

--- a/lib/utils/isAfterStandardPropertyDeclaration.js
+++ b/lib/utils/isAfterStandardPropertyDeclaration.js
@@ -8,7 +8,7 @@ const isStandardSyntaxDeclaration = require('./isStandardSyntaxDeclaration');
 /**
  * @param {import('postcss').Node} node
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	const prevNode = getPreviousNonSharedLineCommentNode(node);
 
 	return (

--- a/lib/utils/isBlocklessAtRuleAfterBlocklessAtRule.js
+++ b/lib/utils/isBlocklessAtRuleAfterBlocklessAtRule.js
@@ -7,7 +7,7 @@ const hasBlock = require('./hasBlock');
  * @param {import('postcss').AtRule} atRule
  * @returns {boolean}
  */
-module.exports = function(atRule) {
+module.exports = function (atRule) {
 	if (atRule.type !== 'atrule') {
 		return false;
 	}

--- a/lib/utils/isBlocklessAtRuleAfterSameNameBlocklessAtRule.js
+++ b/lib/utils/isBlocklessAtRuleAfterSameNameBlocklessAtRule.js
@@ -8,7 +8,7 @@ const isBlocklessAtRuleAfterBlocklessAtRule = require('./isBlocklessAtRuleAfterB
  * @param {import('postcss').AtRule} atRule
  * @returns {boolean}
  */
-module.exports = function(atRule) {
+module.exports = function (atRule) {
 	if (!isBlocklessAtRuleAfterBlocklessAtRule(atRule)) {
 		return false;
 	}

--- a/lib/utils/isCounterIncrementCustomIdentValue.js
+++ b/lib/utils/isCounterIncrementCustomIdentValue.js
@@ -7,7 +7,7 @@ const keywordSets = require('../reference/keywordSets');
  *
  * @param {string} value
  */
-module.exports = function(value) {
+module.exports = function (value) {
 	const valueLowerCase = value.toLowerCase();
 
 	if (

--- a/lib/utils/isCounterResetCustomIdentValue.js
+++ b/lib/utils/isCounterResetCustomIdentValue.js
@@ -7,7 +7,7 @@ const keywordSets = require('../reference/keywordSets');
  *
  * @param {string} value
  */
-module.exports = function(value) {
+module.exports = function (value) {
 	const valueLowerCase = value.toLowerCase();
 
 	if (

--- a/lib/utils/isCustomElement.js
+++ b/lib/utils/isCustomElement.js
@@ -11,7 +11,7 @@ const svgTags = require('svg-tags');
  * @param {string} selector
  * @returns {boolean}
  */
-module.exports = function(selector) {
+module.exports = function (selector) {
 	if (!/^[a-z]/.test(selector)) {
 		return false;
 	}

--- a/lib/utils/isCustomMediaQuery.js
+++ b/lib/utils/isCustomMediaQuery.js
@@ -5,6 +5,6 @@
  * @param {string} mediaQuery
  * @returns {boolean}
  */
-module.exports = function(mediaQuery) {
+module.exports = function (mediaQuery) {
 	return mediaQuery.startsWith('--');
 };

--- a/lib/utils/isCustomProperty.js
+++ b/lib/utils/isCustomProperty.js
@@ -5,6 +5,6 @@
  * @param {string} property
  * @returns {boolean}
  */
-module.exports = function(property) {
+module.exports = function (property) {
 	return property.startsWith('--');
 };

--- a/lib/utils/isCustomPropertySet.js
+++ b/lib/utils/isCustomPropertySet.js
@@ -9,7 +9,7 @@ const hasBlock = require('../utils/hasBlock');
  * @param {import('postcss').Rule} node
  * @returns {boolean}
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	const selector = _.get(node, 'raws.selector.raw', node.selector);
 
 	return (

--- a/lib/utils/isCustomSelector.js
+++ b/lib/utils/isCustomSelector.js
@@ -6,6 +6,6 @@
  * @param {string} selector
  * @returns {boolean}
  */
-module.exports = function(selector) {
+module.exports = function (selector) {
 	return selector.startsWith(':--');
 };

--- a/lib/utils/isFirstNested.js
+++ b/lib/utils/isFirstNested.js
@@ -6,7 +6,7 @@ const { isComment, hasSource } = require('./typeGuards');
  * @param {import('postcss').Node} statement
  * @returns {boolean}
  */
-module.exports = function(statement) {
+module.exports = function (statement) {
 	const parentNode = statement.parent;
 
 	if (parentNode === undefined || parentNode.type === 'root') {

--- a/lib/utils/isFirstNodeOfRoot.js
+++ b/lib/utils/isFirstNodeOfRoot.js
@@ -6,7 +6,7 @@ const { isRoot } = require('./typeGuards');
  * @param {import('postcss').Node} node
  * @returns {boolean}
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	if (isRoot(node)) return false;
 
 	const parentNode = node.parent;

--- a/lib/utils/isKeyframeRule.js
+++ b/lib/utils/isKeyframeRule.js
@@ -6,7 +6,7 @@
  * @param {import('postcss').Rule} rule
  * @returns {boolean}
  */
-module.exports = function(rule) {
+module.exports = function (rule) {
 	const parent = rule.parent;
 
 	return parent.type === 'atrule' && parent.name.toLowerCase() === 'keyframes';

--- a/lib/utils/isKeyframeSelector.js
+++ b/lib/utils/isKeyframeSelector.js
@@ -8,7 +8,7 @@ const keywordSets = require('../reference/keywordSets');
  * @param {string} selector
  * @returns {boolean}
  */
-module.exports = function(selector) {
+module.exports = function (selector) {
 	if (keywordSets.keyframeSelectorKeywords.has(selector)) {
 		return true;
 	}

--- a/lib/utils/isLessVariable.js
+++ b/lib/utils/isLessVariable.js
@@ -6,7 +6,7 @@ const hasBlock = require('./hasBlock');
  * @param {import('postcss').AtRule} atRule
  * @returns {boolean}
  */
-module.exports = function(atRule) {
+module.exports = function (atRule) {
 	// @ts-ignore TODO TYPES LESS property variable does not exists in types
 	return (atRule.type === 'atrule' && atRule.variable && !hasBlock(atRule)) || false;
 };

--- a/lib/utils/isMap.js
+++ b/lib/utils/isMap.js
@@ -6,7 +6,7 @@
  * @param {ValueNode | undefined} valueNode
  * @returns {boolean}
  */
-module.exports = function(valueNode) {
+module.exports = function (valueNode) {
 	if (!valueNode) {
 		return false;
 	}

--- a/lib/utils/isNumbery.js
+++ b/lib/utils/isNumbery.js
@@ -6,7 +6,7 @@
  *
  * @param {string | number} value
  */
-module.exports = function(value) {
+module.exports = function (value) {
 	/* eslint-disable eqeqeq */
 	return value.toString().trim().length !== 0 && Number(value) == value;
 	/* eslint-enable eqeqeq */

--- a/lib/utils/isOnlyWhitespace.js
+++ b/lib/utils/isOnlyWhitespace.js
@@ -8,7 +8,7 @@ const isWhitespace = require('./isWhitespace');
  * @param {string} input
  * @returns {boolean}
  */
-module.exports = function(input) {
+module.exports = function (input) {
 	let isOnlyWhitespace = true;
 
 	for (let i = 0, l = input.length; i < l; i++) {

--- a/lib/utils/isRangeContextMediaFeature.js
+++ b/lib/utils/isRangeContextMediaFeature.js
@@ -6,6 +6,6 @@
  * @param {string} mediaFeature feature
  * @return {boolean} If `true`, media feature is a range context one
  */
-module.exports = function(mediaFeature) {
+module.exports = function (mediaFeature) {
 	return mediaFeature.includes('=') || mediaFeature.includes('<') || mediaFeature.includes('>');
 };

--- a/lib/utils/isSingleLineString.js
+++ b/lib/utils/isSingleLineString.js
@@ -7,6 +7,6 @@
  * @param {string} input
  * @return {boolean}
  */
-module.exports = function(input) {
+module.exports = function (input) {
 	return !/[\n\r]/.test(input);
 };

--- a/lib/utils/isStandardSyntaxAtRule.js
+++ b/lib/utils/isStandardSyntaxAtRule.js
@@ -6,7 +6,7 @@
  * @param {import('postcss').AtRule} atRule postcss at-rule node
  * @return {boolean} If `true`, the declaration is standard
  */
-module.exports = function(atRule) {
+module.exports = function (atRule) {
 	// Ignore scss `@content` inside mixins
 	if (!atRule.nodes && atRule.params === '') {
 		return false;

--- a/lib/utils/isStandardSyntaxCombinator.js
+++ b/lib/utils/isStandardSyntaxCombinator.js
@@ -6,7 +6,7 @@
  * @param {import('postcss-selector-parser').Combinator} node postcss-selector-parser node (of type combinator)
  * @return {boolean} If `true`, the combinator is standard
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	// Ignore reference combinators like `/deep/`
 	return node.type === 'combinator' && !node.value.startsWith('/') && !node.value.endsWith('/');
 };

--- a/lib/utils/isStandardSyntaxDeclaration.js
+++ b/lib/utils/isStandardSyntaxDeclaration.js
@@ -14,7 +14,7 @@ function isStandardSyntaxLang(lang) {
  *
  * @param {import('postcss').Declaration} decl
  */
-module.exports = function(decl) {
+module.exports = function (decl) {
 	const prop = decl.prop;
 	const parent = decl.parent;
 

--- a/lib/utils/isStandardSyntaxFunction.js
+++ b/lib/utils/isStandardSyntaxFunction.js
@@ -6,7 +6,7 @@
  * @param {import('postcss-value-parser').Node} node
  * @returns {boolean}
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	// Function nodes without names are things in parentheses like Sass lists
 	if (!node.value) {
 		return false;

--- a/lib/utils/isStandardSyntaxMediaFeature.js
+++ b/lib/utils/isStandardSyntaxMediaFeature.js
@@ -8,7 +8,7 @@ const hasInterpolation = require('../utils/hasInterpolation');
  * @param {string} mediaFeature
  * @returns {boolean}
  */
-module.exports = function(mediaFeature) {
+module.exports = function (mediaFeature) {
 	// Remove outside parens
 	mediaFeature = mediaFeature.slice(1, -1);
 

--- a/lib/utils/isStandardSyntaxMediaFeatureName.js
+++ b/lib/utils/isStandardSyntaxMediaFeatureName.js
@@ -6,7 +6,7 @@
  * @param {string} mediaFeatureName
  * @returns {boolean}
  */
-module.exports = function(mediaFeatureName) {
+module.exports = function (mediaFeatureName) {
 	// SCSS interpolation
 	if (/#{.+?}|\$.+?/.test(mediaFeatureName)) {
 		return false;

--- a/lib/utils/isStandardSyntaxProperty.js
+++ b/lib/utils/isStandardSyntaxProperty.js
@@ -8,7 +8,7 @@ const hasInterpolation = require('../utils/hasInterpolation');
  * @param {string} property
  * @returns {boolean}
  */
-module.exports = function(property) {
+module.exports = function (property) {
 	// SCSS var (e.g. $var: x), list (e.g. $list: (x)) or map (e.g. $map: (key:value))
 	if (property.startsWith('$')) {
 		return false;

--- a/lib/utils/isStandardSyntaxRule.js
+++ b/lib/utils/isStandardSyntaxRule.js
@@ -10,7 +10,7 @@ const isStandardSyntaxSelector = require('../utils/isStandardSyntaxSelector');
  * @param {import('postcss').Rule} rule
  * @returns {boolean}
  */
-module.exports = function(rule) {
+module.exports = function (rule) {
 	// Get full selector
 	const selector = _.get(rule, 'raws.selector.raw', rule.selector);
 

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -8,7 +8,7 @@ const hasInterpolation = require('../utils/hasInterpolation');
  * @param {string} selector
  * @returns {boolean}
  */
-module.exports = function(selector) {
+module.exports = function (selector) {
 	// SCSS or Less interpolation
 	if (hasInterpolation(selector)) {
 		return false;

--- a/lib/utils/isStandardSyntaxTypeSelector.js
+++ b/lib/utils/isStandardSyntaxTypeSelector.js
@@ -8,7 +8,7 @@ const keywordSets = require('../reference/keywordSets');
  * @param {import('postcss-selector-parser').Tag} node postcss-selector-parser node (of type tag)
  * @return {boolean} If `true`, the type selector is standard
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	// postcss-selector-parser includes the arguments to nth-child() functions
 	// as "tags", so we need to ignore them ourselves.
 	// The fake-tag's "parent" is actually a selector node, whose parent

--- a/lib/utils/isStandardSyntaxUrl.js
+++ b/lib/utils/isStandardSyntaxUrl.js
@@ -11,7 +11,7 @@ const hasTplInterpolation = require('../utils/hasTplInterpolation');
  * @param {string} url
  * @returns {boolean}
  */
-module.exports = function(url) {
+module.exports = function (url) {
 	if (url.length === 0) {
 		return true;
 	}

--- a/lib/utils/isStandardSyntaxValue.js
+++ b/lib/utils/isStandardSyntaxValue.js
@@ -8,7 +8,7 @@ const hasInterpolation = require('../utils/hasInterpolation');
  * @param {string} value
  * @returns {boolean}
  */
-module.exports = function(value) {
+module.exports = function (value) {
 	let normalizedValue = value;
 
 	// Ignore operators before variables (example -$variable)

--- a/lib/utils/isValidFontSize.js
+++ b/lib/utils/isValidFontSize.js
@@ -9,7 +9,7 @@ const valueParser = require('postcss-value-parser');
  * @param {string} word
  * @returns {boolean}
  */
-module.exports = function(word) {
+module.exports = function (word) {
 	if (!word) {
 		return false;
 	}

--- a/lib/utils/isValidHex.js
+++ b/lib/utils/isValidHex.js
@@ -6,6 +6,6 @@
  * @param {string} value
  * @returns {boolean}
  */
-module.exports = function(value) {
+module.exports = function (value) {
 	return /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value);
 };

--- a/lib/utils/isVariable.js
+++ b/lib/utils/isVariable.js
@@ -6,6 +6,6 @@
  * @param {string} word
  * @returns {boolean}
  */
-module.exports = function(word) {
+module.exports = function (word) {
 	return word.toLowerCase().startsWith('var(');
 };

--- a/lib/utils/isWhitespace.js
+++ b/lib/utils/isWhitespace.js
@@ -6,6 +6,6 @@
  * @param {string} char
  * @returns {boolean}
  */
-module.exports = function(char) {
+module.exports = function (char) {
 	return [' ', '\n', '\t', '\r', '\f'].includes(char);
 };

--- a/lib/utils/nodeContextLookup.js
+++ b/lib/utils/nodeContextLookup.js
@@ -10,7 +10,7 @@
  *
  * For a usage example, see `selector-no-descending-specificity`.
  */
-module.exports = function() {
+module.exports = function () {
 	const contextMap = new Map();
 
 	return {

--- a/lib/utils/rawNodeString.js
+++ b/lib/utils/rawNodeString.js
@@ -7,7 +7,7 @@
  *
  * @returns {string}
  */
-module.exports = function(node) {
+module.exports = function (node) {
 	let result = '';
 
 	if (node.raws.before) {

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -27,7 +27,7 @@ const _ = require('lodash');
  * You *must* pass *either* a node or a line number.
  * @param {Violation} violation
  */
-module.exports = function(violation) {
+module.exports = function (violation) {
 	const ruleName = violation.ruleName;
 	const result = violation.result;
 	const message = violation.message;

--- a/lib/utils/ruleMessages.js
+++ b/lib/utils/ruleMessages.js
@@ -10,7 +10,7 @@
  *   and values are either message strings or functions that return message strings
  * @return {{[k: string]: string|Function}} New message object, whose messages will be marked with the rule name
  */
-module.exports = function(ruleName, messages) {
+module.exports = function (ruleName, messages) {
 	return Object.keys(messages).reduce(
 		/**
 		 * @param {{[k: string]: string|Function}} newMessages

--- a/lib/utils/transformSelector.js
+++ b/lib/utils/transformSelector.js
@@ -7,7 +7,7 @@ const selectorParser = require('postcss-selector-parser');
  * @param {import('postcss').Node} node
  * @param {Function} cb
  */
-module.exports = function(result, node, cb) {
+module.exports = function (result, node, cb) {
 	try {
 		// @ts-ignore TODO TYPES wrong postcss-selector-parser definitions
 		return selectorParser(cb).processSync(node, { updateSelector: true });

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -27,7 +27,7 @@ const ignoredOptions = ['severity', 'message'];
  * @return {boolean} Whether or not the options are valid (true = valid)
  */
 
-module.exports = function(result, ruleName, ...optionDescriptions) {
+module.exports = function (result, ruleName, ...optionDescriptions) {
 	let noErrors = true;
 
 	optionDescriptions.forEach((optionDescription) => {

--- a/lib/utils/whitespaceChecker.js
+++ b/lib/utils/whitespaceChecker.js
@@ -66,7 +66,7 @@ const isWhitespace = require('./isWhitespace');
  *
  * @returns {object} The checker, with its exposed checking functions
  */
-module.exports = function(targetWhitespace, expectation, messages) {
+module.exports = function (targetWhitespace, expectation, messages) {
 	// Keep track of active arguments in order to avoid passing
 	// too much stuff around, making signatures long and confusing.
 	// This variable gets reset anytime a checking function is called.
@@ -237,7 +237,7 @@ module.exports = function(targetWhitespace, expectation, messages) {
 		const index = _activeArgs2.index;
 		const err = _activeArgs2.err;
 
-		const expectedChar = (function() {
+		const expectedChar = (function () {
 			if (targetWhitespace === 'newline') {
 				return '\n';
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7211,9 +7211,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "np": "^6.2.0",
     "npm-run-all": "^4.1.5",
     "postcss-import": "^12.0.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.2",
     "remark-cli": "^8.0.0",
     "remark-preset-lint-recommended": "^3.0.3",
     "remark-preset-prettier": "^0.4.0",


### PR DESCRIPTION
This PR adds the Prettier 2.0 fixes for #4669 

- https://github.com/stylelint/stylelint/commit/ef51c3b02fcb3ff50f5e44d4d927b6f262b296be [You are encouraged to use the new default value for `endOfLine`, which is now `lf`.](https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-endofline-to-lf-7435httpsgithubcomprettierprettierpull7435-by-kachkaevhttpsgithubcomkachkaev)

- https://github.com/stylelint/stylelint/commit/a2f47d98a09dd38eaab2c049194714db65fbaca2 [Always add a space after the function keyword](https://prettier.io/blog/2020/03/21/2.0.0.html#always-add-a-space-after-the-function-keyword-3903httpsgithubcomprettierprettierpull3903-by-j-f1httpsgithubcomj-f1-josephfrazierhttpsgithubcomjosephfrazier-sosukesuzukihttpsgithubcomsosukesuzuki-thorn0httpsgithubcomthorn0-7516httpsgithubcomprettierprettierpull7516-by-bakkothttpsgithubcombakkot)

Use the [hide white-space](https://github.com/stylelint/stylelint/pull/4679/files?diff=unified&w=1) diff view for easier review