### PR TITLE
Set `target-branch` for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     labels:
       - 'pr: dependencies'
     versioning-strategy: increase
+    target-branch: 'v14' # TODO: Remove when releasing v14.


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None. This changes just the Dependabot configuration.

> Is there anything in the PR that needs further explanation?

Currently, outdated packages are as below:

<details>

```console
$ npm outdated
Package                   Current  Wanted  Latest  Location                               Depended by
@types/debug                4.1.5   4.1.7   4.1.7  node_modules/@types/debug              stylelint
@types/file-entry-cache     5.0.1   5.0.2   5.0.2  node_modules/@types/file-entry-cache   stylelint
@types/micromatch           4.0.1   4.0.2   4.0.2  node_modules/@types/micromatch         stylelint
@types/postcss-less         4.0.0   4.0.1   4.0.1  node_modules/@types/postcss-less       stylelint
@types/style-search         0.1.1   0.1.3   0.1.3  node_modules/@types/style-search       stylelint
@types/write-file-atomic    3.0.1   3.0.2   3.0.2  node_modules/@types/write-file-atomic  stylelint
chalk                       4.1.1   4.1.2   4.1.2  node_modules/chalk                     stylelint
debug                       4.3.1   4.3.2   4.3.2  node_modules/debug                     stylelint
eslint                     7.25.0  7.32.0  7.32.0  node_modules/eslint                    stylelint
execall                     2.0.0   2.0.0   3.0.0  node_modules/execall                   stylelint
fast-glob                   3.2.5   3.2.7   3.2.7  node_modules/fast-glob                 stylelint
get-stdin                   8.0.0   8.0.0   9.0.0  node_modules/get-stdin                 stylelint
globby                     11.0.3  11.0.4  12.0.0  node_modules/globby                    stylelint
husky                       6.0.0   6.0.0   7.0.1  node_modules/husky                     stylelint
jest                       27.0.1  27.0.6  27.0.6  node_modules/jest                      stylelint
known-css-properties       0.21.0  0.21.0  0.23.0  node_modules/known-css-properties      stylelint
lint-staged                10.5.4  10.5.4  11.1.2  node_modules/lint-staged               stylelint
log-symbols                 4.1.0   4.1.0   5.0.0  node_modules/log-symbols               stylelint
mathml-tag-names            2.1.3   2.1.3   3.0.1  node_modules/mathml-tag-names          stylelint
meow                        9.0.0   9.0.0  10.1.1  node_modules/meow                      stylelint
postcss                     8.3.0   8.3.6   8.3.6  node_modules/postcss                   stylelint
postcss-less                4.0.1   4.0.1   5.0.0  node_modules/postcss-less              stylelint
postcss-safe-parser         5.0.2   5.0.2   6.0.0  node_modules/postcss-safe-parser       stylelint
postcss-scss                3.0.5   3.0.5   4.0.0  node_modules/postcss-scss              stylelint
prettier                    2.2.1   2.2.1   2.3.2  node_modules/prettier                  stylelint
remark-cli                  9.0.0   9.0.0  10.0.0  node_modules/remark-cli                stylelint
slash                       3.0.0   3.0.0   4.0.0  node_modules/slash                     stylelint
string-width                4.2.2   4.2.2   5.0.0  node_modules/string-width              stylelint
strip-ansi                  6.0.0   6.0.0   7.0.0  node_modules/strip-ansi                stylelint
sugarss                     3.0.3   3.0.3   4.0.1  node_modules/sugarss                   stylelint
table                       6.6.0   6.7.1   6.7.1  node_modules/table                     stylelint
typescript                  4.2.4   4.3.5   4.3.5  node_modules/typescript                stylelint
```

</details>

I think it better to bump some packages even on the `v14` branch (especially `postcss-*` packages).

See also:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#target-branch
