### PR TITLE
Fix false negatives for CSS variables in alpha-value-notation

### DIFF
--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -47,6 +47,9 @@ testRule({
 			code: 'a { color: hsla(var(--hue), var(--sat), var(--sat), var(--alpha)) }',
 		},
 		{
+			code: 'a { color: hsl(var(--hsl) / 0.5) }',
+		},
+		{
 			code: 'a { color: lch(56.29% 19.86 10 / var(--alpha)) }',
 		},
 		{
@@ -99,6 +102,20 @@ testRule({
 			message: messages.expected('50%', '0.5'),
 			line: 1,
 			column: 26,
+		},
+		{
+			code: 'a { color: hsl(var(--hsl) / 50%) }',
+			fixed: 'a { color: hsl(var(--hsl) / 0.5) }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 29,
+		},
+		{
+			code: 'a { color: hsl(var(--hsl) / /* comment*/ 50%) }',
+			fixed: 'a { color: hsl(var(--hsl) / /* comment*/ 0.5) }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 42,
 		},
 		{
 			code: stripIndent`

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -130,6 +130,14 @@ function findAlphaInFunction(node) {
 
 	if (args.length === 4) return args[3];
 
+	const slashNodeIndex = node.nodes.findIndex(({ type, value }) => type === 'div' && value === '/');
+
+	if (slashNodeIndex !== -1) {
+		const nodesAfterSlash = node.nodes.slice(slashNodeIndex + 1, node.nodes.length);
+
+		return nodesAfterSlash.find(({ type }) => type === 'word');
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/5129

> Is there anything in the PR that needs further explanation?

I ran into this bug while preparing a new release of [stylelint-scales](https://github.com/signal-noise/stylelint-scales).

As mentioned in https://github.com/stylelint/stylelint/issues/5129, the best we can do is narrow down the possibilities of what a particular node could represent. This pull request uses in the slash within modern colour function notation as a fallback to find the `<alpha-value>`.
