### PR TITLE
Properly set the errored property for --report options

### DIFF
--- a/lib/prepareReturnValue.js
+++ b/lib/prepareReturnValue.js
@@ -34,7 +34,10 @@ function prepareReturnValue(stylelintResults, options, formatter) {
 	if (reportDescriptionlessDisables) descriptionlessDisables(stylelintResults);
 
 	const errored = stylelintResults.some(
-		(result) => result.errored || result.parseErrors.length > 0,
+		(result) =>
+			result.errored ||
+			result.parseErrors.length > 0 ||
+			result.warnings.some((warning) => warning.severity === 'error'),
 	);
 
 	/** @type {StylelintStandaloneReturnValue} */

--- a/system-tests/003/__snapshots__/fs.test.js.snap
+++ b/system-tests/003/__snapshots__/fs.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`no-fs - zen garden CSS with standard config 1`] = `
+exports[`fs - zen garden CSS with standard config 1`] = `
 Object {
   "errored": true,
   "output": Array [

--- a/system-tests/003/fs.test.js
+++ b/system-tests/003/fs.test.js
@@ -5,7 +5,7 @@ const { caseConfigFile, caseFilesForFix, prepForSnapshot } = require('../systemT
 
 const CASE_NUMBER = '003';
 
-it('no-fs - zen garden CSS with standard config', async () => {
+it('fs - zen garden CSS with standard config', async () => {
 	expect(
 		prepForSnapshot(
 			await stylelint.lint({

--- a/system-tests/004/__snapshots__/fs.test.js.snap
+++ b/system-tests/004/__snapshots__/fs.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`no-fs - errored state for reportNeedlessDisables 1`] = `
+exports[`fs - errored state for reportNeedlessDisables 1`] = `
 Object {
   "errored": true,
   "output": Array [
@@ -42,7 +42,7 @@ Object {
 }
 `;
 
-exports[`no-fs - no errored state 1`] = `
+exports[`fs - no errored state 1`] = `
 Object {
   "errored": false,
   "output": Array [

--- a/system-tests/004/__snapshots__/fs.test.js.snap
+++ b/system-tests/004/__snapshots__/fs.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`no-fs - errored state for reportNeedlessDisables 1`] = `
+Object {
+  "errored": true,
+  "output": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [
+        Object {
+          "column": 1,
+          "line": 1,
+          "rule": "--report-needless-disables",
+          "severity": "error",
+          "text": "Needless disable for \\"block-no-empty\\"",
+        },
+      ],
+    },
+  ],
+  "reportedDisables": Array [],
+  "results": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "ignored": undefined,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [
+        Object {
+          "column": 1,
+          "line": 1,
+          "rule": "--report-needless-disables",
+          "severity": "error",
+          "text": "Needless disable for \\"block-no-empty\\"",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`no-fs - no errored state 1`] = `
+Object {
+  "errored": false,
+  "output": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [],
+    },
+  ],
+  "reportedDisables": Array [],
+  "results": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "ignored": undefined,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [],
+    },
+  ],
+}
+`;

--- a/system-tests/004/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/004/__snapshots__/no-fs.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`no-fs - errored state for reportNeedlessDisables 1`] = `
+Object {
+  "errored": true,
+  "output": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [
+        Object {
+          "column": 1,
+          "line": 1,
+          "rule": "--report-needless-disables",
+          "severity": "error",
+          "text": "Needless disable for \\"block-no-empty\\"",
+        },
+      ],
+    },
+  ],
+  "reportedDisables": Array [],
+  "results": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "ignored": undefined,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [
+        Object {
+          "column": 1,
+          "line": 1,
+          "rule": "--report-needless-disables",
+          "severity": "error",
+          "text": "Needless disable for \\"block-no-empty\\"",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`no-fs - no errored state 1`] = `
+Object {
+  "errored": false,
+  "output": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [],
+    },
+  ],
+  "reportedDisables": Array [],
+  "results": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "ignored": undefined,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "warnings": Array [],
+    },
+  ],
+}
+`;

--- a/system-tests/004/config.json
+++ b/system-tests/004/config.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"block-no-empty": true
+	}
+}

--- a/system-tests/004/fs.test.js
+++ b/system-tests/004/fs.test.js
@@ -5,7 +5,7 @@ const { caseConfigFile, caseFilesForFix, prepForSnapshot } = require('../systemT
 
 const CASE_NUMBER = '004';
 
-it('no-fs - errored state for reportNeedlessDisables', async () => {
+it('fs - errored state for reportNeedlessDisables', async () => {
 	expect(
 		prepForSnapshot(
 			await stylelint.lint({
@@ -17,7 +17,7 @@ it('no-fs - errored state for reportNeedlessDisables', async () => {
 	).toMatchSnapshot();
 }, 10000);
 
-it('no-fs - no errored state', async () => {
+it('fs - no errored state', async () => {
 	expect(
 		prepForSnapshot(
 			await stylelint.lint({

--- a/system-tests/004/fs.test.js
+++ b/system-tests/004/fs.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const stylelint = require('../../lib');
+const { caseConfigFile, caseFilesForFix, prepForSnapshot } = require('../systemTestUtils');
+
+const CASE_NUMBER = '004';
+
+it('no-fs - errored state for reportNeedlessDisables', async () => {
+	expect(
+		prepForSnapshot(
+			await stylelint.lint({
+				files: await caseFilesForFix(CASE_NUMBER),
+				configFile: caseConfigFile(CASE_NUMBER),
+				reportNeedlessDisables: true,
+			}),
+		),
+	).toMatchSnapshot();
+}, 10000);
+
+it('no-fs - no errored state', async () => {
+	expect(
+		prepForSnapshot(
+			await stylelint.lint({
+				files: await caseFilesForFix(CASE_NUMBER),
+				configFile: caseConfigFile(CASE_NUMBER),
+			}),
+		),
+	).toMatchSnapshot();
+}, 10000);

--- a/system-tests/004/no-fs.test.js
+++ b/system-tests/004/no-fs.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const stylelint = require('../../lib');
+const { caseConfig, caseCode, prepForSnapshot } = require('../systemTestUtils');
+
+const CASE_NUMBER = '004';
+
+it('no-fs - errored state for reportNeedlessDisables', async () => {
+	expect(
+		prepForSnapshot(
+			await stylelint.lint({
+				code: await caseCode(CASE_NUMBER),
+				config: await caseConfig(CASE_NUMBER),
+				reportNeedlessDisables: true,
+			}),
+		),
+	).toMatchSnapshot();
+}, 10000);
+
+it('no-fs - no errored state', async () => {
+	expect(
+		prepForSnapshot(
+			await stylelint.lint({
+				code: await caseCode(CASE_NUMBER),
+				config: await caseConfig(CASE_NUMBER),
+			}),
+		),
+	).toMatchSnapshot();
+}, 10000);

--- a/system-tests/004/stylesheet.css
+++ b/system-tests/004/stylesheet.css
@@ -1,0 +1,4 @@
+/* stylelint-disable block-no-empty */
+a {
+  color: red;
+}


### PR DESCRIPTION
This sets the `errored` property (and thus the exit code) as long as
any warning has severity "error", which includes warnings generated by
--report options.

Closes #5046