### PR TITLE
Add Node.js 14 to CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12]
+        node: [14]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: ubuntu-latest
-            node: 12
+            node: 14
 
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12]
+        node: [14]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12]
+        node: [10, 12, 14]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: ubuntu-latest


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js 14 [goes LTS on 27.10.2020](https://nodejs.org/en/about/releases/). We need to be sure stylelint works there. ~~As soon it went LTS we could switch default Node.js version for linting and coverage to 14.~~ Decided to change it now, because I see no downsides of not doing so now.
