### PR TITLE
Refactor to improve types for `media-feature-*` rules

### DIFF
--- a/lib/rules/findMediaOperator.js
+++ b/lib/rules/findMediaOperator.js
@@ -1,11 +1,17 @@
-// @ts-nocheck
-
 'use strict';
 
-const rangeOperators = ['>=', '<=', '>', '<', '='];
 const styleSearch = require('style-search');
 
-module.exports = function (atRule, cb) {
+const rangeOperators = ['>=', '<=', '>', '<', '='];
+
+/** @typedef {import('style-search').StyleSearchMatch} StyleSearchMatch */
+
+/**
+ * @template {import('postcss').AtRule} T
+ * @param {T} atRule
+ * @param {(match: StyleSearchMatch, params: string, atRule: T) => void} cb
+ */
+module.exports = function findMediaOperator(atRule, cb) {
 	if (atRule.name.toLowerCase() !== 'media') {
 		return;
 	}

--- a/lib/rules/media-feature-parentheses-space-inside/index.js
+++ b/lib/rules/media-feature-parentheses-space-inside/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -17,10 +15,11 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before ")"',
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -33,13 +32,14 @@ function rule(expectation, options, context) {
 			// will be at atRule.raws.params.raw
 			const params = (atRule.raws.params && atRule.raws.params.raw) || atRule.params;
 			const indexBoost = atRuleParamIndex(atRule);
+			/** @type {Array<{ message: string, index: number }>} */
 			const violations = [];
 
 			const parsedParams = valueParser(params).walk((node) => {
 				if (node.type === 'function') {
 					const len = valueParser.stringify(node).length;
 
-					if (expectation === 'never') {
+					if (primary === 'never') {
 						if (/[ \t]/.test(node.before)) {
 							if (context.fix) node.before = '';
 
@@ -57,7 +57,7 @@ function rule(expectation, options, context) {
 								index: node.sourceIndex - 2 + len + indexBoost,
 							});
 						}
-					} else if (expectation === 'always') {
+					} else if (primary === 'always') {
 						if (node.before === '') {
 							if (context.fix) node.before = ' ';
 
@@ -98,7 +98,7 @@ function rule(expectation, options, context) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-range-operator-space-after/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after range operator',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -30,7 +29,9 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkAtRules(/^media$/i, (atRule) => {
+			/** @type {number[]} */
 			const fixOperatorIndices = [];
+			/** @type {((index: number) => void) | null} */
 			const fix = context.fix ? (index) => fixOperatorIndices.push(index) : null;
 
 			findMediaOperator(atRule, (match, params, node) => {
@@ -46,9 +47,9 @@ function rule(expectation, options, context) {
 						const beforeOperator = params.slice(0, index + 1);
 						const afterOperator = params.slice(index + 1);
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							params = beforeOperator + afterOperator.replace(/^\s*/, ' ');
-						} else if (expectation === 'never') {
+						} else if (primary === 'never') {
 							params = beforeOperator + afterOperator.replace(/^\s*/, '');
 						}
 					});
@@ -61,6 +62,12 @@ function rule(expectation, options, context) {
 			}
 		});
 
+		/**
+		 * @param {import('style-search').StyleSearchMatch} match
+		 * @param {string} params
+		 * @param {import('postcss').AtRule} node
+		 * @param {((index: number) => void) | null} fix
+		 */
 		function checkAfterOperator(match, params, node, fix) {
 			const endIndex = match.startIndex + match.target.length - 1;
 
@@ -85,7 +92,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-range-operator-space-before/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before range operator',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -30,7 +29,9 @@ function rule(expectation, options, context) {
 		}
 
 		root.walkAtRules(/^media$/i, (atRule) => {
+			/** @type {number[]} */
 			const fixOperatorIndices = [];
+			/** @type {((index: number) => void) | null} */
 			const fix = context.fix ? (index) => fixOperatorIndices.push(index) : null;
 
 			findMediaOperator(atRule, (match, params, node) => {
@@ -46,9 +47,9 @@ function rule(expectation, options, context) {
 						const beforeOperator = params.slice(0, index);
 						const afterOperator = params.slice(index);
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							params = beforeOperator.replace(/\s*$/, ' ') + afterOperator;
-						} else if (expectation === 'never') {
+						} else if (primary === 'never') {
 							params = beforeOperator.replace(/\s*$/, '') + afterOperator;
 						}
 					});
@@ -61,6 +62,12 @@ function rule(expectation, options, context) {
 			}
 		});
 
+		/**
+		 * @param {import('style-search').StyleSearchMatch} match
+		 * @param {string} params
+		 * @param {import('postcss').AtRule} node
+		 * @param {((index: number) => void) | null} fix
+		 */
 		function checkBeforeOperator(match, params, node, fix) {
 			// The extra `+ 1` is because the match itself contains
 			// the character before the operator
@@ -85,7 +92,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `media-feature-*` rules.

