### PR TITLE
Fix false positives for objects in declaration-block-trailing-semicolon

### DIFF
--- a/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
@@ -24,10 +24,6 @@ testRule({
 			code: 'a { color: red; &:hover { color: pink; }}',
 			description: 'nesting with first-level decl',
 		},
-		{
-			code: 'background: white',
-			description: 'not a rule',
-		},
 	],
 
 	reject: [
@@ -79,10 +75,6 @@ testRule({
 		{
 			code: 'a { background: orange; color: pink }',
 			description: 'multi-line declaration block without trailing semicolon',
-		},
-		{
-			code: 'background: white;',
-			description: 'not a rule',
 		},
 	],
 
@@ -176,6 +168,31 @@ testRule({
 			message: messages.rejected,
 			line: 1,
 			column: 22,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['always'],
+	syntax: 'css-in-js',
+	fix: true,
+
+	accept: [
+		{
+			code: 'const C = () => { return <a style={{ color: "red" }}></a> }',
+			description: 'css-in-js object',
+		},
+	],
+
+	reject: [
+		{
+			code: 'const C = styled.a`color: red`;',
+			fixed: 'const C = styled.a`color: red;`;',
+			description: 'css-in-js template literal',
+			message: messages.expected,
+			line: 1,
+			column: 29,
 		},
 	],
 });

--- a/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
@@ -24,6 +24,10 @@ testRule({
 			code: 'a { color: red; &:hover { color: pink; }}',
 			description: 'nesting with first-level decl',
 		},
+		{
+			code: 'background: white',
+			description: 'not a rule',
+		},
 	],
 
 	reject: [
@@ -75,6 +79,10 @@ testRule({
 		{
 			code: 'a { background: orange; color: pink }',
 			description: 'multi-line declaration block without trailing semicolon',
+		},
+		{
+			code: 'background: white;',
+			description: 'not a rule',
 		},
 	],
 

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -42,6 +42,10 @@ function rule(expectation, _, context) {
 		});
 
 		root.walkDecls((decl) => {
+			if (decl.parent.type !== 'rule' && decl.parent.type !== 'atrule') {
+				return;
+			}
+
 			if (decl !== decl.parent.last) {
 				return;
 			}

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -42,7 +42,7 @@ function rule(expectation, _, context) {
 		});
 
 		root.walkDecls((decl) => {
-			if (decl.parent.type !== 'rule' && decl.parent.type !== 'atrule') {
+			if (decl.parent.type === 'object') {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #4650 

> Is there anything in the PR that needs further explanation?

Yes; @jeddy3 suggests a solution in https://github.com/stylelint/stylelint/issues/4650#issuecomment-599205149 that did not work for me: `isStandardSyntaxRule` only accepts Rule nodes, but if used in `declaration-block-trailing-semicolon`, it would also be given AtRule nodes (like in the SCSS test case: `a { @foo { color: pink } }`). This complicates things further because `isStandardSyntaxRule` examines the `selector` of the Rule which it receives, and AtRule has no `selector`.

This simple solution seems to work for now.
