### PR TITLE
Add named-grid-areas-no-invalid

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -17,6 +17,10 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 - [`font-family-no-duplicate-names`](../../../lib/rules/font-family-no-duplicate-names/README.md): Disallow duplicate font family names.
 - [`font-family-no-missing-generic-family-keyword`](../../../lib/rules/font-family-no-missing-generic-family-keyword/README.md): Disallow missing generic families in lists of font family names.
 
+### Named Grid Areas
+
+- [`named-grid-areas-no-invalid`](../../../lib/rules/named-grid-areas-no-invalid/README.md): Disallow invalid named grid areas.
+
 ### Function
 
 - [`function-calc-no-invalid`](../../../lib/rules/function-calc-no-invalid/README.md): Disallow an invalid expression within `calc` functions.

--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -17,7 +17,7 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 - [`font-family-no-duplicate-names`](../../../lib/rules/font-family-no-duplicate-names/README.md): Disallow duplicate font family names.
 - [`font-family-no-missing-generic-family-keyword`](../../../lib/rules/font-family-no-missing-generic-family-keyword/README.md): Disallow missing generic families in lists of font family names.
 
-### Named Grid Areas
+### Named grid areas
 
 - [`named-grid-areas-no-invalid`](../../../lib/rules/named-grid-areas-no-invalid/README.md): Disallow invalid named grid areas.
 

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -231,6 +231,7 @@ const rules = {
 	'media-query-list-comma-space-before': importLazy(() =>
 		require('./media-query-list-comma-space-before'),
 	)(),
+	'named-grid-areas-no-invalid': importLazy(() => require('./named-grid-areas-no-invalid'))(),
 	'no-descending-specificity': importLazy(() => require('./no-descending-specificity'))(),
 	'no-duplicate-at-import-rules': importLazy(() => require('./no-duplicate-at-import-rules'))(),
 	'no-duplicate-selectors': importLazy(() => require('./no-duplicate-selectors'))(),

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -9,6 +9,7 @@ a { grid-template-areas:
       "b b b"; }
 /**   ↑
  *  This named grid area */
+```
 
 ## Options
 

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -4,10 +4,11 @@ Disallow invalid named grid areas.
 
 <!-- prettier-ignore -->
 ```css
-a { color: pink; }···
-/**               ↑
- *  This whitespace */
-```
+a { grid-template-areas: 
+      "a a a"
+      "b b b"; }
+/**   ↑
+ *  This named grid area */
 
 ## Options
 

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -1,0 +1,44 @@
+# named-grid-areas-no-invalid
+
+Disallow invalid named grid areas in `grid-template-areas`
+
+<!-- prettier-ignore -->
+```css
+a { color: pink; }···
+/**               ↑
+ *  This whitespace */
+```
+
+## Options
+
+### `true`
+
+The following patterns are considered violations:
+
+All strings must define the same number of cell tokens
+<!-- prettier-ignore -->
+```css
+grid-template-areas: "a a a"
+                     "b b b";
+```
+
+All strings must define at least one cell token
+<!-- prettier-ignore -->
+```css
+grid-template-areas: ""
+```
+
+If a named grid area spans multiple grid cells, but those cells do not form a single filled-in rectangle, the declaration is invalid.
+<!-- prettier-ignore -->
+```css
+grid-template-areas: "a a a"
+                     "b b a";
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+grid-template-areas: "a a a"
+                     "b b b";
+```

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -15,7 +15,7 @@ a { color: pink; }···
 
 The following patterns are considered violations:
 
-All strings must define the same number of cell tokens
+All strings must define the same number of cell tokens.
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -1,6 +1,6 @@
 # named-grid-areas-no-invalid
 
-Disallow invalid named grid areas in `grid-template-areas`
+Disallow invalid named grid areas.
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -16,19 +16,22 @@ a { color: pink; }···
 The following patterns are considered violations:
 
 All strings must define the same number of cell tokens
+
 <!-- prettier-ignore -->
 ```css
 grid-template-areas: "a a a"
-                     "b b b";
+                     "b b b b";
 ```
 
 All strings must define at least one cell token
+
 <!-- prettier-ignore -->
 ```css
 grid-template-areas: ""
 ```
 
 If a named grid area spans multiple grid cells, but those cells do not form a single filled-in rectangle, the declaration is invalid.
+
 <!-- prettier-ignore -->
 ```css
 grid-template-areas: "a a a"
@@ -41,4 +44,9 @@ The following patterns are _not_ considered violations:
 ```css
 grid-template-areas: "a a a"
                      "b b b";
+```
+
+<!-- prettier-ignore -->
+```css
+grid-template-areas: none;
 ```

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -20,39 +20,39 @@ All strings must define the same number of cell tokens.
 
 <!-- prettier-ignore -->
 ```css
-grid-template-areas: "a a a"
-                     "b b b b";
+a { grid-template-areas: "a a a"
+                         "b b b b"; }
 ```
 
-All strings must define at least one cell token
+All strings must define at least one cell token.
 
 <!-- prettier-ignore -->
 ```css
-grid-template-areas: ""
+a { grid-template-areas: "" }
 ```
 
 All named grid areas that spans multiple grid cells must form a single filled-in rectangle.
 
 <!-- prettier-ignore -->
 ```css
-grid-template-areas: "a a a"
-                     "b b a";
+a { grid-template-areas: "a a a"
+                         "b b a"; }
 ```
 
 The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-grid-template-areas: "a a a"
-                     "b b b";
+a { grid-template-areas: "a a a"
+                         "b b b"; }
 ```
 
 <!-- prettier-ignore -->
 ```css
-grid-template-areas: "a a a" "b b b";
+a { grid-template-areas: "a a a" "b b b"; }
 ```
 
 <!-- prettier-ignore -->
 ```css
-grid-template-areas: none;
+a { grid-template-areas: none; }
 ```

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -48,5 +48,10 @@ grid-template-areas: "a a a"
 
 <!-- prettier-ignore -->
 ```css
+grid-template-areas: "a a a" "b b b";
+```
+
+<!-- prettier-ignore -->
+```css
 grid-template-areas: none;
 ```

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -31,7 +31,7 @@ All strings must define at least one cell token
 grid-template-areas: ""
 ```
 
-If a named grid area spans multiple grid cells, but those cells do not form a single filled-in rectangle, the declaration is invalid.
+All named grid areas that spans multiple grid cells must form a single filled-in rectangle.
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -54,25 +54,6 @@ testRule({
 
 	reject: [
 		{
-			code: 'a { grid-template-areas: foo "a a a" bar "b b b" baz; }',
-			warnings: [
-				{ message: messages.noInvalidSymbols('foo'), line: 1, column: 26 },
-				{ message: messages.noInvalidSymbols('bar'), line: 1, column: 38 },
-				{ message: messages.noInvalidSymbols('baz'), line: 1, column: 50 },
-			],
-		},
-		{
-			code: stripIndent`
-				a { 
-					grid-template-areas: "a a a"
-						foo
-						"b b b";
-				}`,
-			message: messages.noInvalidSymbols('foo'),
-			line: 3,
-			column: 3,
-		},
-		{
 			code: 'a { grid-template-areas: "a a a" "b b"; }',
 			message: messages.notRectangular(),
 			line: 1,

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -36,7 +36,7 @@ testRule({
 			code: 'a { grid-template-areas:    none; }',
 		},
 		{
-			code: 'a {grid-template-areas: /*comment*/ none /* comment */; }',
+			code: 'a { grid-template-areas: /*comment*/ none /* comment */; }',
 		},
 		{
 			code: 'a {grid-template-areas: /*comment*/ NONE /* comment */; }',

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -24,9 +24,35 @@ testRule({
 		{
 			code: 'div { grid-template-areas: none; }',
 		},
+		{
+			code: 'div { grid-template-areas:    none; }',
+		},
+		{
+			code: 'div { grid-template-areas: /* comment "" " */ none; }',
+		},
+		{
+			code: `div { grid-template-areas: 
+/* "comment" */ none /* "comment " */; }`,
+		},
 	],
 
 	reject: [
+		{
+			code: 'a { grid-template-areas: foo "a a a" bar "b b b" baz; }',
+			warnings: [
+				{ message: messages.noInvalidSymbols('foo'), line: 1, column: 26 },
+				{ message: messages.noInvalidSymbols('bar'), line: 1, column: 38 },
+				{ message: messages.noInvalidSymbols('baz'), line: 1, column: 50 },
+			],
+		},
+		{
+			code: `a { grid-template-areas: "a a a"  
+                          foo
+                          "b b b"; }`,
+			message: messages.noInvalidSymbols('foo'),
+			line: 2,
+			column: 27,
+		},
 		{
 			code: 'div { grid-template-areas: "a a a" "b b"; }',
 			message: messages.notRectangular(),
@@ -49,9 +75,37 @@ testRule({
 		},
 		{
 			code: 'div { grid-template-areas: ""; }',
-			message: messages.noRows(),
+			message: messages.noEmptyRows(),
 			line: 1,
-			column: 7,
+			column: 28,
+		},
+		{
+			code: 'a { grid-template-areas: /* "comment" */ ""; }',
+			message: messages.noEmptyRows(),
+			line: 1,
+			column: 42,
+		},
+		{
+			code: `a { grid-template-areas: 
+ ""; }`,
+			message: messages.noEmptyRows(),
+			line: 2,
+			column: 2,
+		},
+		{
+			code: `a { grid-template-areas: "" "" ""; }`,
+			warnings: [
+				{ message: messages.noEmptyRows(), line: 1, column: 26 },
+				{ message: messages.noEmptyRows(), line: 1, column: 29 },
+				{ message: messages.noEmptyRows(), line: 1, column: 32 },
+			],
+		},
+		{
+			code: `a { grid-template-areas: /* none */
+ "" /* none */; }`,
+			message: messages.noEmptyRows(),
+			line: 2,
+			column: 2,
 		},
 	],
 });

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -39,7 +39,7 @@ testRule({
 			code: 'a { grid-template-areas: /*comment*/ none /* comment */; }',
 		},
 		{
-			code: 'a {grid-template-areas: /*comment*/ NONE /* comment */; }',
+			code: 'a { grid-template-areas: /*comment*/ NONE /* comment */; }',
 		},
 		{
 			code: 'a {grid-template-areas: NONE; }',

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -79,6 +79,12 @@ testRule({
 			column: 7,
 		},
 		{
+			code: 'div { grid-template-areas: "a c a" "c b a"; }',
+			message: messages.notContiguousOrRectangular(['a', 'c']),
+			line: 1,
+			column: 7,
+		},
+		{
 			code: stripIndent`
 			  div { 
 					grid-template-areas: "header header header header"

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -9,7 +9,7 @@ testRule({
 
 	accept: [
 		{
-			code: 'div { grid-template-areas: "a a a" "b b b"; }',
+			code: 'a { grid-template-areas: "a a a" "b b b"; }',
 		},
 		{
 			code: `div { grid-template-areas: "head head"

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const stripIndent = require('common-tags').stripIndent;
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -12,14 +13,21 @@ testRule({
 			code: 'a { grid-template-areas: "a a a" "b b b"; }',
 		},
 		{
-			code: `div { grid-template-areas: "head head"
-"nav  main"
-"nav  foot";}`,
+			code: stripIndent`
+				div { 
+					grid-template-areas: "head head"
+					                     "nav  main"
+															 "nav  foot";
+				}`,
 		},
 		{
-			code: `div { grid-template-areas: /* "" */ "head head"
-"nav  main" /* "a b c" */
-"nav  foot" /* "" */;}`,
+			code: stripIndent`
+				div { 
+					grid-template-areas: 
+						/* "" */ "head head"
+						"nav  main" /* "a b c" */
+						"nav  foot" /* "" */;
+				}`,
 		},
 		{
 			code: 'div { grid-template-areas: none; }',
@@ -31,8 +39,10 @@ testRule({
 			code: 'div { grid-template-areas: /* comment "" " */ none; }',
 		},
 		{
-			code: `div { grid-template-areas: 
-/* "comment" */ none /* "comment " */; }`,
+			code: stripIndent`
+			div { 
+				grid-template-areas: /* "comment" */ none /* "comment " */; 
+			}`,
 		},
 	],
 
@@ -46,12 +56,15 @@ testRule({
 			],
 		},
 		{
-			code: `a { grid-template-areas: "a a a"  
-                          foo
-                          "b b b"; }`,
+			code: stripIndent`
+				a { 
+					grid-template-areas: "a a a"  
+                               foo
+                               "b b b"; 
+				}`,
 			message: messages.noInvalidSymbols('foo'),
-			line: 2,
-			column: 27,
+			line: 3,
+			column: 28,
 		},
 		{
 			code: 'div { grid-template-areas: "a a a" "b b"; }',
@@ -66,12 +79,15 @@ testRule({
 			column: 7,
 		},
 		{
-			code: `div { grid-template-areas: "header header header header"
-"main main . sidebar"
-"footer footer footer header"; }`,
+			code: stripIndent`
+			  div { 
+					grid-template-areas: "header header header header"
+                               "main main . sidebar"
+                               "footer footer footer header"; 
+				}`,
 			message: messages.notContiguousOrRectangular(['header']),
-			line: 1,
-			column: 7,
+			line: 2,
+			column: 2,
 		},
 		{
 			code: 'div { grid-template-areas: ""; }',
@@ -86,14 +102,16 @@ testRule({
 			column: 42,
 		},
 		{
-			code: `a { grid-template-areas: 
- ""; }`,
+			code: stripIndent`
+			a { grid-template-areas: 
+			   ""; 
+			}`,
 			message: messages.noEmptyRows(),
 			line: 2,
-			column: 2,
+			column: 4,
 		},
 		{
-			code: `a { grid-template-areas: "" "" ""; }`,
+			code: 'a { grid-template-areas: "" "" ""; }',
 			warnings: [
 				{ message: messages.noEmptyRows(), line: 1, column: 26 },
 				{ message: messages.noEmptyRows(), line: 1, column: 29 },
@@ -101,11 +119,14 @@ testRule({
 			],
 		},
 		{
-			code: `a { grid-template-areas: /* none */
- "" /* none */; }`,
+			code: stripIndent`
+			a { 
+				grid-template-areas: /* none */
+ 			    "" /* none */; 
+			}`,
 			message: messages.noEmptyRows(),
-			line: 2,
-			column: 2,
+			line: 3,
+			column: 6,
 		},
 	],
 });

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -14,7 +14,7 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				div { 
+				a { 
 					grid-template-areas: "head head"
 					                     "nav  main"
 															 "nav  foot";
@@ -22,7 +22,7 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				div { 
+				a { 
 					grid-template-areas: 
 						/* "" */ "head head"
 						"nav  main" /* "a b c" */
@@ -30,17 +30,17 @@ testRule({
 				}`,
 		},
 		{
-			code: 'div { grid-template-areas: none; }',
+			code: 'a { grid-template-areas: none; }',
 		},
 		{
-			code: 'div { grid-template-areas:    none; }',
+			code: 'a { grid-template-areas:    none; }',
 		},
 		{
-			code: 'div { grid-template-areas: /* comment "" " */ none; }',
+			code: 'a { grid-template-areas: /* comment "" " */ none; }',
 		},
 		{
 			code: stripIndent`
-			div { 
+			a { 
 				grid-template-areas: /* "comment" */ none /* "comment " */; 
 			}`,
 		},
@@ -67,26 +67,26 @@ testRule({
 			column: 28,
 		},
 		{
-			code: 'div { grid-template-areas: "a a a" "b b"; }',
+			code: 'a { grid-template-areas: "a a a" "b b"; }',
 			message: messages.notRectangular(),
 			line: 1,
 			column: 7,
 		},
 		{
-			code: 'div { grid-template-areas: "a a a" "b b a"; }',
+			code: 'a { grid-template-areas: "a a a" "b b a"; }',
 			message: messages.notContiguousOrRectangular(['a']),
 			line: 1,
 			column: 7,
 		},
 		{
-			code: 'div { grid-template-areas: "a c a" "c b a"; }',
+			code: 'a { grid-template-areas: "a c a" "c b a"; }',
 			message: messages.notContiguousOrRectangular(['a', 'c']),
 			line: 1,
 			column: 7,
 		},
 		{
 			code: stripIndent`
-			  div { 
+			  a { 
 					grid-template-areas: "header header header header"
                                "main main . sidebar"
                                "footer footer footer header"; 
@@ -96,7 +96,7 @@ testRule({
 			column: 2,
 		},
 		{
-			code: 'div { grid-template-areas: ""; }',
+			code: 'a { grid-template-areas: ""; }',
 			message: messages.noEmptyRows(),
 			line: 1,
 			column: 28,

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -13,6 +13,9 @@ testRule({
 			code: 'a { grid-template-areas: "a a a" "b b b"; }',
 		},
 		{
+			code: 'a { GRID-TEMPLATE-AREAS: "a a a" "b b b"; }',
+		},
+		{
 			code: stripIndent`
 				a { 
 					grid-template-areas: "head head"
@@ -124,6 +127,12 @@ testRule({
 			message: messages.expectedToken(),
 			line: 3,
 			column: 4,
+		},
+		{
+			code: 'a { GRID-TEMPLATE-AREAS: ""; }',
+			message: messages.expectedToken(),
+			line: 1,
+			column: 26,
 		},
 	],
 });

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -42,7 +42,7 @@ testRule({
 			code: 'a { grid-template-areas: /*comment*/ NONE /* comment */; }',
 		},
 		{
-			code: 'a {grid-template-areas: NONE; }',
+			code: 'a { grid-template-areas: NONE; }',
 		},
 		{
 			code: 'a { grid-template-areas: /* comment "" " */ none; }',

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -17,6 +17,11 @@ testRule({
 "nav  foot";}`,
 		},
 		{
+			code: `div { grid-template-areas: /* "" */ "head head"
+"nav  main" /* "a b c" */
+"nav  foot" /* "" */;}`,
+		},
+		{
 			code: 'div { grid-template-areas: none; }',
 		},
 	],

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -42,6 +42,9 @@ testRule({
 			code: 'a {grid-template-areas: /*comment*/ NONE /* comment */; }',
 		},
 		{
+			code: 'a {grid-template-areas: NONE; }',
+		},
+		{
 			code: 'a { grid-template-areas: /* comment "" " */ none; }',
 		},
 		{

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -40,9 +40,9 @@ testRule({
 		},
 		{
 			code: stripIndent`
-			a { 
-				grid-template-areas: /* "comment" */ none /* "comment " */; 
-			}`,
+				a { 
+					grid-template-areas: /* "comment" */ none /* "comment " */; 
+				}`,
 		},
 	],
 
@@ -109,9 +109,9 @@ testRule({
 		},
 		{
 			code: stripIndent`
-			a { grid-template-areas: 
-			   ""; 
-			}`,
+				a { grid-template-areas: 
+			   	""; 
+				}`,
 			message: messages.noEmptyRows(),
 			line: 2,
 			column: 4,
@@ -126,10 +126,10 @@ testRule({
 		},
 		{
 			code: stripIndent`
-			a { 
-				grid-template-areas: /* none */
- 					"" /* none */; 
-			}`,
+				a { 
+					grid-template-areas: /* none */
+ 						"" /* none */; 
+				}`,
 			message: messages.noEmptyRows(),
 			line: 3,
 			column: 6,

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -58,21 +58,22 @@ testRule({
 	reject: [
 		{
 			code: 'a { grid-template-areas: "a a a" "b b"; }',
-			message: messages.notRectangular(),
+			message: messages.expectedSameNumber(),
 			line: 1,
 			column: 26,
 		},
 		{
 			code: 'a { grid-template-areas: "a a a" "b b a"; }',
-			message: messages.notContiguousOrRectangular(['a']),
+			message: messages.expectedRectangle('a'),
 			line: 1,
 			column: 26,
 		},
 		{
 			code: 'a { grid-template-areas: "a c a" "c b a"; }',
-			message: messages.notContiguousOrRectangular(['a', 'c']),
-			line: 1,
-			column: 26,
+			warnings: [
+				{ message: messages.expectedRectangle('a'), line: 1, column: 26 },
+				{ message: messages.expectedRectangle('c'), line: 1, column: 26 },
+			],
 		},
 		{
 			code: stripIndent`
@@ -81,19 +82,19 @@ testRule({
 						"main main . sidebar"
 						"footer footer footer header"; 
 				}`,
-			message: messages.notContiguousOrRectangular(['header']),
+			message: messages.expectedRectangle('header'),
 			line: 2,
 			column: 23,
 		},
 		{
 			code: 'a { grid-template-areas: ""; }',
-			message: messages.noEmptyRows(),
+			message: messages.expectedToken(),
 			line: 1,
 			column: 26,
 		},
 		{
 			code: 'a { grid-template-areas: /* "comment" */ ""; }',
-			message: messages.noEmptyRows(),
+			message: messages.expectedToken(),
 			line: 1,
 			column: 42,
 		},
@@ -102,16 +103,16 @@ testRule({
 				a { grid-template-areas: 
 			   	""; 
 				}`,
-			message: messages.noEmptyRows(),
+			message: messages.expectedToken(),
 			line: 2,
 			column: 4,
 		},
 		{
 			code: 'a { grid-template-areas: "" "" ""; }',
 			warnings: [
-				{ message: messages.noEmptyRows(), line: 1, column: 26 },
-				{ message: messages.noEmptyRows(), line: 1, column: 29 },
-				{ message: messages.noEmptyRows(), line: 1, column: 32 },
+				{ message: messages.expectedToken(), line: 1, column: 26 },
+				{ message: messages.expectedToken(), line: 1, column: 29 },
+				{ message: messages.expectedToken(), line: 1, column: 32 },
 			],
 		},
 		{
@@ -120,7 +121,7 @@ testRule({
 					grid-template-areas: /* none */
  						"" /* none */; 
 				}`,
-			message: messages.noEmptyRows(),
+			message: messages.expectedToken(),
 			line: 3,
 			column: 4,
 		},

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -36,6 +36,12 @@ testRule({
 			code: 'a { grid-template-areas:    none; }',
 		},
 		{
+			code: 'a {grid-template-areas: /*comment*/ none /* comment */; }',
+		},
+		{
+			code: 'a {grid-template-areas: /*comment*/ NONE /* comment */; }',
+		},
+		{
 			code: 'a { grid-template-areas: /* comment "" " */ none; }',
 		},
 		{
@@ -64,25 +70,25 @@ testRule({
 				}`,
 			message: messages.noInvalidSymbols('foo'),
 			line: 3,
-			column: 28,
+			column: 3,
 		},
 		{
 			code: 'a { grid-template-areas: "a a a" "b b"; }',
 			message: messages.notRectangular(),
 			line: 1,
-			column: 7,
+			column: 5,
 		},
 		{
 			code: 'a { grid-template-areas: "a a a" "b b a"; }',
 			message: messages.notContiguousOrRectangular(['a']),
 			line: 1,
-			column: 7,
+			column: 5,
 		},
 		{
 			code: 'a { grid-template-areas: "a c a" "c b a"; }',
 			message: messages.notContiguousOrRectangular(['a', 'c']),
 			line: 1,
-			column: 7,
+			column: 5,
 		},
 		{
 			code: stripIndent`
@@ -99,7 +105,7 @@ testRule({
 			code: 'a { grid-template-areas: ""; }',
 			message: messages.noEmptyRows(),
 			line: 1,
-			column: 28,
+			column: 26,
 		},
 		{
 			code: 'a { grid-template-areas: /* "comment" */ ""; }',
@@ -132,7 +138,7 @@ testRule({
 				}`,
 			message: messages.noEmptyRows(),
 			line: 3,
-			column: 6,
+			column: 4,
 		},
 	],
 });

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -16,8 +16,8 @@ testRule({
 			code: stripIndent`
 				a { 
 					grid-template-areas: "head head"
-					                     "nav  main"
-															 "nav  foot";
+						"nav  main"
+						"nav  foot";
 				}`,
 		},
 		{
@@ -58,9 +58,9 @@ testRule({
 		{
 			code: stripIndent`
 				a { 
-					grid-template-areas: "a a a"  
-                               foo
-                               "b b b"; 
+					grid-template-areas: "a a a"
+						foo
+						"b b b";
 				}`,
 			message: messages.noInvalidSymbols('foo'),
 			line: 3,
@@ -88,8 +88,8 @@ testRule({
 			code: stripIndent`
 			  a { 
 					grid-template-areas: "header header header header"
-                               "main main . sidebar"
-                               "footer footer footer header"; 
+						"main main . sidebar"
+						"footer footer footer header"; 
 				}`,
 			message: messages.notContiguousOrRectangular(['header']),
 			line: 2,
@@ -128,7 +128,7 @@ testRule({
 			code: stripIndent`
 			a { 
 				grid-template-areas: /* none */
- 			    "" /* none */; 
+ 					"" /* none */; 
 			}`,
 			message: messages.noEmptyRows(),
 			line: 3,

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { messages, ruleName } = require('..');
+
+testRule({
+	ruleName,
+
+	config: [true],
+
+	accept: [
+		{
+			code: 'div { grid-template-areas: "a a a" "b b b"; }',
+		},
+		{
+			code: `div { grid-template-areas: "head head"
+"nav  main"
+"nav  foot";}`,
+		},
+		{
+			code: 'div { grid-template-areas: none; }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'div { grid-template-areas: "a a a" "b b"; }',
+			message: messages.notRectangular(),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: 'div { grid-template-areas: "a a a" "b b a"; }',
+			message: messages.notContiguousOrRectangular(['a']),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: `div { grid-template-areas: "header header header header"
+"main main . sidebar"
+"footer footer footer header"; }`,
+			message: messages.notContiguousOrRectangular(['header']),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: 'div { grid-template-areas: ""; }',
+			message: messages.noRows(),
+			line: 1,
+			column: 7,
+		},
+	],
+});

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -57,19 +57,19 @@ testRule({
 			code: 'a { grid-template-areas: "a a a" "b b"; }',
 			message: messages.notRectangular(),
 			line: 1,
-			column: 5,
+			column: 26,
 		},
 		{
 			code: 'a { grid-template-areas: "a a a" "b b a"; }',
 			message: messages.notContiguousOrRectangular(['a']),
 			line: 1,
-			column: 5,
+			column: 26,
 		},
 		{
 			code: 'a { grid-template-areas: "a c a" "c b a"; }',
 			message: messages.notContiguousOrRectangular(['a', 'c']),
 			line: 1,
-			column: 5,
+			column: 26,
 		},
 		{
 			code: stripIndent`
@@ -80,7 +80,7 @@ testRule({
 				}`,
 			message: messages.notContiguousOrRectangular(['header']),
 			line: 2,
-			column: 2,
+			column: 23,
 		},
 		{
 			code: 'a { grid-template-areas: ""; }',

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -29,15 +29,10 @@ function rule(actual) {
 
 		root.walkDecls('grid-template-areas', (decl) => {
 			const value = decl.value;
-			const parsedValue = valueParser(value);
 
-			if (
-				parsedValue.nodes.length > 0 &&
-				parsedValue.nodes[0].type === 'word' &&
-				parsedValue.nodes[0].value === 'none'
-			) {
-				return;
-			}
+			if (value.toLowerCase().trim() === 'none') return;
+
+			const parsedValue = valueParser(value);
 
 			let areas = [];
 			let reportSent = false;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -59,6 +59,8 @@ function rule(actual) {
 
 			if (!isRectangular(areas)) {
 				complain(messages.expectedSameNumber());
+
+				return;
 			}
 
 			const notContiguousOrRectangular = findNotContiguousOrRectangular(areas);

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -46,11 +46,13 @@ function rule(actual) {
 			let reportSent = false;
 
 			parsedValue.walk((node) => {
-				if (node.type === 'string' && node.value === '') {
-					complain(messages.expectedToken(), node.sourceIndex);
+				if (node.type === 'string') {
+					if (node.value === '') {
+						complain(messages.expectedToken(), node.sourceIndex);
 
-					reportSent = true;
-				} else if (node.type === 'string' && node.value !== '') {
+						reportSent = true;
+					}
+
 					areas.push(_.compact(node.value.trim().split(' ')));
 				}
 			});

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -42,19 +42,20 @@ function rule(actual) {
 
 			const parsedValue = valueParser(value);
 
-			let areas = [];
+			const areas = [];
 			let reportSent = false;
 
-			parsedValue.walk((node) => {
-				if (node.type === 'string') {
-					if (node.value === '') {
-						complain(messages.expectedToken(), node.sourceIndex);
+			parsedValue.walk(({ sourceIndex, type, value: tokenValue }) => {
+				if (type !== 'string') return;
 
-						reportSent = true;
-					}
+				if (tokenValue === '') {
+					complain(messages.expectedToken(), sourceIndex);
+					reportSent = true;
 
-					areas.push(_.compact(node.value.trim().split(' ')));
+					return;
 				}
+
+				areas.push(_.compact(tokenValue.trim().split(' ')));
 			});
 
 			if (reportSent) return;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const _ = require('lodash');
+const declarationValueIndex = require('../../utils/declarationValueIndex');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -11,7 +12,8 @@ const valueParser = require('postcss-value-parser');
 const ruleName = 'named-grid-areas-no-invalid';
 
 const messages = ruleMessages(ruleName, {
-	noRows: () => 'no rows defined',
+	noEmptyRows: () => 'empty row',
+	noInvalidSymbols: (symbol) => `${symbol} is not a valid`,
 	notRectangular: () => 'template is not rectangular',
 	notContiguousOrRectangular: (areaNames) =>
 		`The following areas are not contiguous or rectangular ${areaNames.join(', ')}`,
@@ -27,28 +29,45 @@ function rule(actual) {
 
 		root.walkDecls('grid-template-areas', (decl) => {
 			const value = decl.value;
-			const parsedValues = valueParser(value).nodes;
+			const parsedValue = valueParser(value);
 
 			if (
-				parsedValues.length > 0 &&
-				parsedValues[0].type === 'word' &&
-				parsedValues[0].value === 'none'
+				parsedValue.nodes.length > 0 &&
+				parsedValue.nodes[0].type === 'word' &&
+				parsedValue.nodes[0].value === 'none'
 			) {
 				return;
 			}
 
-			const areas = areasArray(parsedValues);
+			let rows = [];
 
-			if (_.isEmpty(areas) || _.isEmpty(areas[0])) {
-				report({
-					message: messages.noRows(),
-					node: decl,
-					result,
-					ruleName,
-				});
+			parsedValue.walk((node) => {
+				if (node.type !== 'string' && node.type !== 'space') {
+					report({
+						message: messages.noInvalidSymbols(node.value),
+						node: decl,
+						index: declarationValueIndex(decl) + node.sourceIndex,
+						result,
+						ruleName,
+					});
+				} else if (node.type === 'string' && node.value === '') {
+					report({
+						message: messages.noEmptyRows(node.value),
+						node: decl,
+						index: declarationValueIndex(decl) + node.sourceIndex,
+						result,
+						ruleName,
+					});
+				} else if (node.type === 'string' && node.value !== '') {
+					rows.push(node);
+				}
+			});
 
+			if (_.isEmpty(rows)) {
 				return;
 			}
+
+			const areas = areasArray(rows);
 
 			if (!isRectangular(areas)) {
 				report({
@@ -73,11 +92,8 @@ function rule(actual) {
 	};
 }
 
-function areasArray(parsedValues) {
-	const gridTemplateRows = _.filter(parsedValues, { type: 'string' });
-	const rows = gridTemplateRows.map((v) => v.value);
-
-	return rows.map((row) => _.compact(row.trim().split(' ')));
+function areasArray(rows) {
+	return rows.map((row) => _.compact(row.value.trim().split(' ')));
 }
 
 function columnsPerRow(areas) {

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -40,12 +40,10 @@ function rule(actual) {
 
 			if (value.toLowerCase().trim() === 'none') return;
 
-			const parsedValue = valueParser(value);
-
 			const areas = [];
 			let reportSent = false;
 
-			parsedValue.walk(({ sourceIndex, type, value: tokenValue }) => {
+			valueParser(value).walk(({ sourceIndex, type, value: tokenValue }) => {
 				if (type !== 'string') return;
 
 				if (tokenValue === '') {

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -4,6 +4,8 @@
 
 const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const findNotContiguousOrRectangular = require('./utils/findNotContiguousOrRectangular');
+const isRectangular = require('./utils/isRectangular');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -71,56 +73,6 @@ function rule(actual) {
 			}
 		});
 	};
-}
-
-function columnsPerRow(areas) {
-	return areas.map((row) => row.length);
-}
-
-function isRectangular(areas) {
-	return columnsPerRow(areas).every((val, i, arr) => val === arr[0]);
-}
-
-function isContiguousAndRectangular(areas, name) {
-	const indicesByRow = areas.map((row) => {
-		const indices = [];
-		let idx = row.indexOf(name);
-
-		while (idx !== -1) {
-			indices.push(idx);
-			idx = row.indexOf(name, idx + 1);
-		}
-
-		return indices;
-	});
-
-	for (let i = 0; i < indicesByRow.length; i++) {
-		for (let j = i + 1; j < indicesByRow.length; j++) {
-			if (indicesByRow[i].length === 0 || indicesByRow[j].length === 0) {
-				continue;
-			}
-
-			if (!_.isEqual(indicesByRow[i], indicesByRow[j])) {
-				return false;
-			}
-		}
-	}
-
-	return true;
-}
-
-function namedAreas(areas) {
-	const names = new Set(_.flatten(areas));
-
-	names.delete('.');
-
-	return Array.from(names);
-}
-
-function findNotContiguousOrRectangular(areas) {
-	return Array.from(
-		new Set(namedAreas(areas).filter((name) => !isContiguousAndRectangular(areas, name))),
-	);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -13,7 +13,7 @@ const ruleName = 'named-grid-areas-no-invalid';
 
 const messages = ruleMessages(ruleName, {
 	noEmptyRows: () => 'empty row',
-	noInvalidSymbols: (symbol) => `${symbol} is not a valid`,
+	noInvalidSymbols: (symbol) => `${symbol} is not a valid, only strings allowed`,
 	notRectangular: () => 'template is not rectangular',
 	notContiguousOrRectangular: (areaNames) =>
 		`The following areas are not contiguous or rectangular ${areaNames.join(', ')}`,

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -39,7 +39,7 @@ function rule(actual) {
 				return;
 			}
 
-			let rows = [];
+			let areas = [];
 			let reportSent = false;
 
 			parsedValue.walk((node) => {
@@ -64,15 +64,13 @@ function rule(actual) {
 
 					reportSent = true;
 				} else if (node.type === 'string' && node.value !== '') {
-					rows.push(node);
+					areas.push(_.compact(node.value.trim().split(' ')));
 				}
 			});
 
 			if (reportSent) {
 				return;
 			}
-
-			const areas = areasArray(rows);
 
 			if (!isRectangular(areas)) {
 				report({
@@ -95,10 +93,6 @@ function rule(actual) {
 			}
 		});
 	};
-}
-
-function areasArray(rows) {
-	return rows.map((row) => _.compact(row.value.trim().split(' ')));
 }
 
 function columnsPerRow(areas) {

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -66,7 +66,7 @@ function isContiguousAndRectangular(areas, name) {
 }
 
 function namedAreas(areas) {
-	const names = new Set(areas.flat());
+	const names = new Set(_.flatten(areas));
 
 	names.delete('.');
 

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -5,6 +5,7 @@
 const _ = require('lodash');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 
 const ruleName = 'named-grid-areas-no-invalid';
@@ -16,8 +17,14 @@ const messages = ruleMessages(ruleName, {
 		`The following areas are not contiguous or rectangular ${areaNames.join(', ')}`,
 });
 
-function rule() {
+function rule(actual) {
 	return (root, result) => {
+		const validOptions = validateOptions(result, ruleName, { actual });
+
+		if (!validOptions) {
+			return;
+		}
+
 		root.walkDecls('grid-template-areas', (decl) => {
 			const value = decl.value;
 			const parsedValues = valueParser(value).nodes;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -25,7 +25,7 @@ function rule(actual) {
 			return;
 		}
 
-		root.walkDecls('grid-template-areas', (decl) => {
+		root.walkDecls(/^grid-template-areas$/i, (decl) => {
 			function complain(message, sourceIndex = 0) {
 				report({
 					message,

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -1,0 +1,123 @@
+// @ts-nocheck
+
+'use strict';
+
+const _ = require('lodash');
+const report = require('../../utils/report');
+const ruleMessages = require('../../utils/ruleMessages');
+
+const ruleName = 'named-grid-areas-no-invalid';
+
+const messages = ruleMessages(ruleName, {
+	noRows: () => 'no rows defined',
+	notRectangular: () => 'template is not rectangular',
+	notContiguousOrRectangular: (areaNames) =>
+		`The following areas are not contiguous or rectangular ${areaNames.join(', ')}`,
+});
+
+function areasArray(gridTemplateString) {
+	const rows = Array.from(gridTemplateString.matchAll(/["']([^"']*)["']/g)).map(
+		(match) => match[1],
+	);
+
+	return rows.map((row) => _.compact(row.trim().split(' ')));
+}
+
+function columnsPerRow(areas) {
+	return areas.map((row) => row.length);
+}
+
+function isRectangular(areas) {
+	return columnsPerRow(areas).every((val, i, arr) => val === arr[0]);
+}
+
+function isContiguousAndRectangular(areas, name) {
+	const indicesByRow = areas.map((row) => {
+		const indices = [];
+		let idx = row.indexOf(name);
+
+		while (idx !== -1) {
+			indices.push(idx);
+			idx = row.indexOf(name, idx + 1);
+		}
+
+		return indices;
+	});
+
+	for (let i = 0; i < indicesByRow.length; i++) {
+		for (let j = i + 1; j < indicesByRow.length; j++) {
+			if (indicesByRow[i].length === 0 || indicesByRow[j].length === 0) {
+				continue;
+			}
+
+			if (!_.isEqual(indicesByRow[i], indicesByRow[j])) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+function namedAreas(areas) {
+	const names = new Set(areas.flat());
+
+	names.delete('.');
+
+	return Array.from(names);
+}
+
+function findNotContiguousOrRectangular(areas) {
+	return Array.from(
+		new Set(namedAreas(areas).filter((name) => !isContiguousAndRectangular(areas, name))),
+	);
+}
+
+function rule() {
+	return (root, result) => {
+		root.walkDecls('grid-template-areas', (decl) => {
+			const value = decl.value;
+
+			if (value === 'none') {
+				return;
+			}
+
+			const areas = areasArray(value);
+
+			if (_.isEmpty(areas) || _.isEmpty(areas[0])) {
+				report({
+					message: messages.noRows(),
+					node: decl,
+					result,
+					ruleName,
+				});
+
+				return;
+			}
+
+			if (!isRectangular(areas)) {
+				report({
+					message: messages.notRectangular(),
+					node: decl,
+					result,
+					ruleName,
+				});
+			}
+
+			const notContiguousOrRectangular = findNotContiguousOrRectangular(areas);
+
+			if (!_.isEmpty(notContiguousOrRectangular)) {
+				report({
+					message: messages.notContiguousOrRectangular(notContiguousOrRectangular),
+					node: decl,
+					result,
+					ruleName,
+				});
+			}
+		});
+	};
+}
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+module.exports = rule;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -5,6 +5,7 @@
 const _ = require('lodash');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const valueParser = require('postcss-value-parser');
 
 const ruleName = 'named-grid-areas-no-invalid';
 
@@ -15,16 +16,9 @@ const messages = ruleMessages(ruleName, {
 		`The following areas are not contiguous or rectangular ${areaNames.join(', ')}`,
 });
 
-function areasArray(gridTemplateString) {
-	const regex = /["']([^"']*)["']/g;
-	let captureGroups = [];
-	let rows = [];
-	let index = 0;
-
-	while ((captureGroups = regex.exec(gridTemplateString)) !== null) {
-		rows[index] = captureGroups[1];
-		index++;
-	}
+function areasArray(parsedValues) {
+	const gridTemplateRows = _.filter(parsedValues, { type: 'string' });
+	const rows = gridTemplateRows.map((v) => v.value);
 
 	return rows.map((row) => _.compact(row.trim().split(' ')));
 }
@@ -79,24 +73,21 @@ function findNotContiguousOrRectangular(areas) {
 	);
 }
 
-function removeComment(value) {
-	const regex = /\s*(?!<")\/\*[^*]+\*\/(?!")\s*/g;
-
-	return value.replace(regex, '');
-}
-
 function rule() {
 	return (root, result) => {
 		root.walkDecls('grid-template-areas', (decl) => {
 			const value = decl.value;
+			const parsedValues = valueParser(value).nodes;
 
-			if (value === 'none') {
+			if (
+				parsedValues.length > 0 &&
+				parsedValues[0].type === 'word' &&
+				parsedValues[0].value === 'none'
+			) {
 				return;
 			}
 
-			const valueWithoutComment = removeComment(value);
-
-			const areas = areasArray(valueWithoutComment);
+			const areas = areasArray(parsedValues);
 
 			if (_.isEmpty(areas) || _.isEmpty(areas[0])) {
 				report({

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -26,16 +26,6 @@ function rule(actual) {
 		}
 
 		root.walkDecls(/^grid-template-areas$/i, (decl) => {
-			function complain(message, sourceIndex = 0) {
-				report({
-					message,
-					node: decl,
-					index: declarationValueIndex(decl) + sourceIndex,
-					result,
-					ruleName,
-				});
-			}
-
 			const { value } = decl;
 
 			if (value.toLowerCase().trim() === 'none') return;
@@ -69,6 +59,16 @@ function rule(actual) {
 			notContiguousOrRectangular.sort().forEach((name) => {
 				complain(messages.expectedRectangle(name));
 			});
+
+			function complain(message, sourceIndex = 0) {
+				report({
+					message,
+					node: decl,
+					index: declarationValueIndex(decl) + sourceIndex,
+					result,
+					ruleName,
+				});
+			}
 		});
 	};
 }

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -12,11 +12,9 @@ const valueParser = require('postcss-value-parser');
 const ruleName = 'named-grid-areas-no-invalid';
 
 const messages = ruleMessages(ruleName, {
-	noEmptyRows: () => 'empty row',
-	noInvalidSymbols: (symbol) => `${symbol} is not a valid, only strings allowed`,
-	notRectangular: () => 'template is not rectangular',
-	notContiguousOrRectangular: (areaNames) =>
-		`The following areas are not contiguous or rectangular ${areaNames.join(', ')}`,
+	expectedToken: () => 'Expected cell token within string',
+	expectedSameNumber: () => 'Expected same number of cell tokens in each string',
+	expectedRectangle: (name) => `Expected single filled-in rectangle for "${name}"`,
 });
 
 function rule(actual) {
@@ -49,7 +47,7 @@ function rule(actual) {
 
 			parsedValue.walk((node) => {
 				if (node.type === 'string' && node.value === '') {
-					complain(messages.noEmptyRows(node.value), node.sourceIndex);
+					complain(messages.expectedToken(), node.sourceIndex);
 
 					reportSent = true;
 				} else if (node.type === 'string' && node.value !== '') {
@@ -60,14 +58,14 @@ function rule(actual) {
 			if (reportSent) return;
 
 			if (!isRectangular(areas)) {
-				complain(messages.notRectangular());
+				complain(messages.expectedSameNumber());
 			}
 
 			const notContiguousOrRectangular = findNotContiguousOrRectangular(areas);
 
-			if (!_.isEmpty(notContiguousOrRectangular)) {
-				complain(messages.notContiguousOrRectangular(notContiguousOrRectangular.sort()));
-			}
+			notContiguousOrRectangular.sort().forEach((name) => {
+				complain(messages.expectedRectangle(name));
+			});
 		});
 	};
 }

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -85,7 +85,7 @@ function rule(actual) {
 
 			if (!_.isEmpty(notContiguousOrRectangular)) {
 				report({
-					message: messages.notContiguousOrRectangular(notContiguousOrRectangular),
+					message: messages.notContiguousOrRectangular(notContiguousOrRectangular.sort()),
 					node: decl,
 					result,
 					ruleName,

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -38,17 +38,7 @@ function rule(actual) {
 			let reportSent = false;
 
 			parsedValue.walk((node) => {
-				if (node.type !== 'string' && node.type !== 'space') {
-					report({
-						message: messages.noInvalidSymbols(node.value),
-						node: decl,
-						index: declarationValueIndex(decl) + node.sourceIndex,
-						result,
-						ruleName,
-					});
-
-					reportSent = true;
-				} else if (node.type === 'string' && node.value === '') {
+				if (node.type === 'string' && node.value === '') {
 					report({
 						message: messages.noEmptyRows(node.value),
 						node: decl,

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -16,6 +16,56 @@ const messages = ruleMessages(ruleName, {
 		`The following areas are not contiguous or rectangular ${areaNames.join(', ')}`,
 });
 
+function rule() {
+	return (root, result) => {
+		root.walkDecls('grid-template-areas', (decl) => {
+			const value = decl.value;
+			const parsedValues = valueParser(value).nodes;
+
+			if (
+				parsedValues.length > 0 &&
+				parsedValues[0].type === 'word' &&
+				parsedValues[0].value === 'none'
+			) {
+				return;
+			}
+
+			const areas = areasArray(parsedValues);
+
+			if (_.isEmpty(areas) || _.isEmpty(areas[0])) {
+				report({
+					message: messages.noRows(),
+					node: decl,
+					result,
+					ruleName,
+				});
+
+				return;
+			}
+
+			if (!isRectangular(areas)) {
+				report({
+					message: messages.notRectangular(),
+					node: decl,
+					result,
+					ruleName,
+				});
+			}
+
+			const notContiguousOrRectangular = findNotContiguousOrRectangular(areas);
+
+			if (!_.isEmpty(notContiguousOrRectangular)) {
+				report({
+					message: messages.notContiguousOrRectangular(notContiguousOrRectangular),
+					node: decl,
+					result,
+					ruleName,
+				});
+			}
+		});
+	};
+}
+
 function areasArray(parsedValues) {
 	const gridTemplateRows = _.filter(parsedValues, { type: 'string' });
 	const rows = gridTemplateRows.map((v) => v.value);
@@ -71,56 +121,6 @@ function findNotContiguousOrRectangular(areas) {
 	return Array.from(
 		new Set(namedAreas(areas).filter((name) => !isContiguousAndRectangular(areas, name))),
 	);
-}
-
-function rule() {
-	return (root, result) => {
-		root.walkDecls('grid-template-areas', (decl) => {
-			const value = decl.value;
-			const parsedValues = valueParser(value).nodes;
-
-			if (
-				parsedValues.length > 0 &&
-				parsedValues[0].type === 'word' &&
-				parsedValues[0].value === 'none'
-			) {
-				return;
-			}
-
-			const areas = areasArray(parsedValues);
-
-			if (_.isEmpty(areas) || _.isEmpty(areas[0])) {
-				report({
-					message: messages.noRows(),
-					node: decl,
-					result,
-					ruleName,
-				});
-
-				return;
-			}
-
-			if (!isRectangular(areas)) {
-				report({
-					message: messages.notRectangular(),
-					node: decl,
-					result,
-					ruleName,
-				});
-			}
-
-			const notContiguousOrRectangular = findNotContiguousOrRectangular(areas);
-
-			if (!_.isEmpty(notContiguousOrRectangular)) {
-				report({
-					message: messages.notContiguousOrRectangular(notContiguousOrRectangular),
-					node: decl,
-					result,
-					ruleName,
-				});
-			}
-		});
-	};
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -73,6 +73,12 @@ function findNotContiguousOrRectangular(areas) {
 	);
 }
 
+function removeComment(value) {
+	const regex = /\s*(?!<")\/\*[^*]+\*\/(?!")\s*/g;
+
+	return value.replace(regex, '');
+}
+
 function rule() {
 	return (root, result) => {
 		root.walkDecls('grid-template-areas', (decl) => {
@@ -82,7 +88,9 @@ function rule() {
 				return;
 			}
 
-			const areas = areasArray(value);
+			const valueWithoutComment = removeComment(value);
+
+			const areas = areasArray(valueWithoutComment);
 
 			if (_.isEmpty(areas) || _.isEmpty(areas[0])) {
 				report({

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -36,7 +36,7 @@ function rule(actual) {
 				});
 			}
 
-			const value = decl.value;
+			const { value } = decl;
 
 			if (value.toLowerCase().trim() === 'none') return;
 

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -28,6 +28,16 @@ function rule(actual) {
 		}
 
 		root.walkDecls('grid-template-areas', (decl) => {
+			function complain(message, sourceIndex = 0) {
+				report({
+					message,
+					node: decl,
+					index: declarationValueIndex(decl) + sourceIndex,
+					result,
+					ruleName,
+				});
+			}
+
 			const value = decl.value;
 
 			if (value.toLowerCase().trim() === 'none') return;
@@ -39,13 +49,7 @@ function rule(actual) {
 
 			parsedValue.walk((node) => {
 				if (node.type === 'string' && node.value === '') {
-					report({
-						message: messages.noEmptyRows(node.value),
-						node: decl,
-						index: declarationValueIndex(decl) + node.sourceIndex,
-						result,
-						ruleName,
-					});
+					complain(messages.noEmptyRows(node.value), node.sourceIndex);
 
 					reportSent = true;
 				} else if (node.type === 'string' && node.value !== '') {
@@ -53,28 +57,16 @@ function rule(actual) {
 				}
 			});
 
-			if (reportSent) {
-				return;
-			}
+			if (reportSent) return;
 
 			if (!isRectangular(areas)) {
-				report({
-					message: messages.notRectangular(),
-					node: decl,
-					result,
-					ruleName,
-				});
+				complain(messages.notRectangular());
 			}
 
 			const notContiguousOrRectangular = findNotContiguousOrRectangular(areas);
 
 			if (!_.isEmpty(notContiguousOrRectangular)) {
-				report({
-					message: messages.notContiguousOrRectangular(notContiguousOrRectangular.sort()),
-					node: decl,
-					result,
-					ruleName,
-				});
+				complain(messages.notContiguousOrRectangular(notContiguousOrRectangular.sort()));
 			}
 		});
 	};

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -16,9 +16,15 @@ const messages = ruleMessages(ruleName, {
 });
 
 function areasArray(gridTemplateString) {
-	const rows = Array.from(gridTemplateString.matchAll(/["']([^"']*)["']/g)).map(
-		(match) => match[1],
-	);
+	const regex = /["']([^"']*)["']/g;
+	let captureGroups = [];
+	let rows = [];
+	let index = 0;
+
+	while ((captureGroups = regex.exec(gridTemplateString)) !== null) {
+		rows[index] = captureGroups[1];
+		index++;
+	}
 
 	return rows.map((row) => _.compact(row.trim().split(' ')));
 }

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -40,6 +40,7 @@ function rule(actual) {
 			}
 
 			let rows = [];
+			let reportSent = false;
 
 			parsedValue.walk((node) => {
 				if (node.type !== 'string' && node.type !== 'space') {
@@ -50,6 +51,8 @@ function rule(actual) {
 						result,
 						ruleName,
 					});
+
+					reportSent = true;
 				} else if (node.type === 'string' && node.value === '') {
 					report({
 						message: messages.noEmptyRows(node.value),
@@ -58,12 +61,14 @@ function rule(actual) {
 						result,
 						ruleName,
 					});
+
+					reportSent = true;
 				} else if (node.type === 'string' && node.value !== '') {
 					rows.push(node);
 				}
 			});
 
-			if (_.isEmpty(rows)) {
+			if (reportSent) {
 				return;
 			}
 

--- a/lib/rules/named-grid-areas-no-invalid/utils/__tests__/findNotContiguousOrRectangular.test.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/__tests__/findNotContiguousOrRectangular.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const findNotContiguousOrRectangular = require('../findNotContiguousOrRectangular');
+
+describe('findNotContiguousOrRectangular finds', () => {
+	test('nothing', () => {
+		expect(
+			findNotContiguousOrRectangular([
+				['a', 'a', '.'],
+				['a', 'a', '.'],
+				['.', 'b', 'c'],
+			]),
+		).toEqual([]);
+	});
+
+	test('non-contiguous area', () => {
+		expect(
+			findNotContiguousOrRectangular([
+				['a', 'a', '.'],
+				['a', 'a', '.'],
+				['.', 'b', 'a'],
+			]),
+		).toEqual(['a']);
+	});
+
+	test('non-contiguous area when area is not in an adjacent row', () => {
+		expect(
+			findNotContiguousOrRectangular([
+				['header', 'header', 'header', 'header'],
+				['main', 'main', '.', 'sidebar'],
+				['footer', 'footer', 'footer', 'header'],
+			]),
+		).toEqual(['header']);
+	});
+});

--- a/lib/rules/named-grid-areas-no-invalid/utils/__tests__/isRectangular.test.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/__tests__/isRectangular.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const isRectangular = require('../isRectangular');
+
+describe('isRectangular is', () => {
+	test('true when rectangular', () => {
+		expect(
+			isRectangular([
+				['a', 'a', '.'],
+				['a', 'a', '.'],
+				['.', 'b', 'c'],
+			]),
+		).toEqual(true);
+	});
+
+	test('false when not-rectangular', () => {
+		expect(
+			isRectangular([
+				['a', 'a', '.'],
+				['a', 'a'],
+				['.', 'b', 'a'],
+			]),
+		).toEqual(false);
+	});
+});

--- a/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
@@ -2,6 +2,12 @@
 
 const _ = require('lodash');
 
+/**
+ *
+ * @param {string[][]} areas
+ * @param {string} name
+ * @returns {boolean}
+ */
 function isContiguousAndRectangular(areas, name) {
 	const indicesByRow = areas.map((row) => {
 		const indices = [];
@@ -30,6 +36,11 @@ function isContiguousAndRectangular(areas, name) {
 	return true;
 }
 
+/**
+ *
+ * @param {string[][]} areas
+ * @returns {string[]}
+ */
 function namedAreas(areas) {
 	const names = new Set(_.flatten(areas));
 
@@ -38,6 +49,11 @@ function namedAreas(areas) {
 	return Array.from(names);
 }
 
+/**
+ *
+ * @param {string[][]} areas
+ * @returns {string[]}
+ */
 function findNotContiguousOrRectangular(areas) {
 	return Array.from(
 		new Set(namedAreas(areas).filter((name) => !isContiguousAndRectangular(areas, name))),
@@ -45,5 +61,3 @@ function findNotContiguousOrRectangular(areas) {
 }
 
 module.exports = findNotContiguousOrRectangular;
-module.namedAreas = namedAreas;
-module.isContiguousAndRectangular;

--- a/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
@@ -55,9 +55,7 @@ function namedAreas(areas) {
  * @returns {string[]}
  */
 function findNotContiguousOrRectangular(areas) {
-	return Array.from(
-		new Set(namedAreas(areas).filter((name) => !isContiguousAndRectangular(areas, name))),
-	);
+	return namedAreas(areas).filter((name) => !isContiguousAndRectangular(areas, name));
 }
 
 module.exports = findNotContiguousOrRectangular;

--- a/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const _ = require('lodash');
+
+function isContiguousAndRectangular(areas, name) {
+	const indicesByRow = areas.map((row) => {
+		const indices = [];
+		let idx = row.indexOf(name);
+
+		while (idx !== -1) {
+			indices.push(idx);
+			idx = row.indexOf(name, idx + 1);
+		}
+
+		return indices;
+	});
+
+	for (let i = 0; i < indicesByRow.length; i++) {
+		for (let j = i + 1; j < indicesByRow.length; j++) {
+			if (indicesByRow[i].length === 0 || indicesByRow[j].length === 0) {
+				continue;
+			}
+
+			if (!_.isEqual(indicesByRow[i], indicesByRow[j])) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+function namedAreas(areas) {
+	const names = new Set(_.flatten(areas));
+
+	names.delete('.');
+
+	return Array.from(names);
+}
+
+function findNotContiguousOrRectangular(areas) {
+	return Array.from(
+		new Set(namedAreas(areas).filter((name) => !isContiguousAndRectangular(areas, name))),
+	);
+}
+
+module.exports = findNotContiguousOrRectangular;
+module.namedAreas = namedAreas;
+module.isContiguousAndRectangular;

--- a/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
@@ -3,19 +3,12 @@
 /**
  *
  * @param {string[][]} areas
- * @returns {number[]}
- */
-function columnsPerRow(areas) {
-	return areas.map((row) => row.length);
-}
-
-/**
- *
- * @param {string[][]} areas
  * @returns {boolean}
  */
 function isRectangular(areas) {
-	return columnsPerRow(areas).every((val, i, arr) => val === arr[0]);
+	const columnsPerRow = areas.map((row) => row.length);
+
+	return columnsPerRow.every((val, i, arr) => val === arr[0]);
 }
 
 module.exports = isRectangular;

--- a/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
@@ -1,12 +1,21 @@
 'use strict';
 
+/**
+ *
+ * @param {string[][]} areas
+ * @returns {number[]}
+ */
 function columnsPerRow(areas) {
 	return areas.map((row) => row.length);
 }
 
+/**
+ *
+ * @param {string[][]} areas
+ * @returns {boolean}
+ */
 function isRectangular(areas) {
 	return columnsPerRow(areas).every((val, i, arr) => val === arr[0]);
 }
 
 module.exports = isRectangular;
-module.columnsPerRow = columnsPerRow;

--- a/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function columnsPerRow(areas) {
+	return areas.map((row) => row.length);
+}
+
+function isRectangular(areas) {
+	return columnsPerRow(areas).every((val, i, arr) => val === arr[0]);
+}
+
+module.exports = isRectangular;
+module.columnsPerRow = columnsPerRow;

--- a/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
@@ -6,9 +6,7 @@
  * @returns {boolean}
  */
 function isRectangular(areas) {
-	const columnsPerRow = areas.map((row) => row.length);
-
-	return columnsPerRow.every((val, i, arr) => val === arr[0]);
+	return areas.every((row, i, arr) => row.length === arr[0].length);
 }
 
 module.exports = isRectangular;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5155

> Is there anything in the PR that needs further explanation?

Adds rule to validate CSS grid areas to the spec defined here: https://drafts.csswg.org/css-grid/#grid-template-areas-property
