### PR TITLE
Fix false positives for WebExtension replacement keywords in value-keyword-case

### DIFF
--- a/lib/utils/__tests__/isStandardSyntaxValue.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxValue.test.js
@@ -42,4 +42,10 @@ describe('isStandardSyntaxValue', () => {
 	it('less interpolation', () => {
 		expect(isStandardSyntaxValue('@{var}')).toBeFalsy();
 	});
+	it('WebExtension replacement keyword', () => {
+		expect(isStandardSyntaxValue('__MSG_@@bidi_dir__')).toBeFalsy();
+	});
+	it('negative WebExtension replacement keyword', () => {
+		expect(isStandardSyntaxValue('__msg_@@bidi_dir__')).toBeTruthy();
+	});
 });

--- a/lib/utils/isStandardSyntaxValue.js
+++ b/lib/utils/isStandardSyntaxValue.js
@@ -36,5 +36,12 @@ module.exports = function (value) {
 		return false;
 	}
 
+	// WebExtension replacement keyword used by Chrome/Firefox
+	// more information: https://developer.chrome.com/extensions/i18n
+	// and https://github.com/stylelint/stylelint/issues/4707
+	if (/__MSG_[^\s]+__/.test(value)) {
+		return false;
+	}
+
 	return true;
 };


### PR DESCRIPTION
Hi there, 

This is a PR that aims to address #4707, by adding a regex match to `isStandardSyntaxValue` that ignores values of the form `/__MSG_[^\s]+__/`, a set of runtime values often used by browsers for internationalization (more information [here](https://developer.chrome.com/extensions/i18n), as mentioned in the issue discussion). I also added two tests, one that checks for the positive, and one that checks for case-sensitivity.

As `value-keyword-case` uses `isStandardSyntaxValue`, this should resolve the false positive originally brought up in the issue.

Locally, this PR passes `npm run format` and `npm run test`.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4707.

> Is there anything in the PR that needs further explanation?

Not on my end! Let me know if I should change the comments or add more tests.
