### PR TITLE
Fix false negatives for grid shorthands in named-grid-areas-no-invalid

### DIFF
--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -17,7 +17,7 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				a { 
+				a {
 					grid-template-areas: "head head"
 						"nav  main"
 						"nav  foot";
@@ -25,8 +25,8 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				a { 
-					grid-template-areas: 
+				a {
+					grid-template-areas:
 						/* "" */ "head head"
 						"nav  main" /* "a b c" */
 						"nav  foot" /* "" */;
@@ -52,8 +52,17 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				a { 
-					grid-template-areas: /* "comment" */ none /* "comment " */; 
+				a {
+					grid-template-areas: /* "comment" */ none /* "comment " */;
+				}`,
+		},
+		{
+			code: stripIndent`
+				a {
+					grid-template:
+						"a a a" 40px
+						"b c c" 40px
+						"b c c" 40px / 1fr 1fr 1fr;
 				}`,
 		},
 	],
@@ -80,10 +89,10 @@ testRule({
 		},
 		{
 			code: stripIndent`
-			  a { 
+			  a {
 					grid-template-areas: "header header header header"
 						"main main . sidebar"
-						"footer footer footer header"; 
+						"footer footer footer header";
 				}`,
 			message: messages.expectedRectangle('header'),
 			line: 2,
@@ -103,8 +112,8 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				a { grid-template-areas: 
-			   	""; 
+				a { grid-template-areas:
+			   	"";
 				}`,
 			message: messages.expectedToken(),
 			line: 2,
@@ -120,9 +129,9 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				a { 
+				a {
 					grid-template-areas: /* none */
- 						"" /* none */; 
+ 						"" /* none */;
 				}`,
 			message: messages.expectedToken(),
 			line: 3,
@@ -133,6 +142,24 @@ testRule({
 			message: messages.expectedToken(),
 			line: 1,
 			column: 26,
+		},
+		{
+			code: stripIndent`
+				a {
+					grid-template:
+						"a a" 40px
+						"b c c" 40px
+						"b c c" 40px / 1fr 1fr 1fr;
+				}`,
+			message: messages.expectedSameNumber(),
+			line: 3,
+			column: 3,
+		},
+		{
+			code: `a { grid: "" 200px "b" min-content; }`,
+			message: messages.expectedToken(),
+			line: 1,
+			column: 11,
 		},
 	],
 });

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -117,7 +117,7 @@ testRule({
 				}`,
 			message: messages.expectedToken(),
 			line: 2,
-			column: 4,
+			column: 2,
 		},
 		{
 			code: 'a { grid-template-areas: "" "" ""; }',

--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -113,7 +113,7 @@ testRule({
 		{
 			code: stripIndent`
 				a { grid-template-areas:
-			   	"";
+					"";
 				}`,
 			message: messages.expectedToken(),
 			line: 2,

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -25,7 +25,7 @@ const rule = (primary) => {
 			return;
 		}
 
-		root.walkDecls(/^grid-template-areas$/i, (decl) => {
+		root.walkDecls(/^grid$|^grid-template|$^grid-template-areas|$/i, (decl) => {
 			const { value } = decl;
 
 			if (value.toLowerCase().trim() === 'none') return;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -25,7 +25,7 @@ const rule = (primary) => {
 			return;
 		}
 
-		root.walkDecls(/^grid$|^grid-template|$^grid-template-areas|$/i, (decl) => {
+		root.walkDecls(/^(?:grid|grid-template|grid-template-areas)$/i, (decl) => {
 			const { value } = decl;
 
 			if (value.toLowerCase().trim() === 'none') return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/pull/5513#pullrequestreview-746590742

> Is there anything in the PR that needs further explanation?

[`grid`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid) and [`grid-template`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template).
