### PR TITLE
Refactor to improve types for `color-*` rules

### DIFF
--- a/lib/reference/namedColorData.js
+++ b/lib/reference/namedColorData.js
@@ -1,5 +1,6 @@
 'use strict';
 
+/** @type {Record<string, string[]>} */
 module.exports = {
 	aliceblue: ['#f0f8ff', '#fff0f8ff'],
 	antiquewhite: ['#faebd7', '#fffaebd7'],

--- a/lib/rules/color-function-notation/index.js
+++ b/lib/rules/color-function-notation/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const valueParser = require('postcss-value-parser');
@@ -20,7 +18,8 @@ const messages = ruleMessages(ruleName, {
 const LEGACY_FUNCS = new Set(['rgba', 'hsla']);
 const LEGACY_NOTATION_FUNCS = new Set(['rgb', 'rgba', 'hsl', 'hsla']);
 
-function rule(primary, secondary, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -34,9 +33,9 @@ function rule(primary, secondary, context) {
 			const parsedValue = valueParser(getDeclarationValue(decl));
 
 			parsedValue.walk((node) => {
-				const { value, type, sourceIndex, nodes } = node;
+				if (node.type !== 'function') return;
 
-				if (type !== 'function') return;
+				const { value, sourceIndex, nodes } = node;
 
 				if (!LEGACY_NOTATION_FUNCS.has(value.toLowerCase())) return;
 
@@ -52,6 +51,7 @@ function rule(primary, secondary, context) {
 						if (isComma(childNode)) {
 							// Non-alpha commas to space and alpha commas to slashes
 							if (commaCount < 2) {
+								// @ts-expect-error -- TS2322: Type '"space"' is not assignable to type '"div"'.
 								childNode.type = 'space';
 								childNode.value = atLeastOneSpace(childNode.after);
 								commaCount++;
@@ -89,16 +89,26 @@ function rule(primary, secondary, context) {
 			}
 		});
 	};
-}
+};
 
+/**
+ * @param {string} whitespace
+ */
 function atLeastOneSpace(whitespace) {
 	return whitespace !== '' ? whitespace : ' ';
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ * @returns {node is import('postcss-value-parser').DivNode}
+ */
 function isComma(node) {
 	return node.type === 'div' && node.value === ',';
 }
 
+/**
+ * @param {import('postcss-value-parser').FunctionNode} node
+ */
 function hasCommas(node) {
 	return node.nodes && node.nodes.some((childNode) => isComma(childNode));
 }

--- a/lib/rules/color-hex-alpha/index.js
+++ b/lib/rules/color-hex-alpha/index.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -16,7 +15,8 @@ const messages = ruleMessages(ruleName, {
 
 const HEX = /^#([\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
 
-function rule(primary) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -49,16 +49,25 @@ function rule(primary) {
 			});
 		});
 	};
-}
+};
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isUrlFunction({ type, value }) {
 	return type === 'function' && value === 'url';
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isHexColor({ type, value }) {
 	return type === 'word' && HEX.test(value);
 }
 
+/**
+ * @param {string} hex
+ */
 function hasAlphaChannel(hex) {
 	return hex.length === 5 || hex.length === 9;
 }

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const valueParser = require('postcss-value-parser');
@@ -20,10 +18,11 @@ const messages = ruleMessages(ruleName, {
 const HEX = /^#[0-9A-Za-z]+/;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['lower', 'upper'],
 		});
 
@@ -42,7 +41,7 @@ function rule(expectation, options, context) {
 
 				if (!isHexColor(node)) return;
 
-				const expected = expectation === 'lower' ? value.toLowerCase() : value.toUpperCase();
+				const expected = primary === 'lower' ? value.toLowerCase() : value.toUpperCase();
 
 				if (value === expected) return;
 
@@ -67,12 +66,18 @@ function rule(expectation, options, context) {
 			}
 		});
 	};
-}
+};
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isIgnoredFunction({ type, value }) {
 	return type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase());
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isHexColor({ type, value }) {
 	return type === 'word' && HEX.test(value);
 }

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const valueParser = require('postcss-value-parser');
@@ -20,10 +18,11 @@ const messages = ruleMessages(ruleName, {
 const HEX = /^#[0-9A-Za-z]+/;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
-function rule(expectation, _, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['short', 'long'],
 		});
 
@@ -42,15 +41,15 @@ function rule(expectation, _, context) {
 
 				if (!isHexColor(node)) return;
 
-				if (expectation === 'long' && hexValue.length !== 4 && hexValue.length !== 5) {
+				if (primary === 'long' && hexValue.length !== 4 && hexValue.length !== 5) {
 					return;
 				}
 
-				if (expectation === 'short' && (hexValue.length < 6 || !canShrink(hexValue))) {
+				if (primary === 'short' && (hexValue.length < 6 || !canShrink(hexValue))) {
 					return;
 				}
 
-				const variant = expectation === 'long' ? longer : shorter;
+				const variant = primary === 'long' ? longer : shorter;
 				const expectedHex = variant(hexValue);
 
 				if (context.fix) {
@@ -74,8 +73,11 @@ function rule(expectation, _, context) {
 			}
 		});
 	};
-}
+};
 
