### PR TITLE
Use official `postcss-scss` types

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -4,5 +4,4 @@ declare module 'import-lazy';
 declare module 'postcss-html';
 declare module 'postcss-less';
 declare module 'postcss-sass';
-declare module 'postcss-scss';
 declare module 'sugarss';


### PR DESCRIPTION
The `postcss-scss` package has own types already.
https://github.com/postcss/postcss-scss/blob/2.1.1/lib/scss-syntax.d.ts

> Which issue, if any, is this issue related to?

Related to #4496

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
