### PR TITLE
Use built-in type definitions of `import-lazy`

### DIFF
--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -3,10 +3,10 @@
 const importLazy = require('import-lazy');
 
 module.exports = {
-	compact: importLazy(() => require('./compactFormatter'))(),
-	json: importLazy(() => require('./jsonFormatter'))(),
-	string: importLazy(() => require('./stringFormatter'))(),
-	tap: importLazy(() => require('./tapFormatter'))(),
-	unix: importLazy(() => require('./unixFormatter'))(),
-	verbose: importLazy(() => require('./verboseFormatter'))(),
+	compact: importLazy(() => require('./compactFormatter'))('compactFormatter'),
+	json: importLazy(() => require('./jsonFormatter'))('jsonFormatter'),
+	string: importLazy(() => require('./stringFormatter'))('stringFormatter'),
+	tap: importLazy(() => require('./tapFormatter'))('tapFormatter'),
+	unix: importLazy(() => require('./unixFormatter'))('unixFormatter'),
+	verbose: importLazy(() => require('./verboseFormatter'))('verboseFormatter'),
 };

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,6 +1,5 @@
 declare module '@stylelint/postcss-css-in-js';
 declare module '@stylelint/postcss-markdown';
-declare module 'import-lazy';
 declare module 'postcss-html';
 declare module 'postcss-sass';
 declare module 'sugarss';


### PR DESCRIPTION
This change uses the built-in type definitions of the `import-lazy` package.

`importLazy()` accepts an argument as a module ID:
https://github.com/sindresorhus/import-lazy/blob/v4.0.0/index.js#L2-L3

If omitting a module ID, the following TS error occurs:

```console
$ npm run lint:types

> stylelint@13.12.0 lint:types
> tsc

lib/formatters/index.js:6:11 - error TS2554: Expected 1 arguments, but got 0.

6  compact: importLazy(() => require('./compactFormatter'))(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/import-lazy/index.d.ts:24:5
    24 ): (moduleId: string) => T;
           ~~~~~~~~~~~~~~~~
    An argument for 'moduleId' was not provided.


Found 1 error.
```

> Which issue, if any, is this issue related to?

See:
- https://github.com/stylelint/stylelint/issues/4399#issuecomment-803565238
- https://github.com/stylelint/stylelint/issues/4399#issuecomment-816834682

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
