### PR TITLE
Fix `disableRanges.test.js` that uses callbacks

### DIFF
--- a/lib/__tests__/disableRanges.test.js
+++ b/lib/__tests__/disableRanges.test.js
@@ -2,1006 +2,981 @@
 
 const _ = require('lodash');
 const assignDisabledRanges = require('../assignDisabledRanges');
-const less = require('postcss-less');
 const postcss = require('postcss');
-const scss = require('postcss-scss');
+const postcssLess = require('postcss-less');
+const postcssScss = require('postcss-scss');
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect*"] }] */
 
-it('no disabling', () => {
-	return testDisableRanges('a {}').then((result) => {
-		expect(result.stylelint.disabledRanges).toEqual({ all: [] });
-	});
+it('no disabling', async () => {
+	const result = await testDisableRanges('a {}');
+
+	expect(result.stylelint.disabledRanges).toEqual({ all: [] });
 });
 
-it('disable without re-enabling', () => {
-	return testDisableRanges('/* stylelint-disable */\na {}').then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 1,
-					strictStart: true,
-				},
-			],
-		});
-	});
-});
-
-it('disable and re-enable', () => {
-	return testDisableRanges(`a {}
-    /* stylelint-disable */
-    b {}
-    /* stylelint-enable */
-    .foo {}`).then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 2,
-					end: 4,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-		});
-	});
-});
-
-it('disable and re-enable twice', () => {
-	return testDisableRanges(`a {}
-    /* stylelint-disable */
-    b {}
-    /* stylelint-enable */
-    .foo {}
-    /* stylelint-disable */
-    b {}
-    /* stylelint-enable */
-    .foo {}`).then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 2,
-					end: 4,
-					strictStart: true,
-					strictEnd: true,
-				},
-				{
-					start: 6,
-					end: 8,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-		});
-	});
-});
-
-it('disable rule without re-enabling', () => {
-	return testDisableRanges('/* stylelint-disable foo-bar */\na {}')
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'foo-bar': [
-					{
-						start: 1,
-						strictStart: true,
-						end: undefined,
-						strictEnd: undefined,
-					},
-				],
-			});
-		})
-		.then(() => {
-			return testDisableRanges(
-				'/* stylelint-disable selector-combinator-space-before */\n' + 'a {}',
-			).then((result) => {
-				expectDisableRanges(result, {
-					all: [],
-					'selector-combinator-space-before': [
-						{
-							start: 1,
-							strictStart: true,
-							end: undefined,
-							strictEnd: undefined,
-						},
-					],
-				});
-			});
-		});
-});
-
-it('mixed disabling of specific and all rules, enabling of all', () => {
-	return testDisableRanges(`a {}
-    /* stylelint-disable foo-bar */
-    b {}
-    /* stylelint-enable */
-    .foo {}
-    /* stylelint-disable foo-bar,baz-maz */
-    b {}
-    /* stylelint-enable */
-    .foo {}`).then((result) => {
-		expectDisableRanges(result, {
-			all: [],
-			'foo-bar': [
-				{
-					start: 2,
-					end: 4,
-					strictStart: true,
-					strictEnd: false,
-				},
-				{
-					start: 6,
-					end: 8,
-					strictStart: true,
-					strictEnd: false,
-				},
-			],
-			'baz-maz': [
-				{
-					start: 6,
-					end: 8,
-					strictStart: true,
-					strictEnd: false,
-				},
-			],
-		});
-	});
-});
-
-it('disable rules with newline in rule list', () => {
-	return testDisableRanges('/* stylelint-disable foo-bar, hoo-hah,\n\tslime */\n' + 'b {}\n').then(
-		(result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'foo-bar': [
-					{
-						start: 1,
-						strictStart: true,
-					},
-				],
-				'hoo-hah': [
-					{
-						start: 1,
-						strictStart: true,
-					},
-				],
-				slime: [
-					{
-						start: 1,
-						strictStart: true,
-					},
-				],
-			});
-		},
+it('disable without re-enabling', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable */
+		a {}`,
 	);
-});
 
-it('disable single line all rules', () => {
-	return testDisableRanges('a {} /* stylelint-disable-line */').then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 1,
-					end: 1,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-		});
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 1,
+				strictStart: true,
+			},
+		],
 	});
 });
 
-it('disable single line one rule', () => {
-	return testDisableRanges('a {} /* stylelint-disable-line block-no-empty */').then((result) => {
-		expectDisableRanges(result, {
-			all: [],
-			'block-no-empty': [
-				{
-					start: 1,
-					end: 1,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-		});
-	});
-});
-
-it('disable single line multiple rules', () => {
-	return testDisableRanges('b {}\n\na {} /* stylelint-disable-line block-no-empty, blergh */').then(
-		(result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'block-no-empty': [
-					{
-						start: 3,
-						end: 3,
-						strictStart: true,
-						strictEnd: true,
-					},
-				],
-				blergh: [
-					{
-						start: 3,
-						end: 3,
-						strictStart: true,
-						strictEnd: true,
-					},
-				],
-			});
-		},
+it('disable and re-enable', async () => {
+	const result = await testDisableRanges(
+		`a {}
+		/* stylelint-disable */
+		b {}
+		/* stylelint-enable */
+		.foo {}`,
 	);
+
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 2,
+				end: 4,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+	});
+});
+
+it('disable and re-enable twice', async () => {
+	const result = await testDisableRanges(
+		`a {}
+		/* stylelint-disable */
+		b {}
+		/* stylelint-enable */
+		.foo {}
+		/* stylelint-disable */
+		b {}
+		/* stylelint-enable */
+		.foo {}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 2,
+				end: 4,
+				strictStart: true,
+				strictEnd: true,
+			},
+			{
+				start: 6,
+				end: 8,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+	});
+});
+
+it('disable rule without re-enabling', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable foo-bar */
+		a {}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'foo-bar': [
+			{
+				start: 1,
+				strictStart: true,
+				end: undefined,
+				strictEnd: undefined,
+			},
+		],
+	});
+
+	const result_2 = await testDisableRanges(
+		`/* stylelint-disable selector-combinator-space-before */
+		a {}`,
+	);
+
+	expectDisableRanges(result_2, {
+		all: [],
+		'selector-combinator-space-before': [
+			{
+				start: 1,
+				strictStart: true,
+				end: undefined,
+				strictEnd: undefined,
+			},
+		],
+	});
+});
+
+it('mixed disabling of specific and all rules, enabling of all', async () => {
+	const result = await testDisableRanges(
+		`a {}
+		/* stylelint-disable foo-bar */
+		b {}
+		/* stylelint-enable */
+		.foo {}
+		/* stylelint-disable foo-bar,baz-maz */
+		b {}
+		/* stylelint-enable */
+		.foo {}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'foo-bar': [
+			{
+				start: 2,
+				end: 4,
+				strictStart: true,
+				strictEnd: false,
+			},
+			{
+				start: 6,
+				end: 8,
+				strictStart: true,
+				strictEnd: false,
+			},
+		],
+		'baz-maz': [
+			{
+				start: 6,
+				end: 8,
+				strictStart: true,
+				strictEnd: false,
+			},
+		],
+	});
+});
+
+it('disable rules with newline in rule list', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable foo-bar, hoo-hah,
+		slime */
+		b {}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'foo-bar': [
+			{
+				start: 1,
+				strictStart: true,
+			},
+		],
+		'hoo-hah': [
+			{
+				start: 1,
+				strictStart: true,
+			},
+		],
+		slime: [
+			{
+				start: 1,
+				strictStart: true,
+			},
+		],
+	});
+});
+
+it('disable single line all rules', async () => {
+	const result = await testDisableRanges('a {} /* stylelint-disable-line */');
+
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 1,
+				end: 1,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+	});
+});
+
+it('disable single line one rule', async () => {
+	const result = await testDisableRanges('a {} /* stylelint-disable-line block-no-empty */');
+
+	expectDisableRanges(result, {
+		all: [],
+		'block-no-empty': [
+			{
+				start: 1,
+				end: 1,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+	});
+});
+
+it('disable single line multiple rules', async () => {
+	const result = await testDisableRanges(
+		`b {}
+
+		a {} /* stylelint-disable-line block-no-empty, blergh */`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'block-no-empty': [
+			{
+				start: 3,
+				end: 3,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		blergh: [
+			{
+				start: 3,
+				end: 3,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+	});
 });
 
 it('disable single line one rule and re-enable all', () => {
-	return testDisableRanges(
-		'a {} /* stylelint-disable-line block-no-empty */\n/* stylelint-enable */',
-		() => {
-			throw new Error('should have errored');
-		},
-	).catch((err) => {
-		expect(err.reason).toBe('No rules have been disabled');
-	});
+	return expect(
+		testDisableRanges(
+			`a {} /* stylelint-disable-line block-no-empty */
+			/* stylelint-enable */`,
+		),
+	).rejects.toThrow('No rules have been disabled');
 });
 
-it('disable next line all rules', () => {
-	return testDisableRanges('/* stylelint-disable-next-line */\na {} ').then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 2,
-					end: 2,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-		});
-	});
-});
-
-it('disable next line one rule', () => {
-	return testDisableRanges('/* stylelint-disable-next-line block-no-empty */\na {}').then(
-		(result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'block-no-empty': [
-					{
-						start: 2,
-						end: 2,
-						strictStart: true,
-						strictEnd: true,
-					},
-				],
-			});
-		},
+it('disable next line all rules', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable-next-line */
+		a {} `,
 	);
+
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 2,
+				end: 2,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+	});
 });
 
