### PR TITLE
Add `customSyntax` option to configuration object (#4843)

### DIFF
--- a/lib/__tests__/fixtures/custom-parser.js
+++ b/lib/__tests__/fixtures/custom-parser.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('postcss-safe-parser/lib/safe-parse');
+module.exports = require('postcss-safe-parser');

--- a/lib/__tests__/fixtures/custom-syntax.js
+++ b/lib/__tests__/fixtures/custom-syntax.js
@@ -1,3 +1,8 @@
 'use strict';
 
-module.exports = require('postcss-scss/lib/scss-syntax');
+const postcssScss = require('postcss-scss');
+
+module.exports = {
+	parse: postcssScss.parse,
+	stringify: postcssScss.stringify,
+};

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -97,6 +97,52 @@ it('standalone with path to custom syntax', () => {
 	});
 });
 
+it('standalone with custom syntax as npm package name', () => {
+	const config = {
+		rules: {
+			'block-no-empty': true,
+		},
+	};
+
+	return standalone({
+		config,
+		customSyntax: 'postcss-scss',
+		code: '$foo: bar; // foo;\nb {}',
+		formatter: stringFormatter,
+	}).then((linted) => {
+		const results = linted.results;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].warnings).toHaveLength(1);
+		expect(results[0].warnings[0].line).toBe(2);
+		expect(results[0].warnings[0].column).toBe(3);
+		expect(results[0].warnings[0].rule).toBe('block-no-empty');
+	});
+});
+
+it('standalone with custom syntax as npm package', () => {
+	const config = {
+		rules: {
+			'block-no-empty': true,
+		},
+	};
+
+	return standalone({
+		config,
+		customSyntax: require('postcss-scss'),
+		code: '$foo: bar; // foo;\nb {}',
+		formatter: stringFormatter,
+	}).then((linted) => {
+		const results = linted.results;
+
+		expect(results).toHaveLength(1);
+		expect(results[0].warnings).toHaveLength(1);
+		expect(results[0].warnings[0].line).toBe(2);
+		expect(results[0].warnings[0].column).toBe(3);
+		expect(results[0].warnings[0].rule).toBe('block-no-empty');
+	});
+});
+
 it('rejects on unknown custom syntax option', async () => {
 	await expect(
 		standalone({
@@ -139,4 +185,112 @@ it('rejects when customSyntax and syntax are set', async () => {
 	).rejects.toThrow(
 		'The "syntax" (--syntax) option has been removed. Install the appropriate syntax and use the "customSyntax" (--custom-syntax) option instead',
 	);
+});
+
+describe('customSyntax set in the config', () => {
+	it('standalone with path to custom parser', () => {
+		const config = {
+			customSyntax: `${fixturesPath}/custom-parser`,
+			rules: {
+				'block-no-empty': true,
+			},
+		};
+
+		return standalone({
+			config,
+			code: '.foo { width: 200px }\n.bar {',
+			formatter: stringFormatter,
+		}).then((linted) => {
+			const results = linted.results;
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0].line).toBe(2);
+			expect(results[0].warnings[0].column).toBe(6);
+			expect(results[0].warnings[0].rule).toBe('block-no-empty');
+		});
+	});
+
+	it('standalone with custom syntax as npm package name', () => {
+		const config = {
+			customSyntax: 'postcss-scss',
+			rules: {
+				'block-no-empty': true,
+			},
+		};
+
+		return standalone({
+			config,
+			code: '$foo: bar; // foo;\nb {}',
+			formatter: stringFormatter,
+		}).then((linted) => {
+			const results = linted.results;
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0].line).toBe(2);
+			expect(results[0].warnings[0].column).toBe(3);
+			expect(results[0].warnings[0].rule).toBe('block-no-empty');
+		});
+	});
+
+	it('standalone with custom syntax as npm package', () => {
+		const config = {
+			customSyntax: require('postcss-scss'),
+			rules: {
+				'block-no-empty': true,
+			},
+		};
+
+		return standalone({
+			config,
+			code: '$foo: bar; // foo;\nb {}',
+			formatter: stringFormatter,
+		}).then((linted) => {
+			const results = linted.results;
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0].line).toBe(2);
+			expect(results[0].warnings[0].column).toBe(3);
+			expect(results[0].warnings[0].rule).toBe('block-no-empty');
+		});
+	});
+
+	it('standalone with path to custom syntax', () => {
+		const config = {
+			customSyntax: `${fixturesPath}/custom-syntax`,
+			rules: {
+				'block-no-empty': true,
+			},
+		};
+
+		return standalone({
+			config,
+			code: '$foo: bar; // foo;\nb {}',
+			formatter: stringFormatter,
+		}).then((linted) => {
+			const results = linted.results;
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0].line).toBe(2);
+			expect(results[0].warnings[0].column).toBe(3);
+			expect(results[0].warnings[0].rule).toBe('block-no-empty');
+		});
+	});
+
+	it('rejects on unknown custom syntax option', async () => {
+		await expect(
+			standalone({
+				code: '',
+				config: {
+					customSyntax: 'unknown-module',
+					rules: { 'block-no-empty': 'wahoo' },
+				},
+			}),
+		).rejects.toThrow(
+			'Cannot resolve custom syntax module unknown-module. Check that module unknown-module is available and spelled correctly.',
+		);
+	});
 });

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -471,6 +471,10 @@ function addOptions(stylelint, config) {
 			stylelint._options.reportDescriptionlessDisables;
 	}
 
