### PR TITLE
Refactor to improve types for `block-*` rules

### DIFF
--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const addEmptyLineAfter = require('../../utils/addEmptyLineAfter');
@@ -21,17 +19,18 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before closing brace',
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: expectation,
+				actual: primary,
 				possible: ['always-multi-line', 'never'],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					except: ['after-closing-brace'],
 				},
@@ -47,6 +46,9 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			// Return early if blockless or has empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
@@ -70,16 +72,14 @@ function rule(expectation, options, context) {
 
 				// Reverse the primary options if `after-closing-brace` is set
 				if (
-					optionsMatches(options, 'except', 'after-closing-brace') &&
+					optionsMatches(secondaryOptions, 'except', 'after-closing-brace') &&
 					statement.type === 'atrule' &&
 					!childNodeTypes.includes('decl')
 				) {
-					return expectation === 'never';
+					return primary === 'never';
 				}
 
-				return Boolean(
-					expectation === 'always-multi-line' && !isSingleLineString(blockString(statement)),
-				);
+				return primary === 'always-multi-line' && !isSingleLineString(blockString(statement));
 			})();
 
 			// Check for at least one empty line
@@ -91,10 +91,14 @@ function rule(expectation, options, context) {
 			}
 
 			if (context.fix) {
+				const { newline } = context;
+
+				if (typeof newline !== 'string') return;
+
 				if (expectEmptyLineBefore) {
-					addEmptyLineAfter(statement, context.newline);
+					addEmptyLineAfter(statement, newline);
 				} else {
-					removeEmptyLinesAfter(statement, context.newline);
+					removeEmptyLinesAfter(statement, newline);
 				}
 
 				return;
@@ -111,7 +115,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -22,15 +20,16 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "}" of a multi-line block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: expectation,
+				actual: primary,
 				possible: [
 					'always',
 					'always-single-line',
@@ -40,7 +39,7 @@ function rule(expectation, options, context) {
 				],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreAtRules: [isString],
 				},
@@ -56,12 +55,18 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			if (!hasBlock(statement)) {
 				return;
 			}
 
-			if (optionsMatches(options, 'ignoreAtRules', statement.name)) {
+			if (
+				statement.type === 'atrule' &&
+				optionsMatches(secondaryOptions, 'ignoreAtRules', statement.name)
+			) {
 				return;
 			}
 
@@ -100,20 +105,24 @@ function rule(expectation, options, context) {
 				lineCheckStr: blockString(statement),
 				err: (msg) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
-							const index = nodeToCheck.raws.before.search(/\r?\n/);
+						const nodeToCheckRaws = nodeToCheck.raws;
+
+						if (typeof nodeToCheckRaws.before !== 'string') return;
+
+						if (primary.startsWith('always')) {
+							const index = nodeToCheckRaws.before.search(/\r?\n/);
 
 							if (index >= 0) {
-								nodeToCheck.raws.before = nodeToCheck.raws.before.slice(index);
+								nodeToCheckRaws.before = nodeToCheckRaws.before.slice(index);
 							} else {
-								nodeToCheck.raws.before = context.newline + nodeToCheck.raws.before;
+								nodeToCheckRaws.before = context.newline + nodeToCheckRaws.before;
 							}
 
 							return;
 						}
 
-						if (expectation.startsWith('never')) {
-							nodeToCheck.raws.before = '';
+						if (primary.startsWith('never')) {
+							nodeToCheckRaws.before = '';
 
 							return;
 						}
@@ -130,7 +139,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-newline-before/index.js
+++ b/lib/rules/block-closing-brace-newline-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -18,10 +16,11 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: 'Unexpected whitespace before "}" of a multi-line block',
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -33,6 +32,9 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			// Return early if blockless or has empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
@@ -61,40 +63,47 @@ function rule(expectation, options, context) {
 			// ignore any other whitespace between them, because that
 			// will be checked by the indentation rule.
 			if (!after.startsWith('\n') && !after.startsWith('\r\n')) {
-				if (expectation === 'always') {
+				if (primary === 'always') {
 					complain(messages.expectedBefore);
-				} else if (blockIsMultiLine && expectation === 'always-multi-line') {
+				} else if (blockIsMultiLine && primary === 'always-multi-line') {
 					complain(messages.expectedBeforeMultiLine);
 				}
 			}
 
-			if (after !== '' && blockIsMultiLine && expectation === 'never-multi-line') {
+			if (after !== '' && blockIsMultiLine && primary === 'never-multi-line') {
 				complain(messages.rejectedBeforeMultiLine);
 			}
 
+			/**
+			 * @param {string} message
+			 */
 			function complain(message) {
 				if (context.fix) {
-					if (expectation.startsWith('always')) {
-						const firstWhitespaceIndex = statement.raws.after.search(/\s/);
+					const statementRaws = statement.raws;
+
+					if (typeof statementRaws.after !== 'string') return;
+
+					if (primary.startsWith('always')) {
+						const firstWhitespaceIndex = statementRaws.after.search(/\s/);
 						const newlineBefore =
 							firstWhitespaceIndex >= 0
-								? statement.raws.after.slice(0, firstWhitespaceIndex)
-								: statement.raws.after;
+								? statementRaws.after.slice(0, firstWhitespaceIndex)
+								: statementRaws.after;
 						const newlineAfter =
-							firstWhitespaceIndex >= 0 ? statement.raws.after.slice(firstWhitespaceIndex) : '';
+							firstWhitespaceIndex >= 0 ? statementRaws.after.slice(firstWhitespaceIndex) : '';
 						const newlineIndex = newlineAfter.search(/\r?\n/);
 
 						if (newlineIndex >= 0) {
-							statement.raws.after = newlineBefore + newlineAfter.slice(newlineIndex);
+							statementRaws.after = newlineBefore + newlineAfter.slice(newlineIndex);
 						} else {
-							statement.raws.after = newlineBefore + context.newline + newlineAfter;
+							statementRaws.after = newlineBefore + context.newline + newlineAfter;
 						}
 
 						return;
 					}
 
-					if (expectation === 'never-multi-line') {
-						statement.raws.after = statement.raws.after.replace(/\s/g, '');
+					if (primary === 'never-multi-line') {
+						statementRaws.after = statementRaws.after.replace(/\s/g, '');
 
 						return;
 					}
@@ -110,7 +119,7 @@ function rule(expectation, options, context) {
 			}
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-space-after/index.js
+++ b/lib/rules/block-closing-brace-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -21,12 +19,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "}" of a multi-line block',
 });
 
-function rule(expectation) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: [
 				'always',
 				'never',
@@ -45,6 +44,9 @@ function rule(expectation) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			const nextNode = statement.next();
 
@@ -81,7 +83,7 @@ function rule(expectation) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-closing-brace-space-before/index.js
+++ b/lib/rules/block-closing-brace-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -21,12 +19,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "}" of a multi-line block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: [
 				'always',
 				'never',
@@ -45,6 +44,9 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			// Return early if blockless or has empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
@@ -65,14 +67,18 @@ function rule(expectation, options, context) {
 				index: source.length - 1,
 				err: (msg) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
-							statement.raws.after = statement.raws.after.replace(/\s*$/, ' ');
+						const statementRaws = statement.raws;
+
+						if (typeof statementRaws.after !== 'string') return;
+
+						if (primary.startsWith('always')) {
+							statementRaws.after = statementRaws.after.replace(/\s*$/, ' ');
 
 							return;
 						}
 
-						if (expectation.startsWith('never')) {
-							statement.raws.after = statement.raws.after.replace(/\s*$/, '');
+						if (primary.startsWith('never')) {
+							statementRaws.after = statementRaws.after.replace(/\s*$/, '');
 
 							return;
 						}
@@ -89,7 +95,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const beforeBlockString = require('../../utils/beforeBlockString');
@@ -17,7 +15,8 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty block',
 });
 
-function rule(primary, options = {}) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -27,7 +26,7 @@ function rule(primary, options = {}) {
 				possible: isBoolean,
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['comments'],
 				},
@@ -39,12 +38,15 @@ function rule(primary, options = {}) {
 			return;
 		}
 
-		const ignoreComments = optionsMatches(options, 'ignore', 'comments');
+		const ignoreComments = optionsMatches(secondaryOptions, 'ignore', 'comments');
 
 		// Check both kinds of statements: rules and at-rules
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			if (!hasEmptyBlock(statement) && !ignoreComments) {
 				return;
@@ -76,7 +78,7 @@ function rule(primary, options = {}) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-newline-after/index.js
+++ b/lib/rules/block-opening-brace-newline-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const beforeBlockString = require('../../utils/beforeBlockString');
@@ -20,12 +18,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "{" of a multi-line block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -37,6 +36,9 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
@@ -45,17 +47,22 @@ function rule(expectation, options, context) {
 
 			const backupCommentNextBefores = new Map();
 
-			// next node with checking newlines after comment
+			/**
+			 * next node with checking newlines after comment
+			 *
+			 * @param {import('postcss').ChildNode | undefined} startNode
+			 * @returns {import('postcss').ChildNode | undefined}
+			 */
 			function nextNode(startNode) {
-				if (!startNode || !startNode.next) return null;
+				if (!startNode || !startNode.next) return;
 
 				if (startNode.type === 'comment') {
 					const reNewLine = /\r?\n/;
-					const newLineMatch = reNewLine.test(startNode.raws.before);
+					const newLineMatch = reNewLine.test(startNode.raws.before || '');
 
 					const next = startNode.next();
 
-					if (next && newLineMatch && !reNewLine.test(next.raws.before)) {
+					if (next && newLineMatch && !reNewLine.test(next.raws.before || '')) {
 						backupCommentNextBefores.set(next, next.raws.before);
 						next.raws.before = startNode.raws.before;
 					}
@@ -79,13 +86,17 @@ function rule(expectation, options, context) {
 				lineCheckStr: blockString(statement),
 				err: (m) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
-							const index = nodeToCheck.raws.before.search(/\r?\n/);
+						const nodeToCheckRaws = nodeToCheck.raws;
+
+						if (typeof nodeToCheckRaws.before !== 'string') return;
+
+						if (primary.startsWith('always')) {
+							const index = nodeToCheckRaws.before.search(/\r?\n/);
 
 							if (index >= 0) {
-								nodeToCheck.raws.before = nodeToCheck.raws.before.slice(index);
+								nodeToCheckRaws.before = nodeToCheckRaws.before.slice(index);
 							} else {
-								nodeToCheck.raws.before = context.newline + nodeToCheck.raws.before;
+								nodeToCheckRaws.before = context.newline + nodeToCheckRaws.before;
 							}
 
 							backupCommentNextBefores.delete(nodeToCheck);
@@ -93,7 +104,7 @@ function rule(expectation, options, context) {
 							return;
 						}
 
-						if (expectation === 'never-multi-line') {
+						if (primary === 'never-multi-line') {
 							// Restore the `before` of the node next to the comment node.
 							backupCommentNextBefores.forEach((before, node) => {
 								node.raws.before = before;
@@ -105,8 +116,12 @@ function rule(expectation, options, context) {
 							let fixTarget = statement.first;
 
 							while (fixTarget) {
-								if (reNewLine.test(fixTarget.raws.before)) {
-									fixTarget.raws.before = fixTarget.raws.before.replace(/\r?\n/g, '');
+								const fixTargetRaws = fixTarget.raws;
+
+								if (typeof fixTargetRaws.before !== 'string') continue;
+
+								if (reNewLine.test(fixTargetRaws.before || '')) {
+									fixTargetRaws.before = fixTargetRaws.before.replace(/\r?\n/g, '');
 								}
 
 								if (fixTarget.type !== 'comment') {
@@ -116,7 +131,7 @@ function rule(expectation, options, context) {
 								fixTarget = fixTarget.next();
 							}
 
-							nodeToCheck.raws.before = '';
+							nodeToCheckRaws.before = '';
 
 							return;
 						}
@@ -138,7 +153,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-newline-before/index.js
+++ b/lib/rules/block-opening-brace-newline-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const beforeBlockString = require('../../utils/beforeBlockString');
@@ -21,12 +19,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "{" of a multi-line block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: [
 				'always',
 				'always-single-line',
@@ -44,6 +43,9 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
@@ -67,23 +69,27 @@ function rule(expectation, options, context) {
 				index: source.length,
 				err: (m) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
-							const spaceIndex = statement.raws.between.search(/\s+$/);
+						const statementRaws = statement.raws;
+
+						if (typeof statementRaws.between !== 'string') return;
+
+						if (primary.startsWith('always')) {
+							const spaceIndex = statementRaws.between.search(/\s+$/);
 
 							if (spaceIndex >= 0) {
 								statement.raws.between =
-									statement.raws.between.slice(0, spaceIndex) +
+									statementRaws.between.slice(0, spaceIndex) +
 									context.newline +
-									statement.raws.between.slice(spaceIndex);
+									statementRaws.between.slice(spaceIndex);
 							} else {
-								statement.raws.between += context.newline;
+								statementRaws.between += context.newline;
 							}
 
 							return;
 						}
 
-						if (expectation.startsWith('never')) {
-							statement.raws.between = statement.raws.between.replace(/\s*$/, '');
+						if (primary.startsWith('never')) {
+							statementRaws.between = statementRaws.between.replace(/\s*$/, '');
 
 							return;
 						}
@@ -100,7 +106,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-space-after/index.js
+++ b/lib/rules/block-opening-brace-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const beforeBlockString = require('../../utils/beforeBlockString');
@@ -22,12 +20,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "{" of a multi-line block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: [
 				'always',
 				'never',
@@ -46,6 +45,9 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
@@ -57,14 +59,18 @@ function rule(expectation, options, context) {
 				index: 0,
 				err: (m) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
-							statement.first.raws.before = ' ';
+						const statementFirst = statement.first;
+
+						if (statementFirst == null) return;
+
+						if (primary.startsWith('always')) {
+							statementFirst.raws.before = ' ';
 
 							return;
 						}
 
-						if (expectation.startsWith('never')) {
-							statement.first.raws.before = '';
+						if (primary.startsWith('never')) {
+							statementFirst.raws.before = '';
 
 							return;
 						}
@@ -81,7 +87,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const beforeBlockString = require('../../utils/beforeBlockString');
@@ -24,15 +22,16 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "{" of a multi-line block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: expectation,
+				actual: primary,
 				possible: [
 					'always',
 					'never',
@@ -43,7 +42,7 @@ function rule(expectation, options, context) {
 				],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreAtRules: [isString, isRegExp],
 					ignoreSelectors: [isString, isRegExp],
@@ -60,6 +59,9 @@ function rule(expectation, options, context) {
 		root.walkRules(check);
 		root.walkAtRules(check);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function check(statement) {
 			// Return early if blockless or has an empty block
 			if (!hasBlock(statement) || hasEmptyBlock(statement)) {
@@ -67,12 +69,18 @@ function rule(expectation, options, context) {
 			}
 
 			// Return early if at-rule is to be ignored
-			if (optionsMatches(options, 'ignoreAtRules', statement.name)) {
+			if (
+				statement.type === 'atrule' &&
+				optionsMatches(secondaryOptions, 'ignoreAtRules', statement.name)
+			) {
 				return;
 			}
 
 			// Return early if selector is to be ignored
-			if (optionsMatches(options, 'ignoreSelectors', statement.selector)) {
+			if (
+				statement.type === 'rule' &&
+				optionsMatches(secondaryOptions, 'ignoreSelectors', statement.selector)
+			) {
 				return;
 			}
 
@@ -93,13 +101,13 @@ function rule(expectation, options, context) {
 				lineCheckStr: blockString(statement),
 				err: (m) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
+						if (primary.startsWith('always')) {
 							statement.raws.between = ' ';
 
 							return;
 						}
 
-						if (expectation.startsWith('never')) {
+						if (primary.startsWith('never')) {
 							statement.raws.between = '';
 
 							return;
@@ -117,7 +125,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/utils/__tests__/blockString.test.js
+++ b/lib/utils/__tests__/blockString.test.js
@@ -15,6 +15,10 @@ it('blockString at-rules', () => {
 	).toBe('{\n  0% {\n  top: 0;\n}\n\n  100% {\n  top: 10px;\n}\n}');
 });
 
+it('blockString no block', () => {
+	expect(postcssCheck('@import url(foo.css);')).toBe('');
+});
+
 function postcssCheck(cssString) {
 	const root = postcss.parse(cssString);
 

--- a/lib/utils/addEmptyLineAfter.js
+++ b/lib/utils/addEmptyLineAfter.js
@@ -1,29 +1,28 @@
 'use strict';
 
-/** @typedef {import('postcss').ChildNode & { raws: import('postcss').ChildNode['raws'] & { after?: string } }} ChildNode */
-
 /**
  * Add an empty line after a node. Mutates the node.
  *
- * @param {ChildNode} node
- * @param {'\n' | '\r\n'} newline
- * @returns {ChildNode}
+ * @template {import('postcss').Rule | import('postcss').AtRule} T
+ * @param {T} node
+ * @param {string} newline
+ * @returns {T}
  */
-function addEmptyLineAfter(node, newline) {
-	if (node.raws.after === undefined) {
+module.exports = function addEmptyLineAfter(node, newline) {
+	const { raws } = node;
+
+	if (typeof raws.after !== 'string') {
 		return node;
 	}
 
-	const spaces = node.raws.after.split(';');
+	const spaces = raws.after.split(';');
 	const after = spaces[spaces.length - 1] || '';
 
 	if (!/\r?\n/.test(after)) {
-		node.raws.after += newline.repeat(2);
+		raws.after += newline.repeat(2);
 	} else {
-		node.raws.after = node.raws.after.replace(/(\r?\n)/, `${newline}$1`);
+		raws.after = raws.after.replace(/(\r?\n)/, `${newline}$1`);
 	}
 
 	return node;
-}
-
-module.exports = addEmptyLineAfter;
+};

--- a/lib/utils/addEmptyLineBefore.js
+++ b/lib/utils/addEmptyLineBefore.js
@@ -9,14 +9,16 @@
  * @returns {T}
  */
 module.exports = function addEmptyLineBefore(node, newline) {
-	if (node.raws.before === undefined) {
+	const { raws } = node;
+
+	if (typeof raws.before !== 'string') {
 		return node;
 	}
 
-	if (!/\r?\n/.test(node.raws.before)) {
-		node.raws.before = newline.repeat(2) + node.raws.before;
+	if (!/\r?\n/.test(raws.before)) {
+		raws.before = newline.repeat(2) + raws.before;
 	} else {
-		node.raws.before = node.raws.before.replace(/(\r?\n)/, `${newline}$1`);
+		raws.before = raws.before.replace(/(\r?\n)/, `${newline}$1`);
 	}
 
 	return node;

--- a/lib/utils/blockString.js
+++ b/lib/utils/blockString.js
@@ -10,15 +10,14 @@ const rawNodeString = require('./rawNodeString');
 /**
  * Return a CSS statement's block -- the string that starts and `{` and ends with `}`.
  *
- * If the statement has no block (e.g. `@import url(foo.css);`),
- * return false.
+ * If the statement has no block (e.g. `@import url(foo.css);`), returns an empty string.
  *
  * @param {Rule | AtRule} statement - postcss rule or at-rule node
- * @return {string | boolean}
+ * @returns {string}
  */
-module.exports = function (statement) {
+module.exports = function blockString(statement) {
 	if (!hasBlock(statement)) {
-		return false;
+		return '';
 	}
 
 	return rawNodeString(statement).slice(beforeBlockString(statement).length);

--- a/lib/utils/removeEmptyLinesAfter.js
+++ b/lib/utils/removeEmptyLinesAfter.js
@@ -3,13 +3,13 @@
 /**
  * Remove empty lines before a node. Mutates the node.
  *
- * @param {import('postcss').Node} node
- * @param {'\n' | '\r\n'} newline
+ * @template {import('postcss').Rule | import('postcss').AtRule} T
+ * @param {T} node
+ * @param {string} newline
+ * @returns {T}
  */
-function removeEmptyLinesAfter(node, newline) {
+module.exports = function removeEmptyLinesAfter(node, newline) {
 	node.raws.after = node.raws.after ? node.raws.after.replace(/(\r?\n\s*\r?\n)+/g, newline) : '';
 
 	return node;
-}
-
-module.exports = removeEmptyLinesAfter;
+};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #4496
(see also #5418)

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `block-*` rules.
In addition, it improves the types of some utilities.
