### PR TITLE
Fix TypeError for inline comments and autofix for sugarss in max-empty-lines 

### DIFF
--- a/lib/rules/max-empty-lines/__tests__/index.js
+++ b/lib/rules/max-empty-lines/__tests__/index.js
@@ -480,6 +480,50 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [2],
+	skipBasicChecks: true,
+	syntax: 'sugarss',
+	fix: true,
+
+	accept: [
+		{
+			code: '\n\n// one',
+		},
+		{
+			code: '// one\n\n',
+		},
+		{
+			code: '// one\n\n\n// two\n',
+		},
+	],
+
+	reject: [
+		{
+			code: '\n\n\n// one',
+			fixed: '\n\n// one',
+			message: messages.expected(2),
+			line: 3,
+			column: 1,
+		},
+		{
+			code: '// one\n\n\n',
+			fixed: '// one\n\n',
+			message: messages.expected(2),
+			line: 4,
+			column: 1,
+		},
+		{
+			code: '// one\n\n\n\n// two\n',
+			fixed: '// one\n\n\n// two\n',
+			message: messages.expected(2),
+			line: 4,
+			column: 1,
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: [2, { ignore: 'comments' }],
 	fix: true,
 

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -154,7 +154,7 @@ function rule(max, options, context) {
 		function replaceEmptyLines(max, str, isSpecialCase = false) {
 			const repeatTimes = isSpecialCase ? max : max + 1;
 
-			if (repeatTimes === 0) {
+			if (repeatTimes === 0 || typeof str !== 'string') {
 				return '';
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/4820

> Is there anything in the PR that needs further explanation?

max-empty-lines/index.js line 58
https://github.com/stylelint/stylelint/blob/master/lib/rules/max-empty-lines/index.js#L60

```javascript
if (!ignoreComments) {
    node.raws.left = getChars(node.raws.left);
    node.raws.right = getChars(node.raws.right);
}
```

for sugarss inline comment node.raws.right may get a undefined.
