### PR TITLE
Fix ReDoS issue (#5128)

### DIFF
--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -628,7 +628,7 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 	}
 
 	const indents = [];
-	const foundIndents = /(?:^|\n)([ \t]*)\S[^\r\n]*(?:\r?\n\s*)*$/m.exec(root.raws.beforeStart);
+	const foundIndents = /(?:^|\n)([ \t]*)\S/m.exec(root.raws.beforeStart);
 
 	// The indent level of the CSS code block in non-CSS-like files is determined by the shortest indent of non-empty line.
 	if (foundIndents) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #5128.

> Is there anything in the PR that needs further explanation?

RegExp in question was added in https://github.com/stylelint/stylelint/pull/3557 for `baseIndentLevel` and it is only for HTML and CSS-in-JS files. Since we don't support these syntaxes and tests are skipped, no tests are failing :)

In fact we have no running tests for `baseIndentLevel`.