### PR TITLE
Use own vendor utility instead of PostCSS

### DIFF
--- a/lib/rules/at-rule-allowed-list/index.js
+++ b/lib/rules/at-rule-allowed-list/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'at-rule-allowed-list';
 
@@ -36,7 +36,7 @@ function rule(listInput) {
 				return;
 			}
 
-			if (list.includes(postcss.vendor.unprefixed(name).toLowerCase())) {
+			if (list.includes(vendor.unprefixed(name).toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/at-rule-blacklist/index.js
+++ b/lib/rules/at-rule-blacklist/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'at-rule-blacklist';
 
@@ -41,7 +41,7 @@ function rule(listInput) {
 				return;
 			}
 
-			if (!list.includes(postcss.vendor.unprefixed(name).toLowerCase())) {
+			if (!list.includes(vendor.unprefixed(name).toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/at-rule-disallowed-list/index.js
+++ b/lib/rules/at-rule-disallowed-list/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'at-rule-disallowed-list';
 
@@ -36,7 +36,7 @@ function rule(listInput) {
 				return;
 			}
 
-			if (!list.includes(postcss.vendor.unprefixed(name).toLowerCase())) {
+			if (!list.includes(vendor.unprefixed(name).toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/at-rule-no-unknown/index.js
+++ b/lib/rules/at-rule-no-unknown/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const keywordSets = require('../../reference/keywordSets');
 const optionsMatches = require('../../utils/optionsMatches');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'at-rule-no-unknown';
 
@@ -48,7 +48,7 @@ function rule(actual, options) {
 				return;
 			}
 
-			if (postcss.vendor.prefix(name) || keywordSets.atRules.has(name.toLowerCase())) {
+			if (vendor.prefix(name) || keywordSets.atRules.has(name.toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/at-rule-whitelist/index.js
+++ b/lib/rules/at-rule-whitelist/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'at-rule-whitelist';
 
@@ -41,7 +41,7 @@ function rule(listInput) {
 				return;
 			}
 
-			if (list.includes(postcss.vendor.unprefixed(name).toLowerCase())) {
+			if (list.includes(vendor.unprefixed(name).toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -5,11 +5,11 @@
 const _ = require('lodash');
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
 const optionsMatches = require('../../utils/optionsMatches');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const shorthandData = require('../../reference/shorthandData');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-block-no-redundant-longhand-properties';
 
@@ -51,8 +51,8 @@ function rule(actual, options) {
 
 			eachDecl((decl) => {
 				const prop = decl.prop.toLowerCase();
-				const unprefixedProp = postcss.vendor.unprefixed(prop);
-				const prefix = postcss.vendor.prefix(prop);
+				const unprefixedProp = vendor.unprefixed(prop);
+				const prefix = vendor.prefix(prop);
 
 				const shorthandProperties = longhandProperties[unprefixedProp];
 

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -3,11 +3,11 @@
 'use strict';
 
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const shorthandData = require('../../reference/shorthandData');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-block-no-shorthand-property-overrides';
 
@@ -28,8 +28,8 @@ function rule(actual) {
 
 			eachDecl((decl) => {
 				const prop = decl.prop;
-				const unprefixedProp = postcss.vendor.unprefixed(prop);
-				const prefix = postcss.vendor.prefix(prop).toLowerCase();
+				const unprefixedProp = vendor.unprefixed(prop);
+				const prefix = vendor.prefix(prop).toLowerCase();
 
 				const overrideables = shorthandData[unprefixedProp.toLowerCase()];
 

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-unit-allowed-list';
 
@@ -33,7 +33,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 
 			const propList = _.find(list, (units, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),

--- a/lib/rules/declaration-property-unit-blacklist/index.js
+++ b/lib/rules/declaration-property-unit-blacklist/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-unit-blacklist';
 
@@ -41,7 +41,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 
 			const propList = _.find(list, (units, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-unit-disallowed-list';
 
@@ -33,7 +33,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 
 			const propList = _.find(list, (units, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),

--- a/lib/rules/declaration-property-unit-whitelist/index.js
+++ b/lib/rules/declaration-property-unit-whitelist/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-unit-whitelist';
 
@@ -41,7 +41,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 
 			const propList = _.find(list, (units, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-value-allowed-list';
 
@@ -30,7 +30,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 			const propList = _.find(list, (values, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);

--- a/lib/rules/declaration-property-value-blacklist/index.js
+++ b/lib/rules/declaration-property-value-blacklist/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-value-blacklist';
 
@@ -38,7 +38,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 			const propList = _.find(list, (values, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-value-disallowed-list';
 
@@ -30,7 +30,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 			const propList = _.find(list, (values, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);

--- a/lib/rules/declaration-property-value-whitelist/index.js
+++ b/lib/rules/declaration-property-value-whitelist/index.js
@@ -4,10 +4,10 @@
 
 const _ = require('lodash');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-property-value-whitelist';
 
@@ -38,7 +38,7 @@ function rule(list) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 			const propList = _.find(list, (values, propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);

--- a/lib/rules/function-allowed-list/index.js
+++ b/lib/rules/function-allowed-list/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'function-allowed-list';
 
@@ -43,7 +43,7 @@ function rule(listInput) {
 					return;
 				}
 
-				if (matchesStringOrRegExp(postcss.vendor.unprefixed(node.value), list)) {
+				if (matchesStringOrRegExp(vendor.unprefixed(node.value), list)) {
 					return;
 				}
 

--- a/lib/rules/function-blacklist/index.js
+++ b/lib/rules/function-blacklist/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'function-blacklist';
 
@@ -46,7 +46,7 @@ function rule(list) {
 					return;
 				}
 
-				if (!matchesStringOrRegExp(postcss.vendor.unprefixed(node.value), list)) {
+				if (!matchesStringOrRegExp(vendor.unprefixed(node.value), list)) {
 					return;
 				}
 

--- a/lib/rules/function-disallowed-list/index.js
+++ b/lib/rules/function-disallowed-list/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'function-disallowed-list';
 
@@ -41,7 +41,7 @@ function rule(list) {
 					return;
 				}
 
-				if (!matchesStringOrRegExp(postcss.vendor.unprefixed(node.value), list)) {
+				if (!matchesStringOrRegExp(vendor.unprefixed(node.value), list)) {
 					return;
 				}
 

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -5,11 +5,11 @@
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const functionArgumentsSearch = require('../../utils/functionArgumentsSearch');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'function-linear-gradient-no-nonstandard-direction';
 
@@ -83,7 +83,7 @@ function rule(actual) {
 							return;
 						}
 
-						const withToPrefix = !postcss.vendor.prefix(valueNode.value);
+						const withToPrefix = !vendor.prefix(valueNode.value);
 
 						if (!isStandardDirection(firstArg, withToPrefix)) {
 							complain();

--- a/lib/rules/function-whitelist/index.js
+++ b/lib/rules/function-whitelist/index.js
@@ -6,11 +6,11 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'function-whitelist';
 
@@ -48,7 +48,7 @@ function rule(listInput) {
 					return;
 				}
 
-				if (matchesStringOrRegExp(postcss.vendor.unprefixed(node.value), list)) {
+				if (matchesStringOrRegExp(vendor.unprefixed(node.value), list)) {
 					return;
 				}
 

--- a/lib/rules/media-feature-name-no-unknown/index.js
+++ b/lib/rules/media-feature-name-no-unknown/index.js
@@ -10,11 +10,11 @@ const isStandardSyntaxMediaFeatureName = require('../../utils/isStandardSyntaxMe
 const keywordSets = require('../../reference/keywordSets');
 const mediaParser = require('postcss-media-query-parser').default;
 const optionsMatches = require('../../utils/optionsMatches');
-const postcss = require('postcss');
 const rangeContextNodeParser = require('../rangeContextNodeParser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'media-feature-name-no-unknown';
 
@@ -67,10 +67,7 @@ function rule(actual, options) {
 					return;
 				}
 
-				if (
-					postcss.vendor.prefix(value) ||
-					keywordSets.mediaFeatureNames.has(value.toLowerCase())
-				) {
+				if (vendor.prefix(value) || keywordSets.mediaFeatureNames.has(value.toLowerCase())) {
 					return;
 				}
 

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -7,11 +7,11 @@ const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const mediaParser = require('postcss-media-query-parser').default;
-const postcss = require('postcss');
 const rangeContextNodeParser = require('../rangeContextNodeParser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'media-feature-name-value-allowed-list';
 
@@ -57,7 +57,7 @@ function rule(list) {
 				for (let i = 0; i < values.length; i++) {
 					const valueNode = values[i];
 					const value = valueNode.value;
-					const unprefixedMediaFeatureName = postcss.vendor.unprefixed(mediaFeatureName);
+					const unprefixedMediaFeatureName = vendor.unprefixed(mediaFeatureName);
 
 					const allowedValues = _.find(list, (v, featureName) =>
 						matchesStringOrRegExp(unprefixedMediaFeatureName, featureName),

--- a/lib/rules/media-feature-name-value-whitelist/index.js
+++ b/lib/rules/media-feature-name-value-whitelist/index.js
@@ -7,11 +7,11 @@ const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const mediaParser = require('postcss-media-query-parser').default;
-const postcss = require('postcss');
 const rangeContextNodeParser = require('../rangeContextNodeParser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'media-feature-name-value-whitelist';
 
@@ -65,7 +65,7 @@ function rule(list) {
 				for (let i = 0; i < values.length; i++) {
 					const valueNode = values[i];
 					const value = valueNode.value;
-					const unprefixedMediaFeatureName = postcss.vendor.unprefixed(mediaFeatureName);
+					const unprefixedMediaFeatureName = vendor.unprefixed(mediaFeatureName);
 
 					const allowedValues = _.find(list, (v, featureName) =>
 						matchesStringOrRegExp(unprefixedMediaFeatureName, featureName),

--- a/lib/rules/property-allowed-list/index.js
+++ b/lib/rules/property-allowed-list/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'property-allowed-list';
 
@@ -39,7 +39,7 @@ function rule(list) {
 				return;
 			}
 
-			if (matchesStringOrRegExp(postcss.vendor.unprefixed(prop), list)) {
+			if (matchesStringOrRegExp(vendor.unprefixed(prop), list)) {
 				return;
 			}
 

--- a/lib/rules/property-blacklist/index.js
+++ b/lib/rules/property-blacklist/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'property-blacklist';
 
@@ -44,7 +44,7 @@ function rule(list) {
 				return;
 			}
 
-			if (!matchesStringOrRegExp(postcss.vendor.unprefixed(prop), list)) {
+			if (!matchesStringOrRegExp(vendor.unprefixed(prop), list)) {
 				return;
 			}
 

--- a/lib/rules/property-disallowed-list/index.js
+++ b/lib/rules/property-disallowed-list/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'property-disallowed-list';
 
@@ -39,7 +39,7 @@ function rule(list) {
 				return;
 			}
 
-			if (!matchesStringOrRegExp(postcss.vendor.unprefixed(prop), list)) {
+			if (!matchesStringOrRegExp(vendor.unprefixed(prop), list)) {
 				return;
 			}
 

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -7,11 +7,11 @@ const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const optionsMatches = require('../../utils/optionsMatches');
-const postcss = require('postcss');
 const properties = require('known-css-properties').all;
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'property-no-unknown';
 
@@ -59,7 +59,7 @@ function rule(actual, options) {
 				return;
 			}
 
-			if (!shouldCheckPrefixed && postcss.vendor.prefix(prop)) {
+			if (!shouldCheckPrefixed && vendor.prefix(prop)) {
 				return;
 			}
 

--- a/lib/rules/property-no-vendor-prefix/index.js
+++ b/lib/rules/property-no-vendor-prefix/index.js
@@ -5,10 +5,10 @@
 const _ = require('lodash');
 const isAutoprefixable = require('../../utils/isAutoprefixable');
 const optionsMatches = require('../../utils/optionsMatches');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'property-no-vendor-prefix';
 
@@ -37,7 +37,7 @@ function rule(actual, options, context) {
 
 		root.walkDecls((decl) => {
 			const prop = decl.prop;
-			const unprefixedProp = postcss.vendor.unprefixed(prop);
+			const unprefixedProp = vendor.unprefixed(prop);
 
 			//return early if property is to be ignored
 			if (optionsMatches(options, 'ignoreProperties', unprefixedProp)) {

--- a/lib/rules/property-whitelist/index.js
+++ b/lib/rules/property-whitelist/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'property-whitelist';
 
@@ -44,7 +44,7 @@ function rule(list) {
 				return;
 			}
 
-			if (matchesStringOrRegExp(postcss.vendor.unprefixed(prop), list)) {
+			if (matchesStringOrRegExp(vendor.unprefixed(prop), list)) {
 				return;
 			}
 

--- a/lib/rules/selector-pseudo-class-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-allowed-list/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-class-allowed-list';
 
@@ -50,7 +50,7 @@ function rule(list) {
 
 					const name = value.slice(1);
 
-					if (matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-class-blacklist/index.js
+++ b/lib/rules/selector-pseudo-class-blacklist/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-class-blacklist';
 
@@ -59,7 +59,7 @@ function rule(list) {
 
 					const name = value.slice(1);
 
-					if (!matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (!matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-class-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-disallowed-list/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-class-disallowed-list';
 
@@ -51,7 +51,7 @@ function rule(list) {
 
 					const name = value.slice(1);
 
-					if (!matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (!matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -11,10 +11,10 @@ const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector')
 const keywordSets = require('../../reference/keywordSets');
 const optionsMatches = require('../../utils/optionsMatches');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-class-no-unknown';
 
@@ -74,7 +74,7 @@ function rule(actual, options) {
 						index = atRuleParamIndex(node) + pseudoNode.sourceIndex;
 					} else {
 						if (
-							postcss.vendor.prefix(name) ||
+							vendor.prefix(name) ||
 							keywordSets.pseudoClasses.has(name) ||
 							keywordSets.pseudoElements.has(name)
 						) {
@@ -92,7 +92,7 @@ function rule(actual, options) {
 						} while (prevPseudoElement);
 
 						if (prevPseudoElement) {
-							const prevPseudoElementValue = postcss.vendor.unprefixed(
+							const prevPseudoElementValue = vendor.unprefixed(
 								prevPseudoElement.value.toLowerCase().slice(2),
 							);
 

--- a/lib/rules/selector-pseudo-class-whitelist/index.js
+++ b/lib/rules/selector-pseudo-class-whitelist/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-class-whitelist';
 
@@ -58,7 +58,7 @@ function rule(list) {
 
 					const name = value.slice(1);
 
-					if (matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-element-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-allowed-list/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-element-allowed-list';
 
@@ -50,7 +50,7 @@ function rule(list) {
 
 					const name = value.slice(2);
 
-					if (matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-element-blacklist/index.js
+++ b/lib/rules/selector-pseudo-element-blacklist/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-element-blacklist';
 
@@ -58,7 +58,7 @@ function rule(list) {
 
 					const name = value.slice(2);
 
-					if (!matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (!matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-element-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-disallowed-list/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-element-disallowed-list';
 
@@ -50,7 +50,7 @@ function rule(list) {
 
 					const name = value.slice(2);
 
-					if (!matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (!matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -8,10 +8,10 @@ const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector')
 const keywordSets = require('../../reference/keywordSets');
 const optionsMatches = require('../../utils/optionsMatches');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-element-no-unknown';
 
@@ -70,7 +70,7 @@ function rule(actual, options) {
 
 					const name = value.slice(2);
 
-					if (postcss.vendor.prefix(name) || keywordSets.pseudoElements.has(name.toLowerCase())) {
+					if (vendor.prefix(name) || keywordSets.pseudoElements.has(name.toLowerCase())) {
 						return;
 					}
 

--- a/lib/rules/selector-pseudo-element-whitelist/index.js
+++ b/lib/rules/selector-pseudo-element-whitelist/index.js
@@ -6,10 +6,10 @@ const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'selector-pseudo-element-whitelist';
 
@@ -58,7 +58,7 @@ function rule(list) {
 
 					const name = value.slice(2);
 
-					if (matchesStringOrRegExp(postcss.vendor.unprefixed(name), list)) {
+					if (matchesStringOrRegExp(vendor.unprefixed(name), list)) {
 						return;
 					}
 

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -4,11 +4,11 @@
 
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'shorthand-property-no-redundant-values';
 
@@ -90,7 +90,7 @@ function rule(actual, secondary, context) {
 			const prop = decl.prop;
 			const value = decl.value;
 
-			const normalizedProp = postcss.vendor.unprefixed(prop.toLowerCase());
+			const normalizedProp = vendor.unprefixed(prop.toLowerCase());
 
 			if (hasIgnoredCharacters(value) || !isShorthandProperty(normalizedProp)) {
 				return;

--- a/lib/rules/time-min-milliseconds/index.js
+++ b/lib/rules/time-min-milliseconds/index.js
@@ -11,6 +11,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'time-min-milliseconds';
 
@@ -43,7 +44,7 @@ function rule(minimum, options) {
 		}
 
 		root.walkDecls((decl) => {
-			const propertyName = postcss.vendor.unprefixed(decl.prop.toLowerCase());
+			const propertyName = vendor.unprefixed(decl.prop.toLowerCase());
 
 			if (
 				keywordSets.longhandTimeProperties.has(propertyName) &&

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -10,11 +10,11 @@ const isMap = require('../../utils/isMap');
 const keywordSets = require('../../reference/keywordSets');
 const mediaParser = require('postcss-media-query-parser').default;
 const optionsMatches = require('../../utils/optionsMatches');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'unit-no-unknown';
 
@@ -121,7 +121,7 @@ function rule(actual, options) {
 
 						if (/^(?:-webkit-)?image-set[\s(]/i.test(value)) {
 							const imageSet = parsedValue.nodes.find(
-								(node) => postcss.vendor.unprefixed(node.value) === 'image-set',
+								(node) => vendor.unprefixed(node.value) === 'image-set',
 							);
 							const imageSetValueLastIndex = _.last(imageSet.nodes).sourceIndex;
 

--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -7,11 +7,11 @@ const isAutoprefixable = require('../../utils/isAutoprefixable');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const optionsMatches = require('../../utils/optionsMatches');
-const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
+const vendor = require('../../utils/vendor');
 
 const ruleName = 'value-no-vendor-prefix';
 
@@ -51,7 +51,7 @@ function rule(actual, options, context) {
 
 			const prop = decl.prop;
 			const value = decl.value;
-			const unprefixedValue = postcss.vendor.unprefixed(value);
+			const unprefixedValue = vendor.unprefixed(value);
 
 			//return early if value is to be ignored
 			if (optionsMatches(options, 'ignoreValues', unprefixedValue)) {

--- a/lib/utils/__tests__/vendor.test.js
+++ b/lib/utils/__tests__/vendor.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const vendor = require('../vendor');
+
+const VALUE = '-1px -1px 1px rgba(0, 0, 0, 0.2) inset';
+
+it('returns prefix', () => {
+	expect(vendor.prefix('-moz-color')).toEqual('-moz-');
+	expect(vendor.prefix('color')).toEqual('');
+	expect(vendor.prefix(VALUE)).toEqual('');
+});
+
+it('returns unprefixed version', () => {
+	expect(vendor.unprefixed('-moz-color')).toEqual('color');
+	expect(vendor.unprefixed('color')).toEqual('color');
+	expect(vendor.unprefixed(VALUE)).toEqual(VALUE);
+});

--- a/lib/utils/vendor.js
+++ b/lib/utils/vendor.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * Contains helpers for working with vendor prefixes.
+ *
+ * Copied from https://github.com/postcss/postcss/commit/777c55b5d2a10605313a4972888f4f32005f5ac2
+ *
+ * @namespace vendor
+ */
+module.exports = {
+	/**
+	 * Returns the vendor prefix extracted from an input string.
+	 *
+	 * @param {string} prop String with or without vendor prefix.
+	 *
+	 * @return {string} vendor prefix or empty string
+	 *
+	 * @example
+	 * vendor.prefix('-moz-tab-size') //=> '-moz-'
+	 * vendor.prefix('tab-size')      //=> ''
+	 */
+	prefix(prop) {
+		let match = prop.match(/^(-\w+-)/);
+
+		if (match) {
+			return match[0];
+		}
+
+		return '';
+	},
+
+	/**
+	 * Returns the input string stripped of its vendor prefix.
+	 *
+	 * @param {string} prop String with or without vendor prefix.
+	 *
+	 * @return {string} String name without vendor prefixes.
+	 *
+	 * @example
+	 * vendor.unprefixed('-moz-tab-size') //=> 'tab-size'
+	 */
+	unprefixed(prop) {
+		return prop.replace(/^-\w+-/, '');
+	},
+};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to https://github.com/stylelint/stylelint/issues/4942.

> Is there anything in the PR that needs further explanation?

`postcss.vendor` was removed in PostCSS 8. I did what Andrey Sitnik did with Autoprefixer: copied `vendor` to project :)