### PR TITLE
Adds ignoreSelectors:[] to max-nesting-depth

### DIFF
--- a/lib/rules/max-nesting-depth/__tests__/index.js
+++ b/lib/rules/max-nesting-depth/__tests__/index.js
@@ -219,6 +219,35 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [0, { ignoreSelectors: ['a', '.b', '/\\[.*?\\]/'] }],
+	syntax: 'scss',
+
+	accept: [
+		{
+			code: '.foo { a { }}',
+			description: 'Nested, matches ignored selector string',
+		},
+		{
+			code: '.foo { &[disabled] { }}',
+			description: 'Nested, matches ignored selector regex',
+		},
+		{
+			code: '.foo { .b { .c { }}}',
+			description: 'Doubly-nested, matches ignored selector',
+		},
+	],
+
+	reject: [
+		{
+			code: '.foo { &.bar { }}',
+			message: messages.expected(0),
+			description: 'Non-ignored nested selector',
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: [1],
 	skipBasicChecks: true,
 	syntax: 'scss',

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -35,6 +35,7 @@ function rule(max, options) {
 				possible: {
 					ignore: ['blockless-at-rules', 'pseudo-classes'],
 					ignoreAtRules: [_.isString, _.isRegExp],
+					ignoreSelectors: [_.isString, _.isRegExp],
 				},
 			},
 		);
@@ -72,6 +73,10 @@ function rule(max, options) {
 		const parent = node.parent;
 
 		if (isIgnoreAtRule(parent)) {
+			return 0;
+		}
+
+		if (optionsMatches(options, 'ignoreSelectors', node.selector)) {
 			return 0;
 		}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

Hey there! This is a (hopefully simple) PR that addresses the option requested in #4805, namely adding `ignoreSelectors: []` to the `max-nesting-depth` rule. As suggested, I made the inputs of a string/regex type, and added a check as we traverse up the tree - very similar to the `ignoreAtRules` option.

I wrote a handful of simple test cases, but I'm not sure if they're enough - please let me know if I've missed anything (especially some edge cases)!

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4805.

> Is there anything in the PR that needs further explanation?

Seems good on my end! Let me know if I should add more unit tests, or if there are edge cases I haven't considered.
