### PR TITLE
A small refactor

### DIFF
--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -5,16 +5,19 @@ const LazyResult = require('postcss/lib/lazy-result');
 const postcss = require('postcss');
 const syntaxes = require('./syntaxes');
 
+/** @typedef {import('postcss').Result} Result */
+/** @typedef {import('postcss').Syntax} Syntax */
+/** @typedef {import('stylelint').CustomSyntax} CustomSyntax */
+/** @typedef {import('stylelint').GetPostcssOptions} GetPostcssOptions */
 /** @typedef {import('stylelint').StylelintInternalApi} StylelintInternalApi */
-/** @typedef {{parse: any, stringify: any}} Syntax */
 
 const postcssProcessor = postcss();
 
 /**
  * @param {StylelintInternalApi} stylelint
- * @param {import('stylelint').GetPostcssOptions} options
+ * @param {GetPostcssOptions} options
  *
- * @returns {Promise<import('postcss').Result>}
+ * @returns {Promise<Result>}
  */
 module.exports = function (stylelint, options = {}) {
 	const cached = options.filePath ? stylelint._postcssResultCache.get(options.filePath) : undefined;
@@ -40,25 +43,7 @@ module.exports = function (stylelint, options = {}) {
 			let syntax = null;
 
 			if (stylelint._options.customSyntax) {
-				try {
-					// TODO TYPES determine which type has customSyntax
-					const customSyntax = /** @type {any} */ require(stylelint._options.customSyntax);
-
-					/*
-					 * PostCSS allows for syntaxes that only contain a parser, however,
-					 * it then expects the syntax to be set as the `parser` option rather than `syntax`.
-					 */
-					if (!customSyntax.parse) {
-						syntax = {
-							parse: customSyntax,
-							stringify: postcss.stringify,
-						};
-					} else {
-						syntax = customSyntax;
-					}
-				} catch (e) {
-					throw new Error(`Cannot resolve custom syntax module ${stylelint._options.customSyntax}`);
-				}
+				syntax = getCustomSyntax(stylelint._options.customSyntax);
 			} else if (stylelint._options.syntax) {
 				if (stylelint._options.syntax === 'css') {
 					syntax = cssSyntax(stylelint);
@@ -124,6 +109,33 @@ module.exports = function (stylelint, options = {}) {
 			return postcssResult;
 		});
 };
+
+/**
+ * @param {CustomSyntax} customSyntax
+ * @returns {Syntax}
+ */
+function getCustomSyntax(customSyntax) {
+	let resolved;
+
+	try {
+		resolved = require(customSyntax);
+	} catch (error) {
+		throw new Error(`Cannot resolve custom syntax module ${customSyntax}`);
+	}
+
+	/*
+	 * PostCSS allows for syntaxes that only contain a parser, however,
+	 * it then expects the syntax to be set as the `parse` option.
+	 */
+	if (!resolved.parse) {
+		resolved = {
+			parse: resolved,
+			stringify: postcss.stringify,
+		};
+	}
+
+	return resolved;
+}
 
 /**
  * @param {string} filePath

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -25,6 +25,7 @@ const writeFileAtomic = require('write-file-atomic');
 /** @typedef {import('stylelint').StylelintStandaloneReturnValue} StylelintStandaloneReturnValue */
 /** @typedef {import('stylelint').StylelintResult} StylelintResult */
 /** @typedef {import('stylelint').Formatter} Formatter */
+/** @typedef {import('stylelint').FormatterIdentifier} FormatterIdentifier */
 
 /**
  * @param {StylelintStandaloneOptions} options
@@ -79,20 +80,10 @@ module.exports = function (options) {
 	/** @type {Formatter} */
 	let formatterFunction;
 
-	if (typeof formatter === 'string') {
-		formatterFunction = formatters[formatter];
-
-		if (formatterFunction === undefined) {
-			return Promise.reject(
-				new Error(
-					`You must use a valid formatter option: ${getFormatterOptionsText()} or a function`,
-				),
-			);
-		}
-	} else if (typeof formatter === 'function') {
-		formatterFunction = formatter;
-	} else {
-		formatterFunction = formatters.json;
+	try {
+		formatterFunction = getFormatterFunction(formatter);
+	} catch (error) {
+		return Promise.reject(error);
 	}
 
 	const stylelint = createStylelint({
@@ -287,6 +278,31 @@ module.exports = function (options) {
 			return rtn;
 		});
 };
+
+/**
+ * @param {FormatterIdentifier | undefined} selected
+ * @returns {Formatter}
+ */
+function getFormatterFunction(selected) {
+	/** @type {Formatter} */
+	let formatterFunction;
+
+	if (typeof selected === 'string') {
+		formatterFunction = formatters[selected];
+
+		if (formatterFunction === undefined) {
+			throw new Error(
+				`You must use a valid formatter option: ${getFormatterOptionsText()} or a function`,
+			);
+		}
+	} else if (typeof selected === 'function') {
+		formatterFunction = selected;
+	} else {
+		formatterFunction = formatters.json;
+	}
+
+	return formatterFunction;
+}
 
 /**
  * @param {import('stylelint').StylelintInternalApi} stylelint

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -90,6 +90,8 @@ declare module 'stylelint' {
 
 	export type FormatterIdentifier = 'compact' | 'json' | 'string' | 'unix' | 'verbose' | Formatter;
 
+	export type CustomSyntax = string;
+
 	export type StylelintOptions = {
 		config?: StylelintConfig;
 		configFile?: string;
@@ -100,7 +102,7 @@ declare module 'stylelint' {
 		reportInvalidScopeDisables?: boolean;
 		reportNeedlessDisables?: boolean;
 		syntax?: string;
-		customSyntax?: string;
+		customSyntax?: CustomSyntax;
 		fix?: boolean;
 	};
 
@@ -110,7 +112,7 @@ declare module 'stylelint' {
 		filePath?: string;
 		codeProcessors?: Array<Function>;
 		syntax?: string;
-		customSyntax?: string;
+		customSyntax?: CustomSyntax;
 	};
 
 	export type GetLintSourceOptions = GetPostcssOptions & { existingPostcssResult?: Result };
@@ -158,7 +160,7 @@ declare module 'stylelint' {
 		reportInvalidScopeDisables?: boolean;
 		maxWarnings?: number;
 		syntax?: string;
-		customSyntax?: string;
+		customSyntax?: CustomSyntax;
 		formatter?: FormatterIdentifier;
 		disableDefaultIgnores?: boolean;
 		fix?: boolean;


### PR DESCRIPTION
Another refactor. This moves a couple of chunks of functionality out to separate functions. It's not particularly essential, but (imo) makes it easier to understand what's happening in each file.

This should be the last bit of refactoring from PR #4796.  The remaining follow-on PRs should result in new (or changed) functionality instead of rearranging internals.

> Which issue, if any, is this issue related to?

Related to issue #3935

> Is there anything in the PR that needs further explanation?

This change is a small part of the changes in PR #4796