### PR TITLE
Remove unused line in lintSource.js

### DIFF
--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -55,9 +55,6 @@ module.exports = function lintSource(stylelint, options = {}) {
 				postcssResult = createEmptyPostcssResult(inputFilePath);
 			}
 
-			// @ts-ignore
-			postcssResult.standaloneIgnored = true; // TODO: remove need for this
-
 			return postcssResult;
 		}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, it's a housekeeping change. This line appears to be unused.

> Is there anything in the PR that needs further explanation?

This line was [removed in July 2017](https://github.com/stylelint/stylelint/pull/2735/files#diff-5ad37590092c2098f0fb6d72557720ddL49). It was [re-added a couple of months later](https://github.com/stylelint/stylelint/commit/5df5e4251d5484cc8181f00fe640c915e367a060#diff-5ad37590092c2098f0fb6d72557720ddR116).

I can't find any other references to `standaloneIgnored` in the current release. I'm guessing that it was re-added in error.
