### PR TITLE
Add support for stylelintIgnore package.json property

### DIFF
--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -68,16 +68,24 @@ module.exports = function (options) {
 		if (readError.code !== FILE_NOT_FOUND_ERROR_CODE) throw readError;
 	}
 
-	const ignorePattern = options.ignorePattern || [];
-	const ignoreFiles = require(path.resolve(process.cwd(), 'package.json'));
-	let jsonIgnoreText = '';
+	let pkgIgnoreFiles = '';
 
-	if (Object.prototype.hasOwnProperty.call(ignoreFiles, 'stylelintignore')) {
-		jsonIgnoreText = ignoreFiles.stylelintignore;
+	const pkgRootFilePath = path.resolve(process.cwd(), 'package.json');
+	const pkgRoot = fs.readFileSync(pkgRootFilePath, 'utf-8');
+	const pkgObject = JSON.parse(pkgRoot);
+
+	if (Object.prototype.hasOwnProperty.call(pkgObject, 'stylelintignore')) {
+		pkgIgnoreFiles = pkgObject.stylelintignore;
+
+		// If the stylelintignore property has invalid value type ignore it by
+		// setting it to empty string
+		if (!Array.isArray(pkgIgnoreFiles) || typeof pkgIgnoreFiles !== 'string') {
+			pkgIgnoreFiles = '';
+		}
 	}
 
-	const ignorer = ignore().add(ignoreText).add(ignorePattern).add(jsonIgnoreText);
-
+	const ignorePattern = options.ignorePattern || [];
+	const ignorer = ignore().add(ignoreText).add(pkgIgnoreFiles).add(ignorePattern);
 	const isValidCode = typeof code === 'string';
 
 	if ((!files && !isValidCode) || (files && (code || isValidCode))) {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -69,7 +69,14 @@ module.exports = function (options) {
 	}
 
 	const ignorePattern = options.ignorePattern || [];
-	const ignorer = ignore().add(ignoreText).add(ignorePattern);
+	const ignoreFiles = require(path.resolve(process.cwd(), 'package.json'));
+	let jsonIgnoreText = '';
+
+	if (Object.prototype.hasOwnProperty.call(ignoreFiles, 'stylelintignore')) {
+		jsonIgnoreText = ignoreFiles.stylelintignore;
+	}
+
+	const ignorer = ignore().add(ignoreText).add(ignorePattern).add(jsonIgnoreText);
 
 	const isValidCode = typeof code === 'string';
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #3627

> Is there anything in the PR that needs further explanation?

With this change, stylelint will be able to ignore files specified in package.json via property stylelintignore, the value for the property can be either string or array of files and it silently ignores if the property if it contains an invalid value type.
This change also breaks some ignore file tests but tested via CLI worked fine.
