### PR TITLE
Refactor to remove some uses of `_.get` and `_.set`

### DIFF
--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 const COMMAND_PREFIX = 'stylelint-';
 const disableCommand = `${COMMAND_PREFIX}disable`;
 const enableCommand = `${COMMAND_PREFIX}enable`;
@@ -254,7 +252,9 @@ module.exports = function (root, result) {
 				}
 
 				Object.entries(disabledRanges).forEach(([ruleName, ranges]) => {
-					if (!_.get(ranges[ranges.length - 1], 'end')) {
+					const lastRange = ranges[ranges.length - 1];
+
+					if (!lastRange || !lastRange.end) {
 						endDisabledRange(endLine, ruleName, ruleName === ALL_RULES);
 					}
 				});
@@ -404,7 +404,7 @@ module.exports = function (root, result) {
 
 		if (!ranges[ranges.length - 1]) return false;
 
-		if (!_.get(ranges[ranges.length - 1], 'end')) return true;
+		if (!ranges[ranges.length - 1].end) return true;
 
 		return false;
 	}

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -402,9 +402,11 @@ module.exports = function (root, result) {
 
 		if (!ranges) return false;
 
-		if (!ranges[ranges.length - 1]) return false;
+		const lastRange = ranges[ranges.length - 1];
 
-		if (!ranges[ranges.length - 1].end) return true;
+		if (!lastRange) return false;
+
+		if (!lastRange.end) return true;
 
 		return false;
 	}

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -22,14 +22,14 @@ module.exports = function (results) {
 
 	output += chalk.underline(`${checkedDisplay} ${sourceWord} checked\n`);
 	results.forEach((result) => {
-		let formatting = 'green';
+		let formatting = chalk.green;
 
 		if (result.errored) {
-			formatting = 'red';
+			formatting = chalk.red;
 		} else if (result.warnings.length) {
-			formatting = 'yellow';
+			formatting = chalk.yellow;
 		} else if (result.ignored) {
-			formatting = 'dim';
+			formatting = chalk.dim;
 		}
 
 		let sourceText = `${result.source}`;
@@ -38,7 +38,7 @@ module.exports = function (results) {
 			sourceText += ' (ignored)';
 		}
 
-		output += _.get(chalk, formatting)(` ${sourceText}\n`);
+		output += formatting(` ${sourceText}\n`);
 	});
 
 	const warnings = _.flatten(results.map((r) => r.warnings));

--- a/lib/normalizeAllRuleSettings.js
+++ b/lib/normalizeAllRuleSettings.js
@@ -16,9 +16,7 @@ function normalizeAllRuleSettings(config) {
 
 	if (!config.rules) return config;
 
-	for (const ruleName of Object.keys(config.rules)) {
-		const rawRuleSettings = config.rules[ruleName];
-
+	for (const [ruleName, rawRuleSettings] of Object.entries(config.rules)) {
 		const rule = rules[ruleName] || (config.pluginFunctions && config.pluginFunctions[ruleName]);
 
 		if (!rule) {

--- a/lib/normalizeAllRuleSettings.js
+++ b/lib/normalizeAllRuleSettings.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const normalizeRuleSettings = require('./normalizeRuleSettings');
 const rules = require('./rules');
 
@@ -17,10 +16,10 @@ function normalizeAllRuleSettings(config) {
 
 	if (!config.rules) return config;
 
-	Object.keys(config.rules).forEach((ruleName) => {
-		const rawRuleSettings = _.get(config, ['rules', ruleName]);
+	for (const ruleName of Object.keys(config.rules)) {
+		const rawRuleSettings = config.rules[ruleName];
 
-		const rule = rules[ruleName] || _.get(config, ['pluginFunctions', ruleName]);
+		const rule = rules[ruleName] || (config.pluginFunctions && config.pluginFunctions[ruleName]);
 
 		if (!rule) {
 			normalizedRules[ruleName] = [];
@@ -28,10 +27,10 @@ function normalizeAllRuleSettings(config) {
 			normalizedRules[ruleName] = normalizeRuleSettings(
 				rawRuleSettings,
 				ruleName,
-				_.get(rule, 'primaryOptionArray'),
+				rule.primaryOptionArray,
 			);
 		}
-	});
+	}
 
 	config.rules = normalizedRules;
 

--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -46,7 +46,9 @@ module.exports = function (
 	if (primaryOptionArray === undefined) {
 		const rule = rules[ruleName];
 
-		primaryOptionArray = _.get(rule, 'primaryOptionArray');
+		if (rule && 'primaryOptionArray' in rule) {
+			primaryOptionArray = rule.primaryOptionArray;
+		}
 	}
 
 	if (!primaryOptionArray) {

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const createStylelint = require('./createStylelint');
 const globby = require('globby');
 const path = require('path');
@@ -41,7 +40,7 @@ module.exports = function (options) {
 		configOverrides,
 	});
 
-	const cwd = _.get(globbyOptions, 'cwd', process.cwd());
+	const cwd = (globbyOptions && globbyOptions.cwd) || process.cwd();
 	const absoluteFilePath = !path.isAbsolute(filePath)
 		? path.join(cwd, filePath)
 		: path.normalize(filePath);

--- a/lib/reportDisables.js
+++ b/lib/reportDisables.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const _ = require('lodash');
-
 /** @typedef {import('stylelint').RangeType} RangeType */
 /** @typedef {import('stylelint').DisableReportRange} DisabledRange */
+/** @typedef {import('stylelint').StylelintResult} StylelintResult */
+/** @typedef {import('stylelint').StylelintConfigRuleSettings<any, Object>} StylelintConfigRuleSettings */
 
 /**
  * Returns a report describing which `results` (if any) contain disabled ranges
  * for rules that disallow disables via `reportDisables: true`.
  *
- * @param {import('stylelint').StylelintResult[]} results
+ * @param {StylelintResult[]} results
  */
 module.exports = function (results) {
 	results.forEach((result) => {
@@ -25,19 +25,21 @@ module.exports = function (results) {
 
 		const config = result._postcssResult.stylelint.config;
 
+		if (!config || !config.rules) return;
+
 		// If no rules actually disallow disables, don't bother looking for ranges
 		// that correspond to disabled rules.
-		if (!Object.values(_.get(config, 'rules', {})).some(reportDisablesForRule)) {
-			return [];
+		if (!Object.values(config.rules).some(reportDisablesForRule)) {
+			return;
 		}
 
-		Object.keys(rangeData).forEach((rule) => {
-			rangeData[rule].forEach((range) => {
-				if (!reportDisablesForRule(_.get(config, ['rules', rule], []))) return;
+		for (const rule of Object.keys(rangeData)) {
+			for (const range of rangeData[rule]) {
+				if (!reportDisablesForRule(config.rules[rule] || [])) continue;
 
 				// If the comment doesn't have a location, we can't report a useful error.
 				// In practice we expect all comments to have locations, though.
-				if (!range.comment.source || !range.comment.source.start) return;
+				if (!range.comment.source || !range.comment.source.start) continue;
 
 				result.warnings.push({
 					text: `Rule "${rule}" may not be disabled`,
@@ -46,17 +48,17 @@ module.exports = function (results) {
 					column: range.comment.source.start.column,
 					severity: 'error',
 				});
-			});
-		});
+			}
+		}
 	});
 };
 
 /**
- * @param {[any, object]|null} options
+ * @param {StylelintConfigRuleSettings} options
  * @return {boolean}
  */
 function reportDisablesForRule(options) {
-	if (!options) return false;
+	if (!options || !options[1]) return false;
 
-	return _.get(options[1], 'reportDisables', false);
+	return Boolean(options[1].reportDisables);
 }

--- a/lib/reportDisables.js
+++ b/lib/reportDisables.js
@@ -33,8 +33,8 @@ module.exports = function (results) {
 			return;
 		}
 
-		for (const rule of Object.keys(rangeData)) {
-			for (const range of rangeData[rule]) {
+		for (const [rule, ranges] of Object.entries(rangeData)) {
+			for (const range of ranges) {
 				if (!reportDisablesForRule(config.rules[rule] || [])) continue;
 
 				// If the comment doesn't have a location, we can't report a useful error.

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -53,12 +53,10 @@ function rule(maxLength, options, context) {
 
 		EXCLUDED_PATTERNS.forEach((pattern) =>
 			execall(pattern, rootString).forEach((match) => {
-				const startOfSubString = match.index + match.match.indexOf(match.subMatches[0] || '');
+				const subMatch = match.subMatches[0] || '';
+				const startOfSubString = match.index + match.match.indexOf(subMatch);
 
-				return skippedSubStrings.push([
-					startOfSubString,
-					startOfSubString + (match.subMatches[0] ? match.subMatches[0].length : 0),
-				]);
+				return skippedSubStrings.push([startOfSubString, startOfSubString + subMatch.length]);
 			}),
 		);
 

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -53,12 +53,11 @@ function rule(maxLength, options, context) {
 
 		EXCLUDED_PATTERNS.forEach((pattern) =>
 			execall(pattern, rootString).forEach((match) => {
-				const startOfSubString =
-					match.index + match.match.indexOf(_.get(match, 'subMatches[0]', ''));
+				const startOfSubString = match.index + match.match.indexOf(match.subMatches[0] || '');
 
 				return skippedSubStrings.push([
 					startOfSubString,
-					startOfSubString + _.get(match, 'subMatches[0].length', 0),
+					startOfSubString + (match.subMatches[0] ? match.subMatches[0].length : 0),
 				]);
 			}),
 		);

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -39,7 +39,7 @@ function rule(actual, options) {
 			return;
 		}
 
-		const shouldDisallowDuplicateInList = _.get(options, 'disallowInList');
+		const shouldDisallowDuplicateInList = options && options.disallowInList;
 
 		// The top level of this map will be rule sources.
 		// Each source maps to another map, which maps rule parents to a set of selectors.

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -43,7 +43,7 @@ function rule(actual, options) {
 			return;
 		}
 
-		const shouldCheckPrefixed = _.get(options, 'checkPrefixed');
+		const shouldCheckPrefixed = options && options.checkPrefixed;
 
 		root.walkDecls(checkStatement);
 

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -41,7 +41,7 @@ function rule(pattern, options) {
 			return;
 		}
 
-		const shouldResolveNestedSelectors = _.get(options, 'resolveNestedSelectors');
+		const shouldResolveNestedSelectors = options && options.resolveNestedSelectors;
 		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkRules((ruleNode) => {

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -152,7 +152,7 @@ function hasNextSiblingCombinator(node) {
 function isCombinator(node) {
 	if (!node) return false;
 
-	return _.get(node, 'type') === 'combinator';
+	return node.type === 'combinator';
 }
 
 function isDescendantCombinator(node) {

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -46,7 +46,8 @@ function rule(expectation, secondary, context) {
 			return;
 		}
 
-		const avoidEscape = _.get(secondary, 'avoidEscape', true);
+		const avoidEscape =
+			secondary && secondary.avoidEscape !== undefined ? secondary.avoidEscape : true;
 
 		root.walk((node) => {
 			switch (node.type) {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -172,7 +172,7 @@ module.exports = function (options) {
 	}
 
 	fileList = fileList.map((entry) => {
-		const cwd = _.get(globbyOptions, 'cwd', process.cwd());
+		const cwd = (globbyOptions && globbyOptions.cwd) || process.cwd();
 		const absolutePath = !path.isAbsolute(entry) ? path.join(cwd, entry) : path.normalize(entry);
 
 		if (fs.existsSync(absolutePath)) {
@@ -215,7 +215,7 @@ module.exports = function (options) {
 				return Promise.all([]);
 			}
 
-			const cwd = _.get(globbyOptions, 'cwd', process.cwd());
+			const cwd = (globbyOptions && globbyOptions.cwd) || process.cwd();
 			let absoluteFilePaths = filePaths.map((filePath) => {
 				const absoluteFilepath = !path.isAbsolute(filePath)
 					? path.join(cwd, filePath)

--- a/lib/utils/getNextNonSharedLineCommentNode.js
+++ b/lib/utils/getNextNonSharedLineCommentNode.js
@@ -23,7 +23,7 @@ module.exports = function getNextNonSharedLineCommentNode(node) {
 	/** @type {Node | void} */
 	const nextNode = node.next();
 
-	if (_.get(nextNode, 'type') !== 'comment') {
+	if (!nextNode || nextNode.type !== 'comment') {
 		return nextNode;
 	}
 

--- a/lib/utils/getPreviousNonSharedLineCommentNode.js
+++ b/lib/utils/getPreviousNonSharedLineCommentNode.js
@@ -22,7 +22,7 @@ module.exports = function getPreviousNonSharedLineCommentNode(node) {
 
 	const previousNode = node.prev();
 
-	if (!previousNode || _.get(previousNode, 'type') !== 'comment') {
+	if (!previousNode || previousNode.type !== 'comment') {
 		return previousNode;
 	}
 

--- a/lib/utils/isAfterStandardPropertyDeclaration.js
+++ b/lib/utils/isAfterStandardPropertyDeclaration.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const getPreviousNonSharedLineCommentNode = require('./getPreviousNonSharedLineCommentNode');
 const isCustomProperty = require('./isCustomProperty');
 const isStandardSyntaxDeclaration = require('./isStandardSyntaxDeclaration');
@@ -15,6 +14,6 @@ module.exports = function (node) {
 		prevNode !== undefined &&
 		prevNode.type === 'decl' &&
 		isStandardSyntaxDeclaration(prevNode) &&
-		!isCustomProperty(_.get(prevNode, 'prop', ''))
+		!isCustomProperty(prevNode.prop || '')
 	);
 };

--- a/lib/utils/isBlocklessAtRuleAfterSameNameBlocklessAtRule.js
+++ b/lib/utils/isBlocklessAtRuleAfterSameNameBlocklessAtRule.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const getPreviousNonSharedLineCommentNode = require('./getPreviousNonSharedLineCommentNode');
 const isBlocklessAtRuleAfterBlocklessAtRule = require('./isBlocklessAtRuleAfterBlocklessAtRule');
 
@@ -15,5 +14,9 @@ module.exports = function (atRule) {
 
 	const previousNode = getPreviousNonSharedLineCommentNode(atRule);
 
-	return _.get(previousNode, 'name') === atRule.name;
+	if (previousNode && 'name' in previousNode) {
+		return previousNode.name === atRule.name;
+	}
+
+	return false;
 };

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /** @typedef {{
   ruleName: string,
   result: import('stylelint').PostcssResult,
@@ -83,7 +81,11 @@ module.exports = function (violation) {
 		}
 	}
 
-	const severity = _.get(result.stylelint, ['ruleSeverities', ruleName]);
+	if (!result.stylelint.ruleSeverities) {
+		result.stylelint.ruleSeverities = {};
+	}
+
+	const severity = result.stylelint.ruleSeverities[ruleName];
 
 	if (!result.stylelint.stylelintError && severity === 'error') {
 		result.stylelint.stylelintError = true;
@@ -107,7 +109,11 @@ module.exports = function (violation) {
 		warningProperties.word = word;
 	}
 
-	const warningMessage = _.get(result.stylelint, ['customMessages', ruleName], message);
+	if (!result.stylelint.customMessages) {
+		result.stylelint.customMessages = {};
+	}
+
+	const warningMessage = result.stylelint.customMessages[ruleName] || message;
 
 	result.warn(warningMessage, warningProperties);
 };

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -81,11 +81,7 @@ module.exports = function (violation) {
 		}
 	}
 
-	if (!result.stylelint.ruleSeverities) {
-		result.stylelint.ruleSeverities = {};
-	}
-
-	const severity = result.stylelint.ruleSeverities[ruleName];
+	const severity = result.stylelint.ruleSeverities && result.stylelint.ruleSeverities[ruleName];
 
 	if (!result.stylelint.stylelintError && severity === 'error') {
 		result.stylelint.stylelintError = true;
@@ -109,11 +105,8 @@ module.exports = function (violation) {
 		warningProperties.word = word;
 	}
 
-	if (!result.stylelint.customMessages) {
-		result.stylelint.customMessages = {};
-	}
-
-	const warningMessage = result.stylelint.customMessages[ruleName] || message;
+	const warningMessage =
+		(result.stylelint.customMessages && result.stylelint.customMessages[ruleName]) || message;
 
 	result.warn(warningMessage, warningProperties);
 };

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -42,7 +42,12 @@ module.exports = function (result, ruleName, ...optionDescriptions) {
 		result.warn(message, {
 			stylelintType: 'invalidOption',
 		});
-		_.set(result, 'stylelint.stylelintError', true);
+		result.stylelint = result.stylelint || {
+			disabledRanges: {},
+			ruleSeverities: {},
+			customMessages: {},
+		};
+		result.stylelint.stylelintError = true;
 	}
 
 	return noErrors;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'stylelint' {
 	import { Comment, Result, ResultMessage, Root, Syntax, WarningOptions, Warning } from 'postcss';
+	import { GlobbyOptions } from 'globby';
 
 	export type Severity = 'warning' | 'error';
 
@@ -140,11 +141,13 @@ declare module 'stylelint' {
 
 	export type StylelintPluginContext = { fix?: boolean; newline?: string };
 
-	export type StylelintRule = (
+	export type StylelintRule = ((
 		primaryOption: any,
 		secondaryOptions: object,
 		context: StylelintPluginContext,
-	) => (root: Root, result: PostcssResult) => Promise<void> | void;
+	) => (root: Root, result: PostcssResult) => Promise<void> | void) & {
+		primaryOptionArray?: boolean;
+	};
 
 	export type GetPostcssOptions = {
 		code?: string;
@@ -183,7 +186,7 @@ declare module 'stylelint' {
 
 	export type StylelintStandaloneOptions = {
 		files?: string | Array<string>;
-		globbyOptions?: Object;
+		globbyOptions?: GlobbyOptions;
 		cache?: boolean;
 		cacheLocation?: string;
 		code?: string;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

Most of the code is self-explanatory. I replaced the simpler uses of `_.get` and `_.set` with native code.

I had to change a couple of `array.forEach` loops to regular `for … of array` loops to make `tsc` happy. I also updated the JSDoc types in a couple places for the same reason.