### PR TITLE
Fix false negatives for css-in-js object notation in color-hex-case

### DIFF
--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -231,7 +231,7 @@ testRule({
 
 			message: messages.expected('#aBABAA', '#ababaa'),
 			line: 3,
-			column: 15,
+			column: 13,
 		},
 		{
 			code: `
@@ -246,9 +246,9 @@ testRule({
 			`,
 
 			warnings: [
-				{ message: messages.expected('#AAA', '#aaa'), line: 3, column: 36 },
-				{ message: messages.expected('#FaFa', '#fafa'), line: 3, column: 42 },
-				{ message: messages.expected('#0000FFcc', '#0000ffcc'), line: 3, column: 49 },
+				{ message: messages.expected('#AAA', '#aaa'), line: 3, column: 34 },
+				{ message: messages.expected('#FaFa', '#fafa'), line: 3, column: 40 },
+				{ message: messages.expected('#0000FFcc', '#0000ffcc'), line: 3, column: 47 },
 			],
 		},
 	],
@@ -320,7 +320,7 @@ testRule({
 
 			message: messages.expected('#aBABAB', '#ABABAB'),
 			line: 3,
-			column: 15,
+			column: 13,
 		},
 		{
 			code: `
@@ -335,9 +335,9 @@ testRule({
 			`,
 
 			warnings: [
-				{ message: messages.expected('#aaa', '#AAA'), line: 3, column: 36 },
-				{ message: messages.expected('#FaFa', '#FAFA'), line: 3, column: 42 },
-				{ message: messages.expected('#0000FFcc', '#0000FFCC'), line: 3, column: 49 },
+				{ message: messages.expected('#aaa', '#AAA'), line: 3, column: 34 },
+				{ message: messages.expected('#FaFa', '#FAFA'), line: 3, column: 40 },
+				{ message: messages.expected('#0000FFcc', '#0000FFCC'), line: 3, column: 47 },
 			],
 		},
 	],

--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -173,154 +173,93 @@ testRule({
 	accept: [
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	stroke: "url(#gradiantA)",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "#aaa",
+						});
+			`,
+		},
+		{
+			code: `
+						import styled from 'styled-components';
+						export const s = styled.a({
+							stroke: "url(#AAA)",
+						});
+			`,
 			description: 'href with location',
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "pink",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "PINK",
+						});
+			`,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#000",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							background: "linear-gradient(#aaa, #ffff, #0000ffcc)",
+						});
+			`,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #fff, #ababab",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled("a::before")({
+							content: '"#ABABAB"',
+						});
+			`,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#0000ffcc",
-});
-`,
-			description: 'eight digits',
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#00fc",
-});
-`,
-			description: 'four digits',
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	padding: "000",
-});
-`,
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled("a::before")({
-	content: '"#ABABA"',
-});
-`,
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "white /* #FFF */",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "white /* #FFF */",
+						});
+			`,
 		},
 	],
 
 	reject: [
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#aBABA",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "#aBABAA",
+						});
+			`,
 			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#ababa",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "#ababaa",
+						});
+			`,
 
-			message: messages.expected('#aBABA', '#ababa'),
+			message: messages.expected('#aBABAA', '#ababaa'),
 			line: 4,
-			column: 9,
+			column: 15,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000F, #fff, #abababA",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							background: "linear-gradient(#AAA, #FaFa, #0000FFcc)",
+						});
+			`,
 			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000f, #fff, #abababa",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							background: "linear-gradient(#aaa, #fafa, #0000ffcc)",
