### PR TITLE
Migrate stylelint PostCSS plugin to Visitors API

### DIFF
--- a/lib/__tests__/defaultSeverity.test.js
+++ b/lib/__tests__/defaultSeverity.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcss = require('postcss');
 const postcssPlugin = require('../postcssPlugin');
 
 it('`defaultSeverity` option set to warning', async () => {
@@ -10,7 +11,7 @@ it('`defaultSeverity` option set to warning', async () => {
 		},
 	};
 
-	const result = await postcssPlugin.process('a {}', { from: undefined }, config);
+	const result = await postcss([postcssPlugin(config)]).process('a {}', { from: undefined });
 
 	expect(result.warnings()).toMatchObject([
 		expect.objectContaining({

--- a/lib/__tests__/ignoreDisables.test.js
+++ b/lib/__tests__/ignoreDisables.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcss = require('postcss');
 const postcssPlugin = require('../postcssPlugin');
 const standalone = require('../standalone');
 
@@ -19,14 +20,12 @@ describe('ignoreDisables with postcssPlugins', () => {
 	let result;
 
 	beforeEach(async () => {
-		result = await postcssPlugin.process(
-			css,
-			{ from: undefined },
-			{
+		result = await postcss([
+			postcssPlugin({
 				config,
 				ignoreDisables: true,
-			},
-		);
+			}),
+		]).process(css, { from: undefined });
 	});
 
 	it('expected number of warnings', () => {

--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -2,30 +2,34 @@
 
 const configurationError = require('../utils/configurationError');
 const path = require('path');
+const postcss = require('postcss');
 const postcssPlugin = require('../postcssPlugin');
 
 it('`config` option is `null`', () => {
-	return expect(postcssPlugin.process('a {}', { from: undefined })).rejects.toMatchObject({
+	return expect(
+		postcss([postcssPlugin()]).process('a {}', { from: undefined }),
+	).rejects.toMatchObject({
 		message: expect.stringMatching('No configuration provided'),
 	});
 });
 
-it('`configFile` option with absolute path', () => {
+it('`configFile` option with absolute path', async () => {
 	const config = {
 		configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
 	};
 
-	return postcssPlugin.process('a {}', { from: undefined }, config).then((postcssResult) => {
-		const warnings = postcssResult.warnings();
-
-		expect(warnings).toHaveLength(1);
-		expect(warnings[0].text).toContain('block-no-empty');
+	const postcssResult = await postcss([postcssPlugin(config)]).process('a {}', {
+		from: undefined,
 	});
+	const warnings = postcssResult.warnings();
+
+	expect(warnings).toHaveLength(1);
+	expect(warnings[0].text).toContain('block-no-empty');
 });
 
 it('`configFile` with bad path', () => {
 	return expect(
-		postcssPlugin.process('a {}', { from: undefined }, { configFile: './herby.json' }),
+		postcss([postcssPlugin({ configFile: './herby.json' })]).process('a {}', { from: undefined }),
 	).rejects.toHaveProperty('code', 'ENOENT');
 });
 
@@ -34,7 +38,9 @@ it('`configFile` option without rules', () => {
 		configFile: path.join(__dirname, 'fixtures/config-without-rules.json'),
 	};
 
-	return expect(postcssPlugin.process('a {}', { from: undefined }, config)).rejects.toEqual(
+	return expect(
+		postcss([postcssPlugin(config)]).process('a {}', { from: undefined }),
+	).rejects.toEqual(
 		configurationError(
 			'No rules found within configuration. Have you provided a "rules" property?',
 		),
@@ -47,7 +53,9 @@ it('`configFile` option with undefined rule', () => {
 	};
 	const ruleName = 'unknown-rule';
 
-	return expect(postcssPlugin.process('a {}', { from: undefined }, config)).resolves.toMatchObject({
+	return expect(
+		postcss([postcssPlugin(config)]).process('a {}', { from: undefined }),
+	).resolves.toMatchObject({
 		messages: [
 			expect.objectContaining({
 				line: 1,
@@ -66,13 +74,11 @@ it('`ignoreFiles` options is not empty and file ignored', () => {
 			'block-no-empty': true,
 		},
 		ignoreFiles: '**/foo.css',
-		from: 'foo.css',
 	};
 
-	return expect(postcssPlugin.process('a {}', { from: undefined }, config)).resolves.toHaveProperty(
-		'stylelint.ignored',
-		true,
-	);
+	return expect(
+		postcss([postcssPlugin(config)]).process('a {}', { from: 'foo.css' }),
+	).resolves.toHaveProperty('stylelint.ignored', true);
 });
 
 it('`ignoreFiles` options is not empty and file not ignored', () => {
@@ -81,11 +87,10 @@ it('`ignoreFiles` options is not empty and file not ignored', () => {
 			'block-no-empty': true,
 		},
 		ignoreFiles: '**/bar.css',
-		from: 'foo.css',
 	};
 
 	return expect(
-		postcssPlugin.process('a {}', { from: undefined }, config),
+		postcss([postcssPlugin(config)]).process('a {}', { from: 'foo.css' }),
 	).resolves.not.toHaveProperty('stylelint.ignored');
 });
 
@@ -108,11 +113,10 @@ describe('stylelintignore', () => {
 					'block-no-empty': true,
 				},
 			},
-			from: 'postcssstylelintignore.css',
 		};
 
 		return expect(
-			postcssPlugin.process('a {}', { from: undefined }, options),
+			postcss([postcssPlugin(options)]).process('a {}', { from: 'postcssstylelintignore.css' }),
 		).resolves.toHaveProperty('stylelint.ignored', true);
 	});
 
@@ -123,12 +127,11 @@ describe('stylelintignore', () => {
 					'block-no-empty': true,
 				},
 			},
-			from: 'foo.css',
 			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
 		};
 
 		return expect(
-			postcssPlugin.process('a {}', { from: undefined }, options),
+			postcss([postcssPlugin(options)]).process('a {}', { from: 'foo.css' }),
 		).resolves.toHaveProperty('stylelint.ignored', true);
 	});
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,22 +12,19 @@ const standalone = require('./standalone');
 const validateOptions = require('./utils/validateOptions');
 
 /**
- * TODO TYPES change any to appropriated options
- * @type {import('postcss').Plugin & Partial<import('stylelint').StylelintPublicAPI>}
+ * @type {import('postcss').PluginCreator<import('stylelint').PostcssPluginOptions> & import('stylelint').StylelintPublicAPI}
  */
-const api = postcssPlugin;
+module.exports = postcssPlugin;
 
-api.utils = {
+module.exports.utils = {
 	report,
 	ruleMessages,
 	validateOptions,
 	checkAgainstRule,
 };
 
-api.lint = standalone;
-api.rules = rules;
-api.formatters = formatters;
-api.createPlugin = createPlugin;
-api.createLinter = createStylelint;
-
-module.exports = api;
+module.exports.lint = standalone;
+module.exports.rules = rules;
+module.exports.formatters = formatters;
+module.exports.createPlugin = createPlugin;
+module.exports.createLinter = createStylelint;

--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -31,7 +31,6 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 			throw new Error('Unexpected Postcss root object!');
 		}
 
-		// @ts-ignore TODO TYPES property css does not exists
 		const newlineMatch = postcssDoc.source && postcssDoc.source.input.css.match(/\r?\n/);
 
 		newline = newlineMatch ? newlineMatch[0] : getOsEol();

--- a/lib/postcssPlugin.js
+++ b/lib/postcssPlugin.js
@@ -1,26 +1,41 @@
-// @ts-nocheck
 'use strict';
 
 const createStylelint = require('./createStylelint');
 const path = require('path');
-const postcss = require('postcss');
 
-module.exports = postcss.plugin('stylelint', (options = {}) => {
-	const tailoredOptions = options.rules ? { config: options } : options;
+/** @typedef {import('stylelint').PostcssPluginOptions} PostcssPluginOptions */
+/** @typedef {import('stylelint').StylelintConfig} StylelintConfig */
+
+/**
+ * @type {import('postcss').PluginCreator<PostcssPluginOptions>}
+ * */
+module.exports = (options = {}) => {
+	const tailoredOptions = isConfig(options) ? { config: options } : options;
 	const stylelint = createStylelint(tailoredOptions);
 
-	return (root, result) => {
-		let filePath = options.from;
+	return {
+		postcssPlugin: 'stylelint',
+		Once(root, { result }) {
+			let filePath = root.source && root.source.input.file;
 
-		if (!filePath) filePath = root.source && root.source.input.file;
+			if (filePath && !path.isAbsolute(filePath)) {
+				filePath = path.join(process.cwd(), filePath);
+			}
 
-		if (filePath && !path.isAbsolute(filePath)) {
-			filePath = path.join(process.cwd(), filePath);
-		}
-
-		return stylelint._lintSource({
-			filePath,
-			existingPostcssResult: result,
-		});
+			return stylelint._lintSource({
+				filePath,
+				existingPostcssResult: result,
+			});
+		},
 	};
-});
+};
+
+module.exports.postcss = true;
+
+/**
+ * @param {PostcssPluginOptions} options
+ * @returns {options is StylelintConfig}
+ */
+function isConfig(options) {
+	return 'rules' in options;
+}

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -253,13 +253,11 @@ module.exports = function (options) {
 							options.fix &&
 							!postcssResult.stylelint.disableWritingFix
 						) {
-							// @ts-ignore TODO TYPES toString accepts 0 arguments
 							const fixedCss = postcssResult.root.toString(postcssResult.opts.syntax);
 
 							if (
 								postcssResult.root &&
 								postcssResult.root.source &&
-								// @ts-ignore TODO TYPES css is unknown property
 								postcssResult.root.source.input.css !== fixedCss
 							) {
 								fixFile = writeFileAtomic(absoluteFilepath, fixedCss);

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -302,4 +302,8 @@ declare module 'stylelint' {
 	};
 
 	export type StylelintDisableOptionsReport = Array<StylelintDisableReportEntry>;
+
+	export type PostcssPluginOptions =
+		| Omit<StylelintStandaloneOptions, 'syntax' | 'customSyntax'>
+		| StylelintConfig;
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #4942

> Is there anything in the PR that needs further explanation?

That was easier than I though. Basically I needed to change only our PostCSS plugin part to Visitors API to avoid warnings in tests. Nothing changes in execution order.

I think for us to embrace Visitors API in rules many changes needs to be done. Currently `stylelint` is not a PostCSS plugin. It uses PostCSS internals like `LazyResult` to go around PostCSS API. And then we call rule functions, which looks like PostCSS 7- plugins, but not exactly. So we don't use PostCSS API to parse code and run rules as plugins.

Project to use Visitors API could be a big refactor, and change in how stylelint works internally. I think we can do it after `v14` release.
