### PR TITLE
Add autofix to selector-attribute-quotes

### DIFF
--- a/lib/rules/selector-attribute-quotes/README.md
+++ b/lib/rules/selector-attribute-quotes/README.md
@@ -9,6 +9,8 @@ Require or disallow quotes for attribute values.
  * These quotes */
 ```
 
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix most of the problems reported by this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -108,6 +108,27 @@ testRule({
 			line: 1,
 			column: 13,
 		},
+		{
+			code: `[href=te\\'s\\"t] { }`,
+			fixed: `[href="te's\\"t"] { }`,
+			message: messages.expected(`te's"t`),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: '[href=\\"test\\"] { }',
+			fixed: '[href="\\"test\\""] { }',
+			message: messages.expected('"test"'),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: "[href=\\'test\\'] { }",
+			fixed: `[href="'test'"] { }`,
+			message: messages.expected("'test'"),
+			line: 1,
+			column: 7,
+		},
 	],
 });
 
@@ -134,6 +155,15 @@ testRule({
 		},
 		{
 			code: `a[href=te\\'s\\"t] { }`,
+			description: 'attribute contains inner quotes',
+		},
+		{
+			code: '[href=\\"test\\"] { }',
+			description: 'escaped double-quotes are not considered as framing quotes',
+		},
+		{
+			code: "[href=\\'test\\'] { }",
+			description: 'escaped single-quotes are not considered as framing quotes',
 		},
 	],
 
