### PR TITLE
Fix no files matching the pattern error square brackets and dash

### DIFF
--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -184,6 +184,18 @@ module.exports = function (options) {
 		fileCache.destroy();
 	}
 
+	// Escape square brackets
+	fileList = fileList.map((p) => {
+		let path = p;
+
+		if (path.match(/[[\]]/g)) {
+			path = path.split('[').join('\\[');
+			path = path.split(']').join('\\]');
+		}
+
+		return path;
+	});
+
 	return globby(fileList, globbyOptions)
 		.then((filePaths) => {
 			// The ignorer filter needs to check paths relative to cwd


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- #4855 
- https://github.com/sindresorhus/globby/issues/81

> Is there anything in the PR that needs further explanation?

[The related issue](https://github.com/sindresorhus/globby/issues/81) has already been opened on repository of `globby`, but it's been passed few years since the issue was opened. So everybody is solving themselves as I do with this PR.

It would be better if I could change `globby` to some other packages like `fast-glob` or `node-glub` but I couldn't because I worried that i can't handle whole side-effects of that change.

I just focused the issue that i've met.
Any suggestions will be appreciated.