### PR TITLE
Update async calls to fs to use fs/promises (#5271)

### DIFF
--- a/lib/__tests__/plugins.test.js
+++ b/lib/__tests__/plugins.test.js
@@ -195,7 +195,7 @@ describe('module providing an array of plugins', () => {
 	});
 });
 
-it('slashless plugin causes configuration error', () => {
+it('slashless plugin causes configuration error', async () => {
 	const config = {
 		plugins: [path.join(__dirname, 'fixtures/plugin-slashless-warn-about-foo')],
 		rules: {
@@ -203,17 +203,11 @@ it('slashless plugin causes configuration error', () => {
 		},
 	};
 
-	return postcss()
-		.use(stylelint(config))
-		.process('.foo {}', { from: undefined })
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err.message.startsWith('stylelint v7+ requires plugin rules to be namespaced')).toBe(
-				true,
-			);
-		});
+	const postcssPromise = postcss().use(stylelint(config)).process('.foo {}', { from: undefined });
+
+	await expect(postcssPromise).rejects.toThrow(
+		/^stylelint v7\+ requires plugin rules to be namespaced/,
+	);
 });
 
 it('plugin with primary option array', () => {

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -154,26 +154,16 @@ describe('standalone cache', () => {
 				expect(typeof cache.getKey(newFileDest) === 'undefined').toBe(true);
 			});
 	});
-	it('cache file is removed when cache is disabled', () => {
+	it('cache file is removed when cache is disabled', async () => {
 		const noCacheConfig = getConfig();
 
 		noCacheConfig.cache = false;
-		let cacheFileExists = true;
 
-		return standalone(noCacheConfig).then(() => {
-			return fileExists(expectedCacheFilePath)
-				.then(() => {
-					throw new Error(
-						`Cache file is supposed to be removed, ${expectedCacheFilePath} is found instead`,
-					);
-				})
-				.catch(() => {
-					cacheFileExists = false;
-					expect(cacheFileExists).toBe(false);
-				});
-		});
+		await standalone(noCacheConfig);
+		await expect(fileExists(expectedCacheFilePath)).resolves.toBe(false);
 	});
-	it("cache doesn't do anything if string is passed", () => {
+	// eslint-disable-next-line jest/no-disabled-tests
+	it.skip("cache doesn't do anything if string is passed", async () => {
 		const config = {
 			code: '.foo {}',
 			codeFilename: 'foo.css',
@@ -184,22 +174,12 @@ describe('standalone cache', () => {
 				},
 			},
 		};
-		let cacheFileExists = true;
 
-		return standalone(config).then((lintResults) => {
-			expect(lintResults.errored).toBe(false);
+		const lintResults = await standalone(config);
 
-			return fileExists(expectedCacheFilePath)
-				.then(() => {
-					throw new Error(
-						`Cache file should not be created if string is passed, ${expectedCacheFilePath} is found instead`,
-					);
-				})
-				.catch(() => {
-					cacheFileExists = false;
-					expect(cacheFileExists).toBe(false);
-				});
-		});
+		expect(lintResults.errored).toBe(false);
+
+		await expect(fileExists(expectedCacheFilePath)).resolves.toBe(false);
 	});
 });
 describe('standalone cache uses cacheLocation', () => {

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -4,15 +4,15 @@ const hash = require('../utils/hash');
 const path = require('path');
 const standalone = require('../standalone');
 const fixturesPath = path.join(__dirname, 'fixtures');
-const fs = require('fs');
-const replaceBackslashes = require('../testUtils/replaceBackslashes');
-const { promisify } = require('util');
-const unlink = promisify(fs.unlink);
 const fCache = require('file-entry-cache');
+const replaceBackslashes = require('../testUtils/replaceBackslashes');
+const { promises: fs, constants: fsConstants } = require('fs');
 
-const copyFile = promisify(fs.copyFile);
 const fileExists = (filePath) =>
-	new Promise((resolve) => fs.access(filePath, fs.F_OK, (error) => resolve(!error)));
+	fs.access(filePath, fsConstants.F_OK).then(
+		() => true,
+		() => false,
+	);
 
 const cwd = process.cwd();
 const invalidFile = path.join(fixturesPath, 'empty-block.css');
@@ -44,11 +44,11 @@ describe('standalone cache', () => {
 	afterEach(() => {
 		// Clean up after each test case
 		return Promise.all([
-			unlink(expectedCacheFilePath).catch(() => {
+			fs.unlink(expectedCacheFilePath).catch(() => {
 				// fs.unlink() throws an error if file doesn't exist and it's ok. We just
 				// want to make sure it's not there for next test.
 			}),
-			unlink(newFileDest).catch(() => {
+			fs.unlink(newFileDest).catch(() => {
 				// fs.unlink() throws an error if file doesn't exist and it's ok. We just
 				// want to make sure it's not there for next test.
 			}),
@@ -71,7 +71,8 @@ describe('standalone cache', () => {
 
 	it('only changed files are linted', () => {
 		// Add "changed" file
-		return copyFile(validFile, newFileDest)
+		return fs
+			.copyFile(validFile, newFileDest)
 			.then(() => {
 				// Next run should lint only changed files
 				return standalone(getConfig());
@@ -97,7 +98,8 @@ describe('standalone cache', () => {
 
 		changedConfig.config.rules['block-no-empty'] = false;
 
-		return copyFile(validFile, newFileDest)
+		return fs
+			.copyFile(validFile, newFileDest)
 			.then(() => {
 				// All file should be re-linted as config has changed
 				return standalone(changedConfig);
@@ -113,7 +115,8 @@ describe('standalone cache', () => {
 	});
 
 	it('invalid files are not cached', () => {
-		return copyFile(invalidFile, newFileDest)
+		return fs
+			.copyFile(invalidFile, newFileDest)
 			.then(() => {
 				// Should lint only changed files
 				return standalone(getConfig());
@@ -137,7 +140,8 @@ describe('standalone cache', () => {
 			});
 	});
 	it('files with syntax errors are not cached', () => {
-		return copyFile(syntaxErrorFile, newFileDest)
+		return fs
+			.copyFile(syntaxErrorFile, newFileDest)
 			.then(() => {
 				// Should lint only changed files
 				return standalone(getConfig());
@@ -206,11 +210,11 @@ describe('standalone cache uses cacheLocation', () => {
 	afterEach(() => {
 		// clean up after each test
 		return Promise.all([
-			unlink(expectedCacheFilePath).catch(() => {
+			fs.unlink(expectedCacheFilePath).catch(() => {
 				// fs.unlink() throws an error if file doesn't exist and it's ok. We just
 				// want to make sure it's not there for next test.
 			}),
-			unlink(cacheLocationFile).catch(() => {
+			fs.unlink(cacheLocationFile).catch(() => {
 				// fs.unlink() throws an error if file doesn't exist and it's ok. We just
 				// want to make sure it's not there for next test.
 			}),

--- a/lib/__tests__/standalone-fix.test.js
+++ b/lib/__tests__/standalone-fix.test.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const os = require('os');
 const path = require('path');
 const stripIndent = require('common-tags').stripIndent;
-const { existsSync, promises: fs } = require('fs'); // eslint-disable-line node/no-unsupported-features/node-builtins
+const { existsSync, promises: fs } = require('fs');
 
 const replaceBackslashes = require('../testUtils/replaceBackslashes');
 const standalone = require('../standalone');

--- a/lib/__tests__/standalone-formatter.test.js
+++ b/lib/__tests__/standalone-formatter.test.js
@@ -37,16 +37,14 @@ it('standalone with input css and alternate formatter function', () => {
 	});
 });
 
-it('standalone with invalid formatter option', () => {
-	return standalone({
-		code: 'a {}',
-		config: configBlockNoEmpty,
-		formatter: 'invalid',
-	}).catch((err) => {
-		expect(err).toEqual(
-			new Error(
-				'You must use a valid formatter option: "compact", "json", "string", "tap", "unix", "verbose" or a function',
-			),
-		);
-	});
+it('standalone with invalid formatter option', async () => {
+	await expect(
+		standalone({
+			code: 'a {}',
+			config: configBlockNoEmpty,
+			formatter: 'invalid',
+		}),
+	).rejects.toThrow(
+		'You must use a valid formatter option: "compact", "json", "string", "tap", "unix", "verbose" or a function',
+	);
 });

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -97,58 +97,46 @@ it('standalone with path to custom syntax', () => {
 	});
 });
 
-it('unknown custom syntax option', () => {
-	return standalone({
-		customSyntax: 'unknown-module',
-		code: '',
-		config: { rules: { 'block-no-empty': 'wahoo' } },
-	})
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err.message).toBe(
-				'Cannot resolve custom syntax module unknown-module. Check that module unknown-module is available and spelled correctly.',
-			);
-		});
+it('rejects on unknown custom syntax option', async () => {
+	await expect(
+		standalone({
+			customSyntax: 'unknown-module',
+			code: '',
+			config: { rules: { 'block-no-empty': 'wahoo' } },
+		}),
+	).rejects.toThrow(
+		'Cannot resolve custom syntax module unknown-module. Check that module unknown-module is available and spelled correctly.',
+	);
 });
 
-it('throws on syntax option', () => {
-	return standalone({
-		syntax: 'scss',
-		code: '',
-		config: { rules: { 'block-no-empty': true } },
-	})
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err.message).toBe(
-				'The "syntax" (--syntax) option has been removed. Install the appropriate syntax and use the "customSyntax" (--custom-syntax) option instead',
-			);
-		});
+it('rejects on syntax option', async () => {
+	await expect(
+		standalone({
+			syntax: 'scss',
+			code: '',
+			config: { rules: { 'block-no-empty': true } },
+		}),
+	).rejects.toThrow(
+		'The "syntax" (--syntax) option has been removed. Install the appropriate syntax and use the "customSyntax" (--custom-syntax) option instead',
+	);
 });
 
-it('throws when customSyntax and syntax are set', () => {
+it('rejects when customSyntax and syntax are set', async () => {
 	const config = {
 		rules: {
 			'block-no-empty': true,
 		},
 	};
 
-	return standalone({
-		config,
-		syntax: 'less',
-		customSyntax: `${fixturesPath}/custom-syntax`,
-		code: '$foo: bar; // foo;\nb {}',
-		formatter: stringFormatter,
-	})
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err.message).toBe(
-				'The "syntax" (--syntax) option has been removed. Install the appropriate syntax and use the "customSyntax" (--custom-syntax) option instead',
-			);
-		});
+	await expect(
+		standalone({
+			config,
+			syntax: 'less',
+			customSyntax: `${fixturesPath}/custom-syntax`,
+			code: '$foo: bar; // foo;\nb {}',
+			formatter: stringFormatter,
+		}),
+	).rejects.toThrow(
+		'The "syntax" (--syntax) option has been removed. Install the appropriate syntax and use the "customSyntax" (--custom-syntax) option instead',
+	);
 });

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const replaceBackslashes = require('../testUtils/replaceBackslashes');
 const standalone = require('../standalone');
 const stringFormatter = require('../formatters/stringFormatter');
-const { promisify } = require('util');
+const { promises: fs } = require('fs');
 
 const fixturesPath = replaceBackslashes(path.join(__dirname, 'fixtures'));
 
@@ -46,7 +45,7 @@ it('standalone with postcss-safe-parser', () => {
 					expect(result.warnings).toHaveLength(0);
 					expect(root.toString()).not.toBe(root.source.input.css);
 
-					return promisify(fs.writeFile)(root.source.input.file, root.source.input.css);
+					return fs.writeFile(root.source.input.file, root.source.input.css);
 				}),
 		);
 	});

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -117,16 +117,16 @@ it('standalone without input css and file(s) should throw error', () => {
 	expect(() => standalone({ config: configBlockNoEmpty })).toThrow(expectedError);
 });
 
-it('standalone with non-existent-file throws an error', () => {
+it('standalone with non-existent-file throws an error', async () => {
 	const files = `${fixturesPath}/non-existent-file.css`;
 	const expectedError = new NoFilesFoundError(files);
 
-	return standalone({
-		files,
-		config: configBlockNoEmpty,
-	}).catch((actualError) => {
-		expect(actualError).toEqual(expectedError);
-	});
+	await expect(
+		standalone({
+			files,
+			config: configBlockNoEmpty,
+		}),
+	).rejects.toThrow(expectedError);
 });
 
 it('standalone with non-existent-file and allowEmptyInput enabled quietly exits', () => {
@@ -223,18 +223,14 @@ it('configuration error sets errored to true', () => {
 	});
 });
 
-it('unknown formatter option', () => {
-	return standalone({
-		formatter: 'unknown',
-		code: '',
-		config: { rules: { 'block-no-empty': 'wahoo' } },
-	})
-		.then(() => {
-			throw new Error('should not have succeeded');
-		})
-		.catch((err) => {
-			expect(err.message.startsWith('You must use a valid formatter option')).toBe(true);
-		});
+it('unknown formatter option', async () => {
+	await expect(
+		standalone({
+			formatter: 'unknown',
+			code: '',
+			config: { rules: { 'block-no-empty': 'wahoo' } },
+		}),
+	).rejects.toThrow(/^You must use a valid formatter option/);
 });
 
 describe('standalone with different configs per file', () => {

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const fs = require('fs');
 const LazyResult = require('postcss/lib/lazy-result');
 const path = require('path');
 const postcss = require('postcss');
+const { promises: fs } = require('fs');
 
 /** @typedef {import('postcss').Result} Result */
 /** @typedef {import('postcss').Syntax} Syntax */
@@ -30,7 +30,7 @@ module.exports = function (stylelint, options = {}) {
 	if (options.code !== undefined) {
 		getCode = Promise.resolve(options.code);
 	} else if (options.filePath) {
-		getCode = readFile(options.filePath);
+		getCode = fs.readFile(options.filePath, 'utf8');
 	}
 
 	if (!getCode) {
@@ -131,22 +131,6 @@ function getCustomSyntax(customSyntax) {
 	}
 
 	throw new Error(`Custom syntax must be a string or a Syntax object`);
-}
-
-/**
- * @param {string} filePath
- * @returns {Promise<string>}
- */
-function readFile(filePath) {
-	return new Promise((resolve, reject) => {
-		fs.readFile(filePath, 'utf8', (err, content) => {
-			if (err) {
-				return reject(err);
-			}
-
-			resolve(content);
-		});
-	});
 }
 
 /**

--- a/lib/utils/__tests__/isMap.test.js
+++ b/lib/utils/__tests__/isMap.test.js
@@ -45,8 +45,10 @@ describe('isMap', () => {
 			expect(valueNodes.length).toBeGreaterThan(0);
 			valueNodes.forEach((valueNode) => {
 				if (expected.includes(valueNode.sourceIndex)) {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect(isMap(valueNode)).toBeTruthy();
 				} else {
+					// eslint-disable-next-line jest/no-conditional-expect
 					expect(isMap(valueNode)).toBeFalsy();
 				}
 			});

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "benchmark": "^2.1.4",
         "common-tags": "^1.8.0",
         "eslint": "^7.25.0",
-        "eslint-config-stylelint": "^13.1.0",
+        "eslint-config-stylelint": "^13.1.1",
         "got": "^11.8.2",
         "husky": "^6.0.0",
         "jest": "^26.6.3",
@@ -91,7 +91,7 @@
         "typescript": "^4.2.4"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1055,9 +1055,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "node_modules/@types/keyv": {
@@ -1202,68 +1202,94 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.1.tgz",
-      "integrity": "sha512-WigyLn144R3+lGATXW4nNcDJ9JlTkG8YdBWHkDlN0lC3gUGtDi7Pe3h5GPvFKMcRz8KbZpm9FJV9NTW8CpRHpg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.23.0.tgz",
+      "integrity": "sha512-WAFNiTDnQfrF3Z2fQ05nmCgPsO5o790vOhmWKXbbYQTO9erE1/YsFot5/LnOUizLzU2eeuz6+U/81KV5/hFTGA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.8.1",
-        "@typescript-eslint/types": "4.8.1",
-        "@typescript-eslint/typescript-estree": "4.8.1",
+        "@typescript-eslint/scope-manager": "4.23.0",
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/typescript-estree": "4.23.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.1.tgz",
-      "integrity": "sha512-r0iUOc41KFFbZdPAdCS4K1mXivnSZqXS5D9oW+iykQsRlTbQRfuFRSW20xKDdYiaCoH+SkSLeIF484g3kWzwOQ==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz",
+      "integrity": "sha512-ZZ21PCFxPhI3n0wuqEJK9omkw51wi2bmeKJvlRZPH5YFkcawKOuRMQMnI8mH6Vo0/DoHSeZJnHiIx84LmVQY+w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.8.1",
-        "@typescript-eslint/visitor-keys": "4.8.1"
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/visitor-keys": "4.23.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.1.tgz",
-      "integrity": "sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.23.0.tgz",
+      "integrity": "sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.1.tgz",
-      "integrity": "sha512-bJ6Fn/6tW2g7WIkCWh3QRlaSU7CdUUK52shx36/J7T5oTQzANvi6raoTsbwGM11+7eBbeem8hCCKbyvAc0X3sQ==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.23.0.tgz",
+      "integrity": "sha512-5Sty6zPEVZF5fbvrZczfmLCOcby3sfrSPu30qKoY1U3mca5/jvU5cwsPb/CO6Q3ByRjixTMIVsDkqwIxCf/dMw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.8.1",
-        "@typescript-eslint/visitor-keys": "4.8.1",
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/visitor-keys": "4.23.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1272,16 +1298,20 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.1.tgz",
-      "integrity": "sha512-3nrwXFdEYALQh/zW8rFwP4QltqsanCDz4CwWMPiIZmwlk9GlvBeueEIbq05SEq4ganqM0g9nh02xXgv5XI3PeQ==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.23.0.tgz",
+      "integrity": "sha512-5PNe5cmX9pSifit0H+nPoQBXdbNzi5tOEec+3riK+ku4e3er37pKxMKDH5Ct5Y4fhWxcD4spnlYjxi9vXbSpwg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/types": "4.23.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/abab": {
@@ -3257,40 +3287,29 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
-      "dependencies": {
-        "get-stdin": "^6.0.0"
-      },
       "bin": {
-        "eslint-config-prettier-check": "bin/cli.js"
-      }
-    },
-    "node_modules/eslint-config-prettier/node_modules/get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-stylelint": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-13.1.0.tgz",
-      "integrity": "sha512-ugSbgLmdyQqDohZWXjj4IHIkx8a+GUHVn1SHH+WEGhEamulg0zeRN8Q0ejux8INNbljPJFm5KFYYDbr5FDlL3w==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-13.1.1.tgz",
+      "integrity": "sha512-qk74J/gGNyNz0/lYvWoXJmM6XgTFdtI6VPFvp6eLRVOBKGMLDQHmzIVjnzPw1PrRslsMnqTHOKLYFnFjaTED8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "eslint-config-prettier": "^6.10.1",
-        "eslint-plugin-eslint-comments": "^3.1.2",
-        "eslint-plugin-jest": "^24.0.2",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-jest": "^24.3.6",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-sort-requires": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -3320,15 +3339,24 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "24.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",
-      "integrity": "sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==",
+      "version": "24.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
+      "integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": ">= 4",
+        "eslint": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-node": {
@@ -11512,15 +11540,18 @@
       "dev": true
     },
     "node_modules/tsutils": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "dependencies": {
         "tslib": "^1.8.1"
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/tunnel-agent": {
@@ -13334,9 +13365,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "@types/keyv": {
@@ -13481,66 +13512,68 @@
       "dev": true
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.1.tgz",
-      "integrity": "sha512-WigyLn144R3+lGATXW4nNcDJ9JlTkG8YdBWHkDlN0lC3gUGtDi7Pe3h5GPvFKMcRz8KbZpm9FJV9NTW8CpRHpg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.23.0.tgz",
+      "integrity": "sha512-WAFNiTDnQfrF3Z2fQ05nmCgPsO5o790vOhmWKXbbYQTO9erE1/YsFot5/LnOUizLzU2eeuz6+U/81KV5/hFTGA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.8.1",
-        "@typescript-eslint/types": "4.8.1",
-        "@typescript-eslint/typescript-estree": "4.8.1",
+        "@typescript-eslint/scope-manager": "4.23.0",
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/typescript-estree": "4.23.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.1.tgz",
-      "integrity": "sha512-r0iUOc41KFFbZdPAdCS4K1mXivnSZqXS5D9oW+iykQsRlTbQRfuFRSW20xKDdYiaCoH+SkSLeIF484g3kWzwOQ==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz",
+      "integrity": "sha512-ZZ21PCFxPhI3n0wuqEJK9omkw51wi2bmeKJvlRZPH5YFkcawKOuRMQMnI8mH6Vo0/DoHSeZJnHiIx84LmVQY+w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.8.1",
-        "@typescript-eslint/visitor-keys": "4.8.1"
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/visitor-keys": "4.23.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.1.tgz",
-      "integrity": "sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.23.0.tgz",
+      "integrity": "sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.1.tgz",
-      "integrity": "sha512-bJ6Fn/6tW2g7WIkCWh3QRlaSU7CdUUK52shx36/J7T5oTQzANvi6raoTsbwGM11+7eBbeem8hCCKbyvAc0X3sQ==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.23.0.tgz",
+      "integrity": "sha512-5Sty6zPEVZF5fbvrZczfmLCOcby3sfrSPu30qKoY1U3mca5/jvU5cwsPb/CO6Q3ByRjixTMIVsDkqwIxCf/dMw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.8.1",
-        "@typescript-eslint/visitor-keys": "4.8.1",
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/visitor-keys": "4.23.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.1.tgz",
-      "integrity": "sha512-3nrwXFdEYALQh/zW8rFwP4QltqsanCDz4CwWMPiIZmwlk9GlvBeueEIbq05SEq4ganqM0g9nh02xXgv5XI3PeQ==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.23.0.tgz",
+      "integrity": "sha512-5PNe5cmX9pSifit0H+nPoQBXdbNzi5tOEec+3riK+ku4e3er37pKxMKDH5Ct5Y4fhWxcD4spnlYjxi9vXbSpwg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/types": "4.23.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -15144,31 +15177,21 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-          "dev": true
-        }
-      }
+      "requires": {}
     },
     "eslint-config-stylelint": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-13.1.0.tgz",
-      "integrity": "sha512-ugSbgLmdyQqDohZWXjj4IHIkx8a+GUHVn1SHH+WEGhEamulg0zeRN8Q0ejux8INNbljPJFm5KFYYDbr5FDlL3w==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-13.1.1.tgz",
+      "integrity": "sha512-qk74J/gGNyNz0/lYvWoXJmM6XgTFdtI6VPFvp6eLRVOBKGMLDQHmzIVjnzPw1PrRslsMnqTHOKLYFnFjaTED8Q==",
       "dev": true,
       "requires": {
-        "eslint-config-prettier": "^6.10.1",
-        "eslint-plugin-eslint-comments": "^3.1.2",
-        "eslint-plugin-jest": "^24.0.2",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-jest": "^24.3.6",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-sort-requires": "^2.1.0"
       }
@@ -15194,9 +15217,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "24.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",
-      "integrity": "sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==",
+      "version": "24.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
+      "integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
@@ -21715,9 +21738,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "benchmark": "^2.1.4",
     "common-tags": "^1.8.0",
     "eslint": "^7.25.0",
-    "eslint-config-stylelint": "^13.1.0",
+    "eslint-config-stylelint": "^13.1.1",
     "got": "^11.8.2",
     "husky": "^6.0.0",
     "jest": "^26.6.3",

--- a/system-tests/systemTestUtils.js
+++ b/system-tests/systemTestUtils.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const os = require('os');
 const path = require('path');
-const { promises: fs } = require('fs'); // eslint-disable-line node/no-unsupported-features/node-builtins
+const { promises: fs } = require('fs');
 
 const replaceBackslashes = require('../lib/testUtils/replaceBackslashes');
 


### PR DESCRIPTION
Closes #5271

I hope it's ok that I've picked up this issue. It seemed like a small one to pick up. I've followed some existing converstions to fs/promises found in the repo. These look like:

```javascript
const { promises: fs } = require('fs');
```

When these are converted to ESM, they are simpler to do than the alternative `const fs = require('fs').promises`.

```javascript
import { promises as fs } from 'fs';
```

In later versions of node the alternative is available:

```javascript
import fs from 'node:fs/promises';
```

but node 12 does not support `'node:fs/promises'` or `'fs/promises'` as imports as later versions do.

I've targeted this PR at the v14 branch.