@@ -200,6 +230,34 @@ testRule({
 			message: messages.rejected('value'),
 			line: 1,
 			column: 13,
+		},
+		{
+			code: `[href="te'st"] { }`,
+			fixed: "[href=te\\'st] { }",
+			message: messages.rejected("te'st"),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: `[href='te"st'] { }`,
+			fixed: '[href=te\\"st] { }',
+			message: messages.rejected('te"st'),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: "[href='te\\'s\\'t'] { }",
+			fixed: "[href=te\\'s\\'t] { }",
+			message: messages.rejected("te's't"),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: '[href="te\\"s\\"t"] { }',
+			fixed: '[href=te\\"s\\"t] { }',
+			message: messages.rejected('te"s"t'),
+			line: 1,
+			column: 7,
 		},
 	],
 });

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -6,6 +6,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
+	fix: true,
 
 	accept: [
 		{
@@ -54,41 +55,55 @@ testRule({
 			code: 'html { --custom-property-set: {} }',
 			description: 'custom property set in selector',
 		},
+		{
+			code: `a[href="te's't"] { }`,
+			description: 'double-quoted attribute contains single quote',
+		},
+		{
+			code: `a[href='te"s"t'] { }`,
+			description: 'single-quoted attribute contains double quote',
+		},
 	],
 
 	reject: [
 		{
 			code: 'a[title=flower] { }',
+			fixed: 'a[title="flower"] { }',
 			message: messages.expected('flower'),
 			line: 1,
 			column: 9,
 		},
 		{
 			code: 'a[ title=flower ] { }',
+			fixed: 'a[ title="flower" ] { }',
 			message: messages.expected('flower'),
 			line: 1,
 			column: 10,
 		},
 		{
 			code: '[class^=top] { }',
+			fixed: '[class^="top"] { }',
 			message: messages.expected('top'),
 			line: 1,
 			column: 9,
 		},
 		{
 			code: '[class ^= top] { }',
+			fixed: '[class ^= "top"] { }',
 			message: messages.expected('top'),
 			line: 1,
 			column: 11,
 		},
 		{
 			code: '[frame=hsides i] { }',
+			fixed: '[frame="hsides" i] { }',
 			message: messages.expected('hsides'),
 			line: 1,
 			column: 8,
 		},
 		{
 			code: '[data-style=value][data-loading] { }',
+			fixed: '[data-style="value"][data-loading] { }',
 			message: messages.expected('value'),
 			line: 1,
 			column: 13,
@@ -99,6 +114,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
+	fix: true,
 
 	accept: [
 		{
@@ -116,59 +132,71 @@ testRule({
 		{
 			code: '[data-style=value][data-loading] { }',
 		},
+		{
+			code: `a[href=te\\'s\\"t] { }`,
+		},
 	],
 
 	reject: [
 		{
 			code: 'a[target="_blank"] { }',
+			fixed: 'a[target=_blank] { }',
 			message: messages.rejected('_blank'),
 			line: 1,
 			column: 10,
 		},
 		{
 			code: 'a[ target="_blank" ] { }',
+			fixed: 'a[ target=_blank ] { }',
 			message: messages.rejected('_blank'),
 			line: 1,
 			column: 11,
 		},
 		{
 			code: '[class|="top"] { }',
+			fixed: '[class|=top] { }',
 			message: messages.rejected('top'),
 			line: 1,
 			column: 9,
 		},
 		{
 			code: '[class |= "top"] { }',
+			fixed: '[class |= top] { }',
 			message: messages.rejected('top'),
 			line: 1,
 			column: 11,
 		},
 		{
 			code: "[title~='text'] { }",
+			fixed: '[title~=text] { }',
 			message: messages.rejected('text'),
 			line: 1,
 			column: 9,
 		},
 		{
 			code: "[data-attribute='component'] { }",
+			fixed: '[data-attribute=component] { }',
 			message: messages.rejected('component'),
 			line: 1,
 			column: 17,
 		},
 		{
 			code: '[frame="hsides" i] { }',
+			fixed: '[frame=hsides i] { }',
 			message: messages.rejected('hsides'),
 			line: 1,
 			column: 8,
 		},
 		{
 			code: "[frame='hsides' i] { }",
+			fixed: '[frame=hsides i] { }',
 			message: messages.rejected('hsides'),
 			line: 1,
 			column: 8,
 		},
 		{
 			code: "[data-style='value'][data-loading] { }",
+			fixed: '[data-style=value][data-loading] { }',
 			message: messages.rejected('value'),
 			line: 1,
 			column: 13,

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -259,6 +259,13 @@ testRule({
 			line: 1,
 			column: 7,
 		},
+		{
+			code: 'a[target="_blank"], /* comment */ a { }',
+			fixed: 'a[target=_blank], /* comment */ a { }',
+			message: messages.rejected('_blank'),
+			line: 1,
+			column: 10,
+		},
 	],
 });
 

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -15,7 +15,9 @@ const messages = ruleMessages(ruleName, {
 	rejected: (value) => `Unexpected quotes around "${value}"`,
 });
 
-function rule(expectation) {
+const acceptedQuoteMark = '"';
+
+function rule(expectation, secondary, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: expectation,
@@ -36,25 +38,41 @@ function rule(expectation) {
 			}
 
 			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
+				let selectorFixed = false;
+
 				selectorTree.walkAttributes((attributeNode) => {
 					if (!attributeNode.operator) {
 						return;
 					}
 
 					if (!attributeNode.quoted && expectation === 'always') {
-						complain(
-							messages.expected(attributeNode.value),
-							attributeNode.sourceIndex + attributeNode.offsetOf('value'),
-						);
+						if (context.fix) {
+							selectorFixed = true;
+							attributeNode.quoteMark = acceptedQuoteMark;
+						} else {
+							complain(
+								messages.expected(attributeNode.value),
+								attributeNode.sourceIndex + attributeNode.offsetOf('value'),
+							);
+						}
 					}
 
 					if (attributeNode.quoted && expectation === 'never') {
-						complain(
-							messages.rejected(attributeNode.value),
-							attributeNode.sourceIndex + attributeNode.offsetOf('value'),
-						);
+						if (context.fix) {
+							selectorFixed = true;
+							attributeNode.quoteMark = null;
+						} else {
+							complain(
+								messages.rejected(attributeNode.value),
+								attributeNode.sourceIndex + attributeNode.offsetOf('value'),
+							);
+						}
 					}
 				});
+
+				if (selectorFixed) {
+					ruleNode.selector = selectorTree.toString();
+				}
 			});
 
 			function complain(message, index) {

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const getRuleSelector = require('../../utils/getRuleSelector');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
@@ -37,7 +38,7 @@ function rule(expectation, secondary, context) {
 				return;
 			}
 
-			parseSelector(ruleNode.selector, result, ruleNode, (selectorTree) => {
+			parseSelector(getRuleSelector(ruleNode), result, ruleNode, (selectorTree) => {
 				let selectorFixed = false;
 
 				selectorTree.walkAttributes((attributeNode) => {

--- a/lib/utils/getRuleSelector.js
+++ b/lib/utils/getRuleSelector.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const _ = require('lodash');
+
+/**
+ * @param {import('postcss').Rule} ruleNode
+ * @returns {string}
+ */
+function getRuleSelector(ruleNode) {
+	return _.get(ruleNode, 'raws.selector.raw', ruleNode.selector);
+}
+
+module.exports = getRuleSelector;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Have added autofix to `selector-attribute-quotes` rule as dicussed in issue [#5211](https://github.com/stylelint/stylelint/issues/5211) 

> Is there anything in the PR that needs further explanation?

Some of the unit tests can be a bit confusing. They cover pretty unusual but valid selectors:
```css
[href=te\'s\"t] { }
[href=\"test\"] { }
[href=\'test\'] { }
[href="te'st"] { }
[href='te"st'] { }
[href='te\'st'] { }
[href="te\"st"] { }
```