### PR TITLE
Fix false positives for valueless attribute selectors in selector-attribute-name-disallowed-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project are documented in this file.
 
+## Head
+
+- Fixed: `selector-attribute-name-disallowed-list` false positives for valueless attribute selectors ([#5060](https://github.com/stylelint/stylelint/pull/5060)).
+
 ## 13.8.0
 
 - Deprecated: `StylelintStandaloneReturnValue.reportedDisables`, `.descriptionlessDisables`, `.needlessDisables`, and `.invalidScopeDisables`. `.reportedDisables` will always be empty and the other properties will always be undefined, since these errors now show up in `.results` instead ([#4973](https://github.com/stylelint/stylelint/pull/4973)).

--- a/lib/rules/selector-attribute-name-disallowed-list/__tests__/index.js
+++ b/lib/rules/selector-attribute-name-disallowed-list/__tests__/index.js
@@ -5,7 +5,7 @@ const { messages, ruleName } = require('..');
 testRule({
 	ruleName,
 
-	config: ['class', 'id', '/^data-/'],
+	config: ['class', 'disabled', 'id', '/^data-/'],
 
 	accept: [
 		{
@@ -38,6 +38,12 @@ testRule({
 		{
 			code: '[class *= "foo"] { }',
 			message: messages.rejected('class'),
+			line: 1,
+			column: 2,
+		},
+		{
+			code: '[disabled] { }',
+			message: messages.rejected('disabled'),
 			line: 1,
 			column: 2,
 		},

--- a/lib/rules/selector-attribute-name-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-name-disallowed-list/index.js
@@ -34,7 +34,7 @@ function rule(listInput) {
 				return;
 			}
 
-			if (!ruleNode.selector.includes('[') || !ruleNode.selector.includes('=')) {
+			if (!ruleNode.selector.includes('[')) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5059.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

/cc @rletsin 
