### PR TITLE
Refactor to improve types for `custom-*` rules

### DIFF
--- a/lib/rules/custom-media-pattern/index.js
+++ b/lib/rules/custom-media-pattern/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -14,10 +12,11 @@ const messages = ruleMessages(ruleName, {
 	expected: (pattern) => `Expected custom media query name to match pattern "${pattern}"`,
 });
 
-function rule(pattern) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: pattern,
+			actual: primary,
 			possible: [isRegExp, isString],
 		});
 
@@ -25,21 +24,25 @@ function rule(pattern) {
 			return;
 		}
 
-		const regexpPattern = isString(pattern) ? new RegExp(pattern) : pattern;
+		const regexpPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkAtRules((atRule) => {
 			if (atRule.name.toLowerCase() !== 'custom-media') {
 				return;
 			}
 
-			const customMediaName = atRule.params.match(/^--(\S+)\b/)[1];
+			const match = atRule.params.match(/^--(\S+)\b/);
+
+			if (match == null) throw new Error(`Unexpected at-rule params: "${atRule.params}"`);
+
+			const customMediaName = match[1];
 
 			if (regexpPattern.test(customMediaName)) {
 				return;
 			}
 
 			report({
-				message: messages.expected(pattern),
+				message: messages.expected(primary),
 				node: atRule,
 				index: atRuleParamIndex(atRule),
 				result,
@@ -47,7 +50,7 @@ function rule(pattern) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -24,17 +24,17 @@ const messages = ruleMessages(ruleName, {
 });
 
 /** @type {import('stylelint').StylelintRule} */
-const rule = (expectation, options, context) => {
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: expectation,
+				actual: primary,
 				possible: ['always', 'never'],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					except: ['first-nested', 'after-comment', 'after-custom-property'],
 					ignore: ['after-comment', 'first-nested', 'inside-single-line-block'],
@@ -60,18 +60,18 @@ const rule = (expectation, options, context) => {
 			}
 
 			// Optionally ignore the node if a comment precedes it
-			if (optionsMatches(options, 'ignore', 'after-comment') && isAfterComment(decl)) {
+			if (optionsMatches(secondaryOptions, 'ignore', 'after-comment') && isAfterComment(decl)) {
 				return;
 			}
 
 			// Optionally ignore the node if it is the first nested
-			if (optionsMatches(options, 'ignore', 'first-nested') && isFirstNested(decl)) {
+			if (optionsMatches(secondaryOptions, 'ignore', 'first-nested') && isFirstNested(decl)) {
 				return;
 			}
 
 			// Optionally ignore nodes inside single-line blocks
 			if (
-				optionsMatches(options, 'ignore', 'inside-single-line-block') &&
+				optionsMatches(secondaryOptions, 'ignore', 'inside-single-line-block') &&
 				parent != null &&
 				(isAtRule(parent) || isRule(parent)) &&
 				isSingleLineString(blockString(parent))
@@ -79,13 +79,14 @@ const rule = (expectation, options, context) => {
 				return;
 			}
 
-			let expectEmptyLineBefore = expectation === 'always';
+			let expectEmptyLineBefore = primary === 'always';
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (
-				(optionsMatches(options, 'except', 'first-nested') && isFirstNested(decl)) ||
-				(optionsMatches(options, 'except', 'after-comment') && isAfterComment(decl)) ||
-				(optionsMatches(options, 'except', 'after-custom-property') && isAfterCustomProperty(decl))
+				(optionsMatches(secondaryOptions, 'except', 'first-nested') && isFirstNested(decl)) ||
+				(optionsMatches(secondaryOptions, 'except', 'after-comment') && isAfterComment(decl)) ||
+				(optionsMatches(secondaryOptions, 'except', 'after-custom-property') &&
+					isAfterCustomProperty(decl))
 			) {
 				expectEmptyLineBefore = !expectEmptyLineBefore;
 			}

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const addEmptyLineBefore = require('../../utils/addEmptyLineBefore');
@@ -16,6 +14,7 @@ const removeEmptyLinesBefore = require('../../utils/removeEmptyLinesBefore');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isAtRule, isDeclaration, isRule } = require('../../utils/typeGuards');
 
 const ruleName = 'custom-property-empty-line-before';
 
@@ -24,7 +23,8 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before custom property',
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (expectation, options, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -72,6 +72,8 @@ function rule(expectation, options, context) {
 			// Optionally ignore nodes inside single-line blocks
 			if (
 				optionsMatches(options, 'ignore', 'inside-single-line-block') &&
+				parent != null &&
+				(isAtRule(parent) || isRule(parent)) &&
 				isSingleLineString(blockString(parent))
 			) {
 				return;
@@ -97,6 +99,8 @@ function rule(expectation, options, context) {
 
 			// Fix
 			if (context.fix) {
+				if (context.newline == null) return;
+
 				if (expectEmptyLineBefore) {
 					addEmptyLineBefore(decl, context.newline);
 				} else {
@@ -116,12 +120,15 @@ function rule(expectation, options, context) {
 			});
 		});
 	};
-}
+};
 
+/**
+ * @param {import('postcss').Declaration} decl
+ */
 function isAfterCustomProperty(decl) {
 	const prevNode = getPreviousNonSharedLineCommentNode(decl);
 
-	return prevNode && prevNode.prop && isCustomProperty(prevNode.prop);
+	return prevNode != null && isDeclaration(prevNode) && isCustomProperty(prevNode.prop);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/custom-property-no-missing-var-function/index.js
+++ b/lib/rules/custom-property-no-missing-var-function/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const valueParser = require('postcss-value-parser');
@@ -16,22 +14,22 @@ const messages = ruleMessages(ruleName, {
 	rejected: (customProperty) => `Unexpected missing var function for "${customProperty}"`,
 });
 
-function rule(actual) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual,
-		});
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) return;
 
-		const customProperties = new Set();
+		/** @type {Set<string>} */
+		const knownCustomProperties = new Set();
 
 		root.walkAtRules(/^property$/i, (atRule) => {
-			customProperties.add(atRule.params);
+			knownCustomProperties.add(atRule.params);
 		});
 
 		root.walkDecls(({ prop }) => {
-			if (isCustomProperty(prop)) customProperties.add(prop);
+			if (isCustomProperty(prop)) knownCustomProperties.add(prop);
 		});
 
 		root.walkDecls((decl) => {
@@ -43,7 +41,7 @@ function rule(actual) {
 
 				if (!isDashedIdent(node)) return;
 
-				if (!isKnownCustomProperty(node)) return;
+				if (!knownCustomProperties.has(node.value)) return;
 
 				report({
 					message: messages.rejected(node.value),
@@ -56,17 +54,19 @@ function rule(actual) {
 				return false;
 			});
 		});
-
-		function isKnownCustomProperty({ value }) {
-			return customProperties.has(value);
-		}
 	};
-}
+};
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isDashedIdent({ type, value }) {
 	return type === 'word' && value.startsWith('--');
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isVarFunction({ type, value }) {
 	return type === 'function' && value === 'var';
 }

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isCustomProperty = require('../../utils/isCustomProperty');
@@ -14,10 +12,11 @@ const messages = ruleMessages(ruleName, {
 	expected: (pattern) => `Expected custom property name to match pattern "${pattern}"`,
 });
 
-function rule(pattern) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: pattern,
+			actual: primary,
 			possible: [isRegExp, isString],
 		});
 
@@ -25,7 +24,7 @@ function rule(pattern) {
 			return;
 		}
 
-		const regexpPattern = isString(pattern) ? new RegExp(pattern) : pattern;
+		const regexpPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkDecls((decl) => {
 			const prop = decl.prop;
@@ -39,14 +38,14 @@ function rule(pattern) {
 			}
 
 			report({
-				message: messages.expected(pattern),
+				message: messages.expected(primary),
 				node: decl,
 				result,
 				ruleName,
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Related to #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `custom-*` rules.
