### PR TITLE
Add alpha-value-notation

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -77,9 +77,13 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 
 ## Limit language features
 
+### Alpha-value
+
+- [`alpha-value-notation`](../../../lib/rules/alpha-value-notation/README.md): Specify percentage or number notation for alpha-values (Autofixable).
+
 ### Hue
 
-- [`hue-degree-notation`](../../../lib/rules/hue-degree-notation/README.md): Specify number or angle notation for degree hues.
+- [`hue-degree-notation`](../../../lib/rules/hue-degree-notation/README.md): Specify number or angle notation for degree hues (Autofixable).
 
 ### Color
 

--- a/lib/rules/alpha-value-notation/README.md
+++ b/lib/rules/alpha-value-notation/README.md
@@ -1,0 +1,110 @@
+# alpha-value-notation
+
+Specify percentage or number notation for alpha-values.
+
+<!-- prettier-ignore -->
+```css
+    a { color: rgb(0 0 0 / 0.5) }
+/**                        ↑
+ *                         This notation */
+```
+
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+
+## Options
+
+`string`: `"number"|"percentage"`
+
+### `"number"`
+
+Alpha-values _must always_ use the number notation.
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { opacity: 50% }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: rgb(0 0 0 / 50%) }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { opacity: 0.5 }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: rgb(0 0 0 / 0.5) }
+```
+
+### `"percentage"`
+
+Alpha-values _must always_ use percentage notation.
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { opacity: 0.5 }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: rgb(0 0 0 / 0.5) }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { opacity: 50% }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: rgb(0 0 0 / 50%) }
+```
+
+## Optional secondary options
+
+### `exceptProperties: ["/regex/", /regex/, "string"]`
+
+Reverse the primary option for matching properties.
+
+For example with `"percentage"`.
+
+Given:
+
+```
+["opacity"]
+```
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { opacity: 50% }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: rgb(0 0 0 / 0.5) }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { opacity: 0.5 }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: rgb(0 0 0 / 50%) }
+```

--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -1,0 +1,267 @@
+'use strict';
+
+const stripIndent = require('common-tags').stripIndent;
+
+const { messages, ruleName } = require('..');
+
+testRule({
+	ruleName,
+	config: ['number'],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { opacity: 0.1 }',
+		},
+		{
+			code: 'a { shape-image-threshold: .5 }',
+		},
+		{
+			code: 'a { OPACITY: /*comment*/0.1 }',
+		},
+		{
+			code: 'a { opacity: var(--alpha) }',
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 0.5) }',
+		},
+		{
+			code: 'a { color: rgb(0 0 0 / 0.5) }',
+		},
+		{
+			code: 'a { color: hsl(198deg 28% 50% / .50) }',
+		},
+		{
+			code: 'a { color: hsla(30, 100%, 50%, .6) }',
+		},
+		{
+			code: 'a { color: RGB(0 0 0 / 0.5) }',
+		},
+		{
+			code: 'a { color: hsla(var(--hue), var(--sat), var(--sat), var(--alpha)) }',
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10 / var(--alpha)) }',
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 0.5/*comment*/) }',
+		},
+		{
+			code: 'a { color: rgb(0 0 0 / /*comment*/0.5) }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { opacity: 10% }',
+			fixed: 'a { opacity: 0.1 }',
+			message: messages.expected('10%', '0.1'),
+			line: 1,
+			column: 14,
+		},
+		{
+			code: 'a { shape-image-threshold: 50% }',
+			fixed: 'a { shape-image-threshold: 0.5 }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 28,
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 50%) }',
+			fixed: 'a { color: rgba(0, 0, 0, 0.5) }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 26,
+		},
+		{
+			code: 'a { color: rgb(0 0 0 / 50%) }',
+			fixed: 'a { color: rgb(0 0 0 / 0.5) }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 24,
+		},
+		{
+			code: 'a { color: HSL(198DEG 28% 50% / 10%) }',
+			fixed: 'a { color: HSL(198DEG 28% 50% / 0.1) }',
+			message: messages.expected('10%', '0.1'),
+			line: 1,
+			column: 33,
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 50%/*comment*/) }',
+			fixed: 'a { color: rgba(0, 0, 0, 0.5/*comment*/) }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 26,
+		},
+		{
+			code: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hwb(270 60% 70% / 10%)
+						lch(56.29% 19.86 236.62 / 40%)
+					);
+				}
+			`,
+			fixed: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hwb(270 60% 70% / 0.1)
+						lch(56.29% 19.86 236.62 / 0.4)
+					);
+				}
+			`,
+			warnings: [
+				{ message: messages.expected('10%', '0.1'), line: 4, column: 21 },
+				{ message: messages.expected('40%', '0.4'), line: 5, column: 29 },
+			],
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['percentage'],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { opacity: 10% }',
+		},
+		{
+			code: 'a { shape-image-threshold: 50% }',
+		},
+		{
+			code: 'a { OPACITY: /*comment*/10% }',
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 50%) }',
+		},
+		{
+			code: 'a { color: RGB(0 0 0 / 50%) }',
+		},
+		{
+			code: 'a { color: lch(56.29% 19.86 10 / var(--alpha)) }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { opacity: 0.1 }',
+			fixed: 'a { opacity: 10% }',
+			message: messages.expected('0.1', '10%'),
+			line: 1,
+			column: 14,
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, .5) }',
+			fixed: 'a { color: rgba(0, 0, 0, 50%) }',
+			message: messages.expected('.5', '50%'),
+			line: 1,
+			column: 26,
+		},
+		{
+			code: 'a { color: HSL(198DEG 28% 50% / 0.1) }',
+			fixed: 'a { color: HSL(198DEG 28% 50% / 10%) }',
+			message: messages.expected('0.1', '10%'),
+			line: 1,
+			column: 33,
+		},
+		{
+			code: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hwb(270 60% 70% / 0.1)
+						lch(56.29% 19.86 236.62 / 0.40)
+					);
+				}
+			`,
+			fixed: stripIndent`
+				a {
+					background-image: linear-gradient(
+						to right,
+						hwb(270 60% 70% / 10%)
+						lch(56.29% 19.86 236.62 / 40%)
+					);
+				}
+			`,
+			warnings: [
+				{ message: messages.expected('0.1', '10%'), line: 4, column: 21 },
+				{ message: messages.expected('0.40', '40%'), line: 5, column: 29 },
+			],
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['number', { exceptProperties: ['opacity'] }],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { opacity: 50% }',
+		},
+		{
+			code: 'a { shape-image-threshold: .5 }',
+		},
+		{
+			code: 'a { color: rgb(0 0 0 / 0.5) }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { opacity: 0.1 }',
+			fixed: 'a { opacity: 10% }',
+			message: messages.expected('0.1', '10%'),
+			line: 1,
+			column: 14,
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 50%) }',
+			fixed: 'a { color: rgba(0, 0, 0, 0.5) }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 26,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['percentage', { exceptProperties: ['opacity'] }],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { opacity: 0.5 }',
+		},
+		{
+			code: 'a { shape-image-threshold: 50% }',
+		},
+		{
+			code: 'a { color: rgb(0 0 0 / 50%) }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { opacity: 10% }',
+			fixed: 'a { opacity: 0.1 }',
+			message: messages.expected('10%', '0.1'),
+			line: 1,
+			column: 14,
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 0.5) }',
+			fixed: 'a { color: rgba(0, 0, 0, 50%) }',
+			message: messages.expected('0.5', '50%'),
+			line: 1,
+			column: 26,
+		},
+	],
+});

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -1,0 +1,162 @@
+// @ts-nocheck
+
+'use strict';
+
+const _ = require('lodash');
+const valueParser = require('postcss-value-parser');
+
+const declarationValueIndex = require('../../utils/declarationValueIndex');
+const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
+const optionsMatches = require('../../utils/optionsMatches');
+const report = require('../../utils/report');
+const ruleMessages = require('../../utils/ruleMessages');
+const validateOptions = require('../../utils/validateOptions');
+
+const ruleName = 'alpha-value-notation';
+
+const messages = ruleMessages(ruleName, {
+	expected: (unfixed, fixed) => `Expected ${unfixed} to be ${fixed}`,
+});
+
+const ALPHA_PROPS = ['opacity', 'shape-image-threshold'];
+const ALPHA_FUNCS = ['hsl', 'hsla', 'hwb', 'lab', 'lch', 'rgb', 'rgba'];
+
+function rule(primary, options, context) {
+	return (root, result) => {
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: ['number', 'percentage'],
+			},
+			{
+				actual: options,
+				possible: {
+					exceptProperties: [_.isString, _.isRegExp],
+				},
+				optional: true,
+			},
+		);
+
+		if (!validOptions) return;
+
+		root.walkDecls((decl) => {
+			if (!isStandardSyntaxDeclaration(decl)) return;
+
+			let needsFix = false;
+			const parsedValue = valueParser(getValue(decl));
+
+			parsedValue.walk((node) => {
+				let alpha;
+
+				if (ALPHA_PROPS.includes(decl.prop.toLowerCase())) {
+					alpha = findAlphaInValue(node);
+				} else {
+					if (node.type !== 'function') return;
+
+					if (!ALPHA_FUNCS.includes(node.value.toLowerCase())) return;
+
+					alpha = findAlphaInFunction(node);
+				}
+
+				const { value } = alpha;
+
+				if (!isStandardSyntaxValue(value)) return;
+
+				if (!isNumber(value) && !isPercentage(value)) return;
+
+				const optionFuncs = {
+					number: {
+						expFunc: isNumber,
+						fixFunc: asNumber,
+					},
+					percentage: {
+						expFunc: isPercentage,
+						fixFunc: asPercentage,
+					},
+				};
+
+				let expectation = primary;
+
+				if (optionsMatches(options, 'exceptProperties', decl.prop)) {
+					expectation = Object.keys(optionFuncs).filter((key) => key !== expectation);
+				}
+
+				if (optionFuncs[expectation].expFunc(value)) return;
+
+				const fixed = optionFuncs[expectation].fixFunc(value);
+				const unfixed = value;
+
+				if (context.fix) {
+					alpha.value = fixed;
+					needsFix = true;
+
+					return;
+				}
+
+				report({
+					message: messages.expected(unfixed, fixed),
+					node: decl,
+					index: declarationValueIndex(decl) + alpha.sourceIndex,
+					result,
+					ruleName,
+				});
+			});
+
+			if (needsFix) {
+				setValue(decl, parsedValue.toString());
+			}
+		});
+	};
+}
+
+function asPercentage(value) {
+	return `${value * 100}%`;
+}
+
+function asNumber(value) {
+	const { number } = valueParser.unit(value);
+
+	return number / 100;
+}
+
+function findAlphaInValue(node) {
+	return node.type === 'word' || node.type === 'function' ? node : false;
+}
+
+function findAlphaInFunction(node) {
+	const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
+
+	if (args.length === 4) return args[3];
+
+	return false;
+}
+
+function isPercentage(value) {
+	const { unit } = valueParser.unit(value);
+
+	return unit && unit === '%';
+}
+
+function isNumber(value) {
+	const { unit } = valueParser.unit(value);
+
+	return unit === '';
+}
+
+function getValue(decl) {
+	return decl.raws.value ? decl.raws.value.raw : decl.value;
+}
+
+function setValue(decl, value) {
+	if (decl.raws.value) decl.raws.value.raw = value;
+	else decl.value = value;
+
+	return decl;
+}
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+module.exports = rule;

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -6,6 +6,7 @@ const importLazy = require('import-lazy');
 
 /** @type {{[k: string]: Function}} */
 const rules = {
+	'alpha-value-notation': importLazy(() => require('./alpha-value-notation'))(),
 	'at-rule-blacklist': importLazy(() => require('./at-rule-blacklist'))(),
 	'at-rule-empty-line-before': importLazy(() => require('./at-rule-empty-line-before'))(),
 	'at-rule-name-case': importLazy(() => require('./at-rule-name-case'))(),


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4720 

> Is there anything in the PR that needs further explanation?

I added an `exceptProperties` option as support for percentage alpha-values for `opacity` was added in a [later spec](https://drafts.csswg.org/css-color/#transparency), it [isn't supported in some browsers like Safari](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity#Browser_compatibility), and  I don't think [postcss-preset-env](https://preset-env.cssdb.org/) transpiles it yet.

When this rule and the other two new rules are in, I'll create a follow-up issue to refactor some of the shared functions into utils, e.g. `getValue` and `setValue`.

