### PR TITLE
Refactor to improve types for `declaration-block-*` rules

### DIFF
--- a/lib/reference/shorthandData.js
+++ b/lib/reference/shorthandData.js
@@ -1,5 +1,6 @@
 'use strict';
 
+/** @type {Record<string, string[]>} */
 module.exports = {
 	margin: ['margin-top', 'margin-bottom', 'margin-left', 'margin-right'],
 	padding: ['padding-top', 'padding-bottom', 'padding-left', 'padding-right'],

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
@@ -15,9 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected duplicate "${property}"`,
 });
 
-function rule(on) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual: on });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -54,7 +53,7 @@ function rule(on) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-no-duplicate-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
@@ -17,14 +15,15 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected duplicate "${property}"`,
 });
 
-function rule(on, options) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
-			{ actual: on },
+			{ actual: primary },
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['consecutive-duplicates', 'consecutive-duplicates-with-different-values'],
 					ignoreProperties: [isString],
@@ -38,7 +37,9 @@ function rule(on, options) {
 		}
 
 		eachDeclarationBlock(root, (eachDecl) => {
+			/** @type {string[]} */
 			const decls = [];
+			/** @type {string[]} */
 			const values = [];
 
 			eachDecl((decl) => {
@@ -54,7 +55,7 @@ function rule(on, options) {
 				}
 
 				// Return early if the property is to be ignored
-				if (optionsMatches(options, 'ignoreProperties', prop)) {
+				if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) {
 					return;
 				}
 
@@ -66,7 +67,13 @@ function rule(on, options) {
 				const indexDuplicate = decls.indexOf(prop.toLowerCase());
 
 				if (indexDuplicate !== -1) {
-					if (optionsMatches(options, 'ignore', 'consecutive-duplicates-with-different-values')) {
+					if (
+						optionsMatches(
+							secondaryOptions,
+							'ignore',
+							'consecutive-duplicates-with-different-values',
+						)
+					) {
 						// if duplicates are not consecutive
 						if (indexDuplicate !== decls.length - 1) {
 							report({
@@ -95,7 +102,7 @@ function rule(on, options) {
 					}
 
 					if (
-						optionsMatches(options, 'ignore', 'consecutive-duplicates') &&
+						optionsMatches(secondaryOptions, 'ignore', 'consecutive-duplicates') &&
 						indexDuplicate === decls.length - 1
 					) {
 						return;
@@ -114,7 +121,7 @@ function rule(on, options) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const arrayEqual = require('../../utils/arrayEqual');
@@ -18,14 +16,15 @@ const messages = ruleMessages(ruleName, {
 	expected: (props) => `Expected shorthand property "${props}"`,
 });
 
-function rule(actual, options) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
-			{ actual },
+			{ actual: primary },
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreShorthands: [isString, isRegExp],
 				},
@@ -38,8 +37,8 @@ function rule(actual, options) {
 		}
 
 		const longhandProperties = Object.entries(shorthandData).reduce(
-			(longhandProps, [key, values]) => {
-				if (optionsMatches(options, 'ignoreShorthands', key)) {
+			(/** @type {Record<string, string[]>} */ longhandProps, [key, values]) => {
+				if (optionsMatches(secondaryOptions, 'ignoreShorthands', key)) {
 					return longhandProps;
 				}
 
@@ -53,6 +52,7 @@ function rule(actual, options) {
 		);
 
 		eachDeclarationBlock(root, (eachDecl) => {
+			/** @type {Record<string, string[]>} */
 			const longhandDeclarations = {};
 
 			eachDecl((decl) => {
@@ -98,7 +98,7 @@ function rule(actual, options) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
@@ -15,15 +13,17 @@ const messages = ruleMessages(ruleName, {
 	rejected: (shorthand, original) => `Unexpected shorthand "${shorthand}" after "${original}"`,
 });
 
-function rule(actual) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
 		}
 
 		eachDeclarationBlock(root, (eachDecl) => {
+			/** @type {Record<string, string>} */
 			const declarations = {};
 
 			eachDecl((decl) => {
@@ -54,7 +54,7 @@ function rule(actual) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-newline-after/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -9,6 +7,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
+const { isAtRule, isRule } = require('../../utils/typeGuards');
 
 const ruleName = 'declaration-block-semicolon-newline-after';
 
@@ -18,12 +17,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected newline after ";" in a multi-line declaration block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -34,6 +34,12 @@ function rule(expectation, options, context) {
 		root.walkDecls((decl) => {
 			// Ignore last declaration if there's no trailing semicolon
 			const parentRule = decl.parent;
+
+			if (!parentRule) throw new Error('A parent node must be present');
+
+			if (!isAtRule(parentRule) && !isRule(parentRule)) {
+				return;
+			}
 
 			if (!parentRule.raws.semicolon && parentRule.last === decl) {
 				return;
@@ -58,7 +64,7 @@ function rule(expectation, options, context) {
 				lineCheckStr: blockString(parentRule),
 				err: (m) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
+						if (primary.startsWith('always')) {
 							const index = nodeToCheck.raws.before.search(/\r?\n/);
 
 							if (index >= 0) {
@@ -70,7 +76,7 @@ function rule(expectation, options, context) {
 							return;
 						}
 
-						if (expectation === 'never-multi-line') {
+						if (primary === 'never-multi-line') {
 							nodeToCheck.raws.before = '';
 
 							return;
@@ -88,7 +94,7 @@ function rule(expectation, options, context) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-newline-before/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -7,6 +5,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
+const { isAtRule, isRule } = require('../../utils/typeGuards');
 
 const ruleName = 'declaration-block-semicolon-newline-before';
 
@@ -17,12 +16,13 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace before ";" in a multi-line declaration block',
 });
 
-function rule(expectation) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -32,6 +32,12 @@ function rule(expectation) {
 
 		root.walkDecls((decl) => {
 			const parentRule = decl.parent;
+
+			if (!parentRule) throw new Error('A parent node must be present');
+
+			if (!isAtRule(parentRule) && !isRule(parentRule)) {
+				return;
+			}
 
 			if (!parentRule.raws.semicolon && parentRule.last === decl) {
 				return;
@@ -55,7 +61,7 @@ function rule(expectation) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-space-after/index.js
+++ b/lib/rules/declaration-block-semicolon-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -8,6 +6,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
+const { isAtRule, isRule } = require('../../utils/typeGuards');
 
 const ruleName = 'declaration-block-semicolon-space-after';
 
@@ -20,12 +19,13 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace after ";" in a single-line declaration block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return function (root, result) {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never', 'always-single-line', 'never-single-line'],
 		});
 
@@ -36,6 +36,12 @@ function rule(expectation, options, context) {
 		root.walkDecls((decl) => {
 			// Ignore last declaration if there's no trailing semicolon
 			const parentRule = decl.parent;
+
+			if (!parentRule) throw new Error('A parent node must be present');
+
+			if (!isAtRule(parentRule) && !isRule(parentRule)) {
+				return;
+			}
 
 			if (!parentRule.raws.semicolon && parentRule.last === decl) {
 				return;
@@ -53,13 +59,13 @@ function rule(expectation, options, context) {
 				lineCheckStr: blockString(parentRule),
 				err: (m) => {
 					if (context.fix) {
-						if (expectation.startsWith('always')) {
+						if (primary.startsWith('always')) {
 							nextDecl.raws.before = ' ';
 
 							return;
 						}
 
-						if (expectation.startsWith('never')) {
+						if (primary.startsWith('never')) {
 							nextDecl.raws.before = '';
 
 							return;
@@ -77,7 +83,7 @@ function rule(expectation, options, context) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const blockString = require('../../utils/blockString');
@@ -9,6 +7,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const whitespaceChecker = require('../../utils/whitespaceChecker');
+const { isAtRule, isRule } = require('../../utils/typeGuards');
 
 const ruleName = 'declaration-block-semicolon-space-before';
 
@@ -21,12 +20,13 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace before ";" in a single-line declaration block',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never', 'always-single-line', 'never-single-line'],
 		});
 
@@ -37,6 +37,12 @@ function rule(expectation, options, context) {
 		root.walkDecls((decl) => {
 			// Ignore last declaration if there's no trailing semicolon
 			const parentRule = decl.parent;
+
+			if (!parentRule) throw new Error('A parent node must be present');
+
+			if (!isAtRule(parentRule) && !isRule(parentRule)) {
+				return;
+			}
 
 			if (!parentRule.raws.semicolon && parentRule.last === decl) {
 				return;
@@ -52,7 +58,7 @@ function rule(expectation, options, context) {
 					if (context.fix) {
 						const value = getDeclarationValue(decl);
 
-						if (expectation.startsWith('always')) {
+						if (primary.startsWith('always')) {
 							if (decl.important) {
 								decl.raws.important = ' !important ';
 							} else {
@@ -62,8 +68,8 @@ function rule(expectation, options, context) {
 							return;
 						}
 
-						if (expectation.startsWith('never')) {
-							if (decl.important) {
+						if (primary.startsWith('never')) {
+							if (decl.raws.important) {
 								decl.raws.important = decl.raws.important.replace(/\s*$/, '');
 							} else {
 								setDeclarationValue(decl, value.replace(/\s*$/, ''));
@@ -84,7 +90,7 @@ function rule(expectation, options, context) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-single-line-max-declarations/index.js
+++ b/lib/rules/declaration-block-single-line-max-declarations/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const beforeBlockString = require('../../utils/beforeBlockString');
@@ -16,10 +14,11 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} ${max === 1 ? 'declaration' : 'declarations'}`,
 });
 
-function rule(quantity) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: quantity,
+			actual: primary,
 			possible: [isNumber],
 		});
 
@@ -38,12 +37,12 @@ function rule(quantity) {
 
 			const decls = ruleNode.nodes.filter((node) => node.type === 'decl');
 
-			if (decls.length <= quantity) {
+			if (decls.length <= primary) {
 				return;
 			}
 
 			report({
-				message: messages.expected(quantity),
+				message: messages.expected(primary),
 				node: ruleNode,
 				index: beforeBlockString(ruleNode, { noRawBefore: true }).length,
 				result,
@@ -51,7 +50,7 @@ function rule(quantity) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const hasBlock = require('../../utils/hasBlock');
@@ -15,17 +13,18 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected trailing semicolon',
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: expectation,
+				actual: primary,
 				possible: ['always', 'never'],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['single-declaration'],
 				},
@@ -38,6 +37,8 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkAtRules((atRule) => {
+			if (!atRule.parent) throw new Error('A parent node must be present');
+
 			if (atRule.parent === root) {
 				return;
 			}
@@ -54,6 +55,8 @@ function rule(expectation, options, context) {
 		});
 
 		root.walkDecls((decl) => {
+			if (!decl.parent) throw new Error('A parent node must be present');
+
 			if (decl.parent.type === 'object') {
 				return;
 			}
@@ -65,16 +68,26 @@ function rule(expectation, options, context) {
 			checkLastNode(decl);
 		});
 
+		/**
+		 * @param {import('postcss').Node} node
+		 */
 		function checkLastNode(node) {
+			if (!node.parent) throw new Error('A parent node must be present');
+
 			const hasSemicolon = node.parent.raws.semicolon;
-			const ignoreSingleDeclaration = optionsMatches(options, 'ignore', 'single-declaration');
-			let message;
+			const ignoreSingleDeclaration = optionsMatches(
+				secondaryOptions,
+				'ignore',
+				'single-declaration',
+			);
 
 			if (ignoreSingleDeclaration && node.parent.first === node) {
 				return;
 			}
 
-			if (expectation === 'always') {
+			let message;
+
+			if (primary === 'always') {
 				if (hasSemicolon) {
 					return;
 				}
@@ -92,7 +105,7 @@ function rule(expectation, options, context) {
 				}
 
 				message = messages.expected;
-			} else if (expectation === 'never') {
+			} else if (primary === 'never') {
 				if (!hasSemicolon) {
 					return;
 				}
@@ -105,6 +118,8 @@ function rule(expectation, options, context) {
 				}
 
 				message = messages.rejected;
+			} else {
+				throw new Error(`Unexpected primary option: "${primary}"`);
 			}
 
 			report({
@@ -116,7 +131,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `declaration-block-*` rules.
