### PR TITLE
docs: add Mega-Linter in Other integrations

### DIFF
--- a/docs/user-guide/integrations/other.md
+++ b/docs/user-guide/integrations/other.md
@@ -6,6 +6,7 @@ Other integrations built and maintained by the community.
 
 - [codacy-stylelint](https://github.com/codacy/codacy-stylelint) - [Codacy](https://www.codacy.com/) engine for stylelint
 - [codeclimate-stylelint](https://github.com/gilbarbara/codeclimate-stylelint) - Code Climate engine for stylelint
+- [Mega-Linter](https://nvuillam.github.io/mega-linter) - 70+ linters for any type of projects, usable in CI or locally, embedding [stylelint](https://nvuillam.github.io/mega-linter/descriptors/css_stylelint/) in default configuration
 - [reviewdog/action-stylelint](https://github.com/reviewdog/action-stylelint) - GitHub Action to run stylelint with [reviewdog](https://github.com/reviewdog/reviewdog)
 
 ## Version Control


### PR DESCRIPTION
In added stylelint in Mega-Linter, with associated documentation

Is this ok for you ?

Doc page -> https://nvuillam.github.io/mega-linter/descriptors/css_stylelint/

> Which issue, if any, is this issue related to?

None, as it's a documentation enhancement

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory
