### PR TITLE
docs: other: add putout

### DIFF
--- a/docs/user-guide/integrations/other.md
+++ b/docs/user-guide/integrations/other.md
@@ -15,3 +15,4 @@ Other integrations built and maintained by the community.
 ## Command Line Tools
 
 - [stylelint-find-rules](https://github.com/alexilyaev/stylelint-find-rules) - find Stylelint rules that you don't have in your config.
+- [putout](https://github.com/coderaiser/putout) - pluggable and configurable code transformer.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

e.g. "Closes #000" or "None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."

Just integrated `stylelint` into [Putout code transformer](https://github.com/coderaiser/putout) as [processor-css](https://github.com/coderaiser/putout/tree/master/packages/processor-css), so now it can be used with `eslint`, `remark`, `putout` itself, and other [processors](https://github.com/coderaiser/putout#processors) :).
