### PR TITLE
Fix false positives for flex in length-zero-no-unit

### DIFF
--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -221,6 +221,14 @@ testRule({
 			code: 'a { lIne-hEight: 0px; }',
 		},
 		{
+			code: 'a { flex: 0px; }',
+			description: 'ignore flex property',
+		},
+		{
+			code: 'a { Flex: 0px; }',
+			description: 'ignore cased flex property',
+		},
+		{
 			code: 'a { grid-auto-columns: 0fr; }',
 			description: 'ignore some grid properties with `fr`',
 		},

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -107,6 +107,8 @@ function rule(primary, secondary, context) {
 
 			if (isLineHeight(prop)) return;
 
+			if (isFlex(prop)) return;
+
 			if (optionsMatches(secondary, 'ignore', 'custom-properties') && isCustomProperty(prop))
 				return;
 
@@ -140,6 +142,10 @@ function isLineHeightValue({ prop }, nodes, index) {
 
 function isLineHeight(prop) {
 	return prop.toLowerCase() === 'line-height';
+}
+
+function isFlex(prop) {
+	return prop.toLowerCase() === 'flex';
 }
 
 function isWord({ type }) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4831
Closes #5024

> Is there anything in the PR that needs further explanation?

Implements https://github.com/stylelint/stylelint/pull/5024#issuecomment-826058241