-it('disable next line multiple rules', () => {
-	return testDisableRanges(
+it('disable next line one rule', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable-next-line block-no-empty */
+		a {}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'block-no-empty': [
+			{
+				start: 2,
+				end: 2,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+	});
+});
+
+it('disable next line multiple rules', async () => {
+	const result = await testDisableRanges(
 		`
-    b {}
+		b {}
 
-    /* stylelint-disable-next-line block-no-empty, blergh */
-    a {}`,
-		(result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'block-no-empty': [
-					{
-						start: 5,
-						end: 5,
-						strictStart: true,
-						strictEnd: true,
-					},
-				],
-				blergh: [
-					{
-						start: 5,
-						end: 5,
-						strictStart: true,
-						strictEnd: true,
-					},
-				],
-			});
-		},
+		/* stylelint-disable-next-line block-no-empty, blergh */
+		a {}`,
 	);
-});
 
-it('SCSS // line-disabling comment', () => {
-	const scssSource = `a {
-    color: pink !important; // stylelint-disable-line declaration-no-important
-  }`;
-
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						end: 2,
-						strictStart: true,
-						strictEnd: true,
-					},
-				],
-			});
-		});
-});
-
-it('Less // line-disabling comment', () => {
-	const lessSource = `a {
-    color: pink !important; // stylelint-disable-line declaration-no-important
-  }`;
-
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(lessSource, { syntax: less, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						end: 2,
-						strictStart: true,
-						strictEnd: true,
-					},
-				],
-			});
-		});
-});
-
-it('nested ranges all rule-specific', () => {
-	return testDisableRanges(`/* stylelint-disable foo */
-    /* stylelint-disable bar */
-    /* stylelint-disable baz, hop */
-    /* stylelint-enable bar */
-    /* stylelint-enable foo, hop */
-    /* stylelint-enable baz */`).then((result) => {
-		expectDisableRanges(result, {
-			all: [],
-			foo: [
-				{
-					start: 1,
-					end: 5,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-			bar: [
-				{
-					start: 2,
-					end: 4,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-			baz: [
-				{
-					start: 3,
-					end: 6,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-			hop: [
-				{
-					start: 3,
-					end: 5,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'block-no-empty': [
+			{
+				start: 5,
+				end: 5,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		blergh: [
+			{
+				start: 5,
+				end: 5,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
 	});
 });
 
-it('nested ranges all for all rules', () => {
-	return testDisableRanges(`/* stylelint-disable */
-    /* stylelint-enable bar */
-    /* stylelint-disable bar */
-    /* stylelint-enable */`).then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 1,
-					end: 4,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-			bar: [
-				{
-					start: 1,
-					end: 2,
-					strictStart: false,
-					strictEnd: true,
-				},
-				{
-					start: 3,
-					end: 4,
-					strictStart: true,
-					strictEnd: false,
-				},
-			],
-		});
+it('SCSS // line-disabling comment', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			color: pink !important; // stylelint-disable-line declaration-no-important
+		}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				end: 2,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
 	});
 });
 
-it('nested ranges disable rules enable all', () => {
-	return testDisableRanges(`/* stylelint-disable foo */
-    /* stylelint-disable bar, baz */
-    /* stylelint-enable */`).then((result) => {
-		expectDisableRanges(result, {
-			all: [],
-			foo: [
-				{
-					start: 1,
-					end: 3,
-					strictStart: true,
-					strictEnd: false,
-				},
-			],
-			bar: [
-				{
-					start: 2,
-					end: 3,
-					strictStart: true,
-					strictEnd: false,
-				},
-			],
-			baz: [
-				{
-					start: 2,
-					end: 3,
-					strictStart: true,
-					strictEnd: false,
-				},
-			],
-		});
+it('Less // line-disabling comment', async () => {
+	const result = await testDisableRangesLess(
+		`a {
+			color: pink !important; // stylelint-disable-line declaration-no-important
+		}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				end: 2,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
 	});
 });
 
