### PR TITLE
Lazy load `autoprefixer` module

### DIFF
--- a/lib/utils/isAutoprefixable.js
+++ b/lib/utils/isAutoprefixable.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const autoprefixer = require('autoprefixer');
-const Browsers = require('autoprefixer/lib/browsers');
-const Prefixes = require('autoprefixer/lib/prefixes');
-
 /**
  * Use Autoprefixer's secret powers to determine whether or
  * not a certain CSS identifier contains a vendor prefix that
@@ -13,10 +9,32 @@ const Prefixes = require('autoprefixer/lib/prefixes');
  * vendor prefixes.
  */
 
-const prefixes = new Prefixes(
-	autoprefixer.data.prefixes,
-	new Browsers(autoprefixer.data.browsers, []),
-);
+// NOTE: Lazy loading to avoid performance degrades.
+
+/** @type {import('autoprefixer') | undefined} */
+let autoprefixerCache;
+const autoprefixer = () => {
+	if (!autoprefixerCache) {
+		autoprefixerCache = require('autoprefixer');
+	}
+
+	return autoprefixerCache;
+};
+
+/** @type {import('autoprefixer/lib/prefixes') | undefined} */
+let prefixesCache;
+const prefixes = () => {
+	if (!prefixesCache) {
+		const Browsers = require('autoprefixer/lib/browsers');
+		const Prefixes = require('autoprefixer/lib/prefixes');
+
+		const data = autoprefixer().data;
+
+		prefixesCache = new Prefixes(data.prefixes, new Browsers(data.browsers, []));
+	}
+
+	return prefixesCache;
+};
 
 /**
  * Most identifier types have to be looked up in a unique way,
@@ -28,7 +46,7 @@ module.exports = {
 	 * @returns {boolean}
 	 */
 	atRuleName(identifier) {
-		return Boolean(prefixes.remove[`@${identifier.toLowerCase()}`]);
+		return Boolean(prefixes().remove[`@${identifier.toLowerCase()}`]);
 	},
 
 	/**
@@ -36,7 +54,7 @@ module.exports = {
 	 * @returns {boolean}
 	 */
 	selector(identifier) {
-		return prefixes.remove.selectors.some((/** @type {{ prefixed: string}} */ selectorObj) => {
+		return prefixes().remove.selectors.some((/** @type {{ prefixed: string}} */ selectorObj) => {
 			return identifier.toLowerCase() === selectorObj.prefixed;
 		});
 	},
@@ -54,7 +72,7 @@ module.exports = {
 	 * @returns {boolean}
 	 */
 	property(identifier) {
-		return Boolean(autoprefixer.data.prefixes[prefixes.unprefixed(identifier.toLowerCase())]);
+		return Boolean(autoprefixer().data.prefixes[prefixes().unprefixed(identifier.toLowerCase())]);
 	},
 
 	/**
@@ -64,8 +82,8 @@ module.exports = {
 	 * @returns {boolean}
 	 */
 	propertyValue(prop, value) {
-		const possiblePrefixableValues =
-			(prefixes.remove[prop.toLowerCase()] && prefixes.remove[prop.toLowerCase()].values) || false;
+		const remove = prefixes().remove[prop.toLowerCase()];
+		const possiblePrefixableValues = (remove && remove.values) || false;
 
 		return (
 			possiblePrefixableValues &&


### PR DESCRIPTION
This change is based on my patch on <https://github.com/stylelint/stylelint/issues/4971#issuecomment-705320007>.
This mainly lazy-loads the [`autoprefixer`](https://github.com/postcss/autoprefixer) module in `lib/utils/isAutoprefixable.js`.

> Which issue, if any, is this issue related to?

Maybe fix #4971

> Is there anything in the PR that needs further explanation?

I don't know how to get an effective benchmark for this change. Could you lease help if you have any good ideas?
