### PR TITLE
Refactor `lib/__tests__/standalone-fix.test.js`

### DIFF
--- a/lib/__tests__/standalone-fix.test.js
+++ b/lib/__tests__/standalone-fix.test.js
@@ -1,19 +1,18 @@
 'use strict';
 
 const _ = require('lodash');
-const del = require('del');
 const os = require('os');
 const path = require('path');
 const stripIndent = require('common-tags').stripIndent;
-const { promises: fs } = require('fs'); // eslint-disable-line node/no-unsupported-features/node-builtins
+const { existsSync, promises: fs } = require('fs'); // eslint-disable-line node/no-unsupported-features/node-builtins
 
 const replaceBackslashes = require('../testUtils/replaceBackslashes');
 const standalone = require('../standalone');
 
-const fixturesPath = replaceBackslashes(path.join(__dirname, 'fixtures'));
+const fixturesPath = (...elems) => replaceBackslashes(path.join(__dirname, 'fixtures', ...elems));
 
-it('outputs fixed code when input is code string', () => {
-	return standalone({
+it('outputs fixed code when input is code string', async () => {
+	const result = await standalone({
 		code: '  a { color: red; }',
 		config: {
 			rules: {
@@ -21,15 +20,15 @@ it('outputs fixed code when input is code string', () => {
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe('a { color: red; }');
 	});
+
+	expect(result.output).toBe('a { color: red; }');
 });
 
-it('does not modify shorthand object syntax when autofixing', () => {
+it('does not modify shorthand object syntax when autofixing', async () => {
 	const codeString = `const width = '100px'; const x = <div style={{width}}>Hi</div>`;
 
-	return standalone({
+	const result = await standalone({
 		code: codeString,
 		syntax: 'css-in-js',
 		config: {
@@ -38,13 +37,13 @@ it('does not modify shorthand object syntax when autofixing', () => {
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe(codeString);
 	});
+
+	expect(result.output).toBe(codeString);
 });
 
-it('apply indentation autofix at last', () => {
-	return standalone({
+it('apply indentation autofix at last', async () => {
+	const result = await standalone({
 		code:
 			'a {\nbox-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);\n}',
 		config: {
@@ -54,22 +53,21 @@ it('apply indentation autofix at last', () => {
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe(
-			'a {\n  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1),\n    0 0 0 1px rgba(0, 0, 0, 0.2),\n    inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);\n}',
-		);
 	});
+
+	expect(result.output).toBe(
+		'a {\n  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1),\n    0 0 0 1px rgba(0, 0, 0, 0.2),\n    inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);\n}',
+	);
 });
 
-it("doesn't fix with stylelint-disable commands", () => {
+it("doesn't fix with stylelint-disable commands", async () => {
 	const code = `
-	/* stylelint-disable */
-	a {
-		color: red;
-	}
-	`;
+		/* stylelint-disable */
+		a {
+			color: red;
+		}`;
 
-	return standalone({
+	const result = await standalone({
 		code,
 		config: {
 			rules: {
@@ -77,20 +75,19 @@ it("doesn't fix with stylelint-disable commands", () => {
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe(code);
 	});
+
+	expect(result.output).toBe(code);
 });
 
-it("doesn't fix with scoped stylelint-disable commands", () => {
+it("doesn't fix with scoped stylelint-disable commands", async () => {
 	const code = `
-	/* stylelint-disable indentation */
-	a {
-		color: red;
-	}
-	`;
+		/* stylelint-disable indentation */
+		a {
+			color: red;
+		}`;
 
-	return standalone({
+	const result = await standalone({
 		code,
 		config: {
 			rules: {
@@ -98,20 +95,19 @@ it("doesn't fix with scoped stylelint-disable commands", () => {
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe(code);
 	});
+
+	expect(result.output).toBe(code);
 });
 
-it("doesn't fix with multiple scoped stylelint-disable commands", () => {
+it("doesn't fix with multiple scoped stylelint-disable commands", async () => {
 	const code = `
-	/* stylelint-disable indentation, color-hex-length */
-	a {
-		color: #ffffff;
-	}
-	`;
+		/* stylelint-disable indentation, color-hex-length */
+		a {
+			color: #ffffff;
+		}`;
 
-	return standalone({
+	const result = await standalone({
 		code,
 		config: {
 			rules: {
@@ -120,19 +116,18 @@ it("doesn't fix with multiple scoped stylelint-disable commands", () => {
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe(code);
 	});
+
+	expect(result.output).toBe(code);
 });
 
-it("the color-hex-length rule doesn't fix with scoped stylelint-disable commands", () => {
-	return standalone({
+it("the color-hex-length rule doesn't fix with scoped stylelint-disable commands", async () => {
+	const result = await standalone({
 		code: stripIndent`
-				/* stylelint-disable color-hex-length */
-				a {
+			/* stylelint-disable color-hex-length */
+			a {
 				color: #ffffff;
-				}
-				`,
+			}`,
 		config: {
 			rules: {
 				indentation: 2,
@@ -140,24 +135,22 @@ it("the color-hex-length rule doesn't fix with scoped stylelint-disable commands
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe(stripIndent`
-				/* stylelint-disable color-hex-length */
-				a {
-				  color: #ffffff;
-				}
-				`);
 	});
+
+	expect(result.output).toBe(stripIndent`
+		/* stylelint-disable color-hex-length */
+		a {
+		  color: #ffffff;
+		}`);
 });
 
-it("the indentation rule doesn't fix with scoped stylelint-disable commands", () => {
-	return standalone({
+it("the indentation rule doesn't fix with scoped stylelint-disable commands", async () => {
+	const result = await standalone({
 		code: stripIndent`
-				/* stylelint-disable indentation */
-				a {
+			/* stylelint-disable indentation */
+			a {
 				color: #ffffff;
-				}
-				`,
+			}`,
 		config: {
 			rules: {
 				indentation: 2,
@@ -165,33 +158,34 @@ it("the indentation rule doesn't fix with scoped stylelint-disable commands", ()
 			},
 		},
 		fix: true,
-	}).then((result) => {
-		expect(result.output).toBe(stripIndent`
-				/* stylelint-disable indentation */
-				a {
-				color: #fff;
-				}
-				`);
 	});
+
+	expect(result.output).toBe(stripIndent`
+		/* stylelint-disable indentation */
+		a {
+			color: #fff;
+		}`);
 });
 
 describe('writing fixes to files', () => {
 	let tmpDir;
 	let tempFile;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		tmpDir = os.tmpdir();
 		tempFile = replaceBackslashes(path.join(tmpDir, `stylesheet-${_.uniqueId()}.css`));
 
-		return fs.copyFile(`${fixturesPath}/fix.css`, tempFile);
+		await fs.copyFile(fixturesPath('fix.css'), tempFile);
 	});
 
-	afterEach(() => {
-		return del(tempFile, { force: true });
+	afterEach(async () => {
+		if (existsSync(tempFile)) {
+			await fs.unlink(tempFile);
+		}
 	});
 
-	it('overwrites the original file', () => {
-		return standalone({
+	it('overwrites the original file', async () => {
+		const output = await standalone({
 			files: [tempFile],
 			config: {
 				rules: {
@@ -201,17 +195,17 @@ describe('writing fixes to files', () => {
 				},
 			},
 			fix: true,
-		}).then((output) => {
-			const result = output.results[0]._postcssResult;
-
-			return fs.readFile(tempFile, 'utf8').then((fileContent) => {
-				expect(fileContent).toBe(result.root.toString(result.opts.syntax));
-			});
 		});
+
+		const result = output.results[0]._postcssResult;
+
+		const fileContent = await fs.readFile(tempFile, 'utf8');
+
+		expect(fileContent).toBe(result.root.toString(result.opts.syntax));
 	});
 
-	it("doesn't write to ignored file", () => {
-		return standalone({
+	it("doesn't write to ignored file", async () => {
+		await standalone({
 			files: [tempFile],
 			config: {
 				ignoreFiles: tempFile,
@@ -222,18 +216,17 @@ describe('writing fixes to files', () => {
 				},
 			},
 			fix: true,
-		}).then(() => {
-			return fs.readFile(tempFile, 'utf8').then((newFile) => {
-				return fs.readFile(`${fixturesPath}/fix.css`, 'utf8').then((oldFile) => {
-					expect(newFile).toBe(oldFile);
-				});
-			});
 		});
+
+		const newFile = await fs.readFile(tempFile, 'utf8');
+		const oldFile = await fs.readFile(fixturesPath('fix.css'), 'utf8');
+
+		expect(newFile).toBe(oldFile);
 	});
 
 	// eslint-disable-next-line jest/no-disabled-tests
-	it.skip("doesn't strip BOM", () => {
-		return standalone({
+	it.skip("doesn't strip BOM", async () => {
+		await standalone({
 			files: [tempFile],
 			config: {
 				rules: {
@@ -243,10 +236,10 @@ describe('writing fixes to files', () => {
 				},
 			},
 			fix: true,
-		}).then(() => {
-			return fs.readFile(tempFile, 'utf8').then((fileContent) => {
-				expect(fileContent.startsWith('\uFEFF')).toBe(true);
-			});
 		});
+
+		const fileContent = await fs.readFile(tempFile, 'utf8');
+
+		expect(fileContent.startsWith('\uFEFF')).toBe(true);
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "@types/write-file-atomic": "^3.0.1",
         "benchmark": "^2.1.4",
         "common-tags": "^1.8.0",
-        "del": "^6.0.0",
         "eslint": "^7.25.0",
         "eslint-config-stylelint": "^13.1.0",
         "got": "^11.8.2",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "@types/write-file-atomic": "^3.0.1",
     "benchmark": "^2.1.4",
     "common-tags": "^1.8.0",
-    "del": "^6.0.0",
     "eslint": "^7.25.0",
     "eslint-config-stylelint": "^13.1.0",
     "got": "^11.8.2",


### PR DESCRIPTION
- Remove the `del` package that will be needless.
- Use async/await syntax for readability. (#4881)
- Fix CSS code indent for consistency.

> Which issue, if any, is this issue related to?

A part of #4881

> Is there anything in the PR that needs further explanation?

`del` is still in `package-lock.json` as a sub-dependency of `np`:

```console
$ npm ls del
stylelint@13.13.0 /Users/masafumi.koba/git/stylelint/stylelint
└─┬ np@7.4.0
  └── del@6.0.0
```
