### PR TITLE
Fix false positives for prefers-contrast in media-feature-name-no-unknown

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -608,7 +608,7 @@ keywordSets.mediaFeatureNames = uniteSets(keywordSets.deprecatedMediaFeatureName
 	'overflow-inline',
 	'pointer',
 	'prefers-color-scheme',
-	'prefers-contrast'
+	'prefers-contrast',
 	'prefers-reduced-motion',
 	'prefers-reduced-transparency',
 	'resolution',

--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -608,6 +608,7 @@ keywordSets.mediaFeatureNames = uniteSets(keywordSets.deprecatedMediaFeatureName
 	'overflow-inline',
 	'pointer',
 	'prefers-color-scheme',
+	'prefers-contrast'
 	'prefers-reduced-motion',
 	'prefers-reduced-transparency',
 	'resolution',


### PR DESCRIPTION
This is a new media query added to CSS Media Queries Level 5 to utilize the contrast preference operating systems provide.

> Which issue, if any, is this issue related to?

Closes #5427

> Is there anything in the PR that needs further explanation?

Please see issue #5427