### PR TITLE
Add a reportDescriptionlessDisables flag

### DIFF
--- a/lib/__tests__/__snapshots__/cli.test.js.snap
+++ b/lib/__tests__/__snapshots__/cli.test.js.snap
@@ -122,6 +122,11 @@ exports[`CLI --help 1`] = `
       Report stylelint-disable comments that used for rules that don't exist within the configuration object.
       The process will exit with code 2 if invalid scope disables are found.
 
+    --report-descriptionless-disables, --rdd
+
+      Report stylelint-disable comments without a description.
+      The process will exit with code 2 if descriptionless disables are found.
+
     --max-warnings, --mw
 
       Number of warnings above which the process will exit with code 2.

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -26,6 +26,7 @@ describe('buildCLI', () => {
 			ignoreDisables: false,
 			printConfig: false,
 			quiet: false,
+			reportDescriptionlessDisables: false,
 			reportInvalidScopeDisables: false,
 			reportNeedlessDisables: false,
 			stdin: false,
@@ -255,6 +256,22 @@ describe('CLI', () => {
 		expect(process.stdout.write).toHaveBeenNthCalledWith(
 			1,
 			expect.stringContaining('forbidden disable: block-no-empty'),
+		);
+	});
+
+	it('reports descriptionless disables', async () => {
+		await cli([
+			'--config',
+			replaceBackslashes(path.join(fixturesPath, 'config-block-no-empty.json')),
+			replaceBackslashes(path.join(fixturesPath, 'empty-block-with-relevant-disable.css')),
+		]);
+
+		expect(process.exitCode).toBe(2);
+
+		expect(process.stdout.write).toHaveBeenCalledTimes(1);
+		expect(process.stdout.write).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining('descriptionless disable: block-no-empty'),
 		);
 	});
 

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -261,6 +261,7 @@ describe('CLI', () => {
 
 	it('reports descriptionless disables', async () => {
 		await cli([
+			'--report-descriptionless-disables',
 			'--config',
 			replaceBackslashes(path.join(fixturesPath, 'config-block-no-empty.json')),
 			replaceBackslashes(path.join(fixturesPath, 'empty-block-with-relevant-disable.css')),

--- a/lib/__tests__/descriptionlessDisables.test.js
+++ b/lib/__tests__/descriptionlessDisables.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const standalone = require('../standalone');
+const stripIndent = require('common-tags').stripIndent;
+
+it('descriptionlessDisables', () => {
+	const config = {
+		rules: { 'block-no-empty': true },
+	};
+
+	const css = stripIndent`
+    /* stylelint-disable -- Description */
+    a {}
+    /* stylelint-enable */
+    a {
+      b {} /* stylelint-disable-line block-no-empty -- Description */
+    }
+    /* stylelint-disable */
+    a { color: pink; }
+    /* stylelint-enable */
+    a {
+      b { color: pink; } /* stylelint-disable-line block-no-empty */
+    }
+    `;
+
+	return standalone({
+		config,
+		code: css,
+		reportDescriptionlessDisables: true,
+	}).then((linted) => {
+		const report = linted.descriptionlessDisables;
+
+		expect(report).toHaveLength(1);
+		expect(report[0].ranges).toEqual([
+			{
+				start: 7,
+				end: 9,
+				rule: 'all',
+				unusedRule: 'all',
+			},
+			{
+				start: 11,
+				end: 11,
+				rule: 'block-no-empty',
+				unusedRule: 'block-no-empty',
+			},
+		]);
+	});
+});

--- a/lib/__tests__/descriptionlessDisables.test.js
+++ b/lib/__tests__/descriptionlessDisables.test.js
@@ -14,13 +14,20 @@ it('descriptionlessDisables', () => {
     /* stylelint-enable */
     a {
       b {} /* stylelint-disable-line block-no-empty -- Description */
-    }
+		}
+    /* stylelint-disable-next-line block-no-empty
+     * --
+     * Description */
+    a {}
+
     /* stylelint-disable */
-    a { color: pink; }
+    a {}
     /* stylelint-enable */
     a {
-      b { color: pink; } /* stylelint-disable-line block-no-empty */
+      b {} /* stylelint-disable-line block-no-empty */
     }
+    /* stylelint-disable-next-line block-no-empty */
+    a {}
     `;
 
 	return standalone({
@@ -33,14 +40,20 @@ it('descriptionlessDisables', () => {
 		expect(report).toHaveLength(1);
 		expect(report[0].ranges).toEqual([
 			{
-				start: 7,
-				end: 9,
+				start: 12,
+				end: 14,
 				rule: 'all',
 				unusedRule: 'all',
 			},
 			{
-				start: 11,
-				end: 11,
+				start: 16,
+				end: 16,
+				rule: 'block-no-empty',
+				unusedRule: 'block-no-empty',
+			},
+			{
+				start: 19,
+				end: 19,
 				rule: 'block-no-empty',
 				unusedRule: 'block-no-empty',
 			},

--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -653,6 +653,7 @@ it('disable (with description) without re-enabling', () => {
 				{
 					start: 1,
 					strictStart: true,
+					description: 'Description',
 				},
 			],
 		});
@@ -672,6 +673,7 @@ it('disable and re-enable (with descriptions)', () => {
 					end: 4,
 					strictStart: true,
 					strictEnd: true,
+					description: 'Description',
 				},
 			],
 		});
@@ -689,6 +691,7 @@ it('disable rule (with description) without re-enabling', () => {
 						strictStart: true,
 						end: undefined,
 						strictEnd: undefined,
+						description: 'Description',
 					},
 				],
 			});
@@ -706,18 +709,21 @@ it('disable rules (with description) with newline in rule list', () => {
 				{
 					start: 1,
 					strictStart: true,
+					description: 'Description',
 				},
 			],
 			'hoo-hah': [
 				{
 					start: 1,
 					strictStart: true,
+					description: 'Description',
 				},
 			],
 			slime: [
 				{
 					start: 1,
 					strictStart: true,
+					description: 'Description',
 				},
 			],
 		});
