### PR TITLE
Bump known-css-properties from 0.19.0 to 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5210,9 +5210,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.19.0.tgz",
-      "integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA=="
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.20.0.tgz",
+      "integrity": "sha512-URvsjaA9ypfreqJ2/ylDr5MUERhJZ+DhguoWRr2xgS5C7aGCalXo+ewL+GixgKBfhT2vuL02nbIgNGqVWgTOYw=="
     },
     "latest-version": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "ignore": "^5.1.8",
     "import-lazy": "^4.0.0",
     "imurmurhash": "^0.1.4",
-    "known-css-properties": "^0.19.0",
+    "known-css-properties": "^0.20.0",
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "mathml-tag-names": "^2.1.3",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4966

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
