### PR TITLE
Refactor to remove `_.trim`

### DIFF
--- a/lib/rules/function-url-no-scheme-relative/index.js
+++ b/lib/rules/function-url-no-scheme-relative/index.js
@@ -24,7 +24,7 @@ function rule(actual) {
 
 		root.walkDecls((decl) => {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
-				const url = args.replace(/^[ '"]+|[ '"]+$/g, '');
+				const url = args.trim().replace(/^['"]+|['"]+$/g, '');
 
 				if (!isStandardSyntaxUrl(url) || !url.startsWith('//')) {
 					return;

--- a/lib/rules/function-url-no-scheme-relative/index.js
+++ b/lib/rules/function-url-no-scheme-relative/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const functionArgumentsSearch = require('../../utils/functionArgumentsSearch');
 const isStandardSyntaxUrl = require('../../utils/isStandardSyntaxUrl');
 const report = require('../../utils/report');
@@ -25,7 +24,7 @@ function rule(actual) {
 
 		root.walkDecls((decl) => {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
-				const url = _.trim(args, ' \'"');
+				const url = args.replace(/^[ '"]+|[ '"]+$/g, '');
 
 				if (!isStandardSyntaxUrl(url) || !url.startsWith('//')) {
 					return;

--- a/lib/rules/function-url-scheme-allowed-list/index.js
+++ b/lib/rules/function-url-scheme-allowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const functionArgumentsSearch = require('../../utils/functionArgumentsSearch');
 const getSchemeFromUrl = require('../../utils/getSchemeFromUrl');
 const isStandardSyntaxUrl = require('../../utils/isStandardSyntaxUrl');
@@ -31,13 +30,13 @@ function rule(list) {
 
 		root.walkDecls((decl) => {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
-				const unspacedUrlString = _.trim(args, ' ');
+				const unspacedUrlString = args.trim();
 
 				if (!isStandardSyntaxUrl(unspacedUrlString)) {
 					return;
 				}
 
-				const urlString = _.trim(unspacedUrlString, '\'"');
+				const urlString = unspacedUrlString.replace(/^['"]+|['"]+$/g, '');
 				const scheme = getSchemeFromUrl(urlString);
 
 				if (scheme === null) {

--- a/lib/rules/function-url-scheme-disallowed-list/index.js
+++ b/lib/rules/function-url-scheme-disallowed-list/index.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const _ = require('lodash');
 const functionArgumentsSearch = require('../../utils/functionArgumentsSearch');
 const getSchemeFromUrl = require('../../utils/getSchemeFromUrl');
 const isStandardSyntaxUrl = require('../../utils/isStandardSyntaxUrl');
@@ -31,13 +30,13 @@ function rule(list) {
 
 		root.walkDecls((decl) => {
 			functionArgumentsSearch(decl.toString().toLowerCase(), 'url', (args, index) => {
-				const unspacedUrlString = _.trim(args, ' ');
+				const unspacedUrlString = args.trim();
 
 				if (!isStandardSyntaxUrl(unspacedUrlString)) {
 					return;
 				}
 
-				const urlString = _.trim(unspacedUrlString, '\'"');
+				const urlString = unspacedUrlString.replace(/^['"]+|['"]+$/g, '');
 				const scheme = getSchemeFromUrl(urlString);
 
 				if (scheme === null) {


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

The regular expression `/^[ '"]+|[ '"]+$/g` matches one or more space, `'`, or `"` characters at the beginning or end of the string. Therefore, `string.replace(/^[ '"]+|[ '"]+$/g, '')` is equivalent to `_.trim(string, ' \'"')`.

`string.trim()` is a built-in function that removes whitespace, so `string.trim()` is equivalent to `_.trim(string, ' ')`.