### PR TITLE
Add ignoreContextFunctionalPseudoClasses to selector-max-id

### DIFF
--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -79,7 +79,7 @@ The following patterns are _not_ considered violations:
 
 Ignore selectors inside of specified [functional pseudo-classes](https://drafts.csswg.org/selectors-4/#pseudo-classes) that provide [evaluation contexts](https://drafts.csswg.org/selectors-4/#specificity-rules).
 
-For example, with the following config:
+Given:
 
 ```js
 config: [0, { ignoreContextFunctionalPseudoClasses: [":not", /^:(h|H)as$/] }];
@@ -89,23 +89,17 @@ The following patterns are considered violations:
 
 <!-- prettier-ignore -->
 ```css
-a:matches(#foo){
-  color: black;
-}
+a:matches(#foo) {}
 ```
 
 While the following patters are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-a:not(#foo){
-  color: black;
-}
+a:not(#foo) {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-a:has(#foo){
-  color: black;
-}
+a:has(#foo) {}
 ```

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -74,3 +74,38 @@ The following patterns are _not_ considered violations:
 /* `#bar` is inside `:not()`, so it is evaluated separately */
 #foo #bar:not(#baz) {}
 ```
+
+### `ignoreContextFunctionalPseudoClasses: ["/regex/", /regex/, "non-regex"]`
+
+Ignore selectors inside of specified [functional pseudo-classes](https://drafts.csswg.org/selectors-4/#pseudo-classes) that provide [evaluation contexts](https://drafts.csswg.org/selectors-4/#specificity-rules).
+
+For example, with the following config:
+
+```js
+config: [0, { ignoreContextFunctionalPseudoClasses: [":not", /^:(h|H)as$/] }];
+```
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a:matches(#foo){
+  color: black;
+}
+```
+
+While the following patters are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a:not(#foo){
+  color: black;
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a:has(#foo){
+  color: black;
+}
+```

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -82,7 +82,7 @@ Ignore selectors inside of specified [functional pseudo-classes](https://drafts.
 Given:
 
 ```js
-[":not", /^:(h|H)as$/]
+[":not", /^:(h|H)as$/];
 ```
 
 The following patterns are considered violations:

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -82,7 +82,7 @@ Ignore selectors inside of specified [functional pseudo-classes](https://drafts.
 Given:
 
 ```js
-config: [0, { ignoreContextFunctionalPseudoClasses: [":not", /^:(h|H)as$/] }];
+[":not", /^:(h|H)as$/]
 ```
 
 The following patterns are considered violations:

--- a/lib/rules/selector-max-id/__tests__/index.js
+++ b/lib/rules/selector-max-id/__tests__/index.js
@@ -462,7 +462,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [0, { ignoreContextFunctionalPseudoClasses: [':not', /^:(i|I)s$/] }],
+	config: [0, { ignoreContextFunctionalPseudoClasses: [':not', /^:(h|H)as$/] }],
 
 	accept: [
 		{
@@ -470,17 +470,17 @@ testRule({
 			description: 'selector within ignored pseudo-class (string input)',
 		},
 		{
-			code: 'a:is(#foo) { color: black; }',
+			code: 'a:has(#foo) { color: black; }',
 			description: 'selector within ignored pseudo-class (regex input)',
 		},
 	],
 	reject: [
 		{
-			code: 'a:where(#foo) { color: black; }',
+			code: 'a:matches(#foo) { color: black; }',
 			description: 'selector within non-ignored pseudo class',
 			message: messages.expected('#foo', 0),
 			line: 1,
-			column: 8,
+			column: 11,
 		},
 	],
 });

--- a/lib/rules/selector-max-id/__tests__/index.js
+++ b/lib/rules/selector-max-id/__tests__/index.js
@@ -466,17 +466,17 @@ testRule({
 
 	accept: [
 		{
-			code: 'a:not(#foo) { color: black; }',
+			code: 'a:not(#foo) {}',
 			description: 'selector within ignored pseudo-class (string input)',
 		},
 		{
-			code: 'a:has(#foo) { color: black; }',
+			code: 'a:has(#foo) {}',
 			description: 'selector within ignored pseudo-class (regex input)',
 		},
 	],
 	reject: [
 		{
-			code: 'a:matches(#foo) { color: black; }',
+			code: 'a:matches(#foo) {}',
 			description: 'selector within non-ignored pseudo class',
 			message: messages.expected('#foo', 0),
 			line: 1,

--- a/lib/rules/selector-max-id/__tests__/index.js
+++ b/lib/rules/selector-max-id/__tests__/index.js
@@ -459,3 +459,28 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: [0, { ignoreContextFunctionalPseudoClasses: [':not', /^:(i|I)s$/] }],
+
+	accept: [
+		{
+			code: 'a:not(#foo) { color: black; }',
+			description: 'selector within ignored pseudo-class (string input)',
+		},
+		{
+			code: 'a:is(#foo) { color: black; }',
+			description: 'selector within ignored pseudo-class (regex input)',
+		},
+	],
+	reject: [
+		{
+			code: 'a:where(#foo) { color: black; }',
+			description: 'selector within non-ignored pseudo class',
+			message: messages.expected('#foo', 0),
+			line: 1,
+			column: 8,
+		},
+	],
+});

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -2,8 +2,10 @@
 
 'use strict';
 
+const _ = require('lodash');
 const isLogicalCombination = require('../../utils/isLogicalCombination');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
+// const optionsMatches = require('../../utils/optionsMatches');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const resolvedNestedSelector = require('postcss-resolve-nested-selector');
@@ -17,16 +19,27 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} ID ${max === 1 ? 'selector' : 'selectors'}`,
 });
 
-function rule(max) {
+function rule(max, options) {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: max,
-			possible: [
-				function (max) {
-					return typeof max === 'number' && max >= 0;
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: max,
+				possible: [
+					function (max) {
+						return typeof max === 'number' && max >= 0;
+					},
+				],
+			},
+			{
+				actual: options,
+				possible: {
+					ignoreContextFunctionalPseudoClasses: [_.isString, _.isRegExp],
 				},
-			],
-		});
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
 			return;
@@ -34,8 +47,13 @@ function rule(max) {
 
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
-				// Only traverse inside actual selectors and logical combinations
-				if (childNode.type === 'selector' || isLogicalCombination(childNode)) {
+				// Only traverse inside actual selectors and logical combinations that are not part of ignored functional pseudo-classes
+				if (
+					childNode.type === 'selector' ||
+					isLogicalCombination(childNode)
+					// (isLogicalCombination(childNode) &&
+					// 	!isIgnoredContextFunctionalPseudoClass(childNode, options))
+				) {
 					checkSelector(childNode, ruleNode);
 				}
 
@@ -52,6 +70,13 @@ function rule(max) {
 				});
 			}
 		}
+
+		// function isIgnoredContextFunctionalPseudoClass(node, options) {
+		// 	return (
+		// 		node.type === 'pseudo' &&
+		// 		optionsMatches(options, 'ignoreContextFunctionalPseudoClasses', node.value)
+		// 	);
+		// }
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -5,7 +5,7 @@
 const _ = require('lodash');
 const isLogicalCombination = require('../../utils/isLogicalCombination');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
-// const optionsMatches = require('../../utils/optionsMatches');
+const optionsMatches = require('../../utils/optionsMatches');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const resolvedNestedSelector = require('postcss-resolve-nested-selector');
@@ -50,9 +50,8 @@ function rule(max, options) {
 				// Only traverse inside actual selectors and logical combinations that are not part of ignored functional pseudo-classes
 				if (
 					childNode.type === 'selector' ||
-					isLogicalCombination(childNode)
-					// (isLogicalCombination(childNode) &&
-					// 	!isIgnoredContextFunctionalPseudoClass(childNode, options))
+					(isLogicalCombination(childNode) &&
+						!isIgnoredContextFunctionalPseudoClass(childNode, options))
 				) {
 					checkSelector(childNode, ruleNode);
 				}
@@ -71,12 +70,12 @@ function rule(max, options) {
 			}
 		}
 
-		// function isIgnoredContextFunctionalPseudoClass(node, options) {
-		// 	return (
-		// 		node.type === 'pseudo' &&
-		// 		optionsMatches(options, 'ignoreContextFunctionalPseudoClasses', node.value)
-		// 	);
-		// }
+		function isIgnoredContextFunctionalPseudoClass(node, options) {
+			return (
+				node.type === 'pseudo' &&
+				optionsMatches(options, 'ignoreContextFunctionalPseudoClasses', node.value)
+			);
+		}
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {


### PR DESCRIPTION
Hi there, 

This PR implements an option requested in #4619, the verbose `ignoreContextFunctionalPseudoClasses` to `selector-max-id`. In addition to modifying the rule, it also introduces a set of simple test cases (only testing on `:not`, `:has`, and `:matches` currently), and adds documentation to explain the usage of the rule.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4619.

> Is there anything in the PR that needs further explanation?

As mentioned in the issue discussion, it looks like `stylelint/lib/utils/isLogicalCombination.js` needs to be updated to support more pseudo-classes, such as `:is` and `:where` (and possibly `:nth-child`); will follow up on this!
