### PR TITLE
Fix some tests that use callbacks

### DIFF
--- a/lib/utils/__tests__/findAtRuleContext.test.js
+++ b/lib/utils/__tests__/findAtRuleContext.test.js
@@ -12,13 +12,11 @@ it('findAtRuleContext', () => {
 	@media (min-width: 900px) {
 		c {}
 	}
-	d {}
 	`;
 
 	expect(findAtRuleContext(rule(css, 'a'))).toBeNull();
 	expect(findAtRuleContext(rule(css, 'b'))).toHaveProperty('params', 'print');
 	expect(findAtRuleContext(rule(css, 'c'))).toHaveProperty('params', '(min-width: 900px)');
-	expect(findAtRuleContext(rule(css, 'd'))).toBeNull();
 });
 
 function rule(css, selector) {

--- a/lib/utils/__tests__/findAtRuleContext.test.js
+++ b/lib/utils/__tests__/findAtRuleContext.test.js
@@ -22,7 +22,7 @@ it('findAtRuleContext', () => {
 function rule(css, selector) {
 	const rules = [];
 
-	postcss.parse(css).walkRules(selector, (rule) => rules.push(rule));
+	postcss.parse(css).walkRules(selector, (r) => rules.push(r));
 
 	return rules[0];
 }

--- a/lib/utils/__tests__/findAtRuleContext.test.js
+++ b/lib/utils/__tests__/findAtRuleContext.test.js
@@ -5,31 +5,26 @@ const postcss = require('postcss');
 
 it('findAtRuleContext', () => {
 	const css = `
-    a {}
-    @media print {
-      b {}
-    }
-    @media (min-width: 900px) {
-      c {}
-    }
-    d {}
-  `;
+	a {}
+	@media print {
+		b {}
+	}
+	@media (min-width: 900px) {
+		c {}
+	}
+	d {}
+	`;
 
-	postcss.parse(css).walkRules((rule) => {
-		switch (rule.selector) {
-			case 'a':
-				expect(findAtRuleContext(rule)).toBeNull();
-				break;
-			case 'b':
-				expect(findAtRuleContext(rule).params).toBe('print');
-				break;
-			case 'c':
-				expect(findAtRuleContext(rule).params).toBe('(min-width: 900px)');
-				break;
-			case 'd':
-				expect(findAtRuleContext(rule)).toBeNull();
-				break;
-			default:
-		}
-	});
+	expect(findAtRuleContext(rule(css, 'a'))).toBeNull();
+	expect(findAtRuleContext(rule(css, 'b'))).toHaveProperty('params', 'print');
+	expect(findAtRuleContext(rule(css, 'c'))).toHaveProperty('params', '(min-width: 900px)');
+	expect(findAtRuleContext(rule(css, 'd'))).toBeNull();
 });
+
+function rule(css, selector) {
+	const rules = [];
+
+	postcss.parse(css).walkRules(selector, (rule) => rules.push(rule));
+
+	return rules[0];
+}

