### PR TITLE
Fix TypeError for shorthand animation in time-min-milliseconds

### DIFF
--- a/lib/rules/time-min-milliseconds/__tests__/index.js
+++ b/lib/rules/time-min-milliseconds/__tests__/index.js
@@ -10,6 +10,15 @@ testRule({
 
 	accept: [
 		{
+			code: 'a { animation: none; }',
+		},
+		{
+			code: 'a { animation: none, my-animation; }',
+		},
+		{
+			code: 'a { transition: opacity var(--x) var(--y) ease-out }',
+		},
+		{
 			code: 'a { transition-delay: 0.1s; }',
 		},
 		{
@@ -314,6 +323,15 @@ testRule({
 	config: [MIN_VALUE, { ignore: ['delay'] }],
 
 	accept: [
+		{
+			code: 'a { animation: none; }',
+		},
+		{
+			code: 'a { animation: none, my-animation; }',
+		},
+		{
+			code: 'a { transition: opacity var(--x) var(--y) ease-out }',
+		},
 		{
 			code: 'a { transition-duration: 0.15s; }',
 		},

--- a/lib/rules/time-min-milliseconds/index.js
+++ b/lib/rules/time-min-milliseconds/index.js
@@ -63,7 +63,7 @@ function rule(minimum, options) {
 						// Check only duration time values
 						const duration = getDuration(valueList);
 
-						if (!isAcceptableTime(duration)) {
+						if (duration && !isAcceptableTime(duration)) {
 							complain(decl, decl.value.indexOf(duration));
 						}
 					} else {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Refs #4782

> Is there anything in the PR that needs further explanation?

The TypeError is only triggered when the new `ignore: ["delay"]` option is used (which was added in https://github.com/stylelint/stylelint/pull/4743). So the actual problem in #4782 may be an unrelated regression.

---

We'll need to [refactor the code](https://github.com/stylelint/stylelint/pull/4743#pullrequestreview-406653509) for `time-min-milliseconds` to address https://github.com/stylelint/stylelint/issues/4751 at some point.


