### PR TITLE
Refactor to improve types for `no-descending-specificity` rule

### DIFF
--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const findAtRuleContext = require('../../utils/findAtRuleContext');
@@ -21,17 +19,18 @@ const messages = ruleMessages(ruleName, {
 	rejected: (b, a) => `Expected selector "${b}" to come before selector "${a}"`,
 });
 
-function rule(on, options) {
+/** @type {import('stylelint').StylelintRule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: on,
+				actual: primary,
 			},
 			{
 				optional: true,
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['selectors-within-list'],
 				},
@@ -52,7 +51,7 @@ function rule(on, options) {
 
 			// Ignores selectors within list of selectors
 			if (
-				optionsMatches(options, 'ignore', 'selectors-within-list') &&
+				optionsMatches(secondaryOptions, 'ignore', 'selectors-within-list') &&
 				ruleNode.selectors.length > 1
 			) {
 				return;
@@ -87,6 +86,12 @@ function rule(on, options) {
 			});
 		});
 
+		/**
+		 * @param {import('postcss-selector-parser').Root} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 * @param {number} sourceIndex
+		 * @param {Map<any, any>} comparisonContext
+		 */
 		function checkSelector(selectorNode, ruleNode, sourceIndex, comparisonContext) {
 			const selector = selectorNode.toString();
 			const referenceSelectorNode = lastCompoundSelectorWithoutPseudoClasses(selectorNode);
@@ -99,6 +104,7 @@ function rule(on, options) {
 				return;
 			}
 
+			/** @type {Array<{ selector: string, specificity: import('specificity').SpecificityArray }>} */
 			const priorComparableSelectors = comparisonContext.get(referenceSelectorNode);
 
 			priorComparableSelectors.forEach((priorEntry) => {
@@ -116,12 +122,13 @@ function rule(on, options) {
 			priorComparableSelectors.push(entry);
 		}
 	};
-}
+};
 
+/**
+ * @param {import('postcss-selector-parser').Root} selectorNode
+ */
 function lastCompoundSelectorWithoutPseudoClasses(selectorNode) {
-	const nodesByCombinator = selectorNode.nodes[0].split((node) => {
-		return node.type === 'combinator';
-	});
+	const nodesByCombinator = selectorNode.nodes[0].split((node) => node.type === 'combinator');
 	const nodesAfterLastCombinator = nodesByCombinator[nodesByCombinator.length - 1];
 
 	const nodesWithoutPseudoClasses = nodesAfterLastCombinator

--- a/lib/utils/nodeContextLookup.js
+++ b/lib/utils/nodeContextLookup.js
@@ -10,16 +10,19 @@
  *
  * For a usage example, see `selector-no-descending-specificity`.
  */
-module.exports = function () {
+module.exports = function nodeContextLookup() {
 	const contextMap = new Map();
 
 	return {
 		/**
 		 * @param {import('postcss').Node} node
+		 * @param {any[]} subContexts
+		 * @returns {Map<any, any>}
 		 */
-		getContext(node, /** @type {any[]} */ ...subContexts) {
-			// TODO TYPES node.source possible undefined
-			const nodeSource = /** @type {import('postcss').Source} */ (node.source).input.from;
+		getContext(node, ...subContexts) {
+			if (!node.source) throw new Error('The node source must be present');
+
+			const nodeSource = node.source.input.from;
 			const baseContext = creativeGetMap(contextMap, nodeSource);
 
 			return subContexts.reduce((result, context) => {

--- a/types/postcss-resolve-nested-selector/index.d.ts
+++ b/types/postcss-resolve-nested-selector/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'postcss-resolve-nested-selector' {
+	import { Node } from 'postcss';
+
+	function resolvedNestedSelector(selector: string, node: Node): string[];
+
+	export = resolvedNestedSelector;
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `no-descending-specificity` rule.
Also, this adds the types for `postcss-resolve-nested-selector` and improves the types of `lib/utils/nodeContextLookup.js`.
