### PR TITLE
Fix categorisation of notation rules

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -82,6 +82,14 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 - [`color-named`](../../../lib/rules/color-named/README.md): Require (where possible) or disallow named colors.
 - [`color-no-hex`](../../../lib/rules/color-no-hex/README.md): Disallow hex colors.
 
+### Length
+
+- [`length-zero-no-unit`](../../../lib/rules/length-zero-no-unit/README.md): Disallow units for zero lengths (Autofixable).
+
+### Font weight
+
+- [`font-weight-notation`](../../../lib/rules/font-weight-notation/README.md): Require numeric or named (where possible) `font-weight` values. Also, when named values are expected, require only valid names.
+
 ### Function
 
 - [`function-blacklist`](../../../lib/rules/function-blacklist/README.md): Specify a blacklist of disallowed functions.
@@ -162,6 +170,7 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 - [`selector-pseudo-class-blacklist`](../../../lib/rules/selector-pseudo-class-blacklist/README.md): Specify a blacklist of disallowed pseudo-class selectors.
 - [`selector-pseudo-class-whitelist`](../../../lib/rules/selector-pseudo-class-whitelist/README.md): Specify a whitelist of allowed pseudo-class selectors.
 - [`selector-pseudo-element-blacklist`](../../../lib/rules/selector-pseudo-element-blacklist/README.md): Specify a blacklist of disallowed pseudo-element selectors.
+- [`selector-pseudo-element-colon-notation`](../../../lib/rules/selector-pseudo-element-colon-notation/README.md): Specify single or double colon notation for applicable pseudo-elements (Autofixable).
 - [`selector-pseudo-element-whitelist`](../../../lib/rules/selector-pseudo-element-whitelist/README.md): Specify a whitelist of allowed pseudo-element selectors.
 
 ### Media feature
@@ -202,10 +211,6 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 
 - [`font-family-name-quotes`](../../../lib/rules/font-family-name-quotes/README.md): Specify whether or not quotation marks should be used around font family names.
 
-### Font weight
-
-- [`font-weight-notation`](../../../lib/rules/font-weight-notation/README.md): Require numeric or named (where possible) `font-weight` values. Also, when named values are expected, require only valid names.
-
 ### Function
 
 - [`function-comma-newline-after`](../../../lib/rules/function-comma-newline-after/README.md): Require a newline or disallow whitespace after the commas of functions (Autofixable).
@@ -227,10 +232,6 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 ### String
 
 - [`string-quotes`](../../../lib/rules/string-quotes/README.md): Specify single or double quotes around strings (Autofixable).
-
-### Length
-
-- [`length-zero-no-unit`](../../../lib/rules/length-zero-no-unit/README.md): Disallow units for zero lengths (Autofixable).
 
 ### Unit
 
@@ -297,7 +298,6 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 - [`selector-pseudo-class-case`](../../../lib/rules/selector-pseudo-class-case/README.md): Specify lowercase or uppercase for pseudo-class selectors (Autofixable).
 - [`selector-pseudo-class-parentheses-space-inside`](../../../lib/rules/selector-pseudo-class-parentheses-space-inside/README.md): Require a single space or disallow whitespace on the inside of the parentheses within pseudo-class selectors (Autofixable).
 - [`selector-pseudo-element-case`](../../../lib/rules/selector-pseudo-element-case/README.md): Specify lowercase or uppercase for pseudo-element selectors (Autofixable).
-- [`selector-pseudo-element-colon-notation`](../../../lib/rules/selector-pseudo-element-colon-notation/README.md): Specify single or double colon notation for applicable pseudo-elements (Autofixable).
 - [`selector-type-case`](../../../lib/rules/selector-type-case/README.md): Specify lowercase or uppercase for type selectors (Autofixable).
 
 ### Selector list


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates to https://github.com/stylelint/stylelint/pull/4760, https://github.com/stylelint/stylelint/issues/4721 and https://github.com/stylelint/stylelint/issues/4720.

> Is there anything in the PR that needs further explanation?

These existing three rules belong in the limit language features category as none are just stylistic. For example, `selector-pseudo-element-colon-notation`, like the upcoming `color-function-notation` rule, is about compatibility.

The stylistic category becomes only concerned with whitespace, case, quotes and trailing/leading zeroes.
