### PR TITLE
Fix false positives for namespaced variables in property-no-unknown

### DIFF
--- a/lib/rules/property-no-unknown/__tests__/index.js
+++ b/lib/rules/property-no-unknown/__tests__/index.js
@@ -87,6 +87,10 @@ testRule({
 			description: 'ignore SCSS variables',
 		},
 		{
+			code: '.foo { namespace.$bgColor: white; }',
+			description: 'ignore SCSS variables within namespace',
+		},
+		{
 			code: '.foo { #{$prop}: black; }',
 			description: 'ignore property interpolation',
 		},

--- a/lib/utils/__tests__/isScssVariable.test.js
+++ b/lib/utils/__tests__/isScssVariable.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const isScssVariable = require('../isScssVariable');
+
+describe('isScssVariable', () => {
+	it('sass variable', () => {
+		expect(isScssVariable('$sass-variable')).toBeTruthy();
+	});
+	it('sass variable within namespace', () => {
+		expect(isScssVariable('namespace.$sass-variable')).toBeTruthy();
+	});
+	it('sass interpolation', () => {
+		expect(isScssVariable('#{$Attr}-color')).toBeFalsy();
+	});
+	it('single word property', () => {
+		expect(isScssVariable('top')).toBeFalsy();
+	});
+	it('hyphenated property', () => {
+		expect(isScssVariable('border-top-left-radius')).toBeFalsy();
+	});
+	it('property with vendor prefix', () => {
+		expect(isScssVariable('-webkit-appearance')).toBeFalsy();
+	});
+	it('custom property', () => {
+		expect(isScssVariable('--custom-property')).toBeFalsy();
+	});
+	it('less variable', () => {
+		expect(isScssVariable('@var')).toBeFalsy();
+	});
+	it('less append property value with comma', () => {
+		expect(isScssVariable('transform+')).toBeFalsy();
+	});
+	it('less append property value with space', () => {
+		expect(isScssVariable('transform+_')).toBeFalsy();
+	});
+});

--- a/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
@@ -121,6 +121,18 @@ describe('isStandardSyntaxDeclaration', () => {
 		});
 	});
 
+	it('scss var within namespace', () => {
+		scssDecls('namespace.$var: b', (decl) => {
+			expect(isStandardSyntaxDeclaration(decl)).toBeFalsy();
+		});
+	});
+
+	it('nested scss var within namespace', () => {
+		scssDecls('a { namespace.$var: b }', (decl) => {
+			expect(isStandardSyntaxDeclaration(decl)).toBeFalsy();
+		});
+	});
+
 	it('sass list', () => {
 		sassDecls('$list: (key: value, key2: value2)', (decl) => {
 			expect(isStandardSyntaxDeclaration(decl)).toBeFalsy();

--- a/lib/utils/__tests__/isStandardSyntaxProperty.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxProperty.test.js
@@ -18,6 +18,9 @@ describe('isStandardSyntaxProperty', () => {
 	it('sass variable', () => {
 		expect(isStandardSyntaxProperty('$sass-variable')).toBeFalsy();
 	});
+	it('sass variable within namespace', () => {
+		expect(isStandardSyntaxProperty('namespace.$sass-variable')).toBeFalsy();
+	});
 	it('sass interpolation', () => {
 		expect(isStandardSyntaxProperty('#{$Attr}-color')).toBeFalsy();
 	});

--- a/lib/utils/isScssVariable.js
+++ b/lib/utils/isScssVariable.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Check whether a property is SCSS variable
+ *
+ * @param {string} property
+ * @returns {boolean}
+ */
+module.exports = function (property) {
+	// SCSS var (e.g. $var: x), list (e.g. $list: (x)) or map (e.g. $map: (key:value))
+	if (property.startsWith('$')) {
+		return true;
+	}
+
+	// SCSS var within a namespace (e.g. namespace.$var: x)
+	if (property.includes('.$')) {
+		return true;
+	}
+
+	return false;
+};

--- a/lib/utils/isStandardSyntaxDeclaration.js
+++ b/lib/utils/isStandardSyntaxDeclaration.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const isScssVariable = require('./isScssVariable');
 const { isRoot } = require('./typeGuards');
 
 /**
@@ -29,8 +30,8 @@ module.exports = function (decl) {
 		return false;
 	}
 
-	// Sass var (e.g. $var: x), nested list (e.g. $list: (x)) or nested map (e.g. $map: (key:value))
-	if (prop[0] === '$') {
+	// SCSS var
+	if (isScssVariable(prop)) {
 		return false;
 	}
 
@@ -54,11 +55,6 @@ module.exports = function (decl) {
 	// Less &:extend
 	// @ts-ignore TODO TYPES extend does not exists
 	if (decl.extend) {
-		return false;
-	}
-
-	// Sass variables within a namespace (e.g. namespace.$var: x)
-	if (prop.includes('.$') && prop[0] !== '.' && prop[prop.length - 1] !== '$') {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxDeclaration.js
+++ b/lib/utils/isStandardSyntaxDeclaration.js
@@ -57,5 +57,10 @@ module.exports = function (decl) {
 		return false;
 	}
 
+	// Sass variables within a namespace (e.g. namespace.$var: x)
+	if (prop.includes('.$') && prop[0] !== '.' && prop[prop.length - 1] !== '$') {
+		return false;
+	}
+
 	return true;
 };

--- a/lib/utils/isStandardSyntaxProperty.js
+++ b/lib/utils/isStandardSyntaxProperty.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const hasInterpolation = require('../utils/hasInterpolation');
+const isScssVariable = require('./isScssVariable');
 
 /**
  * Check whether a property is standard
@@ -9,8 +10,8 @@ const hasInterpolation = require('../utils/hasInterpolation');
  * @returns {boolean}
  */
 module.exports = function (property) {
-	// SCSS var (e.g. $var: x), list (e.g. $list: (x)) or map (e.g. $map: (key:value))
-	if (property.startsWith('$')) {
+	// SCSS var
+	if (isScssVariable(property)) {
 		return false;
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4544

> Is there anything in the PR that needs further explanation?

I didn't add test cases of `isStandardSyntaxDeclaration` for Sass indented syntax because the `postcss-sass` parser does not understand `@use` syntax yet (https://github.com/AleshaOleg/postcss-sass/issues/145).