### PR TITLE
GH-4917 Amend always test case

### DIFF
--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -278,16 +278,6 @@ testRule({
 			code: '/* foo */\r\n\r\n@media {}',
 			description: 'CRLF',
 		},
-		{
-			code: '// foo\n// bar\n@media {}',
-		},
-		{
-			code: '// foo\n// bar\n\n@media{}',
-		},
-		{
-			code: '// foo\r\n// bar\r\n\r\n@media {}',
-			description: 'CRLF',
-		},
 	],
 
 	reject: [
@@ -303,6 +293,26 @@ testRule({
 			line: 2,
 			column: 1,
 			description: 'after shared-line comment',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['always', { ignore: ['after-comment'] }],
+	syntax: 'scss',
+	fix: true,
+
+	accept: [
+		{
+			code: '// foo\n// bar\n@media {}',
+		},
+		{
+			code: '// foo\n// bar\n\n@media{}',
+		},
+		{
+			code: '// foo\r\n// bar\r\n\r\n@media {}',
+			description: 'CRLF',
 		},
 	],
 });

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -278,6 +278,16 @@ testRule({
 			code: '/* foo */\r\n\r\n@media {}',
 			description: 'CRLF',
 		},
+		{
+			code: '// foo\n// bar\n@media {}',
+		},
+		{
+			code: '// foo\n// bar\n\n@media{}',
+		},
+		{
+			code: '// foo\r\n// bar\r\n\r\n@media {}',
+			description: 'CRLF',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes GH-4917.

> Is there anything in the PR that needs further explanation?

At the moment, yes. This is just a Draft PR because after amending the test cases for the `at-rule-empty-line-before`, tests pass. I have confirmed that the test cases I added are being executed. I would expect tests to show a failure, since the test cases I’m adding are representative of the bug described in GH-4917.

I’ll appreciate any guidance on this issue, as I may be doing something wrong in my test cases.

## Testing Instructions

For running tests locally, I’ve taken the following steps:
- `npm ci`
- `npm run watch`
- Select option `o` to run files changed since last commit (before committing, of course).
- After tests were done, I searched the console output to confirm that my test cases had indeed been run as part of the suite. Each one of them showed as passing.

If you clone this branch and want to run this suite, you can:
- `npm run watch`
- Select the `p` option.
- Type `at-rule-empty-line-before`.
- Use the down arrow key to select the only file that matches.
- Press `Enter`.

You should see 1 test suite run with 362 tests passing and none failing.