### PR TITLE
Fix husky configuration and remove needless packages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no lint-staged
+npx --no-install lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,6 @@
 #!/bin/sh
+[ -n "$CI" ] && exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+npx --no lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "version": "13.12.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
@@ -85,7 +84,6 @@
         "eslint-config-stylelint": "^13.1.0",
         "got": "^11.8.2",
         "husky": "^5.1.3",
-        "is-ci": "^3.0.0",
         "jest": "^26.6.3",
         "jest-circus": "^26.6.3",
         "jest-preset-stylelint": "^3.0.0",
@@ -93,7 +91,6 @@
         "lint-staged": "^10.5.4",
         "np": "^7.4.0",
         "npm-run-all": "^4.1.5",
-        "pinst": "^2.1.6",
         "postcss-import": "^12.0.1",
         "prettier": "^2.2.1",
         "remark-cli": "^9.0.0",
@@ -2224,12 +2221,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/ci-info": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.1.1.tgz",
-      "integrity": "sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==",
-      "dev": true
-    },
     "node_modules/cjs-module-lexer": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
@@ -4126,26 +4117,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5121,18 +5092,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
-      "dev": true,
-      "dependencies": {
-        "ci-info": "^3.1.1"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -9042,21 +9001,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "dependencies": {
-        "fromentries": "^1.3.2"
-      },
-      "bin": {
-        "pinst": "bin.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/pirates": {
@@ -14347,12 +14291,6 @@
         }
       }
     },
-    "ci-info": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.1.1.tgz",
-      "integrity": "sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==",
-      "dev": true
-    },
     "cjs-module-lexer": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
@@ -15872,12 +15810,6 @@
         "map-cache": "^0.2.2"
       }
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -16647,15 +16579,6 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
       "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
-    },
-    "is-ci": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^3.1.1"
-      }
     },
     "is-core-module": {
       "version": "2.1.0",
@@ -19748,15 +19671,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
-    },
-    "pinst": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
-      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.3.2"
-      }
     },
     "pirates": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -38,24 +38,17 @@
   "scripts": {
     "benchmark-rule": "node scripts/benchmark-rule.js",
     "format": "prettier . --write",
-    "postinstall": "is-ci || husky install",
     "jest": "jest",
     "lint": "npm-run-all --parallel lint:*",
     "lint:formatting": "prettier . --check",
     "lint:js": "eslint . --cache --max-warnings=0",
     "lint:md": "remark . --quiet --frail",
     "lint:types": "tsc",
-    "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable",
+    "prepare": "husky install",
     "release": "np",
     "pretest": "npm run lint",
     "test": "jest --coverage",
     "watch": "jest --watch"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "*.js": "eslint --cache --fix",
@@ -188,7 +181,6 @@
     "eslint-config-stylelint": "^13.1.0",
     "got": "^11.8.2",
     "husky": "^5.1.3",
-    "is-ci": "^3.0.0",
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "jest-preset-stylelint": "^3.0.0",
@@ -196,7 +188,6 @@
     "lint-staged": "^10.5.4",
     "np": "^7.4.0",
     "npm-run-all": "^4.1.5",
-    "pinst": "^2.1.6",
     "postcss-import": "^12.0.1",
     "prettier": "^2.2.1",
     "remark-cli": "^9.0.0",


### PR DESCRIPTION
`husky` no longer requires `pinst` and `is-ci` since v5.1.2.
(see <https://github.com/typicode/husky/commit/84be6755c77ee81b14260765f2224e70f6bca8df>)

So, this change simplifies the `husky` configuration and removes the needless packages.
See also <https://typicode.github.io/husky>.

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

None.