+						});
+			`,
 
 			warnings: [
-				{ message: messages.expected('#000F', '#000f'), line: 4, column: 13 },
-				{ message: messages.expected('#abababA', '#abababa'), line: 4, column: 26 },
+				{ message: messages.expected('#AAA', '#aaa'), line: 4, column: 36 },
+				{ message: messages.expected('#FaFa', '#fafa'), line: 4, column: 42 },
+				{ message: messages.expected('#0000FFcc', '#0000ffcc'), line: 4, column: 49 },
 			],
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #FFFFAZ, #ababab",
-});
-`,
-			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #ffffaz, #ababab",
-});
-`,
-
-			message: messages.expected('#FFFFAZ', '#ffffaz'),
-			line: 4,
-			column: 19,
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #fff, #12345AA",
-});
-`,
-			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #fff, #12345aa",
-});
-`,
-
-			message: messages.expected('#12345AA', '#12345aa'),
-			line: 4,
-			column: 25,
 		},
 	],
 });
@@ -333,154 +272,93 @@ testRule({
 	accept: [
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	stroke: "url(#gradiantA)",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "#AAA",
+						});
+			`,
+		},
+		{
+			code: `
+						import styled from 'styled-components';
+						export const s = styled.a({
+							stroke: "url(#aaa)",
+						});
+			`,
 			description: 'href with location',
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "pink",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "pink",
+						});
+			`,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#000",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							background: "linear-gradient(#AAA, #FFFF, #0000FFCC)",
+						});
+			`,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #FFF, #ABABAB",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled("a::before")({
+							content: '"#ababab"',
+						});
+			`,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#0000FFCC",
-});
-`,
-			description: 'eight digits',
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#00FC",
-});
-`,
-			description: 'four digits',
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	padding: "000",
-});
-`,
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled("a::before")({
-	content: '"#ababa"',
-});
-`,
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "white /* #fff */",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "white /* #fff */",
+						});
+			`,
 		},
 	],
 
 	reject: [
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#aBABA",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "#aBABAB",
+						});
+			`,
 			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	color: "#ABABA",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							color: "#ABABAB",
+						});
+			`,
 
-			message: messages.expected('#aBABA', '#ABABA'),
+			message: messages.expected('#aBABAB', '#ABABAB'),
 			line: 4,
-			column: 9,
+			column: 15,
 		},
 		{
 			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000f, #FFF, #abababA",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							background: "linear-gradient(#aaa, #FaFa, #0000FFcc)",
+						});
+			`,
 			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000F, #FFF, #ABABABA",
-});
-`,
+						import styled from 'styled-components';
+						export const s = styled.a({
+							background: "linear-gradient(#AAA, #FAFA, #0000FFCC)",
+						});
+			`,
 
 			warnings: [
-				{ message: messages.expected('#000f', '#000F'), line: 4, column: 13 },
-				{ message: messages.expected('#abababA', '#ABABABA'), line: 4, column: 26 },
+				{ message: messages.expected('#aaa', '#AAA'), line: 4, column: 36 },
+				{ message: messages.expected('#FaFa', '#FAFA'), line: 4, column: 42 },
+				{ message: messages.expected('#0000FFcc', '#0000FFCC'), line: 4, column: 49 },
 			],
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #ffffaz, #ABABAB",
-});
-`,
-			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #FFFFAZ, #ABABAB",
-});
-`,
-
-			message: messages.expected('#ffffaz', '#FFFFAZ'),
-			line: 4,
-			column: 19,
-		},
-		{
-			code: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #FFF, #12345aa",
-});
-`,
-			fixed: `
-import styled from 'styled-components';
-export const s = styled.a({
-	something: "#000, #FFF, #12345AA",
-});
-`,
-
-			message: messages.expected('#12345aa', '#12345AA'),
-			line: 4,
-			column: 25,
 		},
 	],
 });

--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -164,3 +164,323 @@ testRule(
 		],
 	}),
 );
