### PR TITLE
Fix typos

### DIFF
--- a/docs/user-guide/usage/cli.md
+++ b/docs/user-guide/usage/cli.md
@@ -54,7 +54,7 @@ Specify the formatter to format your results. More info about this option in [st
 
 ### `--ignore-disables, --id`
 
-Ignore `styleline-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments. More info about this option in [standard options](options.md#ignoreDisables).
+Ignore `stylelint-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments. More info about this option in [standard options](options.md#ignoreDisables).
 
 ### `--ignore-path, -i`
 

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -134,7 +134,7 @@ A path to a file containing patterns describing files to ignore. The path can be
 
 CLI flags: `--ignore-disables, --id`
 
-Ignore `styleline-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments.
+Ignore `stylelint-disable` (e.g. `/* stylelint-disable block-no-empty */`) comments.
 
 You can use this option to see what your linting results would be like without those exceptions.
 

--- a/lib/__tests__/__snapshots__/cli.test.js.snap
+++ b/lib/__tests__/__snapshots__/cli.test.js.snap
@@ -72,7 +72,7 @@ exports[`CLI --help 1`] = `
 
     --ignore-disables, --id
 
-      Ignore styleline-disable comments.
+      Ignore stylelint-disable comments.
 
     --disable-default-ignores, --di
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -155,7 +155,7 @@ const meowOptions = {
 
       --ignore-disables, --id
 
-        Ignore styleline-disable comments.
+        Ignore stylelint-disable comments.
 
       --disable-default-ignores, --di
 


### PR DESCRIPTION
In various files around the repo, `stylelint` has been spelled as `styleline`. This commit fixes all mistypes.