### PR TITLE
Add hue-degree-notation

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -77,6 +77,10 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 
 ## Limit language features
 
+### Hue
+
+- [`hue-degree-notation`](../../../lib/rules/hue-degree-notation/README.md): Specify number or angle notation for degree hues.
+
 ### Color
 
 - [`color-named`](../../../lib/rules/color-named/README.md): Require (where possible) or disallow named colors.

--- a/lib/rules/hue-degree-notation/README.md
+++ b/lib/rules/hue-degree-notation/README.md
@@ -1,0 +1,74 @@
+# hue-degree-notation
+
+Specify number or angle notation for degree hues.
+
+<!-- prettier-ignore -->
+```css
+    a { color: hsl(198deg 28% 50%) }
+/**                ↑
+ *                 This notation */
+```
+
+Because hues are so often given in degrees, a hue can also be given as a number, which is interpreted as a number of degrees.
+
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+
+## Options
+
+`string`: `"angle"|"number"`
+
+### `"angle"`
+
+Degree hues _must always_ use angle notation.
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { color: hsl(198 28% 50%) }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: lch(56.29% 19.86 10 / 15%) }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { color: hsl(198deg 28% 50%) }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: lch(56.29% 19.86 10deg / 15%) }
+```
+
+### `"number"`
+
+Degree hues _must always_ use the number notation.
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { color: hsl(198deg 28% 50%) }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: lch(56.29% 19.86 10deg / 15%) }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { color: hsl(198 28% 50%) }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: lch(56.29% 19.86 10 / 15%) }
+```

