### PR TITLE
Fix false positives for :autofill in selector-pseudo-class-no-unknown

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -160,7 +160,7 @@ keywordSets.levelOneAndTwoPseudoElements = new Set([
 ]);
 
 // These are the ones that require double-colon notation
-keywordSets.levelThreePseudoElements = new Set([
+keywordSets.levelThreeAndUpPseudoElements = new Set([
 	'before',
 	'after',
 	'first-line',
@@ -206,7 +206,7 @@ keywordSets.vendorSpecificPseudoElements = new Set([
 
 keywordSets.pseudoElements = uniteSets(
 	keywordSets.levelOneAndTwoPseudoElements,
-	keywordSets.levelThreePseudoElements,
+	keywordSets.levelThreeAndUpPseudoElements,
 	keywordSets.vendorSpecificPseudoElements,
 	keywordSets.shadowTreePseudoElements,
 );
@@ -229,8 +229,13 @@ keywordSets.aNPlusBOfSNotationPseudoClasses = new Set(['nth-child', 'nth-last-ch
 keywordSets.otherPseudoClasses = new Set([
 	'active',
 	'any-link',
+	'autofill',
 	'blank',
 	'checked',
+	/*
+	  https://www.w3.org/Style/CSS/Test/CSS3/Selectors/20011105/html/tests/css3-modsel-85.html
+	  https://www.w3.org/Style/CSS/Test/CSS3/Selectors/20011105/html/tests/css3-modsel-84.html
+	*/
 	'contains',
 	'current',
 	'default',
@@ -273,7 +278,6 @@ keywordSets.otherPseudoClasses = new Set([
 	'target',
 	'user-error',
 	'user-invalid',
-	'val',
 	'valid',
 	'visited',
 ]);


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #5168

> Is there anything in the PR that needs further explanation?

I consider removing `:contains()` a breaking change hence it will have to wait for the next major.
FYI it was dropped ["due to a lack of implementations"](https://lists.w3.org/Archives/Public/www-style/2012Apr/0377.html).
e.g. Selenium used Sizzle which supported `:contains()`.

`:val()` was erroneously added because it was listed in [one of the specification's examples](https://drafts.csswg.org/selectors-4/#example-37a1ab6b).
ref: https://github.com/lloyd/JSONSelect/blob/master/JSONSelect.md#language-overview