### PR TITLE
Fix false positives for variables in font-family-no-missing-generic-family-keyword

### DIFF
--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -54,6 +54,16 @@ a { font: inherit; }
 a { font: caption; }
 ```
 
+<!-- prettier-ignore -->
+```css
+a { font-family: var(--font-family-common); }
+```
+
+<!-- prettier-ignore -->
+```css
+a { font-family: Helvetica, var(--font-family-common); }
+```
+
 ## Optional secondary options
 
 ### `ignoreFontFamilies: ["/regex/", /regex/, "string"]`

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
@@ -76,10 +76,22 @@ testRule({
 			code: 'a { font: @font-family; }',
 		},
 		{
+			code: 'a { font: "font", @font-family; }',
+		},
+		{
 			code: 'a { font: $font-family; }',
 		},
 		{
+			code: 'a { font: "font", $font-family; }',
+		},
+		{
 			code: 'a { font: namespace.$font-family; }',
+		},
+		{
+			code: 'a { font: "font", namespace.$font-family; }',
+		},
+		{
+			code: 'a { font-family: var(--font); }',
 		},
 		{
 			code: 'a { font-family: "font", var(--font); }',

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -4,6 +4,7 @@
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const findFontFamily = require('../../utils/findFontFamily');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const isVariable = require('../../utils/isVariable');
 const keywordSets = require('../../reference/keywordSets');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -22,6 +23,12 @@ const messages = ruleMessages(ruleName, {
 
 const isFamilyNameKeyword = (node) =>
 	!node.quote && keywordSets.fontFamilyKeywords.has(node.value.toLowerCase());
+
+const isLastFontFamilyVariable = (value) => {
+	const lastValue = postcss.list.comma(value).pop();
+
+	return isVariable(lastValue) || !isStandardSyntaxValue(lastValue);
+};
 
 function rule(actual, options) {
 	return (root, result) => {
@@ -56,6 +63,10 @@ function rule(actual, options) {
 				return;
 			}
 
+			if (isLastFontFamilyVariable(decl.value)) {
+				return;
+			}
+
 			const fontFamilies = findFontFamily(decl.value);
 
 			if (fontFamilies.length === 0) {
@@ -63,10 +74,6 @@ function rule(actual, options) {
 			}
 
 			if (fontFamilies.some(isFamilyNameKeyword)) {
-				return;
-			}
-
-			if (postcss.list.space(decl.value).some(isVariable)) {
 				return;
 			}
 


### PR DESCRIPTION
This change aims to ignore any variables (e.g. `var()`, `$var`, `@var` etc.) for the `font-family-no-missing-generic-family-keyword` rule.

> Which issue, if any, is this issue related to?

Fix #4765 (retry of #4806)

> Is there anything in the PR that needs further explanation?

This PR ignores **always** any variables for the `font-family` property, but perhaps some people might want to ignore **explicitly** via the `ignoreFontFamilies` secondary option as below:

```js
{
  "ignoreFontFamilies": [/\$fontFamily/]
}
```

Could you please give me feedback about this point?