-it('nested ranges mix disabling enabling all rules and specific rules', () => {
-	return testDisableRanges(`/* stylelint-disable */
-    /* stylelint-enable foo */
-    /* stylelint-enable */
-    /* stylelint-disable bar */`).then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 1,
-					end: 3,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-			foo: [
-				{
-					start: 1,
-					end: 2,
-					strictStart: false,
-					strictEnd: true,
-				},
-			],
-			bar: [
-				{
-					start: 1,
-					end: 3,
-					strictStart: false,
-					strictEnd: false,
-				},
-				{
-					start: 4,
-					strictStart: true,
-					strictEnd: undefined,
-					end: undefined,
-				},
-			],
-		});
+it('nested ranges all rule-specific', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable foo */
+		/* stylelint-disable bar */
+		/* stylelint-disable baz, hop */
+		/* stylelint-enable bar */
+		/* stylelint-enable foo, hop */
+		/* stylelint-enable baz */`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		foo: [
+			{
+				start: 1,
+				end: 5,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		bar: [
+			{
+				start: 2,
+				end: 4,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		baz: [
+			{
+				start: 3,
+				end: 6,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		hop: [
+			{
+				start: 3,
+				end: 5,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
 	});
 });
 
-it('nested ranges another mix', () => {
-	return testDisableRanges(`/* stylelint-disable */
-    /* stylelint-enable bar */
-    /* stylelint-enable foo */
-    /* stylelint-disable foo */
-    /* stylelint-enable */`).then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 1,
-					end: 5,
-					strictStart: true,
-					strictEnd: true,
-				},
-			],
-			bar: [
-				{
-					start: 1,
-					end: 2,
-					strictStart: false,
-					strictEnd: true,
-				},
-			],
-			foo: [
-				{
-					start: 1,
-					end: 3,
-					strictStart: false,
-					strictEnd: true,
-				},
-				{
-					start: 4,
-					end: 5,
-					strictStart: true,
-					strictEnd: false,
-				},
-			],
-		});
+it('nested ranges all for all rules', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable */
+		/* stylelint-enable bar */
+		/* stylelint-disable bar */
+		/* stylelint-enable */`,
+	);
+
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 1,
+				end: 4,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		bar: [
+			{
+				start: 1,
+				end: 2,
+				strictStart: false,
+				strictEnd: true,
+			},
+			{
+				start: 3,
+				end: 4,
+				strictStart: true,
+				strictEnd: false,
+			},
+		],
+	});
+});
+
+it('nested ranges disable rules enable all', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable foo */
+		/* stylelint-disable bar, baz */
+		/* stylelint-enable */`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		foo: [
+			{
+				start: 1,
+				end: 3,
+				strictStart: true,
+				strictEnd: false,
+			},
+		],
+		bar: [
+			{
+				start: 2,
+				end: 3,
+				strictStart: true,
+				strictEnd: false,
+			},
+		],
+		baz: [
+			{
+				start: 2,
+				end: 3,
+				strictStart: true,
+				strictEnd: false,
+			},
+		],
+	});
+});
+
+it('nested ranges mix disabling enabling all rules and specific rules', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable */
+		/* stylelint-enable foo */
+		/* stylelint-enable */
+		/* stylelint-disable bar */`,
+	);
+
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 1,
+				end: 3,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		foo: [
+			{
+				start: 1,
+				end: 2,
+				strictStart: false,
+				strictEnd: true,
+			},
+		],
+		bar: [
+			{
+				start: 1,
+				end: 3,
+				strictStart: false,
+				strictEnd: false,
+			},
+			{
+				start: 4,
+				strictStart: true,
+				strictEnd: undefined,
+				end: undefined,
+			},
+		],
+	});
+});
+
+it('nested ranges another mix', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable */
+		/* stylelint-enable bar */
+		/* stylelint-enable foo */
+		/* stylelint-disable foo */
+		/* stylelint-enable */`,
+	);
+
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 1,
+				end: 5,
+				strictStart: true,
+				strictEnd: true,
+			},
+		],
+		bar: [
+			{
+				start: 1,
+				end: 2,
+				strictStart: false,
+				strictEnd: true,
+			},
+		],
+		foo: [
+			{
+				start: 1,
+				end: 3,
+				strictStart: false,
+				strictEnd: true,
+			},
+			{
+				start: 4,
+				end: 5,
+				strictStart: true,
+				strictEnd: false,
+			},
+		],
 	});
 });
 
 it('disable line for all rules after disabling all', () => {
-	return testDisableRanges(
-		`/* stylelint-disable */
-    a {} /* stylelint-disable-line */`,
-		() => {
-			throw new Error('should have errored');
-		},
-	).catch((err) => {
-		expect(err.reason).toBe('All rules have already been disabled');
-	});
+	return expect(
+		testDisableRanges(
+			`/* stylelint-disable */
+			a {} /* stylelint-disable-line */`,
+		),
+	).rejects.toThrow('All rules have already been disabled');
 });
 
 it('disable line for one rule after disabling all', () => {
-	return testDisableRanges(
-		`/* stylelint-disable */
-    a {} /* stylelint-disable-line foo */`,
-		() => {
-			throw new Error('should have errored');
-		},
-	).catch((err) => {
-		expect(err.reason).toBe('All rules have already been disabled');
-	});
+	return expect(
+		testDisableRanges(
+			`/* stylelint-disable */
+			a {} /* stylelint-disable-line foo */`,
+		),
+	).rejects.toThrow('All rules have already been disabled');
 });
 
-it('disable line for rule after disabling rule', () => {
-	return testDisableRanges(
-		`/* stylelint-disable foo */
-    a {} /* stylelint-disable-line foo */`,
-		() => {
-			throw new Error('should have errored');
-		},
-	).catch((err) => {
-		expect(err.reason).toBe('"foo" has already been disabled');
-	});
+it('disable line for rule after disabling rule', async () => {
+	return expect(
+		testDisableRanges(
+			`/* stylelint-disable foo */
+			a {} /* stylelint-disable-line foo */`,
+		),
+	).rejects.toThrow('"foo" has already been disabled');
 });
 
-it('disable all twice on the same line', () => {
-	return testDisableRanges('/* stylelint-disable */ /* stylelint-disable */', () => {
-		throw new Error('should have errored');
-	}).catch((err) => {
-		expect(err.reason).toBe('All rules have already been disabled');
-	});
+it('disable all twice on the same line', async () => {
+	return expect(
+		testDisableRanges('/* stylelint-disable */ /* stylelint-disable */'),
+	).rejects.toThrow('All rules have already been disabled');
 });
 
-it('disable rule twice on the same line', () => {
-	return testDisableRanges('/* stylelint-disable foo */ /* stylelint-disable foo*/', () => {
-		throw new Error('should have errored');
-	}).catch((err) => {
-		expect(err.reason).toBe('"foo" has already been disabled');
-	});
+it('disable rule twice on the same line', async () => {
+	return expect(
+		testDisableRanges('/* stylelint-disable foo */ /* stylelint-disable foo*/'),
+	).rejects.toThrow('"foo" has already been disabled');
 });
 
-it('enable all without disabling any', () => {
-	return testDisableRanges('/* stylelint-enable */', () => {
-		throw new Error('should have errored');
-	}).catch((err) => {
-		expect(err.reason).toBe('No rules have been disabled');
-	});
+it('enable all without disabling any', async () => {
+	return expect(testDisableRanges('/* stylelint-enable */')).rejects.toThrow(
+		'No rules have been disabled',
+	);
 });
 
-it('enable rule without disabling any', () => {
-	return testDisableRanges('/* stylelint-enable foo */', () => {
-		throw new Error('should have errored');
-	}).catch((err) => {
-		expect(err.reason).toBe('"foo" has not been disabled');
-	});
+it('enable rule without disabling any', async () => {
+	return expect(testDisableRanges('/* stylelint-enable foo */')).rejects.toThrow(
+		'"foo" has not been disabled',
+	);
 });
 
-it('enable rule without disabling rule', () => {
-	return testDisableRanges(
-		`/* stylelint-disable */
-    /* stylelint-enable bar */
-    /* stylelint-enable foo */
-    /* stylelint-disable foo */
-    /* stylelint-enable bar */
-    /* stylelint-enable */`,
-		() => {
-			throw new Error('should have errored');
-		},
-	).catch((err) => {
-		expect(err.reason).toBe('"bar" has not been disabled');
-	});
+it('enable rule without disabling rule', async () => {
+	return expect(
+		testDisableRanges(
+			`/* stylelint-disable */
+			/* stylelint-enable bar */
+			/* stylelint-enable foo */
+			/* stylelint-disable foo */
+			/* stylelint-enable bar */
+			/* stylelint-enable */`,
+		),
+	).rejects.toThrow('"bar" has not been disabled');
 });
 
 // Command comment descriptions.
 
-it('disable (with description) without re-enabling', () => {
-	return testDisableRanges('/* stylelint-disable -- Description */\na {}').then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 1,
-					strictStart: true,
-					description: 'Description',
-				},
-			],
-		});
-	});
-});
-
-it('disable and re-enable (with descriptions)', () => {
-	return testDisableRanges(`a {}
-    /* stylelint-disable -- Description */
-    b {}
-    /* stylelint-enable -- Description */
-    .foo {}`).then((result) => {
-		expectDisableRanges(result, {
-			all: [
-				{
-					start: 2,
-					end: 4,
-					strictStart: true,
-					strictEnd: true,
-					description: 'Description',
-				},
-			],
-		});
-	});
-});
-
-it('disable rule (with description) without re-enabling', () => {
-	return testDisableRanges('/* stylelint-disable foo-bar -- Description */\na {}').then(
-		(result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'foo-bar': [
-					{
-						start: 1,
-						strictStart: true,
-						end: undefined,
-						strictEnd: undefined,
-						description: 'Description',
-					},
-				],
-			});
-		},
+it('disable (with description) without re-enabling', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable -- Description */
+		a {}`,
 	);
