### PR TITLE
Refactor `lib/__tests__/extends.test.js`

### DIFF
--- a/lib/__tests__/extends.test.js
+++ b/lib/__tests__/extends.test.js
@@ -8,65 +8,61 @@ const standalone = require('../standalone');
 
 const fixturesPath = path.join(__dirname, 'fixtures');
 
-it('basic extending', () => {
-	return standalone({
+it('basic extending', async () => {
+	const linted = await standalone({
 		code: 'a {}',
 		config: configExtendingOne,
 		configBasedir: path.join(__dirname, 'fixtures'),
-	}).then((linted) => {
-		expect(typeof linted.output).toBe('string');
-		expect(linted.results).toHaveLength(1);
-		expect(linted.results[0].warnings).toHaveLength(1);
-		expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
 	});
+
+	expect(typeof linted.output).toBe('string');
+	expect(linted.results).toHaveLength(1);
+	expect(linted.results[0].warnings).toHaveLength(1);
+	expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
 });
 
-it('recursive extending', () => {
-	return standalone({
+it('recursive extending', async () => {
+	const linted = await standalone({
 		code: 'a {}',
 		config: configExtendingAnotherExtend,
 		configBasedir: path.join(__dirname, 'fixtures'),
-	}).then((linted) => {
-		expect(typeof linted.output).toBe('string');
-		expect(linted.results).toHaveLength(1);
-		expect(linted.results[0].warnings).toHaveLength(1);
-		expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
 	});
+
+	expect(typeof linted.output).toBe('string');
+	expect(linted.results).toHaveLength(1);
+	expect(linted.results[0].warnings).toHaveLength(1);
+	expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
 });
 
-it('extending with overrides', () => {
-	return standalone({
+it('extending with overrides', async () => {
+	const linted = await standalone({
 		code: 'a {}',
 		config: configExtendingThreeWithOverride,
 		configBasedir: path.join(__dirname, 'fixtures'),
-	}).then((linted) => {
-		expect(linted.results[0].warnings).toHaveLength(0);
 	});
+
+	expect(linted.results[0].warnings).toHaveLength(0);
 });
 
 it('extending configuration and no configBasedir', () => {
-	return standalone({
-		code: 'a {}',
-		config: configExtendingOne,
-	})
-		.then(() => {
-			throw new Error('should have failed');
-		})
-		.catch((err) => {
-			expect(err.code).toBe(78);
-		});
+	return expect(
+		standalone({
+			code: 'a {}',
+			config: configExtendingOne,
+		}),
+	).rejects.toHaveProperty('code', 78);
 });
 
-it('extending a config that is overridden', () => {
-	return standalone({
+it('extending a config that is overridden', async () => {
+	const linted = await standalone({
 		code: 'a { b: "c" }',
 		config: {
 			extends: [`${fixturesPath}/config-string-quotes-single`],
 			rules: { 'string-quotes': 'double' },
 		},
-	}).then((linted) => {
-		expect(linted.results[0].warnings).toHaveLength(0);
 	});
+
+	expect(linted.results[0].warnings).toHaveLength(0);
 });
 
 describe('extending a config from process.cwd', () => {
@@ -81,14 +77,14 @@ describe('extending a config from process.cwd', () => {
 		process.chdir(actualCwd);
 	});
 
-	it('works', () => {
-		return standalone({
+	it('works', async () => {
+		const linted = await standalone({
 			code: 'a { b: "c" }',
 			config: {
 				extends: ['./fixtures/config-string-quotes-single'],
 			},
-		}).then((linted) => {
-			expect(linted.results[0].warnings).toHaveLength(1);
 		});
+
+		expect(linted.results[0].warnings).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
This change aims to improve the test code readability via async/await syntax or Jest's matchers.
(avoiding callbacks as possible)

See also <https://jestjs.io/docs/asynchronous>

> Which issue, if any, is this issue related to?

A part of #4881

> Is there anything in the PR that needs further explanation?

I think it easier to view the diff if using ["Hide whitespace changes"](https://github.com/stylelint/stylelint/pull/5280/files?w=1).
