### PR TITLE
Fix TypeError for custom properties fallback in length-zero-no-unit

### DIFF
--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -238,7 +238,7 @@ testRule({
 			description: 'ignore line-height in font declaration',
 		},
 		{
-			code: 'a { font: var(--foo, normal normal 400 16px/0 cursive); }',
+			code: 'a { font: var(--foo, normal normal 400 16px/0px cursive); }',
 			description: 'ignore line-height in font declaration within var function',
 		},
 		{

--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -238,6 +238,10 @@ testRule({
 			description: 'ignore line-height in font declaration',
 		},
 		{
+			code: 'a { font: var(--foo, normal normal 400 16px/0 cursive); }',
+			description: 'ignore line-height in font declaration within var function',
+		},
+		{
 			code: 'a { font: normal normal 400 1.2em cursive; }',
 			description: 'do not fail if no line-height in font declaration',
 		},
@@ -529,6 +533,13 @@ testRule({
 			message: messages.rejected,
 			line: 1,
 			column: 30,
+		},
+		{
+			code: 'a { margin: var(--foo, 0px); }',
+			fixed: 'a { margin: var(--foo, 0); }',
+			message: messages.rejected,
+			line: 1,
+			column: 25,
 		},
 	],
 });

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -43,10 +43,13 @@ function rule(actual, secondary, context) {
 			parsedValue.walk((node, nodeIndex) => {
 				if (decl.prop.toLowerCase() === 'font' && node.type === 'div' && node.value === '/') {
 					const lineHeightNode = parsedValue.nodes[nodeIndex + 1];
-					const lineHeightNodeValue = valueParser.stringify(lineHeightNode);
+					
+					if (lineHeightNode) {
+						const lineHeightNodeValue = valueParser.stringify(lineHeightNode);
 
-					for (let i = 0; i < lineHeightNodeValue.length; i++) {
-						ignorableIndexes[lineHeightNode.sourceIndex + i] = true;
+						for (let i = 0; i < lineHeightNodeValue.length; i++) {
+							ignorableIndexes[lineHeightNode.sourceIndex + i] = true;
+						}
 					}
 
 					return;

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -40,16 +40,13 @@ function rule(actual, secondary, context) {
 			const ignorableIndexes = new Array(stringValue.length).fill(false);
 			const parsedValue = valueParser(stringValue);
 
-			parsedValue.walk((node, nodeIndex) => {
+			parsedValue.walk((node, nodeIndex, nodes) => {
 				if (decl.prop.toLowerCase() === 'font' && node.type === 'div' && node.value === '/') {
-					const lineHeightNode = parsedValue.nodes[nodeIndex + 1];
-					
-					if (lineHeightNode) {
-						const lineHeightNodeValue = valueParser.stringify(lineHeightNode);
+					const lineHeightNode = nodes[nodeIndex + 1];
+					const lineHeightNodeValue = valueParser.stringify(lineHeightNode);
 
-						for (let i = 0; i < lineHeightNodeValue.length; i++) {
-							ignorableIndexes[lineHeightNode.sourceIndex + i] = true;
-						}
+					for (let i = 0; i < lineHeightNodeValue.length; i++) {
+						ignorableIndexes[lineHeightNode.sourceIndex + i] = true;
 					}
 
 					return;


### PR DESCRIPTION
e.g.

```css
font: var(--Funnel-header-font, 600 16px/1.5 var(--font-header));
```

lineHeightNode is undefined, so we just need to check for it.