-});
 
-it('disable rules (with description) with newline in rule list', () => {
-	return testDisableRanges(
-		'/* stylelint-disable foo-bar, hoo-hah,\n\tslime -- Description */\n' + 'b {}\n',
-	).then((result) => {
-		expectDisableRanges(result, {
-			all: [],
-			'foo-bar': [
-				{
-					start: 1,
-					strictStart: true,
-					description: 'Description',
-				},
-			],
-			'hoo-hah': [
-				{
-					start: 1,
-					strictStart: true,
-					description: 'Description',
-				},
-			],
-			slime: [
-				{
-					start: 1,
-					strictStart: true,
-					description: 'Description',
-				},
-			],
-		});
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 1,
+				strictStart: true,
+				description: 'Description',
+			},
+		],
 	});
 });
 
-it('SCSS // line-disabling comment (with description)', () => {
-	const scssSource = `a {
-    color: pink !important; // stylelint-disable-line declaration-no-important -- Description
-  }`;
+it('disable and re-enable (with descriptions)', async () => {
+	const result = await testDisableRanges(
+		`a {}
+		/* stylelint-disable -- Description */
+		b {}
+		/* stylelint-enable -- Description */
+		.foo {}`,
+	);
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						end: 2,
-						strictStart: true,
-						strictEnd: true,
-						description: 'Description',
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [
+			{
+				start: 2,
+				end: 4,
+				strictStart: true,
+				strictEnd: true,
+				description: 'Description',
+			},
+		],
+	});
 });
 
-it('SCSS // disable next-line comment (with multi-line description)', () => {
-	const scssSource = `a {
-    // stylelint-disable-next-line declaration-no-important
-    // --
-    // Long-winded description
-    color: pink !important;
-  }`;
+it('disable rule (with description) without re-enabling', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable foo-bar -- Description */
+		a {}`,
+	);
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 5,
-						end: 5,
-						strictStart: true,
-						strictEnd: true,
-						description: 'Long-winded description',
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'foo-bar': [
+			{
+				start: 1,
+				strictStart: true,
+				end: undefined,
+				strictEnd: undefined,
+				description: 'Description',
+			},
+		],
+	});
 });
 
-it('SCSS // disable comment (with // comment after blank line)', () => {
-	const scssSource = `a {
-    // stylelint-disable declaration-no-important
+it('disable rules (with description) with newline in rule list', async () => {
+	const result = await testDisableRanges(
+		`/* stylelint-disable foo-bar, hoo-hah,
+		slime -- Description */
+		b {}`,
+	);
 
-    // Unrelated
-    color: pink !important;
-  }`;
-
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						strictStart: true,
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'foo-bar': [
+			{
+				start: 1,
+				strictStart: true,
+				description: 'Description',
+			},
+		],
+		'hoo-hah': [
+			{
+				start: 1,
+				strictStart: true,
+				description: 'Description',
+			},
+		],
+		slime: [
+			{
+				start: 1,
+				strictStart: true,
+				description: 'Description',
+			},
+		],
+	});
 });
 
-it('SCSS // disable comment (with // comment immediately after)', () => {
-	const scssSource = `a {
-    // stylelint-disable declaration-no-important
-    // Unrelated
-    color: pink !important;
-  }`;
+it('SCSS // line-disabling comment (with description)', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			color: pink !important; // stylelint-disable-line declaration-no-important -- Description
+		}`,
+	);
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						strictStart: true,
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				end: 2,
+				strictStart: true,
+				strictEnd: true,
+				description: 'Description',
+			},
+		],
+	});
 });
 