--- a/lib/utils/__tests__/isContextFunctionalPseudoClass.test.js
+++ b/lib/utils/__tests__/isContextFunctionalPseudoClass.test.js
@@ -4,45 +4,33 @@ const isContextFunctionalPseudoClass = require('../isContextFunctionalPseudoClas
 const parseSelector = require('postcss-selector-parser');
 const postcss = require('postcss');
 
-function selector(css, cb) {
+function pseudo(css) {
+	const pseudos = [];
+
 	postcss.parse(css).walkRules((rule) => {
 		parseSelector((selectorAST) => {
-			selectorAST.walkPseudos(cb);
+			selectorAST.walkPseudos((pseudo) => pseudos.push(pseudo));
 		}).processSync(rule.selector);
 	});
+
+	return pseudos[0];
 }
 
 describe('isContextFunctionalPseudoClass', () => {
 	it('handles non-context-functional pseudo-classes, like hover', () => {
-		selector('a:hover {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(false);
-		});
+		expect(isContextFunctionalPseudoClass(pseudo('a:hover {}'))).toBe(false);
 	});
 
 	it('handles logical combinations, ', () => {
-		selector('a:has(.foo) {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(true);
-		});
-		selector('a:is(.foo) {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(true);
-		});
-		selector('a:matches(.foo) {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(true);
-		});
-		selector('a:not(.foo) {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(true);
-		});
-		selector('a:where(.foo) {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(true);
-		});
+		expect(isContextFunctionalPseudoClass(pseudo('a:has(.foo) {}'))).toBe(true);
+		expect(isContextFunctionalPseudoClass(pseudo('a:is(.foo) {}'))).toBe(true);
+		expect(isContextFunctionalPseudoClass(pseudo('a:matches(.foo) {}'))).toBe(true);
+		expect(isContextFunctionalPseudoClass(pseudo('a:not(.foo) {}'))).toBe(true);
+		expect(isContextFunctionalPseudoClass(pseudo('a:where(.foo) {}'))).toBe(true);
 	});
 
 	it('handles tree structural/NPlusBOfSNotationPseudoClasses classes', () => {
-		selector('a:nth-child(n+7) {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(true);
-		});
-		selector('a:nth-last-child(n+7) {}', (selector) => {
-			expect(isContextFunctionalPseudoClass(selector)).toBe(true);
-		});
+		expect(isContextFunctionalPseudoClass(pseudo('a:nth-child(n+7) {}'))).toBe(true);
+		expect(isContextFunctionalPseudoClass(pseudo('a:nth-last-child(n+7) {}'))).toBe(true);
 	});
 });

