### PR TITLE
Improve inline comment merging

### DIFF
--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -854,7 +854,7 @@ it('SCSS /* disable comment (with // comment after blank line)', () => {
 
 it('SCSS // disable comment (with // comment immediately before)', () => {
 	const scssSource = `a {
-		// Unrelated
+    // Unrelated
     // stylelint-disable declaration-no-important
     color: pink !important;
   }`;
@@ -877,8 +877,8 @@ it('SCSS // disable comment (with // comment immediately before)', () => {
 
 it('SCSS two adjacent // disable comments ', () => {
 	const scssSource = `a {
-		// stylelint-disable declaration-no-important
-		// stylelint-disable foo-bar
+    // stylelint-disable declaration-no-important
+    // stylelint-disable foo-bar
     color: pink !important;
   }`;
 
@@ -906,11 +906,11 @@ it('SCSS two adjacent // disable comments ', () => {
 
 it('SCSS two adjacent // disable comments with multi-line descriptions ', () => {
 	const scssSource = `a {
-		// stylelint-disable declaration-no-important --
-		// Description 1
-		// stylelint-disable foo-bar
-		// --
-		// Description 2
+    // stylelint-disable declaration-no-important --
+    // Description 1
+    // stylelint-disable foo-bar
+    // --
+    // Description 2
     color: pink !important;
   }`;
 
@@ -940,9 +940,9 @@ it('SCSS two adjacent // disable comments with multi-line descriptions ', () => 
 
 it('SCSS two // disable comments with an unrelated comment between them', () => {
 	const scssSource = `a {
-		// stylelint-disable declaration-no-important
-		// Unrelated
-		// stylelint-disable foo-bar
+    // stylelint-disable declaration-no-important
+    // Unrelated
+    // stylelint-disable foo-bar
     color: pink !important;
   }`;
 

--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -805,6 +805,29 @@ it('SCSS // disable comment (with // comment after blank line)', () => {
 		});
 });
 
+it('SCSS // disable comment (with // comment immediately after)', () => {
+	const scssSource = `a {
+    // stylelint-disable declaration-no-important
+    // Unrelated
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 2,
+						strictStart: true,
+					},
+				],
+			});
+		});
+});
+
 it('SCSS /* disable comment (with // comment after blank line)', () => {
 	const scssSource = `a {
     /* stylelint-disable declaration-no-important */
@@ -822,6 +845,122 @@ it('SCSS /* disable comment (with // comment after blank line)', () => {
 				'declaration-no-important': [
 					{
 						start: 2,
+						strictStart: true,
+					},
+				],
+			});
+		});
+});
+
+it('SCSS // disable comment (with // comment immediately before)', () => {
+	const scssSource = `a {
+		// Unrelated
+    // stylelint-disable declaration-no-important
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 3,
+						strictStart: true,
+					},
+				],
+			});
+		});
+});
+
+it('SCSS two adjacent // disable comments ', () => {
+	const scssSource = `a {
+		// stylelint-disable declaration-no-important
+		// stylelint-disable foo-bar
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 2,
+						strictStart: true,
+					},
+				],
+				'foo-bar': [
+					{
+						start: 3,
+						strictStart: true,
+					},
+				],
+			});
+		});
+});
+
+it('SCSS two adjacent // disable comments with multi-line descriptions ', () => {
+	const scssSource = `a {
+		// stylelint-disable declaration-no-important --
+		// Description 1
+		// stylelint-disable foo-bar
+		// --
+		// Description 2
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 2,
+						strictStart: true,
+						description: 'Description 1',
+					},
+				],
+				'foo-bar': [
+					{
+						start: 4,
+						strictStart: true,
+						description: 'Description 2',
+					},
+				],
+			});
+		});
+});
+
+it('SCSS two // disable comments with an unrelated comment between them', () => {
+	const scssSource = `a {
+		// stylelint-disable declaration-no-important
+		// Unrelated
+		// stylelint-disable foo-bar
+    color: pink !important;
+  }`;
+
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(scssSource, { syntax: scss, from: undefined })
+		.then((result) => {
+			expect(result.stylelint.disabledRanges).toEqual({
+				all: [],
+				'declaration-no-important': [
+					{
+						start: 2,
+						strictStart: true,
+					},
+				],
+				'foo-bar': [
+					{
+						start: 4,
 						strictStart: true,
 					},
 				],

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -66,35 +66,53 @@ module.exports = function (root, result) {
 		if (inlineEnd) {
 			// Ignore comments already processed by grouping with a previous one.
 			if (inlineEnd === comment) inlineEnd = null;
-		} else if (isInlineComment(comment)) {
-			const fullComment = comment.clone();
-			let next = comment.next();
-			let lastLine = (comment.source && comment.source.end && comment.source.end.line) || 0;
 
-			while (next && next.type === 'comment') {
-				/** @type {PostcssComment} */
-				const current = next;
-
-				if (!isInlineComment(current)) break;
-
-				const currentLine = (current.source && current.source.end && current.source.end.line) || 0;
-
-				if (lastLine + 1 !== currentLine) break;
-
-				fullComment.text += `\n${current.text}`;
-
-				if (fullComment.source && current.source) {
-					fullComment.source.end = current.source.end;
-				}
-
-				inlineEnd = current;
-				next = current.next();
-				lastLine = currentLine;
-			}
-			checkComment(fullComment);
-		} else {
-			checkComment(comment);
+			return;
 		}
+
+		const next = comment.next();
+
+		// If any of these conditions are not met, do not merge comments.
+		if (
+			!(
+				isInlineComment(comment) &&
+				comment.text.startsWith('stylelint-') &&
+				next &&
+				next.type === 'comment' &&
+				(comment.text.includes('--') || next.text.startsWith('--'))
+			)
+		) {
+			checkComment(comment);
+
+			return;
+		}
+
+		let lastLine = (comment.source && comment.source.end && comment.source.end.line) || 0;
+		const fullComment = comment.clone();
+
+		/** @type {PostcssComment} */
+		let current = next;
+
+		while (isInlineComment(current) && !current.text.startsWith('stylelint-')) {
+			const currentLine = (current.source && current.source.end && current.source.end.line) || 0;
+
+			if (lastLine + 1 !== currentLine) break;
+
+			fullComment.text += `\n${current.text}`;
+
+			if (fullComment.source && current.source) {
+				fullComment.source.end = current.source.end;
+			}
+
+			inlineEnd = current;
+			const next = current.next();
+
+			if (!next || next.type !== 'comment') break;
+
+			current = next;
+			lastLine = currentLine;
+		}
+		checkComment(fullComment);
 	});
 
 	return result;

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -130,7 +130,7 @@ module.exports = function (root, result) {
 	 * @param {PostcssComment} comment
 	 */
 	function isStylelintCommand(comment) {
-		return /^stylelint-(disable|enable)/.test(comment.text);
+		return comment.text.startsWith(disableCommand) || comment.text.startsWith(enableCommand);
 	}
 
 	/**

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -76,7 +76,7 @@ module.exports = function (root, result) {
 		if (
 			!(
 				isInlineComment(comment) &&
-				comment.text.startsWith('stylelint-') &&
+				isStylelintCommand(comment) &&
 				next &&
 				next.type === 'comment' &&
 				(comment.text.includes('--') || next.text.startsWith('--'))
@@ -93,7 +93,7 @@ module.exports = function (root, result) {
 		/** @type {PostcssComment} */
 		let current = next;
 
-		while (isInlineComment(current) && !current.text.startsWith('stylelint-')) {
+		while (isInlineComment(current) && !isStylelintCommand(current)) {
 			const currentLine = (current.source && current.source.end && current.source.end.line) || 0;
 
 			if (lastLine + 1 !== currentLine) break;
@@ -124,6 +124,13 @@ module.exports = function (root, result) {
 		// We check both here because the Sass parser uses `raws.inline` to indicate
 		// inline comments, while the Less parser uses `inline`.
 		return comment.inline || comment.raws.inline;
+	}
+
+	/**
+	 * @param {PostcssComment} comment
+	 */
+	function isStylelintCommand(comment) {
+		return /^stylelint-(disable|enable)/.test(comment.text);
 	}
 
 	/**


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #4937.

> Is there anything in the PR that needs further explanation?

This now only starts a merge when the comment begins with `stylelint-` and either the first line contains `--` or the second line starts with `--`.

The merge will end whenever another line starts with `stylelint-` to allow for adjacent stylelint commands.
