### PR TITLE
Refactor `validateOptions()` utility

### DIFF
--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -5,7 +5,11 @@ const { isPlainObject } = require('is-plain-object');
 
 const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables']);
 
-/** @typedef {{possible: any, actual: any, optional?: boolean}} Options */
+/** @typedef {(value: unknown) => boolean} PossibleFunc */
+
+/** @typedef {boolean | number | string | PossibleFunc} Possible */
+
+/** @typedef {{possible: (undefined | PossibleFunc | Possible[] | Record<string, Possible[]>), actual: unknown, optional?: boolean}} Options */
 
 /**
  * Validate a rule's options.
@@ -27,8 +31,7 @@ const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables']);
  *    - `optional` (optional): If this is `true`, `actual` can be undefined.
  * @return {boolean} Whether or not the options are valid (true = valid)
  */
-
-module.exports = function (result, ruleName, ...optionDescriptions) {
+module.exports = function validateOptions(result, ruleName, ...optionDescriptions) {
 	let noErrors = true;
 
 	optionDescriptions.forEach((optionDescription) => {
@@ -57,7 +60,7 @@ module.exports = function (result, ruleName, ...optionDescriptions) {
 /**
  * @param {Options} opts
  * @param {string} ruleName
- * @param {(s: string) => void} complain
+ * @param {(message: string) => void} complain
  */
 function validate(opts, ruleName, complain) {
 	const possible = opts.possible;
@@ -109,19 +112,19 @@ function validate(opts, ruleName, complain) {
 
 	// If `possible` is an array instead of an object ...
 	if (Array.isArray(possible)) {
-		[].concat(actual).forEach((a) => {
+		for (const a of [actual].flat()) {
 			if (isValid(possible, a)) {
-				return;
+				continue;
 			}
 
 			complain(`Invalid option value "${String(a)}" for rule "${ruleName}"`);
-		});
+		}
 
 		return;
 	}
 
 	// If actual is NOT an object ...
-	if (!isPlainObject(actual)) {
+	if (!isPlainObject(actual) || typeof actual !== 'object' || actual == null) {
 		complain(
 			`Invalid option value ${JSON.stringify(actual)} for rule "${ruleName}": should be an object`,
 		);
@@ -129,38 +132,36 @@ function validate(opts, ruleName, complain) {
 		return;
 	}
 
-	Object.keys(actual).forEach((optionName) => {
+	for (const [optionName, optionValue] of Object.entries(actual)) {
 		if (IGNORED_OPTIONS.has(optionName)) {
-			return;
+			continue;
 		}
 
-		if (!possible[optionName]) {
+		const possibleValue = possible && possible[optionName];
+
+		if (!possibleValue) {
 			complain(`Invalid option name "${optionName}" for rule "${ruleName}"`);
 
-			return;
+			continue;
 		}
 
-		const actualOptionValue = actual[optionName];
-
-		[].concat(actualOptionValue).forEach((a) => {
-			if (isValid(possible[optionName], a)) {
-				return;
+		for (const a of [optionValue].flat()) {
+			if (isValid(possibleValue, a)) {
+				continue;
 			}
 
 			complain(`Invalid value "${a}" for option "${optionName}" of rule "${ruleName}"`);
-		});
-	});
+		}
+	}
 }
 
 /**
- * @param {any|Function} possible
- * @param {any} actual
+ * @param {Possible | Possible[]} possible
+ * @param {unknown} actual
  * @returns {boolean}
  */
 function isValid(possible, actual) {
-	const possibleList = /** @type {Array<any|Function>} */ ([]).concat(possible);
-
-	for (const possibility of possibleList) {
+	for (const possibility of [possible].flat()) {
 		if (typeof possibility === 'function' && possibility(actual)) {
 			return true;
 		}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Related to #4496

> Is there anything in the PR that needs further explanation?

- Improve types avoiding `any`
- Use `for...of` instead of `forEach` (`continue` is clearer than `return`)
- Use `flat()` instead of `[].concat()` idiom (avoiding type errors)
