### PR TITLE
Fix invalid position for attribute selector

### DIFF
--- a/lib/rules/string-no-newline/index.js
+++ b/lib/rules/string-no-newline/index.js
@@ -66,7 +66,8 @@ function rule(actual) {
 					].reduce(
 						(index, str) => index + str.length,
 						// index of the start of our attribute node in our source
-						attributeNode.sourceIndex,
+						// plus 1 for the opening quotation mark
+						attributeNode.sourceIndex + 1,
 					);
 
 					report({


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates to https://github.com/stylelint/stylelint/pull/5304

> Is there anything in the PR that needs further explanation?

The opening quote doesn't seem to be included in the `leftContext` anymore, so we need to account for it.
