### PR TITLE
Refactor to improve types for some rules

### DIFF
--- a/lib/rules/keyframe-declaration-no-important/index.js
+++ b/lib/rules/keyframe-declaration-no-important/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -12,9 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected !important',
 });
 
-function rule(actual) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -36,7 +35,7 @@ function rule(actual) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/keyframes-name-pattern/index.js
+++ b/lib/rules/keyframes-name-pattern/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -15,10 +13,11 @@ const messages = ruleMessages(ruleName, {
 		`Expected keyframe name "${keyframeName}" to match pattern "${pattern}"`,
 });
 
-function rule(pattern) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: pattern,
+			actual: primary,
 			possible: [isRegExp, isString],
 		});
 
@@ -26,7 +25,7 @@ function rule(pattern) {
 			return;
 		}
 
-		const regex = isString(pattern) ? new RegExp(pattern) : pattern;
+		const regex = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkAtRules(/keyframes/i, (keyframesNode) => {
 			const value = keyframesNode.params;
@@ -37,14 +36,14 @@ function rule(pattern) {
 
 			report({
 				index: atRuleParamIndex(keyframesNode),
-				message: messages.expected(value, pattern),
+				message: messages.expected(value, primary),
 				node: keyframesNode,
 				ruleName,
 				result,
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const valueParser = require('postcss-value-parser');
@@ -26,7 +24,8 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected unit',
 });
 
-function rule(primary, secondary, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -35,7 +34,7 @@ function rule(primary, secondary, context) {
 				actual: primary,
 			},
 			{
-				actual: secondary,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['custom-properties'],
 					ignoreFunctions: [isString, isRegExp],
@@ -48,12 +47,17 @@ function rule(primary, secondary, context) {
 
 		let needsFix;
 
+		/**
+		 * @param {import('postcss').Node} node
+		 * @param {number} nodeIndex
+		 * @param {import('postcss-value-parser').Node} valueNode
+		 */
 		function check(node, nodeIndex, valueNode) {
 			const { value, sourceIndex } = valueNode;
 
 			if (isMathFunction(valueNode)) return false;
 
-			if (isFunction(valueNode) && optionsMatches(secondary, 'ignoreFunctions', value))
+			if (isFunction(valueNode) && optionsMatches(secondaryOptions, 'ignoreFunctions', value))
 				return false;
 
 			if (!isWord(valueNode)) return;
@@ -88,6 +92,9 @@ function rule(primary, secondary, context) {
 			});
 		}
 
+		/**
+		 * @param {import('postcss').AtRule} node
+		 */
 		function checkAtRule(node) {
 			if (!isStandardSyntaxAtRule(node)) return;
 
@@ -105,6 +112,9 @@ function rule(primary, secondary, context) {
 			}
 		}
 
+		/**
+		 * @param {import('postcss').Declaration} node
+		 */
 		function checkDecl(node) {
 			needsFix = false;
 
@@ -114,7 +124,7 @@ function rule(primary, secondary, context) {
 
 			if (isFlex(prop)) return;
 
-			if (optionsMatches(secondary, 'ignore', 'custom-properties') && isCustomProperty(prop))
+			if (optionsMatches(secondaryOptions, 'ignore', 'custom-properties') && isCustomProperty(prop))
 				return;
 
 			const index = declarationValueIndex(node);
@@ -134,8 +144,13 @@ function rule(primary, secondary, context) {
 		root.walkAtRules(checkAtRule);
 		root.walkDecls(checkDecl);
 	};
-}
+};
 
+/**
+ * @param {import('postcss').Declaration} decl
+ * @param {import('postcss-value-parser').Node[]} nodes
+ * @param {number} index
+ */
 function isLineHeightValue({ prop }, nodes, index) {
 	return (
 		prop.toLowerCase() === 'font' &&
@@ -145,30 +160,51 @@ function isLineHeightValue({ prop }, nodes, index) {
 	);
 }
 
+/**
+ * @param {string} prop
+ */
 function isLineHeight(prop) {
 	return prop.toLowerCase() === 'line-height';
 }
 
+/**
+ * @param {string} prop
+ */
 function isFlex(prop) {
 	return prop.toLowerCase() === 'flex';
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isWord({ type }) {
 	return type === 'word';
 }
 
+/**
+ * @param {string} unit
+ */
 function isLength(unit) {
 	return keywordSets.lengthUnits.has(unit.toLowerCase());
 }
 
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
 function isFunction({ type }) {
 	return type === 'function';
 }
 
+/**
+ * @param {string} unit
+ */
 function isFraction(unit) {
 	return unit.toLowerCase() === 'fr';
 }
 
+/**
+ * @param {string} number
+ */
 function isZero(number) {
 	return Number.parseFloat(number) === 0;
 }

--- a/lib/rules/linebreaks/index.js
+++ b/lib/rules/linebreaks/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const postcss = require('postcss');
@@ -13,10 +11,11 @@ const messages = ruleMessages(ruleName, {
 	expected: (linebreak) => `Expected linebreak to be ${linebreak}`,
 });
 
-function rule(actual, secondary, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual,
+			actual: primary,
 			possible: ['unix', 'windows'],
 		});
 
@@ -24,24 +23,37 @@ function rule(actual, secondary, context) {
 			return;
 		}
 
-		const shouldHaveCR = actual === 'windows';
+		const shouldHaveCR = primary === 'windows';
 
 		if (context.fix) {
-			const propertiesToUpdate = ['selector', 'value', 'text'];
-			const rawsPropertiesToUpdate = ['before', 'after'];
-
 			root.walk((node) => {
-				for (const property of propertiesToUpdate) {
-					node[property] = fixData(node[property]);
+				if ('selector' in node) {
+					node.selector = fixData(node.selector);
 				}
 
-				for (const property of rawsPropertiesToUpdate) {
-					node.raws[property] = fixData(node.raws[property]);
+				if ('value' in node) {
+					node.value = fixData(node.value);
+				}
+
+				if ('text' in node) {
+					node.text = fixData(node.text);
+				}
+
+				if (node.raws.before) {
+					node.raws.before = fixData(node.raws.before);
+				}
+
+				if ('after' in node.raws && node.raws.after) {
+					node.raws.after = fixData(node.raws.after);
 				}
 			});
 
-			root.raws.after = fixData(root.raws.after);
+			if ('after' in root.raws && root.raws.after) {
+				root.raws.after = fixData(root.raws.after);
+			}
 		} else {
+			if (root.source == null) throw new Error('The root node must have a source');
+
 			const lines = root.source.input.css.split('\n');
 
 			for (let i = 0; i < lines.length; i++) {
@@ -60,6 +72,9 @@ function rule(actual, secondary, context) {
 			}
 		}
 
+		/**
+		 * @param {string} dataToCheck
+		 */
 		function hasError(dataToCheck) {
 			const hasNewlineToVerify = /[\r\n]/.test(dataToCheck);
 			const hasCR = hasNewlineToVerify ? /\r/.test(dataToCheck) : false;
@@ -67,6 +82,9 @@ function rule(actual, secondary, context) {
 			return hasNewlineToVerify && hasCR !== shouldHaveCR;
 		}
 
+		/**
+		 * @param {string} data
+		 */
 		function fixData(data) {
 			if (data) {
 				let res = data.replace(/\r/g, '');
@@ -81,23 +99,28 @@ function rule(actual, secondary, context) {
 			return data;
 		}
 
+		/**
+		 * @param {number} line
+		 * @param {number} column
+		 */
 		function reportNewlineError(line, column) {
 			// Creating a node manually helps us to point to empty lines.
 			const node = postcss.rule({
 				source: {
-					start: { line, column },
+					start: { line, column, offset: 0 },
+					input: new postcss.Input(''),
 				},
 			});
 
 			report({
-				message: messages.expected(actual),
+				message: messages.expected(primary),
 				node,
 				result,
 				ruleName,
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the following rules:
- `keyframe-declaration-no-important`
- `keyframes-name-pattern`
- `length-zero-no-unit`
- `linebreaks`
