### PR TITLE
Refactor `lib/__tests__/postcssPlugin.test.js`

### DIFF
--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -5,14 +5,9 @@ const path = require('path');
 const postcssPlugin = require('../postcssPlugin');
 
 it('`config` option is `null`', () => {
-	return postcssPlugin
-		.process('a {}', { from: undefined })
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err.message).toContain('No configuration provided');
-		});
+	return expect(postcssPlugin.process('a {}', { from: undefined })).rejects.toMatchObject({
+		message: expect.stringMatching('No configuration provided'),
+	});
 });
 
 it('`configFile` option with absolute path', () => {
@@ -29,14 +24,9 @@ it('`configFile` option with absolute path', () => {
 });
 
 it('`configFile` with bad path', () => {
-	return postcssPlugin
-		.process('a {}', { from: undefined }, { configFile: './herby.json' })
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err.code).toBe('ENOENT');
-		});
+	return expect(
+		postcssPlugin.process('a {}', { from: undefined }, { configFile: './herby.json' }),
+	).rejects.toHaveProperty('code', 'ENOENT');
 });
 
 it('`configFile` option without rules', () => {
@@ -44,18 +34,11 @@ it('`configFile` option without rules', () => {
 		configFile: path.join(__dirname, 'fixtures/config-without-rules.json'),
 	};
 
-	return postcssPlugin
-		.process('a {}', { from: undefined }, config)
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err).toEqual(
-				configurationError(
-					'No rules found within configuration. Have you provided a "rules" property?',
-				),
-			);
-		});
+	return expect(postcssPlugin.process('a {}', { from: undefined }, config)).rejects.toEqual(
+		configurationError(
+			'No rules found within configuration. Have you provided a "rules" property?',
+		),
+	);
 });
 
 it('`configFile` option with undefined rule', () => {
@@ -64,8 +47,8 @@ it('`configFile` option with undefined rule', () => {
 	};
 	const ruleName = 'unknown-rule';
 
-	return postcssPlugin.process('a {}', { from: undefined }, config).then((result) => {
-		expect(result.messages).toContainEqual(
+	return expect(postcssPlugin.process('a {}', { from: undefined }, config)).resolves.toMatchObject({
+		messages: [
 			expect.objectContaining({
 				line: 1,
 				column: 1,
@@ -73,7 +56,7 @@ it('`configFile` option with undefined rule', () => {
 				text: `Unknown rule ${ruleName}.`,
 				severity: 'error',
 			}),
-		);
+		],
 	});
 });
 
@@ -86,9 +69,10 @@ it('`ignoreFiles` options is not empty and file ignored', () => {
 		from: 'foo.css',
 	};
 
-	return postcssPlugin.process('a {}', { from: undefined }, config).then((postcssResult) => {
-		expect(postcssResult.stylelint.ignored).toBeTruthy();
-	});
+	return expect(postcssPlugin.process('a {}', { from: undefined }, config)).resolves.toHaveProperty(
+		'stylelint.ignored',
+		true,
+	);
 });
 
 it('`ignoreFiles` options is not empty and file not ignored', () => {
@@ -100,9 +84,9 @@ it('`ignoreFiles` options is not empty and file not ignored', () => {
 		from: 'foo.css',
 	};
 
-	return postcssPlugin.process('a {}', { from: undefined }, config).then((postcssResult) => {
-		expect(postcssResult.stylelint.ignored).toBeFalsy();
-	});
+	return expect(
+		postcssPlugin.process('a {}', { from: undefined }, config),
+	).resolves.not.toHaveProperty('stylelint.ignored');
 });
 
 describe('stylelintignore', () => {
@@ -127,9 +111,9 @@ describe('stylelintignore', () => {
 			from: 'postcssstylelintignore.css',
 		};
 
-		return postcssPlugin.process('a {}', { from: undefined }, options).then((postcssResult) => {
-			expect(postcssResult.stylelint.ignored).toBeTruthy();
-		});
+		return expect(
+			postcssPlugin.process('a {}', { from: undefined }, options),
+		).resolves.toHaveProperty('stylelint.ignored', true);
 	});
 
 	it('postcssPlugin with ignorePath and file is ignored', () => {
@@ -143,8 +127,8 @@ describe('stylelintignore', () => {
 			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
 		};
 
-		return postcssPlugin.process('a {}', { from: undefined }, options).then((postcssResult) => {
-			expect(postcssResult.stylelint.ignored).toBeTruthy();
-		});
+		return expect(
+			postcssPlugin.process('a {}', { from: undefined }, options),
+		).resolves.toHaveProperty('stylelint.ignored', true);
 	});
 });


### PR DESCRIPTION
This refactoring aims to make the usage of `Promise` in the test safer.
(via `.resolves`, `.rejects`, and other Jest matchers)

See also <https://jestjs.io/docs/expect>.

As a result, we can remove callbacks (which may not be performed) from the test.

> Which issue, if any, is this issue related to?

Part of #4881

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
