### PR TITLE
Add a reportDisables secondary option

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -57,7 +57,7 @@ And the second argument (`returnValue`) is an object (type `StylelintStandaloneR
       "ranges": [
         {
           "start": 10,
-          "unusedRule": "indentation"
+          "rule": "indentation"
         }
       ]
     }
@@ -69,7 +69,7 @@ And the second argument (`returnValue`) is an object (type `StylelintStandaloneR
       "ranges": [
         {
           "start": 1,
-          "unusedRule": "color-named"
+          "rule": "color-named"
         }
       ]
     }

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -135,6 +135,26 @@ For example:
 
 Reporters may use these severity levels to display violations or exit the process differently.
 
+### `reportDisables`
+
+You can set the `reportDisables` secondary option to report any disable comments for this rule, effectively disallowing authors to opt out of it.
+
+For example:
+
+```json
+{
+  "rules": {
+    "indentation": [
+      2,
+      {
+        "except": ["value"],
+        "reportDisables": true
+      }
+    ]
+  }
+}
+```
+
 ## `defaultSeverity`
 
 You can set the default severity level for all rules that do not have a severity specified in their secondary options. For example, you can set the default severity to `"warning"`:

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -242,6 +242,22 @@ describe('CLI', () => {
 		);
 	});
 
+	it('reports disallowed disables', async () => {
+		await cli([
+			'--config',
+			replaceBackslashes(path.join(fixturesPath, 'config-block-no-empty-report-disables.json')),
+			replaceBackslashes(path.join(fixturesPath, 'empty-block-with-relevant-disable.css')),
+		]);
+
+		expect(process.exitCode).toBe(2);
+
+		expect(process.stdout.write).toHaveBeenCalledTimes(1);
+		expect(process.stdout.write).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining('unused rule: block-no-empty'),
+		);
+	});
+
 	it('--stdin', async () => {
 		await cli(['--stdin', '--config', `${fixturesPath}/config-no-empty-source.json`]);
 

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -234,7 +234,7 @@ describe('CLI', () => {
 		expect(process.stdout.write).toHaveBeenCalledTimes(2);
 		expect(process.stdout.write).toHaveBeenNthCalledWith(
 			1,
-			expect.stringContaining('unused rule: color-named'),
+			expect.stringContaining('needless disable: color-named'),
 		);
 		expect(process.stdout.write).toHaveBeenNthCalledWith(
 			2,
@@ -254,7 +254,7 @@ describe('CLI', () => {
 		expect(process.stdout.write).toHaveBeenCalledTimes(1);
 		expect(process.stdout.write).toHaveBeenNthCalledWith(
 			1,
-			expect.stringContaining('unused rule: block-no-empty'),
+			expect.stringContaining('forbidden disable: block-no-empty'),
 		);
 	});
 

--- a/lib/__tests__/fixtures/config-block-no-empty-report-disables.json
+++ b/lib/__tests__/fixtures/config-block-no-empty-report-disables.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"block-no-empty": [true, { "reportDisables": true }]
+	}
+}

--- a/lib/__tests__/fixtures/empty-block-with-relevant-disable.css
+++ b/lib/__tests__/fixtures/empty-block-with-relevant-disable.css
@@ -1,0 +1,2 @@
+/* stylelint-disable block-no-empty */
+a {}

--- a/lib/__tests__/invalidScopeDisables.test.js
+++ b/lib/__tests__/invalidScopeDisables.test.js
@@ -40,8 +40,8 @@ it('invalidScopeDisables simple case', () => {
 		expect(report).toHaveLength(1);
 		expect(report[0].ranges).toHaveLength(2);
 		expect(report[0].ranges).toEqual([
-			{ end: 3, start: 1, unusedRule: 'block-no-empty' },
-			{ end: 5, start: 5, unusedRule: 'block-no-empty' },
+			{ end: 3, start: 1, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+			{ end: 5, start: 5, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
 		]);
 	});
 });
@@ -65,11 +65,11 @@ it('invalidScopeDisables complex case', () => {
 		expect(invalidScopeDisables(linted.results, config)).toEqual([
 			{
 				source: source('disabled-ranges-1.css'),
-				ranges: [{ start: 1, end: 3, unusedRule: 'color-named' }],
+				ranges: [{ start: 1, end: 3, rule: 'color-named', unusedRule: 'color-named' }],
 			},
 			{
 				source: source('disabled-ranges-2.css'),
-				ranges: [{ start: 5, end: 5, unusedRule: 'color-named' }],
+				ranges: [{ start: 5, end: 5, rule: 'color-named', unusedRule: 'color-named' }],
 			},
 		]);
 	});
@@ -91,7 +91,7 @@ it('invalidScopeDisables ignored case', () => {
 		expect(invalidScopeDisables(linted.results, config)).toEqual([
 			{
 				source: source('disabled-ranges-1.css'),
-				ranges: [{ start: 5, end: 7, unusedRule: 'block-no-empty' }],
+				ranges: [{ start: 5, end: 7, rule: 'block-no-empty', unusedRule: 'block-no-empty' }],
 			},
 		]);
 	});
@@ -119,6 +119,7 @@ it('invalidScopeDisables for config file', () => {
 			{
 				end: undefined,
 				start: 4,
+				rule: 'foo',
 				unusedRule: 'foo',
 			},
 		]);

--- a/lib/__tests__/needlessDisables.test.js
+++ b/lib/__tests__/needlessDisables.test.js
@@ -42,8 +42,8 @@ it('needlessDisables simple case', () => {
 
 		expect(report).toHaveLength(1);
 		expect(report[0].ranges).toEqual([
-			{ start: 7, end: 9, unusedRule: 'all' },
-			{ start: 11, end: 11, unusedRule: 'block-no-empty' },
+			{ start: 7, end: 9, rule: 'all', unusedRule: 'all' },
+			{ start: 11, end: 11, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
 		]);
 	});
 });
@@ -70,17 +70,17 @@ it('needlessDisables complex case', () => {
 			{
 				source: source('disabled-ranges-1.css'),
 				ranges: [
-					{ start: 1, end: 3, unusedRule: 'color-named' },
-					{ start: 5, end: 7, unusedRule: 'block-no-empty' },
-					{ start: 10, end: 10, unusedRule: 'block-no-empty' },
+					{ start: 1, end: 3, rule: 'color-named', unusedRule: 'color-named' },
+					{ start: 5, end: 7, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+					{ start: 10, end: 10, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
 				],
 			},
 			{
 				source: source('disabled-ranges-2.css'),
 				ranges: [
-					{ start: 5, end: 5, unusedRule: 'color-named' },
-					{ start: 6, end: 6, unusedRule: 'block-no-empty' },
-					{ start: 8, end: 10, unusedRule: 'block-no-empty' },
+					{ start: 5, end: 5, rule: 'color-named', unusedRule: 'color-named' },
+					{ start: 6, end: 6, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+					{ start: 8, end: 10, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
 				],
 			},
 		]);
@@ -104,9 +104,9 @@ it('needlessDisables ignored case', () => {
 			{
 				source: source('disabled-ranges-1.css'),
 				ranges: [
-					{ start: 1, end: 3, unusedRule: 'color-named' },
-					{ start: 5, end: 7, unusedRule: 'block-no-empty' },
-					{ start: 10, end: 10, unusedRule: 'all' },
+					{ start: 1, end: 3, rule: 'color-named', unusedRule: 'color-named' },
+					{ start: 5, end: 7, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+					{ start: 10, end: 10, rule: 'all', unusedRule: 'all' },
 				],
 			},
 		]);

--- a/lib/__tests__/reportDisables.test.js
+++ b/lib/__tests__/reportDisables.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const standalone = require('../standalone');
+const stripIndent = require('common-tags').stripIndent;
+
+describe('reportDisables', () => {
+	it('reports a disabled comment', () => {
+		const config = {
+			rules: { 'block-no-empty': [true, { reportDisables: true }] },
+		};
+
+		const css = stripIndent`
+    /* stylelint-disable block-no-empty */
+    a {}
+    /* stylelint-enable block-no-empty */
+    a {
+      b {} /* stylelint-disable-line block-no-empty */
+    }
+    `;
+
+		return standalone({ config, code: css }).then((linted) => {
+			const report = linted.reportedDisables;
+
+			expect(report).toHaveLength(1);
+			expect(report[0].ranges).toEqual([
+				{ start: 1, end: 3, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+				{ start: 5, end: 5, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+			]);
+
+			// Although these disables are reported as issues, they're still in effect
+			// so the underlying lint issues are not reported.
+			expect(linted.results[0].warnings).toHaveLength(0);
+		});
+	});
+
+	it('reports an ignored disabled comment', () => {
+		const config = {
+			rules: { 'block-no-empty': [true, { reportDisables: true }] },
+		};
+
+		const css = stripIndent`
+    /* stylelint-disable block-no-empty */
+    a {}
+    /* stylelint-enable block-no-empty */
+    a {
+      b {} /* stylelint-disable-line block-no-empty */
+    }
+    `;
+
+		return standalone({
+			config,
+			code: css,
+			ignoreDisables: true,
+		}).then((linted) => {
+			const report = linted.reportedDisables;
+
+			expect(report).toHaveLength(1);
+			expect(report[0].ranges).toEqual([
+				{ start: 1, end: 3, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+				{ start: 5, end: 5, rule: 'block-no-empty', unusedRule: 'block-no-empty' },
+			]);
+
+			expect(linted.results[0].warnings).toHaveLength(2);
+		});
+	});
+
+	it("doesn't report disables by default", () => {
+		const config = {
+			rules: { 'block-no-empty': [true] },
+		};
+
+		const css = stripIndent`
+    /* stylelint-disable block-no-empty */
+    a {}
+    /* stylelint-enable block-no-empty */
+    a {
+      b {} /* stylelint-disable-line block-no-empty */
+    }
+    `;
+
+		return standalone({ config, code: css }).then((linted) => {
+			const report = linted.reportedDisables;
+
+			expect(report).toHaveLength(0);
+		});
+	});
+
+	// This should be handled by the global `reportUnscopedDisables` option (#2292).
+	it("doesn't report unscoped disables", () => {
+		const config = {
+			rules: { 'block-no-empty': [true, { reportDisables: true }] },
+		};
+
+		const css = stripIndent`
+    a {} /* stylelint-disable-line */
+    `;
+
+		return standalone({ config, code: css }).then((linted) => {
+			const report = linted.reportedDisables;
+
+			expect(report).toHaveLength(1);
+			expect(report[0].ranges).toHaveLength(0);
+		});
+	});
+});

--- a/lib/__tests__/standalone-invalidScopeDisables.test.js
+++ b/lib/__tests__/standalone-invalidScopeDisables.test.js
@@ -25,6 +25,7 @@ it('standalone with input css and `reportInvalidScopeDisables`', () => {
 		expect(invalidScopeDisables[0].ranges).toHaveLength(1);
 		expect(invalidScopeDisables[0].ranges[0]).toEqual({
 			start: 1,
+			rule: 'color-named',
 			unusedRule: 'color-named',
 		});
 	});
@@ -45,6 +46,7 @@ it('standalone with input file(s) and `reportInvalidScopeDisables`', () => {
 		);
 		expect(invalidScopeDisables[0].ranges[0]).toEqual({
 			start: 1,
+			rule: 'color-named',
 			unusedRule: 'color-named',
 		});
 	});

--- a/lib/__tests__/standalone-needlessDisables.test.js
+++ b/lib/__tests__/standalone-needlessDisables.test.js
@@ -27,6 +27,7 @@ it('standalone with input css and `reportNeedlessDisables`', () => {
 		expect(needlessDisables[0].ranges).toHaveLength(1);
 		expect(needlessDisables[0].ranges[0]).toEqual({
 			start: 1,
+			rule: 'color-named',
 			unusedRule: 'color-named',
 		});
 
@@ -130,6 +131,7 @@ it('standalone with input file(s) and `reportNeedlessDisables`', () => {
 		);
 		expect(needlessDisables[0].ranges[0]).toEqual({
 			start: 1,
+			rule: 'color-named',
 			unusedRule: 'color-named',
 		});
 	});

--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.js
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.js
@@ -64,6 +64,7 @@ describe('stylelintignore', () => {
 				expect(data).toEqual({
 					errored: false,
 					output: '[]',
+					reportedDisables: [],
 					results: [],
 				});
 			});
@@ -98,6 +99,7 @@ describe('stylelintignore', () => {
 				expect(data).toEqual({
 					errored: false,
 					output: '[]',
+					reportedDisables: [],
 					results: [],
 				});
 			});
@@ -112,6 +114,7 @@ describe('stylelintignore', () => {
 				expect(data).toEqual({
 					errored: false,
 					output: '[]',
+					reportedDisables: [],
 					results: [],
 				});
 			});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -481,12 +481,18 @@ module.exports = (argv) => {
 				.then((linted) => {
 					const reports = [];
 
-					const report = disableOptionsReportStringFormatter(linted.reportedDisables || []);
+					const report = disableOptionsReportStringFormatter(
+						linted.reportedDisables || [],
+						'forbidden disable',
+					);
 
 					if (report) reports.push(report);
 
 					if (reportNeedlessDisables) {
-						const report = disableOptionsReportStringFormatter(linted.needlessDisables || []);
+						const report = disableOptionsReportStringFormatter(
+							linted.needlessDisables || [],
+							'needless disable',
+						);
 
 						if (report) {
 							reports.push(report);
@@ -494,7 +500,10 @@ module.exports = (argv) => {
 					}
 
 					if (reportInvalidScopeDisables) {
-						const report = disableOptionsReportStringFormatter(linted.invalidScopeDisables || []);
+						const report = disableOptionsReportStringFormatter(
+							linted.invalidScopeDisables || [],
+							'disable with invalid scope',
+						);
 
 						if (report) {
 							reports.push(report);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -481,6 +481,10 @@ module.exports = (argv) => {
 				.then((linted) => {
 					const reports = [];
 
+					const report = disableOptionsReportStringFormatter(linted.reportedDisables || []);
+
+					if (report) reports.push(report);
+
 					if (reportNeedlessDisables) {
 						const report = disableOptionsReportStringFormatter(linted.needlessDisables || []);
 

--- a/lib/formatters/__tests__/disableOptionsReportStringFormatter.test.js
+++ b/lib/formatters/__tests__/disableOptionsReportStringFormatter.test.js
@@ -11,15 +11,15 @@ describe('disableOptionsReportStringFormatter', () => {
 				{
 					source: 'foo',
 					ranges: [
-						{ start: 1, end: 3, unusedRule: 'baz' },
-						{ start: 7, unusedRule: 'all' },
+						{ start: 1, end: 3, rule: 'baz' },
+						{ start: 7, rule: 'all' },
 					],
 				},
 				{
 					source: 'bar',
 					ranges: [
-						{ start: 19, end: 33, unusedRule: 'all' },
-						{ start: 99, end: 102, unusedRule: 'baz' },
+						{ start: 19, end: 33, rule: 'all' },
+						{ start: 99, end: 102, rule: 'baz' },
 					],
 				},
 				{

--- a/lib/formatters/__tests__/disableOptionsReportStringFormatter.test.js
+++ b/lib/formatters/__tests__/disableOptionsReportStringFormatter.test.js
@@ -7,36 +7,39 @@ const stripIndent = require('common-tags').stripIndent;
 describe('disableOptionsReportStringFormatter', () => {
 	it('formatter stringified', () => {
 		const actual = stripAnsi(
-			disableOptionsReportStringFormatterTest([
-				{
-					source: 'foo',
-					ranges: [
-						{ start: 1, end: 3, rule: 'baz' },
-						{ start: 7, rule: 'all' },
-					],
-				},
-				{
-					source: 'bar',
-					ranges: [
-						{ start: 19, end: 33, rule: 'all' },
-						{ start: 99, end: 102, rule: 'baz' },
-					],
-				},
-				{
-					sourc: 'baz',
-					ranges: [],
-				},
-			]),
+			disableOptionsReportStringFormatterTest(
+				[
+					{
+						source: 'foo',
+						ranges: [
+							{ start: 1, end: 3, rule: 'baz' },
+							{ start: 7, rule: 'all' },
+						],
+					},
+					{
+						source: 'bar',
+						ranges: [
+							{ start: 19, end: 33, rule: 'all' },
+							{ start: 99, end: 102, rule: 'baz' },
+						],
+					},
+					{
+						sourc: 'baz',
+						ranges: [],
+					},
+				],
+				'wrong disable',
+			),
 		);
 
 		let expected = stripIndent`
       foo
-      unused rule: baz, start line: 1, end line: 3
-      unused rule: all, start line: 7
+      wrong disable: baz, start line: 1, end line: 3
+      wrong disable: all, start line: 7
 
       bar
-      unused rule: all, start line: 19, end line: 33
-      unused rule: baz, start line: 99, end line: 102`;
+      wrong disable: all, start line: 19, end line: 33
+      wrong disable: baz, start line: 99, end line: 102`;
 
 		expected = `\n${expected}\n`;
 

--- a/lib/formatters/disableOptionsReportStringFormatter.js
+++ b/lib/formatters/disableOptionsReportStringFormatter.js
@@ -32,7 +32,7 @@ module.exports = function (report) {
 		output += chalk.underline(logFrom(sourceReport.source || '')) + '\n';
 
 		sourceReport.ranges.forEach((range) => {
-			output += `unused rule: ${range.unusedRule}, start line: ${range.start}`;
+			output += `unused rule: ${range.rule}, start line: ${range.start}`;
 
 			if (range.end !== undefined) {
 				output += `, end line: ${range.end}`;

--- a/lib/formatters/disableOptionsReportStringFormatter.js
+++ b/lib/formatters/disableOptionsReportStringFormatter.js
@@ -15,9 +15,10 @@ function logFrom(fromValue) {
 
 /**
  * @param {import('stylelint').StylelintDisableOptionsReport} report
+ * @param {string} message
  * @returns {string}
  */
-module.exports = function (report) {
+module.exports = function (report, message) {
 	if (!report) return '';
 
 	let output = '';
@@ -32,7 +33,7 @@ module.exports = function (report) {
 		output += chalk.underline(logFrom(sourceReport.source || '')) + '\n';
 
 		sourceReport.ranges.forEach((range) => {
-			output += `unused rule: ${range.rule}, start line: ${range.start}`;
+			output += `${message}: ${range.rule}, start line: ${range.start}`;
 
 			if (range.end !== undefined) {
 				output += `, end line: ${range.end}`;

--- a/lib/invalidScopeDisables.js
+++ b/lib/invalidScopeDisables.js
@@ -1,7 +1,6 @@
 'use strict';
 
 /** @typedef {import('stylelint').RangeType} RangeType */
-/** @typedef {import('stylelint').UnusedRange} UnusedRange */
 /** @typedef {import('stylelint').StylelintDisableOptionsReport} StylelintDisableOptionsReport */
 
 /**
@@ -45,9 +44,10 @@ module.exports = function (results) {
 				}
 
 				sourceReport.ranges.push({
-					unusedRule: rule,
+					rule,
 					start: range.start,
 					end: range.end,
+					unusedRule: rule,
 				});
 			});
 		});

--- a/lib/needlessDisables.js
+++ b/lib/needlessDisables.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 
 /** @typedef {import('stylelint').RangeType} RangeType */
-/** @typedef {import('stylelint').UnusedRange} UnusedRange */
+/** @typedef {import('stylelint').DisableReportRange} DisableReportRange */
 /** @typedef {import('stylelint').StylelintDisableOptionsReport} StylelintDisableOptionsReport */
 
 /**
@@ -20,7 +20,7 @@ module.exports = function (results) {
 			return;
 		}
 
-		/** @type {{ranges: UnusedRange[], source: string}} */
+		/** @type {{ranges: DisableReportRange[], source: string}} */
 		const unused = { source: result.source || '', ranges: [] };
 
 		/** @type {{[ruleName: string]: Array<RangeType>}} */
@@ -68,6 +68,7 @@ module.exports = function (results) {
 				// mark this range as unused
 				if (!range.used && !alreadyMarkedUnused) {
 					unused.ranges.push({
+						rule,
 						start: range.start,
 						end: range.end,
 						unusedRule: rule,

--- a/lib/prepareReturnValue.js
+++ b/lib/prepareReturnValue.js
@@ -2,6 +2,7 @@
 
 const invalidScopeDisables = require('./invalidScopeDisables');
 const needlessDisables = require('./needlessDisables');
+const reportDisables = require('./reportDisables');
 
 /** @typedef {import('stylelint').Formatter} Formatter */
 /** @typedef {import('stylelint').StylelintResult} StylelintResult */
@@ -27,6 +28,7 @@ function prepareReturnValue(stylelintResults, options, formatter) {
 		errored,
 		results: [],
 		output: '',
+		reportedDisables: reportDisables(stylelintResults),
 	};
 
 	if (reportNeedlessDisables) {

--- a/lib/reportDisables.js
+++ b/lib/reportDisables.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const _ = require('lodash');
+
+/** @typedef {import('stylelint').RangeType} RangeType */
+/** @typedef {import('stylelint').DisableReportRange} DisabledRange */
+/** @typedef {import('stylelint').StylelintDisableOptionsReport} StylelintDisableOptionsReport */
+
+/**
+ * Returns a report describing which `results` (if any) contain disabled ranges
+ * for rules that disallow disables via `reportDisables: true`.
+ *
+ * @param {import('stylelint').StylelintResult[]} results
+ * @returns {StylelintDisableOptionsReport}
+ */
+module.exports = function (results) {
+	/** @type {StylelintDisableOptionsReport} */
+	const report = [];
+
+	results.forEach((result) => {
+		// File with `CssSyntaxError` don't have `_postcssResult`s.
+		if (!result._postcssResult) {
+			return;
+		}
+
+		/** @type {{ranges: DisabledRange[], source: string}} */
+		const reported = { source: result.source || '', ranges: [] };
+
+		/** @type {{[ruleName: string]: Array<RangeType>}} */
+		const rangeData = result._postcssResult.stylelint.disabledRanges;
+
+		if (!rangeData) return;
+
+		const config = result._postcssResult.stylelint.config;
+
+		// If no rules actually disallow disables, don't bother looking for ranges
+		// that correspond to disabled rules.
+		if (!Object.values(_.get(config, 'rules', {})).some(reportDisablesForRule)) {
+			return [];
+		}
+
+		Object.keys(rangeData).forEach((rule) => {
+			rangeData[rule].forEach((range) => {
+				if (!reportDisablesForRule(_.get(config, ['rules', rule], []))) return;
+
+				// If an equivalent range has already been reported, don't report this
+				// range as well.
+				const duplicate = reported.ranges.find((reportedRange) => {
+					return reportedRange.start === range.start && reportedRange.end === range.end;
+				});
+
+				if (duplicate) return;
+
+				reported.ranges.push({
+					rule,
+					start: range.start,
+					end: range.end,
+					unusedRule: rule,
+				});
+			});
+		});
+
+		reported.ranges = _.sortBy(reported.ranges, ['start', 'end']);
+
+		report.push(reported);
+	});
+
+	return report;
+};
+
+/**
+ * @param {[any, object]|null} options
+ * @return {boolean}
+ */
+function reportDisablesForRule(options) {
+	if (!options) return false;
+
+	return _.get(options[1], 'reportDisables', false);
+}

--- a/lib/reportDisables.js
+++ b/lib/reportDisables.js
@@ -43,14 +43,6 @@ module.exports = function (results) {
 			rangeData[rule].forEach((range) => {
 				if (!reportDisablesForRule(_.get(config, ['rules', rule], []))) return;
 
-				// If an equivalent range has already been reported, don't report this
-				// range as well.
-				const duplicate = reported.ranges.find((reportedRange) => {
-					return reportedRange.start === range.start && reportedRange.end === range.end;
-				});
-
-				if (duplicate) return;
-
 				reported.ranges.push({
 					rule,
 					start: range.start,

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 
-const ignoredOptions = ['severity', 'message'];
+const ignoredOptions = ['severity', 'message', 'reportDisables'];
 
 /** @typedef {{possible: any, actual: any, optional: boolean}} Options */
 

--- a/system-tests/001/__snapshots__/fs.test.js.snap
+++ b/system-tests/001/__snapshots__/fs.test.js.snap
@@ -12,6 +12,7 @@ Object {
       "warnings": Array [],
     },
   ],
+  "reportedDisables": Array [],
   "results": Array [
     Object {
       "deprecations": Array [],

--- a/system-tests/001/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/001/__snapshots__/no-fs.test.js.snap
@@ -12,6 +12,7 @@ Object {
       "warnings": Array [],
     },
   ],
+  "reportedDisables": Array [],
   "results": Array [
     Object {
       "deprecations": Array [],

--- a/system-tests/002/__snapshots__/fs.test.js.snap
+++ b/system-tests/002/__snapshots__/fs.test.js.snap
@@ -34,6 +34,7 @@ Object {
       ],
     },
   ],
+  "reportedDisables": Array [],
   "results": Array [
     Object {
       "deprecations": Array [],

--- a/system-tests/002/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/002/__snapshots__/no-fs.test.js.snap
@@ -34,6 +34,7 @@ Object {
       ],
     },
   ],
+  "reportedDisables": Array [],
   "results": Array [
     Object {
       "deprecations": Array [],

--- a/system-tests/003/__snapshots__/fs.test.js.snap
+++ b/system-tests/003/__snapshots__/fs.test.js.snap
@@ -20,6 +20,7 @@ Object {
       ],
     },
   ],
+  "reportedDisables": Array [],
   "results": Array [
     Object {
       "deprecations": Array [],

--- a/system-tests/003/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/003/__snapshots__/no-fs.test.js.snap
@@ -216,6 +216,7 @@ footer a:visited {
   height: 110px;
 }
 ",
+  "reportedDisables": Array [],
   "results": Array [
     Object {
       "deprecations": Array [],

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -242,9 +242,9 @@ declare module 'stylelint' {
 			maxWarnings: number;
 			foundWarnings: number;
 		};
+		reportedDisables: StylelintDisableOptionsReport;
 		needlessDisables?: StylelintDisableOptionsReport;
 		invalidScopeDisables?: StylelintDisableOptionsReport;
-		disallowedDisables?: StylelintDisableOptionsReport;
 	};
 
 	export type StylelintPublicAPI = {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -216,21 +216,22 @@ declare module 'stylelint' {
 		_postcssResult?: PostcssResult;
 	};
 
-	export type UnusedRange = {
-		unusedRule: string;
+	export type DisableReportRange = {
+		rule: string;
 		start: number;
 		end?: number;
+
+		// This is for backwards-compatibility with formatters that were written
+		// when this name was used instead of `rule`. It should be avoided for new
+		// formatters.
+		unusedRule: string;
 	};
 
 	export type RangeType = DisabledRange & { used?: boolean };
 
 	export type StylelintDisableReportEntry = {
 		source?: string;
-		ranges: Array<{
-			unusedRule: string;
-			start: number;
-			end?: number;
-		}>;
+		ranges: Array<DisableReportRange>;
 	};
 
 	export type StylelintStandaloneReturnValue = {
@@ -243,6 +244,7 @@ declare module 'stylelint' {
 		};
 		needlessDisables?: StylelintDisableOptionsReport;
 		invalidScopeDisables?: StylelintDisableOptionsReport;
+		disallowedDisables?: StylelintDisableOptionsReport;
 	};
 
 	export type StylelintPublicAPI = {


### PR DESCRIPTION
This allows config authors to specify that certain rules may not be disabled by authors.