### PR TITLE
Fix comments in findAnimationName to not refer to font

### DIFF
--- a/lib/utils/findAnimationName.js
+++ b/lib/utils/findAnimationName.js
@@ -9,7 +9,7 @@ const postcssValueParser = require('postcss-value-parser');
 /** @typedef {import('postcss-value-parser').Node} Node */
 
 /**
- * Get the font-families within a `font` shorthand property value.
+ * Get the animation name within an `animation` shorthand property value.
  *
  * @param {string} value
  *
@@ -40,7 +40,7 @@ module.exports = function findAnimationName(value) {
 
 		const valueLowerCase = valueNode.value.toLowerCase();
 
-		// Ignore non standard syntax
+		// Ignore non-standard syntax
 		if (!isStandardSyntaxValue(valueLowerCase)) {
 			return;
 		}
@@ -50,7 +50,7 @@ module.exports = function findAnimationName(value) {
 			return;
 		}
 
-		// Ignore keywords for other font parts
+		// Ignore keywords for other animation parts
 		if (keywordSets.animationShorthandKeywords.has(valueLowerCase)) {
 			return;
 		}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