+	if (stylelint._options.customSyntax) {
+		augmentedConfig.customSyntax = stylelint._options.customSyntax;
+	}
+
 	return augmentedConfig;
 }
 

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -19,7 +19,7 @@ const postcssProcessor = postcss();
  *
  * @returns {Promise<Result>}
  */
-module.exports = function (stylelint, options = {}) {
+module.exports = function getPostcssResult(stylelint, options = {}) {
 	const cached = options.filePath ? stylelint._postcssResultCache.get(options.filePath) : undefined;
 
 	if (cached) return Promise.resolve(cached);
@@ -48,8 +48,8 @@ module.exports = function (stylelint, options = {}) {
 			/** @type {Syntax | null} */
 			let syntax = null;
 
-			if (stylelint._options.customSyntax) {
-				syntax = getCustomSyntax(stylelint._options.customSyntax);
+			if (options.customSyntax) {
+				syntax = getCustomSyntax(options.customSyntax);
 			} else {
 				syntax = cssSyntax(stylelint, options.filePath);
 			}

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -89,6 +89,7 @@ module.exports = function lintSource(stylelint, options = {}) {
 					codeFilename: options.codeFilename,
 					filePath: inputFilePath,
 					codeProcessors: config.codeProcessors,
+					customSyntax: config.customSyntax,
 				})
 				.then((postcssResult) => {
 					const stylelintPostcssResult = Object.assign(postcssResult, {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -56,6 +56,7 @@ declare module 'stylelint' {
 		reportInvalidScopeDisables?: DisableSettings;
 		reportDescriptionlessDisables?: DisableSettings;
 		overrides?: StylelintConfigOverride[];
+		customSyntax?: CustomSyntax;
 	};
 
 	// A meta-type that returns a union over all properties of `T` whose values


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4843.

> Is there anything in the PR that needs further explanation?

It was easier than I though :) Two previous PRs I made recently definitely helped :)

---

Something that we might need to document somewhere or changes. Probably I had to write this in `overrides` PR.

It is true for v13 (except `overrides`) and for all options which could be specified in config, API, and CLI.

Priority of options:

1. `overrides` in config.
2. Option specified in CLI/API.
3. Option in config.

For example, if we have this config:

```json
{
	"customSyntax": "postcss-sass",
	"rules": {
		"block-no-empty": true
	},
	"overrides": [{
		"files": "*.css",
		"customSyntax": "postcss-safe-parser"
	}]
}
```

And run stylelint like this:

```
stylelint --custom-syntax "postcss-scss" "style.css"
```

File would be linted with `postcss-safe-parser`. If were remove `overrides` file would be linted with `postcss-scss`. And finally if we remove `--custom-syntax` file would be linted with `postcss-sass`.

Maybe we need to switch `overrides` and CLI/API order, so CLI/API has highest priority than `overrides`.