### PR TITLE
Removes DisableReportRange.unusedRule from types

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -256,11 +256,6 @@ declare module 'stylelint' {
 		rule: string;
 		start: number;
 		end?: number;
-
-		// This is for backwards-compatibility with formatters that were written
-		// when this name was used instead of `rule`. It should be avoided for new
-		// formatters.
-		unusedRule: string;
 	};
 
 	export type RangeType = DisabledRange & { used?: boolean };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4899.

> Is there anything in the PR that needs further explanation?

Relatively short PR that follows up on the change made in #4897. Pretty sure this is a quick and simple change, but let me know if I've missed anything!
