### PR TITLE
Refactor `lib/__tests__/createLinter.test.js`

### DIFF
--- a/lib/__tests__/createLinter.test.js
+++ b/lib/__tests__/createLinter.test.js
@@ -8,20 +8,18 @@ it('createLinter().getConfigForFile augmented config loads', () => {
 	const linter = stylelint.createLinter();
 	const filepath = path.join(__dirname, 'fixtures/getConfigForFile/a/b/foo.css');
 
-	return linter.getConfigForFile(filepath).then((result) => {
-		expect(result).toEqual({
-			config: {
-				plugins: [path.join(__dirname, '/fixtures/plugin-warn-about-foo.js')],
-				rules: {
-					'block-no-empty': [true],
-					'plugin/warn-about-foo': ['always'],
-				},
-				pluginFunctions: {
-					'plugin/warn-about-foo': pluginWarnAboutFoo.rule,
-				},
+	return expect(linter.getConfigForFile(filepath)).resolves.toEqual({
+		config: {
+			plugins: [path.join(__dirname, '/fixtures/plugin-warn-about-foo.js')],
+			rules: {
+				'block-no-empty': [true],
+				'plugin/warn-about-foo': ['always'],
 			},
-			filepath: path.join(__dirname, 'fixtures/getConfigForFile/a/.stylelintrc'),
-		});
+			pluginFunctions: {
+				'plugin/warn-about-foo': pluginWarnAboutFoo.rule,
+			},
+		},
+		filepath: path.join(__dirname, 'fixtures/getConfigForFile/a/.stylelintrc'),
 	});
 });
 
@@ -32,12 +30,12 @@ it('createLinter().isPathIgnored', () => {
 	};
 	const linter = stylelint.createLinter({ config });
 
-	return Promise.all([
-		linter.isPathIgnored('a.css'),
-		linter.isPathIgnored('foo/bar/baz.css'),
-		linter.isPathIgnored('foo/bar/baz.scss'),
-		linter.isPathIgnored('foo/invalid-hex.css'),
-	]).then((results) => {
-		expect(results).toEqual([true, true, false, false]);
-	});
+	return expect(
+		Promise.all([
+			linter.isPathIgnored('a.css'),
+			linter.isPathIgnored('foo/bar/baz.css'),
+			linter.isPathIgnored('foo/bar/baz.scss'),
+			linter.isPathIgnored('foo/invalid-hex.css'),
+		]),
+	).resolves.toEqual([true, true, false, false]);
 });


### PR DESCRIPTION
This refactoring removes callbacks via Jest `.resolves`.
See also <https://jestjs.io/docs/asynchronous#resolves--rejects>

> Which issue, if any, is this issue related to?

Part of #4881

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
