### PR TITLE
Always infer syntax for known file formats, even with processors.

### DIFF
--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -60,7 +60,7 @@ module.exports = function (stylelint, options = {}) {
 
 					syntax = syntaxes[stylelint._options.syntax];
 				}
-			} else if (!(options.codeProcessors && options.codeProcessors.length)) {
+			} else {
 				const autoSyntax = require('postcss-syntax');
 
 				// TODO: investigate why lazy import HTML syntax causes


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

closes #5117

> Is there anything in the PR that needs further explanation?

Unfortunately, I but couldn't figure out a minimal reproduction so I couldn't add a test. I suspect it might only break in our case because of some interaction with `processors: ['stylelint-processor-styled-components']`. However, I can confirm:

- An example of a scss file in our repository that errors without this code, but is fixed with this code:
  ```scss
  .foo {
    // a nested comment
    &--bar { color: red; }
  }
  ```
- The code in this PR fixes the issue in our repository.
- The tests seem to pass, so in theory this shouldn't break anything.

I understand if you still don't want to merge this but i've spent a couple hours on this and don't have time to dive any further. (We actually ended up passing `-s scss` to work around this issue, so it's no longer blocking us.)