### PR TITLE
Add missing `media-feature-name-value-whitelist` to rule list

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -209,6 +209,7 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 - [`media-feature-name-disallowed-list`](../../../lib/rules/media-feature-name-disallowed-list/README.md): Specify a list of disallowed media feature names.
 - [`media-feature-name-no-vendor-prefix`](../../../lib/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names (Autofixable).
 - [`media-feature-name-value-allowed-list`](../../../lib/rules/media-feature-name-value-allowed-list/README.md): Specify a list of allowed media feature name and value pairs.
+- [`media-feature-name-value-whitelist`](../../../lib/rules/media-feature-name-value-whitelist/README.md): Specify a list of allowed media feature name and value pairs. **(deprecated)**
 - [`media-feature-name-whitelist`](../../../lib/rules/media-feature-name-whitelist/README.md): Specify a list of allowed media feature names. **(deprecated)**
 
 ### Custom media


### PR DESCRIPTION
This PR adds the missing `media-feature-name-value-whitelist` rule to the rule list document.

https://github.com/stylelint/stylelint/blob/7449dc004c9e75119423cd7e4f3780ba895b5c89/lib/rules/media-feature-name-value-whitelist/README.md

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