+
+testRule({
+	ruleName,
+	config: ['lower'],
+	syntax: 'css-in-js',
+	fix: true,
+	accept: [
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	stroke: "url(#gradiantA)",
+});
+`,
+			description: 'href with location',
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "pink",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#000",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #fff, #ababab",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#0000ffcc",
+});
+`,
+			description: 'eight digits',
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#00fc",
+});
+`,
+			description: 'four digits',
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	padding: "000",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled("a::before")({
+	content: '"#ABABA"',
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "white /* #FFF */",
+});
+`,
+		},
+	],
+
+	reject: [
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#aBABA",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#ababa",
+});
+`,
+
+			message: messages.expected('#aBABA', '#ababa'),
+			line: 4,
+			column: 9,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000F, #fff, #abababA",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000f, #fff, #abababa",
+});
+`,
+
+			warnings: [
+				{ message: messages.expected('#000F', '#000f'), line: 4, column: 13 },
+				{ message: messages.expected('#abababA', '#abababa'), line: 4, column: 26 },
+			],
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #FFFFAZ, #ababab",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #ffffaz, #ababab",
+});
+`,
+
+			message: messages.expected('#FFFFAZ', '#ffffaz'),
+			line: 4,
+			column: 19,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #fff, #12345AA",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #fff, #12345aa",
+});
+`,
+
+			message: messages.expected('#12345AA', '#12345aa'),
+			line: 4,
+			column: 25,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['upper'],
+	syntax: 'css-in-js',
+	fix: true,
+	accept: [
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	stroke: "url(#gradiantA)",
+});
+`,
+			description: 'href with location',
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "pink",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#000",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #FFF, #ABABAB",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#0000FFCC",
+});
+`,
+			description: 'eight digits',
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#00FC",
+});
+`,
+			description: 'four digits',
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	padding: "000",
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled("a::before")({
+	content: '"#ababa"',
+});
+`,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "white /* #fff */",
+});
+`,
+		},
+	],
+
+	reject: [
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#aBABA",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	color: "#ABABA",
+});
+`,
+
+			message: messages.expected('#aBABA', '#ABABA'),
+			line: 4,
+			column: 9,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000f, #FFF, #abababA",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000F, #FFF, #ABABABA",
+});
+`,
+
+			warnings: [
+				{ message: messages.expected('#000f', '#000F'), line: 4, column: 13 },
+				{ message: messages.expected('#abababA', '#ABABABA'), line: 4, column: 26 },
+			],
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #ffffaz, #ABABAB",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #FFFFAZ, #ABABAB",
+});
+`,
+
+			message: messages.expected('#ffffaz', '#FFFFAZ'),
+			line: 4,
+			column: 19,
+		},
+		{
+			code: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #FFF, #12345aa",
+});
+`,
+			fixed: `
+import styled from 'styled-components';
+export const s = styled.a({
+	something: "#000, #FFF, #12345AA",
+});
+`,
+
+			message: messages.expected('#12345aa', '#12345AA'),
+			line: 4,
+			column: 25,
+		},
+	],
+});

--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -173,45 +173,45 @@ testRule({
 	accept: [
 		{
 			code: `