-it('SCSS /* disable comment (with // comment after blank line)', () => {
-	const scssSource = `a {
-    /* stylelint-disable declaration-no-important */
+it('SCSS // disable next-line comment (with multi-line description)', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			// stylelint-disable-next-line declaration-no-important
+			// --
+			// Long-winded description
+			color: pink !important;
+		}`,
+	);
 
-    // Unrelated
-    color: pink !important;
-  }`;
-
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						strictStart: true,
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 5,
+				end: 5,
+				strictStart: true,
+				strictEnd: true,
+				description: 'Long-winded description',
+			},
+		],
+	});
 });
 
-it('SCSS // disable comment (with // comment immediately before)', () => {
-	const scssSource = `a {
-    // Unrelated
-    // stylelint-disable declaration-no-important
-    color: pink !important;
-  }`;
+it('SCSS // disable comment (with // comment after blank line)', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			// stylelint-disable declaration-no-important
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 3,
-						strictStart: true,
-					},
-				],
-			});
-		});
+			// Unrelated
+			color: pink !important;
+		}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				strictStart: true,
+			},
+		],
+	});
 });
 
-it('SCSS two adjacent // disable comments', () => {
-	const scssSource = `a {
-    // stylelint-disable declaration-no-important
-    // stylelint-disable foo-bar
-    color: pink !important;
-  }`;
+it('SCSS // disable comment (with // comment immediately after)', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			// stylelint-disable declaration-no-important
+			// Unrelated
+			color: pink !important;
+		}`,
+	);
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						strictStart: true,
-					},
-				],
-				'foo-bar': [
-					{
-						start: 3,
-						strictStart: true,
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				strictStart: true,
+			},
+		],
+	});
 });
 
