### PR TITLE
Remove `@types/browserslist` and update `browserslist`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
         "@stylelint/prettier-config": "^2.0.0",
         "@stylelint/remark-preset": "^2.0.0",
         "@types/balanced-match": "^1.0.1",
-        "@types/browserslist": "^4.8.0",
         "@types/debug": "^4.1.5",
         "@types/file-entry-cache": "^5.0.1",
         "@types/global-modules": "^2.0.0",
@@ -967,12 +966,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.0.tgz",
       "integrity": "sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==",
-      "dev": true
-    },
-    "node_modules/@types/browserslist": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@types/browserslist/-/browserslist-4.8.0.tgz",
-      "integrity": "sha512-4PyO9OM08APvxxo1NmQyQKlJdowPCOQIy5D/NLO3aO0vGC57wsMptvGp3b8IbYnupFZr92l1dlVief1JvS6STQ==",
       "dev": true
     },
     "node_modules/@types/cacheable-request": {
@@ -1953,21 +1946,25 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.14.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-      "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001157",
+        "caniuse-lite": "^1.0.30001181",
         "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.591",
+        "electron-to-chromium": "^1.3.649",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.66"
+        "node-releases": "^1.1.70"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/bser": {
@@ -2078,9 +2075,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001158",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz",
-      "integrity": "sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g=="
+      "version": "1.0.30001194",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
+      "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA=="
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -3048,9 +3045,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.597",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.597.tgz",
-      "integrity": "sha512-VJI21MucKaqyFw0oe3j9BIg+nDF4MHzUZAmUwZzrxho+s8zPCD13Fds07Rgu+MTtAadO4tYTKFdAUksKYUyIJw=="
+      "version": "1.3.678",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.678.tgz",
+      "integrity": "sha512-E5ha1pE9+aWWrT2fUD5wdPBWUnYtKnEnloewbtVyrkAs79HvodOiNO4rMR94+hKbxgMFQG4fnPQACOc1cfMfBg=="
     },
     "node_modules/elegant-spinner": {
       "version": "1.0.1",
@@ -7818,9 +7815,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.67",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.0",
@@ -13296,12 +13293,6 @@
       "integrity": "sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==",
       "dev": true
     },
-    "@types/browserslist": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@types/browserslist/-/browserslist-4.8.0.tgz",
-      "integrity": "sha512-4PyO9OM08APvxxo1NmQyQKlJdowPCOQIy5D/NLO3aO0vGC57wsMptvGp3b8IbYnupFZr92l1dlVief1JvS6STQ==",
-      "dev": true
-    },
     "@types/cacheable-request": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
@@ -14131,15 +14122,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.14.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-      "integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
       "requires": {
-        "caniuse-lite": "^1.0.30001157",
+        "caniuse-lite": "^1.0.30001181",
         "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.591",
+        "electron-to-chromium": "^1.3.649",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.66"
+        "node-releases": "^1.1.70"
       }
     },
     "bser": {
@@ -14232,9 +14223,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001158",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz",
-      "integrity": "sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g=="
+      "version": "1.0.30001194",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
+      "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -15015,9 +15006,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.597",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.597.tgz",
-      "integrity": "sha512-VJI21MucKaqyFw0oe3j9BIg+nDF4MHzUZAmUwZzrxho+s8zPCD13Fds07Rgu+MTtAadO4tYTKFdAUksKYUyIJw=="
+      "version": "1.3.678",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.678.tgz",
+      "integrity": "sha512-E5ha1pE9+aWWrT2fUD5wdPBWUnYtKnEnloewbtVyrkAs79HvodOiNO4rMR94+hKbxgMFQG4fnPQACOc1cfMfBg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -18797,9 +18788,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.67",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-      "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
     "normalize-package-data": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "@stylelint/prettier-config": "^2.0.0",
     "@stylelint/remark-preset": "^2.0.0",
     "@types/balanced-match": "^1.0.1",
-    "@types/browserslist": "^4.8.0",
     "@types/debug": "^4.1.5",
     "@types/file-entry-cache": "^5.0.1",
     "@types/global-modules": "^2.0.0",


### PR DESCRIPTION
`@types/browserslist@4.15.0` has been deprecated because `browserslist@4.16.3` provides its own type definitions.
So, this change removes `@types/browserslist` and updates `browserslist` to the latest version.

I execute the following commands to update `package.json` and `package-lock.json`:

```shell
npm rm @types/browserslist
npm up browserslist
```

See below:
- https://www.npmjs.com/package/@types/browserslist/v/4.15.0
- https://github.com/browserslist/browserslist/blob/4.16.3/index.d.ts

> Which issue, if any, is this issue related to?

Close #5118

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
