### PR TITLE
Ignore length-zero-no-unit violations found within var() functions if custom properties are ignored

### DIFF
--- a/lib/rules/length-zero-no-unit/README.md
+++ b/lib/rules/length-zero-no-unit/README.md
@@ -61,9 +61,14 @@ a { top: 1.001vh }
 
 Ignore units for zero length in custom properties.
 
-The following pattern is _not_ considered a violation:
+The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
 a { --x: 0px; }
+```
+
+<!-- prettier-ignore -->
+```css
+div { width: calc(var(--x, 0px) + 10px); }
 ```

--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -607,6 +607,14 @@ testRule({
 			code: 'a { --x: 0px; }',
 			description: 'custom properties',
 		},
+		{
+			code: 'div { width: var(--x, 0px); }',
+			description: 'var function',
+		},
+		{
+			code: 'div { width: calc(var(--x, 0px) + 10px); }',
+			description: 'nested var function',
+		},
 	],
 });
 

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -151,6 +151,36 @@ function rule(actual, secondary, context) {
 					return;
 				}
 
+				// Ignore matches found within var() functions if custom properties are ignored
+				if (optionsMatches(secondary, 'ignore', 'custom-properties')) {
+					const valueWithZeroStartWithinValue =
+						valueWithZeroStart - node.prop.length - node.raws.between.length;
+					const parsedDeclaration = valueParser(node.value);
+					let foundWithinVarFunction = false;
+
+					parsedDeclaration.walk((declarationNode) => {
+						if (declarationNode.type !== 'function' && declarationNode.value !== 'var') {
+							return;
+						}
+
+						if (
+							declarationNode.nodes.find(
+								(paramNode) =>
+									paramNode.sourceIndex >= valueWithZeroStartWithinValue ||
+									valueWithZeroStartWithinValue < paramNode.sourceIndex + paramNode.value.length,
+							)
+						) {
+							foundWithinVarFunction = true;
+
+							return false;
+						}
+					});
+
+					if (foundWithinVarFunction) {
+						return;
+					}
+				}
+
 				if (context.fix) {
 					fixPositions.unshift({
 						startIndex: valueWithZeroStart,


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Related to https://github.com/stylelint/stylelint/issues/4945, but limited to the var() function for now

> Is there anything in the PR that needs further explanation?

Should be self-explanatory. More than happy to answer questions if there are any