-it('SCSS two adjacent // disable comments with multi-line descriptions', () => {
-	const scssSource = `a {
-    // stylelint-disable declaration-no-important --
-    // Description 1
-    // stylelint-disable foo-bar
-    // --
-    // Description 2
-    color: pink !important;
-  }`;
+it('SCSS /* disable comment (with // comment after blank line)', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			/* stylelint-disable declaration-no-important */
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						strictStart: true,
-						description: 'Description 1',
-					},
-				],
-				'foo-bar': [
-					{
-						start: 4,
-						strictStart: true,
-						description: 'Description 2',
-					},
-				],
-			});
-		});
+			// Unrelated
+			color: pink !important;
+		}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				strictStart: true,
+			},
+		],
+	});
 });
 
-it('SCSS two // disable comments with an unrelated comment between them', () => {
-	const scssSource = `a {
-    // stylelint-disable declaration-no-important
-    // Unrelated
-    // stylelint-disable foo-bar
-    color: pink !important;
-  }`;
+it('SCSS // disable comment (with // comment immediately before)', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			// Unrelated
+			// stylelint-disable declaration-no-important
+			color: pink !important;
+		}`,
+	);
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(scssSource, { syntax: scss, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						strictStart: true,
-					},
-				],
-				'foo-bar': [
-					{
-						start: 4,
-						strictStart: true,
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 3,
+				strictStart: true,
+			},
+		],
+	});
 });
 
-it('Less // line-disabling comment (with description)', () => {
-	const lessSource = `a {
-    color: pink !important; // stylelint-disable-line declaration-no-important -- Description
-  }`;
+it('SCSS two adjacent // disable comments', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			// stylelint-disable declaration-no-important
+			// stylelint-disable foo-bar
+			color: pink !important;
+		}`,
+	);
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(lessSource, { syntax: less, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 2,
-						end: 2,
-						strictStart: true,
-						strictEnd: true,
-						description: 'Description',
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				strictStart: true,
+			},
+		],
+		'foo-bar': [
+			{
+				start: 3,
+				strictStart: true,
+			},
+		],
+	});
 });
 
