### PR TITLE
Fix error message percentage/number precision for alpha-value-notation

### DIFF
--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -124,6 +124,22 @@ testRule({
 				{ message: messages.expected('40%', '0.4'), line: 5, column: 29 },
 			],
 		},
+		{
+			code: 'a { opacity: 14% }',
+			fixed: 'a { opacity: 0.14 }',
+			message: messages.expected('14%', '0.14'),
+			line: 1,
+			column: 14,
+			description: 'properly deals with floating-point conversions',
+		},
+		{
+			code: 'a { opacity: 0.3% }',
+			fixed: 'a { opacity: 0.003 }',
+			message: messages.expected('0.3%', '0.003'),
+			line: 1,
+			column: 14,
+			description: 'properly deals with floating-point conversions',
+		},
 	],
 });
 
@@ -199,6 +215,22 @@ testRule({
 				{ message: messages.expected('0.40', '40%'), line: 5, column: 29 },
 			],
 		},
+		{
+			code: 'a { opacity: 0.14 }',
+			fixed: 'a { opacity: 14% }',
+			message: messages.expected('0.14', '14%'),
+			line: 1,
+			column: 14,
+			description: 'properly deals with floating-point conversions',
+		},
+		{
+			code: 'a { opacity: 0.003 }',
+			fixed: 'a { opacity: 0.3% }',
+			message: messages.expected('0.003', '0.3%'),
+			line: 1,
+			column: 14,
+			description: 'properly deals with floating-point conversions',
+		},
 	],
 });
 
@@ -268,54 +300,6 @@ testRule({
 			message: messages.expected('0.5', '50%'),
 			line: 1,
 			column: 26,
-		},
-	],
-});
-
-// testing that floating point-rounded numbers-to-percentages are handled properly
-testRule({
-	ruleName,
-	config: ['percentage'],
-	fix: true,
-
-	reject: [
-		{
-			code: 'a { opacity: 0.14 }',
-			fixed: 'a { opacity: 14% }',
-			message: messages.expected('0.14', '14%'),
-			line: 1,
-			column: 14,
-		},
-		{
-			code: 'a { opacity: 0.003 }',
-			fixed: 'a { opacity: 0.3% }',
-			message: messages.expected('0.003', '0.3%'),
-			line: 1,
-			column: 14,
-		},
-	],
-});
-
-// testing that floating point-rounded percentages-to-numbers are handled properly
-testRule({
-	ruleName,
-	config: ['number'],
-	fix: true,
-
-	reject: [
-		{
-			code: 'a { opacity: 14% }',
-			fixed: 'a { opacity: 0.14 }',
-			message: messages.expected('14%', '0.14'),
-			line: 1,
-			column: 14,
-		},
-		{
-			code: 'a { opacity: 0.3% }',
-			fixed: 'a { opacity: 0.003 }',
-			message: messages.expected('0.3%', '0.003'),
-			line: 1,
-			column: 14,
 		},
 	],
 });

--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -271,3 +271,51 @@ testRule({
 		},
 	],
 });
+
+// testing that floating point-rounded numbers-to-percentages are handled properly
+testRule({
+	ruleName,
+	config: ['percentage'],
+	fix: true,
+
+	reject: [
+		{
+			code: 'a { opacity: 0.14 }',
+			fixed: 'a { opacity: 14% }',
+			message: messages.expected('0.14', '14%'),
+			line: 1,
+			column: 14,
+		},
+		{
+			code: 'a { opacity: 0.003 }',
+			fixed: 'a { opacity: 0.3% }',
+			message: messages.expected('0.003', '0.3%'),
+			line: 1,
+			column: 14,
+		},
+	],
+});
+
+// testing that floating point-rounded percentages-to-numbers are handled properly
+testRule({
+	ruleName,
+	config: ['number'],
+	fix: true,
+
+	reject: [
+		{
+			code: 'a { opacity: 14% }',
+			fixed: 'a { opacity: 0.14 }',
+			message: messages.expected('14%', '0.14'),
+			line: 1,
+			column: 14,
+		},
+		{
+			code: 'a { opacity: 0.3% }',
+			fixed: 'a { opacity: 0.003 }',
+			message: messages.expected('0.3%', '0.003'),
+			line: 1,
+			column: 14,
+		},
+	],
+});

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -115,13 +115,13 @@ function rule(primary, options, context) {
 }
 
 function asPercentage(value) {
-	return `${value * 100}%`;
+	return `${Number((value * 100).toPrecision(3))}%`;
 }
 
 function asNumber(value) {
 	const { number } = valueParser.unit(value);
 
-	return number / 100;
+	return Number((number / 100).toPrecision(3));
 }
 
 function findAlphaInValue(node) {


### PR DESCRIPTION
Hi there,

This is a PR that aims to tackle a problem addressed in #4792, namely that with floating-point conversions, the error messages (and "fixed" outputs) have numbers that are unpleasant to look at/unreasonable. 

My preliminary shot at this (which might need some feedback) is to use Javascript's in-built [`.toPrecision()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Number/toPrecision) function. I used this instead of [`.toFixed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) as the latter rounds down very small numbers to 0 (e.g. `0.003`, which I included as a test case), which would create an incorrect error message. I added these precision-specifies to `asNumber()` and `asPercentage()`.

I am curious if this is the correct approach to solve this problem:
* I (somewhat arbitrarily) chose a precision of `3` digits - is this an alright magic number? should this be user-configurable?
* Is using `.toPrecision()` the right way to go around this? I wasn't able to personally find any problems, but I imagine it might create some problems with too many trailing zeroes, or possibly truncating important data
* Should I be covering more edge cases (e.g. very large or very very small numbers), or is that out of scope of stylelint? Should I add special checks in the functions?

Would love to get @jeddy3's input since they implemented the rule, or @m-allanson who originally responded to the issue!

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4792.

> Is there anything in the PR that needs further explanation?

Nothing else not in this giant wall of text of a PR 😄 
