### PR TITLE
fix rule doc on declaration-property-value-allowed

### DIFF
--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -62,11 +62,6 @@ The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-a { color: pink; }
-```
-
-<!-- prettier-ignore -->
-```css
 a { whitespace: nowrap; }
 ```
 
@@ -88,9 +83,4 @@ a { color: green; }
 <!-- prettier-ignore -->
 ```css
 a { background-color: green; }
-```
-
-<!-- prettier-ignore -->
-```css
-a { background: pink; }
 ```


### PR DESCRIPTION
the patterns `a { background: pink; }` and `a { color: pink; }` are both considered violations and not considered violations. See https://github.com/stylelint/stylelint/tree/64078f5b7fb7cdf892a32840ee9a9c906c7c5a1e/lib/rules/declaration-property-value-allowed-list#options

Not only does this not make sense, but it is not consistent with the tests
https://github.com/stylelint/stylelint/blob/64078f5b7fb7cdf892a32840ee9a9c906c7c5a1e/lib/rules/declaration-property-value-allowed-list/__tests__/index.js#L26-L31
which checks accepts only the color green, not pink.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