-it('Less // disable next-line comment (with multi-line description)', () => {
-	const lessSource = `a {
-    // stylelint-disable-next-line declaration-no-important
-    // --
-    // Long-winded description
-    color: pink !important;
-  }`;
+it('SCSS two adjacent // disable comments with multi-line descriptions', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			// stylelint-disable declaration-no-important --
+			// Description 1
+			// stylelint-disable foo-bar
+			// --
+			// Description 2
+			color: pink !important;
+		}`,
+	);
 
-	return postcss()
-		.use(assignDisabledRanges)
-		.process(lessSource, { syntax: less, from: undefined })
-		.then((result) => {
-			expectDisableRanges(result, {
-				all: [],
-				'declaration-no-important': [
-					{
-						start: 5,
-						end: 5,
-						strictStart: true,
-						strictEnd: true,
-						description: 'Long-winded description',
-					},
-				],
-			});
-		});
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				strictStart: true,
+				description: 'Description 1',
+			},
+		],
+		'foo-bar': [
+			{
+				start: 4,
+				strictStart: true,
+				description: 'Description 2',
+			},
+		],
+	});
+});
+
+it('SCSS two // disable comments with an unrelated comment between them', async () => {
+	const result = await testDisableRangesScss(
+		`a {
+			// stylelint-disable declaration-no-important
+			// Unrelated
+			// stylelint-disable foo-bar
+			color: pink !important;
+		}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				strictStart: true,
+			},
+		],
+		'foo-bar': [
+			{
+				start: 4,
+				strictStart: true,
+			},
+		],
+	});
+});
+
+it('Less // line-disabling comment (with description)', async () => {
+	const result = await testDisableRangesLess(
+		`a {
+			color: pink !important; // stylelint-disable-line declaration-no-important -- Description
+		}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 2,
+				end: 2,
+				strictStart: true,
+				strictEnd: true,
+				description: 'Description',
+			},
+		],
+	});
+});
+
+it('Less // disable next-line comment (with multi-line description)', async () => {
+	const result = await testDisableRangesLess(
+		`a {
+			// stylelint-disable-next-line declaration-no-important
+			// --
+			// Long-winded description
+			color: pink !important;
+		}`,
+	);
+
+	expectDisableRanges(result, {
+		all: [],
+		'declaration-no-important': [
+			{
+				start: 5,
+				end: 5,
+				strictStart: true,
+				strictEnd: true,
+				description: 'Long-winded description',
+			},
+		],
+	});
 });
 
 function expectDisableRanges(result, expected) {
@@ -1027,6 +1002,16 @@ function expectDisableRange(actual, expected) {
 	expect(actualMutable).toEqual(expected);
 }
 
-function testDisableRanges(source, cb) {
-	return postcss().use(assignDisabledRanges).process(source, { from: undefined }).then(cb);
+function testDisableRanges(source, options) {
+	return postcss()
+		.use(assignDisabledRanges)
+		.process(source, { from: undefined, ...options });
+}
+
+function testDisableRangesLess(source) {
+	return testDisableRanges(source, { syntax: postcssLess });
+}
+
+function testDisableRangesScss(source) {
+	return testDisableRanges(source, { syntax: postcssScss });
 }


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

This is a part of #4881.

> Is there anything in the PR that needs further explanation?

This change uses `async/await` a lot to avoid callbacks.

Also, it uses [`.rejects`](https://jestjs.io/docs/en/tutorial-async.html#rejects) of Jest to test thrown errors, instead of `throw/catch`.

Besides, it uses template literals a lot for the readability of multi-line CSS code.

---

Recommended **splitted** diff view: https://github.com/stylelint/stylelint/pull/4991/files?diff=split&w=1