--- a/lib/rules/hue-degree-notation/__tests__/index.js
+++ b/lib/rules/hue-degree-notation/__tests__/index.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const stripIndent = require('common-tags').stripIndent;
+
+const { messages, ruleName } = require('..');
+
+testRule({
+	ruleName,
+	config: ['angle'],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { color: hsl(270deg 60% 50%) }',
+		},
+		{
+			code: 'a { color: hwb(120deg 0% 0%) }',
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10deg) }',
+		},
+		{
+			code: 'a { color: hsl(170deg 60% 50% / 15%) }',
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10deg / 100%) }',
+		},
+		{
+			code: 'a { color: hsl(4.71239rad 60% 70%) }',
+		},
+		{
+			code: 'a { color: hsl(.75turn 60% 70%) }',
+		},
+		{
+			code: 'a { color: hsl(270deg, 60%, 50%) }',
+		},
+		{
+			code: 'a { color: hsla(270deg, 60%, 50%, 15%) }',
+		},
+		{
+			code: 'a { color: HSL(270deg 60% 70%) }',
+		},
+		{
+			code: 'a { color: hsl(270DEG 60% 70%) }',
+		},
+		{
+			code: 'a { color: hsl(var(--hue) var(--sat) var(--sat) / var(--alpha)) }',
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 var(--hue) / 100%) }',
+		},
+		{
+			code: 'a { color: hsl(/*comment*/270deg 60% 50%) }',
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10deg/*comment*/) }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { color: hsl(120 60% 70%) }',
+			fixed: 'a { color: hsl(120deg 60% 70%) }',
+			message: messages.expected('120', '120deg'),
+			line: 1,
+			column: 16,
+		},
+		{
+			code: 'a { color: HSL(120 60% 70% / 10%) }',
+			fixed: 'a { color: HSL(120deg 60% 70% / 10%) }',
+			message: messages.expected('120', '120deg'),
+			line: 1,
+			column: 16,
+		},
+		{
+			code: 'a { color: hwb(180 0% 0%) }',
+			fixed: 'a { color: hwb(180deg 0% 0%) }',
+			message: messages.expected('180', '180deg'),
+			line: 1,
+			column: 16,
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10) }',
+			fixed: 'a { color: lch(56.29% 19.86 10deg) }',
+			message: messages.expected('10', '10deg'),
+			line: 1,
+			column: 29,
+		},
+		{
+			code: 'a { color: hsl(/*comment*/120 60% 70%) }',
+			fixed: 'a { color: hsl(/*comment*/120deg 60% 70%) }',
+			message: messages.expected('120', '120deg'),
+			line: 1,
+			column: 27,
+		},
+		{
+			code: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hsl(270 60% 70%)
+						lch(56.29% 19.86 236.62)
+					);
+				}
+			`,
+			fixed: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hsl(270deg 60% 70%)
+						lch(56.29% 19.86 236.62deg)
+					);
+				}
+			`,
+			warnings: [
+				{ message: messages.expected('270', '270deg'), line: 4, column: 7 },
+				{ message: messages.expected('236.62', '236.62deg'), line: 5, column: 20 },
+			],
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['number'],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { color: hsl(270 60% 50%) }',
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10) }',
+		},
+		{
+			code: 'a { color: hsla(270, 60%, 50%, 15%) }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { color: hsl(120deg 60% 70%) }',
+			fixed: 'a { color: hsl(120 60% 70%) }',
+			message: messages.expected('120deg', '120'),
+			line: 1,
+			column: 16,
+		},
+		{
+			code: 'a { color: HSL(120deg 60% 70% / 10%) }',
+			fixed: 'a { color: HSL(120 60% 70% / 10%) }',
+			message: messages.expected('120deg', '120'),
+			line: 1,
+			column: 16,
+		},
+		{
+			code: 'a { color: HSLA(120DEG, 60%, 70%, 10%) }',
+			fixed: 'a { color: HSLA(120, 60%, 70%, 10%) }',
+			message: messages.expected('120DEG', '120'),
+			line: 1,
+			column: 17,
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10deg) }',
+			fixed: 'a { color: lch(56.29% 19.86 10) }',
+			message: messages.expected('10deg', '10'),
+			line: 1,
+			column: 29,
+		},
+		{
+			code: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hsl(270deg 60% 70%)
+						lch(56.29% 19.86 236.62deg)
+					);
+				}
+			`,
+			fixed: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hsl(270 60% 70%)
+						lch(56.29% 19.86 236.62)
+					);
+				}
+			`,
+			warnings: [
+				{ message: messages.expected('270deg', '270'), line: 4, column: 7 },
+				{ message: messages.expected('236.62deg', '236.62'), line: 5, column: 20 },
+			],
+		},
+	],
+});

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -1,0 +1,131 @@
+// @ts-nocheck
+
+'use strict';
+
+const valueParser = require('postcss-value-parser');
+
+const declarationValueIndex = require('../../utils/declarationValueIndex');
+const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
+const report = require('../../utils/report');
+const ruleMessages = require('../../utils/ruleMessages');
+const validateOptions = require('../../utils/validateOptions');
+
+const ruleName = 'hue-degree-notation';
+
+const messages = ruleMessages(ruleName, {
+	expected: (unfixed, fixed) => `Expected ${unfixed} to be ${fixed}`,
+});
+
+const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];
+const HUE_THIRD_ARG_FUNCS = ['lch'];
+const HUE_FUNCS = [...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS];
+
+function rule(primary, secondary, context) {
+	return (root, result) => {
+		const validOptions = validateOptions(result, ruleName, {
+			actual: primary,
+			possible: ['angle', 'number'],
+		});
+
+		if (!validOptions) return;
+
+		root.walkDecls((decl) => {
+			if (!isStandardSyntaxDeclaration(decl)) return;
+
+			let needsFix = false;
+			const parsedValue = valueParser(getValue(decl));
+
+			parsedValue.walk((node) => {
+				if (node.type !== 'function') return;
+
+				if (!HUE_FUNCS.includes(node.value.toLowerCase())) return;
+
+				const hue = findHue(node);
+				const { value } = hue;
+
+				if (!isStandardSyntaxValue(value)) return;
+
+				if (!isDegree(value) && !isNumber(value)) return;
+
+				if (primary === 'angle' && isDegree(value)) return;
+
+				if (primary === 'number' && isNumber(value)) return;
+
+				const fixed = primary === 'angle' ? asDegree(value) : asNumber(value);
+				const unfixed = value;
+
+				if (context.fix) {
+					hue.value = fixed;
+					needsFix = true;
+
+					return;
+				}
+
+				report({
+					message: messages.expected(unfixed, fixed),
+					node: decl,
+					index: declarationValueIndex(decl) + hue.sourceIndex,
+					result,
+					ruleName,
+				});
+			});
+
+			if (needsFix) {
+				setValue(decl, parsedValue.toString());
+			}
+		});
+	};
+}
+
+function asDegree(value) {
+	return `${value}deg`;
+}
+
+function asNumber(value) {
+	const { number } = valueParser.unit(value);
+
+	return number;
+}
+
+function findHue(node) {
+	const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
+	const value = node.value.toLowerCase();
+
+	if (HUE_FIRST_ARG_FUNCS.includes(value)) {
+		return args[0];
+	}
+
+	if (HUE_THIRD_ARG_FUNCS.includes(value)) {
+		return args[2];
+	}
+
+	return false;
+}
+
+function isDegree(value) {
+	const { unit } = valueParser.unit(value);
+
+	return unit && unit.toLowerCase() === 'deg';
+}
+
+function isNumber(value) {
+	const { unit } = valueParser.unit(value);
+
+	return unit === '';
+}
+
+function getValue(decl) {
+	return decl.raws.value ? decl.raws.value.raw : decl.value;
+}
+
+function setValue(decl, value) {
+	if (decl.raws.value) decl.raws.value.raw = value;
+	else decl.value = value;
+
+	return decl;
+}
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+module.exports = rule;

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -143,6 +143,7 @@ const rules = {
 	'function-url-scheme-whitelist': importLazy(() => require('./function-url-scheme-whitelist'))(),
 	'function-whitelist': importLazy(() => require('./function-whitelist'))(),
 	'function-whitespace-after': importLazy(() => require('./function-whitespace-after'))(),
+	'hue-degree-notation': importLazy(() => require('./hue-degree-notation'))(),
 	'keyframe-declaration-no-important': importLazy(() =>
 		require('./keyframe-declaration-no-important'),
 	)(),


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4721

> Is there anything in the PR that needs further explanation?

The rule can autofix both primary options as this rule is about explicitness vs shorthand convenience (with neither option being more right than the other), unlike [`color-function-notation`](https://github.com/stylelint/stylelint/pull/4760) which is concerned with modern vs legacy syntax.