### PR TITLE
Refactor to improve types for `hue-*` rules

### DIFF
--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const valueParser = require('postcss-value-parser');
@@ -22,7 +20,8 @@ const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];
 const HUE_THIRD_ARG_FUNCS = ['lch'];
 const HUE_FUNCS = new Set([...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS]);
 
-function rule(primary, secondary, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -78,18 +77,29 @@ function rule(primary, secondary, context) {
 			}
 		});
 	};
-}
+};
 
+/**
+ * @param {string} value
+ */
 function asDegree(value) {
 	return `${value}deg`;
 }
 
+/**
+ * @param {string} value
+ */
 function asNumber(value) {
-	const { number } = valueParser.unit(value);
+	const dimension = valueParser.unit(value);
 
-	return number;
+	if (dimension) return dimension.number;
+
+	throw new TypeError(`The "${value}" value must have a unit`);
 }
 
+/**
+ * @param {import('postcss-value-parser').FunctionNode} node
+ */
 function findHue(node) {
 	const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
 	const value = node.value.toLowerCase();
@@ -102,19 +112,25 @@ function findHue(node) {
 		return args[2];
 	}
 
-	return false;
+	return undefined;
 }
 
+/**
+ * @param {string} value
+ */
 function isDegree(value) {
-	const { unit } = valueParser.unit(value);
+	const dimension = valueParser.unit(value);
 
-	return unit && unit.toLowerCase() === 'deg';
+	return dimension && dimension.unit.toLowerCase() === 'deg';
 }
 
+/**
+ * @param {string} value
+ */
 function isNumber(value) {
-	const { unit } = valueParser.unit(value);
+	const dimension = valueParser.unit(value);
 
-	return unit === '';
+	return dimension && dimension.unit === '';
 }
 
 rule.ruleName = ruleName;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `hue-*` rules.
