### PR TITLE
Add ignoreFunctions: [] to value-keyword-case

### DIFF
--- a/lib/rules/value-keyword-case/README.md
+++ b/lib/rules/value-keyword-case/README.md
@@ -256,3 +256,65 @@ a {
   Background: deepPink;
 }
 ```
+
+### `ignoreFunctions: ["/regex/", /regex/, "non-regex"]`
+
+Ignore case of the values inside the listed functions.
+
+For example, with `"upper"`.
+
+```js
+["/^(f|F)oo$/", "t"];
+```
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a {
+  display: b(inline);
+}
+```
+
+```css
+a {
+  color: bar(--camelCase);
+}
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a {
+  display: t(flex);
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+  display: t(fLeX);
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+  color: t(--camelCase);
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+  color: foo(--camelCase);
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+  color: Foo(--camelCase);
+}
+```

--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -2225,3 +2225,44 @@ testRule(rule, {
 		},
 	],
 });
+
+testRule(rule, {
+	ruleName,
+	config: ['upper', { ignoreFunctions: ['t', /^(f|F)oo$/] }],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { display: t(flex); }',
+		},
+		{
+			code: 'a { display: t(fLeX); }',
+		},
+		{
+			code: 'a { color: t(--camelCase); }',
+		},
+		{
+			code: 'a { color: foo(--camelCase); }',
+		},
+		{
+			code: 'a { color: Foo(--camelCase); }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { display: b(inline); }',
+			fixed: 'a { display: b(INLINE); }',
+			message: messages.expected('inline', 'INLINE'),
+			line: 1,
+			column: 16,
+		},
+		{
+			code: 'a { display: bar(--camelCase); }',
+			fixed: 'a { display: bar(--CAMELCASE); }',
+			message: messages.expected('--camelCase', '--CAMELCASE'),
+			line: 1,
+			column: 18,
+		},
+	],
+});

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -46,6 +46,7 @@ function rule(expectation, options, context) {
 				possible: {
 					ignoreProperties: [_.isString, _.isRegExp],
 					ignoreKeywords: [_.isString, _.isRegExp],
+					ignoreFunctions: [_.isString, _.isRegExp],
 				},
 				optional: true,
 			},
@@ -79,6 +80,18 @@ function rule(expectation, options, context) {
 						valueLowerCase === 'counter' ||
 						valueLowerCase === 'counters' ||
 						valueLowerCase === 'attr')
+				) {
+					return false;
+				}
+
+				// ignore keywords within ignoreFunctions functions
+
+				const ignoreFunctions = (options && options.ignoreFunctions) || [];
+
+				if (
+					node.type === 'function' &&
+					ignoreFunctions.length > 0 &&
+					matchesStringOrRegExp(valueLowerCase, ignoreFunctions)
 				) {
 					return false;
 				}


### PR DESCRIPTION
Hi there,

This is a PR that adds an `ignoreFunctions: []` option to the `value-keyword-case` rule, as requested in #4648! I did this by adding the option to the valid option list, and then using `matchesStringOrRegExp` on the passed-in options. I also added tests based off of the discussion in the issue comments, and added documentation on the option to the rule's documentation page.

On my end, I ran `npm run format` and `npm run test`, and everything seems to work as intended. Let me know if there are any edge-cases/tests that I should add to the PR!

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4648.

> Is there anything in the PR that needs further explanation?

Nope!