### PR TITLE
Remove invalid `-webkit- old***` from `isAutoprefixable()`

### DIFF
--- a/lib/utils/isAutoprefixable.js
+++ b/lib/utils/isAutoprefixable.js
@@ -3,12 +3,16 @@
 const vendor = require('./vendor');
 
 /**
- * Extract each list using the internal API of Autoprefixer:
+ * Extract each list using the internal API of Autoprefixer 10.2.5.
+ *
+ * @see {@link https://github.com/postcss/autoprefixer/tree/10.2.5}
  *
  * @example
  * const autoprefixer = require('autoprefixer');
  * const Browsers = require('autoprefixer/lib/browsers');
  * const Prefixes = require('autoprefixer/lib/prefixes');
+ * const utils = require('autoprefixer/lib/utils');
+ *
  * const prefixes = new Prefixes(autoprefixer.data.prefixes, new Browsers(autoprefixer.data.browsers, []));
  */
 
@@ -204,7 +208,10 @@ const PROPERTIES = new Set([
  * Object.values(prefixes.remove)
  *   .filter((p) => Array.isArray(p.values))
  *   .flatMap((p) => p.values)
- *   .map((p) => p.prefixed);
+ *   .map((p) => utils.removeNote(p.prefixed)) // normalize '-webkit- old'
+ *   .filter((p) => !p.endsWith('-'));         // remove '-webkit-' only
+ *
+ * @see {@link https://github.com/stylelint/stylelint/pull/5312/files#r636018013}
  */
 const PROPERTY_VALUES = new Set([
 	'-moz-available',
@@ -240,10 +247,6 @@ const PROPERTY_VALUES = new Set([
 	'-o-radial-gradient',
 	'-o-repeating-linear-gradient',
 	'-o-repeating-radial-gradient',
-	'-webkit- oldlinear-gradient',
-	'-webkit- oldradial-gradient',
-	'-webkit- oldrepeating-linear-gradient',
-	'-webkit- oldrepeating-radial-gradient',
 	'-webkit-box',
 	'-webkit-calc',
 	'-webkit-cross-fade',

--- a/lib/utils/isAutoprefixable.js
+++ b/lib/utils/isAutoprefixable.js
@@ -5,7 +5,7 @@ const vendor = require('./vendor');
 /**
  * Extract each list using the internal API of Autoprefixer 10.2.5.
  *
- * @see {@link https://github.com/postcss/autoprefixer/tree/10.2.5}
+ * @see https://github.com/postcss/autoprefixer/tree/10.2.5
  *
  * @example
  * const autoprefixer = require('autoprefixer');
@@ -211,7 +211,7 @@ const PROPERTIES = new Set([
  *   .map((p) => utils.removeNote(p.prefixed)) // normalize '-webkit- old'
  *   .filter((p) => !p.endsWith('-'));         // remove '-webkit-' only
  *
- * @see {@link https://github.com/stylelint/stylelint/pull/5312/files#r636018013}
+ * @see https://github.com/stylelint/stylelint/pull/5312/files#r636018013
  */
 const PROPERTY_VALUES = new Set([
 	'-moz-available',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Follow-up of #5312
See also <https://github.com/stylelint/stylelint/pull/5312/files#r636018013> for details. Thanks to @victor-homyakov! 👏🏼  

> Is there anything in the PR that needs further explanation?

This PR aims to remove invalid prefixed property values with `-webkit- old`, e.g. `-webkit- oldlinear-gradient`.

We can produce the new list of values as below:

`package.json`:

```json
{
  "dependencies": {
    "autoprefixer": "10.2.5"
  }
}
```

`index.js`:

```js
const autoprefixer = require('autoprefixer');
const Browsers = require('autoprefixer/lib/browsers');
const Prefixes = require('autoprefixer/lib/prefixes');
const utils = require('autoprefixer/lib/utils');

const prefixes = new Prefixes(autoprefixer.data.prefixes, new Browsers(autoprefixer.data.browsers, []));

const values = Object.values(prefixes.remove)
  .filter((p) => Array.isArray(p.values))
  .flatMap((p) => p.values)
  .map((p) => utils.removeNote(p.prefixed)) // normalize '-webkit- old'
  .filter((p) => !p.endsWith('-'));         // remove '-webkit-' only

console.log(new Set(values.sort()));
```

Run:

```console
$ node index.js
Set(56) {
  '-moz-available',
  '-moz-box',
  '-moz-calc',
  '-moz-crisp-edges',
  '-moz-element',
  '-moz-fit-content',
  '-moz-grab',
  '-moz-grabbing',
  '-moz-inline-box',
  '-moz-isolate',
  '-moz-isolate-override',
  '-moz-linear-gradient',
  '-moz-max-content',
  '-moz-min-content',
  '-moz-plaintext',
  '-moz-radial-gradient',
  '-moz-repeating-linear-gradient',
  '-moz-repeating-radial-gradient',
  '-moz-zoom-in',
  '-moz-zoom-out',
  '-ms-flexbox',
  '-ms-grid',
  '-ms-inline-flexbox',
  '-ms-inline-grid',
  '-ms-linear-gradient',
  '-ms-radial-gradient',
  '-ms-repeating-linear-gradient',
  '-ms-repeating-radial-gradient',
  '-o-linear-gradient',
  '-o-pixelated',
  '-o-radial-gradient',
  '-o-repeating-linear-gradient',
  '-o-repeating-radial-gradient',
  '-webkit-box',
  '-webkit-calc',
  '-webkit-cross-fade',
  '-webkit-fill-available',
  '-webkit-filter',
  '-webkit-fit-content',
  '-webkit-flex',
  '-webkit-grab',
  '-webkit-grabbing',
  '-webkit-image-set',
  '-webkit-inline-box',
  '-webkit-inline-flex',
  '-webkit-isolate',
  '-webkit-linear-gradient',
  '-webkit-max-content',
  '-webkit-min-content',
  '-webkit-optimize-contrast',
  '-webkit-radial-gradient',
  '-webkit-repeating-linear-gradient',
  '-webkit-repeating-radial-gradient',
  '-webkit-sticky',
  '-webkit-zoom-in',
  '-webkit-zoom-out'
}
```