@@ -741,6 +747,7 @@ it('SCSS // line-disabling comment (with description)', () => {
 						end: 2,
 						strictStart: true,
 						strictEnd: true,
+						description: 'Description',
 					},
 				],
 			});
@@ -767,6 +774,7 @@ it('SCSS // disable next-line comment (with multi-line description)', () => {
 						end: 5,
 						strictStart: true,
 						strictEnd: true,
+						description: 'Long-winded description',
 					},
 				],
 			});
@@ -790,6 +798,7 @@ it('Less // line-disabling comment (with description)', () => {
 						end: 2,
 						strictStart: true,
 						strictEnd: true,
+						description: 'Description',
 					},
 				],
 			});
@@ -816,6 +825,7 @@ it('Less // disable next-line comment (with multi-line description)', () => {
 						end: 5,
 						strictStart: true,
 						strictEnd: true,
+						description: 'Long-winded description',
 					},
 				],
 			});

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -18,16 +18,18 @@ const ALL_RULES = 'all';
 /**
  * @param {number} start
  * @param {boolean} strictStart
+ * @param {string|undefined} description
  * @param {number} [end]
  * @param {boolean} [strictEnd]
  * @returns {DisabledRange}
  */
-function createDisableRange(start, strictStart, end, strictEnd) {
+function createDisableRange(start, strictStart, description, end, strictEnd) {
 	return {
 		start,
 		end: end || undefined,
 		strictStart,
 		strictEnd: typeof strictEnd === 'boolean' ? strictEnd : undefined,
+		description,
 	};
 }
 
@@ -106,9 +108,10 @@ module.exports = function (root, result) {
 	function processDisableLineCommand(comment) {
 		if (comment.source && comment.source.start) {
 			const line = comment.source.start.line;
+			const description = getDescription(comment.text);
 
 			getCommandRules(disableLineCommand, comment.text).forEach((ruleName) => {
-				disableLine(line, ruleName, comment);
+				disableLine(line, ruleName, comment, description);
 			});
 		}
 	}
@@ -119,9 +122,10 @@ module.exports = function (root, result) {
 	function processDisableNextLineCommand(comment) {
 		if (comment.source && comment.source.end) {
 			const line = comment.source.end.line;
+			const description = getDescription(comment.text);
 
 			getCommandRules(disableNextLineCommand, comment.text).forEach((ruleName) => {
-				disableLine(line + 1, ruleName, comment);
+				disableLine(line + 1, ruleName, comment, description);
 			});
 		}
 	}
@@ -130,8 +134,9 @@ module.exports = function (root, result) {
 	 * @param {number} line
 	 * @param {string} ruleName
 	 * @param {PostcssComment} comment
+	 * @param {string|undefined} description
 	 */
-	function disableLine(line, ruleName, comment) {
+	function disableLine(line, ruleName, comment, description) {
 		if (ruleIsDisabled(ALL_RULES)) {
 			throw comment.error('All rules have already been disabled', {
 				plugin: 'stylelint',
@@ -144,7 +149,7 @@ module.exports = function (root, result) {
 
 				const strict = disabledRuleName === ALL_RULES;
 
-				startDisabledRange(line, disabledRuleName, strict);
+				startDisabledRange(line, disabledRuleName, strict, description);
 				endDisabledRange(line, disabledRuleName, strict);
 			});
 		} else {
@@ -154,7 +159,7 @@ module.exports = function (root, result) {
 				});
 			}
 
-			startDisabledRange(line, ruleName, true);
+			startDisabledRange(line, ruleName, true, description);
 			endDisabledRange(line, ruleName, true);
 		}
 	}
@@ -163,6 +168,8 @@ module.exports = function (root, result) {
 	 * @param {PostcssComment} comment
 	 */
 	function processDisableCommand(comment) {
+		const description = getDescription(comment.text);
+
 		getCommandRules(disableCommand, comment.text).forEach((ruleToDisable) => {
 			const isAllRules = ruleToDisable === ALL_RULES;
 
@@ -182,10 +189,10 @@ module.exports = function (root, result) {
 
 				if (isAllRules) {
 					Object.keys(disabledRanges).forEach((ruleName) => {
-						startDisabledRange(line, ruleName, ruleName === ALL_RULES);
+						startDisabledRange(line, ruleName, ruleName === ALL_RULES, description);
 					});
 				} else {
-					startDisabledRange(line, ruleToDisable, true);
+					startDisabledRange(line, ruleToDisable, true, description);
 				}
 			}
 		});
@@ -225,8 +232,8 @@ module.exports = function (root, result) {
 			if (ruleIsDisabled(ALL_RULES) && disabledRanges[ruleToEnable] === undefined) {
 				// Get a starting point from the where all rules were disabled
 				if (!disabledRanges[ruleToEnable]) {
-					disabledRanges[ruleToEnable] = disabledRanges.all.map(({ start, end }) =>
-						createDisableRange(start, false, end, false),
+					disabledRanges[ruleToEnable] = disabledRanges.all.map(({ start, end, description }) =>
+						createDisableRange(start, false, description, end, false),
 					);
 				} else {
 					const range = _.last(disabledRanges[ALL_RULES]);
@@ -298,12 +305,25 @@ module.exports = function (root, result) {
 	}
 
 	/**
+	 * @param {string} fullText
+	 * @returns {string|undefined}
+	 */
+	function getDescription(fullText) {
+		const descriptionStart = fullText.indexOf('--');
+
+		if (descriptionStart === -1) return;
+
+		return fullText.slice(descriptionStart + 2).trim();
+	}
+
+	/**
 	 * @param {number} line
 	 * @param {string} ruleName
 	 * @param {boolean} strict
+	 * @param {string|undefined} description
 	 */
-	function startDisabledRange(line, ruleName, strict) {
-		const rangeObj = createDisableRange(line, strict);
+	function startDisabledRange(line, ruleName, strict, description) {
+		const rangeObj = createDisableRange(line, strict, description);
 
 		ensureRuleRanges(ruleName);
 		disabledRanges[ruleName].push(rangeObj);
@@ -331,8 +351,8 @@ module.exports = function (root, result) {
 	 */
 	function ensureRuleRanges(ruleName) {
 		if (!disabledRanges[ruleName]) {
-			disabledRanges[ruleName] = disabledRanges.all.map(({ start, end }) =>
-				createDisableRange(start, false, end, false),
+			disabledRanges[ruleName] = disabledRanges.all.map(({ start, end, description }) =>
+				createDisableRange(start, false, description, end, false),
 			);
 		}
 	}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,6 +39,7 @@ const EXIT_CODE_ERROR = 2;
  * @property {string} [stdinFilename]
  * @property {boolean} [reportNeedlessDisables]
  * @property {boolean} [reportInvalidScopeDisables]
+ * @property {boolean} [reportDescriptionlessDisables]
  * @property {number} [maxWarnings]
  * @property {string | boolean} quiet
  * @property {string} [syntax]
@@ -73,6 +74,7 @@ const EXIT_CODE_ERROR = 2;
  * @property {string} [outputFile]
  * @property {boolean} [reportNeedlessDisables]
  * @property {boolean} [reportInvalidScopeDisables]
+ * @property {boolean} [reportDescriptionlessDisables]
  * @property {boolean} [disableDefaultIgnores]
  * @property {number} [maxWarnings]
  * @property {string} [syntax]
@@ -204,6 +206,11 @@ const meowOptions = {
         Report stylelint-disable comments that used for rules that don't exist within the configuration object.
         The process will exit with code ${EXIT_CODE_ERROR} if invalid scope disables are found.
 
+      --report-descriptionless-disables, --rdd
+
+        Report stylelint-disable comments without a description.
+        The process will exit with code ${EXIT_CODE_ERROR} if descriptionless disables are found.
+
       --max-warnings, --mw
 
         Number of warnings above which the process will exit with code ${EXIT_CODE_ERROR}.
@@ -290,6 +297,10 @@ const meowOptions = {
 		},
 		quiet: {
 			alias: 'q',
+			type: 'boolean',
+		},
+		reportDescriptionlessDisables: {
+			alias: 'rdd',
 			type: 'boolean',
 		},
 		reportInvalidScopeDisables: {
@@ -417,6 +428,7 @@ module.exports = (argv) => {
 
 	const reportNeedlessDisables = cli.flags.reportNeedlessDisables;
 	const reportInvalidScopeDisables = cli.flags.reportInvalidScopeDisables;
+	const reportDescriptionlessDisables = cli.flags.reportDescriptionlessDisables;
 
 	if (reportNeedlessDisables) {
 		optionsBase.reportNeedlessDisables = reportNeedlessDisables;
@@ -424,6 +436,10 @@ module.exports = (argv) => {
 
 	if (reportInvalidScopeDisables) {
 		optionsBase.reportInvalidScopeDisables = reportInvalidScopeDisables;
+	}
+
+	if (reportDescriptionlessDisables) {
+		optionsBase.reportDescriptionlessDisables = reportDescriptionlessDisables;
 	}
 
 	const maxWarnings = cli.flags.maxWarnings;
@@ -503,6 +519,17 @@ module.exports = (argv) => {
 						const report = disableOptionsReportStringFormatter(
 							linted.invalidScopeDisables || [],
 							'disable with invalid scope',
+						);
+
+						if (report) {
+							reports.push(report);
+						}
+					}
+
+					if (reportDescriptionlessDisables) {
+						const report = disableOptionsReportStringFormatter(
+							linted.descriptionlessDisables || [],
+							'descriptionless disable',
 						);
 
 						if (report) {

--- a/lib/descriptionlessDisables.js
+++ b/lib/descriptionlessDisables.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/** @typedef {import('stylelint').RangeType} RangeType */
+/** @typedef {import('stylelint').DisableReportRange} DisableReportRange */
+/** @typedef {import('stylelint').StylelintDisableOptionsReport} StylelintDisableOptionsReport */
+
+/**
+ * @param {import('stylelint').StylelintResult[]} results
+ * @returns {StylelintDisableOptionsReport}
+ */
+module.exports = function (results) {
+	/** @type {StylelintDisableOptionsReport} */
+	const report = [];
+
+	results.forEach((result) => {
+		// File with `CssSyntaxError` have not `_postcssResult`
+		if (!result._postcssResult) {
+			return;
+		}
+
+		const rangeData = result._postcssResult.stylelint.disabledRanges;
+
+		/** @type {import('stylelint').StylelintDisableReportEntry} */
+		const entry = { source: result.source, ranges: [] };
+
+		Object.keys(rangeData).forEach((rule) => {
+			rangeData[rule].forEach((range) => {
+				if (range.description) return;
+
+				// Avoid duplicates from stylelint-disable comments with multiple rules.
+				const alreadyReported = entry.ranges.find((existing) => {
+					return existing.start === range.start && existing.end === range.end;
+				});
+
+				if (alreadyReported) return;
+
+				entry.ranges.push({
+					rule,
+					start: range.start,
+					end: range.end,
+					unusedRule: rule,
+				});
+			});
+		});
+
+		if (entry.ranges.length > 0) {
+			report.push(entry);
+		}
+	});
+
+	return report;
+};

--- a/lib/prepareReturnValue.js
+++ b/lib/prepareReturnValue.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const descriptionlessDisables = require('./descriptionlessDisables');
 const invalidScopeDisables = require('./invalidScopeDisables');
 const needlessDisables = require('./needlessDisables');
 const reportDisables = require('./reportDisables');
@@ -17,7 +18,12 @@ const reportDisables = require('./reportDisables');
  * @returns {StylelintStandaloneReturnValue}
  */
 function prepareReturnValue(stylelintResults, options, formatter) {
-	const { reportNeedlessDisables, reportInvalidScopeDisables, maxWarnings } = options;
+	const {
+		reportNeedlessDisables,
+		reportInvalidScopeDisables,
+		reportDescriptionlessDisables,
+		maxWarnings,
+	} = options;
 
 	const errored = stylelintResults.some(
 		(result) => result.errored || result.parseErrors.length > 0,
@@ -37,6 +43,10 @@ function prepareReturnValue(stylelintResults, options, formatter) {
 
 	if (reportInvalidScopeDisables) {
 		returnValue.invalidScopeDisables = invalidScopeDisables(stylelintResults);
+	}
+
+	if (reportDescriptionlessDisables) {
+		returnValue.descriptionlessDisables = descriptionlessDisables(stylelintResults);
 	}
 
 	if (maxWarnings !== undefined) {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -47,6 +47,7 @@ module.exports = function (options) {
 	const ignoreDisables = options.ignoreDisables;
 	const reportNeedlessDisables = options.reportNeedlessDisables;
 	const reportInvalidScopeDisables = options.reportInvalidScopeDisables;
+	const reportDescriptionlessDisables = options.reportDescriptionlessDisables;
 	const syntax = options.syntax;
 	const allowEmptyInput = options.allowEmptyInput || false;
 	const useCache = options.cache || false;
@@ -95,6 +96,7 @@ module.exports = function (options) {
 		ignorePath: ignoreFilePath,
 		reportNeedlessDisables,
 		reportInvalidScopeDisables,
+		reportDescriptionlessDisables,
 		syntax,
 		customSyntax,
 		fix,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -36,6 +36,7 @@ declare module 'stylelint' {
 		end?: number;
 		strictEnd?: boolean;
 		rules?: string[];
+		description?: string;
 	};
 
 	export type DisabledRangeObject = {
@@ -53,6 +54,7 @@ declare module 'stylelint' {
 		ignored?: boolean;
 		ignoreDisables?: boolean;
 		reportNeedlessDisables?: boolean;
+		reportDescriptionlessDisables?: boolean;
 		stylelintError?: boolean;
 		disableWritingFix?: boolean;
 		config?: StylelintConfig;
@@ -101,6 +103,7 @@ declare module 'stylelint' {
 		ignorePath?: string;
 		reportInvalidScopeDisables?: boolean;
 		reportNeedlessDisables?: boolean;
+		reportDescriptionlessDisables?: boolean;
 		syntax?: string;
 		customSyntax?: CustomSyntax;
 		fix?: boolean;
@@ -164,6 +167,7 @@ declare module 'stylelint' {
 		ignoreDisables?: boolean;
 		ignorePath?: string;
 		ignorePattern?: string[];
+		reportDescriptionlessDisables?: boolean;
 		reportNeedlessDisables?: boolean;
 		reportInvalidScopeDisables?: boolean;
 		maxWarnings?: number;
@@ -243,6 +247,7 @@ declare module 'stylelint' {
 			foundWarnings: number;
 		};
 		reportedDisables: StylelintDisableOptionsReport;
+		descriptionlessDisables?: StylelintDisableOptionsReport;
 		needlessDisables?: StylelintDisableOptionsReport;
 		invalidScopeDisables?: StylelintDisableOptionsReport;
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #4868.

> Is there anything in the PR that needs further explanation?

This now adds the description, if any to the `DisabledRange` objects and then reports any ranges without descriptions if the flag is passed. For adding the new flag, I mostly mirrored what already exists for needless and invalid-scope disables, so let me know if I missed anything.