### PR TITLE
Refactor to improve types for `media-query-*` rules

### DIFF
--- a/lib/rules/media-query-list-comma-newline-after/index.js
+++ b/lib/rules/media-query-list-comma-newline-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -31,6 +30,7 @@ function rule(expectation, options, context) {
 
 		// Only check for the newline after the comma, while allowing
 		// arbitrary indentation after the newline
+		/** @type {Map<import('postcss').AtRule, number[]> | undefined} */
 		let fixData;
 
 		mediaQueryListCommaWhitespaceChecker({
@@ -38,7 +38,7 @@ function rule(expectation, options, context) {
 			result,
 			locationChecker: checker.afterOneOnly,
 			checkedRuleName: ruleName,
-			allowTrailingComments: expectation.startsWith('always'),
+			allowTrailingComments: primary.startsWith('always'),
 			fix: context.fix
 				? (atRule, index) => {
 						const paramCommaIndex = index - atRuleParamIndex(atRule);
@@ -64,11 +64,11 @@ function rule(expectation, options, context) {
 						const beforeComma = params.slice(0, index + 1);
 						const afterComma = params.slice(index + 1);
 
-						if (expectation.startsWith('always')) {
+						if (primary.startsWith('always')) {
 							params = /^\s*\r?\n/.test(afterComma)
 								? beforeComma + afterComma.replace(/^[^\S\r\n]*/, '')
 								: beforeComma + context.newline + afterComma;
-						} else if (expectation.startsWith('never')) {
+						} else if (primary.startsWith('never')) {
 							params = beforeComma + afterComma.replace(/^\s*/, '');
 						}
 					});
@@ -81,7 +81,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-query-list-comma-newline-before/index.js
+++ b/lib/rules/media-query-list-comma-newline-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const mediaQueryListCommaWhitespaceChecker = require('../mediaQueryListCommaWhitespaceChecker');
@@ -15,12 +13,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
-function rule(expectation) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -35,7 +34,7 @@ function rule(expectation) {
 			checkedRuleName: ruleName,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -17,12 +15,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never', 'always-single-line', 'never-single-line'],
 		});
 
@@ -30,6 +29,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		/** @type {Map<import('postcss').AtRule, number[]> | undefined} */
 		let fixData;
 
 		mediaQueryListCommaWhitespaceChecker({
@@ -62,9 +62,9 @@ function rule(expectation, options, context) {
 						const beforeComma = params.slice(0, index + 1);
 						const afterComma = params.slice(index + 1);
 
-						if (expectation.startsWith('always')) {
+						if (primary.startsWith('always')) {
 							params = beforeComma + afterComma.replace(/^\s*/, ' ');
-						} else if (expectation.startsWith('never')) {
+						} else if (primary.startsWith('never')) {
 							params = beforeComma + afterComma.replace(/^\s*/, '');
 						}
 					});
@@ -77,7 +77,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-query-list-comma-space-before/index.js
+++ b/lib/rules/media-query-list-comma-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
@@ -17,12 +15,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never', 'always-single-line', 'never-single-line'],
 		});
 
@@ -30,6 +29,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		/** @type {Map<import('postcss').AtRule, number[]> | undefined} */
 		let fixData;
 
 		mediaQueryListCommaWhitespaceChecker({
@@ -62,9 +62,9 @@ function rule(expectation, options, context) {
 						const beforeComma = params.slice(0, index);
 						const afterComma = params.slice(index);
 
-						if (expectation.startsWith('always')) {
+						if (primary.startsWith('always')) {
 							params = beforeComma.replace(/\s*$/, ' ') + afterComma;
-						} else if (expectation.startsWith('never')) {
+						} else if (primary.startsWith('never')) {
 							params = beforeComma.replace(/\s*$/, '') + afterComma;
 						}
 					});
@@ -77,7 +77,7 @@ function rule(expectation, options, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/mediaQueryListCommaWhitespaceChecker.js
+++ b/lib/rules/mediaQueryListCommaWhitespaceChecker.js
@@ -1,12 +1,20 @@
-// @ts-nocheck
-
 'use strict';
 
 const atRuleParamIndex = require('../utils/atRuleParamIndex');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function (opts) {
+/**
+ * @param {{
+ *   root: import('postcss').Root,
+ *   result: import('stylelint').PostcssResult,
+ *   locationChecker: (args: { source: string, index: number, err: (message: string) => void }) => void,
+ *   checkedRuleName: string,
+ *   fix?: ((atRule: import('postcss').AtRule, index: number) => boolean) | null | undefined,
+ *   allowTrailingComments?: boolean,
+ * }} opts
+ */
+module.exports = function mediaQueryListCommaWhitespaceChecker(opts) {
 	opts.root.walkAtRules(/^media$/i, (atRule) => {
 		const params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
@@ -30,11 +38,16 @@ module.exports = function (opts) {
 		});
 	});
 
+	/**
+	 * @param {string} source
+	 * @param {number} index
+	 * @param {import('postcss').AtRule} node
+	 */
 	function checkComma(source, index, node) {
 		opts.locationChecker({
 			source,
 			index,
-			err: (m) => {
+			err: (message) => {
 				const commaIndex = index + atRuleParamIndex(node);
 
 				if (opts.fix && opts.fix(node, commaIndex)) {
@@ -42,7 +55,7 @@ module.exports = function (opts) {
 				}
 
 				report({
-					message: m,
+					message,
 					node,
 					index: commaIndex,
 					result: opts.result,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `media-query-*` rules.
