### PR TITLE
Document all CLI parameters in one place

### DIFF
--- a/docs/user-guide/usage/cli.md
+++ b/docs/user-guide/usage/cli.md
@@ -16,13 +16,57 @@ In addition to the [standard options](options.md), the CLI accepts:
 
 The process exits without throwing an error when glob pattern matches no files.
 
+### `--cache-location`
+
+Path to a file or directory for the cache location. More info about this option in [standard options](options.md#cacheLocation).
+
+### `--cache`
+
+Store the results of processed files so that stylelint only operates on the changed ones. By default, the cache is stored in `./.stylelintcache` in `process.cwd()`. More info about this option in [standard options](options.md#cache).
+
 ### `--color, --no-color`
 
 Force enabling/disabling of color.
 
+### `--config-basedir`
+
+Absolute path to the directory that relative paths defining "extends" and "plugins" are _relative to_. Only necessary if these values are relative paths. More info about this option in [standard options](options.md#configBasedir).
+
+### `--config`
+
+Path to a JSON, YAML, or JS file that contains your [configuration object](../configure.md). More info about this option in [standard options](options.md#configFile).
+
+### `--custom-syntax`
+
+Specify a custom syntax to use on your code. Use this option if you want to force a specific syntax that's not already built into stylelint. More info about this option in [standard options](options.md#customSyntax).
+
+### `--disable-default-ignores, --di`
+
+Disable the default ignores. stylelint will not automatically ignore the contents of `node_modules`. More info about this option in [standard options](options.md#disableDefaultIgnores).
+
+### `--fix`
+
+Automatically fix, where possible, violations reported by rules. More info about this option in [standard options](options.md#fix).
+
+### `--formatter, -f` | `--custom-formatter`
+
+Specify the formatter to format your results. More info about this option in [standard options](options.md#formatter).
+
+### `--ignore-disables, --id`
+
+Ignore `styleline-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments. More info about this option in [standard options](options.md#ignoreDisables).
+
+### `--ignore-path, -i`
+
+A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, stylelint looks for `.stylelintignore` in `process.cwd()`. More info about this option in [standard options](options.md#ignorePath).
+
 ### `--ignore-pattern, --ip`
 
 Pattern of files to ignore (in addition to those in `.stylelintignore`).
+
+### `--max-warnings, --mw`
+
+Set a limit to the number of warnings accepted. More info about this option in [standard options](options.md#maxWarnings).
 
 ### `--output-file, -o`
 
@@ -36,9 +80,29 @@ Print the configuration for the given path. stylelint outputs the configuration 
 
 Only register violations for rules with an "error"-level severity (ignore "warning"-level).
 
+### `--report-descriptionless-disables, --rdd`
+
+Produce a report of the `stylelint-disable` comments without a description. More info about this option in [standard options](options.md#reportDescriptionlessDisables).
+
+### `--report-invalid-scope-disables, --risd`
+
+Produce a report of the `stylelint-disable` comments that used for rules that don't exist within the configuration object. More info about this option in [standard options](options.md#reportInvalidScopeDisables).
+
+### `--report-needless-disables, --rd`
+
+Produce a report to clean up your codebase, keeping only the `stylelint-disable` comments that serve a purpose. More info about this option in [standard options](options.md#reportNeedlessDisables).
+
+### `--stdin-filename`
+
+A filename to assign the input. More info about this option in [standard options](options.md#codeFilename).
+
 ### `--stdin`
 
 Accept stdin input even if it is empty.
+
+### `--syntax, -s`
+
+Specify a syntax. More info about this option in [standard options](options.md#syntax).
 
 ### `--version, -v`
 


### PR DESCRIPTION
It's inconvenient to find documentation for a CLI parameters, because all parameters are split into two pages: [CLI](https://stylelint.io/user-guide/usage/cli) and [Options](https://stylelint.io/user-guide/usage/options).

This pull request introduce some information duplication, however it makes finding description of a CLI parameter easier. As they all gathered, where is is expected — on a CLI page.