### PR TITLE
Refactor to improve types for `named-grid-areas-no-invalid` rule

### DIFF
--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -18,9 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expectedRectangle: (name) => `Expected single filled-in rectangle for "${name}"`,
 });
 
-function rule(actual) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -31,6 +30,7 @@ function rule(actual) {
 
 			if (value.toLowerCase().trim() === 'none') return;
 
+			/** @type {string[][]} */
 			const areas = [];
 			let reportSent = false;
 
@@ -66,6 +66,10 @@ function rule(actual) {
 				complain(messages.expectedRectangle(name));
 			});
 
+			/**
+			 * @param {string} message
+			 * @param {number} [sourceIndex=0]
+			 */
 			function complain(message, sourceIndex = 0) {
 				report({
 					message,
@@ -77,7 +81,7 @@ function rule(actual) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `named-grid-areas-no-invalid` rule.
