### PR TITLE
Refactor `lib/__tests__/invalidScopeDisables.test.js`

### DIFF
--- a/lib/__tests__/invalidScopeDisables.test.js
+++ b/lib/__tests__/invalidScopeDisables.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const { stripIndent } = require('common-tags');
 
 const replaceBackslashes = require('../testUtils/replaceBackslashes');
 const standalone = require('../standalone');
@@ -17,13 +18,14 @@ it('invalidScopeDisables simple case', async () => {
 		},
 	};
 
-	const css = `
-/* stylelint-disable block-no-empty */
-a {}
-/* stylelint-enable block-no-empty */
-a {
-  b {} /* stylelint-disable-line block-no-empty */
-}`.trim();
+	const css = stripIndent`
+		/* stylelint-disable block-no-empty */
+		a {}
+		/* stylelint-enable block-no-empty */
+		a {
+			b {} /* stylelint-disable-line block-no-empty */
+		}
+		`;
 
 	const { results } = await standalone({
 		config,
@@ -42,7 +44,7 @@ a {
 		},
 		{
 			line: 5,
-			column: 8,
+			column: 7,
 			rule: '--report-invalid-scope-disables',
 			text: 'Rule "block-no-empty" isn\'t enabled',
 			severity: 'error',
@@ -59,13 +61,14 @@ it('invalidScopeDisables from config', async () => {
 		},
 	};
 
-	const css = `
-/* stylelint-disable block-no-empty */
-a {}
-/* stylelint-enable block-no-empty */
-a {
-  b {} /* stylelint-disable-line block-no-empty */
-}`.trim();
+	const css = stripIndent`
+		/* stylelint-disable block-no-empty */
+		a {}
+		/* stylelint-enable block-no-empty */
+		a {
+			b {} /* stylelint-disable-line block-no-empty */
+		}
+		`;
 
 	const { results } = await standalone({
 		config,
@@ -83,7 +86,7 @@ a {
 		},
 		{
 			line: 5,
-			column: 8,
+			column: 7,
 			rule: '--report-invalid-scope-disables',
 			text: 'Rule "block-no-empty" isn\'t enabled',
 			severity: 'error',
@@ -198,13 +201,14 @@ it('invalidScopeDisables true except', async () => {
 		},
 	};
 
-	const css = `
-/* stylelint-disable block-no-empty */
-a {}
-/* stylelint-enable block-no-empty */
-a {
-  b {} /* stylelint-disable-line color-hex-case */
-}`.trim();
+	const css = stripIndent`
+		/* stylelint-disable block-no-empty */
+		a {}
+		/* stylelint-enable block-no-empty */
+		a {
+			b {} /* stylelint-disable-line color-hex-case */
+		}
+		`;
 
 	const { results } = await standalone({
 		config,
@@ -232,13 +236,14 @@ it('invalidScopeDisables false except', async () => {
 		},
 	};
 
-	const css = `
-/* stylelint-disable block-no-empty */
-a {}
-/* stylelint-enable block-no-empty */
-a {
-  b {} /* stylelint-disable-line invalid-hex-case */
-}`.trim();
+	const css = stripIndent`
+		/* stylelint-disable block-no-empty */
+		a {}
+		/* stylelint-enable block-no-empty */
+		a {
+			b {} /* stylelint-disable-line invalid-hex-case */
+		}
+		`;
 
 	const { results } = await standalone({
 		config,
@@ -250,7 +255,7 @@ a {
 	expect(invalidScopeDisables(results[0].warnings)).toEqual([
 		{
 			line: 5,
-			column: 8,
+			column: 7,
 			rule: '--report-invalid-scope-disables',
 			text: 'Rule "invalid-hex-case" isn\'t enabled',
 			severity: 'error',
@@ -266,13 +271,14 @@ it('invalidScopeDisables severity', async () => {
 		},
 	};
 
-	const css = `
-/* stylelint-disable block-no-empty */
-a {}
-/* stylelint-enable block-no-empty */
-a {
-  b {} /* stylelint-disable-line block-no-empty */
-}`.trim();
+	const css = stripIndent`
+		/* stylelint-disable block-no-empty */
+		a {}
+		/* stylelint-enable block-no-empty */
+		a {
+			b {} /* stylelint-disable-line block-no-empty */
+		}
+		`;
 
 	const { results } = await standalone({
 		config,
@@ -291,7 +297,7 @@ a {
 		},
 		{
 			line: 5,
-			column: 8,
+			column: 7,
 			rule: '--report-invalid-scope-disables',
 			text: 'Rule "block-no-empty" isn\'t enabled',
 			severity: 'warning',

--- a/lib/__tests__/invalidScopeDisables.test.js
+++ b/lib/__tests__/invalidScopeDisables.test.js
@@ -1,15 +1,15 @@
 'use strict';
 
 const path = require('path');
+
 const replaceBackslashes = require('../testUtils/replaceBackslashes');
 const standalone = require('../standalone');
-const stripIndent = require('common-tags').stripIndent;
 
 function fixture(name) {
-	return replaceBackslashes(path.join(__dirname, './fixtures/disableOptions', name));
+	return replaceBackslashes(path.join(__dirname, 'fixtures', 'disableOptions', name));
 }
 
-it('invalidScopeDisables simple case', () => {
+it('invalidScopeDisables simple case', async () => {
 	const config = {
 		rules: {
 			'block-closing-brace-newline-after': ['always'],
@@ -17,44 +17,40 @@ it('invalidScopeDisables simple case', () => {
 		},
 	};
 
-	const css = stripIndent`
-    /* stylelint-disable block-no-empty */
-    a {}
-    /* stylelint-enable block-no-empty */
-    a {
-      b {} /* stylelint-disable-line block-no-empty */
-    }
-    `;
+	const css = `
+/* stylelint-disable block-no-empty */
+a {}
+/* stylelint-enable block-no-empty */
+a {
+  b {} /* stylelint-disable-line block-no-empty */
+}`.trim();
 
-	return standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportInvalidScopeDisables: true,
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 1,
-				column: 1,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'error',
-			},
-			{
-				line: 5,
-				column: 8,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 1,
+			column: 1,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'error',
+		},
+		{
+			line: 5,
+			column: 8,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
 });
 
-it('invalidScopeDisables from config', () => {
+it('invalidScopeDisables from config', async () => {
 	const config = {
 		reportInvalidScopeDisables: true,
 		rules: {
@@ -63,50 +59,46 @@ it('invalidScopeDisables from config', () => {
 		},
 	};
 
-	const css = stripIndent`
-    /* stylelint-disable block-no-empty */
-    a {}
-    /* stylelint-enable block-no-empty */
-    a {
-      b {} /* stylelint-disable-line block-no-empty */
-    }
-    `;
+	const css = `
+/* stylelint-disable block-no-empty */
+a {}
+/* stylelint-enable block-no-empty */
+a {
+  b {} /* stylelint-disable-line block-no-empty */
+}`.trim();
 
-	return standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 1,
-				column: 1,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'error',
-			},
-			{
-				line: 5,
-				column: 8,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 1,
+			column: 1,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'error',
+		},
+		{
+			line: 5,
+			column: 8,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
 });
 
-it('invalidScopeDisables complex case', () => {
+it('invalidScopeDisables complex case', async () => {
 	const config = {
 		rules: {
 			'block-no-empty': true,
 		},
 	};
 
-	return standalone({
+	const { results } = await standalone({
 		config,
 		files: [
 			fixture('disabled-ranges-1.css'),
@@ -115,101 +107,90 @@ it('invalidScopeDisables complex case', () => {
 			fixture('disabled-ranges-3.css'),
 		],
 		reportInvalidScopeDisables: true,
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(3);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 1,
-				column: 1,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "color-named" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
-		expect(invalidScopeDisables(results[1].warnings)).toEqual([
-			{
-				line: 5,
-				column: 6,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "color-named" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
-		expect(invalidScopeDisables(results[2].warnings)).toHaveLength(0);
 	});
+
+	expect(results).toHaveLength(3);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 1,
+			column: 1,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "color-named" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
+	expect(invalidScopeDisables(results[1].warnings)).toEqual([
+		{
+			line: 5,
+			column: 6,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "color-named" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
+	expect(invalidScopeDisables(results[2].warnings)).toHaveLength(0);
 });
 
-it('invalidScopeDisables ignored case', () => {
+it('invalidScopeDisables ignored case', async () => {
 	const config = {
 		rules: {
 			'color-named': 'never',
 		},
 	};
 
-	return standalone({
+	const { results } = await standalone({
 		config,
 		files: [fixture('disabled-ranges-1.css'), fixture('ignored-file.css')],
 		ignoreDisables: true,
 		ignorePath: fixture('.stylelintignore'),
 		reportInvalidScopeDisables: true,
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 5,
-				column: 1,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 5,
+			column: 1,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
 });
 
-it('invalidScopeDisables without config', () => {
-	return standalone({
+it('invalidScopeDisables without config', async () => {
+	const { results } = await standalone({
 		config: {
 			rules: {},
 		},
 		code: 'a {}',
 		ignoreDisables: true,
 		reportInvalidScopeDisables: true,
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-		expect(invalidScopeDisables(results[0].warnings)).toHaveLength(0);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toHaveLength(0);
 });
 
-it('invalidScopeDisables for config file', () => {
-	return standalone({
+it('invalidScopeDisables for config file', async () => {
+	const { results } = await standalone({
 		files: [fixture('file-config/disabled-ranges-1.css')],
 		reportInvalidScopeDisables: true,
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 4,
-				column: 1,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "foo" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 4,
+			column: 1,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "foo" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
 });
 
-it('invalidScopeDisables true except', () => {
+it('invalidScopeDisables true except', async () => {
 	const config = {
 		rules: {
 			'block-closing-brace-newline-after': ['always'],
@@ -217,37 +198,33 @@ it('invalidScopeDisables true except', () => {
 		},
 	};
 
-	const css = stripIndent`
-    /* stylelint-disable block-no-empty */
-    a {}
-    /* stylelint-enable block-no-empty */
-    a {
-      b {} /* stylelint-disable-line color-hex-case */
-    }
-    `;
+	const css = `
+/* stylelint-disable block-no-empty */
+a {}
+/* stylelint-enable block-no-empty */
+a {
+  b {} /* stylelint-disable-line color-hex-case */
+}`.trim();
 
-	return standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportInvalidScopeDisables: [true, { except: ['color-hex-case'] }],
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 1,
-				column: 1,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 1,
+			column: 1,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
 });
 
-it('invalidScopeDisables false except', () => {
+it('invalidScopeDisables false except', async () => {
 	const config = {
 		rules: {
 			'block-closing-brace-newline-after': ['always'],
@@ -255,37 +232,33 @@ it('invalidScopeDisables false except', () => {
 		},
 	};
 
-	const css = stripIndent`
-    /* stylelint-disable block-no-empty */
-    a {}
-    /* stylelint-enable block-no-empty */
-    a {
-      b {} /* stylelint-disable-line invalid-hex-case */
-    }
-    `;
+	const css = `
+/* stylelint-disable block-no-empty */
+a {}
+/* stylelint-enable block-no-empty */
+a {
+  b {} /* stylelint-disable-line invalid-hex-case */
+}`.trim();
 
-	return standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportInvalidScopeDisables: [false, { except: 'invalid-hex-case' }],
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 5,
-				column: 8,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "invalid-hex-case" isn\'t enabled',
-				severity: 'error',
-			},
-		]);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 5,
+			column: 8,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "invalid-hex-case" isn\'t enabled',
+			severity: 'error',
+		},
+	]);
 });
 
-it('invalidScopeDisables severity', () => {
+it('invalidScopeDisables severity', async () => {
 	const config = {
 		rules: {
 			'block-closing-brace-newline-after': ['always'],
@@ -293,41 +266,37 @@ it('invalidScopeDisables severity', () => {
 		},
 	};
 
-	const css = stripIndent`
-    /* stylelint-disable block-no-empty */
-    a {}
-    /* stylelint-enable block-no-empty */
-    a {
-      b {} /* stylelint-disable-line block-no-empty */
-    }
-    `;
+	const css = `
+/* stylelint-disable block-no-empty */
+a {}
+/* stylelint-enable block-no-empty */
+a {
+  b {} /* stylelint-disable-line block-no-empty */
+}`.trim();
 
-	return standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportInvalidScopeDisables: [true, { severity: 'warning' }],
-	}).then((linted) => {
-		const results = linted.results;
-
-		expect(results).toHaveLength(1);
-
-		expect(invalidScopeDisables(results[0].warnings)).toEqual([
-			{
-				line: 1,
-				column: 1,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'warning',
-			},
-			{
-				line: 5,
-				column: 8,
-				rule: '--report-invalid-scope-disables',
-				text: 'Rule "block-no-empty" isn\'t enabled',
-				severity: 'warning',
-			},
-		]);
 	});
+
+	expect(results).toHaveLength(1);
+	expect(invalidScopeDisables(results[0].warnings)).toEqual([
+		{
+			line: 1,
+			column: 1,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'warning',
+		},
+		{
+			line: 5,
+			column: 8,
+			rule: '--report-invalid-scope-disables',
+			text: 'Rule "block-no-empty" isn\'t enabled',
+			severity: 'warning',
+		},
+	]);
 });
 
 function invalidScopeDisables(warnings) {


### PR DESCRIPTION
- Reduce callbacks as much as possible via `async/await` syntax. (see also <https://jestjs.io/docs/asynchronous>)
- ~~Replace the use of `stripIndent()` with `trim()`. (avoiding indentation in template string literals)~~
- Re-indent template string literals with TABs.

> Which issue, if any, is this issue related to?

A part of #4881

> Is there anything in the PR that needs further explanation?

It's easier to review the diffs if using ["Hide whitespace changes"](https://github.com/stylelint/stylelint/pull/5285/files?w=1).
