### PR TITLE
Add ignore: [single-declaration] to declaration-block-trailing-semicolon

### DIFF
--- a/lib/rules/declaration-block-trailing-semicolon/README.md
+++ b/lib/rules/declaration-block-trailing-semicolon/README.md
@@ -88,3 +88,38 @@ a { color: pink }
 ```css
 a { background: orange; color: pink }
 ```
+
+## Optional secondary options
+
+### `ignore: ["single-declaration"]`
+
+#### `"single-declaration"`
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+foo { property: value }
+```
+
+<!-- prettier-ignore -->
+```css
+foo { property: value; }
+```
+
+<!-- prettier-ignore -->
+```css
+@keyframes name { from { property: 0 } to { property: 1; } }
+```
+
+With `"always"`:
+
+The following pattern is _still_ considered a violation:
+
+<!-- prettier-ignore -->
+```css
+foo {
+  property: value;
+  bar: qux
+}
+```

--- a/lib/rules/declaration-block-trailing-semicolon/README.md
+++ b/lib/rules/declaration-block-trailing-semicolon/README.md
@@ -93,33 +93,16 @@ a { background: orange; color: pink }
 
 ### `ignore: ["single-declaration"]`
 
-#### `"single-declaration"`
+Ignore declaration blocks that contain a single declaration.
 
 The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-foo { property: value }
+a { color: pink }
 ```
 
 <!-- prettier-ignore -->
 ```css
-foo { property: value; }
-```
-
-<!-- prettier-ignore -->
-```css
-@keyframes name { from { property: 0 } to { property: 1; } }
-```
-
-With `"always"`:
-
-The following pattern is _still_ considered a violation:
-
-<!-- prettier-ignore -->
-```css
-foo {
-  property: value;
-  bar: qux
-}
+a { color: pink; }
 ```

--- a/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
@@ -69,15 +69,15 @@ testRule({
 
 	accept: [
 		{
-			code: 'foo { property: value }',
+			code: 'a { color: pink }',
 			description: 'single declaration without trailing semicolon',
 		},
 		{
-			code: 'foo { property: value; }',
+			code: 'a { color: pink; }',
 			description: 'single declaration with trailing semicolon',
 		},
 		{
-			code: '@keyframes name { from { property: 0 } to { property: 1; } }',
+			code: '@keyframes foo { from { top: 0px } to { top: 1px; } }',
 			description: 'inconsistent case (with and without)',
 		},
 	],
@@ -100,15 +100,15 @@ testRule({
 
 	accept: [
 		{
-			code: 'foo { property: value }',
+			code: 'a { color: pink }',
 			description: 'single declaration without trailing semicolon',
 		},
 		{
-			code: 'foo { property: value; }',
+			code: 'a { color: pink; }',
 			description: 'single declaration with trailing semicolon',
 		},
 		{
-			code: '@keyframes name { from { property: 0 } to { property: 1; } }',
+			code: '@keyframes foo { from { top: 0px } to { top: 1px; } }',
 			description: 'inconsistent case (with and without)',
 		},
 	],

--- a/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
@@ -64,6 +64,58 @@ testRule({
 
 testRule({
 	ruleName,
+	config: ['always', { ignore: 'single-declaration' }],
+	fix: true,
+
+	accept: [
+		{
+			code: 'foo { property: value }',
+			description: 'single declaration without trailing semicolon',
+		},
+		{
+			code: 'foo { property: value; }',
+			description: 'single declaration with trailing semicolon',
+		},
+		{
+			code: '@keyframes name { from { property: 0 } to { property: 1; } }',
+			description: 'inconsistent case (with and without)',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { background: orange; color: pink }',
+			fixed: 'a { background: orange; color: pink; }',
+			description: 'multi declaration block without trailing semicolon',
+			message: messages.expected,
+			line: 1,
+			column: 35,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['never', { ignore: ['single-declaration'] }],
+
+	accept: [
+		{
+			code: 'foo { property: value }',
+			description: 'single declaration without trailing semicolon',
+		},
+		{
+			code: 'foo { property: value; }',
+			description: 'single declaration with trailing semicolon',
+		},
+		{
+			code: '@keyframes name { from { property: 0 } to { property: 1; } }',
+			description: 'inconsistent case (with and without)',
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: ['never'],
 	fix: true,
 

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const hasBlock = require('../../utils/hasBlock');
+const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -14,12 +15,23 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected trailing semicolon',
 });
 
-function rule(expectation, _, context) {
+function rule(expectation, options, context) {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
-			possible: ['always', 'never'],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: expectation,
+				possible: ['always', 'never'],
+			},
+			{
+				actual: options,
+				possible: {
+					ignore: ['single-declaration'],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
 			return;
@@ -54,10 +66,16 @@ function rule(expectation, _, context) {
 		});
 
 		function checkLastNode(node) {
+			const hasSemicolon = node.parent.raws.semicolon;
+			const ignoreSingleDeclaration = optionsMatches(options, 'ignore', 'single-declaration');
 			let message;
 
+			if (ignoreSingleDeclaration && node.parent.first === node) {
+				return;
+			}
+
 			if (expectation === 'always') {
-				if (node.parent.raws.semicolon) {
+				if (hasSemicolon) {
 					return;
 				}
 
@@ -75,7 +93,7 @@ function rule(expectation, _, context) {
 
 				message = messages.expected;
 			} else if (expectation === 'never') {
-				if (!node.parent.raws.semicolon) {
+				if (!hasSemicolon) {
 					return;
 				}
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #5159

> Is there anything in the PR that needs further explanation?

It cannot be named `"except"` because it would require `foo { property: value; }` to be valid for `"never"` which is useless/stupid. Or do you imagine a use case for it that would warrant it?

Should it be supported just for consistency?
**Can an option be exclusive to `"always"`?** If so do you have an example?