### PR TITLE
Bump actions/setup-node from v1 to v2

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -25,9 +25,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
 
       - name: Install latest npm
         run: npm install --global npm@latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,9 +29,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
 
       - name: Install latest npm
         run: npm install --global npm@latest
@@ -56,9 +57,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
 
       - name: Install latest npm
         run: npm install --global npm@latest


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Also, this change sets `cache: npm` (available since v2.2.0). See below:
- https://github.com/actions/setup-node/releases/tag/v2.2.0
- https://github.com/actions/setup-node#caching-packages-dependencies