-						export const s = styled.a({
-							color: "#aaa",
-						});
+				export const s = styled.a({
+					color: "#aaa",
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled.a({
-							stroke: "url(#AAA)",
-						});
+				export const s = styled.a({
+					stroke: "url(#AAA)",
+				});
 			`,
 			description: 'href with location',
 		},
 		{
 			code: `
-						export const s = styled.a({
-							color: "PINK",
-						});
+				export const s = styled.a({
+					color: "PINK",
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled.a({
-							background: "linear-gradient(#aaa, #ffff, #0000ffcc)",
-						});
+				export const s = styled.a({
+					background: "linear-gradient(#aaa, #ffff, #0000ffcc)",
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled("a::before")({
-							content: '"#ABABAB"',
-						});
+				export const s = styled("a::before")({
+					content: '"#ABABAB"',
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled.a({
-							color: "white /* #FFF */",
-						});
+				export const s = styled.a({
+					color: "white /* #FFF */",
+				});
 			`,
 		},
 	],
@@ -219,14 +219,14 @@ testRule({
 	reject: [
 		{
 			code: `
-						export const s = styled.a({
-							color: "#aBABAA",
-						});
+				export const s = styled.a({
+					color: "#aBABAA",
+				});
 			`,
 			fixed: `
-						export const s = styled.a({
-							color: "#ababaa",
-						});
+				export const s = styled.a({
+					color: "#ababaa",
+				});
 			`,
 
 			message: messages.expected('#aBABAA', '#ababaa'),
@@ -235,14 +235,14 @@ testRule({
 		},
 		{
 			code: `
-						export const s = styled.a({
-							background: "linear-gradient(#AAA, #FaFa, #0000FFcc)",
-						});
+				export const s = styled.a({
+					background: "linear-gradient(#AAA, #FaFa, #0000FFcc)",
+				});
 			`,
 			fixed: `
-						export const s = styled.a({
-							background: "linear-gradient(#aaa, #fafa, #0000ffcc)",
-						});
+				export const s = styled.a({
+					background: "linear-gradient(#aaa, #fafa, #0000ffcc)",
+				});
 			`,
 
 			warnings: [
@@ -262,45 +262,45 @@ testRule({
 	accept: [
 		{
 			code: `
-						export const s = styled.a({
-							color: "#AAA",
-						});
+				export const s = styled.a({
+					color: "#AAA",
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled.a({
-							stroke: "url(#aaa)",
-						});
+				export const s = styled.a({
+					stroke: "url(#aaa)",
+				});
 			`,
 			description: 'href with location',
 		},
 		{
 			code: `
-						export const s = styled.a({
-							color: "pink",
-						});
+				export const s = styled.a({
+					color: "pink",
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled.a({
-							background: "linear-gradient(#AAA, #FFFF, #0000FFCC)",
-						});
+				export const s = styled.a({
+					background: "linear-gradient(#AAA, #FFFF, #0000FFCC)",
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled("a::before")({
-							content: '"#ababab"',
-						});
+				export const s = styled("a::before")({
+					content: '"#ababab"',
+				});
 			`,
 		},
 		{
 			code: `
-						export const s = styled.a({
-							color: "white /* #fff */",
-						});
+				export const s = styled.a({
+					color: "white /* #fff */",
+				});
 			`,
 		},
 	],
@@ -308,14 +308,14 @@ testRule({
 	reject: [
 		{
 			code: `
-						export const s = styled.a({
-							color: "#aBABAB",
-						});
+				export const s = styled.a({
+					color: "#aBABAB",
+				});
 			`,
 			fixed: `
-						export const s = styled.a({
-							color: "#ABABAB",
-						});
+				export const s = styled.a({
+					color: "#ABABAB",
+				});
 			`,
 
 			message: messages.expected('#aBABAB', '#ABABAB'),
@@ -324,14 +324,14 @@ testRule({
 		},
 		{
 			code: `
-						export const s = styled.a({
-							background: "linear-gradient(#aaa, #FaFa, #0000FFcc)",
-						});
+				export const s = styled.a({
+					background: "linear-gradient(#aaa, #FaFa, #0000FFcc)",
+				});
 			`,
 			fixed: `
-						export const s = styled.a({
-							background: "linear-gradient(#AAA, #FAFA, #0000FFCC)",
-						});
+				export const s = styled.a({
+					background: "linear-gradient(#AAA, #FAFA, #0000FFCC)",
+				});
 			`,
 
 			warnings: [

--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -173,7 +173,6 @@ testRule({
 	accept: [
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "#aaa",
 						});
@@ -181,7 +180,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							stroke: "url(#AAA)",
 						});
@@ -190,7 +188,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "PINK",
 						});
@@ -198,7 +195,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							background: "linear-gradient(#aaa, #ffff, #0000ffcc)",
 						});
@@ -206,7 +202,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled("a::before")({
 							content: '"#ABABAB"',
 						});
@@ -214,7 +209,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "white /* #FFF */",
 						});
@@ -225,40 +219,36 @@ testRule({
 	reject: [
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "#aBABAA",
 						});
 			`,
 			fixed: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "#ababaa",
 						});
 			`,
 
 			message: messages.expected('#aBABAA', '#ababaa'),
-			line: 4,
+			line: 3,
 			column: 15,
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							background: "linear-gradient(#AAA, #FaFa, #0000FFcc)",
 						});
 			`,
 			fixed: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							background: "linear-gradient(#aaa, #fafa, #0000ffcc)",
 						});
 			`,
 
 			warnings: [
-				{ message: messages.expected('#AAA', '#aaa'), line: 4, column: 36 },
-				{ message: messages.expected('#FaFa', '#fafa'), line: 4, column: 42 },
-				{ message: messages.expected('#0000FFcc', '#0000ffcc'), line: 4, column: 49 },
+				{ message: messages.expected('#AAA', '#aaa'), line: 3, column: 36 },
+				{ message: messages.expected('#FaFa', '#fafa'), line: 3, column: 42 },
+				{ message: messages.expected('#0000FFcc', '#0000ffcc'), line: 3, column: 49 },
 			],
 		},
 	],
@@ -272,7 +262,6 @@ testRule({
 	accept: [
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "#AAA",
 						});
@@ -280,7 +269,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							stroke: "url(#aaa)",
 						});
@@ -289,7 +277,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "pink",
 						});
@@ -297,7 +284,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							background: "linear-gradient(#AAA, #FFFF, #0000FFCC)",
 						});
@@ -305,7 +291,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled("a::before")({
 							content: '"#ababab"',
 						});
@@ -313,7 +298,6 @@ testRule({
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "white /* #fff */",
 						});
@@ -324,40 +308,36 @@ testRule({
 	reject: [
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "#aBABAB",
 						});
 			`,
 			fixed: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							color: "#ABABAB",
 						});
 			`,
 
 			message: messages.expected('#aBABAB', '#ABABAB'),
-			line: 4,
+			line: 3,
 			column: 15,
 		},
 		{
 			code: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							background: "linear-gradient(#aaa, #FaFa, #0000FFcc)",
 						});
 			`,
 			fixed: `
-						import styled from 'styled-components';
 						export const s = styled.a({
 							background: "linear-gradient(#AAA, #FAFA, #0000FFCC)",
 						});
 			`,
 
 			warnings: [
-				{ message: messages.expected('#aaa', '#AAA'), line: 4, column: 36 },
-				{ message: messages.expected('#FaFa', '#FAFA'), line: 4, column: 42 },
-				{ message: messages.expected('#0000FFcc', '#0000FFCC'), line: 4, column: 49 },
+				{ message: messages.expected('#aaa', '#AAA'), line: 3, column: 36 },
+				{ message: messages.expected('#FaFa', '#FAFA'), line: 3, column: 42 },
+				{ message: messages.expected('#0000FFcc', '#0000FFCC'), line: 3, column: 49 },
 			],
 		},
 	],

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -82,8 +82,6 @@ function getValue(decl) {
 function setValue(decl, value) {
 	if (decl.raws.value) decl.raws.value.raw = value;
 	else decl.value = value;
-
-	return decl;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -2,10 +2,11 @@
 
 'use strict';
 
-const blurFunctionArguments = require('../../utils/blurFunctionArguments');
+const valueParser = require('postcss-value-parser');
+
+const declarationValueIndex = require('../../utils/declarationValueIndex');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
-const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'color-hex-case';
@@ -13,6 +14,9 @@ const ruleName = 'color-hex-case';
 const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
+
+const HEX = /^#[0-9A-Za-z]+/;
+const IGNORED_FUNCTIONS = new Set(['url']);
 
 function rule(expectation, options, context) {
 	return (root, result) => {
@@ -26,68 +30,56 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkDecls((decl) => {
-			const declString = blurFunctionArguments(decl.toString(), 'url');
-			const fixPositions = [];
+			const parsedValue = valueParser(getValue(decl));
+			let needsFix = false;
 
-			styleSearch({ source: declString, target: '#' }, (match) => {
-				const hexMatch = /^#[0-9A-Za-z]+/.exec(declString.substr(match.startIndex));
+			parsedValue.walk((node) => {
+				const { type, value } = node;
 
-				if (!hexMatch) {
-					return;
+				// Only traverse a function if it's a color function.
+				if (type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase())) {
+					return false;
 				}
 
-				const hexValue = hexMatch[0];
-				const hexValueLower = hexValue.toLowerCase();
-				const hexValueUpper = hexValue.toUpperCase();
-				const expectedHex = expectation === 'lower' ? hexValueLower : hexValueUpper;
+				// Check to make sure the type is valid and that it matches a hex color code
+				if (type !== 'word' || !HEX.test(value)) return;
 
-				if (hexValue === expectedHex) {
-					return;
-				}
+				const expected = expectation === 'lower' ? value.toLowerCase() : value.toUpperCase();
+
+				if (value === expected) return;
 
 				if (context.fix) {
-					fixPositions.unshift({
-						expectedHex,
-						currentHex: hexValue,
-						startIndex: match.startIndex,
-					});
+					node.value = expected;
+					needsFix = true;
 
 					return;
 				}
 
 				report({
-					message: messages.expected(hexValue, expectedHex),
+					message: messages.expected(value, expected),
 					node: decl,
-					index: match.startIndex,
+					index: declarationValueIndex(decl) + node.sourceIndex,
 					result,
 					ruleName,
 				});
 			});
 
-			if (fixPositions.length) {
-				const declProp = decl.prop;
-				const declBetween = decl.raws.between;
-
-				fixPositions.forEach((fixPosition) => {
-					// 1 — it's a # length
-					decl.value = replaceHex(
-						decl.value,
-						fixPosition.currentHex,
-						fixPosition.expectedHex,
-						fixPosition.startIndex - declProp.length - declBetween.length - 1,
-					);
-				});
+			if (needsFix) {
+				setValue(decl, parsedValue.toString());
 			}
 		});
 	};
 }
 
-function replaceHex(input, searchString, replaceString, startIndex) {
-	const offset = startIndex + 1;
-	const stringStart = input.slice(0, offset);
-	const stringEnd = input.slice(offset + searchString.length);
+function getValue(decl) {
+	return decl.raws.value ? decl.raws.value.raw : decl.value;
+}
 
-	return stringStart + replaceString + stringEnd;
+function setValue(decl, value) {
+	if (decl.raws.value) decl.raws.value.raw = value;
+	else decl.value = value;
+
+	return decl;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -34,15 +34,11 @@ function rule(expectation, options, context) {
 			let needsFix = false;
 
 			parsedValue.walk((node) => {
-				const { type, value } = node;
+				const { value } = node;
 
-				// Only traverse a function if it's a color function.
-				if (type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase())) {
-					return false;
-				}
+				if (isIgnoredFunction(node)) return false;
 
-				// Check to make sure the type is valid and that it matches a hex color code
-				if (type !== 'word' || !HEX.test(value)) return;
+				if (!isHexColor(node)) return;
 
 				const expected = expectation === 'lower' ? value.toLowerCase() : value.toUpperCase();
 
@@ -69,6 +65,14 @@ function rule(expectation, options, context) {
 			}
 		});
 	};
+}
+
+function isIgnoredFunction({ type, value }) {
+	return type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase());
+}
+
+function isHexColor({ type, value }) {
+	return type === 'word' && HEX.test(value);
 }
 
 function getValue(decl) {


### PR DESCRIPTION
As discussed in #4826, `style-search` has false positives when used with `css-in-js` object notation. This change updates the `color-hex-case` rule to use `postcss-value-parser` instead, which has support for `css-in-js` as a syntax.

The unit tests now also include a suite for testing both `upper` and `lower` options for `color-hex-case` with the `css-in-js` syntax.