### PR TITLE
Support multi-line disable descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project are documented in this file.
 - Fixed: inconsistent trailing newlines in CLI error output ([#4876](https://github.com/stylelint/stylelint/pull/4876)).
 - Fixed: `selector-max-*` (except `selector-max-type`) false negatives for `where`, `is`, `nth-child` and `nth-last-child` ([#4842](https://github.com/stylelint/stylelint/pull/4842)).
 - Fixed: `length-zero-no-unit` TypeError for custom properties fallback ([#4860](https://github.com/stylelint/stylelint/pull/4860)).
+- Fixed: false negatives for `where`, `is`, `nth-child` and `nth-last-child` in `selector-max-*` rules (except selector-max-type) ([#4842](https://github.com/stylelint/stylelint/pull/4842)).
+- Fixed: support for multi-line disable descriptions ([#4895](https://github.com/stylelint/stylelint/pull/4895)).
 
 ## 13.6.1
 

--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -749,9 +749,9 @@ it('SCSS // line-disabling comment (with description)', () => {
 
 it('SCSS // disable next-line comment (with multi-line description)', () => {
 	const scssSource = `a {
-		// stylelint-disable-next-line declaration-no-important
-		// --
-		// Long-winded description
+    // stylelint-disable-next-line declaration-no-important
+    // --
+    // Long-winded description
     color: pink !important;
   }`;
 
@@ -798,9 +798,9 @@ it('Less // line-disabling comment (with description)', () => {
 
 it('Less // disable next-line comment (with multi-line description)', () => {
 	const lessSource = `a {
-		// stylelint-disable-next-line declaration-no-important
-		// --
-		// Long-winded description
+    // stylelint-disable-next-line declaration-no-important
+    // --
+    // Long-winded description
     color: pink !important;
   }`;
 

--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -747,6 +747,32 @@ it('SCSS // line-disabling comment (with description)', () => {
 		});
 });
 
+it('SCSS // disable next-line comment (with multi-line description)', () => {
+	const scssSource = `a {
+		// stylelint-disable-next-line declaration-no-important
+		// --
+		// Long-winded description
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 5,
+						end: 5,
+						strictStart: true,
+						strictEnd: true,
+					},
+				],
+			});
+		});
+});
+
 it('Less // line-disabling comment (with description)', () => {
 	const lessSource = `a {
     color: pink !important; // stylelint-disable-line declaration-no-important -- Description
@@ -762,6 +788,32 @@ it('Less // line-disabling comment (with description)', () => {
 					{
 						start: 2,
 						end: 2,
+						strictStart: true,
+						strictEnd: true,
+					},
+				],
+			});
+		});
+});
+
+it('Less // disable next-line comment (with multi-line description)', () => {
+	const lessSource = `a {
+		// stylelint-disable-next-line declaration-no-important
+		// --
+		// Long-winded description
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(lessSource, { syntax: less, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 5,
+						end: 5,
 						strictStart: true,
 						strictEnd: true,
 					},

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -9,7 +9,7 @@ const disableLineCommand = `${COMMAND_PREFIX}disable-line`;
 const disableNextLineCommand = `${COMMAND_PREFIX}disable-next-line`;
 const ALL_RULES = 'all';
 
-/** @typedef {import('postcss').Comment} PostcssComment */
+/** @typedef {import('postcss/lib/comment')} PostcssComment */
 /** @typedef {import('postcss').Root} PostcssRoot */
 /** @typedef {import('stylelint').PostcssResult} PostcssResult */
 /** @typedef {import('stylelint').DisabledRangeObject} DisabledRangeObject */
@@ -53,7 +53,41 @@ module.exports = function (root, result) {
 	};
 
 	result.stylelint.disabledRanges = disabledRanges;
-	root.walkComments(checkComment);
+
+	// Work around postcss/postcss-scss#109 by merging adjacent `//` comments
+	// into a single node before passing to `checkComment`.
+
+	/** @type {PostcssComment?} */
+	let inlineEnd;
+
+	root.walkComments((/** @type {PostcssComment} */ comment) => {
+		if (inlineEnd) {
+			// Ignore comments that were already processed by grouping with
+			if (inlineEnd === comment) inlineEnd = null;
+		} else if (comment.inline || comment.raws.inline) {
+			const fullComment = comment.clone();
+			let next = comment.next();
+
+			while (next && next.type === 'comment') {
+				/** @type {PostcssComment} */
+				const current = next;
+
+				if (!current.inline && !current.raws.inline) break;
+
+				fullComment.text += `\n${current.text}`;
+
+				if (fullComment.source && current.source) {
+					fullComment.source.end = current.source.end;
+				}
+
+				inlineEnd = current;
+				next = current.next();
+			}
+			checkComment(fullComment);
+		} else {
+			checkComment(comment);
+		}
+	});
 
 	return result;
 
@@ -74,8 +108,8 @@ module.exports = function (root, result) {
 	 * @param {PostcssComment} comment
 	 */
 	function processDisableNextLineCommand(comment) {
-		if (comment.source && comment.source.start) {
-			const line = comment.source.start.line;
+		if (comment.source && comment.source.end) {
+			const line = comment.source.end.line;
 
 			getCommandRules(disableNextLineCommand, comment.text).forEach((ruleName) => {
 				disableLine(line + 1, ruleName, comment);

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -62,9 +62,9 @@ module.exports = function (root, result) {
 
 	root.walkComments((/** @type {PostcssComment} */ comment) => {
 		if (inlineEnd) {
-			// Ignore comments that were already processed by grouping with
+			// Ignore comments already processed by grouping with a previous one.
 			if (inlineEnd === comment) inlineEnd = null;
-		} else if (comment.inline || comment.raws.inline) {
+		} else if (isInlineComment(comment)) {
 			const fullComment = comment.clone();
 			let next = comment.next();
 
@@ -72,7 +72,7 @@ module.exports = function (root, result) {
 				/** @type {PostcssComment} */
 				const current = next;
 
-				if (!current.inline && !current.raws.inline) break;
+				if (!isInlineComment(current)) break;
 
 				fullComment.text += `\n${current.text}`;
 
@@ -90,6 +90,15 @@ module.exports = function (root, result) {
 	});
 
 	return result;
+
+	/**
+	 * @param {PostcssComment} comment
+	 */
+	function isInlineComment(comment) {
+		// We check both here because the Sass parser uses `raws.inline` to indicate
+		// inline comments, while the Less parser uses `inline`.
+		return comment.inline || comment.raws.inline;
+	}
 
 	/**
 	 * @param {PostcssComment} comment

--- a/types/postcss/index.d.ts
+++ b/types/postcss/index.d.ts
@@ -1,3 +1,20 @@
+declare module 'postcss/lib/comment' {
+	import { Comment, NodeRaws } from 'postcss';
+
+	interface NodeRawsExt extends NodeRaws {
+		// Used by the SCSS parser to indicate `//` comments.
+		inline?: boolean;
+	}
+
+	interface CommentExt extends Comment {
+		// Used by the Less parser to indicate `//` comments.
+		inline?: boolean;
+		raws: NodeRawsExt;
+	}
+
+	export = CommentExt;
+}
+
 declare module 'postcss/lib/lazy-result' {
 	import {
 		LazyResult,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #4886. 

> Is there anything in the PR that needs further explanation?

This works around postcss/postcss-scss#109 by combining adjacent `//` comments into a single node before passing it to `checkComment`.