### PR TITLE
Set `target-branch:v14` for Dependabot again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0 # TODO: Disable on the default branch during `v14` in progress.
+    open-pull-requests-limit: 5
     labels:
       - 'pr: dependencies'
     versioning-strategy: increase
+    target-branch: 'v14' # TODO: Remove when releasing v14.


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

See #5439 and #5452

> Is there anything in the PR that needs further explanation?

This change is a retry of PR #5439 and also a revert of PR #5452.
Maybe, `target-branch: v14` should be set on the `master` branch, not `v14`.

Note: This PR's base branch should be set to `master`.

