### PR TITLE
Fix `isStandardSyntaxAtRule.test.js` that use callbacks

### DIFF
--- a/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
@@ -8,43 +8,43 @@ const postcssScss = require('postcss-scss');
 
 describe('isStandardSyntaxAtRule', () => {
 	it('non nested at-rules without quotes', () => {
-		expect(isStandardSyntaxAtRule(atRules('@charset UTF-8;')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@charset UTF-8;'))).toBeTruthy();
 	});
 
 	it("non nested at-rules with `'` quotes", () => {
-		expect(isStandardSyntaxAtRule(atRules("@charset 'UTF-8';")[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule("@charset 'UTF-8';"))).toBeTruthy();
 	});
 
 	it('non nested at-rules with `"` quotes', () => {
-		expect(isStandardSyntaxAtRule(atRules('@charset "UTF-8";')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@charset "UTF-8";'))).toBeTruthy();
 	});
 
 	it("non nested at-rules with `'` quotes and without space after name", () => {
-		expect(isStandardSyntaxAtRule(atRules("@charset'UTF-8';")[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule("@charset'UTF-8';"))).toBeTruthy();
 	});
 
 	it('non nested at-rules with `"` quotes and without space after name', () => {
-		expect(isStandardSyntaxAtRule(atRules('@charset"UTF-8";')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@charset"UTF-8";'))).toBeTruthy();
 	});
 
 	it('non nested at-rules with function and without space after name', () => {
-		expect(isStandardSyntaxAtRule(atRules('@import url("fineprint.css") print;')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@import url("fineprint.css") print;'))).toBeTruthy();
 	});
 
 	it('nested at-rules', () => {
-		expect(isStandardSyntaxAtRule(atRules('@media (min-width: 100px) {};')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@media (min-width: 100px) {};'))).toBeTruthy();
 	});
 
 	it('nested at-rules with newline after name', () => {
-		expect(isStandardSyntaxAtRule(atRules('@media\n(min-width: 100px) {};')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@media\n(min-width: 100px) {};'))).toBeTruthy();
 	});
 
 	it('nested at-rules with windows newline after name', () => {
-		expect(isStandardSyntaxAtRule(atRules('@media\r\n(min-width: 100px) {};')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@media\r\n(min-width: 100px) {};'))).toBeTruthy();
 	});
 
 	it('nested at-rules without space after name', () => {
-		expect(isStandardSyntaxAtRule(atRules('@media(min-width: 100px) {};')[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@media(min-width: 100px) {};'))).toBeTruthy();
 	});
 
 	// eslint-disable-next-line jest/no-disabled-tests -- TODO: `postcss-sass` parser does not support `@mixin`.
@@ -97,6 +97,10 @@ function atRules(code, parser = postcss) {
 	parser.parse(code).walkAtRules((rule) => rules.push(rule));
 
 	return rules;
+}
+
+function atRule(code) {
+	return atRules(code)[0];
 }
 
 function sassAtRules(code) {

--- a/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxAtRule.test.js
@@ -1,136 +1,112 @@
 'use strict';
 
 const isStandardSyntaxAtRule = require('../isStandardSyntaxAtRule');
-const less = require('postcss-less');
 const postcss = require('postcss');
-const sass = require('postcss-sass');
-const scss = require('postcss-scss');
+const postcssLess = require('postcss-less');
+const postcssSass = require('postcss-sass');
+const postcssScss = require('postcss-scss');
 
 describe('isStandardSyntaxAtRule', () => {
 	it('non nested at-rules without quotes', () => {
-		atRules('@charset UTF-8;', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@charset UTF-8;')[0])).toBeTruthy();
 	});
 
 	it("non nested at-rules with `'` quotes", () => {
-		atRules("@charset 'UTF-8';", (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules("@charset 'UTF-8';")[0])).toBeTruthy();
 	});
 
 	it('non nested at-rules with `"` quotes', () => {
-		atRules('@charset "UTF-8";', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@charset "UTF-8";')[0])).toBeTruthy();
 	});
 
 	it("non nested at-rules with `'` quotes and without space after name", () => {
-		atRules("@charset'UTF-8';", (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules("@charset'UTF-8';")[0])).toBeTruthy();
 	});
 
 	it('non nested at-rules with `"` quotes and without space after name', () => {
-		atRules('@charset"UTF-8";', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@charset"UTF-8";')[0])).toBeTruthy();
 	});
 
 	it('non nested at-rules with function and without space after name', () => {
-		atRules('@import url("fineprint.css") print;', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@import url("fineprint.css") print;')[0])).toBeTruthy();
 	});
 
 	it('nested at-rules', () => {
-		atRules('@media (min-width: 100px) {};', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@media (min-width: 100px) {};')[0])).toBeTruthy();
 	});
 
 	it('nested at-rules with newline after name', () => {
-		atRules('@media\n(min-width: 100px) {};', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@media\n(min-width: 100px) {};')[0])).toBeTruthy();
 	});
 
 	it('nested at-rules with windows newline after name', () => {
-		atRules('@media\r\n(min-width: 100px) {};', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@media\r\n(min-width: 100px) {};')[0])).toBeTruthy();
 	});
 
 	it('nested at-rules without space after name', () => {
-		atRules('@media(min-width: 100px) {};', (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeTruthy();
-		});
+		expect(isStandardSyntaxAtRule(atRules('@media(min-width: 100px) {};')[0])).toBeTruthy();
 	});
 
-	it('ignore `@content` inside mixins newline', () => {
-		const sass = '@mixin mixin()\n  @content';
+	// eslint-disable-next-line jest/no-disabled-tests -- TODO: `postcss-sass` parser does not support `@mixin`.
+	it.skip('ignore `@content` inside mixins newline', () => {
+		const rules = sassAtRules('@mixin mixin()\n  @content');
 
-		sassAtRules(sass, (atRule) => {
-			if (atRule.name === 'mixin') {
-				return;
-			}
-
-			expect(isStandardSyntaxAtRule(atRule)).toBeFalsy();
-		});
+		expect(rules).toHaveLength(2);
+		expect(rules.map((rule) => rule.name)).toEqual(['mixin', 'content']);
+		expect(isStandardSyntaxAtRule(rules[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(rules[1])).toBeFalsy();
 	});
 
 	it('ignore `@content` inside mixins space', () => {
-		const scss = '@mixin mixin() { @content; };';
+		const rules = scssAtRules('@mixin mixin() { @content; };');
 
-		scssAtRules(scss, (atRule) => {
-			if (atRule.name === 'mixin') {
-				return;
-			}
-
-			expect(isStandardSyntaxAtRule(atRule)).toBeFalsy();
-		});
+		expect(rules).toHaveLength(2);
+		expect(rules.map((rule) => rule.name)).toEqual(['mixin', 'content']);
+		expect(isStandardSyntaxAtRule(rules[0])).toBeTruthy();
+		expect(isStandardSyntaxAtRule(rules[1])).toBeFalsy();
 	});
 
 	it('ignore passing rulesets to mixins', () => {
-		const less = '@detached-ruleset: { background: red; }; .top { @detached-ruleset(); }';
+		const rules = lessAtRules(
+			'@detached-ruleset: { background: red; }; .top { @detached-ruleset(); }',
+		);
 
-		lessAtRules(less, (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeFalsy();
-		});
+		expect(rules).toHaveLength(2);
+		expect(isStandardSyntaxAtRule(rules[0])).toBeFalsy();
+		expect(isStandardSyntaxAtRule(rules[1])).toBeFalsy();
 	});
 
 	it('ignore calling of mixins', () => {
-		const less = 'a { .mixin(); }';
+		const rules = lessAtRules('a { .mixin(); }');
 
-		lessAtRules(less, (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeFalsy();
-		});
+		expect(rules).toHaveLength(1);
+		expect(isStandardSyntaxAtRule(rules[0])).toBeFalsy();
 	});
 
 	it('ignore variables', () => {
-		const less = `
-        @my-variable: 10px;
-        .top { margin-top: @my-variable; }
-    `;
+		const rules = lessAtRules('@my-variable: 10px; .top { margin-top: @my-variable; }');
 
-		lessAtRules(less, (atRule) => {
-			expect(isStandardSyntaxAtRule(atRule)).toBeFalsy();
-		});
+		expect(rules).toHaveLength(1);
+		expect(isStandardSyntaxAtRule(rules[0])).toBeFalsy();
 	});
 });
 
-function atRules(css, cb) {
-	postcss.parse(css).walkAtRules(cb);
+function atRules(code, parser = postcss) {
+	const rules = [];
+
+	parser.parse(code).walkAtRules((rule) => rules.push(rule));
+
+	return rules;
 }
 
-function sassAtRules(css, cb) {
-	sass.parse(css).walkAtRules(cb);
+function sassAtRules(code) {
+	return atRules(code, postcssSass);
 }
 
-function scssAtRules(css, cb) {
-	scss.parse(css).walkAtRules(cb);
+function scssAtRules(code) {
+	return atRules(code, postcssScss);
 }
 
-function lessAtRules(css, cb) {
-	less.parse(css).walkAtRules(cb);
+function lessAtRules(code) {
+	return atRules(code, postcssLess);
 }


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

This is a part of #4881.

> Is there anything in the PR that needs further explanation?

It seems [`postcss-sass`](https://github.com/AleshaOleg/postcss-sass) does not support `@mixin`, so maybe the following test case is incorrect:

https://github.com/stylelint/stylelint/blob/65ab12ebfa08cf92525626836bd9847c8e740da9/lib/utils/__tests__/isStandardSyntaxAtRule.test.js#L70-L80

In this PR, I've marked the case above as skipped.