### PR TITLE
Fix declaration block semicolon newline after false positives

### DIFF
--- a/lib/rules/declaration-block-semicolon-newline-after/__tests__/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/__tests__/index.js
@@ -344,3 +344,45 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: ['always'],
+	fix: true,
+	syntax: 'css-in-js',
+
+	accept: [
+		{
+			code: `<div style={{ color: pink, top: 0 }} />`,
+			description: 'css-in-js object',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['always-multi-line'],
+	fix: true,
+	syntax: 'css-in-js',
+
+	accept: [
+		{
+			code: `<div style={{ color: pink, top: 0 }} />`,
+			description: 'css-in-js object',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['never-multi-line'],
+	fix: true,
+	syntax: 'css-in-js',
+
+	accept: [
+		{
+			code: `<div style={{ color: pink, top: 0 }} />`,
+			description: 'css-in-js object',
+		},
+	],
+});

--- a/lib/rules/declaration-block-semicolon-newline-after/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.js
@@ -31,6 +31,11 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		// Ignore css-in-js object literal
+		if (root.source.lang === 'object-literal') {
+			return;
+		}
+
 		root.walkDecls((decl) => {
 			// Ignore last declaration if there's no trailing semicolon
 			const parentRule = decl.parent;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes #5355. 

> Is there anything in the PR that needs further explanation?

This changes the rule to ignore css-in-js object literals, as the object literals should not contain semicolons and therefore should not require a newline. Previously, the rule required a newline after each comma within the object.