### PR TITLE
Avoid combining disable comments with a blank line

### DIFF
--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -781,6 +781,54 @@ it('SCSS // disable next-line comment (with multi-line description)', () => {
 		});
 });
 
+it('SCSS // disable comment (with // comment after blank line)', () => {
+	const scssSource = `a {
+    // stylelint-disable declaration-no-important
+
+    // Unrelated
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 2,
+						strictStart: true,
+					},
+				],
+			});
+		});
+});
+
+it('SCSS /* disable comment (with // comment after blank line)', () => {
+	const scssSource = `a {
+    /* stylelint-disable declaration-no-important */
+
+    // Unrelated
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 2,
+						strictStart: true,
+					},
+				],
+			});
+		});
+});
+
 it('Less // line-disabling comment (with description)', () => {
 	const lessSource = `a {
     color: pink !important; // stylelint-disable-line declaration-no-important -- Description

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -69,12 +69,17 @@ module.exports = function (root, result) {
 		} else if (isInlineComment(comment)) {
 			const fullComment = comment.clone();
 			let next = comment.next();
+			let lastLine = (comment.source && comment.source.end && comment.source.end.line) || 0;
 
 			while (next && next.type === 'comment') {
 				/** @type {PostcssComment} */
 				const current = next;
 
 				if (!isInlineComment(current)) break;
+
+				const currentLine = (current.source && current.source.end && current.source.end.line) || 0;
+
+				if (lastLine + 1 !== currentLine) break;
 
 				fullComment.text += `\n${current.text}`;
 
@@ -84,6 +89,7 @@ module.exports = function (root, result) {
 
 				inlineEnd = current;
 				next = current.next();
+				lastLine = currentLine;
 			}
 			checkComment(fullComment);
 		} else {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #4911.

> Is there anything in the PR that needs further explanation?

This checks line numbers before combining adjacent `//` comments.
