### PR TITLE
Fix ESLint `no-shadow` violations

### DIFF
--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -72,16 +72,16 @@ module.exports = function (root, result) {
 			return;
 		}
 
-		const next = comment.next();
+		const nextComment = comment.next();
 
 		// If any of these conditions are not met, do not merge comments.
 		if (
 			!(
 				isInlineComment(comment) &&
 				isStylelintCommand(comment) &&
-				next &&
-				next.type === 'comment' &&
-				(comment.text.includes('--') || next.text.startsWith('--'))
+				nextComment &&
+				nextComment.type === 'comment' &&
+				(comment.text.includes('--') || nextComment.text.startsWith('--'))
 			)
 		) {
 			checkComment(comment);
@@ -92,8 +92,7 @@ module.exports = function (root, result) {
 		let lastLine = (comment.source && comment.source.end && comment.source.end.line) || 0;
 		const fullComment = comment.clone();
 
-		/** @type {PostcssComment} */
-		let current = next;
+		let current = nextComment;
 
 		while (isInlineComment(current) && !isStylelintCommand(current)) {
 			const currentLine = (current.source && current.source.end && current.source.end.line) || 0;
@@ -107,8 +106,6 @@ module.exports = function (root, result) {
 			}
 
 			inlineEnd = current;
-			// TODO: Issue #4985
-			// eslint-disable-next-line no-shadow
 			const next = current.next();
 
 			if (!next || next.type !== 'comment') break;

--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -38,22 +38,18 @@ function rule(expectation, options, context) {
 			fix: context.fix
 				? (decl, index) => {
 						let bangIndex = index - declarationValueIndex(decl);
-						const value = getDeclarationValue(decl);
+						const declValue = getDeclarationValue(decl);
 						let target;
 						let setFixed;
 
-						if (bangIndex < value.length) {
-							target = value;
-							// TODO: Issue #4985
-							// eslint-disable-next-line no-shadow
+						if (bangIndex < declValue.length) {
+							target = declValue;
 							setFixed = (value) => {
 								setDeclarationValue(decl, value);
 							};
 						} else if (decl.important) {
 							target = decl.raws.important || ' !important';
-							bangIndex -= value.length;
-							// TODO: Issue #4985
-							// eslint-disable-next-line no-shadow
+							bangIndex -= declValue.length;
 							setFixed = (value) => {
 								decl.raws.important = value;
 							};

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -36,15 +36,13 @@ function rule(actual, options) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		const longhandProperties = _.transform(shorthandData, (result, values, key) => {
+		const longhandProperties = _.transform(shorthandData, (longhandProps, values, key) => {
 			if (optionsMatches(options, 'ignoreShorthands', key)) {
 				return;
 			}
 
 			values.forEach((value) => {
-				(result[value] || (result[value] = [])).push(key);
+				(longhandProps[value] || (longhandProps[value] = [])).push(key);
 			});
 		});
 

--- a/lib/rules/declaration-block-single-line-max-declarations/index.js
+++ b/lib/rules/declaration-block-single-line-max-declarations/index.js
@@ -27,18 +27,16 @@ function rule(quantity) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isSingleLineString(blockString(rule))) {
+		root.walkRules((ruleNode) => {
+			if (!isSingleLineString(blockString(ruleNode))) {
 				return;
 			}
 
-			if (!rule.nodes) {
+			if (!ruleNode.nodes) {
 				return;
 			}
 
-			const decls = rule.nodes.filter((node) => node.type === 'decl');
+			const decls = ruleNode.nodes.filter((node) => node.type === 'decl');
 
 			if (decls.length <= quantity) {
 				return;
@@ -46,8 +44,8 @@ function rule(quantity) {
 
 			report({
 				message: messages.expected(quantity),
-				node: rule,
-				index: beforeBlockString(rule, { noRawBefore: true }).length,
+				node: ruleNode,
+				index: beforeBlockString(ruleNode, { noRawBefore: true }).length,
 				result,
 				ruleName,
 			});

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -186,17 +186,15 @@ function rule(space, options = {}, context) {
 			checkMultilineBit(declString, valueLevel, decl);
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function checkSelector(rule, ruleLevel) {
-			const selector = rule.selector;
+		function checkSelector(ruleNode, ruleLevel) {
+			const selector = ruleNode.selector;
 
 			// Less mixins have params, and they should be indented extra
-			if (rule.params) {
+			if (ruleNode.params) {
 				ruleLevel += 1;
 			}
 
-			checkMultilineBit(selector, ruleLevel, rule);
+			checkMultilineBit(selector, ruleLevel, ruleNode);
 		}
 
 		function checkAtRuleParams(atRule, ruleLevel) {

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -56,12 +56,10 @@ function rule(actual, secondary, context) {
 					return;
 				}
 
-				// TODO: Issue #4985
-				// eslint-disable-next-line no-shadow
-				const stringValue = valueParser.stringify(node);
+				const nodeValue = valueParser.stringify(node);
 				const ignoreFlag = isMathFunction(node);
 
-				for (let i = 0; i < stringValue.length; i++) {
+				for (let i = 0; i < nodeValue.length; i++) {
 					ignorableIndexes[node.sourceIndex + i] = ignoreFlag;
 				}
 			});

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -151,10 +151,8 @@ function rule(max, options, context) {
 			}
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function replaceEmptyLines(max, str, isSpecialCase = false) {
-			const repeatTimes = isSpecialCase ? max : max + 1;
+		function replaceEmptyLines(maxLines, str, isSpecialCase = false) {
+			const repeatTimes = isSpecialCase ? maxLines : maxLines + 1;
 
 			if (repeatTimes === 0 || typeof str !== 'string') {
 				return '';

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -66,19 +66,19 @@ function rule(maxLength, options, context) {
 		skippedSubStrings = skippedSubStrings.sort((a, b) => a[0] - b[0]);
 
 		// Check first line
-		checkNewline(rootString, { endIndex: 0 }, root);
+		checkNewline({ endIndex: 0 });
 		// Check subsequent lines
 		styleSearch({ source: rootString, target: ['\n'], comments: 'check' }, (match) =>
-			checkNewline(rootString, match, root),
+			checkNewline(match),
 		);
 
-		function complain(index, rootNode) {
+		function complain(index) {
 			report({
 				index,
 				result,
 				ruleName,
 				message: messages.expected(maxLength),
-				node: rootNode,
+				node: root,
 			});
 		}
 
@@ -101,9 +101,7 @@ function rule(maxLength, options, context) {
 			return excluded;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function checkNewline(rootString, match, root) {
+		function checkNewline(match) {
 			let nextNewlineIndex = rootString.indexOf('\n', match.endIndex);
 
 			if (rootString[nextNewlineIndex - 1] === '\r') {
@@ -153,7 +151,7 @@ function rule(maxLength, options, context) {
 
 			if (ignoreNonComments) {
 				if (match.insideComment) {
-					return complain(complaintIndex, root);
+					return complain(complaintIndex);
 				}
 
 				// This trimming business is to notice when the line starts a
@@ -165,7 +163,7 @@ function rule(maxLength, options, context) {
 					return;
 				}
 
-				return complain(complaintIndex, root);
+				return complain(complaintIndex);
 			}
 
 			// If there are no spaces besides initial (indent) spaces, ignore it
@@ -175,7 +173,7 @@ function rule(maxLength, options, context) {
 				return;
 			}
 
-			return complain(complaintIndex, root);
+			return complain(complaintIndex);
 		}
 	};
 }

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -87,9 +87,7 @@ function rule(max, options) {
 			const normalized = parser().processSync(selector, { lossless: false });
 			const selectors = normalized.split(',');
 
-			// TODO: Issue #4985
-			// eslint-disable-next-line no-shadow
-			return selectors.every((selector) => selector.startsWith('&:') && selector[2] !== ':');
+			return selectors.every((sel) => sel.startsWith('&:') && sel[2] !== ':');
 		}
 
 		if (

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -46,27 +46,31 @@ function rule(on, options) {
 
 		const selectorContextLookup = nodeContextLookup();
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
+		root.walkRules((ruleNode) => {
 			// Ignore custom property set `--foo: {};`
-			if (isCustomPropertySet(rule)) {
+			if (isCustomPropertySet(ruleNode)) {
 				return;
 			}
 
 			// Ignore nested property `foo: {};`
-			if (!isStandardSyntaxRule(rule)) {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
 			// Ignores selectors within list of selectors
-			if (optionsMatches(options, 'ignore', 'selectors-within-list') && rule.selectors.length > 1) {
+			if (
+				optionsMatches(options, 'ignore', 'selectors-within-list') &&
+				ruleNode.selectors.length > 1
+			) {
 				return;
 			}
 
-			const comparisonContext = selectorContextLookup.getContext(rule, findAtRuleContext(rule));
+			const comparisonContext = selectorContextLookup.getContext(
+				ruleNode,
+				findAtRuleContext(ruleNode),
+			);
 
-			rule.selectors.forEach((selector) => {
+			ruleNode.selectors.forEach((selector) => {
 				const trimSelector = selector.trim();
 
 				// Ignore `.selector, { }`
@@ -75,24 +79,22 @@ function rule(on, options) {
 				}
 
 				// The edge-case of duplicate selectors will act acceptably
-				const index = rule.selector.indexOf(trimSelector);
+				const index = ruleNode.selector.indexOf(trimSelector);
 
 				// Resolve any nested selectors before checking
-				resolvedNestedSelector(selector, rule).forEach((resolvedSelector) => {
-					parseSelector(resolvedSelector, result, rule, (s) => {
+				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+					parseSelector(resolvedSelector, result, ruleNode, (s) => {
 						if (!isStandardSyntaxSelector(resolvedSelector)) {
 							return;
 						}
 
-						checkSelector(s, rule, index, comparisonContext);
+						checkSelector(s, ruleNode, index, comparisonContext);
 					});
 				});
 			});
 		});
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function checkSelector(selectorNode, rule, sourceIndex, comparisonContext) {
+		function checkSelector(selectorNode, ruleNode, sourceIndex, comparisonContext) {
 			const selector = selectorNode.toString();
 			const referenceSelectorNode = lastCompoundSelectorWithoutPseudoClasses(selectorNode);
 			const selectorSpecificity = specificity.calculate(selector)[0].specificityArray;
@@ -111,7 +113,7 @@ function rule(on, options) {
 					report({
 						ruleName,
 						result,
-						node: rule,
+						node: ruleNode,
 						message: messages.rejected(selector, priorEntry.selector),
 						index: sourceIndex,
 					});

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -47,18 +47,17 @@ function rule(actual, options) {
 		// from other rules that share the same parent and the same source.
 		const selectorContextLookup = nodeContextLookup();
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (isKeyframeRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (isKeyframeRule(ruleNode)) {
 				return;
 			}
 
-			const contextSelectorSet = selectorContextLookup.getContext(rule, findAtRuleContext(rule));
-			// TODO: Issue #4985
-			// eslint-disable-next-line no-shadow
-			const resolvedSelectors = rule.selectors.reduce((result, selector) => {
-				return _.union(result, resolvedNestedSelector(selector, rule));
+			const contextSelectorSet = selectorContextLookup.getContext(
+				ruleNode,
+				findAtRuleContext(ruleNode),
+			);
+			const resolvedSelectors = ruleNode.selectors.reduce((selectors, selector) => {
+				return _.union(selectors, resolvedNestedSelector(selector, ruleNode));
 			}, []);
 
 			const normalizedSelectorList = resolvedSelectors.map(normalizeSelector);
@@ -67,7 +66,7 @@ function rule(actual, options) {
 			// doesn't matter
 			const sortedSelectorList = normalizedSelectorList.slice().sort().join(',');
 
-			const selectorLine = rule.source.start.line;
+			const selectorLine = ruleNode.source.start.line;
 
 			// Complain if the same selector list occurs twice
 
@@ -77,7 +76,7 @@ function rule(actual, options) {
 			const selectorListParsed = [];
 
 			if (shouldDisallowDuplicateInList) {
-				parseSelector(sortedSelectorList, result, rule, (selectors) => {
+				parseSelector(sortedSelectorList, result, ruleNode, (selectors) => {
 					selectors.each((s) => {
 						const selector = String(s);
 
@@ -95,13 +94,15 @@ function rule(actual, options) {
 			if (previousDuplicatePosition) {
 				// If the selector isn't nested we can use its raw value; otherwise,
 				// we have to approximate something for the message -- which is close enough
-				const isNestedSelector = resolvedSelectors.join(',') !== rule.selectors.join(',');
-				const selectorForMessage = isNestedSelector ? resolvedSelectors.join(', ') : rule.selector;
+				const isNestedSelector = resolvedSelectors.join(',') !== ruleNode.selectors.join(',');
+				const selectorForMessage = isNestedSelector
+					? resolvedSelectors.join(', ')
+					: ruleNode.selector;
 
 				return report({
 					result,
 					ruleName,
-					node: rule,
+					node: ruleNode,
 					message: messages.rejected(selectorForMessage, previousDuplicatePosition),
 				});
 			}
@@ -110,7 +111,7 @@ function rule(actual, options) {
 			const reportedSelectors = new Set();
 
 			// Or complain if one selector list contains the same selector more than once
-			rule.selectors.forEach((selector) => {
+			ruleNode.selectors.forEach((selector) => {
 				const normalized = normalizeSelector(selector);
 
 				if (presentedSelectors.has(normalized)) {
@@ -121,7 +122,7 @@ function rule(actual, options) {
 					report({
 						result,
 						ruleName,
-						node: rule,
+						node: ruleNode,
 						message: messages.rejected(selector, selectorLine),
 					});
 					reportedSelectors.add(normalized);

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -117,15 +117,13 @@ function rule(on, options, context) {
 					comments: 'check',
 				},
 				(match) => {
-					// TODO: Issue #4985
-					// eslint-disable-next-line no-shadow
-					const errorIndex = findErrorStartIndex(match.startIndex, string, {
+					const index = findErrorStartIndex(match.startIndex, string, {
 						ignoreEmptyLines,
 						isRootFirst,
 					});
 
-					if (errorIndex > -1) {
-						callback(errorIndex);
+					if (index > -1) {
+						callback(index);
 					}
 				},
 			);
@@ -230,9 +228,7 @@ function rule(on, options, context) {
 			}
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function fixText(value, fix, isRootFirst) {
+		function fixText(value, fixFn, isRootFirst) {
 			if (!value) {
 				return;
 			}
@@ -253,7 +249,7 @@ function rule(on, options, context) {
 
 			if (lastIndex) {
 				fixed += value.slice(lastIndex);
-				fix(fixed);
+				fixFn(fixed);
 			}
 		}
 	};

--- a/lib/rules/no-invalid-double-slash-comments/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/index.js
@@ -30,14 +30,13 @@ function rule(actual) {
 				});
 			}
 		});
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			rule.selectors.forEach((selector) => {
+
+		root.walkRules((ruleNode) => {
+			ruleNode.selectors.forEach((selector) => {
 				if (selector.startsWith('//')) {
 					report({
 						message: messages.rejected,
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -52,33 +52,31 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
 			// Ignore the first node
-			if (isFirstNodeOfRoot(rule)) {
+			if (isFirstNodeOfRoot(ruleNode)) {
 				return;
 			}
 
 			// Optionally ignore the expectation if a comment precedes this node
 			if (
 				optionsMatches(options, 'ignore', 'after-comment') &&
-				rule.prev() &&
-				rule.prev().type === 'comment'
+				ruleNode.prev() &&
+				ruleNode.prev().type === 'comment'
 			) {
 				return;
 			}
 
 			// Optionally ignore the node if it is the first nested
-			if (optionsMatches(options, 'ignore', 'first-nested') && isFirstNested(rule)) {
+			if (optionsMatches(options, 'ignore', 'first-nested') && isFirstNested(ruleNode)) {
 				return;
 			}
 
-			const isNested = rule.parent.type !== 'root';
+			const isNested = ruleNode.parent.type !== 'root';
 
 			// Optionally ignore the expectation if inside a block
 			if (optionsMatches(options, 'ignore', 'inside-block') && isNested) {
@@ -86,7 +84,7 @@ function rule(expectation, options, context) {
 			}
 
 			// Ignore if the expectation is for multiple and the rule is single-line
-			if (expectation.includes('multi-line') && isSingleLineString(rule.toString())) {
+			if (expectation.includes('multi-line') && isSingleLineString(ruleNode.toString())) {
 				return;
 			}
 
@@ -94,19 +92,19 @@ function rule(expectation, options, context) {
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (
-				(optionsMatches(options, 'except', 'first-nested') && isFirstNested(rule)) ||
-				(optionsMatches(options, 'except', 'after-rule') && isAfterRule(rule)) ||
+				(optionsMatches(options, 'except', 'first-nested') && isFirstNested(ruleNode)) ||
+				(optionsMatches(options, 'except', 'after-rule') && isAfterRule(ruleNode)) ||
 				(optionsMatches(options, 'except', 'inside-block-and-after-rule') &&
 					isNested &&
-					isAfterRule(rule)) ||
+					isAfterRule(ruleNode)) ||
 				(optionsMatches(options, 'except', 'after-single-line-comment') &&
-					isAfterSingleLineComment(rule)) ||
+					isAfterSingleLineComment(ruleNode)) ||
 				(optionsMatches(options, 'except', 'inside-block') && isNested)
 			) {
 				expectEmptyLineBefore = !expectEmptyLineBefore;
 			}
 
-			const hasEmptyLineBefore = hasEmptyLine(rule.raws.before);
+			const hasEmptyLineBefore = hasEmptyLine(ruleNode.raws.before);
 
 			// Return if the expectation is met
 			if (expectEmptyLineBefore === hasEmptyLineBefore) {
@@ -116,9 +114,9 @@ function rule(expectation, options, context) {
 			// Fix
 			if (context.fix) {
 				if (expectEmptyLineBefore) {
-					addEmptyLineBefore(rule, context.newline);
+					addEmptyLineBefore(ruleNode, context.newline);
 				} else {
-					removeEmptyLinesBefore(rule, context.newline);
+					removeEmptyLinesBefore(ruleNode, context.newline);
 				}
 
 				return;
@@ -128,7 +126,7 @@ function rule(expectation, options, context) {
 
 			report({
 				message,
-				node: rule,
+				node: ruleNode,
 				result,
 				ruleName,
 			});
@@ -136,10 +134,8 @@ function rule(expectation, options, context) {
 	};
 }
 
-// TODO: Issue #4985
-// eslint-disable-next-line no-shadow
-function isAfterRule(rule) {
-	const prevNode = getPreviousNonSharedLineCommentNode(rule);
+function isAfterRule(ruleNode) {
+	const prevNode = getPreviousNonSharedLineCommentNode(ruleNode);
 
 	return prevNode && prevNode.type === 'rule';
 }

--- a/lib/rules/selector-attribute-brackets-space-inside/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.js
@@ -30,21 +30,19 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('[')) {
+			if (!ruleNode.selector.includes('[')) {
 				return;
 			}
 
-			const selector = rule.raws.selector ? rule.raws.selector.raw : rule.selector;
+			const selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
 			let hasFixed;
-			const fixedSelector = parseSelector(selector, result, rule, (selectorTree) => {
+			const fixedSelector = parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
 					const attributeSelectorString = attributeNode.toString();
 
@@ -105,10 +103,10 @@ function rule(expectation, options, context) {
 			});
 
 			if (hasFixed) {
-				if (!rule.raws.selector) {
-					rule.selector = fixedSelector;
+				if (!ruleNode.raws.selector) {
+					ruleNode.selector = fixedSelector;
 				} else {
-					rule.raws.selector.raw = fixedSelector;
+					ruleNode.raws.selector.raw = fixedSelector;
 				}
 			}
 
@@ -118,7 +116,7 @@ function rule(expectation, options, context) {
 					index,
 					result,
 					ruleName,
-					node: rule,
+					node: ruleNode,
 				});
 			}
 		});

--- a/lib/rules/selector-attribute-operator-allowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-allowed-list/index.js
@@ -28,18 +28,16 @@ function rule(listInput) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
+			if (!ruleNode.selector.includes('[') || !ruleNode.selector.includes('=')) {
 				return;
 			}
 
-			parseSelector(rule.selector, result, rule, (selectorTree) => {
+			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
 					const operator = attributeNode.operator;
 
@@ -49,7 +47,7 @@ function rule(listInput) {
 
 					report({
 						message: messages.rejected(operator),
-						node: rule,
+						node: ruleNode,
 						index: attributeNode.sourceIndex + attributeNode.offsetOf('operator'),
 						result,
 						ruleName,

--- a/lib/rules/selector-attribute-operator-blacklist/index.js
+++ b/lib/rules/selector-attribute-operator-blacklist/index.js
@@ -36,18 +36,16 @@ function rule(listInput) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
+			if (!ruleNode.selector.includes('[') || !ruleNode.selector.includes('=')) {
 				return;
 			}
 
-			parseSelector(rule.selector, result, rule, (selectorTree) => {
+			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
 					const operator = attributeNode.operator;
 
@@ -57,7 +55,7 @@ function rule(listInput) {
 
 					report({
 						message: messages.rejected(operator),
-						node: rule,
+						node: ruleNode,
 						index: attributeNode.sourceIndex + attributeNode.offsetOf('operator'),
 						result,
 						ruleName,

--- a/lib/rules/selector-attribute-operator-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-disallowed-list/index.js
@@ -28,18 +28,16 @@ function rule(listInput) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
+			if (!ruleNode.selector.includes('[') || !ruleNode.selector.includes('=')) {
 				return;
 			}
 
-			parseSelector(rule.selector, result, rule, (selectorTree) => {
+			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
 					const operator = attributeNode.operator;
 
@@ -49,7 +47,7 @@ function rule(listInput) {
 
 					report({
 						message: messages.rejected(operator),
-						node: rule,
+						node: ruleNode,
 						index: attributeNode.sourceIndex + attributeNode.offsetOf('operator'),
 						result,
 						ruleName,

--- a/lib/rules/selector-attribute-operator-space-after/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/index.js
@@ -39,12 +39,8 @@ function rule(expectation, options, context) {
 							const rawOperator = _.get(attributeNode, 'raws.operator');
 
 							if (rawOperator) {
-								// TODO: Issue #4985
-								// eslint-disable-next-line no-shadow
-								const operatorAfter = rawOperator.slice(attributeNode.operator.length);
-
 								return {
-									operatorAfter,
+									operatorAfter: rawOperator.slice(attributeNode.operator.length),
 									setOperatorAfter(fixed) {
 										delete attributeNode.raws.operator;
 										_.set(attributeNode, 'raws.spaces.operator.after', fixed);

--- a/lib/rules/selector-attribute-operator-whitelist/index.js
+++ b/lib/rules/selector-attribute-operator-whitelist/index.js
@@ -36,18 +36,16 @@ function rule(listInput) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
+			if (!ruleNode.selector.includes('[') || !ruleNode.selector.includes('=')) {
 				return;
 			}
 
-			parseSelector(rule.selector, result, rule, (selectorTree) => {
+			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
 					const operator = attributeNode.operator;
 
@@ -57,7 +55,7 @@ function rule(listInput) {
 
 					report({
 						message: messages.rejected(operator),
-						node: rule,
+						node: ruleNode,
 						index: attributeNode.sourceIndex + attributeNode.offsetOf('operator'),
 						result,
 						ruleName,

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -26,18 +26,16 @@ function rule(expectation) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
+			if (!ruleNode.selector.includes('[') || !ruleNode.selector.includes('=')) {
 				return;
 			}
 
-			parseSelector(rule.selector, result, rule, (selectorTree) => {
+			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
 					if (!attributeNode.operator) {
 						return;
@@ -65,7 +63,7 @@ function rule(expectation) {
 					index,
 					result,
 					ruleName,
-					node: rule,
+					node: ruleNode,
 				});
 			}
 		});

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -44,13 +44,11 @@ function rule(pattern, options) {
 		const shouldResolveNestedSelectors = _.get(options, 'resolveNestedSelectors');
 		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			const selector = rule.selector;
-			const selectors = rule.selectors;
+		root.walkRules((ruleNode) => {
+			const selector = ruleNode.selector;
+			const selectors = ruleNode.selectors;
 
-			if (!isStandardSyntaxRule(rule)) {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
@@ -60,23 +58,19 @@ function rule(pattern, options) {
 
 			// Only bother resolving selectors that have an interpolating &
 			if (shouldResolveNestedSelectors && hasInterpolatingAmpersand(selector)) {
-				// TODO: Issue #4985
-				// eslint-disable-next-line no-shadow
-				resolveNestedSelector(selector, rule).forEach((selector) => {
-					if (!isStandardSyntaxSelector(selector)) {
+				resolveNestedSelector(selector, ruleNode).forEach((nestedSelector) => {
+					if (!isStandardSyntaxSelector(nestedSelector)) {
 						return;
 					}
 
-					parseSelector(selector, result, rule, (s) => checkSelector(s, rule));
+					parseSelector(nestedSelector, result, ruleNode, (s) => checkSelector(s, ruleNode));
 				});
 			} else {
-				parseSelector(selector, result, rule, (s) => checkSelector(s, rule));
+				parseSelector(selector, result, ruleNode, (s) => checkSelector(s, ruleNode));
 			}
 		});
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function checkSelector(fullSelector, rule) {
+		function checkSelector(fullSelector, ruleNode) {
 			fullSelector.walkClasses((classNode) => {
 				const value = classNode.value;
 				const sourceIndex = classNode.sourceIndex;
@@ -89,7 +83,7 @@ function rule(pattern, options) {
 					result,
 					ruleName,
 					message: messages.expected(value, pattern),
-					node: rule,
+					node: ruleNode,
 					index: sourceIndex,
 				});
 			});

--- a/lib/rules/selector-combinator-allowed-list/index.js
+++ b/lib/rules/selector-combinator-allowed-list/index.js
@@ -27,16 +27,14 @@ function rule(list) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, rule, (fullSelector) => {
+			parseSelector(selector, result, ruleNode, (fullSelector) => {
 				fullSelector.walkCombinators((combinatorNode) => {
 					if (!isStandardSyntaxCombinator(combinatorNode)) {
 						return;
@@ -52,7 +50,7 @@ function rule(list) {
 						result,
 						ruleName,
 						message: messages.rejected(value),
-						node: rule,
+						node: ruleNode,
 						index: combinatorNode.sourceIndex,
 					});
 				});

--- a/lib/rules/selector-combinator-blacklist/index.js
+++ b/lib/rules/selector-combinator-blacklist/index.js
@@ -35,16 +35,14 @@ function rule(list) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, rule, (fullSelector) => {
+			parseSelector(selector, result, ruleNode, (fullSelector) => {
 				fullSelector.walkCombinators((combinatorNode) => {
 					if (!isStandardSyntaxCombinator(combinatorNode)) {
 						return;
@@ -60,7 +58,7 @@ function rule(list) {
 						result,
 						ruleName,
 						message: messages.rejected(value),
-						node: rule,
+						node: ruleNode,
 						index: combinatorNode.sourceIndex,
 					});
 				});

--- a/lib/rules/selector-combinator-disallowed-list/index.js
+++ b/lib/rules/selector-combinator-disallowed-list/index.js
@@ -27,16 +27,14 @@ function rule(list) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, rule, (fullSelector) => {
+			parseSelector(selector, result, ruleNode, (fullSelector) => {
 				fullSelector.walkCombinators((combinatorNode) => {
 					if (!isStandardSyntaxCombinator(combinatorNode)) {
 						return;
@@ -52,7 +50,7 @@ function rule(list) {
 						result,
 						ruleName,
 						message: messages.rejected(value),
-						node: rule,
+						node: ruleNode,
 						index: combinatorNode.sourceIndex,
 					});
 				});

--- a/lib/rules/selector-combinator-whitelist/index.js
+++ b/lib/rules/selector-combinator-whitelist/index.js
@@ -35,16 +35,14 @@ function rule(list) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, rule, (fullSelector) => {
+			parseSelector(selector, result, ruleNode, (fullSelector) => {
 				fullSelector.walkCombinators((combinatorNode) => {
 					if (!isStandardSyntaxCombinator(combinatorNode)) {
 						return;
@@ -60,7 +58,7 @@ function rule(list) {
 						result,
 						ruleName,
 						message: messages.rejected(value),
-						node: rule,
+						node: ruleNode,
 						index: combinatorNode.sourceIndex,
 					});
 				});

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -24,21 +24,19 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
 			let hasFixed = false;
-			const selector = rule.raws.selector ? rule.raws.selector.raw : rule.selector;
+			const selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
 			// Return early for selectors containing comments
 			// TODO: renable when parser and stylelint are compatible
 			if (selector.includes('/*')) return;
 
-			const fixedSelector = parseSelector(selector, result, rule, (fullSelector) => {
+			const fixedSelector = parseSelector(selector, result, ruleNode, (fullSelector) => {
 				fullSelector.walkCombinators((combinatorNode) => {
 					if (combinatorNode.value !== ' ') {
 						return;
@@ -65,7 +63,7 @@ function rule(expectation, options, context) {
 							result,
 							ruleName,
 							message: messages.rejected(value),
-							node: rule,
+							node: ruleNode,
 							index: combinatorNode.sourceIndex,
 						});
 					}
@@ -73,10 +71,10 @@ function rule(expectation, options, context) {
 			});
 
 			if (hasFixed) {
-				if (!rule.raws.selector) {
-					rule.selector = fixedSelector;
+				if (!ruleNode.raws.selector) {
+					ruleNode.selector = fixedSelector;
 				} else {
-					rule.raws.selector.raw = fixedSelector;
+					ruleNode.raws.selector.raw = fixedSelector;
 				}
 			}
 		});

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -29,16 +29,14 @@ function rule(pattern) {
 
 		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, rule, (fullSelector) => {
+			parseSelector(selector, result, ruleNode, (fullSelector) => {
 				fullSelector.walk((selectorNode) => {
 					if (selectorNode.type !== 'id') {
 						return;
@@ -55,7 +53,7 @@ function rule(pattern) {
 						result,
 						ruleName,
 						message: messages.expected(value, pattern),
-						node: rule,
+						node: ruleNode,
 						index: sourceIndex,
 					});
 				});

--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -30,17 +30,15 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
 			// Get raw selector so we can allow end-of-line comments, e.g.
 			// a, /* comment */
 			// b {}
-			const selector = rule.raws.selector ? rule.raws.selector.raw : rule.selector;
+			const selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
 			const fixIndices = [];
 
@@ -76,7 +74,7 @@ function rule(expectation, options, context) {
 
 							report({
 								message: m,
-								node: rule,
+								node: ruleNode,
 								index: match.startIndex,
 								result,
 								ruleName,
@@ -104,10 +102,10 @@ function rule(expectation, options, context) {
 						fixedSelector = beforeSelector + afterSelector;
 					});
 
-				if (rule.raws.selector) {
-					rule.raws.selector.raw = fixedSelector;
+				if (ruleNode.raws.selector) {
+					ruleNode.raws.selector.raw = fixedSelector;
 				} else {
-					rule.selector = fixedSelector;
+					ruleNode.selector = fixedSelector;
 				}
 			}
 		});

--- a/lib/rules/selector-max-empty-lines/index.js
+++ b/lib/rules/selector-max-empty-lines/index.js
@@ -31,20 +31,18 @@ function rule(max, options, context) {
 		const allowedLFNewLinesString = context.fix ? '\n'.repeat(maxAdjacentNewlines) : '';
 		const allowedCRLFNewLinesString = context.fix ? '\r\n'.repeat(maxAdjacentNewlines) : '';
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			const selector = rule.raws.selector ? rule.raws.selector.raw : rule.selector;
+		root.walkRules((ruleNode) => {
+			const selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
 			if (context.fix) {
 				const newSelectorString = selector
 					.replace(new RegExp(violatedLFNewLinesRegex, 'gm'), allowedLFNewLinesString)
 					.replace(new RegExp(violatedCRLFNewLinesRegex, 'gm'), allowedCRLFNewLinesString);
 
-				if (rule.raws.selector) {
-					rule.raws.selector.raw = newSelectorString;
+				if (ruleNode.raws.selector) {
+					ruleNode.raws.selector.raw = newSelectorString;
 				} else {
-					rule.selector = newSelectorString;
+					ruleNode.selector = newSelectorString;
 				}
 			} else if (
 				violatedLFNewLinesRegex.test(selector) ||
@@ -52,7 +50,7 @@ function rule(max, options, context) {
 			) {
 				report({
 					message: messages.expected(max),
-					node: rule,
+					node: ruleNode,
 					index: 0,
 					result,
 					ruleName,

--- a/lib/rules/selector-nested-pattern/index.js
+++ b/lib/rules/selector-nested-pattern/index.js
@@ -28,18 +28,16 @@ function rule(pattern) {
 
 		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (rule.parent.type !== 'rule') {
+		root.walkRules((ruleNode) => {
+			if (ruleNode.parent.type !== 'rule') {
 				return;
 			}
 
-			if (!isStandardSyntaxRule(rule)) {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (normalizedPattern.test(selector)) {
 				return;
@@ -49,7 +47,7 @@ function rule(pattern) {
 				result,
 				ruleName,
 				message: messages.expected(selector, pattern),
-				node: rule,
+				node: ruleNode,
 			});
 		});
 	};

--- a/lib/rules/selector-no-qualifying-type/index.js
+++ b/lib/rules/selector-no-qualifying-type/index.js
@@ -65,18 +65,16 @@ function rule(enabled, options) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (isKeyframeRule(rule)) {
+			if (isKeyframeRule(ruleNode)) {
 				return;
 			}
 
-			if (!isSelectorCharacters(rule.selector)) {
+			if (!isSelectorCharacters(ruleNode.selector)) {
 				return;
 			}
 
@@ -110,19 +108,19 @@ function rule(enabled, options) {
 				});
 			}
 
-			resolvedNestedSelector(rule.selector, rule).forEach((resolvedSelector) => {
+			resolvedNestedSelector(ruleNode.selector, ruleNode).forEach((resolvedSelector) => {
 				if (!isStandardSyntaxSelector(resolvedSelector)) {
 					return;
 				}
 
-				parseSelector(resolvedSelector, result, rule, checkSelector);
+				parseSelector(resolvedSelector, result, ruleNode, checkSelector);
 			});
 
 			function complain(index) {
 				report({
 					ruleName,
 					result,
-					node: rule,
+					node: ruleNode,
 					message: messages.rejected,
 					index,
 				});

--- a/lib/rules/selector-no-vendor-prefix/index.js
+++ b/lib/rules/selector-no-vendor-prefix/index.js
@@ -36,16 +36,14 @@ function rule(actual, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					if (isAutoprefixable.selector(pseudoNode.value)) {
 						if (optionsMatches(options, 'ignoreSelectors', pseudoNode.value)) {
@@ -53,7 +51,7 @@ function rule(actual, options, context) {
 						}
 
 						if (context.fix) {
-							rule.selector = isAutoprefixable.unprefix(rule.selector);
+							ruleNode.selector = isAutoprefixable.unprefix(ruleNode.selector);
 
 							return;
 						}
@@ -62,8 +60,8 @@ function rule(actual, options, context) {
 							result,
 							ruleName,
 							message: messages.rejected(pseudoNode.value),
-							node: rule,
-							index: (rule.raws.before || '').length + pseudoNode.sourceIndex,
+							node: ruleNode,
+							index: (ruleNode.raws.before || '').length + pseudoNode.sourceIndex,
 						});
 					}
 				});

--- a/lib/rules/selector-pseudo-class-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-allowed-list/index.js
@@ -28,20 +28,18 @@ function rule(list) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes(':')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -59,7 +57,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-pseudo-class-blacklist/index.js
+++ b/lib/rules/selector-pseudo-class-blacklist/index.js
@@ -36,20 +36,18 @@ function rule(list) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes(':')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -68,7 +66,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-pseudo-class-case/index.js
+++ b/lib/rules/selector-pseudo-class-case/index.js
@@ -27,23 +27,21 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes(':')) {
 				return;
 			}
 
 			const fixedSelector = parseSelector(
-				rule.raws.selector ? rule.raws.selector.raw : rule.selector,
+				ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector,
 				result,
-				rule,
+				ruleNode,
 				(selectorTree) => {
 					selectorTree.walkPseudos((pseudoNode) => {
 						const pseudo = pseudoNode.value;
@@ -74,7 +72,7 @@ function rule(expectation, options, context) {
 
 						report({
 							message: messages.expected(pseudo, expectedPseudo),
-							node: rule,
+							node: ruleNode,
 							index: pseudoNode.sourceIndex,
 							ruleName,
 							result,
@@ -84,10 +82,10 @@ function rule(expectation, options, context) {
 			);
 
 			if (context.fix) {
-				if (rule.raws.selector) {
-					rule.raws.selector.raw = fixedSelector;
+				if (ruleNode.raws.selector) {
+					ruleNode.raws.selector.raw = fixedSelector;
 				} else {
-					rule.selector = fixedSelector;
+					ruleNode.selector = fixedSelector;
 				}
 			}
 		});

--- a/lib/rules/selector-pseudo-class-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-disallowed-list/index.js
@@ -28,20 +28,18 @@ function rule(list) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes(':')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -60,7 +58,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -41,9 +41,7 @@ function rule(actual, options) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function check(selector, result, node) {
+		function check(selector, node) {
 			parseSelector(selector, result, node, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
@@ -149,7 +147,7 @@ function rule(actual, options) {
 				return;
 			}
 
-			check(selector, result, node);
+			check(selector, node);
 		});
 	};
 }

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -28,20 +28,18 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('(')) {
+			if (!ruleNode.selector.includes('(')) {
 				return;
 			}
 
 			let hasFixed = false;
-			const selector = rule.raws.selector ? rule.raws.selector.raw : rule.selector;
-			const fixedSelector = parseSelector(selector, result, rule, (selectorTree) => {
+			const selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
+			const fixedSelector = parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					if (!pseudoNode.length) {
 						return;
@@ -94,10 +92,10 @@ function rule(expectation, options, context) {
 			});
 
 			if (hasFixed) {
-				if (!rule.raws.selector) {
-					rule.selector = fixedSelector;
+				if (!ruleNode.raws.selector) {
+					ruleNode.selector = fixedSelector;
 				} else {
-					rule.raws.selector.raw = fixedSelector;
+					ruleNode.raws.selector.raw = fixedSelector;
 				}
 			}
 
@@ -107,7 +105,7 @@ function rule(expectation, options, context) {
 					index,
 					result,
 					ruleName,
-					node: rule,
+					node: ruleNode,
 				});
 			}
 		});

--- a/lib/rules/selector-pseudo-class-whitelist/index.js
+++ b/lib/rules/selector-pseudo-class-whitelist/index.js
@@ -36,20 +36,18 @@ function rule(list) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes(':')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -67,7 +65,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-pseudo-element-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-allowed-list/index.js
@@ -28,20 +28,18 @@ function rule(list) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes('::')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -59,7 +57,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-pseudo-element-blacklist/index.js
+++ b/lib/rules/selector-pseudo-element-blacklist/index.js
@@ -36,20 +36,18 @@ function rule(list) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes('::')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -67,7 +65,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-pseudo-element-case/index.js
+++ b/lib/rules/selector-pseudo-element-case/index.js
@@ -27,20 +27,18 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes(':')) {
 				return;
 			}
 
-			transformSelector(result, rule, (selectorTree) => {
+			transformSelector(result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const pseudoElement = pseudoNode.value;
 
@@ -70,7 +68,7 @@ function rule(expectation, options, context) {
 
 					report({
 						message: messages.expected(pseudoElement, expectedPseudoElement),
-						node: rule,
+						node: ruleNode,
 						index: pseudoNode.sourceIndex,
 						ruleName,
 						result,

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -26,14 +26,12 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			// get out early if no pseudo elements or classes
 			if (!selector.includes(':')) {
@@ -59,14 +57,14 @@ function rule(expectation, options, context) {
 				}
 
 				if (context.fix) {
-					fixPositions.unshift({ rule, startIndex: match.startIndex });
+					fixPositions.unshift({ ruleNode, startIndex: match.startIndex });
 
 					return;
 				}
 
 				report({
 					message: messages.expected(expectation),
-					node: rule,
+					node: ruleNode,
 					index: match.startIndex,
 					result,
 					ruleName,
@@ -81,10 +79,10 @@ function rule(expectation, options, context) {
 				const extraColon = expectedSingle ? '' : ':';
 
 				fixPositions.forEach((fixPosition) => {
-					rule.selector =
-						rule.selector.substring(0, fixPosition.startIndex - offset) +
+					ruleNode.selector =
+						ruleNode.selector.substring(0, fixPosition.startIndex - offset) +
 						extraColon +
-						rule.selector.substring(fixPosition.startIndex);
+						ruleNode.selector.substring(fixPosition.startIndex);
 				});
 			}
 		});

--- a/lib/rules/selector-pseudo-element-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-disallowed-list/index.js
@@ -28,20 +28,18 @@ function rule(list) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes('::')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -59,7 +57,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -38,14 +38,12 @@ function rule(actual, options) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			// Return early before parse if no pseudos for performance
 
@@ -53,7 +51,7 @@ function rule(actual, options) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -78,7 +76,7 @@ function rule(actual, options) {
 
 					report({
 						message: messages.rejected(value),
-						node: rule,
+						node: ruleNode,
 						index: pseudoNode.sourceIndex,
 						ruleName,
 						result,

--- a/lib/rules/selector-pseudo-element-whitelist/index.js
+++ b/lib/rules/selector-pseudo-element-whitelist/index.js
@@ -36,20 +36,18 @@ function rule(list) {
 			},
 		);
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			if (!isStandardSyntaxRule(rule)) {
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			const selector = rule.selector;
+			const selector = ruleNode.selector;
 
 			if (!selector.includes('::')) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkPseudos((pseudoNode) => {
 					const value = pseudoNode.value;
 
@@ -67,7 +65,7 @@ function rule(list) {
 					report({
 						index: pseudoNode.sourceIndex,
 						message: messages.rejected(name),
-						node: rule,
+						node: ruleNode,
 						result,
 						ruleName,
 					});

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -40,14 +40,12 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			let hasComments = _.get(rule, 'raws.selector.raw');
-			const selector = hasComments ? hasComments : rule.selector;
-			const selectors = rule.selectors;
+		root.walkRules((ruleNode) => {
+			let hasComments = _.get(ruleNode, 'raws.selector.raw');
+			const selector = hasComments ? hasComments : ruleNode.selector;
+			const selectors = ruleNode.selectors;
 
-			if (!isStandardSyntaxRule(rule)) {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
@@ -55,7 +53,7 @@ function rule(expectation, options, context) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorAST) => {
+			parseSelector(selector, result, ruleNode, (selectorAST) => {
 				selectorAST.walkTags((tag) => {
 					if (!isStandardSyntaxTypeSelector(tag)) {
 						return;
@@ -80,12 +78,12 @@ function rule(expectation, options, context) {
 								hasComments.slice(0, sourceIndex) +
 								expectedValue +
 								hasComments.slice(sourceIndex + value.length);
-							_.set(rule, 'raws.selector.raw', hasComments);
+							_.set(ruleNode, 'raws.selector.raw', hasComments);
 						} else {
-							rule.selector =
-								rule.selector.slice(0, sourceIndex) +
+							ruleNode.selector =
+								ruleNode.selector.slice(0, sourceIndex) +
 								expectedValue +
-								rule.selector.slice(sourceIndex + value.length);
+								ruleNode.selector.slice(sourceIndex + value.length);
 						}
 
 						return;
@@ -93,7 +91,7 @@ function rule(expectation, options, context) {
 
 					report({
 						message: messages.expected(value, expectedValue),
-						node: rule,
+						node: ruleNode,
 						index: sourceIndex,
 						ruleName,
 						result,

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -44,13 +44,11 @@ function rule(actual, options) {
 			return;
 		}
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		root.walkRules((rule) => {
-			const selector = rule.selector;
-			const selectors = rule.selectors;
+		root.walkRules((ruleNode) => {
+			const selector = ruleNode.selector;
+			const selectors = ruleNode.selectors;
 
-			if (!isStandardSyntaxRule(rule)) {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
@@ -58,7 +56,7 @@ function rule(actual, options) {
 				return;
 			}
 
-			parseSelector(selector, result, rule, (selectorTree) => {
+			parseSelector(selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkTags((tagNode) => {
 					if (!isStandardSyntaxTypeSelector(tagNode)) {
 						return;
@@ -101,7 +99,7 @@ function rule(actual, options) {
 
 					report({
 						message: messages.rejected(tagName),
-						node: rule,
+						node: ruleNode,
 						index: tagNode.sourceIndex,
 						ruleName,
 						result,

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -111,9 +111,7 @@ function rule(actual, secondary, context) {
 			}
 
 			const shortestForm = canCondense(...valuesToShorthand);
-			// TODO: Issue #4985
-			// eslint-disable-next-line no-shadow
-			const shortestFormString = shortestForm.filter((value) => value).join(' ');
+			const shortestFormString = shortestForm.filter(Boolean).join(' ');
 			const valuesFormString = valuesToShorthand.join(' ');
 
 			if (shortestFormString.toLowerCase() === valuesFormString.toLowerCase()) {

--- a/lib/rules/string-no-newline/index.js
+++ b/lib/rules/string-no-newline/index.js
@@ -40,19 +40,17 @@ function rule(actual) {
 			}
 		});
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function checkRule(rule) {
+		function checkRule(ruleNode) {
 			// Get out quickly if there are no new line
-			if (!reNewLine.test(rule.selector)) {
+			if (!reNewLine.test(ruleNode.selector)) {
 				return;
 			}
 
-			if (!isStandardSyntaxSelector(rule.selector)) {
+			if (!isStandardSyntaxSelector(ruleNode.selector)) {
 				return;
 			}
 
-			parseSelector(rule.selector, result, rule, (selectorTree) => {
+			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
 				selectorTree.walkAttributes((attributeNode) => {
 					if (!reNewLine.test(attributeNode.value)) {
 						return;
@@ -73,7 +71,7 @@ function rule(actual) {
 
 					report({
 						message: messages.rejected,
-						node: rule,
+						node: ruleNode,
 						index: openIndex,
 						result,
 						ruleName,

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -62,20 +62,18 @@ function rule(expectation, secondary, context) {
 			}
 		});
 
-		// TODO: Issue #4985
-		// eslint-disable-next-line no-shadow
-		function checkRule(rule) {
-			if (!isStandardSyntaxRule(rule)) {
+		function checkRule(ruleNode) {
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (!rule.selector.includes('[') || !rule.selector.includes('=')) {
+			if (!ruleNode.selector.includes('[') || !ruleNode.selector.includes('=')) {
 				return;
 			}
 
 			const fixPositions = [];
 
-			parseSelector(rule.selector, result, rule, (selectorTree) => {
+			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
 				let selectorFixed = false;
 
 				selectorTree.walkAttributes((attributeNode) => {
@@ -99,7 +97,7 @@ function rule(expectation, secondary, context) {
 								} else {
 									report({
 										message: messages.expected(expectation === 'single' ? 'double' : expectation),
-										node: rule,
+										node: ruleNode,
 										index: attributeNode.sourceIndex + attributeNode.offsetOf('value'),
 										result,
 										ruleName,
@@ -121,7 +119,7 @@ function rule(expectation, secondary, context) {
 								} else {
 									report({
 										message: messages.expected(expectation),
-										node: rule,
+										node: ruleNode,
 										index: attributeNode.sourceIndex + attributeNode.offsetOf('value'),
 										result,
 										ruleName,
@@ -142,7 +140,7 @@ function rule(expectation, secondary, context) {
 						} else {
 							report({
 								message: messages.expected(expectation),
-								node: rule,
+								node: ruleNode,
 								index: attributeNode.sourceIndex + attributeNode.offsetOf('value'),
 								result,
 								ruleName,
@@ -152,12 +150,12 @@ function rule(expectation, secondary, context) {
 				});
 
 				if (selectorFixed) {
-					rule.selector = selectorTree.toString();
+					ruleNode.selector = selectorTree.toString();
 				}
 			});
 
 			fixPositions.forEach((fixIndex) => {
-				rule.selector = replaceQuote(rule.selector, fixIndex, correctQuote);
+				ruleNode.selector = replaceQuote(ruleNode.selector, fixIndex, correctQuote);
 			});
 		}
 

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -27,7 +27,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
-		function check(node, value, getIndex) {
+		function check(node, checkedValue, getIndex) {
 			const violations = [];
 
 			function processValue(valueNode) {
@@ -51,11 +51,9 @@ function rule(expectation, options, context) {
 				return true;
 			}
 
-			const parsedValue = valueParser(value).walk((valueNode) => {
+			const parsedValue = valueParser(checkedValue).walk((valueNode) => {
 				// Ignore wrong units within `url` function
 				let needFix = false;
-				// TODO: Issue #4985
-				// eslint-disable-next-line no-shadow
 				const value = valueNode.value;
 
 				if (valueNode.type === 'function' && value.toLowerCase() === 'url') {

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -65,11 +65,9 @@ function rule(actual, options) {
 				}
 
 				if (isMap(valueNode)) {
-					// TODO: Issue #4985
-					// eslint-disable-next-line no-shadow
-					valueNode.nodes.forEach((node, index) => {
+					valueNode.nodes.forEach(({ sourceIndex }, index) => {
 						if (!(index % mapPropertyNameIndexOffset)) {
-							ignoredMapProperties.push(node.sourceIndex);
+							ignoredMapProperties.push(sourceIndex);
 						}
 					});
 				}
@@ -123,9 +121,7 @@ function rule(actual, options) {
 
 						if (/^(?:-webkit-)?image-set[\s(]/i.test(value)) {
 							const imageSet = parsedValue.nodes.find(
-								// TODO: Issue #4985
-								// eslint-disable-next-line no-shadow
-								(node) => vendor.unprefixed(node.value) === 'image-set',
+								(n) => vendor.unprefixed(n.value) === 'image-set',
 							);
 							const imageSetValueLastIndex = _.last(imageSet.nodes).sourceIndex;
 

--- a/lib/utils/__tests__/declarationValueIndex.test.js
+++ b/lib/utils/__tests__/declarationValueIndex.test.js
@@ -28,9 +28,7 @@ describe('declarationValueIndex', () => {
 function decl(css) {
 	const list = [];
 
-	// TODO: Issue #4985
-	// eslint-disable-next-line no-shadow
-	postcss.parse(css).walkDecls((decl) => list.push(decl));
+	postcss.parse(css).walkDecls((d) => list.push(d));
 
 	return list[0];
 }

--- a/lib/utils/__tests__/isSharedLineComment.test.js
+++ b/lib/utils/__tests__/isSharedLineComment.test.js
@@ -193,9 +193,7 @@ describe('isSharedLineComment', () => {
 function comment(css) {
 	const comments = [];
 
-	// TODO: Issue #4985
-	// eslint-disable-next-line no-shadow
-	postcss.parse(css).walkComments((comment) => comments.push(comment));
+	postcss.parse(css).walkComments((c) => comments.push(c));
 
 	return comments[0];
 }

--- a/lib/utils/__tests__/isStandardSyntaxCombinator.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxCombinator.test.js
@@ -57,9 +57,7 @@ function combinator(css) {
 
 	postcss.parse(css).walkRules((rule) => {
 		selectorParser((selectorAST) => {
-			// TODO: Issue #4985
-			// eslint-disable-next-line no-shadow
-			selectorAST.walkCombinators((combinator) => list.push(combinator));
+			selectorAST.walkCombinators((c) => list.push(c));
 		}).processSync(rule.selector);
 	});
 

--- a/lib/utils/validateObjectWithArrayProps.js
+++ b/lib/utils/validateObjectWithArrayProps.js
@@ -24,15 +24,13 @@ module.exports = (validator) => (value) => {
 		return false;
 	}
 
-	// TODO: Issue #4985
-	// eslint-disable-next-line no-shadow
-	return Object.values(value).every((value) => {
-		if (!Array.isArray(value)) {
+	return Object.values(value).every((array) => {
+		if (!Array.isArray(array)) {
 			return false;
 		}
 
 		// Make sure the array items are strings
-		return value.every((item) => {
+		return array.every((item) => {
 			if (Array.isArray(validator)) {
 				return validator.some((v) => v(item));
 			}


### PR DESCRIPTION
This change closes #5013 by fixing all the ESLint `no-shadow` rule violations.

> Which issue, if any, is this issue related to?

Closes #5013

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
