### PR TITLE
Refactor cli.test.js

### DIFF
--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -8,7 +8,7 @@ const cli = require('../cli');
 const pkg = require('../../package.json');
 const replaceBackslashes = require('../testUtils/replaceBackslashes');
 
-const fixturesPath = replaceBackslashes(path.join(__dirname, 'fixtures'));
+const fixturesPath = (...elems) => replaceBackslashes(path.join(__dirname, 'fixtures', ...elems));
 const { buildCLI } = cli;
 
 jest.mock('get-stdin');
@@ -203,8 +203,8 @@ describe('CLI', () => {
 		await cli([
 			'--print-config',
 			'--config',
-			`${fixturesPath}/config-color-no-invalid-hex.json`,
-			`${fixturesPath}/invalid-hex.css`,
+			fixturesPath('config-color-no-invalid-hex.json'),
+			fixturesPath('invalid-hex.css'),
 		]);
 
 		expect(process.exitCode).toBeUndefined();
@@ -227,8 +227,8 @@ describe('CLI', () => {
 		await cli([
 			'--report-needless-disables',
 			'--config',
-			replaceBackslashes(path.join(fixturesPath, 'config-block-no-empty.json')),
-			replaceBackslashes(path.join(fixturesPath, 'empty-block-with-disables.css')),
+			fixturesPath('config-block-no-empty.json'),
+			fixturesPath('empty-block-with-disables.css'),
 		]);
 
 		expect(process.exitCode).toBe(2);
@@ -242,8 +242,8 @@ describe('CLI', () => {
 	it('reports disallowed disables', async () => {
 		await cli([
 			'--config',
-			replaceBackslashes(path.join(fixturesPath, 'config-block-no-empty-report-disables.json')),
-			replaceBackslashes(path.join(fixturesPath, 'empty-block-with-relevant-disable.css')),
+			fixturesPath('config-block-no-empty-report-disables.json'),
+			fixturesPath('empty-block-with-relevant-disable.css'),
 		]);
 
 		expect(process.exitCode).toBe(2);
@@ -258,8 +258,8 @@ describe('CLI', () => {
 		await cli([
 			'--report-descriptionless-disables',
 			'--config',
-			replaceBackslashes(path.join(fixturesPath, 'config-block-no-empty.json')),
-			replaceBackslashes(path.join(fixturesPath, 'empty-block-with-relevant-disable.css')),
+			fixturesPath('config-block-no-empty.json'),
+			fixturesPath('empty-block-with-relevant-disable.css'),
 		]);
 
 		expect(process.exitCode).toBe(2);
@@ -271,7 +271,7 @@ describe('CLI', () => {
 	});
 
 	it('--stdin', async () => {
-		await cli(['--stdin', '--config', `${fixturesPath}/config-no-empty-source.json`]);
+		await cli(['--stdin', '--config', fixturesPath('config-no-empty-source.json')]);
 
 		expect(process.exitCode).toBe(2);
 
@@ -285,8 +285,8 @@ describe('CLI', () => {
 	it('exits with non zero on unfound module in config', async () => {
 		await cli([
 			'--config',
-			replaceBackslashes(path.join(fixturesPath, 'config-require-unknown.js')),
-			replaceBackslashes(path.join(fixturesPath, 'empty-block-with-disables.css')),
+			fixturesPath('config-require-unknown.js'),
+			fixturesPath('empty-block-with-disables.css'),
 		]);
 
 		expect(process.exitCode).toEqual(1);


### PR DESCRIPTION
This refactoring aims to make the code more readable by reducing duplication.

E.g.

```diff
-replaceBackslashes(path.join(fixturesPath, 'config-block-no-empty.json')),
+fixturesPath('config-block-no-empty.json'),
```

> Which issue, if any, is this issue related to?

Preparation for #5265

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
