### PR TITLE
Refactor to remove `_.isPlainObject`

### DIFF
--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const rules = require('./rules');
 
 // Rule settings can take a number of forms, e.g.
@@ -64,8 +63,9 @@ module.exports = function (
 
 	if (
 		rawSettings.length === 2 &&
-		!_.isPlainObject(rawSettings[0]) &&
-		_.isPlainObject(rawSettings[1])
+		!(typeof rawSettings[0] === 'object' && rawSettings[0] !== null) &&
+		typeof rawSettings[1] === 'object' &&
+		rawSettings[1] !== null
 	) {
 		return rawSettings;
 	}

--- a/lib/utils/validateObjectWithArrayProps.js
+++ b/lib/utils/validateObjectWithArrayProps.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  * @template T
  * @typedef {(i: T) => boolean} Validator
@@ -20,7 +18,7 @@ const _ = require('lodash');
  * @returns {(value: {[k: any]: T|T[]}) => boolean}
  */
 module.exports = (validator) => (value) => {
-	if (!_.isPlainObject(value)) {
+	if (typeof value !== 'object' || value === null) {
 		return false;
 	}
 

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -108,7 +108,7 @@ function validate(opts, ruleName, complain) {
 	}
 
 	// If `possible` is an array instead of an object ...
-	if (!_.isPlainObject(possible)) {
+	if (Array.isArray(possible)) {
 		[].concat(actual).forEach((a) => {
 			if (isValid(possible, a)) {
 				return;
@@ -121,7 +121,7 @@ function validate(opts, ruleName, complain) {
 	}
 
 	// If actual is NOT an object ...
-	if (typeof actual !== 'object') {
+	if (typeof actual !== 'object' || actual === null) {
 		complain(
 			`Invalid option value ${JSON.stringify(actual)} for rule "${ruleName}": should be an object`,
 		);


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

`_.isPlainObject` checks the constructor of the object, but it is simpler to just check that it is a non-null object. Otherwise we need code like `Object.prototype.toString.call(obj) === '[object Object]'`.