### PR TITLE
Fix false positives for trailing combinator in selector-combinator-space-after

### DIFF
--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -554,6 +554,10 @@ testRule({
 			code: 'a { > /*comment*/a, > /*comment*/.b{} }',
 			description: 'scss nesting and comment',
 		},
+		{
+			code: 'a ~, b {}',
+			description: 'scss trailing combinator',
+		},
 	],
 
 	reject: [
@@ -595,6 +599,10 @@ testRule({
 		{
 			code: 'a { >/*comment*/a, >/*comment*/.b {} }',
 			description: 'scss nesting and comment',
+		},
+		{
+			code: 'a ~, b {}',
+			description: 'scss trailing combinator',
 		},
 	],
 

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -559,34 +559,6 @@ testRule({
 			description: 'scss trailing combinator',
 		},
 	],
-
-	reject: [
-		{
-			code: 'a { >/*comment*/a {} }',
-			fixed: 'a { > /*comment*/a {} }',
-			description: 'scss nesting and comment',
-			message: messages.expectedAfter('>'),
-			line: 1,
-			column: 5,
-		},
-		{
-			code: 'a { >/*comment*/a, >/*comment*/.b{} }',
-			fixed: 'a { > /*comment*/a, > /*comment*/.b{} }',
-			description: 'scss nesting, comment and comma',
-			warnings: [
-				{
-					message: messages.expectedAfter('>'),
-					line: 1,
-					column: 5,
-				},
-				{
-					message: messages.expectedAfter('>'),
-					line: 1,
-					column: 20,
-				},
-			],
-		},
-	],
 });
 
 testRule({
@@ -603,34 +575,6 @@ testRule({
 		{
 			code: 'a ~, b {}',
 			description: 'scss trailing combinator',
-		},
-	],
-
-	reject: [
-		{
-			code: 'a { > /*comment*/a {} }',
-			fixed: 'a { >/*comment*/a {} }',
-			description: 'scss nesting and comment',
-			message: messages.rejectedAfter('>'),
-			line: 1,
-			column: 5,
-		},
-		{
-			code: 'a { > /*comment*/a, > /*comment*/.b {} }',
-			fixed: 'a { >/*comment*/a, >/*comment*/.b {} }',
-			description: 'scss nesting, comment and comma',
-			warnings: [
-				{
-					message: messages.rejectedAfter('>'),
-					line: 1,
-					column: 5,
-				},
-				{
-					message: messages.rejectedAfter('>'),
-					line: 1,
-					column: 21,
-				},
-			],
 		},
 	],
 });

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const isStandardSyntaxCombinator = require('../utils/isStandardSyntaxCombinator');
 const isStandardSyntaxRule = require('../utils/isStandardSyntaxRule');
 const parseSelector = require('../utils/parseSelector');
 const report = require('../utils/report');
@@ -19,6 +20,11 @@ module.exports = function (opts) {
 
 		const fixedSelector = parseSelector(selector, opts.result, rule, (selectorTree) => {
 			selectorTree.walkCombinators((node) => {
+				// Ignore non-standard combinators
+				if (!isStandardSyntaxCombinator(node)) {
+					return;
+				}
+
 				// Ignore spaced descendant combinator
 				if (/\s/.test(node.value)) {
 					return;

--- a/lib/utils/__tests__/isStandardSyntaxCombinator.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxCombinator.test.js
@@ -60,6 +60,26 @@ describe('isStandardSyntaxCombinator', () => {
 			expect(isStandardSyntaxCombinator(func)).toBeFalsy();
 		});
 	});
+	it('last node is combinator', () => {
+		rules('a ~, {}', (func) => {
+			expect(isStandardSyntaxCombinator(func)).toBeFalsy();
+		});
+	});
+	it('first node is combinator', () => {
+		rules('~ b {}', (func) => {
+			expect(isStandardSyntaxCombinator(func)).toBeFalsy();
+		});
+	});
+	it('last node (in first container) is combinator', () => {
+		rules('a ~, b {}', (func) => {
+			expect(isStandardSyntaxCombinator(func)).toBeFalsy();
+		});
+	});
+	it('first node (in second container) is combinator', () => {
+		rules('a, ~ b {}', (func) => {
+			expect(isStandardSyntaxCombinator(func)).toBeFalsy();
+		});
+	});
 });
 
 function rules(css, cb) {

--- a/lib/utils/isStandardSyntaxCombinator.js
+++ b/lib/utils/isStandardSyntaxCombinator.js
@@ -7,6 +7,28 @@
  * @return {boolean} If `true`, the combinator is standard
  */
 module.exports = function (node) {
+	// if it's not a combinator, then it's not a standard combinator
+	if (node.type !== 'combinator') {
+		return false;
+	}
+
 	// Ignore reference combinators like `/deep/`
-	return node.type === 'combinator' && !node.value.startsWith('/') && !node.value.endsWith('/');
+	if (node.value.startsWith('/') || node.value.endsWith('/')) {
+		return false;
+	}
+
+	// ignore the combinators that are the first or last node in their container
+	if (node.parent !== undefined && node.parent !== null && node.value !== '>') {
+		let parent = node.parent;
+
+		if (node === parent.first) {
+			return false;
+		}
+
+		if (node === parent.last) {
+			return false;
+		}
+	}
+
+	return true;
 };

--- a/lib/utils/isStandardSyntaxCombinator.js
+++ b/lib/utils/isStandardSyntaxCombinator.js
@@ -18,7 +18,7 @@ module.exports = function (node) {
 	}
 
 	// ignore the combinators that are the first or last node in their container
-	if (node.parent !== undefined && node.parent !== null && node.value !== '>') {
+	if (node.parent !== undefined && node.parent !== null) {
 		let parent = node.parent;
 
 		if (node === parent.first) {


### PR DESCRIPTION
Hey there!

This is a PR that tries to fix the false positive brought up in #4584, namely that a trailing combinator (such as the general sibling combinator, `~`) is not properly handled by `selector-combinator-space-after`.

After some discussion in #4849, this PR implements a fix by updating the `isStandardSyntaxCombinator` rule util to ignore certain combinators that are the first or last combinator in their container. Since combinators should *generally* be between two different selectors, we can rule out combinators that... aren't. Then, we use this new utility in `selectorCombinatorSpaceChecker`, which then fixes the false positive in `selector-combinator-space-after`.

I also added some test to verify our functionality, for `isStandardSyntaxCombinator` and for the case mentioned in #4584 in `selector-combinator-space-after`. 

> Which issue, if any, is this issue related to?

Closes #4584.

> Is there anything in the PR that needs further explanation?

First, a quick question about the `>` nesting selector: I had to ignore this, because the following SCSS is standard:

```scss
a {
  > b {
     ...
  }
}

```

Not sure if this is the right approach, or if I should instead update the existing tests. Any thoughts on this would be appreciated.

Also, a meta-note: this is a fresh version of the PR #4849, which had some issues after merging `master` back into the forked repository. Copied over the code to a fresh branch from `master`.
