### PR TITLE
Refactor `lib/__tests__/ignore.test.js`

### DIFF
--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -1,286 +1,279 @@
 'use strict';
 
-const NoFilesFoundError = require('../utils/noFilesFoundError');
 const path = require('path');
+
+const NoFilesFoundError = require('../utils/noFilesFoundError');
 const replaceBackslashes = require('../testUtils/replaceBackslashes');
 const standalone = require('../standalone');
 
-const fixturesPath = replaceBackslashes(path.join(__dirname, 'fixtures'));
+const fixtures = (...elem) => replaceBackslashes(path.join(__dirname, 'fixtures', ...elem));
 
-test('extending config and ignoreFiles glob ignoring single glob', () => {
-	return standalone({
-		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+test('extending config and ignoreFiles glob ignoring single glob', async () => {
+	const { results } = await standalone({
+		files: [fixtures('empty-block.css'), fixtures('invalid-hex.css')],
 		config: {
 			ignoreFiles: '**/invalid-hex.css',
 			extends: ['./config-block-no-empty', './config-color-no-invalid-hex'],
 		},
-		configBasedir: path.join(__dirname, 'fixtures'),
-	}).then(({ results }) => {
-		// two files found
-		expect(results).toHaveLength(2);
-
-		// empty-block.css found
-		expect(results[0].source).toContain('empty-block.css');
-
-		// empty-block.css linted
-		expect(results[0].warnings).toHaveLength(1);
-
-		// invalid-hex.css found
-		expect(results[1].source).toContain('invalid-hex.css');
-
-		// invalid-hex.css not linted
-		expect(results[1].warnings).toHaveLength(0);
-
-		// invalid-hex.css marked as ignored
-		expect(results[1].ignored).toBeTruthy();
+		configBasedir: fixtures(),
 	});
+
+	// two files found
+	expect(results).toHaveLength(2);
+
+	// empty-block.css found
+	expect(results[0].source).toContain('empty-block.css');
+
+	// empty-block.css linted
+	expect(results[0].warnings).toHaveLength(1);
+
+	// invalid-hex.css found
+	expect(results[1].source).toContain('invalid-hex.css');
+
+	// invalid-hex.css not linted
+	expect(results[1].warnings).toHaveLength(0);
+
+	// invalid-hex.css marked as ignored
+	expect(results[1].ignored).toBeTruthy();
 });
 
-test('same as above with no configBasedir, ignore-files path relative to process.cwd', () => {
+test('same as above with no configBasedir, ignore-files path relative to process.cwd', async () => {
 	const actualCwd = process.cwd();
 
 	process.chdir(__dirname);
 
-	return standalone({
-		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+	const { results } = await standalone({
+		files: [fixtures('empty-block.css'), fixtures('invalid-hex.css')],
 		config: {
 			ignoreFiles: 'fixtures/invalid-hex.css',
-			extends: [
-				`${fixturesPath}/config-block-no-empty.json`,
-				`${fixturesPath}/config-color-no-invalid-hex`,
-			],
+			extends: [fixtures('config-block-no-empty.json'), fixtures('config-color-no-invalid-hex')],
 		},
-	}).then(({ results }) => {
-		// two files found
-		expect(results).toHaveLength(2);
-
-		// empty-block.css found
-		expect(results[0].source).toContain('empty-block.css');
-
-		// empty-block.css linted
-		expect(results[0].warnings).toHaveLength(1);
-
-		// invalid-hex.css found
-		expect(results[1].source).toContain('invalid-hex.css');
-
-		// invalid-hex.css not linted
-		expect(results[1].warnings).toHaveLength(0);
-
-		// invalid-hex.css marked as ignored
-		expect(results[1].ignored).toBeTruthy();
-
-		process.chdir(actualCwd);
 	});
+
+	// two files found
+	expect(results).toHaveLength(2);
+
+	// empty-block.css found
+	expect(results[0].source).toContain('empty-block.css');
+
+	// empty-block.css linted
+	expect(results[0].warnings).toHaveLength(1);
+
+	// invalid-hex.css found
+	expect(results[1].source).toContain('invalid-hex.css');
+
+	// invalid-hex.css not linted
+	expect(results[1].warnings).toHaveLength(0);
+
+	// invalid-hex.css marked as ignored
+	expect(results[1].ignored).toBeTruthy();
+
+	process.chdir(actualCwd);
 });
 
-test('absolute ignoreFiles glob path', () => {
-	return standalone({
-		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+test('absolute ignoreFiles glob path', async () => {
+	const { results } = await standalone({
+		files: [fixtures('empty-block.css'), fixtures('invalid-hex.css')],
 		config: {
-			ignoreFiles: [`${fixturesPath}/empty-b*.css`],
+			ignoreFiles: [fixtures('empty-b*.css')],
 			rules: {
 				'block-no-empty': true,
 			},
 		},
-		configBasedir: path.join(__dirname, 'fixtures'),
-	}).then(({ results }) => {
-		// two files found
-		expect(results).toHaveLength(2);
-
-		// first not linted
-		expect(results[0].warnings).toHaveLength(0);
-
-		// first marked as ignored
-		expect(results[0].ignored).toBeTruthy();
-
-		// second has no warnings
-		expect(results[1].warnings).toHaveLength(0);
-
-		// second not marked as ignored
-		expect(results[1].ignored).toBeFalsy();
+		configBasedir: fixtures(),
 	});
+
+	// two files found
+	expect(results).toHaveLength(2);
+
+	// first not linted
+	expect(results[0].warnings).toHaveLength(0);
+
+	// first marked as ignored
+	expect(results[0].ignored).toBeTruthy();
+
+	// second has no warnings
+	expect(results[1].warnings).toHaveLength(0);
+
+	// second not marked as ignored
+	expect(results[1].ignored).toBeFalsy();
 });
 
-test('extending config with ignoreFiles glob ignoring one by negation', () => {
-	return standalone({
-		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+test('extending config with ignoreFiles glob ignoring one by negation', async () => {
+	const { results } = await standalone({
+		files: [fixtures('empty-block.css'), fixtures('invalid-hex.css')],
 		config: {
 			ignoreFiles: ['**/*.css', '!**/invalid-hex.css'],
-			extends: [
-				`${fixturesPath}/config-block-no-empty`,
-				`${fixturesPath}/config-color-no-invalid-hex`,
-			],
+			extends: [fixtures('config-block-no-empty'), fixtures('config-color-no-invalid-hex')],
 		},
-		configBasedir: path.join(__dirname, 'fixtures'),
-	}).then(({ results }) => {
-		// two files found
-		expect(results).toHaveLength(2);
-
-		// empty-block.css found
-		expect(results[0].source).toContain('empty-block.css');
-
-		// empty-block.css has no warnings
-		expect(results[0].warnings).toHaveLength(0);
-
-		// empty-block.css was ignored
-		expect(results[0].ignored).toBeTruthy();
-
-		// invalid-hex.css found
-		expect(results[1].source).toContain('invalid-hex.css');
-
-		// invalid-hex.css has warnings
-		expect(results[1].warnings).toHaveLength(1);
-
-		// invalid-hex.css was not ignored
-		expect(results[1].ignored).toBeFalsy();
+		configBasedir: fixtures(),
 	});
+
+	// two files found
+	expect(results).toHaveLength(2);
+
+	// empty-block.css found
+	expect(results[0].source).toContain('empty-block.css');
+
+	// empty-block.css has no warnings
+	expect(results[0].warnings).toHaveLength(0);
+
+	// empty-block.css was ignored
+	expect(results[0].ignored).toBeTruthy();
+
+	// invalid-hex.css found
+	expect(results[1].source).toContain('invalid-hex.css');
+
+	// invalid-hex.css has warnings
+	expect(results[1].warnings).toHaveLength(1);
+
+	// invalid-hex.css was not ignored
+	expect(results[1].ignored).toBeFalsy();
 });
 
-test('specified `ignorePath` file ignoring one file', () => {
-	const files = [`${fixturesPath}/empty-block.css`];
+test('specified `ignorePath` file ignoring one file', async () => {
+	const files = [fixtures('empty-block.css')];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
 	const actualCwd = process.cwd();
 
 	process.chdir(__dirname);
 
-	return standalone({
-		files,
-		config: {
-			rules: {
-				'block-no-empty': true,
+	await expect(
+		standalone({
+			files,
+			config: {
+				rules: {
+					'block-no-empty': true,
+				},
 			},
-		},
-		ignorePath: path.join(__dirname, 'fixtures/ignore.txt'),
-	}).catch((actualError) => {
-		// no files read
-		expect(actualError).toEqual(noFilesErrorMessage);
+			ignorePath: fixtures('ignore.txt'),
+		}),
+	).rejects.toThrow(noFilesErrorMessage); // no files read
 
-		process.chdir(actualCwd);
-	});
+	process.chdir(actualCwd);
 });
 
-test('specified `ignorePattern` file ignoring one file', () => {
-	const files = [`${fixturesPath}/empty-block.css`];
+test('specified `ignorePattern` file ignoring one file', async () => {
+	const files = [fixtures('empty-block.css')];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
 	const actualCwd = process.cwd();
 
 	process.chdir(__dirname);
 
-	return standalone({
-		files,
-		config: {
-			rules: {
-				'block-no-empty': true,
+	await expect(
+		standalone({
+			files,
+			config: {
+				rules: {
+					'block-no-empty': true,
+				},
 			},
-		},
-		ignorePattern: 'fixtures/empty-block.css',
-	}).catch((actualError) => {
-		// no files read
-		expect(actualError).toEqual(noFilesErrorMessage);
+			ignorePattern: 'fixtures/empty-block.css',
+		}),
+	).rejects.toThrow(noFilesErrorMessage); // no files read
 
-		process.chdir(actualCwd);
-	});
+	process.chdir(actualCwd);
 });
 
-test('specified `ignorePattern` file ignoring two files', () => {
-	const files = [`${fixturesPath}/empty-block.css`, `${fixturesPath}/no-syntax-error.css`];
+test('specified `ignorePattern` file ignoring two files', async () => {
+	const files = [fixtures('empty-block.css'), fixtures('no-syntax-error.css')];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
 	const actualCwd = process.cwd();
 
 	process.chdir(__dirname);
 
-	return standalone({
-		files,
-		config: {
-			rules: {
-				'block-no-empty': true,
+	await expect(
+		standalone({
+			files,
+			config: {
+				rules: {
+					'block-no-empty': true,
+				},
 			},
-		},
-		ignorePattern: ['fixtures/empty-block.css', 'fixtures/no-syntax-error.css'],
-	}).catch((actualError) => {
-		// no files read
-		expect(actualError).toEqual(noFilesErrorMessage);
+			ignorePattern: ['fixtures/empty-block.css', 'fixtures/no-syntax-error.css'],
+		}),
+	).rejects.toThrow(noFilesErrorMessage); // no files read
 
-		process.chdir(actualCwd);
-	});
+	process.chdir(actualCwd);
 });
 
-test('using ignoreFiles with input files that would cause a postcss syntax error', () => {
-	return standalone({
-		files: [`${fixturesPath}/standaloneNoParsing/*`],
+test('using ignoreFiles with input files that would cause a postcss syntax error', async () => {
+	const { results } = await standalone({
+		files: [fixtures('standaloneNoParsing', '*')],
 		config: {
 			ignoreFiles: ['**/*.scss'],
 			rules: {
 				'block-no-empty': true,
 			},
 		},
-	}).then(({ results }) => {
-		// two files found
-		expect(results).toHaveLength(2);
-
-		const one = results.find((result) => result.source.includes('no-syntax-error.css'));
-		const two = results.find((result) => result.source.includes('syntax-error-ignored.scss'));
-
-		// no-syntax-error.css found
-		expect(one.source).toContain('no-syntax-error.css');
-		// no-syntax-error.css linted
-		expect(one.warnings).toHaveLength(0);
-
-		// syntax-error-ignored.scss found
-		expect(two.source).toContain('syntax-error-ignored.scss');
-
-		// syntax-error-ignored.scss not linted
-		expect(two.warnings).toHaveLength(0);
-
-		// syntax-error-ignored.scss marked as ignored
-		expect(two.ignored).toBeTruthy();
 	});
+
+	// two files found
+	expect(results).toHaveLength(2);
+
+	const one = results.find((result) => result.source.includes('no-syntax-error.css'));
+	const two = results.find((result) => result.source.includes('syntax-error-ignored.scss'));
+
+	// no-syntax-error.css found
+	expect(one.source).toContain('no-syntax-error.css');
+
+	// no-syntax-error.css linted
+	expect(one.warnings).toHaveLength(0);
+
+	// syntax-error-ignored.scss found
+	expect(two.source).toContain('syntax-error-ignored.scss');
+
+	// syntax-error-ignored.scss not linted
+	expect(two.warnings).toHaveLength(0);
+
+	// syntax-error-ignored.scss marked as ignored
+	expect(two.ignored).toBeTruthy();
 });
 
-test('extending a config that ignores files', () => {
-	return standalone({
-		files: [`${fixturesPath}/empty-block.css`, `${fixturesPath}/invalid-hex.css`],
+test('extending a config that ignores files', async () => {
+	const { results } = await standalone({
+		files: [fixtures('empty-block.css'), fixtures('invalid-hex.css')],
 		config: {
-			extends: [`${fixturesPath}/config-extending-and-ignoring`],
+			extends: [fixtures('config-extending-and-ignoring')],
 		},
-		configBasedir: path.join(__dirname, 'fixtures'),
-	}).then(({ results }) => {
-		// found correct files
-		expect(results).toHaveLength(2);
-
-		// empty-block.css found
-		expect(results[0].source).toContain('empty-block.css');
-
-		// empty-block.css linted
-		expect(results[0].warnings).toHaveLength(1);
-
-		// invalid-hex.css found
-		expect(results[1].source).toContain('invalid-hex.css');
-
-		// invalid-hex.css not linted
-		expect(results[1].warnings).toHaveLength(0);
+		configBasedir: fixtures(),
 	});
+
+	// found correct files
+	expect(results).toHaveLength(2);
+
+	// empty-block.css found
+	expect(results[0].source).toContain('empty-block.css');
+
+	// empty-block.css linted
+	expect(results[0].warnings).toHaveLength(1);
+
+	// invalid-hex.css found
+	expect(results[1].source).toContain('invalid-hex.css');
+
+	// invalid-hex.css not linted
+	expect(results[1].warnings).toHaveLength(0);
 });
 
-test('using codeFilename and ignoreFiles together', () => {
-	return standalone({
+test('using codeFilename and ignoreFiles together', async () => {
+	const { results } = await standalone({
 		code: 'a {}',
 		codeFilename: replaceBackslashes(path.join(__dirname, 'foo.css')),
 		config: {
 			ignoreFiles: ['**/foo.css'],
 			rules: { 'block-no-empty': true },
 		},
-	}).then(({ results }) => {
-		// no warnings
-		expect(results[0].warnings).toHaveLength(0);
-
-		// ignored
-		expect(results[0].ignored).toBeTruthy();
 	});
+
+	// no warnings
+	expect(results[0].warnings).toHaveLength(0);
+
+	// ignored
+	expect(results[0].ignored).toBeTruthy();
 });
 
-test('using codeFilename and ignoreFiles with configBasedir', () => {
-	return standalone({
+test('using codeFilename and ignoreFiles with configBasedir', async () => {
+	const { results } = await standalone({
 		code: 'a {}',
 		codeFilename: replaceBackslashes(path.join(__dirname, 'foo.css')),
 		config: {
@@ -288,43 +281,43 @@ test('using codeFilename and ignoreFiles with configBasedir', () => {
 			rules: { 'block-no-empty': true },
 		},
 		configBasedir: __dirname,
-	}).then(({ results }) => {
-		// no warnings
-		expect(results[0].warnings).toHaveLength(0);
-
-		// ignored
-		expect(results[0].ignored).toBeTruthy();
 	});
+
+	// no warnings
+	expect(results[0].warnings).toHaveLength(0);
+
+	// ignored
+	expect(results[0].ignored).toBeTruthy();
 });
 
-test('file in node_modules is ignored', () => {
-	const files = [`${fixturesPath}/node_modules/test.css`];
+test('file in node_modules is ignored', async () => {
+	const files = [fixtures('node_modules', 'test.css')];
 	const noFilesErrorMessage = new NoFilesFoundError(files);
 
-	return standalone({
-		files,
-		config: {
-			rules: {
-				'block-no-empty': true,
+	await expect(
+		standalone({
+			files,
+			config: {
+				rules: {
+					'block-no-empty': true,
+				},
 			},
-		},
-	}).catch((actualError) => {
-		expect(actualError).toEqual(noFilesErrorMessage);
-	});
+		}),
+	).rejects.toThrow(noFilesErrorMessage);
 });
 
-test('disableDefaultIgnores allows paths in node_modules', () => {
-	return standalone({
-		files: [`${fixturesPath}/node_modules/test.css`],
+test('disableDefaultIgnores allows paths in node_modules', async () => {
+	const { results } = await standalone({
+		files: [fixtures('node_modules', 'test.css')],
 		disableDefaultIgnores: true,
 		config: {
 			rules: {
 				'block-no-empty': true,
 			},
 		},
-	}).then(({ results }) => {
-		// They are not ignored
-		expect(results).toHaveLength(1);
-		expect(results[0].warnings).toHaveLength(1);
 	});
+
+	// They are not ignored
+	expect(results).toHaveLength(1);
+	expect(results[0].warnings).toHaveLength(1);
 });


### PR DESCRIPTION
This change aims to improve the test code readability via async/await syntax or Jest's matchers.
(avoiding callbacks as much possible)

See also <https://jestjs.io/docs/asynchronous>

> Which issue, if any, is this issue related to?

A part of #4881

> Is there anything in the PR that needs further explanation?

I think it easier to view the diff if using ["Hide whitespace changes"](https://github.com/stylelint/stylelint/pull/5281/files?w=1).
