### PR TITLE
Refactor `lib/utils/validateOptions.js`

### DIFF
--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 
-const ignoredOptions = new Set(['severity', 'message', 'reportDisables']);
+const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables']);
 
 /** @typedef {{possible: any, actual: any, optional?: boolean}} Options */
 
@@ -15,8 +15,8 @@ const ignoredOptions = new Set(['severity', 'message', 'reportDisables']);
  * @param {string} ruleName
  * @param {...Options} optionDescriptions - Each optionDescription can
  *   have the following properties:
- *   	- `actual` (required): the actual passed option value or object.
- *   	- `possible` (required): a schema representation of what values are
+ *   - `actual` (required): the actual passed option value or object.
+ *   - `possible` (required): a schema representation of what values are
  *      valid for those options. `possible` should be an object if the
  *      options are an object, with corresponding keys; if the options are not an
  *      object, `possible` isn't, either. All `possible` value representations
@@ -125,7 +125,7 @@ function validate(opts, ruleName, complain) {
 	}
 
 	Object.keys(actual).forEach((optionName) => {
-		if (ignoredOptions.has(optionName)) {
+		if (IGNORED_OPTIONS.has(optionName)) {
 			return;
 		}
 
@@ -155,9 +155,7 @@ function validate(opts, ruleName, complain) {
 function isValid(possible, actual) {
 	const possibleList = /** @type {Array<any|Function>} */ ([]).concat(possible);
 
-	for (let i = 0, l = possibleList.length; i < l; i++) {
-		const possibility = possibleList[i];
-
+	for (const possibility of possibleList) {
 		if (typeof possibility === 'function' && possibility(actual)) {
 			return true;
 		}


### PR DESCRIPTION
This refactoring aims to make the code a bit more readable in `lib/utils/validateOptions.js`.

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