--- a/lib/utils/__tests__/isContextFunctionalPseudoClass.test.js
+++ b/lib/utils/__tests__/isContextFunctionalPseudoClass.test.js
@@ -9,7 +9,7 @@ function pseudo(css) {
 
 	postcss.parse(css).walkRules((rule) => {
 		parseSelector((selectorAST) => {
-			selectorAST.walkPseudos((pseudo) => pseudos.push(pseudo));
+			selectorAST.walkPseudos((p) => pseudos.push(p));
 		}).processSync(rule.selector);
 	});
 

--- a/lib/utils/__tests__/isMap.test.js
+++ b/lib/utils/__tests__/isMap.test.js
@@ -19,7 +19,11 @@ describe('isMap', () => {
 	];
 
 	test.each(simpleMaps)('simple maps', (css, expected) => {
-		runTests(css, (decl) => {
+		const decls = declarations(css);
+
+		expect(decls).toHaveLength(2);
+
+		decls.forEach((decl) => {
 			const parsedValue = valueParser(decl.value).nodes[0];
 
 			expect(isMap(parsedValue)).toBe(expected);
@@ -27,10 +31,19 @@ describe('isMap', () => {
 	});
 
 	test.each(nestedMaps)('nested maps', (css, expected) => {
-		runTests(css, (decl) => {
+		const decls = declarations(css);
+
+		expect(decls).toHaveLength(2);
+
+		decls.forEach((decl) => {
 			const parsedValue = valueParser(decl.value);
 
-			parsedValue.walk((valueNode) => {
+			const valueNodes = [];
+
+			parsedValue.walk((valueNode) => valueNodes.push(valueNode));
+
+			expect(valueNodes.length).toBeGreaterThan(0);
+			valueNodes.forEach((valueNode) => {
 				if (expected.includes(valueNode.sourceIndex)) {
 					expect(isMap(valueNode)).toBeTruthy();
 				} else {
@@ -43,7 +56,11 @@ describe('isMap', () => {
 	it('empty map returns `false`', () => {
 		const emptyMap = '$map: ();';
 
-		runTests(emptyMap, (decl) => {
+		const decls = declarations(emptyMap);
+
+		expect(decls).toHaveLength(2);
+
+		decls.forEach((decl) => {
 			const parsedValue = valueParser(decl.value);
 
 			expect(isMap(parsedValue)).toBeFalsy();
@@ -51,16 +68,11 @@ describe('isMap', () => {
 	});
 });
 
-function sassDecls(css, cb) {
-	sass.parse(css).walkDecls(cb);
-}
+function declarations(css) {
+	const list = [];
 
-function scssDecls(css, cb) {
-	scss.parse(css).walkDecls(cb);
-}
+	sass.parse(css).walkDecls((decl) => list.push(decl));
+	scss.parse(css).walkDecls((decl) => list.push(decl));
 
-function runTests(css, cb) {
-	[sassDecls, scssDecls].forEach((fn) => {
-		fn(css, cb);
-	});
+	return list;
 }

--- a/lib/utils/__tests__/isStandardSyntaxFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxFunction.test.js
@@ -6,38 +6,32 @@ const valueParser = require('postcss-value-parser');
 
 describe('isStandardSyntaxFunction', () => {
 	it('calc', () => {
-		funcs('a { prop: calc(a + b) }', (func) => {
-			expect(isStandardSyntaxFunction(func)).toBeTruthy();
-		});
+		expect(isStandardSyntaxFunction(func('a { prop: calc(a + b) }'))).toBeTruthy();
 	});
 
 	it('url', () => {
-		funcs("a { prop: url('x.css') }", (func) => {
-			expect(isStandardSyntaxFunction(func)).toBeTruthy();
-		});
+		expect(isStandardSyntaxFunction(func("a { prop: url('x.css') }"))).toBeTruthy();
 	});
 
 	it('scss list', () => {
-		funcs('a { $list: (list) }', (func) => {
-			expect(isStandardSyntaxFunction(func)).toBeFalsy();
-		});
+		expect(isStandardSyntaxFunction(func('a { $list: (list) }'))).toBeFalsy();
 	});
 
 	it('scss map', () => {
-		funcs('a { $map: (key: value) }', (func) => {
-			expect(isStandardSyntaxFunction(func)).toBeFalsy();
-		});
+		expect(isStandardSyntaxFunction(func('a { $map: (key: value) }'))).toBeFalsy();
 	});
 });
 
-function funcs(css, cb) {
+function func(css) {
+	const functions = [];
+
 	postcss.parse(css).walkDecls((decl) => {
 		valueParser(decl.value).walk((valueNode) => {
-			if (valueNode.type !== 'function') {
-				return;
+			if (valueNode.type === 'function') {
+				functions.push(valueNode);
 			}
-
-			cb(valueNode);
 		});
 	});
+
+	return functions[0];
 }

--- a/lib/utils/__tests__/isStandardSyntaxFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxFunction.test.js
@@ -6,19 +6,19 @@ const valueParser = require('postcss-value-parser');
 
 describe('isStandardSyntaxFunction', () => {
 	it('calc', () => {
-		expect(isStandardSyntaxFunction(func('a { prop: calc(a + b) }'))).toBeTruthy();
+		expect(isStandardSyntaxFunction(func('a { prop: calc(a + b) }'))).toBe(true);
 	});
 
 	it('url', () => {
-		expect(isStandardSyntaxFunction(func("a { prop: url('x.css') }"))).toBeTruthy();
+		expect(isStandardSyntaxFunction(func("a { prop: url('x.css') }"))).toBe(true);
 	});
 
 	it('scss list', () => {
-		expect(isStandardSyntaxFunction(func('a { $list: (list) }'))).toBeFalsy();
+		expect(isStandardSyntaxFunction(func('a { $list: (list) }'))).toBe(false);
 	});
 
 	it('scss map', () => {
-		expect(isStandardSyntaxFunction(func('a { $map: (key: value) }'))).toBeFalsy();
+		expect(isStandardSyntaxFunction(func('a { $map: (key: value) }'))).toBe(false);
 	});
 });
 


### PR DESCRIPTION
This PR fixes the following tests that use callbacks:

- `lib/utils/__tests__/findAtRuleContext.test.js`
- `lib/utils/__tests__/isContextFunctionalPseudoClass.test.js`
- `lib/utils/__tests__/isMap.test.js`
- `lib/utils/__tests__/isStandardSyntaxFunction.test.js`

> Which issue, if any, is this issue related to?

This is a part of #4881.

> Is there anything in the PR that needs further explanation?

This PR includes some indentation changes, so I recommend viewing with [hidden whitespace changes](https://github.com/stylelint/stylelint/pull/4970/files?w=1).
