### PR TITLE
Refactor to improve types for `declaration-*` rules

### DIFF
--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -71,6 +71,8 @@ const rule = (primary, _secondaryOptions, context) => {
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});

--- a/lib/rules/declaration-bang-space-before/index.js
+++ b/lib/rules/declaration-bang-space-before/index.js
@@ -72,6 +72,8 @@ const rule = (primary, _secondaryOptions, context) => {
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});

--- a/lib/rules/declaration-colon-newline-after/index.js
+++ b/lib/rules/declaration-colon-newline-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	expectedAfterMultiLine: () => 'Expected newline after ":" with a multi-line declaration',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line'],
 		});
 
@@ -57,6 +56,9 @@ function rule(expectation, options, context) {
 					err: (m) => {
 						if (context.fix) {
 							const between = decl.raws.between;
+
+							if (between == null) throw new Error('`between` must be present');
+
 							const betweenStart = declarationValueIndex(decl) - between.length;
 							const sliceIndex = indexToCheck - betweenStart + 1;
 							const betweenBefore = between.slice(0, sliceIndex);
@@ -83,7 +85,7 @@ function rule(expectation, options, context) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-colon-space-after/index.js
+++ b/lib/rules/declaration-colon-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationColonSpaceChecker = require('../declarationColonSpaceChecker');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	expectedAfterSingleLine: () => 'Expected single space after ":" with a single-line declaration',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never', 'always-single-line'],
 		});
 
@@ -39,24 +38,28 @@ function rule(expectation, options, context) {
 						const colonIndex = index - declarationValueIndex(decl);
 						const between = decl.raws.between;
 
-						if (expectation.startsWith('always')) {
+						if (between == null) throw new Error('`between` must be present');
+
+						if (primary.startsWith('always')) {
 							decl.raws.between =
 								between.slice(0, colonIndex) + between.slice(colonIndex).replace(/^:\s*/, ': ');
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							decl.raws.between =
 								between.slice(0, colonIndex) + between.slice(colonIndex).replace(/^:\s*/, ':');
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationColonSpaceChecker = require('../declarationColonSpaceChecker');
@@ -15,12 +13,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ":"',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -38,24 +37,28 @@ function rule(expectation, options, context) {
 						const colonIndex = index - declarationValueIndex(decl);
 						const between = decl.raws.between;
 
-						if (expectation === 'always') {
+						if (between == null) throw new Error('`between` must be present');
+
+						if (primary === 'always') {
 							decl.raws.between =
 								between.slice(0, colonIndex).replace(/\s*$/, ' ') + between.slice(colonIndex);
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							decl.raws.between =
 								between.slice(0, colonIndex).replace(/\s*$/, '') + between.slice(colonIndex);
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const addEmptyLineBefore = require('../../utils/addEmptyLineBefore');
@@ -17,6 +15,7 @@ const removeEmptyLinesBefore = require('../../utils/removeEmptyLinesBefore');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isAtRule, isRule } = require('../../utils/typeGuards');
 
 const ruleName = 'declaration-empty-line-before';
 
@@ -25,17 +24,18 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before declaration',
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: expectation,
+				actual: primary,
 				possible: ['always', 'never'],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					except: ['first-nested', 'after-comment', 'after-declaration'],
 					ignore: [
@@ -57,8 +57,16 @@ function rule(expectation, options, context) {
 			const prop = decl.prop;
 			const parent = decl.parent;
 
+			if (parent == null) {
+				return;
+			}
+
 			// Ignore the first node
 			if (isFirstNodeOfRoot(decl)) {
+				return;
+			}
+
+			if (!isAtRule(parent) && !isRule(parent)) {
 				return;
 			}
 
@@ -71,38 +79,38 @@ function rule(expectation, options, context) {
 			}
 
 			// Optionally ignore the node if a comment precedes it
-			if (optionsMatches(options, 'ignore', 'after-comment') && isAfterComment(decl)) {
+			if (optionsMatches(secondaryOptions, 'ignore', 'after-comment') && isAfterComment(decl)) {
 				return;
 			}
 
 			// Optionally ignore the node if a declaration precedes it
 			if (
-				optionsMatches(options, 'ignore', 'after-declaration') &&
+				optionsMatches(secondaryOptions, 'ignore', 'after-declaration') &&
 				isAfterStandardPropertyDeclaration(decl)
 			) {
 				return;
 			}
 
 			// Optionally ignore the node if it is the first nested
-			if (optionsMatches(options, 'ignore', 'first-nested') && isFirstNested(decl)) {
+			if (optionsMatches(secondaryOptions, 'ignore', 'first-nested') && isFirstNested(decl)) {
 				return;
 			}
 
 			// Optionally ignore nodes inside single-line blocks
 			if (
-				optionsMatches(options, 'ignore', 'inside-single-line-block') &&
+				optionsMatches(secondaryOptions, 'ignore', 'inside-single-line-block') &&
 				isSingleLineString(blockString(parent))
 			) {
 				return;
 			}
 
-			let expectEmptyLineBefore = expectation === 'always';
+			let expectEmptyLineBefore = primary === 'always';
 
 			// Optionally reverse the expectation if any exceptions apply
 			if (
-				(optionsMatches(options, 'except', 'first-nested') && isFirstNested(decl)) ||
-				(optionsMatches(options, 'except', 'after-comment') && isAfterComment(decl)) ||
-				(optionsMatches(options, 'except', 'after-declaration') &&
+				(optionsMatches(secondaryOptions, 'except', 'first-nested') && isFirstNested(decl)) ||
+				(optionsMatches(secondaryOptions, 'except', 'after-comment') && isAfterComment(decl)) ||
+				(optionsMatches(secondaryOptions, 'except', 'after-declaration') &&
 					isAfterStandardPropertyDeclaration(decl))
 			) {
 				expectEmptyLineBefore = !expectEmptyLineBefore;
@@ -118,6 +126,8 @@ function rule(expectation, options, context) {
 
 			// Fix
 			if (context.fix) {
+				if (context.newline == null) return;
+
 				if (expectEmptyLineBefore) {
 					addEmptyLineBefore(decl, context.newline);
 				} else {
@@ -132,7 +142,7 @@ function rule(expectation, options, context) {
 			report({ message, node: decl, result, ruleName });
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-no-important/index.js
+++ b/lib/rules/declaration-no-important/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -12,9 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected !important',
 });
 
-function rule(actual) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -34,7 +33,7 @@ function rule(actual) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -19,17 +17,18 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 });
 
-function rule(list, options) {
+/** @type {import('stylelint').StylelintRule<Record<string, string[]>>} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: list,
+				actual: primary,
 				possible: [isPlainObject],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['inside-function'],
 				},
@@ -47,10 +46,15 @@ function rule(list, options) {
 
 			const unprefixedProp = vendor.unprefixed(prop);
 
-			const propKey = Object.keys(list).find((propIdentifier) =>
+			const propKey = Object.keys(primary).find((propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);
-			const propList = list[propKey];
+
+			if (!propKey) {
+				return;
+			}
+
+			const propList = primary[propKey];
 
 			if (!propList) {
 				return;
@@ -63,7 +67,7 @@ function rule(list, options) {
 						return false;
 					}
 
-					if (optionsMatches(options, 'ignore', 'inside-function')) {
+					if (optionsMatches(secondaryOptions, 'ignore', 'inside-function')) {
 						return false;
 					}
 				}
@@ -88,7 +92,7 @@ function rule(list, options) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -18,10 +16,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 });
 
-function rule(list) {
+/** @type {import('stylelint').StylelintRule<Record<string, string[]>>} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
+			actual: primary,
 			possible: [isPlainObject],
 		});
 
@@ -35,10 +34,15 @@ function rule(list) {
 
 			const unprefixedProp = vendor.unprefixed(prop);
 
-			const propKey = Object.keys(list).find((propIdentifier) =>
+			const propKey = Object.keys(primary).find((propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);
-			const propList = list[propKey];
+
+			if (!propKey) {
+				return;
+			}
+
+			const propList = primary[propKey];
 
 			if (!propList) {
 				return;
@@ -70,7 +74,7 @@ function rule(list) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
@@ -15,10 +13,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 });
 
-function rule(list) {
+/** @type {import('stylelint').StylelintRule<Record<string, (string | RegExp)[]>>} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
+			actual: primary,
 			possible: [isPlainObject],
 		});
 
@@ -31,10 +30,15 @@ function rule(list) {
 			const value = decl.value;
 
 			const unprefixedProp = vendor.unprefixed(prop);
-			const propKey = Object.keys(list).find((propIdentifier) =>
+			const propKey = Object.keys(primary).find((propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);
-			const propList = list[propKey];
+
+			if (!propKey) {
+				return;
+			}
+
+			const propList = primary[propKey];
 
 			if (!propList || propList.length === 0) {
 				return;
@@ -52,7 +56,7 @@ function rule(list) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
@@ -15,10 +13,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 });
 
-function rule(list) {
+/** @type {import('stylelint').StylelintRule<Record<string, (string | RegExp)[]>>} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
+			actual: primary,
 			possible: [isPlainObject],
 		});
 
@@ -31,10 +30,15 @@ function rule(list) {
 			const value = decl.value;
 
 			const unprefixedProp = vendor.unprefixed(prop);
-			const propKey = Object.keys(list).find((propIdentifier) =>
+			const propKey = Object.keys(primary).find((propIdentifier) =>
 				matchesStringOrRegExp(unprefixedProp, propIdentifier),
 			);
-			const propList = list[propKey];
+
+			if (!propKey) {
+				return;
+			}
+
+			const propList = primary[propKey];
 
 			if (!propList || propList.length === 0) {
 				return;
@@ -52,7 +56,7 @@ function rule(list) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declarationBangSpaceChecker.js
+++ b/lib/rules/declarationBangSpaceChecker.js
@@ -14,7 +14,7 @@ const styleSearch = require('style-search');
  *   locationChecker: LocationChecker,
  *   result: import('stylelint').PostcssResult,
  *   checkedRuleName: string,
- *   fix: ((decl: Declaration, index: number) => void) | null,
+ *   fix: ((decl: Declaration, index: number) => boolean) | null,
  * }} opts
  * @returns {void}
  */

--- a/lib/rules/declarationColonSpaceChecker.js
+++ b/lib/rules/declarationColonSpaceChecker.js
@@ -1,12 +1,21 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../utils/declarationValueIndex');
 const isStandardSyntaxDeclaration = require('../utils/isStandardSyntaxDeclaration');
 const report = require('../utils/report');
 
-module.exports = function (opts) {
+/** @typedef {(args: { source: string, index: number, lineCheckStr: string, err: (message: string) => void }) => void} LocationChecker */
+
+/**
+ * @param {{
+ *   root: import('postcss').Root,
+ *   locationChecker: LocationChecker,
+ *   fix: ((decl: import('postcss').Declaration, index: number) => boolean) | null,
+ *   result: import('stylelint').PostcssResult,
+ *   checkedRuleName: string,
+ * }} opts
+ */
+module.exports = function declarationColonSpaceChecker(opts) {
 	opts.root.walkDecls((decl) => {
 		if (!isStandardSyntaxDeclaration(decl)) {
 			return;
@@ -28,13 +37,13 @@ module.exports = function (opts) {
 				source: propPlusColon,
 				index: i,
 				lineCheckStr: decl.value,
-				err: (m) => {
+				err: (message) => {
 					if (opts.fix && opts.fix(decl, i)) {
 						return;
 					}
 
 					report({
-						message: m,
+						message,
 						node: decl,
 						index: decl.prop.toString().length + 1,
 						result: opts.result,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -146,9 +146,9 @@ declare module 'stylelint' {
 
 	export type StylelintRuleMessages = Record<string, string | ((...args: any[]) => string)>;
 
-	export type StylelintRule = ((
-		primaryOption: any,
-		secondaryOptions: Record<string, any>,
+	export type StylelintRule<P = any, S = any> = ((
+		primaryOption: P,
+		secondaryOptions: Record<string, S>,
 		context: StylelintPluginContext,
 	) => (root: Root, result: PostcssResult) => Promise<void> | void) & {
 		ruleName: string;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes  `// @ts-nocheck` from the remaining `declaration-*` rules.
Also, this adds 2 type parameters to the `StylelintRule` type to pass the type-check.
