### PR TITLE
Refactor to improve types for `max-*` rules

### DIFF
--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -1,7 +1,6 @@
-// @ts-nocheck
-
 'use strict';
 
+const isStandardSyntaxComment = require('../../utils/isStandardSyntaxComment');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -15,7 +14,8 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
-function rule(max, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
 	let emptyLines = 0;
 	let lastIndex = -1;
 
@@ -24,11 +24,11 @@ function rule(max, options, context) {
 			result,
 			ruleName,
 			{
-				actual: max,
+				actual: primary,
 				possible: isNumber,
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['comments'],
 				},
@@ -40,8 +40,8 @@ function rule(max, options, context) {
 			return;
 		}
 
-		const ignoreComments = optionsMatches(options, 'ignore', 'comments');
-		const getChars = replaceEmptyLines.bind(null, max);
+		const ignoreComments = optionsMatches(secondaryOptions, 'ignore', 'comments');
+		const getChars = replaceEmptyLines.bind(null, primary);
 
 		/**
 		 * 1. walk nodes & replace enterchar
@@ -50,8 +50,7 @@ function rule(max, options, context) {
 		if (context.fix) {
 			root.walk((node) => {
 				if (node.type === 'comment') {
-					// for inline comments
-					if (node.raws.inline) {
+					if (!isStandardSyntaxComment(node)) {
 						node.raws.before = getChars(node.raws.before);
 					}
 
@@ -64,7 +63,7 @@ function rule(max, options, context) {
 						node.raws.before = getChars(node.raws.before);
 					}
 
-					if (node.raws.after) {
+					if ('after' in node.raws && node.raws.after) {
 						node.raws.after = getChars(node.raws.after);
 					}
 				}
@@ -76,6 +75,7 @@ function rule(max, options, context) {
 			const rootRawsAfter = root.raws.after;
 
 			// not document node
+			// @ts-expect-error -- TS2339: Property 'document' does not exist on type 'Root'.
 			if ((root.document && root.document.constructor.name) !== 'Document') {
 				if (firstNodeRawsBefore) {
 					root.first.raws.before = getChars(firstNodeRawsBefore, true);
@@ -83,11 +83,11 @@ function rule(max, options, context) {
 
 				if (rootRawsAfter) {
 					// when max setted 0, should be treated as 1 in this situation.
-					root.raws.after = replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter, true);
+					root.raws.after = replaceEmptyLines(primary === 0 ? 1 : primary, rootRawsAfter, true);
 				}
 			} else if (rootRawsAfter) {
 				// `css in js` or `html`
-				root.raws.after = replaceEmptyLines(max === 0 ? 1 : max, rootRawsAfter);
+				root.raws.after = replaceEmptyLines(primary === 0 ? 1 : primary, rootRawsAfter);
 			}
 
 			return;
@@ -108,6 +108,12 @@ function rule(max, options, context) {
 			},
 		);
 
+		/**
+		 * @param {string} source
+		 * @param {number} matchStartIndex
+		 * @param {number} matchEndIndex
+		 * @param {import('postcss').Root} node
+		 */
 		function checkMatch(source, matchStartIndex, matchEndIndex, node) {
 			const eof = matchEndIndex === source.length;
 			let violation = false;
@@ -121,13 +127,13 @@ function rule(max, options, context) {
 
 			lastIndex = matchEndIndex;
 
-			if (emptyLines > max) violation = true;
+			if (emptyLines > primary) violation = true;
 
 			if (!eof && !violation) return;
 
 			if (violation) {
 				report({
-					message: messages.expected(max),
+					message: messages.expected(primary),
 					node,
 					index: matchStartIndex,
 					result,
@@ -136,12 +142,12 @@ function rule(max, options, context) {
 			}
 
 			// Additional check for end of file
-			if (eof && max) {
+			if (eof && primary) {
 				emptyLines++;
 
-				if (emptyLines > max && isEofNode(result.root, node)) {
+				if (emptyLines > primary && isEofNode(result.root, node)) {
 					report({
-						message: messages.expected(max),
+						message: messages.expected(primary),
 						node,
 						index: matchEndIndex,
 						result,
@@ -151,6 +157,11 @@ function rule(max, options, context) {
 			}
 		}
 
+		/**
+		 * @param {number} maxLines
+		 * @param {unknown} str
+		 * @param {boolean?} isSpecialCase
+		 */
 		function replaceEmptyLines(maxLines, str, isSpecialCase = false) {
 			const repeatTimes = isSpecialCase ? maxLines : maxLines + 1;
 
@@ -178,28 +189,31 @@ function rule(max, options, context) {
 				  });
 		}
 	};
-}
+};
 
 /**
  * Checks whether the given node is the last node of file.
- * @param {Document|null} document the document node with `postcss-html` and `postcss-jsx`.
- * @param {Root} root the root node of css
+ * @param {import('stylelint').PostcssResult['root']} document - the document node with `postcss-html` and `postcss-jsx`.
+ * @param {import('postcss').Root} root - the root node of css
  */
 function isEofNode(document, root) {
-	if (!document || document.constructor.name !== 'Document') {
+	if (!document || document.constructor.name !== 'Document' || !('type' in document)) {
 		return true;
 	}
 
 	// In the `postcss-html` and `postcss-jsx` syntax, checks that there is text after the given node.
 	let after;
 
+	// @ts-expect-error -- TS2367: This condition will always return 'false' since the types 'Root' and 'ChildNode | undefined' have no overlap.
 	if (root === document.last) {
 		after = document.raws && document.raws.afterEnd;
 	} else {
+		// @ts-expect-error -- TS2345: Argument of type 'Root' is not assignable to parameter of type 'number | ChildNode'.
 		const rootIndex = document.index(root);
 
 		const nextNode = document.nodes[rootIndex + 1];
 
+		// @ts-expect-error -- TS2339: Property 'beforeStart' does not exist on type 'AtRuleRaws | RuleRaws | DeclarationRaws | CommentRaws'.
 		after = nextNode && nextNode.raws && nextNode.raws.beforeStart;
 	}
 

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const execall = require('execall');
@@ -21,17 +19,18 @@ const messages = ruleMessages(ruleName, {
 		`Expected line length to be no more than ${max} ${max === 1 ? 'character' : 'characters'}`,
 });
 
-function rule(maxLength, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: maxLength,
+				actual: primary,
 				possible: isNumber,
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['non-comments', 'comments'],
 					ignorePattern: [isString, isRegExp],
@@ -44,10 +43,15 @@ function rule(maxLength, options, context) {
 			return;
 		}
 
-		const ignoreNonComments = optionsMatches(options, 'ignore', 'non-comments');
-		const ignoreComments = optionsMatches(options, 'ignore', 'comments');
+		if (root.source == null) {
+			throw new Error('The root node must have a source');
+		}
+
+		const ignoreNonComments = optionsMatches(secondaryOptions, 'ignore', 'non-comments');
+		const ignoreComments = optionsMatches(secondaryOptions, 'ignore', 'comments');
 		const rootString = context.fix ? root.toString() : root.source.input.css;
 		// Array of skipped sub strings, i.e `url(...)`, `@import "..."`
+		/** @type {Array<[number, number]>} */
 		let skippedSubStrings = [];
 		let skippedSubStringsIndex = 0;
 
@@ -69,16 +73,23 @@ function rule(maxLength, options, context) {
 			checkNewline(match),
 		);
 
+		/**
+		 * @param {number} index
+		 */
 		function complain(index) {
 			report({
 				index,
 				result,
 				ruleName,
-				message: messages.expected(maxLength),
+				message: messages.expected(primary),
 				node: root,
 			});
 		}
 
+		/**
+		 * @param {number} start
+		 * @param {number} end
+		 */
 		function tryToPopSubString(start, end) {
 			const [startSubString, endSubString] = skippedSubStrings[skippedSubStringsIndex];
 
@@ -98,6 +109,9 @@ function rule(maxLength, options, context) {
 			return excluded;
 		}
 
+		/**
+		 * @param {import('style-search').StyleSearchMatch | { endIndex: number }} match
+		 */
 		function checkNewline(match) {
 			let nextNewlineIndex = rootString.indexOf('\n', match.endIndex);
 
@@ -117,7 +131,7 @@ function rule(maxLength, options, context) {
 			const lineText = rootString.slice(match.endIndex, nextNewlineIndex);
 
 			// Case sensitive ignorePattern match
-			if (optionsMatches(options, 'ignorePattern', lineText)) {
+			if (optionsMatches(secondaryOptions, 'ignorePattern', lineText)) {
 				return;
 			}
 
@@ -125,14 +139,14 @@ function rule(maxLength, options, context) {
 			// max, ignore it ... So anything below is liable to be complained about.
 			// **Note that the length of any url arguments or import urls
 			// are excluded from the calculation.**
-			if (rawLineLength - excludedLength <= maxLength) {
+			if (rawLineLength - excludedLength <= primary) {
 				return;
 			}
 
 			const complaintIndex = nextNewlineIndex - 1;
 
 			if (ignoreComments) {
-				if (match.insideComment) {
+				if ('insideComment' in match && match.insideComment) {
 					return;
 				}
 
@@ -147,7 +161,7 @@ function rule(maxLength, options, context) {
 			}
 
 			if (ignoreNonComments) {
-				if (match.insideComment) {
+				if ('insideComment' in match && match.insideComment) {
 					return complain(complaintIndex);
 				}
 
@@ -173,7 +187,7 @@ function rule(maxLength, options, context) {
 			return complain(complaintIndex);
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const hasBlock = require('../../utils/hasBlock');
@@ -9,6 +7,7 @@ const parser = require('postcss-selector-parser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isAtRule, isDeclaration, isRoot, isRule } = require('../../utils/typeGuards');
 const { isNumber, isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'max-nesting-depth';
@@ -17,21 +16,25 @@ const messages = ruleMessages(ruleName, {
 	expected: (depth) => `Expected nesting depth to be no more than ${depth}`,
 });
 
-function rule(max, options) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions) => {
+	/**
+	 * @param {import('postcss').Node} node
+	 */
 	const isIgnoreAtRule = (node) =>
-		node.type === 'atrule' && optionsMatches(options, 'ignoreAtRules', node.name);
+		isAtRule(node) && optionsMatches(secondaryOptions, 'ignoreAtRules', node.name);
 
 	return (root, result) => {
 		validateOptions(
 			result,
 			ruleName,
 			{
-				actual: max,
+				actual: primary,
 				possible: [isNumber],
 			},
 			{
 				optional: true,
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['blockless-at-rules', 'pseudo-classes'],
 					ignoreAtRules: [isString, isRegExp],
@@ -42,6 +45,9 @@ function rule(max, options) {
 		root.walkRules(checkStatement);
 		root.walkAtRules(checkStatement);
 
+		/**
+		 * @param {import('postcss').Rule | import('postcss').AtRule} statement
+		 */
 		function checkStatement(statement) {
 			if (isIgnoreAtRule(statement)) {
 				return;
@@ -51,25 +57,34 @@ function rule(max, options) {
 				return;
 			}
 
-			if (statement.selector && !isStandardSyntaxRule(statement)) {
+			if (isRule(statement) && !isStandardSyntaxRule(statement)) {
 				return;
 			}
 
-			const depth = nestingDepth(statement);
+			const depth = nestingDepth(statement, 0);
 
-			if (depth > max) {
+			if (depth > primary) {
 				report({
 					ruleName,
 					result,
 					node: statement,
-					message: messages.expected(max),
+					message: messages.expected(primary),
 				});
 			}
 		}
 	};
 
-	function nestingDepth(node, level = 0) {
+	/**
+	 * @param {import('postcss').Node} node
+	 * @param {number} level
+	 * @returns {number}
+	 */
+	function nestingDepth(node, level) {
 		const parent = node.parent;
+
+		if (parent == null) {
+			throw new Error('The parent node must exist');
+		}
 
 		if (isIgnoreAtRule(parent)) {
 			return 0;
@@ -79,10 +94,13 @@ function rule(max, options) {
 		// when this function, recursively called, receives
 		// a node that is not nested -- a direct child of the
 		// root node
-		if (parent.type === 'root' || (parent.type === 'atrule' && parent.parent.type === 'root')) {
+		if (isRoot(parent) || (isAtRule(parent) && parent.parent && isRoot(parent.parent))) {
 			return level;
 		}
 
+		/**
+		 * @param {string} selector
+		 */
 		function containsPseudoClassesOnly(selector) {
 			const normalized = parser().processSync(selector, { lossless: false });
 			const selectors = normalized.split(',');
@@ -91,11 +109,11 @@ function rule(max, options) {
 		}
 
 		if (
-			(optionsMatches(options, 'ignore', 'blockless-at-rules') &&
-				node.type === 'atrule' &&
-				node.every((child) => child.type !== 'decl')) ||
-			(optionsMatches(options, 'ignore', 'pseudo-classes') &&
-				node.type === 'rule' &&
+			(optionsMatches(secondaryOptions, 'ignore', 'blockless-at-rules') &&
+				isAtRule(node) &&
+				node.every((child) => !isDeclaration(child))) ||
+			(optionsMatches(secondaryOptions, 'ignore', 'pseudo-classes') &&
+				isRule(node) &&
 				containsPseudoClassesOnly(node.selector))
 		) {
 			return nestingDepth(parent, level);
@@ -107,7 +125,7 @@ function rule(max, options) {
 		// until we hit the root node
 		return nestingDepth(parent, level + 1);
 	}
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `max-*` rules.
