### PR TITLE
Describe missing `reportedDisables` and `reportDescriptionlessDisables`

### DIFF
--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -137,7 +137,7 @@ Reporters may use these severity levels to display violations or exit the proces
 
 ### `reportDisables`
 
-You can set the `reportDisables` secondary option to report any disable comments for this rule, effectively disallowing authors to opt out of it.
+You can set the `reportDisables` secondary option to report any `stylelint-disable` comments for this rule, effectively disallowing authors to opt out of it.
 
 For example:
 
@@ -154,6 +154,8 @@ For example:
   }
 }
 ```
+
+The report is included in the [`reportedDisables`](usage/node-api.md#reporteddisables) property to the returned data of Node.js API.
 
 ## `defaultSeverity`
 

--- a/docs/user-guide/usage/node-api.md
+++ b/docs/user-guide/usage/node-api.md
@@ -76,7 +76,7 @@ An array of objects, one for each source, with tells you which `stylelint-disabl
 
 ### `invalidScopeDisables`
 
-An array of objects, one for each source, with tells you which rule in `stylelint-disable <rule>` comment don't exist within the configuration object.
+An array of objects, one for each source, with tells you which rule in a `stylelint-disable <rule>` comment doesn't exist within the configuration object.
 
 ### `descriptionlessDisables`
 

--- a/docs/user-guide/usage/node-api.md
+++ b/docs/user-guide/usage/node-api.md
@@ -66,13 +66,21 @@ An array containing all the stylelint result objects (the objects that formatter
 
 An object containing the maximum number of warnings and the amount found, e.g. `{ maxWarnings: 0, foundWarnings: 12 }`.
 
+### `reportedDisables`
+
+An array of objects, one for each source, with tells you which `stylelint-disable` comments for rules enabled [`reportDisables`](../configure.md#reportdisables).
+
 ### `needlessDisables`
 
-An array of objects, one for each source, with tells you which stylelint-disable comments are not blocking a lint violation
+An array of objects, one for each source, with tells you which `stylelint-disable` comments are not blocking a lint violation.
 
 ### `invalidScopeDisables`
 
 An array of objects, one for each source, with tells you which rule in `stylelint-disable <rule>` comment don't exist within the configuration object.
+
+### `descriptionlessDisables`
+
+An array of objects, one for each source, with tells you which `stylelint-disable` comments without a description.
 
 ## Syntax errors
 

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -179,7 +179,7 @@ a {}
 a {}
 ```
 
-But, the following patterns are _not_ reported:
+But, the following patterns (`stylelint-disable -- <description>`) are _not_ reported:
 
 <!-- prettier-ignore -->
 ```css

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -167,30 +167,30 @@ Produce a report of the `stylelint-disable` comments without a description.
 
 For example, when the configuration `{ block-no-empty: true }` is given, the following patterns are reported:
 
+<!-- prettier-ignore -->
 ```css
 /* stylelint-disable */
-a {
-}
+a {}
 ```
 
+<!-- prettier-ignore -->
 ```css
 /* stylelint-disable-next-line block-no-empty */
-a {
-}
+a {}
 ```
 
 But, the following patterns are _not_ reported:
 
+<!-- prettier-ignore -->
 ```css
 /* stylelint-disable -- This violation is ignorable. */
-a {
-}
+a {}
 ```
 
+<!-- prettier-ignore -->
 ```css
 /* stylelint-disable-next-line block-no-empty -- This violation is ignorable. */
-a {
-}
+a {}
 ```
 
 If descriptionless disables are found, the:

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -141,7 +141,7 @@ You can use this option to see what your linting results would be like without t
 
 CLI flags: `--report-needless-disables, --rd`
 
-Produce a report to clean up your codebase, keeping only the stylelint-disable comments that serve a purpose.
+Produce a report to clean up your codebase, keeping only the `stylelint-disable` comments that serve a purpose.
 
 If needless disables are found, the:
 
@@ -152,12 +152,51 @@ If needless disables are found, the:
 
 CLI flags: `--report-invalid-scope-disables, --risd`
 
-Produce a report of the stylelint-disable comments that used for rules that don't exist within the configuration object.
+Produce a report of the `stylelint-disable` comments that used for rules that don't exist within the configuration object.
 
 If invalid scope disables are found, the:
 
 - CLI process exits with code `2`
 - Node.js API adds a [`invalidScopeDisables`](node-api.md#invalidscopedisables) property to the returned data
+
+## `reportDescriptionlessDisables`
+
+CLI flags: `--report-descriptionless-disables, --rdd`
+
+Produce a report of the `stylelint-disable` comments without a description.
+
+For example, when the configuration `{ block-no-empty: true }` is given, the following patterns are reported:
+
+```css
+/* stylelint-disable */
+a {
+}
+```
+
+```css
+/* stylelint-disable-next-line block-no-empty */
+a {
+}
+```
+
+But, the following patterns are _not_ reported:
+
+```css
+/* stylelint-disable -- This violation is ignorable. */
+a {
+}
+```
+
+```css
+/* stylelint-disable-next-line block-no-empty -- This violation is ignorable. */
+a {
+}
+```
+
+If descriptionless disables are found, the:
+
+- CLI process exits with code `2`
+- Node.js API adds a [`descriptionlessDisables`](node-api.md#descriptionlessdisables) property to the returned data
 
 ## `codeFilename`
 


### PR DESCRIPTION
This documentation change adds missing descriptions about:

- the `reportedDisables` property in the returned data of Node.js API
  - Ref: #4897
- the `reportDescriptionlessDisables` option (flag)
  - Ref: #4907 

> Which issue, if any, is this issue related to?

Close #4912

> Is there anything in the PR that needs further explanation?

In addition, this change unifies the labeling of the `stylelint-disable` comment for clarity.

If there are any weird phrases, please point them out to me. 🙏 
