### PR TITLE
Refactor to improve types for `declaration-bang-space-*` rules

### DIFF
--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationBangSpaceChecker = require('../declarationBangSpaceChecker');
@@ -17,12 +15,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after "!"',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -40,6 +39,7 @@ function rule(expectation, options, context) {
 						let bangIndex = index - declarationValueIndex(decl);
 						const declValue = getDeclarationValue(decl);
 						let target;
+						/** @type {(value: string) => void} */
 						let setFixed;
 
 						if (bangIndex < declValue.length) {
@@ -60,13 +60,13 @@ function rule(expectation, options, context) {
 						const targetBefore = target.slice(0, bangIndex + 1);
 						const targetAfter = target.slice(bangIndex + 1);
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							setFixed(targetBefore + targetAfter.replace(/^\s*/, ' '));
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							setFixed(targetBefore + targetAfter.replace(/^\s*/, ''));
 
 							return true;
@@ -75,7 +75,7 @@ function rule(expectation, options, context) {
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-bang-space-before/index.js
+++ b/lib/rules/declaration-bang-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationBangSpaceChecker = require('../declarationBangSpaceChecker');
@@ -17,12 +15,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before "!"',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -40,6 +39,7 @@ function rule(expectation, options, context) {
 						let bangIndex = index - declarationValueIndex(decl);
 						const value = getDeclarationValue(decl);
 						let target;
+						/** @type {(val: string) => void} */
 						let setFixed;
 
 						if (bangIndex < value.length) {
@@ -60,14 +60,14 @@ function rule(expectation, options, context) {
 						const targetBefore = target.slice(0, bangIndex);
 						const targetAfter = target.slice(bangIndex);
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							// eslint-disable-next-line prefer-template
 							setFixed(targetBefore.replace(/\s*$/, '') + ' ' + targetAfter);
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							setFixed(targetBefore.replace(/\s*$/, '') + targetAfter);
 
 							return true;
@@ -76,7 +76,7 @@ function rule(expectation, options, context) {
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declarationBangSpaceChecker.js
+++ b/lib/rules/declarationBangSpaceChecker.js
@@ -1,12 +1,24 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../utils/declarationValueIndex');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function (opts) {
+/** @typedef {import('postcss').Declaration} Declaration */
+
+/** @typedef {(args: { source: string, index: number, err: (message: string) => void }) => void} LocationChecker */
+
+/**
+ * @param {{
+ *   root: import('postcss').Root,
+ *   locationChecker: LocationChecker,
+ *   result: import('stylelint').PostcssResult,
+ *   checkedRuleName: string,
+ *   fix: ((decl: Declaration, index: number) => void) | null,
+ * }} opts
+ * @returns {void}
+ */
+module.exports = function declarationBangSpaceChecker(opts) {
 	opts.root.walkDecls((decl) => {
 		const indexOffset = declarationValueIndex(decl);
 		const declString = decl.toString();
@@ -21,18 +33,23 @@ module.exports = function (opts) {
 		});
 	});
 
-	function check(source, index, node) {
+	/**
+	 * @param {string} source
+	 * @param {number} index
+	 * @param {Declaration} decl
+	 */
+	function check(source, index, decl) {
 		opts.locationChecker({
 			source,
 			index,
-			err: (m) => {
-				if (opts.fix && opts.fix(node, index)) {
+			err: (message) => {
+				if (opts.fix && opts.fix(decl, index)) {
 					return;
 				}
 
 				report({
-					message: m,
-					node,
+					message,
+					node: decl,
 					index,
 					result: opts.result,
 					ruleName: opts.checkedRuleName,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `declaration-bang-space-*` rules.
Also, it improves the `declarationBangSpaceChecker()` utility.
