### PR TITLE
Refactor to improve types for `indentation` rule

### DIFF
--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const beforeBlockString = require('../../utils/beforeBlockString');
@@ -9,6 +7,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const styleSearch = require('style-search');
 const validateOptions = require('../../utils/validateOptions');
+const { isAtRule, isDeclaration, isRoot, isRule } = require('../../utils/typeGuards');
 const { isBoolean, isNumber, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'indentation';
@@ -16,26 +15,18 @@ const messages = ruleMessages(ruleName, {
 	expected: (x) => `Expected indentation of ${x}`,
 });
 
-/**
- * @param {number|"tab"} space - Number of whitespaces to expect, or else
- *   keyword "tab" for single `\t`
- * @param {object} [options]
- */
-function rule(space, options = {}, context) {
-	const isTab = space === 'tab';
-	const indentChar = isTab ? '\t' : ' '.repeat(space);
-	const warningWord = isTab ? 'tab' : 'space';
-
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions = {}, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: space,
+				actual: primary,
 				possible: [isNumber, 'tab'],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					baseIndentLevel: [isNumber, 'auto'],
 					except: ['block', 'value', 'param'],
@@ -51,9 +42,28 @@ function rule(space, options = {}, context) {
 			return;
 		}
 
+		const spaceCount = isNumber(primary) ? primary : null;
+		const indentChar = spaceCount == null ? '\t' : ' '.repeat(spaceCount);
+		const warningWord = primary === 'tab' ? 'tab' : 'space';
+
+		/** @type {number | 'auto'} */
+		const baseIndentLevel = secondaryOptions.baseIndentLevel;
+		/** @type {boolean} */
+		const indentClosingBrace = secondaryOptions.indentClosingBrace;
+
+		/**
+		 * @param {number} level
+		 */
+		const legibleExpectation = (level) => {
+			const count = spaceCount == null ? level : level * spaceCount;
+			const quantifiedWarningWord = count === 1 ? warningWord : `${warningWord}s`;
+
+			return `${count} ${quantifiedWarningWord}`;
+		};
+
 		// Cycle through all nodes using walk.
 		root.walk((node) => {
-			if (node.type === 'root') {
+			if (isRoot(node)) {
 				// Ignore nested template literals root in css-in-js lang
 				return;
 			}
@@ -62,8 +72,10 @@ function rule(space, options = {}, context) {
 
 			// Cut out any * and _ hacks from `before`
 			const before = (node.raws.before || '').replace(/[*_]$/, '');
-			const after = node.raws.after || '';
+			const after = ('after' in node.raws && node.raws.after) || '';
 			const parent = node.parent;
+
+			if (!parent) throw new Error('A parent node must be present');
 
 			const expectedOpeningBraceIndentation = indentChar.repeat(nodeLevel);
 
@@ -107,10 +119,11 @@ function rule(space, options = {}, context) {
 			// Only inspect `after` strings that start with a newline;
 			// otherwise there's no indentation involved.
 			// And check `indentClosingBrace` to see if it should be indented an extra level.
-			const closingBraceLevel = options.indentClosingBrace ? nodeLevel + 1 : nodeLevel;
+			const closingBraceLevel = indentClosingBrace ? nodeLevel + 1 : nodeLevel;
 			const expectedClosingBraceIndentation = indentChar.repeat(closingBraceLevel);
 
 			if (
+				(isRule(node) || isAtRule(node)) &&
 				hasBlock(node) &&
 				after &&
 				after.includes('\n') &&
@@ -130,24 +143,31 @@ function rule(space, options = {}, context) {
 			}
 
 			// If this is a declaration, check the value
-			if (node.value) {
+			if (isDeclaration(node)) {
 				checkValue(node, nodeLevel);
 			}
 
 			// If this is a rule, check the selector
-			if (node.selector) {
+			if (isRule(node)) {
 				checkSelector(node, nodeLevel);
 			}
 
 			// If this is an at rule, check the params
-			if (node.type === 'atrule') {
+			if (isAtRule(node)) {
 				checkAtRuleParams(node, nodeLevel);
 			}
 		});
 
+		/**
+		 * @param {import('postcss').Node} node
+		 * @param {number} level
+		 * @returns {number}
+		 */
 		function indentationLevel(node, level = 0) {
-			if (node.parent.type === 'root') {
-				return level + getRootBaseIndentLevel(node.parent, options.baseIndentLevel, space);
+			if (!node.parent) throw new Error('A parent node must be present');
+
+			if (isRoot(node.parent)) {
+				return level + getRootBaseIndentLevel(node.parent, baseIndentLevel, primary);
 			}
 
 			let calculatedLevel;
@@ -157,12 +177,12 @@ function rule(space, options = {}, context) {
 			// run this operation
 			calculatedLevel = indentationLevel(node.parent, level + 1);
 
-			// If options.except includes "block",
+			// If `secondaryOptions.except` includes "block",
 			// blocks are taken down one from their calculated level
 			// (all blocks are the same level as their parents)
 			if (
-				optionsMatches(options, 'except', 'block') &&
-				(node.type === 'rule' || node.type === 'atrule') &&
+				optionsMatches(secondaryOptions, 'except', 'block') &&
+				(isRule(node) || isAtRule(node)) &&
 				hasBlock(node)
 			) {
 				calculatedLevel--;
@@ -171,25 +191,36 @@ function rule(space, options = {}, context) {
 			return calculatedLevel;
 		}
 
+		/**
+		 * @param {import('postcss').Declaration} decl
+		 * @param {number} declLevel
+		 */
 		function checkValue(decl, declLevel) {
 			if (!decl.value.includes('\n')) {
 				return;
 			}
 
-			if (optionsMatches(options, 'ignore', 'value')) {
+			if (optionsMatches(secondaryOptions, 'ignore', 'value')) {
 				return;
 			}
 
 			const declString = decl.toString();
-			const valueLevel = optionsMatches(options, 'except', 'value') ? declLevel : declLevel + 1;
+			const valueLevel = optionsMatches(secondaryOptions, 'except', 'value')
+				? declLevel
+				: declLevel + 1;
 
 			checkMultilineBit(declString, valueLevel, decl);
 		}
 
+		/**
+		 * @param {import('postcss').Rule} ruleNode
+		 * @param {number} ruleLevel
+		 */
 		function checkSelector(ruleNode, ruleLevel) {
 			const selector = ruleNode.selector;
 
 			// Less mixins have params, and they should be indented extra
+			// @ts-expect-error -- TS2339: Property 'params' does not exist on type 'Rule'.
 			if (ruleNode.params) {
 				ruleLevel += 1;
 			}
@@ -197,15 +228,19 @@ function rule(space, options = {}, context) {
 			checkMultilineBit(selector, ruleLevel, ruleNode);
 		}
 
+		/**
+		 * @param {import('postcss').AtRule} atRule
+		 * @param {number} ruleLevel
+		 */
 		function checkAtRuleParams(atRule, ruleLevel) {
-			if (optionsMatches(options, 'ignore', 'param')) {
+			if (optionsMatches(secondaryOptions, 'ignore', 'param')) {
 				return;
 			}
 
 			// @nest and SCSS's @at-root rules should be treated like regular rules, not expected
 			// to have their params (selectors) indented
 			const paramLevel =
-				optionsMatches(options, 'except', 'param') ||
+				optionsMatches(secondaryOptions, 'except', 'param') ||
 				atRule.name === 'nest' ||
 				atRule.name === 'at-root'
 					? ruleLevel
@@ -214,38 +249,44 @@ function rule(space, options = {}, context) {
 			checkMultilineBit(beforeBlockString(atRule).trim(), paramLevel, atRule);
 		}
 
+		/**
+		 * @param {string} source
+		 * @param {number} newlineIndentLevel
+		 * @param {import('postcss').Node} node
+		 */
 		function checkMultilineBit(source, newlineIndentLevel, node) {
 			if (!source.includes('\n')) {
 				return;
 			}
 
 			// Data for current node fixing
+			/** @type {Array<{ expectedIndentation: string, currentIndentation: string, startIndex: number }>} */
 			const fixPositions = [];
 
 			// `outsideParens` because function arguments and also non-standard parenthesized stuff like
 			// Sass maps are ignored to allow for arbitrary indentation
 			let parentheticalDepth = 0;
 
+			const ignoreInsideParans = optionsMatches(secondaryOptions, 'ignore', 'inside-parens');
+
 			styleSearch(
 				{
 					source,
 					target: '\n',
-					outsideParens: optionsMatches(options, 'ignore', 'inside-parens'),
+					// @ts-expect-error -- The `outsideParens` option is unsupported. Why?
+					outsideParens: ignoreInsideParans,
 				},
 				(match, matchCount) => {
 					const precedesClosingParenthesis = /^[ \t]*\)/.test(source.slice(match.startIndex + 1));
 
-					if (
-						optionsMatches(options, 'ignore', 'inside-parens') &&
-						(precedesClosingParenthesis || match.insideParens)
-					) {
+					if (ignoreInsideParans && (precedesClosingParenthesis || match.insideParens)) {
 						return;
 					}
 
 					let expectedIndentLevel = newlineIndentLevel;
 
 					// Modififications for parenthetical content
-					if (!optionsMatches(options, 'ignore', 'inside-parens') && match.insideParens) {
+					if (!ignoreInsideParans && match.insideParens) {
 						// If the first match in is within parentheses, reduce the parenthesis penalty
 						if (matchCount === 1) parentheticalDepth -= 1;
 
@@ -282,29 +323,29 @@ function rule(space, options = {}, context) {
 							parentheticalDepth -= 1;
 						}
 
-						switch (options.indentInsideParens) {
+						switch (secondaryOptions.indentInsideParens) {
 							case 'twice':
-								if (!precedesClosingParenthesis || options.indentClosingBrace) {
+								if (!precedesClosingParenthesis || indentClosingBrace) {
 									expectedIndentLevel += 1;
 								}
 
 								break;
 							case 'once-at-root-twice-in-block':
 								if (node.parent === node.root()) {
-									if (precedesClosingParenthesis && !options.indentClosingBrace) {
+									if (precedesClosingParenthesis && !indentClosingBrace) {
 										expectedIndentLevel -= 1;
 									}
 
 									break;
 								}
 
-								if (!precedesClosingParenthesis || options.indentClosingBrace) {
+								if (!precedesClosingParenthesis || indentClosingBrace) {
 									expectedIndentLevel += 1;
 								}
 
 								break;
 							default:
-								if (precedesClosingParenthesis && !options.indentClosingBrace) {
+								if (precedesClosingParenthesis && !indentClosingBrace) {
 									expectedIndentLevel -= 1;
 								}
 						}
@@ -346,7 +387,7 @@ function rule(space, options = {}, context) {
 			);
 
 			if (fixPositions.length) {
-				if (node.type === 'rule') {
+				if (isRule(node)) {
 					fixPositions.forEach((fixPosition) => {
 						node.selector = replaceIndentation(
 							node.selector,
@@ -357,9 +398,13 @@ function rule(space, options = {}, context) {
 					});
 				}
 
-				if (node.type === 'decl') {
+				if (isDeclaration(node)) {
 					const declProp = node.prop;
 					const declBetween = node.raws.between;
+
+					if (!isString(declBetween)) {
+						throw new TypeError('The `between` property must be a string');
+					}
 
 					fixPositions.forEach((fixPosition) => {
 						if (fixPosition.startIndex < declProp.length + declBetween.length) {
@@ -380,10 +425,14 @@ function rule(space, options = {}, context) {
 					});
 				}
 
-				if (node.type === 'atrule') {
+				if (isAtRule(node)) {
 					const atRuleName = node.name;
 					const atRuleAfterName = node.raws.afterName;
 					const atRuleParams = node.params;
+
+					if (!isString(atRuleAfterName)) {
+						throw new TypeError('The `afterName` property must be a string');
+					}
 
 					fixPositions.forEach((fixPosition) => {
 						// 1 — it's a @ length
@@ -407,15 +456,14 @@ function rule(space, options = {}, context) {
 			}
 		}
 	};
+};
 
-	function legibleExpectation(level) {
-		const count = isTab ? level : level * space;
-		const quantifiedWarningWord = count === 1 ? warningWord : `${warningWord}s`;
-
-		return `${count} ${quantifiedWarningWord}`;
-	}
-}
-
+/**
+ * @param {import('postcss').Root} root
+ * @param {number | 'auto'} baseIndentLevel
+ * @param {string} space
+ * @returns {number}
+ */
 function getRootBaseIndentLevel(root, baseIndentLevel, space) {
 	const document = getDocument(root);
 
@@ -423,19 +471,33 @@ function getRootBaseIndentLevel(root, baseIndentLevel, space) {
 		return 0;
 	}
 
-	let indentLevel = root.source.baseIndentLevel;
-
-	if (!Number.isSafeInteger(indentLevel)) {
-		indentLevel = inferRootIndentLevel(root, baseIndentLevel, () =>
-			inferDocIndentSize(document, space),
-		);
-		root.source.baseIndentLevel = indentLevel;
+	if (!root.source) {
+		throw new Error('The root node must have a source');
 	}
 
-	return indentLevel;
+	/** @type {import('postcss').Source & { baseIndentLevel?: number }} */
+	const source = root.source;
+
+	const indentLevel = source.baseIndentLevel;
+
+	if (isNumber(indentLevel) && Number.isSafeInteger(indentLevel)) {
+		return indentLevel;
+	}
+
+	const newIndentLevel = inferRootIndentLevel(root, baseIndentLevel, () =>
+		inferDocIndentSize(document, space),
+	);
+
+	source.baseIndentLevel = newIndentLevel;
+
+	return newIndentLevel;
 }
 
+/**
+ * @param {import('postcss').Node} node
+ */
 function getDocument(node) {
+	// @ts-expect-error -- TS2339: Property 'document' does not exist on type 'Node'.
 	const document = node.document;
 
 	if (document) {
@@ -444,13 +506,24 @@ function getDocument(node) {
 
 	const root = node.root();
 
+	// @ts-expect-error -- TS2339: Property 'document' does not exist on type 'Node'.
 	return root && root.document;
 }
 
+/**
+ * @param {import('postcss').Document} document
+ * @param {string} space
+ * returns {number}
+ */
 function inferDocIndentSize(document, space) {
-	let indentSize = document.source.indentSize;
+	if (!document.source) throw new Error('The document node must have a source');
 
-	if (Number.isSafeInteger(indentSize)) {
+	/** @type {import('postcss').Source & { indentSize?: number }} */
+	const docSource = document.source;
+
+	let indentSize = docSource.indentSize;
+
+	if (isNumber(indentSize) && Number.isSafeInteger(indentSize)) {
 		return indentSize;
 	}
 
@@ -458,18 +531,25 @@ function inferDocIndentSize(document, space) {
 	const indents = source.match(/^ *(?=\S)/gm);
 
 	if (indents) {
-		const scores = {};
+		/** @type {Map<number, number>} */
+		const scores = new Map();
 		let lastIndentSize = 0;
 		let lastLeadingSpacesLength = 0;
+
+		/**
+		 * @param {number} leadingSpacesLength
+		 */
 		const vote = (leadingSpacesLength) => {
 			if (leadingSpacesLength) {
 				lastIndentSize = Math.abs(leadingSpacesLength - lastLeadingSpacesLength) || lastIndentSize;
 
 				if (lastIndentSize > 1) {
-					if (scores[lastIndentSize]) {
-						scores[lastIndentSize]++;
+					const score = scores.get(lastIndentSize);
+
+					if (score) {
+						scores.set(lastIndentSize, score + 1);
 					} else {
-						scores[lastIndentSize] = 1;
+						scores.set(lastIndentSize, 1);
 					}
 				}
 			} else {
@@ -485,37 +565,45 @@ function inferDocIndentSize(document, space) {
 
 		let bestScore = 0;
 
-		for (const indentSizeDate in scores) {
-			if (Object.prototype.hasOwnProperty.call(scores, indentSizeDate)) {
-				const score = scores[indentSizeDate];
-
-				if (score > bestScore) {
-					bestScore = score;
-					indentSize = indentSizeDate;
-				}
+		for (const [indentSizeDate, score] of scores.entries()) {
+			if (score > bestScore) {
+				bestScore = score;
+				indentSize = indentSizeDate;
 			}
 		}
 	}
 
 	indentSize = Number(indentSize) || (indents && indents[0].length) || Number(space) || 2;
-	document.source.indentSize = indentSize;
+	docSource.indentSize = indentSize;
 
 	return indentSize;
 }
 
+/**
+ * @param {import('postcss').Root} root
+ * @param {number | 'auto'} baseIndentLevel
+ * @param {() => number} indentSize
+ * @returns {number}
+ */
 function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
+	/**
+	 * @param {string} indent
+	 */
 	function getIndentLevel(indent) {
-		let tabCount = indent.match(/\t/g);
+		const tabMatch = indent.match(/\t/g);
+		const tabCount = tabMatch ? tabMatch.length : 0;
 
-		tabCount = tabCount ? tabCount.length : 0;
-		let spaceCount = indent.match(/ /g);
-
-		spaceCount = spaceCount ? Math.round(spaceCount.length / indentSize()) : 0;
+		const spaceMatch = indent.match(/ /g);
+		const spaceCount = spaceMatch ? Math.round(spaceMatch.length / indentSize()) : 0;
 
 		return tabCount + spaceCount;
 	}
 
-	if (!Number.isSafeInteger(baseIndentLevel)) {
+	let newBaseIndentLevel = 0;
+
+	if (!isNumber(baseIndentLevel) || !Number.isSafeInteger(baseIndentLevel)) {
+		if (!root.source) throw new Error('The root node must have a source');
+
 		let source = root.source.input.css;
 
 		source = source.replace(/^[^\r\n]+/, (firstLine) => {
@@ -532,7 +620,9 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 			return Math.min(...indents.map(getIndentLevel));
 		}
 
-		baseIndentLevel = 1;
+		newBaseIndentLevel = 1;
+	} else {
+		newBaseIndentLevel = baseIndentLevel;
 	}
 
 	const indents = [];
@@ -566,6 +656,7 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 		let afterEnd;
 
 		if (after.endsWith('\n')) {
+			// @ts-expect-error -- TS2339: Property 'document' does not exist on type 'Root'.
 			const document = root.document;
 
 			if (document) {
@@ -575,6 +666,8 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 			} else {
 				// Nested root node in css-in-js lang
 				const parent = root.parent;
+
+				if (!parent) throw new Error('The root node must have a parent');
 
 				const nextRoot = parent.nodes[parent.nodes.indexOf(root) + 1];
 
@@ -588,12 +681,16 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 	}
 
 	if (indents.length) {
-		return Math.max(...indents.map(getIndentLevel)) + baseIndentLevel;
+		return Math.max(...indents.map(getIndentLevel)) + newBaseIndentLevel;
 	}
 
-	return baseIndentLevel;
+	return newBaseIndentLevel;
 }
 
+/**
+ * @param {string | undefined} str
+ * @param {string} whitespace
+ */
 function fixIndentation(str, whitespace) {
 	if (!isString(str)) {
 		return str;
@@ -602,6 +699,12 @@ function fixIndentation(str, whitespace) {
 	return str.replace(/\n[ \t]*(?=\S|$)/g, `\n${whitespace}`);
 }
 
+/**
+ * @param {string} input
+ * @param {string} searchString
+ * @param {string} replaceString
+ * @param {number} startIndex
+ */
 function replaceIndentation(input, searchString, replaceString, startIndex) {
 	const offset = startIndex + 1;
 	const stringStart = input.slice(0, offset);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `indentation` rule.
But, it uses `// @ts-expect-error` to suppress TypeScript errors that I cannot resolve.
