### PR TITLE
Install `@types/table` type definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -996,6 +996,12 @@
       "integrity": "sha512-PlLI3u2hocS4nbzd9WUzQn/EyFl+NifbssU9QV40XzWOpwf5R7cDod2dmTUKYN7awE9jMrhy9FCO904ZYwaBDw==",
       "dev": true
     },
+    "@types/table": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/table/-/table-5.0.0.tgz",
+      "integrity": "sha512-fQLtGLZXor264zUPWI95WNDsZ3QV43/c0lJpR/h1hhLJumXRmHNsrvBfEzW2YMhb0EWCsn4U6h82IgwsajAuTA==",
+      "dev": true
+    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "@types/postcss-safe-parser": "^4.0.0",
     "@types/style-search": "^0.1.1",
     "@types/svg-tags": "^1.0.0",
+    "@types/table": "^5.0.0",
     "@types/write-file-atomic": "^3.0.1",
     "benchmark": "^2.1.4",
     "common-tags": "^1.8.0",

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -6,4 +6,3 @@ declare module 'postcss-less';
 declare module 'postcss-sass';
 declare module 'postcss-scss';
 declare module 'sugarss';
-declare module 'table';


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

This is a part of #4399.

> Is there anything in the PR that needs further explanation?

This change installs the type definition `@types/table` of the `table` package.
The package is used in `lib/formatters/stringFormatter.js`:

https://github.com/stylelint/stylelint/blob/cecacb9d4fe3b5bae5f264efa6e60c414a0f4946/lib/formatters/stringFormatter.js#L8

See also:
- https://www.npmjs.com/package/table
- https://www.npmjs.com/package/@types/table
