### PR TITLE
Add type definition for `postcss-syntax`

### DIFF
--- a/types/postcss-syntax/index.d.ts
+++ b/types/postcss-syntax/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'postcss-syntax' {
+	import { Syntax } from 'postcss';
+
+	function syntax(config: { [k: string]: Syntax }): Syntax;
+
+	export = syntax;
+}

--- a/types/postcss/index.d.ts
+++ b/types/postcss/index.d.ts
@@ -27,12 +27,6 @@ declare module 'postcss/lib/lazy-result' {
 	export = LazyResultImpl;
 }
 
-declare module 'postcss-syntax' {
-	var result: any; // TODO TYPES
-
-	export = result;
-}
-
 declare module 'postcss/lib/result' {
 	import { Result } from 'postcss';
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

This is a part of #4399.

> Is there anything in the PR that needs further explanation?

This change adds a type definition for the `postcss-syntax` package.
To find the definition easily, this extracts a new file from the `types/postcss/index.d.ts` file.

Note that there is no `@types/postcss-syntax` package.
(see <https://www.npmjs.com/search?q=%40types%2Fpostcss-syntax>)

Here is a main source of the package:
https://github.com/gucong3000/postcss-syntax/blob/v0.36.2/index.js

Also, `postcss-syntax` is used only in `lib/getPostcssResult.js`:

https://github.com/stylelint/stylelint/blob/cecacb9d4fe3b5bae5f264efa6e60c414a0f4946/lib/getPostcssResult.js#L64-L75
