### PR TITLE
Refactor to remove `_.isEqual`

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const _ = require('lodash');
+const arrayEqual = require('../../utils/arrayEqual');
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
@@ -80,7 +80,7 @@ function rule(actual, options) {
 					});
 
 					if (
-						!_.isEqual(
+						!arrayEqual(
 							prefixedShorthandData.sort(),
 							longhandDeclarations[prefixedShorthandProperty].sort(),
 						)

--- a/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/findNotContiguousOrRectangular.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const arrayEqual = require('../../../utils/arrayEqual');
 
 /**
  *
@@ -27,7 +27,7 @@ function isContiguousAndRectangular(areas, name) {
 				continue;
 			}
 
-			if (!_.isEqual(indicesByRow[i], indicesByRow[j])) {
+			if (!arrayEqual(indicesByRow[i], indicesByRow[j])) {
 				return false;
 			}
 		}

--- a/lib/utils/__tests__/arrayEqual.test.js
+++ b/lib/utils/__tests__/arrayEqual.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const arrayEqual = require('../arrayEqual');
+
+describe('arrayEqual', () => {
+	it('handles arrays', () => {
+		expect(arrayEqual([], [])).toBe(true);
+		expect(arrayEqual([1, 2], [1, 2])).toBe(true);
+		expect(arrayEqual([1, 2], [3, 4])).toBe(false);
+		expect(arrayEqual([1, 2], [1, 2, 3])).toBe(false);
+		expect(arrayEqual([1, 2], [])).toBe(false);
+
+		const o1 = { a: 1, b: 2 };
+		const o2 = { a: 1, b: 2 };
+		const o1copy = o1;
+
+		expect(arrayEqual([o1], [o2])).toBe(false);
+		expect(arrayEqual([o1], [o1copy])).toBe(true);
+	});
+
+	it('returns false for non-arrays', () => {
+		expect(arrayEqual({ a: 1 }, [1])).toBe(false);
+		expect(arrayEqual([1], /1/)).toBe(false);
+	});
+});

--- a/lib/utils/arrayEqual.js
+++ b/lib/utils/arrayEqual.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ * Tests if two arrays are equal.
+ *
+ * @param {any} a
+ * @param {any} b
+ * @returns {boolean}
+ */
+function arrayEqual(a, b) {
+	if (!Array.isArray(a) || !Array.isArray(b)) return false;
+
+	if (a.length !== b.length) return false;
+
+	return a.every((elem, index) => elem === b[index]);
+}
+
+module.exports = arrayEqual;

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const arrayEqual = require('./arrayEqual');
 const { isPlainObject } = require('is-plain-object');
 
 const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables']);
@@ -64,7 +65,7 @@ function validate(opts, ruleName, complain) {
 	const actual = opts.actual;
 	const optional = opts.optional;
 
-	if (actual === null || _.isEqual(actual, [null])) {
+	if (actual === null || arrayEqual(actual, [null])) {
 		return;
 	}
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

Since all uses of `_.isEqual` are comparing two arrays, I added a simple utility function to compare arrays.