### PR TITLE
Fix invalid json for max warnings option

### DIFF
--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -303,8 +303,8 @@ describe('CLI', () => {
 			'--formatter=json',
 			'--max-warnings=0',
 			'--config',
-			replaceBackslashes(path.join(fixturesPath, 'default-severity-warning.json')),
-			replaceBackslashes(path.join(fixturesPath, 'empty-block.css')),
+			fixturesPath('default-severity-warning.json'),
+			fixturesPath('empty-block.css'),
 		]);
 
 		expect(process.exitCode).toEqual(2);

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const path = require('path');
+const stripAnsi = require('strip-ansi');
 
 const cli = require('../cli');
 const pkg = require('../../package.json');
@@ -294,6 +295,29 @@ describe('CLI', () => {
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringContaining('Cannot find module'),
+		);
+	});
+
+	it('outputs a valid JSON even if max warnings exceeded', async () => {
+		await cli([
+			'--formatter=json',
+			'--max-warnings=0',
+			'--config',
+			replaceBackslashes(path.join(fixturesPath, 'default-severity-warning.json')),
+			replaceBackslashes(path.join(fixturesPath, 'empty-block.css')),
+		]);
+
+		expect(process.exitCode).toEqual(2);
+
+		expect(process.stdout.write).toHaveBeenCalledTimes(1);
+		const output = JSON.parse(process.stdout.write.mock.calls[0][0]);
+
+		expect(output).toBeInstanceOf(Array);
+		expect(output[0]).toHaveProperty('source', expect.stringContaining('empty-block.css'));
+
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(stripAnsi(process.stderr.write.mock.calls[0][0])).toContain(
+			'Max warnings exceeded: 1 found. 0 allowed',
 		);
 	});
 });

--- a/lib/__tests__/fixtures/default-severity-warning.json
+++ b/lib/__tests__/fixtures/default-severity-warning.json
@@ -1,0 +1,6 @@
+{
+	"defaultSeverity": "warning",
+	"rules": {
+		"block-no-empty": true
+	}
+}

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -509,8 +509,8 @@ module.exports = (argv) => {
 					} else if (maxWarnings !== undefined && linted.maxWarningsExceeded) {
 						const foundWarnings = linted.maxWarningsExceeded.foundWarnings;
 
-						process.stdout.write(
-							`${chalk.red(`Max warnings exceeded: `)}${foundWarnings} found. ${chalk.dim(
+						process.stderr.write(
+							`${EOL}${chalk.red(`Max warnings exceeded: `)}${foundWarnings} found. ${chalk.dim(
 								`${maxWarnings} allowed${EOL}${EOL}`,
 							)}`,
 						);


### PR DESCRIPTION
I think stylelint should output any error or warning messages to STDERR instead of STDOUT.
Because users should expect that *piping* is available.

For example, here is an example of using the `jq` command:

```console
$ stylelint --formatter=json --max-warnings=0 a.css | jq .

Max warnings exceeded: 1 found. 0 allowed

[
  {
    "source": "/tmp/a.css",
    "deprecations": [],
    "invalidOptionWarnings": [],
    "parseErrors": [],
    "errored": false,
    "warnings": [
      {
        "line": 1,
        "column": 2,
        "rule": "block-no-empty",
        "severity": "warning",
        "text": "Unexpected empty block (block-no-empty)"
      }
    ]
  }
]
```

> Which issue, if any, is this issue related to?

Fix #5265 

> Is there anything in the PR that needs further explanation?

In addition, I have inserted `EOL` at the beginning of the warning message so that users can easily read the entire output.
But this change may be out of the scope of this PR. I want feedback, if any.
(I can revert the insertion if anyone opposites it.)

Before:

```console
$ stylelint -f json --max-warnings=0 a.css
[{"source":"/Users/masafumi.koba/git/stylelint/stylelint/a.css","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":false,"warnings":[{"line":1,"column":2,"rule":"block-no-empty","severity":"warning","text":"Unexpected empty block (block-no-empty)"}]}]Max warnings exceeded: 1 found. 0 allowed
```

After:

```console
$ stylelint -f json --max-warnings=0 a.css
[{"source":"/Users/masafumi.koba/git/stylelint/stylelint/a.css","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":false,"warnings":[{"line":1,"column":2,"rule":"block-no-empty","severity":"warning","text":"Unexpected empty block (block-no-empty)"}]}]
Max warnings exceeded: 1 found. 0 allowed
```

---

Note: I will merge the change of #5266 into this PR if approved.