### PR TITLE
Proposal: Add configuration example at end of docs

### DIFF
--- a/lib/rules/selector-no-qualifying-type/README.md
+++ b/lib/rules/selector-no-qualifying-type/README.md
@@ -103,3 +103,26 @@ a#foo {
   margin: 0
 }
 ```
+
+### Configuration example
+
+If you want to allow `class` selectors, update your rule configuration as follows:
+
+```
+"rules": {
+    "selector-no-qualifying-type": [
+    true,
+    {
+      "ignore": ["class"]
+    }
+  ]
+}
+```
+
+To completely disable the rule:
+
+```
+"rules": {
+  "selector-no-qualifying-type": null
+}
+```


### PR DESCRIPTION
A proposal to add configuration examples to the docs for the various rules. It is not often that I need to update or change the default shareable config, but when I do, oh boy 😄 I can never remember how the various rules are configured. As such, I think it would be useful to add little examples like this one to rules that are not a simple `true|false`.

Also, I believe in this case you set the rule to `null` to disable?
