### PR TITLE
Refactor to remove type validation functions

### DIFF
--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const rules = require('./rules');
-const { isPlainObject } = require('./utils/validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 // Rule settings can take a number of forms, e.g.
 // a. "rule-name": null

--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const rules = require('./rules');
+const { isPlainObject } = require('./utils/validateTypes');
 
 // Rule settings can take a number of forms, e.g.
 // a. "rule-name": null
@@ -61,11 +62,7 @@ module.exports = function (
 		return rawSettings;
 	}
 
-	if (
-		rawSettings.length === 2 &&
-		Object.prototype.toString.call(rawSettings[0]) !== '[object Object]' &&
-		Object.prototype.toString.call(rawSettings[1]) === '[object Object]'
-	) {
+	if (rawSettings.length === 2 && !isPlainObject(rawSettings[0]) && isPlainObject(rawSettings[1])) {
 		return rawSettings;
 	}
 

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -13,6 +12,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'alpha-value-notation';
 
@@ -35,7 +35,7 @@ function rule(primary, options, context) {
 			{
 				actual: options,
 				possible: {
-					exceptProperties: [_.isString, _.isRegExp],
+					exceptProperties: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/at-rule-allowed-list/index.js
+++ b/lib/rules/at-rule-allowed-list/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'at-rule-allowed-list';
 
@@ -22,7 +22,7 @@ function rule(listInput) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString],
+			possible: [isString],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/at-rule-disallowed-list/index.js
+++ b/lib/rules/at-rule-disallowed-list/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'at-rule-disallowed-list';
 
@@ -22,7 +22,7 @@ function rule(listInput) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString],
+			possible: [isString],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const addEmptyLineBefore = require('../../utils/addEmptyLineBefore');
 const getPreviousNonSharedLineCommentNode = require('../../utils/getPreviousNonSharedLineCommentNode');
 const hasEmptyLine = require('../../utils/hasEmptyLine');
@@ -17,6 +16,7 @@ const removeEmptyLinesBefore = require('../../utils/removeEmptyLinesBefore');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'at-rule-empty-line-before';
 
@@ -51,7 +51,7 @@ function rule(expectation, options, context) {
 						'blockless-after-same-name-blockless',
 						'blockless-after-blockless',
 					],
-					ignoreAtRules: [_.isString],
+					ignoreAtRules: [isString],
 				},
 				optional: true,
 			},

--- a/lib/rules/at-rule-no-unknown/index.js
+++ b/lib/rules/at-rule-no-unknown/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const keywordSets = require('../../reference/keywordSets');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'at-rule-no-unknown';
 
@@ -26,7 +26,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreAtRules: [_.isString, _.isRegExp],
+					ignoreAtRules: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/at-rule-property-required-list/index.js
+++ b/lib/rules/at-rule-property-required-list/index.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isObject } = require('../../utils/validateTypes');
 
 const ruleName = 'at-rule-property-required-list';
 
