### PR TITLE
Add test against Node.js 16

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14]
+        node: [10, 12, 14, 16]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
           - os: ubuntu-latest


### PR DESCRIPTION
Node.js 16 has been recently released. See also:

- https://medium.com/the-node-js-collection/node-js-16-available-now-7f5099a97e70
- https://nodejs.org/en/blog/release/v16.0.0
- https://github.com/nodejs/Release#release-schedule

According to the release schedule, Node.js 16 will be LTS on **2021-10-26**.

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