+/**
+ * @param {string} hex
+ */
 function canShrink(hex) {
 	hex = hex.toLowerCase();
 
@@ -87,6 +89,9 @@ function canShrink(hex) {
 	);
 }
 
+/**
+ * @param {string} hex
+ */
 function shorter(hex) {
 	let hexVariant = '#';
 
@@ -97,6 +102,9 @@ function shorter(hex) {
 	return hexVariant;
 }
 
+/**
+ * @param {string} hex
+ */
 function longer(hex) {
 	let hexVariant = '#';
 
@@ -107,10 +115,16 @@ function longer(hex) {
 	return hexVariant;
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isIgnoredFunction({ type, value }) {
 	return type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase());
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isHexColor({ type, value }) {
 	return type === 'word' && HEX.test(value);
 }

--- a/lib/rules/color-named/generateColorFuncs.js
+++ b/lib/rules/color-named/generateColorFuncs.js
@@ -1,9 +1,10 @@
-// @ts-nocheck
-
 'use strict';
 
 // these algorithms are sourced from https://drafts.csswg.org/css-color/#color-conversion-code
 
+/**
+ * @param {number[]} RGB
+ */
 function lin_sRGB(RGB) {
 	// convert an array of sRGB values in the range 0.0 - 1.0
 	// to linear light (un-companded) form.
@@ -17,6 +18,10 @@ function lin_sRGB(RGB) {
 	});
 }
 
+/**
+ * @param {number[][]} matrix
+ * @param {number[]} vector
+ */
 function matrixMultiple3d(matrix, vector) {
 	return [
 		matrix[0][0] * vector[0] + matrix[0][1] * vector[1] + matrix[0][2] * vector[2],
@@ -25,6 +30,9 @@ function matrixMultiple3d(matrix, vector) {
 	];
 }
 
+/**
+ * @param {number[]} srgb
+ */
 function srgb2xyz(srgb) {
 	return matrixMultiple3d(
 		[
@@ -36,6 +44,9 @@ function srgb2xyz(srgb) {
 	);
 }
 
+/**
+ * @param {number[]} xyz
+ */
 function chromaticAdaptationD65_D50(xyz) {
 	return matrixMultiple3d(
 		[
@@ -47,6 +58,9 @@ function chromaticAdaptationD65_D50(xyz) {
 	);
 }
 
+/**
+ * @param {number[]} xyzIn
+ */
 function xyz2lab(xyzIn) {
 	// Assuming XYZ is relative to D50, convert to CIE Lab
 	// from CIE standard, which now defines these as a rational fraction
@@ -73,6 +87,11 @@ function xyz2lab(xyzIn) {
 	];
 }
 
+/**
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ */
 function rgb2hsl(r, g, b) {
 	r /= 255;
 	g /= 255;
@@ -110,6 +129,11 @@ function rgb2hsl(r, g, b) {
 	return [Math.round(h), Math.round(s), Math.round(l)];
 }
 
+/**
+ * @param {number} rgb_r
+ * @param {number} rgb_g
+ * @param {number} rgb_b
+ */
 function rgb2hwb(rgb_r, rgb_g, rgb_b) {
 	rgb_r /= 255;
 	rgb_g /= 255;
@@ -134,10 +158,17 @@ function rgb2hwb(rgb_r, rgb_g, rgb_b) {
 	];
 }
 
+/**
+ * @param {number} value
+ */
 function perc255(value) {
 	return `${Math.round((value * 100) / 255)}%`;
 }
 
+/**
+ * @param {string} hexString
+ * @returns {string[]}
+ */
 function generateColorFuncs(hexString) {
 	if (hexString.length !== 7) {
 		throw new Error(

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -27,17 +25,18 @@ const messages = ruleMessages(ruleName, {
 // Todo tested on case insensitivity
 const NODE_TYPES = new Set(['word', 'function']);
 
-function rule(expectation, options) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: expectation,
+				actual: primary,
 				possible: ['never', 'always-where-possible'],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreProperties: [isString, isRegExp],
 					ignore: ['inside-function'],
@@ -51,6 +50,8 @@ function rule(expectation, options) {
 		}
 
 		const namedColors = Object.keys(namedColorDataHex);
+
+		/** @type {Record<string, { hex: string[], func: string[] }>} */
 		const namedColorData = {};
 
 		namedColors.forEach((name) => {
@@ -68,7 +69,7 @@ function rule(expectation, options) {
 			}
 
 			// Return early if the property is to be ignored
-			if (optionsMatches(options, 'ignoreProperties', decl.prop)) {
+			if (optionsMatches(secondaryOptions, 'ignoreProperties', decl.prop)) {
 				return;
 			}
 
@@ -77,7 +78,7 @@ function rule(expectation, options) {
 				const type = node.type;
 				const sourceIndex = node.sourceIndex;
 
-				if (optionsMatches(options, 'ignore', 'inside-function') && type === 'function') {
+				if (optionsMatches(secondaryOptions, 'ignore', 'inside-function') && type === 'function') {
 					return false;
 				}
 
@@ -95,18 +96,14 @@ function rule(expectation, options) {
 				}
 
 				// Check for named colors for "never" option
-				if (
-					expectation === 'never' &&
-					type === 'word' &&
-					namedColors.includes(value.toLowerCase())
-				) {
+				if (primary === 'never' && type === 'word' && namedColors.includes(value.toLowerCase())) {
 					complain(messages.rejected(value), decl, declarationValueIndex(decl) + sourceIndex);
 
 					return;
 				}
 
 				// Check "always-where-possible" option ...
-				if (expectation !== 'always-where-possible') {
+				if (primary !== 'always-where-possible') {
 					return;
 				}
 
@@ -152,6 +149,11 @@ function rule(expectation, options) {
 			});
 		});
 
+		/**
+		 * @param {string} message
+		 * @param {import('postcss').Node} node
+		 * @param {number} index
+		 */
 		function complain(message, node, index) {
 			report({
 				result,
@@ -162,7 +164,7 @@ function rule(expectation, options) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/color-no-hex/index.js
+++ b/lib/rules/color-no-hex/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const valueParser = require('postcss-value-parser');
@@ -19,9 +17,10 @@ const messages = ruleMessages(ruleName, {
 const HEX = /^#[0-9A-Za-z]+/;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
-function rule(actual) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -45,12 +44,18 @@ function rule(actual) {
 			});
 		});
 	};
-}
+};
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isIgnoredFunction({ type, value }) {
 	return type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase());
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isHexColor({ type, value }) {
 	return type === 'word' && HEX.test(value);
 }

--- a/lib/rules/color-no-invalid-hex/index.js
+++ b/lib/rules/color-no-invalid-hex/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -15,9 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (hex) => `Unexpected invalid hex color "${hex}"`,
 });
 
-function rule(actual) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -47,7 +46,7 @@ function rule(actual) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Related to #4496
(see also #5426)

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `color-*` rules.
In addition, it improves the types of some utilities.
