### PR TITLE
Fix shadow part ident falsly parsed as type selector

### DIFF
--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -422,6 +422,10 @@ testRule({
 			code: 'x-foo {}',
 			description: 'custom element',
 		},
+		{
+			code: 'custom-element::part(foo) {}',
+			description: 'shadow parts',
+		},
 	],
 
 	reject: [

--- a/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxTypeSelector.test.js
@@ -75,6 +75,11 @@ describe('isStandardSyntaxTypeSelector', () => {
 			expect(isStandardSyntaxTypeSelector(func)).toBeFalsy();
 		});
 	});
+	it('shadow-parts ident', () => {
+		rules('::part(foo) {}', (func) => {
+			expect(isStandardSyntaxTypeSelector(func)).toBeFalsy();
+		});
+	});
 	it('lowercase reference combinators', () => {
 		rules('.foo /for/ .bar {}', (func) => {
 			expect(isStandardSyntaxTypeSelector(func)).toBeFalsy();

--- a/lib/utils/isStandardSyntaxTypeSelector.js
+++ b/lib/utils/isStandardSyntaxTypeSelector.js
@@ -27,7 +27,8 @@ module.exports = function (node) {
 		if (
 			parentType === 'pseudo' &&
 			(keywordSets.aNPlusBNotationPseudoClasses.has(normalisedParentName) ||
-				keywordSets.linguisticPseudoClasses.has(normalisedParentName))
+				keywordSets.linguisticPseudoClasses.has(normalisedParentName) ||
+				keywordSets.shadowTreePseudoElements.has(normalisedParentName))
 		) {
 			return false;
 		}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #4822 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
