### PR TITLE
Add GitHub Actions for Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
       - 'pr: dependencies'
     versioning-strategy: increase
     target-branch: 'v14' # TODO: Remove when releasing v14.
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - 'pr: dependencies'
+    target-branch: 'v14' # TODO: Remove when releasing v14.


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

See <https://github.com/stylelint/stylelint/pull/5481#issuecomment-899056059>

> Is there anything in the PR that needs further explanation?

Note: `versioning-strategy` is unsupported for `github-actions`.

See also:
- https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
