### PR TITLE
Refactor to remove `_.merge` and `_.mergeWith`

### DIFF
--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const _ = require('lodash');
 const configurationError = require('./utils/configurationError');
 const getModulePath = require('./utils/getModulePath');
 const globjoin = require('globjoin');
+const merge = require('deepmerge');
 const normalizeAllRuleSettings = require('./normalizeAllRuleSettings');
 const path = require('path');
 
@@ -26,11 +26,28 @@ const path = require('path');
  * @returns {Promise<StylelintConfig>}
  */
 function augmentConfigBasic(stylelint, config, configDir, allowOverrides) {
+	/** @typedef {{isMergeableObject: (value: any) => boolean, cloneUnlessOtherwiseSpecified: (value: any, options: ArrayMergeOptions) => any}} ArrayMergeOptions */
+	const replaceSameIndex = (
+		/** @type {any[]} */ target,
+		/** @type {any[]} */ source,
+		/** @type ArrayMergeOptions */ options,
+	) => {
+		const destination = [...target];
+
+		source.forEach((item, index) => {
+			destination[index] = options.cloneUnlessOtherwiseSpecified(item, options);
+		});
+
+		return destination;
+	};
+
 	return Promise.resolve()
 		.then(() => {
 			if (!allowOverrides) return config;
 
-			return _.merge(config, stylelint._options.configOverrides);
+			return merge(config, stylelint._options.configOverrides || {}, {
+				arrayMerge: replaceSameIndex,
+			});
 		})
 		.then((augmentedConfig) => {
 			return extendConfig(stylelint, augmentedConfig, configDir);

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -15,6 +15,20 @@ const path = require('path');
 /** @typedef {import('stylelint').StylelintConfig} StylelintConfig */
 /** @typedef {import('stylelint').CosmiconfigResult} CosmiconfigResult */
 
+/** @type {import('deepmerge').Options} */
+const MERGE_OPTIONS = {
+	arrayMerge: (target, source, options) => {
+		const destination = [...target];
+
+		source.forEach((item, index) => {
+			// @ts-expect-error -- The type definition is insufficient. See https://github.com/TehShrike/deepmerge/pull/231
+			destination[index] = options.cloneUnlessOtherwiseSpecified(item, options);
+		});
+
+		return destination;
+	},
+};
+
 /**
  * - Merges config and configOverrides
  * - Makes all paths absolute
@@ -26,28 +40,11 @@ const path = require('path');
  * @returns {Promise<StylelintConfig>}
  */
 function augmentConfigBasic(stylelint, config, configDir, allowOverrides) {
-	/** @typedef {{isMergeableObject: (value: any) => boolean, cloneUnlessOtherwiseSpecified: (value: any, options: ArrayMergeOptions) => any}} ArrayMergeOptions */
-	const replaceSameIndex = (
-		/** @type {any[]} */ target,
-		/** @type {any[]} */ source,
-		/** @type ArrayMergeOptions */ options,
-	) => {
-		const destination = [...target];
-
-		source.forEach((item, index) => {
-			destination[index] = options.cloneUnlessOtherwiseSpecified(item, options);
-		});
-
-		return destination;
-	};
-
 	return Promise.resolve()
 		.then(() => {
 			if (!allowOverrides) return config;
 
-			return merge(config, stylelint._options.configOverrides || {}, {
-				arrayMerge: replaceSameIndex,
-			});
+			return merge(config, stylelint._options.configOverrides || {}, MERGE_OPTIONS);
 		})
 		.then((augmentedConfig) => {
 			return extendConfig(stylelint, augmentedConfig, configDir);

--- a/lib/testUtils/mergeTestDescriptions.js
+++ b/lib/testUtils/mergeTestDescriptions.js
@@ -1,18 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
+const merge = require('deepmerge');
 
 module.exports = function (...args) {
-	const mergeWithArgs = [{}];
-
-	[...args].forEach((arg) => mergeWithArgs.push(arg));
-	mergeWithArgs.push(mergeCustomizer);
-
-	return _.mergeWith(...mergeWithArgs);
+	return merge.all(args);
 };
-
-function mergeCustomizer(objValue, srcValue) {
-	if (Array.isArray(objValue, mergeCustomizer)) {
-		return objValue.concat(srcValue);
-	}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chalk": "^4.1.1",
         "cosmiconfig": "^7.0.0",
         "debug": "^4.3.1",
+        "deepmerge": "^4.2.2",
         "execall": "^2.0.0",
         "fast-glob": "^3.2.5",
         "fastest-levenshtein": "^1.0.12",
@@ -2716,7 +2717,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12854,8 +12854,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "defer-to-connect": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "chalk": "^4.1.1",
     "cosmiconfig": "^7.0.0",
     "debug": "^4.3.1",
+    "deepmerge": "^4.2.2",
     "execall": "^2.0.0",
     "fast-glob": "^3.2.5",
     "fastest-levenshtein": "^1.0.12",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Ref #4412.

> Is there anything in the PR that needs further explanation?

`_.merge` replaces values at each index (`_.merge([1, 2], [3])` becomes `[3, 2]`). The `replaceSameIndex` array merging function in [`lib/augmentConfig.js`](https://github.com/stylelint/stylelint/pull/5369/files#diff-231823848e62de25699c7b9a8e92b05cc45aaf489c7c1fa417286295d37fcdf6) causes `deepmerge` to use that strategy.

`deepmerge` defaults to concatenating arrays, so the `mergeCustomizer` function used with `_.mergeWith` in [`lib/testUtils/mergeTestDescriptions.js`](https://github.com/stylelint/stylelint/pull/5369/files#diff-124f7773abf544ee51d0acd57be0e09ecf1636008b085830434668f0a1a4adb5) can simply be replaced with the default behavior of `deepmerge`.