### PR TITLE
Fix some false positives in *-no-unknown rules

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -28,6 +28,8 @@ keywordSets.lengthUnits = new Set([
 	'ex',
 	'ch',
 	'rem',
+	'rlh',
+	'lh',
 	// Viewport-percentage lengths
 	'vh',
 	'vw',
@@ -42,6 +44,7 @@ keywordSets.lengthUnits = new Set([
 	'pt',
 	'pc',
 	'q',
+	'mozmm',
 	// Flexible length units
 	'fr',
 ]);
@@ -171,6 +174,7 @@ keywordSets.levelThreePseudoElements = new Set([
 	'shadow',
 	'slotted',
 	'content',
+	'file-selector-button',
 ]);
 
 keywordSets.shadowTreePseudoElements = new Set(['part']);
@@ -265,6 +269,7 @@ keywordSets.otherPseudoClasses = new Set([
 	'required',
 	'root',
 	'scope',
+	'state',
 	'target',
 	'user-error',
 	'user-invalid',
@@ -544,6 +549,7 @@ keywordSets.atRules = uniteSets(keywordSets.pageMarginAtRules, [
 	'nest',
 	'ornaments',
 	'page',
+	'property',
 	'styleset',
 	'stylistic',
 	'supports',
@@ -657,6 +663,7 @@ keywordSets.nonStandardHtmlTags = new Set([
 	'keygen',
 	'listing',
 	'marquee',
+	'nobr',
 	'noembed',
 	'plaintext',
 	'spacer',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#5157

> Is there anything in the PR that needs further explanation?

lh and rlh units are supported by Safari.
https://trac.webkit.org/changeset/259703/webkit/
caveat: https://bugs.webkit.org/show_bug.cgi?id=211351

the commit message lists \@​property but GitHub displays it as @property