### PR TITLE
Fixes `no-duplicate-selectors` false positive when `disallowInList` is set to `true`.

### DIFF
--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -196,6 +196,14 @@ testRule({
 			code: 'input, button {}; textarea {}',
 			description: 'no duplicate within a grouping selector',
 		},
+		{
+			code: '*::x {} x {}',
+			description: 'no duplicate with pseudo-elements',
+		},
+		{
+			code: '*:x {} x {}',
+			description: 'no duplicate with pseudo-selectors',
+		},
 	],
 
 	reject: [

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -72,7 +72,8 @@ function rule(actual, options) {
 				if (shouldDisallowDuplicateInList) {
 					// iterate throw Map for checking, was used this selector in a group selector
 					contextSelectorSet.forEach((selectorLine, selector) => {
-						if (selector.includes(selectorList)) {
+						// Split removes any pseudo elements or selectors
+						if (selector.split(':')[0].includes(selectorList)) {
 							duplicationPosition = selectorLine;
 						}
 					});


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #4683

> Is there anything in the PR that needs further explanation?

PR should strip pseudo elements and selectors when looking for duplicate selectors.
