### PR TITLE
Refactor getting and setting declaration values into utils

### DIFF
--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -6,10 +6,12 @@ const _ = require('lodash');
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'alpha-value-notation';
@@ -43,7 +45,7 @@ function rule(primary, options, context) {
 
 		root.walkDecls((decl) => {
 			let needsFix = false;
-			const parsedValue = valueParser(getValue(decl));
+			const parsedValue = valueParser(getDeclarationValue(decl));
 
 			parsedValue.walk((node) => {
 				let alpha;
@@ -105,7 +107,7 @@ function rule(primary, options, context) {
 			});
 
 			if (needsFix) {
-				setValue(decl, parsedValue.toString());
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 		});
 	};
@@ -151,17 +153,6 @@ function isNumber(value) {
 	const { unit } = valueParser.unit(value);
 
 	return unit === '';
-}
-
-function getValue(decl) {
-	return decl.raws.value ? decl.raws.value.raw : decl.value;
-}
-
-function setValue(decl, value) {
-	if (decl.raws.value) decl.raws.value.raw = value;
-	else decl.value = value;
-
-	return decl;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-function-notation/index.js
+++ b/lib/rules/color-function-notation/index.js
@@ -5,8 +5,10 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'color-function-notation';
@@ -29,7 +31,7 @@ function rule(primary, secondary, context) {
 
 		root.walkDecls((decl) => {
 			let needsFix = false;
-			const parsedValue = valueParser(getValue(decl));
+			const parsedValue = valueParser(getDeclarationValue(decl));
 
 			parsedValue.walk((node) => {
 				const { value, type, sourceIndex, nodes } = node;
@@ -83,7 +85,7 @@ function rule(primary, secondary, context) {
 			});
 
 			if (needsFix) {
-				setValue(decl, parsedValue.toString());
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 		});
 	};
@@ -99,17 +101,6 @@ function isComma(node) {
 
 function hasCommas(node) {
 	return node.nodes && node.nodes.some((childNode) => isComma(childNode));
-}
-
-function getValue(decl) {
-	return decl.raws.value ? decl.raws.value.raw : decl.value;
-}
-
-function setValue(decl, value) {
-	if (decl.raws.value) decl.raws.value.raw = value;
-	else decl.value = value;
-
-	return decl;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -5,8 +5,10 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'color-hex-case';
@@ -30,7 +32,7 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkDecls((decl) => {
-			const parsedValue = valueParser(getValue(decl));
+			const parsedValue = valueParser(getDeclarationValue(decl));
 			let needsFix = false;
 
 			parsedValue.walk((node) => {
@@ -61,7 +63,7 @@ function rule(expectation, options, context) {
 			});
 
 			if (needsFix) {
-				setValue(decl, parsedValue.toString());
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 		});
 	};
@@ -73,15 +75,6 @@ function isIgnoredFunction({ type, value }) {
 
 function isHexColor({ type, value }) {
 	return type === 'word' && HEX.test(value);
-}
-
-function getValue(decl) {
-	return decl.raws.value ? decl.raws.value.raw : decl.value;
-}
-
-function setValue(decl, value) {
-	if (decl.raws.value) decl.raws.value.raw = value;
-	else decl.value = value;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -5,8 +5,10 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'color-hex-length';
@@ -30,7 +32,7 @@ function rule(expectation, _, context) {
 		}
 
 		root.walkDecls((decl) => {
-			const parsedValue = valueParser(getValue(decl));
+			const parsedValue = valueParser(getDeclarationValue(decl));
 			let needsFix = false;
 
 			parsedValue.walk((node) => {
@@ -68,7 +70,7 @@ function rule(expectation, _, context) {
 			});
 
 			if (needsFix) {
-				setValue(decl, parsedValue.toString());
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 		});
 	};
@@ -111,15 +113,6 @@ function isIgnoredFunction({ type, value }) {
 
 function isHexColor({ type, value }) {
 	return type === 'word' && HEX.test(value);
-}
-
-function getValue(decl) {
-	return decl.raws.value ? decl.raws.value.raw : decl.value;
-}
-
-function setValue(decl, value) {
-	if (decl.raws.value) decl.raws.value.raw = value;
-	else decl.value = value;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -4,7 +4,9 @@
 
 const declarationBangSpaceChecker = require('../declarationBangSpaceChecker');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
 
@@ -36,7 +38,7 @@ function rule(expectation, options, context) {
 			fix: context.fix
 				? (decl, index) => {
 						let bangIndex = index - declarationValueIndex(decl);
-						const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+						const value = getDeclarationValue(decl);
 						let target;
 						let setFixed;
 
@@ -45,11 +47,7 @@ function rule(expectation, options, context) {
 							// TODO: Issue #4985
 							// eslint-disable-next-line no-shadow
 							setFixed = (value) => {
-								if (decl.raws.value) {
-									decl.raws.value.raw = value;
-								} else {
-									decl.value = value;
-								}
+								setDeclarationValue(decl, value);
 							};
 						} else if (decl.important) {
 							target = decl.raws.important || ' !important';

--- a/lib/rules/declaration-bang-space-before/index.js
+++ b/lib/rules/declaration-bang-space-before/index.js
@@ -4,7 +4,9 @@
 
 const declarationBangSpaceChecker = require('../declarationBangSpaceChecker');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
 
@@ -36,18 +38,14 @@ function rule(expectation, options, context) {
 			fix: context.fix
 				? (decl, index) => {
 						let bangIndex = index - declarationValueIndex(decl);
-						const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+						const value = getDeclarationValue(decl);
 						let target;
 						let setFixed;
 
 						if (bangIndex < value.length) {
 							target = value;
 							setFixed = (val) => {
-								if (decl.raws.value) {
-									decl.raws.value.raw = val;
-								} else {
-									decl.value = val;
-								}
+								setDeclarationValue(decl, val);
 							};
 						} else if (decl.important) {
 							target = decl.raws.important || ' !important';

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -3,8 +3,10 @@
 'use strict';
 
 const blockString = require('../../utils/blockString');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
 
@@ -48,15 +50,13 @@ function rule(expectation, options, context) {
 				lineCheckStr: blockString(parentRule),
 				err: (m) => {
 					if (context.fix) {
-						const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+						const value = getDeclarationValue(decl);
 
 						if (expectation.startsWith('always')) {
 							if (decl.important) {
 								decl.raws.important = ' !important ';
-							} else if (decl.raws.value) {
-								decl.raws.value.raw = value.replace(/\s*$/, ' ');
 							} else {
-								decl.value = value.replace(/\s*$/, ' ');
+								setDeclarationValue(decl, value.replace(/\s*$/, ' '));
 							}
 
 							return;
@@ -65,10 +65,8 @@ function rule(expectation, options, context) {
 						if (expectation.startsWith('never')) {
 							if (decl.important) {
 								decl.raws.important = decl.raws.important.replace(/\s*$/, '');
-							} else if (decl.raws.value) {
-								decl.raws.value.raw = value.replace(/\s*$/, '');
 							} else {
-								decl.value = value.replace(/\s*$/, '');
+								setDeclarationValue(decl, value.replace(/\s*$/, ''));
 							}
 
 							return;

--- a/lib/rules/function-max-empty-lines/index.js
+++ b/lib/rules/function-max-empty-lines/index.js
@@ -3,8 +3,10 @@
 'use strict';
 
 const _ = require('lodash');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 
@@ -41,7 +43,7 @@ function rule(max, options, context) {
 				return;
 			}
 
-			const stringValue = decl.raws.value ? decl.raws.value.raw : decl.value;
+			const stringValue = getDeclarationValue(decl);
 			const splittedValue = [];
 			let sourceIndexStart = 0;
 
@@ -88,11 +90,7 @@ function rule(max, options, context) {
 					splittedValue.reduce((acc, curr) => acc + curr[0] + curr[1], '') +
 					stringValue.slice(sourceIndexStart);
 
-				if (decl.raws.value) {
-					decl.raws.value.raw = updatedValue;
-				} else {
-					decl.value = updatedValue;
-				}
+				setDeclarationValue(decl, updatedValue);
 			}
 		});
 	};

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -4,11 +4,13 @@
 
 const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const keywordSets = require('../../reference/keywordSets');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 
@@ -48,7 +50,7 @@ function rule(expectation, options, context) {
 
 		root.walkDecls((decl) => {
 			let needFix = false;
-			const parsed = valueParser(decl.raws.value ? decl.raws.value.raw : decl.value);
+			const parsed = valueParser(getDeclarationValue(decl));
 
 			parsed.walk((node) => {
 				if (node.type !== 'function' || !isStandardSyntaxFunction(node)) {
@@ -98,13 +100,7 @@ function rule(expectation, options, context) {
 			});
 
 			if (context.fix && needFix) {
-				const statement = parsed.toString();
-
-				if (decl.raws.value) {
-					decl.raws.value.raw = statement;
-				} else {
-					decl.value = statement;
-				}
+				setDeclarationValue(decl, parsed.toString());
 			}
 		});
 	};

--- a/lib/rules/function-parentheses-newline-inside/index.js
+++ b/lib/rules/function-parentheses-newline-inside/index.js
@@ -2,12 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isSingleLineString = require('../../utils/isSingleLineString');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 
@@ -39,7 +40,7 @@ function rule(expectation, options, context) {
 			}
 
 			let hasFixed = false;
-			const declValue = _.get(decl, 'raws.value.raw', decl.value);
+			const declValue = getDeclarationValue(decl);
 			const parsedValue = valueParser(declValue);
 
 			parsedValue.walk((valueNode) => {
@@ -124,11 +125,7 @@ function rule(expectation, options, context) {
 			});
 
 			if (hasFixed) {
-				if (!decl.raws.value) {
-					decl.value = parsedValue.toString();
-				} else {
-					decl.raws.value.raw = parsedValue.toString();
-				}
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 
 			function complain(message, offset) {

--- a/lib/rules/function-parentheses-space-inside/index.js
+++ b/lib/rules/function-parentheses-space-inside/index.js
@@ -2,12 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isSingleLineString = require('../../utils/isSingleLineString');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 
@@ -41,7 +42,7 @@ function rule(expectation, options, context) {
 			}
 
 			let hasFixed = false;
-			const declValue = _.get(decl, 'raws.value.raw', decl.value);
+			const declValue = getDeclarationValue(decl);
 			const parsedValue = valueParser(declValue);
 
 			parsedValue.walk((valueNode) => {
@@ -143,11 +144,7 @@ function rule(expectation, options, context) {
 			});
 
 			if (hasFixed) {
-				if (!decl.raws.value) {
-					decl.value = parsedValue.toString();
-				} else {
-					decl.raws.value.raw = parsedValue.toString();
-				}
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 
 			function complain(message, offset) {

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -5,9 +5,11 @@
 const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isWhitespace = require('../../utils/isWhitespace');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
 
@@ -148,17 +150,13 @@ function rule(expectation, options, context) {
 			}
 		});
 		root.walkDecls((decl) => {
-			const value = _.get(decl, 'raws.value.raw', decl.value);
+			const value = getDeclarationValue(decl);
 			const fixer = context.fix && createFixer(value);
 
 			check(decl, value, declarationValueIndex, fixer && fixer.applyFix);
 
 			if (fixer && fixer.hasFixed) {
-				if (decl.raws.value) {
-					decl.raws.value.raw = fixer.fixed;
-				} else {
-					decl.value = fixer.fixed;
-				}
+				setDeclarationValue(decl, fixer.fixed);
 			}
 		});
 	};

--- a/lib/rules/functionCommaSpaceChecker.js
+++ b/lib/rules/functionCommaSpaceChecker.js
@@ -2,15 +2,16 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../utils/declarationValueIndex');
+const getDeclarationValue = require('../utils/getDeclarationValue');
 const isStandardSyntaxFunction = require('../utils/isStandardSyntaxFunction');
 const report = require('../utils/report');
+const setDeclarationValue = require('../utils/setDeclarationValue');
 const valueParser = require('postcss-value-parser');
 
 module.exports = function (opts) {
 	opts.root.walkDecls((decl) => {
-		const declValue = _.get(decl, 'raws.value.raw', decl.value);
+		const declValue = getDeclarationValue(decl);
 
 		let hasFixed;
 		const parsedValue = valueParser(declValue);
@@ -102,11 +103,7 @@ module.exports = function (opts) {
 		});
 
 		if (hasFixed) {
-			if (!decl.raws.value) {
-				decl.value = parsedValue.toString();
-			} else {
-				decl.raws.value.raw = parsedValue.toString();
-			}
+			setDeclarationValue(decl, parsedValue.toString());
 		}
 	});
 };

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -5,9 +5,11 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'hue-degree-notation';
@@ -31,7 +33,7 @@ function rule(primary, secondary, context) {
 
 		root.walkDecls((decl) => {
 			let needsFix = false;
-			const parsedValue = valueParser(getValue(decl));
+			const parsedValue = valueParser(getDeclarationValue(decl));
 
 			parsedValue.walk((node) => {
 				if (node.type !== 'function') return;
@@ -72,7 +74,7 @@ function rule(primary, secondary, context) {
 			});
 
 			if (needsFix) {
-				setValue(decl, parsedValue.toString());
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 		});
 	};
@@ -113,17 +115,6 @@ function isNumber(value) {
 	const { unit } = valueParser.unit(value);
 
 	return unit === '';
-}
-
-function getValue(decl) {
-	return decl.raws.value ? decl.raws.value.raw : decl.value;
-}
-
-function setValue(decl, value) {
-	if (decl.raws.value) decl.raws.value.raw = value;
-	else decl.value = value;
-
-	return decl;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -4,6 +4,7 @@
 
 const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const isCounterIncrementCustomIdentValue = require('../../utils/isCounterIncrementCustomIdentValue');
 const isCounterResetCustomIdentValue = require('../../utils/isCounterResetCustomIdentValue');
@@ -61,7 +62,7 @@ function rule(expectation, options, context) {
 			const propLowerCase = decl.prop.toLowerCase();
 			const value = decl.value;
 
-			const parsed = valueParser(decl.raws.value ? decl.raws.value.raw : decl.value);
+			const parsed = valueParser(getDeclarationValue(decl));
 
 			let needFix = false;
 

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -3,7 +3,9 @@
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueListCommaWhitespaceChecker = require('../valueListCommaWhitespaceChecker');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
@@ -75,7 +77,7 @@ function rule(expectation, options, context) {
 					.sort((a, b) => a - b)
 					.reverse()
 					.forEach((index) => {
-						const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+						const value = getDeclarationValue(decl);
 						const valueIndex = index - declarationValueIndex(decl);
 						const beforeValue = value.slice(0, valueIndex + 1);
 						let afterValue = value.slice(valueIndex + 1);
@@ -86,11 +88,7 @@ function rule(expectation, options, context) {
 							afterValue = afterValue.replace(/^\s*/, '');
 						}
 
-						if (decl.raws.value) {
-							decl.raws.value.raw = beforeValue + afterValue;
-						} else {
-							decl.value = beforeValue + afterValue;
-						}
+						setDeclarationValue(decl, beforeValue + afterValue);
 					});
 			});
 		}

--- a/lib/rules/value-list-comma-space-after/index.js
+++ b/lib/rules/value-list-comma-space-after/index.js
@@ -3,7 +3,9 @@
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueListCommaWhitespaceChecker = require('../valueListCommaWhitespaceChecker');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
@@ -61,7 +63,7 @@ function rule(expectation, options, context) {
 				commaIndices
 					.sort((a, b) => b - a)
 					.forEach((index) => {
-						const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+						const value = getDeclarationValue(decl);
 						const valueIndex = index - declarationValueIndex(decl);
 						const beforeValue = value.slice(0, valueIndex + 1);
 						let afterValue = value.slice(valueIndex + 1);
@@ -72,11 +74,7 @@ function rule(expectation, options, context) {
 							afterValue = afterValue.replace(/^\s*/, '');
 						}
 
-						if (decl.raws.value) {
-							decl.raws.value.raw = beforeValue + afterValue;
-						} else {
-							decl.value = beforeValue + afterValue;
-						}
+						setDeclarationValue(decl, beforeValue + afterValue);
 					});
 			});
 		}

--- a/lib/rules/value-list-comma-space-before/index.js
+++ b/lib/rules/value-list-comma-space-before/index.js
@@ -3,7 +3,9 @@
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueListCommaWhitespaceChecker = require('../valueListCommaWhitespaceChecker');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
@@ -61,7 +63,7 @@ function rule(expectation, options, context) {
 				commaIndices
 					.sort((a, b) => b - a)
 					.forEach((index) => {
-						const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+						const value = getDeclarationValue(decl);
 						const valueIndex = index - declarationValueIndex(decl);
 						let beforeValue = value.slice(0, valueIndex);
 						const afterValue = value.slice(valueIndex);
@@ -72,11 +74,7 @@ function rule(expectation, options, context) {
 							beforeValue = beforeValue.replace(/\s*$/, '');
 						}
 
-						if (decl.raws.value) {
-							decl.raws.value.raw = beforeValue + afterValue;
-						} else {
-							decl.value = beforeValue + afterValue;
-						}
+						setDeclarationValue(decl, beforeValue + afterValue);
 					});
 			});
 		}

--- a/lib/rules/value-list-max-empty-lines/index.js
+++ b/lib/rules/value-list-max-empty-lines/index.js
@@ -3,8 +3,10 @@
 'use strict';
 
 const _ = require('lodash');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'value-list-max-empty-lines';
@@ -32,18 +34,14 @@ function rule(max, options, context) {
 		const allowedCRLFNewLinesString = context.fix ? '\r\n'.repeat(maxAdjacentNewlines) : '';
 
 		root.walkDecls((decl) => {
-			const value = decl.raws.value ? decl.raws.value.raw : decl.value;
+			const value = getDeclarationValue(decl);
 
 			if (context.fix) {
 				const newValueString = value
 					.replace(new RegExp(violatedLFNewLinesRegex, 'gm'), allowedLFNewLinesString)
 					.replace(new RegExp(violatedCRLFNewLinesRegex, 'gm'), allowedCRLFNewLinesString);
 
-				if (decl.raws.value) {
-					decl.raws.value.raw = newValueString;
-				} else {
-					decl.value = newValueString;
-				}
+				setDeclarationValue(decl, newValueString);
 			} else if (violatedLFNewLinesRegex.test(value) || violatedCRLFNewLinesRegex.test(value)) {
 				report({
 					message: messages.expected(max),

--- a/lib/utils/getDeclarationValue.js
+++ b/lib/utils/getDeclarationValue.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const _ = require('lodash');
+
+/**
+ * @param {import('postcss').Declaration} decl
+ * @returns {string}
+ */
+module.exports = function getDeclarationValue(decl) {
+	return _.get(decl, 'raws.value.raw', decl.value);
+};

--- a/lib/utils/setDeclarationValue.js
+++ b/lib/utils/setDeclarationValue.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const _ = require('lodash');
+
+/** @typedef {import('postcss').Declaration} Declaration */
+
+/**
+ * @param {Declaration} decl
+ * @param {string} value
+ * @returns {Declaration} The declaration that was passed in.
+ */
+module.exports = function getDeclarationValue(decl, value) {
+	if (_.has(decl, 'raws.value')) {
+		_.set(decl, 'raws.value.raw', value);
+	} else {
+		decl.value = value;
+	}
+
+	return decl;
+};

--- a/lib/utils/setDeclarationValue.js
+++ b/lib/utils/setDeclarationValue.js
@@ -9,7 +9,10 @@ const _ = require('lodash');
  * @param {string} value
  * @returns {Declaration} The declaration that was passed in.
  */
-module.exports = function getDeclarationValue(decl, value) {
+module.exports = function setDeclarationValue(decl, value) {
+	// Lodash is necessary here because the declaration may not strictly adhere
+	// to the current version of PostCSS's Declaration interface.
+	// See also: https://github.com/stylelint/stylelint/pull/5183/files#r588047494
 	if (_.has(decl, 'raws.value')) {
 		_.set(decl, 'raws.value.raw', value);
 	} else {


### PR DESCRIPTION
This change adds two utility functions, `getDeclarationValue` and `setDeclarationValue`, that replace a pattern found across many rule files. Extracting the `getValue` and `setValue` functions across the rule files was mentioned by @jeddy3 in #5106. (But if we want a specific issue to track this as well, I can still file one.)

I was about to tackle replacing another `style-search` based rule, but remembered that I'd probably want this utility function. And this change felt large enough to make on its own without also updating an additional rule.