### PR TITLE
Remove superfluous argument passed to Promise

### DIFF
--- a/lib/__tests__/fixtures/plugin-async.js
+++ b/lib/__tests__/fixtures/plugin-async.js
@@ -24,7 +24,7 @@ const rule = (enabled) => (root, result) => {
 			});
 			resolve();
 		});
-	}, 1);
+	});
 };
 
 module.exports = stylelint.createPlugin(ruleName, rule);


### PR DESCRIPTION
Noticed it while looking at lgtm.com https://lgtm.com/projects/g/stylelint/stylelint/latest/files/lib/__tests__/fixtures/plugin-async.js?sort=name&dir=ASC&mode=heatmap&showExcluded=true
