### PR TITLE
Fix with workaround a TypeError thrown for "html"

### DIFF
--- a/lib/__tests__/fixtures/html.js
+++ b/lib/__tests__/fixtures/html.js
@@ -1,0 +1,5 @@
+'use strict';
+
+let html;
+
+html.replace();

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -238,6 +238,19 @@ it('standalone with automatic syntax inference', () => {
 	});
 });
 
+it('standalone with js file contains html', () => {
+	return standalone({
+		files: `${fixturesPath}/html.js`,
+		config: {
+			rules: {
+				'block-no-empty': true,
+			},
+		},
+	}).then((data) => {
+		expect(data.results[0].errored).toBe(false);
+	});
+});
+
 it('standalone with postcss-safe-parser', () => {
 	return standalone({
 		files: `${fixturesPath}/syntax_error.*`,

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -78,10 +78,15 @@ module.exports = function (stylelint, options = {}) {
 			} else if (!(options.codeProcessors && options.codeProcessors.length)) {
 				const autoSyntax = require('postcss-syntax');
 
+				// TODO: investigate why lazy import HTML syntax causes
+				// JS files with the word "html" to throw TypeError
+				// https://github.com/stylelint/stylelint/issues/4793
+				const { html, ...rest } = syntaxes;
+
 				syntax = autoSyntax({
 					css: cssSyntax(stylelint),
 					jsx: syntaxes['css-in-js'],
-					...syntaxes,
+					...rest,
 				});
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4793

> Is there anything in the PR that needs further explanation?

It's not clear what's happening here, and a deeper investigation is needed. It appears the HTML syntax is somehow interfering with JavaScript files that contain the word "html".

We can workaround the issue by not lazy loading the HTML syntax ourselves and instead relying on postcss-syntax mechanism. We can do this because we are using the original postcss-html module, unlike with postcss-markdown and postcss-css-in-js where we are using our own forks.

I'll create a follow-up issue at some point to discuss what we do about postcss-syntax going forward. At the moment the syntax inferring is being handled by an unmaintained package.
