### PR TITLE
Move function normalizeAllRuleSettings() out to a separate module

### DIFF
--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -4,9 +4,8 @@ const _ = require('lodash');
 const configurationError = require('./utils/configurationError');
 const getModulePath = require('./utils/getModulePath');
 const globjoin = require('globjoin');
-const normalizeRuleSettings = require('./normalizeRuleSettings');
+const normalizeAllRuleSettings = require('./normalizeAllRuleSettings');
 const path = require('path');
-const rules = require('./rules');
 
 /** @typedef {import('stylelint').StylelintConfigPlugins} StylelintConfigPlugins */
 /** @typedef {import('stylelint').StylelintConfigProcessor} StylelintConfigProcessor */
@@ -290,37 +289,6 @@ function addPluginFunctions(config) {
 	}, /** @type {{[k: string]: Function}} */ ({}));
 
 	config.pluginFunctions = pluginFunctions;
-
-	return config;
-}
-
-/**
- * @param {StylelintConfig} config
- * @return {StylelintConfig}
- */
-function normalizeAllRuleSettings(config) {
-	/** @type {StylelintConfigRules} */
-	const normalizedRules = {};
-
-	if (!config.rules) return config;
-
-	Object.keys(config.rules).forEach((ruleName) => {
-		const rawRuleSettings = _.get(config, ['rules', ruleName]);
-
-		const rule = rules[ruleName] || _.get(config, ['pluginFunctions', ruleName]);
-
-		if (!rule) {
-			normalizedRules[ruleName] = [];
-		} else {
-			normalizedRules[ruleName] = normalizeRuleSettings(
-				rawRuleSettings,
-				ruleName,
-				_.get(rule, 'primaryOptionArray'),
-			);
-		}
-	});
-
-	config.rules = normalizedRules;
 
 	return config;
 }

--- a/lib/normalizeAllRuleSettings.js
+++ b/lib/normalizeAllRuleSettings.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const _ = require('lodash');
+const normalizeRuleSettings = require('./normalizeRuleSettings');
+const rules = require('./rules');
+
+/** @typedef {import('stylelint').StylelintConfigRules} StylelintConfigRules */
+/** @typedef {import('stylelint').StylelintConfig} StylelintConfig */
+
+/**
+ * @param {StylelintConfig} config
+ * @return {StylelintConfig}
+ */
+function normalizeAllRuleSettings(config) {
+	/** @type {StylelintConfigRules} */
+	const normalizedRules = {};
+
+	if (!config.rules) return config;
+
+	Object.keys(config.rules).forEach((ruleName) => {
+		const rawRuleSettings = _.get(config, ['rules', ruleName]);
+
+		const rule = rules[ruleName] || _.get(config, ['pluginFunctions', ruleName]);
+
+		if (!rule) {
+			normalizedRules[ruleName] = [];
+		} else {
+			normalizedRules[ruleName] = normalizeRuleSettings(
+				rawRuleSettings,
+				ruleName,
+				_.get(rule, 'primaryOptionArray'),
+			);
+		}
+	});
+
+	config.rules = normalizedRules;
+
+	return config;
+}
+
+module.exports = normalizeAllRuleSettings;


### PR DESCRIPTION
In a future PR this module will be required by the new `browser.js` module. This change has been extracted from: https://github.com/stylelint/stylelint/pull/4796

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to issue https://github.com/stylelint/stylelint/issues/3935

> Is there anything in the PR that needs further explanation?

This change is a small part of the changes in PR https://github.com/stylelint/stylelint/pull/4796
