### PR TITLE
Fix named-grid-area-no-invalid README

### DIFF
--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -4,12 +4,19 @@ Disallow invalid named grid areas.
 
 <!-- prettier-ignore -->
 ```css
-a { grid-template-areas: 
+a { grid-template-areas:
       "a a a"
       "b b b"; }
 /**   ↑
  *  This named grid area */
 ```
+
+For a named grid area to be valid, all strings must define:
+
+- the same number of cell tokens
+- at least one cell token
+
+And all named grid areas that spans multiple grid cells must form a single filled-in rectangle.
 
 ## Options
 
@@ -17,7 +24,10 @@ a { grid-template-areas:
 
 The following patterns are considered violations:
 
-All strings must define the same number of cell tokens.
+<!-- prettier-ignore -->
+```css
+a { grid-template-areas: "" }
+```
 
 <!-- prettier-ignore -->
 ```css
@@ -25,35 +35,16 @@ a { grid-template-areas: "a a a"
                          "b b b b"; }
 ```
 
-All strings must define at least one cell token.
-
-<!-- prettier-ignore -->
-```css
-a { grid-template-areas: "" }
-```
-
-All named grid areas that spans multiple grid cells must form a single filled-in rectangle.
-
 <!-- prettier-ignore -->
 ```css
 a { grid-template-areas: "a a a"
                          "b b a"; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns is _not_ considered a violation:
 
 <!-- prettier-ignore -->
 ```css
 a { grid-template-areas: "a a a"
                          "b b b"; }
-```
-
-<!-- prettier-ignore -->
-```css
-a { grid-template-areas: "a a a" "b b b"; }
-```
-
-<!-- prettier-ignore -->
-```css
-a { grid-template-areas: none; }
 ```

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -41,7 +41,7 @@ a { grid-template-areas: "a a a"
                          "b b a"; }
 ```
 
-The following patterns is _not_ considered a violation:
+The following pattern is _not_ considered a violation:
 
 <!-- prettier-ignore -->
 ```css


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

The invalid patterns aren't given a red background [on the website](https://stylelint.io/user-guide/rules/named-grid-areas-no-invalid). We should have used the ["expanded description"](https://stylelint.io/user-guide/rules/about#readmes) instead.
