### PR TITLE
fix(cli): fix custom formatter import

### DIFF
--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -52,7 +52,7 @@ Options are:
 - `unix`
 - `verbose`
 
-The `formatter` Node.js API option can also accept a function, whereas the `--custom-formatter` CLI flag accepts a path to a JS file exporting one. The function in both cases must fit the signature described in the [Developer Guide](../../developer-guide/formatters.md).
+The `formatter` Node.js API option can also accept a function, whereas the `--custom-formatter` CLI flag accepts a path to a JS file or dependency exporting one. The function in both cases must fit the signature described in the [Developer Guide](../../developer-guide/formatters.md).
 
 ## `cache`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -346,11 +346,14 @@ module.exports = (argv) => {
 	let formatter = cli.flags.formatter;
 
 	if (cli.flags.customFormatter) {
-		const customFormatter = path.isAbsolute(cli.flags.customFormatter)
+		try {
+			  formatter = require(cli.flags.customFormatter);
+		} catch (error) {
+		  const customFormatter = path.isAbsolute(cli.flags.customFormatter)
 			? cli.flags.customFormatter
 			: path.join(process.cwd(), cli.flags.customFormatter);
-
-		formatter = require(customFormatter);
+		  formatter = require(customFormatter);
+		}
 	}
 
 	/** @type {OptionBaseType} */

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -184,7 +184,7 @@ const meowOptions = {
 
       --custom-formatter
 
-        Path to a JS file exporting a custom formatting function.
+        Path to a JS file or dependency exporting a custom formatting function.
 
       --quiet, -q
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 const chalk = require('chalk');
 const checkInvalidCLIOptions = require('./utils/checkInvalidCLIOptions');
 const EOL = require('os').EOL;
+const fs = require('fs');
 const getFormatterOptionsText = require('./utils/getFormatterOptionsText');
 const getModulePath = require('./utils/getModulePath');
 const getStdin = require('get-stdin');
@@ -346,14 +347,14 @@ module.exports = (argv) => {
 	let formatter = cli.flags.formatter;
 
 	if (cli.flags.customFormatter) {
-		try {
-			  formatter = require(cli.flags.customFormatter);
-		} catch (error) {
-		  const customFormatter = path.isAbsolute(cli.flags.customFormatter)
-			? cli.flags.customFormatter
-			: path.join(process.cwd(), cli.flags.customFormatter);
-		  formatter = require(customFormatter);
+		let customFormatter = cli.flags.customFormatter;
+
+		if (fs.existsSync(path.resolve(customFormatter))) {
+			// relative / absolute
+			customFormatter = path.resolve(customFormatter);
 		}
+
+		formatter = require(customFormatter);
 	}
 
 	/** @type {OptionBaseType} */


### PR DESCRIPTION
Until now it was not possible to import a `custom formatter` as dependency via the **CLI** call.
The specified path was handled either as a `relative` or `absolute` file path.
With the current customizations it is possible to import `formatter` as `dependency`.

For this the existence of the file path is checked first, if file does not exist path is treated as `dependency`.

The adjustment is particularly important if `formatter` are used as `dependency`.

Issue #5192