### PR TITLE
Fix incorrect enforce prefix regex documentation

### DIFF
--- a/docs/user-guide/rules/regex.md
+++ b/docs/user-guide/rules/regex.md
@@ -24,6 +24,6 @@ All these patterns disallow CSS identifiers that start with a digit, two hyphens
 
 ## Enforce a prefix
 
-You can ensure a prefix by using a negative lookahead regex.
+You can ensure a prefix by using a positive lookbehind regex.
 
-For example, to ensure all custom properties begin with `my-` use `"custom-property-pattern": "^(?!my-)"`.
+For example, to ensure all custom properties begin with `my-` use `"custom-property-pattern": "(?<=my-)"`.


### PR DESCRIPTION
I'm not sure that I'm right, but your example with negative lookahead regex doesn't work for me. We can write positive lookbehind or just "^my-".

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.