### PR TITLE
Minor lint tweaks

### DIFF
--- a/lib/__tests__/fixtures/plugin-async.js
+++ b/lib/__tests__/fixtures/plugin-async.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stylelint = require('../../');
+const stylelint = require('../..');
 
 const ruleName = 'plugin/async';
 

--- a/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
+++ b/lib/__tests__/fixtures/plugin-conditionally-check-color-hex-case.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stylelint = require('../../');
+const stylelint = require('../..');
 
 const ruleName = 'plugin/conditionally-check-color-hex-case';
 

--- a/lib/__tests__/fixtures/plugin-primary-array.js
+++ b/lib/__tests__/fixtures/plugin-primary-array.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stylelint = require('../../');
+const stylelint = require('../..');
 
 const ruleName = 'plugin/primary-array';
 

--- a/lib/__tests__/fixtures/plugin-slashless-warn-about-foo.js
+++ b/lib/__tests__/fixtures/plugin-slashless-warn-about-foo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stylelint = require('../../');
+const stylelint = require('../..');
 
 const ruleName = 'slashless-warn-about-foo';
 

--- a/lib/__tests__/fixtures/plugin-warn-about-bar.js
+++ b/lib/__tests__/fixtures/plugin-warn-about-bar.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stylelint = require('../../');
+const stylelint = require('../..');
 
 const ruleName = 'plugin/warn-about-bar';
 

--- a/lib/__tests__/fixtures/plugin-warn-about-foo.js
+++ b/lib/__tests__/fixtures/plugin-warn-about-foo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stylelint = require('../../');
+const stylelint = require('../..');
 
 const ruleName = 'plugin/warn-about-foo';
 

--- a/lib/__tests__/fixtures/processor-triple-question-marks.js
+++ b/lib/__tests__/fixtures/processor-triple-question-marks.js
@@ -7,7 +7,7 @@ module.exports = function () {
 
 	return {
 		code(input) {
-			const blocks = execall(/\?\?\?start([\s\S]+?)\?\?\?end/g, input);
+			const blocks = execall(/\?{3}start([\s\S]+?)\?{3}end/g, input);
 			const toLint = blocks.map((match) => match.subMatches[0]).join('\n\n');
 
 			if (toLint.length > 0) {

--- a/lib/__tests__/integration.test.js
+++ b/lib/__tests__/integration.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 const postcss = require('postcss');
 const sassSyntax = require('postcss-sass');
 const scssSyntax = require('postcss-scss');
-const stylelint = require('../');
+const stylelint = require('..');
 
 const config = {
 	rules: {

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -147,7 +147,7 @@ function formatter(messages, source) {
 				: severity,
 			message.text
 				// Remove all control characters (newline, tab and etc)
-				.replace(/[\x01-\x1A]+/g, ' ') // eslint-disable-line no-control-regex
+				.replace(/[\u0001-\u001A]+/g, ' ') // eslint-disable-line no-control-regex
 				.replace(/\.$/, '')
 				// eslint-disable-next-line prefer-template
 				.replace(new RegExp(_.escapeRegExp('(' + message.rule + ')') + '$'), ''),

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -65,7 +65,7 @@ function rule(expectation, options) {
 		function checkArgs(args, node, index, functionName) {
 			let shouldHasQuotes = expectation === 'always';
 
-			const leftTrimmedArgs = args.trimLeft();
+			const leftTrimmedArgs = args.trimStart();
 
 			if (!isStandardSyntaxUrl(leftTrimmedArgs)) {
 				return;

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -262,7 +262,7 @@ function rule(space, options = {}, context) {
 							parentheticalDepth += 1;
 						}
 
-						const followsOpeningBrace = /\{[ \t]*$/.test(source.slice(0, newlineIndex));
+						const followsOpeningBrace = /{[ \t]*$/.test(source.slice(0, newlineIndex));
 
 						if (followsOpeningBrace) {
 							parentheticalDepth += 1;

--- a/lib/rules/linebreaks/__tests__/integration.test.js
+++ b/lib/rules/linebreaks/__tests__/integration.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const stylelint = require('../../../../');
+const stylelint = require('../../../..');
 
 describe('integration tests for linebrakes', () => {
 	it('should not be an error (issues/3635).', () => {

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -12,7 +12,7 @@ const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'max-line-length';
 const EXCLUDED_PATTERNS = [
-	/url\(\s*([^\s].*[^\s])\s*\)/gi, // allow tab, whitespace in url content
+	/url\(\s*(\S.*\S)\s*\)/gi, // allow tab, whitespace in url content
 	/@import\s+(['"].*['"])/gi,
 ];
 

--- a/lib/rules/no-empty-first-line/index.js
+++ b/lib/rules/no-empty-first-line/index.js
@@ -29,7 +29,7 @@ function rule(actual, _, context) {
 
 		if (noEmptyFirstLineTest.test(rootString)) {
 			if (context.fix) {
-				root.nodes[0].raws.before = root.first.raws.before.trimLeft();
+				root.nodes[0].raws.before = root.first.raws.before.trimStart();
 
 				return;
 			}

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -25,7 +25,7 @@ module.exports = function (selector) {
 	}
 
 	// Less mixin with resolved nested selectors (e.g. .foo().bar or .foo(@a, @b)[bar])
-	if (/\.[a-z0-9-_]+\(.*\).+/i.test(selector)) {
+	if (/\.[\w-]+\(.*\).+/i.test(selector)) {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxUrl.js
+++ b/lib/utils/isStandardSyntaxUrl.js
@@ -40,7 +40,7 @@ module.exports = function (url) {
 	// In url without quotes scss variable can be everywhere
 	// But in this case it is allowed to use only specific characters
 	// Also forbidden "/" at the end of url
-	if (url.includes('$') && /^[$\sA-Za-z0-9+-/*_'"/]+$/.test(url) && !url.endsWith('/')) {
+	if (url.includes('$') && /^[$\s\w+-/*'"/]+$/.test(url) && !url.endsWith('/')) {
 		return false;
 	}
 


### PR DESCRIPTION
* simplify regex
* use Unicode escape in regex
* use `trimStart()` instead of the `trimLeft()` alias
* remove unneeded path separator from imports

I split these from the `xo` branch, let me know if you want me to make any changes 🙂

PS. I didn't change the `0-9` to `\d` in regex for now since I wasn't sure if everyone would like this change.