### PR TITLE
Refactor `lib/rules/selector-max-specificity/index.js`

### DIFF
--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -17,10 +17,7 @@ const validateOptions = require('../../utils/validateOptions');
 const ruleName = 'selector-max-specificity';
 
 const messages = ruleMessages(ruleName, {
-	// TODO: Issue #4985
-	// eslint-disable-next-line no-shadow
-	expected: (selector, specificity) =>
-		`Expected "${selector}" to have a specificity no more than "${specificity}"`,
+	expected: (selector, max) => `Expected "${selector}" to have a specificity no more than "${max}"`,
 });
 
 // Return an array representation of zero specificity. We need a new array each time so that it can mutated
@@ -47,12 +44,8 @@ function rule(max, options) {
 			{
 				actual: max,
 				possible: [
-					// TODO: Issue #4985
-					// eslint-disable-next-line no-shadow
-					function (max) {
-						// Check that the max specificity is in the form "a,b,c"
-						return /^\d+,\d+,\d+$/.test(max);
-					},
+					// Check that the max specificity is in the form "a,b,c"
+					(spec) => /^\d+,\d+,\d+$/.test(spec),
 				],
 			},
 			{
@@ -79,12 +72,10 @@ function rule(max, options) {
 
 		// Calculate the the specificity of the most specific direct child
 		const maxChildSpecificity = (node) =>
-			// TODO: Issue #4985
-			// eslint-disable-next-line no-shadow
-			node.reduce((max, child) => {
+			node.reduce((maxSpec, child) => {
 				const childSpecificity = nodeSpecificity(child); // eslint-disable-line no-use-before-define
 
-				return specificity.compare(childSpecificity, max) === 1 ? childSpecificity : max;
+				return specificity.compare(childSpecificity, maxSpec) === 1 ? childSpecificity : maxSpec;
 			}, zeroSpecificity());
 
 		// Calculate the specificity of a pseudo selector including own value and children
@@ -146,23 +137,21 @@ function rule(max, options) {
 
 		const maxSpecificityArray = `0,${max}`.split(',').map(parseFloat);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			// Using rule.selectors gets us each selector in the eventuality we have a comma separated set
-			rule.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, rule).forEach((resolvedSelector) => {
+			// Using `.selectors` gets us each selector in the eventuality we have a comma separated set
+			ruleNode.selectors.forEach((selector) => {
+				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
 					try {
 						// Skip non-standard syntax selectors
 						if (!isStandardSyntaxSelector(resolvedSelector)) {
 							return;
 						}
 
-						parseSelector(resolvedSelector, result, rule, (selectorTree) => {
+						parseSelector(resolvedSelector, result, ruleNode, (selectorTree) => {
 							// Check if the selector specificity exceeds the allowed maximum
 							if (
 								specificity.compare(maxChildSpecificity(selectorTree), maxSpecificityArray) === 1
@@ -170,7 +159,7 @@ function rule(max, options) {
 								report({
 									ruleName,
 									result,
-									node: rule,
+									node: ruleNode,
 									message: messages.expected(resolvedSelector, max),
 									word: selector,
 								});
@@ -178,7 +167,7 @@ function rule(max, options) {
 						});
 					} catch {
 						result.warn('Cannot parse selector', {
-							node: rule,
+							node: ruleNode,
 							stylelintType: 'parseError',
 						});
 					}


### PR DESCRIPTION
This refactoring aims to simplify the code a bit and resolve `no-shadow` violations of ESLint (#5013).

> Which issue, if any, is this issue related to?

Related to #5013

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
