### PR TITLE
Refactor to remove `_.groupBy`

### DIFF
--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
 const chalk = require('chalk');
 const stringFormatter = require('./stringFormatter');
 
+/** @typedef {import('stylelint').Formatter} Formatter */
+/** @typedef {import('stylelint').StylelintWarning} StylelintWarning */
+
 /**
- * @type {import('stylelint').Formatter}
+ * @type {Formatter}
  */
 module.exports = function (results) {
 	let output = stringFormatter(results);
@@ -42,13 +44,13 @@ module.exports = function (results) {
 	});
 
 	const warnings = results.flatMap((r) => r.warnings);
-	const warningsBySeverity = _.groupBy(warnings, 'severity');
+	const warningsBySeverity = groupBy(warnings, (w) => w.severity);
 	const problemWord = warnings.length === 1 ? 'problem' : 'problems';
 
 	output += chalk.underline(`\n${warnings.length} ${problemWord} found\n`);
 
 	for (const [severityLevel, warningList] of Object.entries(warningsBySeverity)) {
-		const warningsByRule = _.groupBy(warningList, 'rule');
+		const warningsByRule = groupBy(warningList, (w) => w.rule);
 
 		output += ` severity level "${severityLevel}": ${warningList.length}\n`;
 
@@ -59,3 +61,24 @@ module.exports = function (results) {
 
 	return `${output}\n`;
 };
+
+/**
+ * @param {StylelintWarning[]} array
+ * @param {(w: StylelintWarning) => string} keyFn
+ */
+function groupBy(array, keyFn) {
+	/** @type {{[s: string]: StylelintWarning[]}} */
+	const result = {};
+
+	for (const item of array) {
+		const key = keyFn(item);
+
+		if (!(key in result)) {
+			result[key] = [];
+		}
+
+		result[key].push(item);
+	}
+
+	return result;
+}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

Since `_.groupBy` is used twice in this file and only in this file, I avoided repeating code by adding a `groupBy` function to this file.