### PR TITLE
Refactor `lib/__tests__/ignoreDisables.test.js`

### DIFF
--- a/lib/__tests__/ignoreDisables.test.js
+++ b/lib/__tests__/ignoreDisables.test.js
@@ -2,34 +2,31 @@
 
 const postcssPlugin = require('../postcssPlugin');
 const standalone = require('../standalone');
-const stripIndent = require('common-tags').stripIndent;
 
 const config = {
 	rules: { 'block-no-empty': true },
 };
 
-const css = stripIndent`
-  /* stylelint-disable */
-  a {}
-  /* stylelint-enable */
-  a {
-    b {} /* stylelint-disable-line block-no-empty */
-  }`;
+const css = `
+/* stylelint-disable */
+a {}
+/* stylelint-enable */
+a {
+	b {} /* stylelint-disable-line block-no-empty */
+}`;
 
 describe('ignoreDisables with postcssPlugins', () => {
 	let result;
 
-	beforeEach(() => {
-		return postcssPlugin
-			.process(
-				css,
-				{ from: undefined },
-				{
-					config,
-					ignoreDisables: true,
-				},
-			)
-			.then((data) => (result = data));
+	beforeEach(async () => {
+		result = await postcssPlugin.process(
+			css,
+			{ from: undefined },
+			{
+				config,
+				ignoreDisables: true,
+			},
+		);
 	});
 
 	it('expected number of warnings', () => {
@@ -48,12 +45,14 @@ describe('ignoreDisables with postcssPlugins', () => {
 describe('ignoreDisables with standalone', () => {
 	let results;
 
-	beforeEach(() => {
-		return standalone({
-			config,
-			code: css,
-			ignoreDisables: true,
-		}).then((data) => (results = data.results));
+	beforeEach(async () => {
+		results = (
+			await standalone({
+				config,
+				code: css,
+				ignoreDisables: true,
+			})
+		).results;
 	});
 
 	it('expected number of warnings', () => {
@@ -72,11 +71,13 @@ describe('ignoreDisables with standalone', () => {
 describe('ignoreDisables with config', () => {
 	let results;
 
-	beforeEach(() => {
-		return standalone({
-			config: { ignoreDisables: true, ...config },
-			code: css,
-		}).then((data) => (results = data.results));
+	beforeEach(async () => {
+		results = (
+			await standalone({
+				config: { ignoreDisables: true, ...config },
+				code: css,
+			})
+		).results;
 	});
 
 	it('expected number of warnings', () => {


### PR DESCRIPTION
This change aims to improve the test code readability via async/await syntax.
(avoiding callbacks as much possible)

See also <https://jestjs.io/docs/asynchronous>

> Which issue, if any, is this issue related to?

A part of #4881

> Is there anything in the PR that needs further explanation?

I think it easier to view the diff if using ["Hide whitespace changes"](https://github.com/stylelint/stylelint/pull/5283/files?w=1).
