### PR TITLE
Refactor to improve types for `media-feature-colon-*` rules

### DIFF
--- a/lib/rules/media-feature-colon-space-after/index.js
+++ b/lib/rules/media-feature-colon-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -15,12 +13,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after ":"',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -28,6 +27,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		/** @type {Map<import('postcss').AtRule, number[]> | undefined} */
 		let fixData;
 
 		mediaFeatureColonSpaceChecker({
@@ -60,9 +60,9 @@ function rule(expectation, options, context) {
 						const beforeColon = params.slice(0, index + 1);
 						const afterColon = params.slice(index + 1);
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							params = beforeColon + afterColon.replace(/^\s*/, ' ');
-						} else if (expectation === 'never') {
+						} else if (primary === 'never') {
 							params = beforeColon + afterColon.replace(/^\s*/, '');
 						}
 					});
@@ -75,7 +75,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-colon-space-before/index.js
+++ b/lib/rules/media-feature-colon-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -15,12 +13,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ":"',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -28,6 +27,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		/** @type {Map<import('postcss').AtRule, number[]> | undefined} */
 		let fixData;
 
 		mediaFeatureColonSpaceChecker({
@@ -60,9 +60,9 @@ function rule(expectation, options, context) {
 						const beforeColon = params.slice(0, index);
 						const afterColon = params.slice(index);
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							params = beforeColon.replace(/\s*$/, ' ') + afterColon;
-						} else if (expectation === 'never') {
+						} else if (primary === 'never') {
 							params = beforeColon.replace(/\s*$/, '') + afterColon;
 						}
 					});
@@ -75,7 +75,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/mediaFeatureColonSpaceChecker.js
+++ b/lib/rules/mediaFeatureColonSpaceChecker.js
@@ -1,12 +1,19 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../utils/atRuleParamIndex');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function (opts) {
+/**
+ * @param {{
+ *   root: import('postcss').Root,
+ *   locationChecker: (args: { source: string, index: number, err: (message: string) => void }) => void,
+ *   fix: ((node: import('postcss').AtRule, index: number) => boolean) | null,
+ *   result: import('stylelint').PostcssResult,
+ *   checkedRuleName: string,
+ * }} opts
+ */
+module.exports = function mediaFeatureColonSpaceChecker(opts) {
 	opts.root.walkAtRules(/^media$/i, (atRule) => {
 		const params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
@@ -15,11 +22,16 @@ module.exports = function (opts) {
 		});
 	});
 
+	/**
+	 * @param {string} source
+	 * @param {number} index
+	 * @param {import('postcss').AtRule} node
+	 */
 	function checkColon(source, index, node) {
 		opts.locationChecker({
 			source,
 			index,
-			err: (m) => {
+			err: (message) => {
 				const colonIndex = index + atRuleParamIndex(node);
 
 				if (opts.fix && opts.fix(node, colonIndex)) {
@@ -27,7 +39,7 @@ module.exports = function (opts) {
 				}
 
 				report({
-					message: m,
+					message,
 					node,
 					index: colonIndex,
 					result: opts.result,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `media-feature-colon-*` rules.
