### PR TITLE
Fix typo and remove inaccurate spaces from quote

### DIFF
--- a/lib/rules/max-empty-lines/README.md
+++ b/lib/rules/max-empty-lines/README.md
@@ -40,7 +40,7 @@ Comment strings are also checked -- so the following is a violation:
 
 
 
- Some years ago -- never mind how log precisely -- ...
+ Some years ago--never mind how long precisely-—...
  */
 ```
 


### PR DESCRIPTION
Great reference, but not grammatically, nor literately, accurate.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory. But, here's some reference:

- [one, of many available, references to the original text](https://time.com/4534903/moby-dick-chapter-one/)
- [em dash is typically used without spaces](https://www.thepunctuationguide.com/em-dash.html)
