### PR TITLE
Fix flaky cache test via `jest.retryTimes()`

### DIFF
--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -38,6 +38,9 @@ function getConfig(additional = {}) {
 }
 
 describe('standalone cache', () => {
+	// NOTE: The test may fail depending on the timing of the access to the cache file. See #5531
+	jest.retryTimes(3);
+
 	const expectedCacheFilePath = path.join(cwd, '.stylelintcache');
 
 	beforeEach(async () => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Close #5531

> Is there anything in the PR that needs further explanation?

See the [Jest doc](https://jestjs.io/docs/jest-object#jestretrytimes).
