### PR TITLE
Refactor to remove remaining uses of `_.get` and `_.set`

### DIFF
--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -78,7 +78,7 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 			return;
 		}
 
-		const ruleSettings = config.rules && config.rules[ruleName];
+		const ruleSettings = config.rules[ruleName];
 
 		if (ruleSettings === null || ruleSettings[0] === null) {
 			return;

--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -78,7 +78,7 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 			return;
 		}
 
-		const ruleSettings = config.rules[ruleName];
+		const ruleSettings = config.rules && config.rules[ruleName];
 
 		if (ruleSettings === null || ruleSettings[0] === null) {
 			return;

--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assignDisabledRanges = require('./assignDisabledRanges');
-const get = require('lodash/get');
 const getOsEol = require('./utils/getOsEol');
 const reportUnknownRuleNames = require('./reportUnknownRuleNames');
 const rulesOrder = require('./rules');
@@ -64,7 +63,8 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 		: [];
 
 	rules.forEach((ruleName) => {
-		const ruleFunction = rulesOrder[ruleName] || get(config, ['pluginFunctions', ruleName]);
+		const ruleFunction =
+			rulesOrder[ruleName] || (config.pluginFunctions && config.pluginFunctions[ruleName]);
 
 		if (ruleFunction === undefined) {
 			performRules.push(
@@ -78,7 +78,7 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 			return;
 		}
 
-		const ruleSettings = get(config, ['rules', ruleName]);
+		const ruleSettings = config.rules && config.rules[ruleName];
 
 		if (ruleSettings === null || ruleSettings[0] === null) {
 			return;
@@ -90,12 +90,9 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 		// Log the rule's severity in the PostCSS result
 		const defaultSeverity = config.defaultSeverity || 'error';
 
-		postcssResult.stylelint.ruleSeverities[ruleName] = get(
-			secondaryOptions,
-			'severity',
-			defaultSeverity,
-		);
-		postcssResult.stylelint.customMessages[ruleName] = get(secondaryOptions, 'message');
+		postcssResult.stylelint.ruleSeverities[ruleName] =
+			(secondaryOptions && secondaryOptions.severity) || defaultSeverity;
+		postcssResult.stylelint.customMessages[ruleName] = secondaryOptions && secondaryOptions.message;
 
 		performRules.push(
 			Promise.all(

--- a/lib/postcssPlugin.js
+++ b/lib/postcssPlugin.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const createStylelint = require('./createStylelint');
 const path = require('path');
 const postcss = require('postcss');
@@ -11,9 +10,11 @@ module.exports = postcss.plugin('stylelint', (options = {}) => {
 	const stylelint = createStylelint(tailoredOptions);
 
 	return (root, result) => {
-		let filePath = options.from || _.get(root, 'source.input.file');
+		let filePath = options.from;
 
-		if (filePath !== undefined && !path.isAbsolute(filePath)) {
+		if (!filePath) filePath = root.source && root.source.input.file;
+
+		if (filePath && !path.isAbsolute(filePath)) {
 			filePath = path.join(process.cwd(), filePath);
 		}
 

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
@@ -136,7 +135,7 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkAtRules(/^import$/i, (atRule) => {
-			const param = _.get(atRule, 'raws.params.raw', atRule.params);
+			const param = (atRule.raws.params && atRule.raws.params.raw) || atRule.params;
 			const fixer = context.fix && createFixer(param);
 
 			check(atRule, param, atRuleParamIndex, fixer && fixer.applyFix);

--- a/lib/rules/linebreaks/index.js
+++ b/lib/rules/linebreaks/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -28,14 +27,17 @@ function rule(actual, secondary, context) {
 		const shouldHaveCR = actual === 'windows';
 
 		if (context.fix) {
-			const propertiesToUpdate = ['selector', 'raws.before', 'raws.after', 'value', 'text'];
+			const propertiesToUpdate = ['selector', 'value', 'text'];
+			const rawsPropertiesToUpdate = ['before', 'after'];
 
 			root.walk((node) => {
-				propertiesToUpdate.forEach((property) => {
-					const fixedData = fixData(_.get(node, property));
+				for (const property of propertiesToUpdate) {
+					node[property] = fixData(node[property]);
+				}
 
-					_.set(node, property, fixedData);
-				});
+				for (const property of rawsPropertiesToUpdate) {
+					node.raws[property] = fixData(node.raws[property]);
+				}
 			});
 
 			root.raws.after = fixData(root.raws.after);

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -71,23 +71,23 @@ function rule(max, options, context) {
 			});
 
 			// first node
-			const firstNodeRawsBefore = _.get(root, 'first.raws.before');
+			const firstNodeRawsBefore = root.first && root.first.raws.before;
 			// root raws
-			const rootRawsAfter = _.get(root, 'raws.after');
+			const rootRawsAfter = root.raws.after;
 
 			// not document node
-			if (_.get(root, 'document.constructor.name') !== 'Document') {
+			if ((root.document && root.document.constructor.name) !== 'Document') {
 				if (firstNodeRawsBefore) {
-					_.set(root, 'first.raws.before', getChars(firstNodeRawsBefore, true));
+					root.first.raws.before = getChars(firstNodeRawsBefore, true);
 				}
 
 				if (rootRawsAfter) {
 					// when max setted 0, should be treated as 1 in this situation.
-					_.set(root, 'raws.after', replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter, true));
+					root.raws.after = replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter, true);
 				}
 			} else if (rootRawsAfter) {
 				// `css in js` or `html`
-				_.set(root, 'raws.after', replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter));
+				root.raws.after = replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter);
 			}
 
 			return;
@@ -194,11 +194,13 @@ function isEofNode(document, root) {
 	let after;
 
 	if (root === document.last) {
-		after = _.get(document, 'raws.afterEnd');
+		after = document.raws && document.raws.afterEnd;
 	} else {
 		const rootIndex = document.index(root);
 
-		after = _.get(document.nodes[rootIndex + 1], 'raws.beforeStart');
+		const nextNode = document.nodes[rootIndex + 1];
+
+		after = nextNode && nextNode.raws && nextNode.raws.beforeStart;
 	}
 
 	return !String(after).trim();

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isCustomMediaQuery = require('../../utils/isCustomMediaQuery');
 const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
@@ -31,7 +30,7 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkAtRules(/^media$/i, (atRule) => {
-			let hasComments = _.get(atRule, 'raws.params.raw');
+			let hasComments = atRule.raws.params && atRule.raws.params.raw;
 			const mediaRule = hasComments ? hasComments : atRule.params;
 
 			mediaParser(mediaRule).walk(/^media-feature$/i, (mediaFeatureNode) => {
@@ -68,7 +67,7 @@ function rule(expectation, options, context) {
 							hasComments.slice(0, sourceIndex) +
 							expectedFeatureName +
 							hasComments.slice(sourceIndex + expectedFeatureName.length);
-						_.set(atRule, 'raws.params.raw', hasComments);
+						atRule.raws.params.raw = hasComments;
 					} else {
 						atRule.params =
 							atRule.params.slice(0, sourceIndex) +

--- a/lib/rules/media-feature-parentheses-space-inside/index.js
+++ b/lib/rules/media-feature-parentheses-space-inside/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -32,7 +31,7 @@ function rule(expectation, options, context) {
 		root.walkAtRules(/^media$/i, (atRule) => {
 			// If there are comments in the params, the complete string
 			// will be at atRule.raws.params.raw
-			const params = _.get(atRule, 'raws.params.raw', atRule.params);
+			const params = (atRule.raws.params && atRule.raws.params.raw) || atRule.params;
 			const indexBoost = atRuleParamIndex(atRule);
 			const violations = [];
 

--- a/lib/rules/selector-attribute-brackets-space-inside/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
@@ -123,7 +122,10 @@ function rule(expectation, options, context) {
 	};
 
 	function fixBefore(attributeNode) {
-		const rawAttrBefore = _.get(attributeNode, 'raws.spaces.attribute.before');
+		const rawAttrBefore =
+			attributeNode.raws.spaces &&
+			attributeNode.raws.spaces.attribute &&
+			attributeNode.raws.spaces.attribute.before;
 		const { attrBefore, setAttrBefore } = rawAttrBefore
 			? {
 					attrBefore: rawAttrBefore,
@@ -132,9 +134,12 @@ function rule(expectation, options, context) {
 					},
 			  }
 			: {
-					attrBefore: _.get(attributeNode, 'spaces.attribute.before', ''),
+					attrBefore:
+						(attributeNode.spaces.attribute && attributeNode.spaces.attribute.before) || '',
 					setAttrBefore(fixed) {
-						_.set(attributeNode, 'spaces.attribute.before', fixed);
+						if (!attributeNode.spaces.attribute) attributeNode.spaces.attribute = {};
+
+						attributeNode.spaces.attribute.before = fixed;
 					},
 			  };
 
@@ -154,7 +159,10 @@ function rule(expectation, options, context) {
 			key = 'attribute';
 		}
 
-		const rawAfter = _.get(attributeNode, `raws.spaces.${key}.after`);
+		const rawAfter =
+			attributeNode.raws.spaces &&
+			attributeNode.raws.spaces[key] &&
+			attributeNode.raws.spaces[key].after;
 		const { after, setAfter } = rawAfter
 			? {
 					after: rawAfter,
@@ -163,9 +171,11 @@ function rule(expectation, options, context) {
 					},
 			  }
 			: {
-					after: _.get(attributeNode, `spaces.${key}.after`, ''),
+					after: (attributeNode.spaces[key] && attributeNode.spaces[key].after) || '',
 					setAfter(fixed) {
-						_.set(attributeNode, `spaces.${key}.after`, fixed);
+						if (!attributeNode.spaces[key]) attributeNode.spaces[key] = {};
+
+						attributeNode.spaces[key].after = fixed;
 					},
 			  };
 

--- a/lib/rules/selector-attribute-operator-space-after/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const ruleMessages = require('../../utils/ruleMessages');
 const selectorAttributeOperatorSpaceChecker = require('../selectorAttributeOperatorSpaceChecker');
 const validateOptions = require('../../utils/validateOptions');
@@ -36,19 +35,28 @@ function rule(expectation, options, context) {
 			fix: context.fix
 				? (attributeNode) => {
 						const { operatorAfter, setOperatorAfter } = (() => {
-							const rawOperator = _.get(attributeNode, 'raws.operator');
+							const rawOperator = attributeNode.raws.operator;
 
 							if (rawOperator) {
 								return {
 									operatorAfter: rawOperator.slice(attributeNode.operator.length),
 									setOperatorAfter(fixed) {
 										delete attributeNode.raws.operator;
-										_.set(attributeNode, 'raws.spaces.operator.after', fixed);
+
+										if (!attributeNode.raws.spaces) attributeNode.raws.spaces = {};
+
+										if (!attributeNode.raws.spaces.operator)
+											attributeNode.raws.spaces.operator = {};
+
+										attributeNode.raws.spaces.operator.after = fixed;
 									},
 								};
 							}
 
-							const rawOperatorAfter = _.get(attributeNode, 'raws.spaces.operator.after');
+							const rawOperatorAfter =
+								attributeNode.raws.spaces &&
+								attributeNode.raws.spaces.operator &&
+								attributeNode.raws.spaces.operator.after;
 
 							if (rawOperatorAfter) {
 								return {
@@ -60,9 +68,12 @@ function rule(expectation, options, context) {
 							}
 
 							return {
-								operatorAfter: _.get(attributeNode, 'spaces.operator.after', ''),
+								operatorAfter:
+									(attributeNode.spaces.operator && attributeNode.spaces.operator.after) || '',
 								setOperatorAfter(fixed) {
-									_.set(attributeNode, 'spaces.operator.after', fixed);
+									if (!attributeNode.spaces.operator) attributeNode.spaces.operator = {};
+
+									attributeNode.spaces.operator.after = fixed;
 								},
 							};
 						})();

--- a/lib/rules/selector-attribute-operator-space-before/index.js
+++ b/lib/rules/selector-attribute-operator-space-before/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const ruleMessages = require('../../utils/ruleMessages');
 const selectorAttributeOperatorSpaceChecker = require('../selectorAttributeOperatorSpaceChecker');
 const validateOptions = require('../../utils/validateOptions');
@@ -36,7 +35,10 @@ function rule(expectation, options, context) {
 			checkBeforeOperator: true,
 			fix: context.fix
 				? (attributeNode) => {
-						const rawAttrAfter = _.get(attributeNode, 'raws.spaces.attribute.after');
+						const rawAttrAfter =
+							attributeNode.raws.spaces &&
+							attributeNode.raws.spaces.attribute &&
+							attributeNode.raws.spaces.attribute.after;
 						const { attrAfter, setAttrAfter } = rawAttrAfter
 							? {
 									attrAfter: rawAttrAfter,
@@ -45,9 +47,12 @@ function rule(expectation, options, context) {
 									},
 							  }
 							: {
-									attrAfter: _.get(attributeNode, 'spaces.attribute.after', ''),
+									attrAfter:
+										(attributeNode.spaces.attribute && attributeNode.spaces.attribute.after) || '',
 									setAttrAfter(fixed) {
-										_.set(attributeNode, 'spaces.attribute.after', fixed);
+										if (!attributeNode.spaces.attribute) attributeNode.spaces.attribute = {};
+
+										attributeNode.spaces.attribute.after = fixed;
 									},
 							  };
 

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -41,7 +41,7 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkRules((ruleNode) => {
-			let hasComments = _.get(ruleNode, 'raws.selector.raw');
+			let hasComments = ruleNode.raws.selector && ruleNode.raws.selector.raw;
 			const selector = hasComments ? hasComments : ruleNode.selector;
 			const selectors = ruleNode.selectors;
 
@@ -78,7 +78,7 @@ function rule(expectation, options, context) {
 								hasComments.slice(0, sourceIndex) +
 								expectedValue +
 								hasComments.slice(sourceIndex + value.length);
-							_.set(ruleNode, 'raws.selector.raw', hasComments);
+							ruleNode.raws.selector.raw = hasComments;
 						} else {
 							ruleNode.selector =
 								ruleNode.selector.slice(0, sourceIndex) +

--- a/lib/utils/declarationValueIndex.js
+++ b/lib/utils/declarationValueIndex.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * Get the index of a declaration's value
  *
@@ -10,12 +8,16 @@ const _ = require('lodash');
  * @returns {number}
  */
 module.exports = function (decl) {
+	// Casting this to any because 'prop' and 'value' do not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = decl.raws;
+
 	return [
-		_.get(decl, 'raws.prop.prefix'),
-		_.get(decl, 'raws.prop.raw', decl.prop),
-		_.get(decl, 'raws.prop.suffix'),
-		_.get(decl, 'raws.between', ':'),
-		_.get(decl, 'raws.value.prefix'),
+		raws.prop && raws.prop.prefix,
+		(raws.prop && raws.prop.raw) || decl.prop,
+		raws.prop && raws.prop.suffix,
+		raws.between || ':',
+		raws.value && raws.value.prefix,
 	].reduce((count, str) => {
 		if (str) {
 			return count + str.length;

--- a/lib/utils/getAtRuleParams.js
+++ b/lib/utils/getAtRuleParams.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * @param {import('postcss').AtRule} atRule
  * @returns {string}
  */
 module.exports = function getAtRuleParams(atRule) {
-	return _.get(atRule, 'raws.params.raw', atRule.params);
+	// Casting this to any because 'params' does not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = atRule.raws;
+
+	return (raws.params && raws.params.raw) || atRule.params;
 };

--- a/lib/utils/getDeclarationValue.js
+++ b/lib/utils/getDeclarationValue.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * @param {import('postcss').Declaration} decl
  * @returns {string}
  */
 module.exports = function getDeclarationValue(decl) {
-	return _.get(decl, 'raws.value.raw', decl.value);
+	// Casting this to any because 'value' does not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = decl.raws;
+
+	return (raws.value && raws.value.raw) || decl.value;
 };

--- a/lib/utils/getNextNonSharedLineCommentNode.js
+++ b/lib/utils/getNextNonSharedLineCommentNode.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const _ = require('lodash');
-
 /** @typedef {import('postcss').Node} Node */
 
 /**
  * @param {Node | void} node
  */
 function getNodeLine(node) {
-	return _.get(node, 'source.start.line');
+	return node && node.source && node.source.start && node.source.start.line;
 }
 
 /**
@@ -29,7 +27,7 @@ module.exports = function getNextNonSharedLineCommentNode(node) {
 
 	if (
 		getNodeLine(node) === getNodeLine(nextNode) ||
-		(nextNode !== undefined && getNodeLine(nextNode) === getNodeLine(nextNode.next()))
+		getNodeLine(nextNode) === getNodeLine(nextNode.next())
 	) {
 		return getNextNonSharedLineCommentNode(nextNode);
 	}

--- a/lib/utils/getPreviousNonSharedLineCommentNode.js
+++ b/lib/utils/getPreviousNonSharedLineCommentNode.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const _ = require('lodash');
-
 /** @typedef {import('postcss').Node} Node */
 
 /**
  * @param {Node} node
  */
 function getNodeLine(node) {
-	return _.get(node, 'source.start.line');
+	return node.source && node.source.start && node.source.start.line;
 }
 
 /**

--- a/lib/utils/getRuleSelector.js
+++ b/lib/utils/getRuleSelector.js
@@ -1,13 +1,15 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * @param {import('postcss').Rule} ruleNode
  * @returns {string}
  */
 function getRuleSelector(ruleNode) {
-	return _.get(ruleNode, 'raws.selector.raw', ruleNode.selector);
+	// Casting this to any because 'value' does not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = ruleNode.raws;
+
+	return (raws.selector && raws.selector.raw) || ruleNode.selector;
 }
 
 module.exports = getRuleSelector;

--- a/lib/utils/isCustomPropertySet.js
+++ b/lib/utils/isCustomPropertySet.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const hasBlock = require('../utils/hasBlock');
 
 /**
@@ -10,7 +9,11 @@ const hasBlock = require('../utils/hasBlock');
  * @returns {boolean}
  */
 module.exports = function (node) {
-	const selector = _.get(node, 'raws.selector.raw', node.selector);
+	// Casting this to any because 'selector' does not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = node.raws;
+
+	const selector = (raws.selector && raws.selector.raw) || node.selector;
 
 	return (
 		node.type === 'rule' && hasBlock(node) && selector.startsWith('--') && selector.endsWith(':')

--- a/lib/utils/isSharedLineComment.js
+++ b/lib/utils/isSharedLineComment.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const getNextNonSharedLineCommentNode = require('./getNextNonSharedLineCommentNode');
 const getPreviousNonSharedLineCommentNode = require('./getPreviousNonSharedLineCommentNode');
 
@@ -12,7 +11,10 @@ const getPreviousNonSharedLineCommentNode = require('./getPreviousNonSharedLineC
  * @param {PostcssNode | void} b
  */
 function nodesShareLines(a, b) {
-	return _.get(a, 'source.end.line') === _.get(b, 'source.start.line');
+	const aLine = a && a.source && a.source.end && a.source.end.line;
+	const bLine = b && b.source && b.source.start && b.source.start.line;
+
+	return aLine === bLine;
 }
 
 /**

--- a/lib/utils/isStandardSyntaxRule.js
+++ b/lib/utils/isStandardSyntaxRule.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const isCustomPropertySet = require('../utils/isCustomPropertySet');
 const isStandardSyntaxSelector = require('../utils/isStandardSyntaxSelector');
 
@@ -15,8 +14,12 @@ module.exports = function (rule) {
 		return false;
 	}
 
+	// Casting this to any because 'selector' does not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = rule.raws;
+
 	// Get full selector
-	const selector = _.get(rule, 'raws.selector.raw', rule.selector);
+	const selector = (raws.selector && raws.selector.raw) || rule.selector;
 
 	if (!isStandardSyntaxSelector(rule.selector)) {
 		return false;

--- a/lib/utils/setAtRuleParams.js
+++ b/lib/utils/setAtRuleParams.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /** @typedef {import('postcss').AtRule} AtRule */
 
 /**
@@ -10,8 +8,12 @@ const _ = require('lodash');
  * @returns {AtRule} The atRulearation that was passed in.
  */
 module.exports = function setAtRuleParams(atRule, params) {
-	if (_.has(atRule, 'raws.params')) {
-		_.set(atRule, 'raws.params.raw', params);
+	// Casting this to any because 'params' does not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = atRule.raws;
+
+	if (raws.params) {
+		raws.params.raw = params;
 	} else {
 		atRule.params = params;
 	}

--- a/lib/utils/setDeclarationValue.js
+++ b/lib/utils/setDeclarationValue.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /** @typedef {import('postcss').Declaration} Declaration */
 
 /**
@@ -10,11 +8,12 @@ const _ = require('lodash');
  * @returns {Declaration} The declaration that was passed in.
  */
 module.exports = function setDeclarationValue(decl, value) {
-	// Lodash is necessary here because the declaration may not strictly adhere
-	// to the current version of PostCSS's Declaration interface.
-	// See also: https://github.com/stylelint/stylelint/pull/5183/files#r588047494
-	if (_.has(decl, 'raws.value')) {
-		_.set(decl, 'raws.value.raw', value);
+	// Casting this to any because 'value' does not exist on type 'NodeRaws'
+	/** @type {any} */
+	const raws = decl.raws;
+
+	if (raws.value) {
+		raws.value.raw = value;
 	} else {
 		decl.value = value;
 	}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

Most of the code is self-explanatory. I replaced the remaining uses of `_.get` and `_.set` with native code.

I had to cast to `any` in a few places to get around the fact that the TypeScript definitions don't include all the properties that we use.