### PR TITLE
Add ignore: ["inside-function"] to declaration-property-unit-allowed-list

### DIFF
--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -24,7 +24,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (named) => `Unexpected named color "${named}"`,
 });
 
-// Todo tested on case insensivity
+// Todo tested on case insensitivity
 const NODE_TYPES = new Set(['word', 'function']);
 
 function rule(expectation, options) {

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -94,23 +94,26 @@ For example, given:
 
 ```
 {
-  '/^border/': ['px'],
-  '/^background/': ['%'],
-}
+  "/^border/": ["px"],
+  "/^background/": ["%"],
+},
+{
+  ignore: ["inside-function"],
+},
 ```
 
 The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-button {
-  button { border: 1px solid hsla(162deg, 51%, 35%, 0.8); }
+a {
+  border: 1px solid hsla(162deg, 51%, 35%, 0.8);
 }
 ```
 
 <!-- prettier-ignore -->
 ```css
-button {
+a {
   background-image: linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8));
 }
 ```

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -98,7 +98,7 @@ For example, given:
   "/^background/": ["%"],
 },
 {
-  ignore: ["inside-function"],
+  "ignore": ["inside-function"],
 },
 ```
 

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -83,3 +83,34 @@ a { animation-duration: 5s; }
 ```css
 a { line-height: 1; }
 ```
+
+## Optional secondary options
+
+### `ignore: ["inside-function"]`
+
+Ignore units that are inside a function.
+
+For example, given:
+
+```
+{
+  '/^border/': ['px'],
+  '/^background/': ['%'],
+}
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+button {
+  button { border: 1px solid hsla(162deg, 51%, 35%, 0.8); }
+}
+```
+
+<!-- prettier-ignore -->
+```css
+button {
+  background-image: linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8));
+}
+```

--- a/lib/rules/declaration-property-unit-allowed-list/__tests__/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/__tests__/index.js
@@ -197,39 +197,39 @@ testRule({
 
 	accept: [
 		{
-			code: 'button { border-color: hsla(162deg, 51%, 35%, 0.8); }',
+			code: 'a { border-color: hsla(162deg, 51%, 35%, 0.8); }',
 		},
 		{
-			code: 'button { border: 1px solid hsla(162deg, 51%, 35%, 0.8); }',
-		},
-		{
-			code:
-				'button { background-image: linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
-		},
-		{
-			code: 'button { background-image: url("https://example.com/img.png"); }',
+			code: 'a { border: 1px solid hsla(162deg, 51%, 35%, 0.8); }',
 		},
 		{
 			code:
-				'button { background: center center / 50% 50% linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
+				'a { background-image: linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
 		},
 		{
-			code: 'button { background-color: var(--bg-color); }',
+			code: 'a { background-image: url("https://example.com/img.png"); }',
+		},
+		{
+			code:
+				'a { background: center center / 50% 50% linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
+		},
+		{
+			code: 'a { background-color: var(--bg-color); }',
 		},
 	],
 
 	reject: [
 		{
-			code: 'button { border: 1rem solid hsla(162deg, 51%, 35%, 0.8); }',
+			code: 'a { border: 1rem solid hsla(162deg, 51%, 35%, 0.8); }',
 			message: messages.rejected('border', 'rem'),
 		},
 		{
-			code: 'button { background-position: 5rem 45%; }',
+			code: 'a { background-position: 5rem 45%; }',
 			message: messages.rejected('background-position', 'rem'),
 		},
 		{
 			code:
-				'button { background: center center / 50px 10% linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
+				'a { background: center center / 50px 10% linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
 			message: messages.rejected('background', 'px'),
 		},
 	],

--- a/lib/rules/declaration-property-unit-allowed-list/__tests__/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/__tests__/index.js
@@ -154,6 +154,10 @@ testRule({
 		{
 			code: 'a { -webkit-animation-duration: 300ms; }',
 		},
+		{
+			code:
+				'a { animation: 3ms cubic-bezier(.17,.67,.83,.67) 1ms infinite alternate none running slidein; }',
+		},
 	],
 
 	reject: [
@@ -172,6 +176,61 @@ testRule({
 		{
 			code: 'a { -webkit-animation-duration: 3s; }',
 			message: messages.rejected('-webkit-animation-duration', 's'),
+		},
+	],
+});
+
+testRule({
+	ruleName,
+
+	config: [
+		{
+			'/^border/': ['px'],
+			'/^background/': ['%'],
+		},
+		{
+			ignore: ['inside-function'],
+		},
+	],
+
+	skipBasicChecks: true,
+
+	accept: [
+		{
+			code: 'button { border-color: hsla(162deg, 51%, 35%, 0.8); }',
+		},
+		{
+			code: 'button { border: 1px solid hsla(162deg, 51%, 35%, 0.8); }',
+		},
+		{
+			code:
+				'button { background-image: linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
+		},
+		{
+			code: 'button { background-image: url("https://example.com/img.png"); }',
+		},
+		{
+			code:
+				'button { background: center center / 50% 50% linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
+		},
+		{
+			code: 'button { background-color: var(--bg-color); }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'button { border: 1rem solid hsla(162deg, 51%, 35%, 0.8); }',
+			message: messages.rejected('border', 'rem'),
+		},
+		{
+			code: 'button { background-position: 5rem 45%; }',
+			message: messages.rejected('background-position', 'rem'),
+		},
+		{
+			code:
+				'button { background: center center / 50px 10% linear-gradient(hsla(162deg, 51%, 35%, 0.8), hsla(62deg, 51%, 35%, 0.8)); }',
+			message: messages.rejected('background', 'px'),
 		},
 	],
 });

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -6,6 +6,7 @@ const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
+const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -18,12 +19,24 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 });
 
-function rule(list) {
+function rule(list, options) {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
-			possible: [_.isObject],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: list,
+				possible: [_.isObject],
+			},
+			{
+				actual: options,
+				possible: {
+					ignoreProperties: [_.isString, _.isRegExp],
+					ignore: ['inside-function'],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
 			return;
@@ -46,6 +59,12 @@ function rule(list) {
 			valueParser(value).walk((node) => {
 				// Ignore wrong units within `url` function
 				if (node.type === 'function' && node.value.toLowerCase() === 'url') {
+					return false;
+				}
+
+				const type = node.type;
+
+				if (optionsMatches(options, 'ignore', 'inside-function') && type === 'function') {
 					return false;
 				}
 

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -57,7 +57,7 @@ function rule(list, options) {
 
 			valueParser(value).walk((node) => {
 				// Ignore wrong units within `url` function
-				if (node.type === 'function' {
+				if (node.type === 'function') {
 					if (node.value.toLowerCase() === 'url') {
 						return false;
 					}
@@ -66,7 +66,6 @@ function rule(list, options) {
 						return false;
 					}
 				}
-
 
 				if (node.type === 'string') {
 					return;

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -31,7 +31,6 @@ function rule(list, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreProperties: [_.isString, _.isRegExp],
 					ignore: ['inside-function'],
 				},
 				optional: true,
@@ -58,15 +57,16 @@ function rule(list, options) {
 
 			valueParser(value).walk((node) => {
 				// Ignore wrong units within `url` function
-				if (node.type === 'function' && node.value.toLowerCase() === 'url') {
-					return false;
+				if (node.type === 'function' {
+					if (node.value.toLowerCase() === 'url') {
+						return false;
+					}
+
+					if (optionsMatches(options, 'ignore', 'inside-function')) {
+						return false;
+					}
 				}
 
-				const type = node.type;
-
-				if (optionsMatches(options, 'ignore', 'inside-function') && type === 'function') {
-					return false;
-				}
 
 				if (node.type === 'string') {
 					return;


### PR DESCRIPTION
Resolves #5140

> Is there anything in the PR that needs further explanation?

This should help support SCSS functions as well, such as the `lighten` color function.
