### PR TITLE
Fix false positives for forced-colors in media-feature-name-* rules

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -527,8 +527,8 @@ keywordSets.pageMarginAtRules = new Set([
 
 // https://developer.mozilla.org/en/docs/Web/CSS/At-rule
 keywordSets.atRules = uniteSets(keywordSets.pageMarginAtRules, [
-	'apply',
 	'annotation',
+	'apply',
 	'character-variant',
 	'charset',
 	'counter-style',
@@ -572,6 +572,7 @@ keywordSets.mediaFeatureNames = uniteSets(keywordSets.deprecatedMediaFeatureName
 	'color',
 	'color-gamut',
 	'color-index',
+	'forced-colors',
 	'grid',
 	'height',
 	'hover',

--- a/lib/rules/media-feature-name-no-unknown/__tests__/index.js
+++ b/lib/rules/media-feature-name-no-unknown/__tests__/index.js
@@ -44,6 +44,9 @@ testRule({
 			code: '@media (--viewport-medium) { }',
 			description: 'ignore css variables',
 		},
+		{
+			code: '@media (forced-colors: active) { }',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #4773.

> Is there anything in the PR that needs further explanation?

- Docs: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
- Spec: https://drafts.csswg.org/mediaqueries-5/#forced-colors
- ChromeStatus entry: https://www.chromestatus.com/feature/5757293075365888
