### PR TITLE
Fix turning off autofix for sources containing scoped disable comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's mighty as it:
 - parses **CSS-like syntaxes** like SCSS, Sass, Less and SugarSS
 - has over **170 built-in rules** to catch errors, apply limits and enforce stylistic conventions
 - supports **plugins** so you can create your own rules or make use of plugins written by the community
-- automatically **fixes** the majority of stylistic violations (_experimental feature_)
+- automatically **fixes** the majority of stylistic violations
 - is **well tested** with over 15000 unit tests
 - supports **shareable configs** that you can extend or create
 - is **unopinionated** so that you can customize it to your exact needs

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -30,7 +30,12 @@ Automatically fix, where possible, violations reported by rules.
 
 For CSS with standard syntax, stylelint uses [postcss-safe-parser](https://github.com/postcss/postcss-safe-parser) to fix syntax errors.
 
-_`fix` is an experimental feature that currently ignores sources with [`/* stylelint-disable */` comments](../ignore-code.md)._
+If a source contains a:
+
+- scoped disable comment, e.g. `/* stylelint-disable indentation */`, any violations reported by the scoped rules will not be automatically fixed anywhere in the source
+- unscoped disable comment, i.e. `/* stylelint-disable */`, the entirety of source will not be automatically fixed
+
+This limitation in being tracked in [issue #2643](https://github.com/stylelint/stylelint/issues/2643).
 
 ## `formatter`
 

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -205,7 +205,11 @@ function lintPostcssResult(stylelint, postcssResult, config) {
 			Promise.all(
 				postcssRoots.map((postcssRoot) =>
 					ruleFunction(primaryOption, secondaryOptions, {
-						fix: stylelint._options.fix && isFileFixCompatible,
+						fix:
+							stylelint._options.fix &&
+							// Next two conditionals are temporary measures until #2643 is resolved
+							isFileFixCompatible &&
+							!postcssResult.stylelint.disabledRanges[ruleName],
 						newline,
 					})(postcssRoot, postcssResult),
 				),
@@ -257,10 +261,7 @@ function createEmptyPostcssResult(filePath) {
  */
 function isFixCompatible({ stylelint }) {
 	// Check for issue #2643
-	const hasUnscopedDisabledRanges = stylelint.disabledRanges.all.length > 0;
-	const hasScopedDisabledRanges = Object.keys(stylelint.disabledRanges).length > 1;
-
-	if (hasUnscopedDisabledRanges || hasScopedDisabledRanges) return false;
+	if (stylelint.disabledRanges.all.length) return false;
 
 	return true;
 }

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -251,15 +251,16 @@ function createEmptyPostcssResult(filePath) {
  * There are currently some bugs in the autofixer of Stylelint.
  * The autofixer does not yet adhere to stylelint-disable comments, so if there are disabled
  * ranges we can not autofix this document. More info in issue #2643.
- * Also, if this document is parsed with postcss-jsx and there are nested template
- * literals, it will duplicate some code. More info in issue #4119.
  *
  * @param {PostcssResult} postcssResult
  * @returns {boolean}
  */
 function isFixCompatible({ stylelint }) {
 	// Check for issue #2643
-	if (stylelint.disabledRanges.all.length) return false;
+	const hasUnscopedDisabledRanges = stylelint.disabledRanges.all.length > 0;
+	const hasScopedDisabledRanges = Object.keys(stylelint.disabledRanges).length > 1;
+
+	if (hasUnscopedDisabledRanges || hasScopedDisabledRanges) return false;
 
 	return true;
 }

--- a/lib/rules/block-closing-brace-newline-after/__tests__/index.js
+++ b/lib/rules/block-closing-brace-newline-after/__tests__/index.js
@@ -46,10 +46,10 @@ testRule(rule, {
 			code: '@media print { a { color: pink; }}\n@media screen { b { color: red; }}',
 		},
 		{
-			code: '.a {} /* stylelint-disable-line block-no-empty */',
+			code: '.a {} /* comment */',
 		},
 		{
-			code: '.a {} /* stylelint-disable-line block-no-empty */\n b {}',
+			code: '.a {} /* comment */\n b {}',
 		},
 		{
 			code: ':root {\n --x { color: pink; };\n --y { color: red; };\n }',
@@ -109,8 +109,8 @@ testRule(rule, {
 			column: 35,
 		},
 		{
-			code: '.a {} /* stylelint-disable-line block-no-empty */ b {}',
-			fixed: '.a {} /* stylelint-disable-line block-no-empty */\n b {}',
+			code: '.a {} /* comment */ b {}',
+			fixed: '.a {} /* comment */\n b {}',
 			message: messages.expectedAfter(),
 			line: 1,
 			column: 6,

--- a/system-tests/fix/fix.test.js
+++ b/system-tests/fix/fix.test.js
@@ -5,6 +5,7 @@ const del = require('del');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const stripIndent = require('common-tags').stripIndent;
 const stylelint = require('../../lib');
 const systemTestUtils = require('../systemTestUtils');
 const { promisify } = require('util');
@@ -218,6 +219,60 @@ describe('fix', () => {
 			})
 			.then((result) => {
 				expect(result.output).toBe(code);
+			});
+	});
+
+	it("the color-hex-length rule doesn't fix with scoped stylelint-disable commands", () => {
+		return stylelint
+			.lint({
+				code: stripIndent`
+					/* stylelint-disable color-hex-length */
+					a {
+					color: #ffffff;
+					}
+					`,
+				config: {
+					rules: {
+						indentation: 2,
+						'color-hex-length': 'short',
+					},
+				},
+				fix: true,
+			})
+			.then((result) => {
+				expect(result.output).toBe(stripIndent`
+					/* stylelint-disable color-hex-length */
+					a {
+					  color: #ffffff;
+					}
+					`);
+			});
+	});
+
+	it("the indentation rule doesn't fix with scoped stylelint-disable commands", () => {
+		return stylelint
+			.lint({
+				code: stripIndent`
+					/* stylelint-disable indentation */
+					a {
+					color: #ffffff;
+					}
+					`,
+				config: {
+					rules: {
+						indentation: 2,
+						'color-hex-length': 'short',
+					},
+				},
+				fix: true,
+			})
+			.then((result) => {
+				expect(result.output).toBe(stripIndent`
+					/* stylelint-disable indentation */
+					a {
+					color: #fff;
+					}
+					`);
 			});
 	});
 });

--- a/system-tests/fix/fix.test.js
+++ b/system-tests/fix/fix.test.js
@@ -173,6 +173,53 @@ describe('fix', () => {
 				expect(result.output).toBe(code);
 			});
 	});
+
+	it("doesn't fix with scoped stylelint-disable commands", () => {
+		const code = `
+		/* stylelint-disable indentation */
+		a {
+			color: red;
+		}
+		`;
+
+		return stylelint
+			.lint({
+				code,
+				config: {
+					rules: {
+						indentation: 2,
+					},
+				},
+				fix: true,
+			})
+			.then((result) => {
+				expect(result.output).toBe(code);
+			});
+	});
+
+	it("doesn't fix with multiple scoped stylelint-disable commands", () => {
+		const code = `
+		/* stylelint-disable indentation, color-hex-length */
+		a {
+			color: #ffffff;
+		}
+		`;
+
+		return stylelint
+			.lint({
+				code,
+				config: {
+					rules: {
+						indentation: 2,
+						'color-hex-length': 'short',
+					},
+				},
+				fix: true,
+			})
+			.then((result) => {
+				expect(result.output).toBe(code);
+			});
+	});
 });
 
 describe('fix with BOM', () => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4704

> Is there anything in the PR that needs further explanation?

We were only disabling autofix on files containing unscoped disable comments. This pull request disables it for both scoped and unscoped.