### PR TITLE
Change dependabot schedule to `weekly`

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,7 @@ version: 1
 update_configs:
   - package_manager: 'javascript'
     directory: '/'
-    update_schedule: 'monthly'
+    update_schedule: 'weekly'
     version_requirement_updates: 'increase_versions'
     default_labels:
       - 'pr: dependencies'


### PR DESCRIPTION
<!---
Except for minor documentation fixes, each pull request must be associated with an open issue. If a corresponding issue does not exist, please stop. Instead, create an issue so we can discuss the change first.

If an issue exists, please continue by answering these two questions:  -->

Example https://github.com/stylelint/stylelint-demo/pull/217, also the VSCode extension just had 12 PRs also, there are too many landing monthly on the same day and the merge conflicts and lock files make this difficult and time consuming to manage so many, increasing the frequency should reduce this, at least worth a try

> Which issue, if any, is this issue related to?
n/a
e.g. "Closes #000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
