### PR TITLE
Fix false positives for dollar variables in no-invalid-position-at-import-rule

### DIFF
--- a/lib/rules/no-invalid-position-at-import-rule/__tests__/index.js
+++ b/lib/rules/no-invalid-position-at-import-rule/__tests__/index.js
@@ -111,3 +111,40 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: [true],
+	syntax: 'scss',
+
+	accept: [
+		{
+			code: stripIndent`
+				$foo: 1;
+				@import 'bar.css';
+			`,
+			description: 'dollar variable',
+		},
+		{
+			code: stripIndent`
+				// comment
+				@import 'foo.css';
+			`,
+			description: 'double slash comment',
+		},
+	],
+
+	reject: [
+		{
+			code: stripIndent`
+				a {}
+				$foo: 0;
+				@import 'bar.css';
+			`,
+			message: messages.rejected,
+			description: '@import after selector with dollar variable',
+			line: 3,
+			column: 1,
+		},
+	],
+});

--- a/lib/rules/no-invalid-position-at-import-rule/index.js
+++ b/lib/rules/no-invalid-position-at-import-rule/index.js
@@ -2,6 +2,8 @@
 
 'use strict';
 
+const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
+const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -25,7 +27,15 @@ function rule(actual) {
 		root.walk((node) => {
 			const nodeName = node.name && node.name.toLowerCase();
 
-			if (node.type === 'comment' || (node.type === 'atrule' && nodeName === 'charset')) {
+			if (
+				(node.type === 'atrule' &&
+					nodeName !== 'charset' &&
+					nodeName !== 'import' &&
+					isStandardSyntaxAtRule(node)) ||
+				(node.type === 'rule' && isStandardSyntaxRule(node))
+			) {
+				invalidPosition = true;
+
 				return;
 			}
 
@@ -38,11 +48,7 @@ function rule(actual) {
 						ruleName,
 					});
 				}
-
-				return;
 			}
-
-			invalidPosition = true;
 		});
 	};
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5263

> Is there anything in the PR that needs further explanation?

Switches the logic around so that the `invalidPosition` flag is set when a standard syntax rule or at-rule (that isn't `charset` or another `import`) is encountered.

It maps neatly onto [the spec](https://drafts.csswg.org/css-cascade/#at-import):

> Any `@import` rules must precede all other valid at-rules and style rules in a style sheet (ignoring `@charset`), or else the `@import` rule is invalid.