@@ -18,7 +18,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isObject],
+			possible: [isObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/at-rule-property-required-list/index.js
+++ b/lib/rules/at-rule-property-required-list/index.js
@@ -6,7 +6,7 @@ const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'at-rule-property-required-list';
 
@@ -18,7 +18,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [isObject],
+			possible: [isPlainObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/at-rule-property-required-list/index.js
+++ b/lib/rules/at-rule-property-required-list/index.js
@@ -6,7 +6,7 @@ const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isPlainObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'at-rule-property-required-list';
 

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const blockString = require('../../utils/blockString');
 const hasBlock = require('../../utils/hasBlock');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -11,6 +10,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'block-closing-brace-newline-after';
 
@@ -42,7 +42,7 @@ function rule(expectation, options, context) {
 			{
 				actual: options,
 				possible: {
-					ignoreAtRules: [_.isString],
+					ignoreAtRules: [isString],
 				},
 				optional: true,
 			},

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const beforeBlockString = require('../../utils/beforeBlockString');
 const hasBlock = require('../../utils/hasBlock');
 const hasEmptyBlock = require('../../utils/hasEmptyBlock');
@@ -10,6 +9,7 @@ const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isBoolean } = require('../../utils/validateTypes');
 
 const ruleName = 'block-no-empty';
 
@@ -24,7 +24,7 @@ function rule(primary, options = {}) {
 			ruleName,
 			{
 				actual: primary,
-				possible: _.isBoolean,
+				possible: isBoolean,
 			},
 			{
 				actual: options,

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const beforeBlockString = require('../../utils/beforeBlockString');
 const blockString = require('../../utils/blockString');
 const hasBlock = require('../../utils/hasBlock');
@@ -12,6 +11,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'block-opening-brace-space-before';
 
@@ -45,8 +45,8 @@ function rule(expectation, options, context) {
 			{
 				actual: options,
 				possible: {
-					ignoreAtRules: [_.isString, _.isRegExp],
-					ignoreSelectors: [_.isString, _.isRegExp],
+					ignoreAtRules: [isString, isRegExp],
+					ignoreSelectors: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
@@ -14,6 +13,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const generateColorFuncs = require('./generateColorFuncs');
 
@@ -39,7 +39,7 @@ function rule(expectation, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreProperties: [_.isString, _.isRegExp],
+					ignoreProperties: [isString, isRegExp],
 					ignore: ['inside-function'],
 				},
 				optional: true,

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const addEmptyLineBefore = require('../../utils/addEmptyLineBefore');
 const hasEmptyLine = require('../../utils/hasEmptyLine');
 const isAfterComment = require('../../utils/isAfterComment');
@@ -14,6 +13,7 @@ const removeEmptyLinesBefore = require('../../utils/removeEmptyLinesBefore');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'comment-empty-line-before';
 
@@ -38,7 +38,7 @@ function rule(expectation, options, context) {
 				possible: {
 					except: ['first-nested'],
 					ignore: ['stylelint-commands', 'after-comment'],
-					ignoreComments: [_.isString, _.isRegExp],
+					ignoreComments: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/comment-pattern/index.js
+++ b/lib/rules/comment-pattern/index.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-const _ = require('lodash');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'comment-pattern';
 
@@ -17,14 +17,14 @@ function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
-			possible: [_.isRegExp, _.isString],
+			possible: [isRegExp, isString],
 		});
 
 		if (!validOptions) {
 			return;
 		}
 
-		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
+		const normalizedPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkComments((comment) => {
 			const text = comment.text;

--- a/lib/rules/comment-word-disallowed-list/index.js
+++ b/lib/rules/comment-word-disallowed-list/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const containsString = require('../../utils/containsString');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'comment-word-disallowed-list';
 
@@ -19,7 +19,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/custom-media-pattern/index.js
+++ b/lib/rules/custom-media-pattern/index.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'custom-media-pattern';
 
@@ -18,14 +18,14 @@ function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
-			possible: [_.isRegExp, _.isString],
+			possible: [isRegExp, isString],
 		});
 
 		if (!validOptions) {
 			return;
 		}
 
-		const regexpPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
+		const regexpPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkAtRules((atRule) => {
 			if (atRule.name.toLowerCase() !== 'custom-media') {

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'custom-property-pattern';
 
@@ -18,14 +18,14 @@ function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
-			possible: [_.isRegExp, _.isString],
+			possible: [isRegExp, isString],
 		});
 
 		if (!validOptions) {
 			return;
 		}
 
-		const regexpPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
+		const regexpPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkDecls((decl) => {
 			const prop = decl.prop;

--- a/lib/rules/declaration-block-no-duplicate-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
@@ -10,6 +9,7 @@ const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-block-no-duplicate-properties';
 
@@ -27,7 +27,7 @@ function rule(on, options) {
 				actual: options,
 				possible: {
 					ignore: ['consecutive-duplicates', 'consecutive-duplicates-with-different-values'],
-					ignoreProperties: [_.isString],
+					ignoreProperties: [isString],
 				},
 				optional: true,
 			},

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -10,6 +10,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const shorthandData = require('../../reference/shorthandData');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-block-no-redundant-longhand-properties';
 
@@ -26,7 +27,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreShorthands: [_.isString, _.isRegExp],
+					ignoreShorthands: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/declaration-block-single-line-max-declarations/index.js
+++ b/lib/rules/declaration-block-single-line-max-declarations/index.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const beforeBlockString = require('../../utils/beforeBlockString');
 const blockString = require('../../utils/blockString');
 const isSingleLineString = require('../../utils/isSingleLineString');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-block-single-line-max-declarations';
 
@@ -20,7 +20,7 @@ function rule(quantity) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: quantity,
-			possible: [_.isNumber],
+			possible: [isNumber],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -12,6 +12,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
+const { isObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-unit-allowed-list';
 
@@ -26,7 +27,7 @@ function rule(list, options) {
 			ruleName,
 			{
 				actual: list,
-				possible: [_.isObject],
+				possible: [isObject],
 			},
 			{
 				actual: options,

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -12,7 +12,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-unit-allowed-list';
 

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -12,7 +12,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
-const { isObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-unit-allowed-list';
 
@@ -27,7 +27,7 @@ function rule(list, options) {
 			ruleName,
 			{
 				actual: list,
-				possible: [isObject],
+				possible: [isPlainObject],
 			},
 			{
 				actual: options,

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -11,7 +11,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
-const { isObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-unit-disallowed-list';
 
@@ -23,7 +23,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [isObject],
+			possible: [isPlainObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -11,6 +11,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
+const { isObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-unit-disallowed-list';
 
@@ -22,7 +23,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isObject],
+			possible: [isObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -11,7 +11,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-unit-disallowed-list';
 

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -8,7 +8,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-value-allowed-list';
 

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -8,6 +8,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-value-allowed-list';
 
@@ -19,7 +20,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isObject],
+			possible: [isObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -8,7 +8,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-value-allowed-list';
 
@@ -20,7 +20,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [isObject],
+			possible: [isPlainObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -8,7 +8,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-value-disallowed-list';
 

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -8,6 +8,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-value-disallowed-list';
 
@@ -19,7 +20,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isObject],
+			possible: [isObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -8,7 +8,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-value-disallowed-list';
 
@@ -20,7 +20,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [isObject],
+			possible: [isPlainObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/font-family-no-duplicate-names/index.js
+++ b/lib/rules/font-family-no-duplicate-names/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const findFontFamily = require('../../utils/findFontFamily');
 const keywordSets = require('../../reference/keywordSets');
@@ -10,6 +9,7 @@ const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'font-family-no-duplicate-names';
 
@@ -29,7 +29,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreFontFamilyNames: [_.isString, _.isRegExp],
+					ignoreFontFamilyNames: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -12,8 +12,7 @@ const postcss = require('postcss');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-
-const _ = require('lodash');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'font-family-no-missing-generic-family-keyword';
 
@@ -39,7 +38,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreFontFamilies: [_.isString, _.isRegExp],
+					ignoreFontFamilies: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/function-allowed-list/index.js
+++ b/lib/rules/function-allowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
@@ -11,6 +10,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'function-allowed-list';
 
@@ -24,7 +24,7 @@ function rule(listInput) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/function-disallowed-list/index.js
+++ b/lib/rules/function-disallowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
@@ -11,6 +10,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'function-disallowed-list';
 
@@ -22,7 +22,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/function-max-empty-lines/index.js
+++ b/lib/rules/function-max-empty-lines/index.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const { isNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'function-max-empty-lines';
 
@@ -26,7 +26,7 @@ function rule(max, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
-			possible: _.isNumber,
+			possible: isNumber,
 		});
 
 		if (!validOptions) {

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
@@ -13,6 +12,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'function-name-case';
 
@@ -38,7 +38,7 @@ function rule(expectation, options, context) {
 			{
 				actual: options,
 				possible: {
-					ignoreFunctions: [_.isString, _.isRegExp],
+					ignoreFunctions: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/function-url-scheme-allowed-list/index.js
+++ b/lib/rules/function-url-scheme-allowed-list/index.js
@@ -10,6 +10,7 @@ const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'function-url-scheme-allowed-list';
 
@@ -21,7 +22,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/function-url-scheme-disallowed-list/index.js
+++ b/lib/rules/function-url-scheme-disallowed-list/index.js
@@ -10,6 +10,7 @@ const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'function-url-scheme-disallowed-list';
 
@@ -21,7 +22,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const beforeBlockString = require('../../utils/beforeBlockString');
 const hasBlock = require('../../utils/hasBlock');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
+const { isBoolean, isNumber, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'indentation';
 const messages = ruleMessages(ruleName, {
@@ -32,16 +32,16 @@ function rule(space, options = {}, context) {
 			ruleName,
 			{
 				actual: space,
-				possible: [_.isNumber, 'tab'],
+				possible: [isNumber, 'tab'],
 			},
 			{
 				actual: options,
 				possible: {
-					baseIndentLevel: [_.isNumber, 'auto'],
+					baseIndentLevel: [isNumber, 'auto'],
 					except: ['block', 'value', 'param'],
 					ignore: ['value', 'param', 'inside-parens'],
 					indentInsideParens: ['twice', 'once-at-root-twice-in-block'],
-					indentClosingBrace: [_.isBoolean],
+					indentClosingBrace: [isBoolean],
 				},
 				optional: true,
 			},
@@ -85,7 +85,7 @@ function rule(space, options = {}, context) {
 				before.slice(lastIndexOfNewline + 1) !== expectedOpeningBraceIndentation
 			) {
 				if (context.fix) {
-					if (isFirstChild && _.isString(node.raws.before)) {
+					if (isFirstChild && isString(node.raws.before)) {
 						node.raws.before = node.raws.before.replace(
 							/^[ \t]*(?=\S|$)/,
 							expectedOpeningBraceIndentation,
@@ -595,7 +595,7 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 }
 
 function fixIndentation(str, whitespace) {
-	if (!_.isString(str)) {
+	if (!isString(str)) {
 		return str;
 	}
 

--- a/lib/rules/keyframes-name-pattern/index.js
+++ b/lib/rules/keyframes-name-pattern/index.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'keyframes-name-pattern';
 
@@ -19,14 +19,14 @@ function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
-			possible: [_.isRegExp, _.isString],
+			possible: [isRegExp, isString],
 		});
 
 		if (!validOptions) {
 			return;
 		}
 
-		const regex = _.isString(pattern) ? new RegExp(pattern) : pattern;
+		const regex = isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkAtRules(/keyframes/i, (keyframesNode) => {
 			const value = keyframesNode.params;

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const valueParser = require('postcss-value-parser');
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -19,6 +18,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const setAtRuleParams = require('../../utils/setAtRuleParams');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'length-zero-no-unit';
 
@@ -38,7 +38,7 @@ function rule(primary, secondary, context) {
 				actual: secondary,
 				possible: {
 					ignore: ['custom-properties'],
-					ignoreFunctions: [_.isString, _.isRegExp],
+					ignoreFunctions: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
+const { isNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'max-empty-lines';
 
@@ -25,7 +25,7 @@ function rule(max, options, context) {
 			ruleName,
 			{
 				actual: max,
-				possible: _.isNumber,
+				possible: isNumber,
 			},
 			{
 				actual: options,

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const execall = require('execall');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
+const { isNumber, isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'max-line-length';
 const EXCLUDED_PATTERNS = [
@@ -28,13 +28,13 @@ function rule(maxLength, options, context) {
 			ruleName,
 			{
 				actual: maxLength,
-				possible: _.isNumber,
+				possible: isNumber,
 			},
 			{
 				actual: options,
 				possible: {
 					ignore: ['non-comments', 'comments'],
-					ignorePattern: [_.isString, _.isRegExp],
+					ignorePattern: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const hasBlock = require('../../utils/hasBlock');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -10,6 +9,7 @@ const parser = require('postcss-selector-parser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isNumber, isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'max-nesting-depth';
 
@@ -27,14 +27,14 @@ function rule(max, options) {
 			ruleName,
 			{
 				actual: max,
-				possible: [_.isNumber],
+				possible: [isNumber],
 			},
 			{
 				optional: true,
 				actual: options,
 				possible: {
 					ignore: ['blockless-at-rules', 'pseudo-classes'],
-					ignoreAtRules: [_.isString, _.isRegExp],
+					ignoreAtRules: [isString, isRegExp],
 				},
 			},
 		);

--- a/lib/rules/media-feature-name-allowed-list/index.js
+++ b/lib/rules/media-feature-name-allowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isCustomMediaQuery = require('../../utils/isCustomMediaQuery');
 const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
@@ -13,6 +12,7 @@ const rangeContextNodeParser = require('../rangeContextNodeParser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'media-feature-name-allowed-list';
 
@@ -24,7 +24,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/media-feature-name-disallowed-list/index.js
+++ b/lib/rules/media-feature-name-disallowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isCustomMediaQuery = require('../../utils/isCustomMediaQuery');
 const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
@@ -13,6 +12,7 @@ const rangeContextNodeParser = require('../rangeContextNodeParser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'media-feature-name-disallowed-list';
 
@@ -24,7 +24,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/media-feature-name-no-unknown/index.js
+++ b/lib/rules/media-feature-name-no-unknown/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isCustomMediaQuery = require('../../utils/isCustomMediaQuery');
 const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
@@ -15,6 +14,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'media-feature-name-no-unknown';
 
@@ -31,7 +31,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreMediaFeatureNames: [_.isString, _.isRegExp],
+					ignoreMediaFeatureNames: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -12,6 +12,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isObject } = require('../../utils/validateTypes');
 
 const ruleName = 'media-feature-name-value-allowed-list';
 
@@ -23,7 +24,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isObject],
+			possible: [isObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -12,7 +12,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'media-feature-name-value-allowed-list';
 
@@ -24,7 +24,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [isObject],
+			possible: [isPlainObject],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -12,7 +12,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('../../utils/validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'media-feature-name-value-allowed-list';
 

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -12,6 +12,7 @@ const report = require('../../utils/report');
 const resolvedNestedSelector = require('postcss-resolve-nested-selector');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isBoolean } = require('../../utils/validateTypes');
 
 const ruleName = 'no-duplicate-selectors';
 
@@ -29,7 +30,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					disallowInList: _.isBoolean,
+					disallowInList: isBoolean,
 				},
 				optional: true,
 			},

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -9,8 +9,8 @@ const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isNumber, isRegExp, isString } = require('../../utils/validateTypes');
 
-const _ = require('lodash');
 const valueParser = require('postcss-value-parser');
 
 const ruleName = 'number-max-precision';
@@ -26,13 +26,13 @@ function rule(precision, options) {
 			ruleName,
 			{
 				actual: precision,
-				possible: [_.isNumber],
+				possible: [isNumber],
 			},
 			{
 				optional: true,
 				actual: options,
 				possible: {
-					ignoreUnits: [_.isString, _.isRegExp],
+					ignoreUnits: [isString, isRegExp],
 				},
 			},
 		);

--- a/lib/rules/property-allowed-list/index.js
+++ b/lib/rules/property-allowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'property-allowed-list';
 
@@ -21,7 +21,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/property-disallowed-list/index.js
+++ b/lib/rules/property-disallowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'property-disallowed-list';
 
@@ -21,7 +21,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
@@ -12,6 +11,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isBoolean, isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'property-no-unknown';
 
@@ -30,10 +30,10 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreProperties: [_.isString, _.isRegExp],
-					checkPrefixed: _.isBoolean,
-					ignoreSelectors: [_.isString, _.isRegExp],
-					ignoreAtRules: [_.isString, _.isRegExp],
+					ignoreProperties: [isString, isRegExp],
+					checkPrefixed: isBoolean,
+					ignoreSelectors: [isString, isRegExp],
+					ignoreAtRules: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/property-no-vendor-prefix/index.js
+++ b/lib/rules/property-no-vendor-prefix/index.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isAutoprefixable = require('../../utils/isAutoprefixable');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'property-no-vendor-prefix';
 
@@ -26,7 +26,7 @@ function rule(actual, options, context) {
 				optional: true,
 				actual: options,
 				possible: {
-					ignoreProperties: [_.isString, _.isRegExp],
+					ignoreProperties: [isString, isRegExp],
 				},
 			},
 		);

--- a/lib/rules/selector-attribute-name-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-name-disallowed-list/index.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-attribute-name-disallowed-list';
 
@@ -22,7 +22,7 @@ function rule(listInput) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-attribute-operator-allowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-allowed-list/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-attribute-operator-allowed-list';
 
@@ -21,7 +21,7 @@ function rule(listInput) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString],
+			possible: [isString],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-attribute-operator-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-disallowed-list/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-attribute-operator-disallowed-list';
 
@@ -21,7 +21,7 @@ function rule(listInput) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString],
+			possible: [isString],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isKeyframeSelector = require('../../utils/isKeyframeSelector');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
@@ -11,6 +10,7 @@ const report = require('../../utils/report');
 const resolveNestedSelector = require('postcss-resolve-nested-selector');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isBoolean, isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-class-pattern';
 
@@ -26,12 +26,12 @@ function rule(pattern, options) {
 			ruleName,
 			{
 				actual: pattern,
-				possible: [_.isRegExp, _.isString],
+				possible: [isRegExp, isString],
 			},
 			{
 				actual: options,
 				possible: {
-					resolveNestedSelectors: _.isBoolean,
+					resolveNestedSelectors: isBoolean,
 				},
 				optional: true,
 			},
@@ -42,7 +42,7 @@ function rule(pattern, options) {
 		}
 
 		const shouldResolveNestedSelectors = options && options.resolveNestedSelectors;
-		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
+		const normalizedPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkRules((ruleNode) => {
 			const selector = ruleNode.selector;

--- a/lib/rules/selector-combinator-allowed-list/index.js
+++ b/lib/rules/selector-combinator-allowed-list/index.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxCombinator = require('../../utils/isStandardSyntaxCombinator');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-combinator-allowed-list';
 
@@ -20,7 +20,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString],
+			possible: [isString],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-combinator-disallowed-list/index.js
+++ b/lib/rules/selector-combinator-disallowed-list/index.js
@@ -2,13 +2,13 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxCombinator = require('../../utils/isStandardSyntaxCombinator');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-combinator-disallowed-list';
 
@@ -20,7 +20,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString],
+			possible: [isString],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-disallowed-list/index.js
+++ b/lib/rules/selector-disallowed-list/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-disallowed-list';
 
@@ -21,7 +21,7 @@ function rule(listInput) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-id-pattern';
 
@@ -20,14 +20,14 @@ function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
-			possible: [_.isRegExp, _.isString],
+			possible: [isRegExp, isString],
 		});
 
 		if (!validOptions) {
 			return;
 		}
 
-		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
+		const normalizedPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -12,6 +11,7 @@ const report = require('../../utils/report');
 const resolvedNestedSelector = require('postcss-resolve-nested-selector');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-max-attribute';
 
@@ -34,7 +34,7 @@ function rule(max, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreAttributes: [_.isString, _.isRegExp],
+					ignoreAttributes: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-max-empty-lines/index.js
+++ b/lib/rules/selector-max-empty-lines/index.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-const _ = require('lodash');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-max-empty-lines';
 
@@ -19,7 +19,7 @@ function rule(max, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
-			possible: _.isNumber,
+			possible: isNumber,
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -12,6 +11,7 @@ const report = require('../../utils/report');
 const resolvedNestedSelector = require('postcss-resolve-nested-selector');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-max-id';
 
@@ -32,7 +32,7 @@ function rule(max, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreContextFunctionalPseudoClasses: [_.isString, _.isRegExp],
+					ignoreContextFunctionalPseudoClasses: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
 const keywordSets = require('../../reference/keywordSets');
@@ -13,6 +12,7 @@ const resolvedNestedSelector = require('postcss-resolve-nested-selector');
 const ruleMessages = require('../../utils/ruleMessages');
 const specificity = require('specificity');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-max-specificity';
 
@@ -51,7 +51,7 @@ function rule(max, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreSelectors: [_.isString, _.isRegExp],
+					ignoreSelectors: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
 const isKeyframeSelector = require('../../utils/isKeyframeSelector');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger');
@@ -16,6 +15,7 @@ const report = require('../../utils/report');
 const resolvedNestedSelector = require('postcss-resolve-nested-selector');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-max-type';
 
@@ -39,7 +39,7 @@ function rule(max, options) {
 				actual: options,
 				possible: {
 					ignore: ['descendant', 'child', 'compounded', 'next-sibling'],
-					ignoreTypes: [_.isString, _.isRegExp],
+					ignoreTypes: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-nested-pattern/index.js
+++ b/lib/rules/selector-nested-pattern/index.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-nested-pattern';
 
@@ -19,14 +19,14 @@ function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: pattern,
-			possible: [_.isRegExp, _.isString],
+			possible: [isRegExp, isString],
 		});
 
 		if (!validOptions) {
 			return;
 		}
 
-		const normalizedPattern = _.isString(pattern) ? new RegExp(pattern) : pattern;
+		const normalizedPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
 		root.walkRules((ruleNode) => {
 			if (ruleNode.parent.type !== 'rule') {

--- a/lib/rules/selector-no-vendor-prefix/index.js
+++ b/lib/rules/selector-no-vendor-prefix/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isAutoprefixable = require('../../utils/isAutoprefixable');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -10,6 +9,7 @@ const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-no-vendor-prefix';
 
@@ -26,7 +26,7 @@ function rule(actual, options, context) {
 			{
 				actual: options,
 				possible: {
-					ignoreSelectors: [_.isString],
+					ignoreSelectors: [isString],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-pseudo-class-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-allowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-pseudo-class-allowed-list';
 
@@ -21,7 +21,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-pseudo-class-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-disallowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-pseudo-class-disallowed-list';
 
@@ -21,7 +21,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isCustomSelector = require('../../utils/isCustomSelector');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
@@ -15,6 +14,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-pseudo-class-no-unknown';
 
@@ -31,7 +31,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignorePseudoClasses: [_.isString],
+					ignorePseudoClasses: [isString],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-pseudo-element-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-allowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-pseudo-element-allowed-list';
 
@@ -21,7 +21,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-pseudo-element-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-disallowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const parseSelector = require('../../utils/parseSelector');
@@ -10,6 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-pseudo-element-disallowed-list';
 
@@ -21,7 +21,7 @@ function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: list,
-			possible: [_.isString, _.isRegExp],
+			possible: [isString, isRegExp],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
 const keywordSets = require('../../reference/keywordSets');
@@ -12,6 +11,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-pseudo-element-no-unknown';
 
@@ -28,7 +28,7 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignorePseudoElements: [_.isString],
+					ignorePseudoElements: [isString],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isKeyframeSelector = require('../../utils/isKeyframeSelector');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const isStandardSyntaxTypeSelector = require('../../utils/isStandardSyntaxTypeSelector');
@@ -11,6 +10,7 @@ const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-type-case';
 
@@ -30,7 +30,7 @@ function rule(expectation, options, context) {
 			{
 				actual: options,
 				possible: {
-					ignoreTypes: [_.isString],
+					ignoreTypes: [isString],
 				},
 				optional: true,
 			},

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const htmlTags = require('html-tags');
 const isCustomElement = require('../../utils/isCustomElement');
 const isKeyframeSelector = require('../../utils/isKeyframeSelector');
@@ -16,6 +15,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const svgTags = require('svg-tags');
 const validateOptions = require('../../utils/validateOptions');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-type-no-unknown';
 
@@ -33,8 +33,8 @@ function rule(actual, options) {
 				actual: options,
 				possible: {
 					ignore: ['custom-elements', 'default-namespace'],
-					ignoreNamespaces: [_.isString, _.isRegExp],
-					ignoreTypes: [_.isString, _.isRegExp],
+					ignoreNamespaces: [isString, isRegExp],
+					ignoreTypes: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -11,6 +10,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const { isBoolean } = require('../../utils/validateTypes');
 
 const ruleName = 'string-quotes';
 
@@ -36,7 +36,7 @@ function rule(expectation, secondary, context) {
 			{
 				actual: secondary,
 				possible: {
-					avoidEscape: _.isBoolean,
+					avoidEscape: isBoolean,
 				},
 				optional: true,
 			},

--- a/lib/rules/time-min-milliseconds/index.js
+++ b/lib/rules/time-min-milliseconds/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const keywordSets = require('../../reference/keywordSets');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -12,6 +11,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
+const { isNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'time-min-milliseconds';
 
@@ -28,7 +28,7 @@ function rule(minimum, options) {
 			ruleName,
 			{
 				actual: minimum,
-				possible: _.isNumber,
+				possible: isNumber,
 			},
 			{
 				actual: options,

--- a/lib/rules/unit-allowed-list/index.js
+++ b/lib/rules/unit-allowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
@@ -12,6 +11,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateObjectWithArrayProps = require('../../utils/validateObjectWithArrayProps');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'unit-allowed-list';
 
@@ -28,13 +28,13 @@ function rule(listInput, options) {
 			ruleName,
 			{
 				actual: list,
-				possible: [_.isString],
+				possible: [isString],
 			},
 			{
 				optional: true,
 				actual: options,
 				possible: {
-					ignoreProperties: validateObjectWithArrayProps([_.isString, _.isRegExp]),
+					ignoreProperties: validateObjectWithArrayProps([isString, isRegExp]),
 				},
 			},
 		);

--- a/lib/rules/unit-disallowed-list/index.js
+++ b/lib/rules/unit-disallowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
@@ -13,6 +12,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateObjectWithArrayProps = require('../../utils/validateObjectWithArrayProps');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'unit-disallowed-list';
 
@@ -37,14 +37,14 @@ function rule(listInput, options) {
 			ruleName,
 			{
 				actual: list,
-				possible: [_.isString],
+				possible: [isString],
 			},
 			{
 				optional: true,
 				actual: options,
 				possible: {
-					ignoreProperties: validateObjectWithArrayProps([_.isString, _.isRegExp]),
-					ignoreMediaFeatureNames: validateObjectWithArrayProps([_.isString, _.isRegExp]),
+					ignoreProperties: validateObjectWithArrayProps([isString, isRegExp]),
+					ignoreMediaFeatureNames: validateObjectWithArrayProps([isString, isRegExp]),
 				},
 			},
 		);

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
@@ -15,6 +14,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'unit-no-unknown';
 
@@ -35,8 +35,8 @@ function rule(actual, options) {
 			{
 				actual: options,
 				possible: {
-					ignoreUnits: [_.isString, _.isRegExp],
-					ignoreFunctions: [_.isString, _.isRegExp],
+					ignoreUnits: [isString, isRegExp],
+					ignoreFunctions: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
@@ -15,6 +14,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'value-keyword-case';
 
@@ -45,9 +45,9 @@ function rule(expectation, options, context) {
 			{
 				actual: options,
 				possible: {
-					ignoreProperties: [_.isString, _.isRegExp],
-					ignoreKeywords: [_.isString, _.isRegExp],
-					ignoreFunctions: [_.isString, _.isRegExp],
+					ignoreProperties: [isString, isRegExp],
+					ignoreKeywords: [isString, isRegExp],
+					ignoreFunctions: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/value-list-max-empty-lines/index.js
+++ b/lib/rules/value-list-max-empty-lines/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-const _ = require('lodash');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
+const { isNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'value-list-max-empty-lines';
 
@@ -21,7 +21,7 @@ function rule(max, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: max,
-			possible: _.isNumber,
+			possible: isNumber,
 		});
 
 		if (!validOptions) {

--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const isAutoprefixable = require('../../utils/isAutoprefixable');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
@@ -12,6 +11,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'value-no-vendor-prefix';
 
@@ -31,7 +31,7 @@ function rule(actual, options, context) {
 				optional: true,
 				actual: options,
 				possible: {
-					ignoreValues: [_.isString],
+					ignoreValues: [isString],
 				},
 			},
 		);

--- a/lib/utils/containsString.js
+++ b/lib/utils/containsString.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const { isString } = require('./validateTypes');
 
 /** @typedef {false | { match: string, pattern: string }} ReturnValue */
 
@@ -42,7 +42,7 @@ module.exports = function containsString(input, comparison) {
 function testAgainstString(value, comparison) {
 	if (!comparison) return false;
 
-	if (!_.isString(comparison)) return false;
+	if (!isString(comparison)) return false;
 
 	if (comparison.startsWith('/') && comparison.endsWith('/')) {
 		return false;

--- a/lib/utils/validateObjectWithArrayProps.js
+++ b/lib/utils/validateObjectWithArrayProps.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isPlainObject } = require('./validateTypes');
+
 /**
  * @template T
  * @typedef {(i: T) => boolean} Validator
@@ -18,7 +20,7 @@
  * @returns {(value: {[k: any]: T|T[]}) => boolean}
  */
 module.exports = (validator) => (value) => {
-	if (Object.prototype.toString.call(value) !== '[object Object]') {
+	if (!isPlainObject(value)) {
 		return false;
 	}
 

--- a/lib/utils/validateObjectWithArrayProps.js
+++ b/lib/utils/validateObjectWithArrayProps.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isPlainObject } = require('./validateTypes');
+const { isPlainObject } = require('is-plain-object');
 
 /**
  * @template T

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { isPlainObject } = require('lodash');
 
 const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables']);
 
@@ -121,7 +122,7 @@ function validate(opts, ruleName, complain) {
 	}
 
 	// If actual is NOT an object ...
-	if (Object.prototype.toString.call(actual) !== '[object Object]') {
+	if (!isPlainObject(actual)) {
 		complain(
 			`Invalid option value ${JSON.stringify(actual)} for rule "${ruleName}": should be an object`,
 		);

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const { isPlainObject } = require('lodash');
+const { isPlainObject } = require('is-plain-object');
 
 const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables']);
 

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -19,15 +19,6 @@ function isNumber(value) {
 }
 
 /**
- * Checks if the value is a plain object.
- * @param {any} value
- * @returns {boolean}
- */
-function isPlainObject(value) {
-	return Object.prototype.toString.call(value) === '[object Object]';
-}
-
-/**
  * Checks if the value is a RegExp object.
  * @param {any} value
  * @returns {boolean}
@@ -48,7 +39,6 @@ function isString(value) {
 module.exports = {
 	isBoolean,
 	isNumber,
-	isPlainObject,
 	isRegExp,
 	isString,
 };

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -19,12 +19,12 @@ function isNumber(value) {
 }
 
 /**
- * Checks if the value is the language type of Object.
+ * Checks if the value is a plain object.
  * @param {any} value
  * @returns {boolean}
  */
-function isObject(value) {
-	return value instanceof Object;
+function isPlainObject(value) {
+	return Object.prototype.toString.call(value) === '[object Object]';
 }
 
 /**
@@ -48,7 +48,7 @@ function isString(value) {
 module.exports = {
 	isBoolean,
 	isNumber,
-	isObject,
+	isPlainObject,
 	isRegExp,
 	isString,
 };

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Checks if the value is a boolean or a Boolean object.
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isBoolean(value) {
+	return typeof value === 'boolean' || value instanceof Boolean;
+}
+
+/**
+ * Checks if the value is a number or a Number object.
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isNumber(value) {
+	return typeof value === 'number' || value instanceof Number;
+}
+
+/**
+ * Checks if the value is the language type of Object.
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isObject(value) {
+	return value instanceof Object;
+}
+
+/**
+ * Checks if the value is a RegExp object.
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isRegExp(value) {
+	return value instanceof RegExp;
+}
+
+/**
+ * Checks if the value is a string or a String object.
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isString(value) {
+	return typeof value === 'string' || value instanceof String;
+}
+
+module.exports = {
+	isBoolean,
+	isNumber,
+	isObject,
+	isRegExp,
+	isString,
+};

--- a/lib/validateDisableSettings.js
+++ b/lib/validateDisableSettings.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
 const validateOptions = require('./utils/validateOptions');
+const { isRegExp, isString } = require('./utils/validateTypes');
 
 /**
  * @typedef {import('stylelint').PostcssResult} PostcssResult
@@ -57,7 +57,7 @@ module.exports = function (result, field) {
 		{
 			actual: options,
 			possible: {
-				except: [_.isString, _.isRegExp],
+				except: [isString, isRegExp],
 			},
 		},
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "ignore": "^5.1.8",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.21.0",
         "lodash": "^4.17.21",
         "log-symbols": "^4.1.0",
@@ -4718,6 +4719,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -14380,6 +14389,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-potential-custom-element-name": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "ignore": "^5.1.8",
     "import-lazy": "^4.0.0",
     "imurmurhash": "^0.1.4",
+    "is-plain-object": "^5.0.0",
     "known-css-properties": "^0.21.0",
     "lodash": "^4.17.21",
     "log-symbols": "^4.1.0",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

This PR removes the following type validation functions that are used in most rules to check types:
- `_.isBoolean`
- `_.isNumber`
- `_.isObject`
- `_.isRegExp`
- `_.isString`

Since these are frequently used together in calls to `validateOptions`, I thought it would be better to combine them into one PR.

This PR adds the 4 simple functions in [`lib/utils/validateTypes.js`](https://github.com/stylelint/stylelint/pull/5341/files#diff-4c56d4c1a85a6bd394b261b4f742fa1f3040377022f7917cfb974a8833ef3618). It also adds the [`is-plain-object`](https://www.npmjs.com/package/is-plain-object) package because that is a more complicated check to write manually – see https://github.com/stylelint/stylelint/pull/5341#discussion_r645215098.