### PR TITLE
Disable Dependabot on default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0 # TODO: Disable on the default branch during `v14` in progress.
     labels:
       - 'pr: dependencies'
     versioning-strategy: increase


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

See #5439

> Is there anything in the PR that needs further explanation?

Currently, we have mainly developed on the `v14` branch.

See also:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit

**Note: This PR's base branch should be `master`.**