### PR TITLE
Export an object from the CSS-in-JS syntax

### DIFF
--- a/lib/__tests__/syntaxes.test.js
+++ b/lib/__tests__/syntaxes.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const syntaxes = require('../syntaxes/index');
+
+const inputs = Object.keys(syntaxes).map((name) => [
+	name,
+	require(`../syntaxes/syntax-${name}.js`), // directly require modules to bypass importLazy() in syntaxes/index.js
+]);
+
+describe('syntaxes', () => {
+	it.each(inputs)('syntax is an object with parse and stringify keys: %s', (name, module) => {
+		expect(module).toMatchObject({
+			parse: expect.any(Function),
+			stringify: expect.any(Function),
+		});
+	});
+});

--- a/lib/syntaxes/syntax-css-in-js.js
+++ b/lib/syntaxes/syntax-css-in-js.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('@stylelint/postcss-css-in-js');
+module.exports = require('@stylelint/postcss-css-in-js')();


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This change is a small part of the changes in PR #4796.

> Is there anything in the PR that needs further explanation?

The CSS-in-JS syntax was previously being exported as a function instead of an object. This worked because functions can still have properties attached to them. It was a bit confusing though. 

This PR updates the syntax to export an object.

After the first commit in this PR, the test should fail like this:

```
 FAIL  lib/__tests__/syntaxes.test.js
  ● syntaxes › syntax is an object with parse and stringify keys: css-in-js

    expect(received).toMatchObject(expected)

    Matcher error: received value must be a non-null object

    Received has type:  function
    Received has value: [Function syntax]

      10 | describe('syntaxes', () => {
      11 |      it.each(inputs)('syntax is an object with parse and stringify keys: %s', (name, module) => {
    > 12 |              expect(module).toMatchObject({
         |                             ^
      13 |                      parse: expect.any(Function),
      14 |                      stringify: expect.any(Function),
      15 |              });

      at lib/__tests__/syntaxes.test.js:12:18

```
