### PR TITLE
Add `quiet` option to Node.js API

### DIFF
--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -187,3 +187,9 @@ CLI flag: `--stdin-filename`
 A filename to assign the input.
 
 If using `code` or `stdin` to pass a source string directly, you can use `codeFilename` to associate that code with a particular filename.
+
+## `quiet`
+
+CLI flag: `--quiet`
+
+Only register violations for rules with an "error"-level severity (ignore "warning"-level).

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -320,4 +320,17 @@ describe('CLI', () => {
 			'Max warnings exceeded: 1 found. 0 allowed',
 		);
 	});
+
+	it('--quiet', async () => {
+		await cli([
+			'--quiet',
+			'--config',
+			fixturesPath('default-severity-warning.json'),
+			fixturesPath('empty-block.css'),
+		]);
+
+		expect(process.exitCode).toEqual(2);
+
+		expect(process.stdout.write).toHaveBeenCalledTimes(0);
+	});
 });

--- a/lib/__tests__/plugins.test.js
+++ b/lib/__tests__/plugins.test.js
@@ -195,7 +195,7 @@ it('slashless plugin causes configuration error', async () => {
 
 	await expect(
 		postcss().use(stylelint(config)).process('.foo {}', { from: undefined }),
-	).rejects.toThrow(/^stylelint v7\+ requires plugin rules to be namespaced/);
+	).rejects.toThrow(/^stylelint requires plugin rules to be namespaced/);
 });
 
 it('plugin with primary option array', async () => {

--- a/lib/__tests__/standalone-quiet.test.js
+++ b/lib/__tests__/standalone-quiet.test.js
@@ -2,7 +2,7 @@
 
 const standalone = require('../standalone');
 
-it('standalone with input css and quiet mode', () => {
+it('standalone with input css and quiet mode (in config)', () => {
 	const config = {
 		quiet: true,
 		rules: {
@@ -11,6 +11,22 @@ it('standalone with input css and quiet mode', () => {
 	};
 
 	return standalone({ code: 'a {}', config }).then((linted) => {
+		expect(linted.results[0].warnings).toEqual([]);
+	});
+});
+
+it('standalone with input css and quiet mode (in option)', () => {
+	const config = {
+		rules: {
+			'block-no-empty': [true, { severity: 'warning' }],
+		},
+	};
+
+	return standalone({
+		code: 'a {}',
+		config,
+		quiet: true,
+	}).then((linted) => {
 		expect(linted.results[0].warnings).toEqual([]);
 	});
 });

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -114,7 +114,7 @@ it('standalone without input css and file(s) should throw error', () => {
 		'You must pass stylelint a `files` glob or a `code` string, though not both',
 	);
 
-	expect(() => standalone({ config: configBlockNoEmpty })).toThrow(expectedError);
+	return expect(() => standalone({ config: configBlockNoEmpty })).rejects.toThrow(expectedError);
 });
 
 it('standalone with non-existent-file throws an error', async () => {

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -36,12 +36,12 @@ function createDisableRange(comment, start, strictStart, description, end, stric
 }
 
 /**
- * Run it like a plugin ...
+ * Run it like a PostCSS plugin
  * @param {PostcssRoot} root
  * @param {PostcssResult} result
  * @returns {PostcssResult}
  */
-module.exports = function (root, result) {
+module.exports = function assignDisabledRanges(root, result) {
 	result.stylelint = result.stylelint || {
 		disabledRanges: {},
 		ruleSeverities: {},

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -28,26 +28,20 @@ const slash = require('slash');
  * @param {string} [filePath]
  * @returns {Promise<StylelintConfig>}
  */
-function augmentConfigBasic(stylelint, config, configDir, allowOverrides, filePath) {
-	return Promise.resolve()
-		.then(() => {
-			if (!allowOverrides) return config;
+async function augmentConfigBasic(stylelint, config, configDir, allowOverrides, filePath) {
+	let augmentedConfig = config;
 
-			return addOptions(stylelint, config);
-		})
-		.then((augmentedConfig) => {
-			return extendConfig(stylelint, augmentedConfig, configDir);
-		})
-		.then((augmentedConfig) => {
-			if (filePath) {
-				return applyOverrides(augmentedConfig, configDir, filePath);
-			}
+	if (allowOverrides) {
+		augmentedConfig = addOptions(stylelint, augmentedConfig);
+	}
 
-			return augmentedConfig;
-		})
-		.then((augmentedConfig) => {
-			return absolutizePaths(augmentedConfig, configDir);
-		});
+	augmentedConfig = await extendConfig(stylelint, augmentedConfig, configDir);
+
+	if (filePath) {
+		augmentedConfig = applyOverrides(augmentedConfig, configDir, filePath);
+	}
+
+	return absolutizePaths(augmentedConfig, configDir);
 }
 
 /**
@@ -58,18 +52,20 @@ function augmentConfigBasic(stylelint, config, configDir, allowOverrides, filePa
  * @param {CosmiconfigResult} [cosmiconfigResult]
  * @returns {Promise<CosmiconfigResult | null>}
  */
-function augmentConfigExtended(stylelint, cosmiconfigResult) {
-	if (!cosmiconfigResult) return Promise.resolve(null);
+async function augmentConfigExtended(stylelint, cosmiconfigResult) {
+	if (!cosmiconfigResult) {
+		return null;
+	}
 
 	const configDir = path.dirname(cosmiconfigResult.filepath || '');
 	const { ignoreFiles, ...cleanedConfig } = cosmiconfigResult.config;
 
-	return augmentConfigBasic(stylelint, cleanedConfig, configDir).then((augmentedConfig) => {
-		return {
-			config: augmentedConfig,
-			filepath: cosmiconfigResult.filepath,
-		};
-	});
+	const augmentedConfig = await augmentConfigBasic(stylelint, cleanedConfig, configDir);
+
+	return {
+		config: augmentedConfig,
+		filepath: cosmiconfigResult.filepath,
+	};
 }
 
 /**
@@ -78,36 +74,33 @@ function augmentConfigExtended(stylelint, cosmiconfigResult) {
  * @param {CosmiconfigResult} [cosmiconfigResult]
  * @returns {Promise<CosmiconfigResult | null>}
  */
-function augmentConfigFull(stylelint, filePath, cosmiconfigResult) {
-	if (!cosmiconfigResult) return Promise.resolve(null);
+async function augmentConfigFull(stylelint, filePath, cosmiconfigResult) {
+	if (!cosmiconfigResult) {
+		return null;
+	}
 
 	const config = cosmiconfigResult.config;
 	const filepath = cosmiconfigResult.filepath;
 
 	const configDir = stylelint._options.configBasedir || path.dirname(filepath || '');
 
-	return augmentConfigBasic(stylelint, config, configDir, true, filePath)
-		.then((augmentedConfig) => {
-			return addPluginFunctions(augmentedConfig);
-		})
-		.then((augmentedConfig) => {
-			return addProcessorFunctions(augmentedConfig);
-		})
-		.then((augmentedConfig) => {
-			if (!augmentedConfig.rules) {
-				throw configurationError(
-					'No rules found within configuration. Have you provided a "rules" property?',
-				);
-			}
+	let augmentedConfig = await augmentConfigBasic(stylelint, config, configDir, true, filePath);
 
-			return normalizeAllRuleSettings(augmentedConfig);
-		})
-		.then((augmentedConfig) => {
-			return {
-				config: augmentedConfig,
-				filepath: cosmiconfigResult.filepath,
-			};
-		});
+	augmentedConfig = addPluginFunctions(augmentedConfig);
+	augmentedConfig = addProcessorFunctions(augmentedConfig);
+
+	if (!augmentedConfig.rules) {
+		throw configurationError(
+			'No rules found within configuration. Have you provided a "rules" property?',
+		);
+	}
+
+	augmentedConfig = normalizeAllRuleSettings(augmentedConfig);
+
+	return {
+		config: augmentedConfig,
+		filepath: cosmiconfigResult.filepath,
+	};
 }
 
 /**
@@ -167,37 +160,34 @@ function absolutizeProcessors(processors, configDir) {
  * @param {string} configDir
  * @return {Promise<StylelintConfig>}
  */
-function extendConfig(stylelint, config, configDir) {
-	if (config.extends === undefined) return Promise.resolve(config);
+async function extendConfig(stylelint, config, configDir) {
+	if (config.extends === undefined) {
+		return config;
+	}
 
-	const normalizedExtends = Array.isArray(config.extends) ? config.extends : [config.extends];
 	const { extends: configExtends, ...originalWithoutExtends } = config;
+	const normalizedExtends = [configExtends].flat();
 
-	const loadExtends = normalizedExtends.reduce((resultPromise, extendLookup) => {
-		return resultPromise.then((resultConfig) => {
-			return loadExtendedConfig(stylelint, resultConfig, configDir, extendLookup).then(
-				(extendResult) => {
-					if (!extendResult) return resultConfig;
+	let resultConfig = originalWithoutExtends;
 
-					return mergeConfigs(resultConfig, extendResult.config);
-				},
-			);
-		});
-	}, Promise.resolve(originalWithoutExtends));
+	for (const extendLookup of normalizedExtends) {
+		const extendResult = await loadExtendedConfig(stylelint, configDir, extendLookup);
 
-	return loadExtends.then((resultConfig) => {
-		return mergeConfigs(resultConfig, originalWithoutExtends);
-	});
+		if (extendResult) {
+			resultConfig = mergeConfigs(resultConfig, extendResult.config);
+		}
+	}
+
+	return mergeConfigs(resultConfig, originalWithoutExtends);
 }
 
 /**
  * @param {StylelintInternalApi} stylelint
- * @param {StylelintConfig} config
  * @param {string} configDir
  * @param {string} extendLookup
  * @return {Promise<CosmiconfigResult | null>}
  */
-function loadExtendedConfig(stylelint, config, configDir, extendLookup) {
+function loadExtendedConfig(stylelint, configDir, extendLookup) {
 	const extendPath = getModulePath(configDir, extendLookup);
 
 	return stylelint._extendExplorer.load(extendPath);
@@ -283,11 +273,16 @@ function mergeConfigs(a, b) {
  * @returns {StylelintConfig}
  */
 function addPluginFunctions(config) {
-	if (!config.plugins) return config;
+	if (!config.plugins) {
+		return config;
+	}
 
-	const normalizedPlugins = Array.isArray(config.plugins) ? config.plugins : [config.plugins];
+	const normalizedPlugins = [config.plugins].flat();
 
-	const pluginFunctions = normalizedPlugins.reduce((result, pluginLookup) => {
+	/** @type {{[k: string]: Function}} */
+	const pluginFunctions = {};
+
+	for (const pluginLookup of normalizedPlugins) {
 		let pluginImport = require(pluginLookup);
 
 		// Handle either ES6 or CommonJS modules
@@ -295,31 +290,24 @@ function addPluginFunctions(config) {
 
 		// A plugin can export either a single rule definition
 		// or an array of them
-		const normalizedPluginImport = Array.isArray(pluginImport) ? pluginImport : [pluginImport];
+		const normalizedPluginImport = [pluginImport].flat();
 
 		normalizedPluginImport.forEach((pluginRuleDefinition) => {
 			if (!pluginRuleDefinition.ruleName) {
 				throw configurationError(
-					'stylelint v3+ requires plugins to expose a ruleName. ' +
-						`The plugin "${pluginLookup}" is not doing this, so will not work ` +
-						'with stylelint v3+. Please file an issue with the plugin.',
+					`stylelint requires plugins to expose a ruleName. The plugin "${pluginLookup}" is not doing this, so will not work with stylelint. Please file an issue with the plugin.`,
 				);
 			}
 
 			if (!pluginRuleDefinition.ruleName.includes('/')) {
 				throw configurationError(
-					'stylelint v7+ requires plugin rules to be namespaced, ' +
-						'i.e. only `plugin-namespace/plugin-rule-name` plugin rule names are supported. ' +
-						`The plugin rule "${pluginRuleDefinition.ruleName}" does not do this, so will not work. ` +
-						'Please file an issue with the plugin.',
+					`stylelint requires plugin rules to be namespaced, i.e. only \`plugin-namespace/plugin-rule-name\` plugin rule names are supported. The plugin rule "${pluginRuleDefinition.ruleName}" does not do this, so will not work. Please file an issue with the plugin.`,
 				);
 			}
 
-			result[pluginRuleDefinition.ruleName] = pluginRuleDefinition.rule;
+			pluginFunctions[pluginRuleDefinition.ruleName] = pluginRuleDefinition.rule;
 		});
-
-		return result;
-	}, /** @type {{[k: string]: Function}} */ ({}));
+	}
 
 	config.pluginFunctions = pluginFunctions;
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -326,7 +326,7 @@ const meowOptions = {
  * @param {string[]} argv
  * @returns {Promise<any>}
  */
-module.exports = (argv) => {
+module.exports = async (argv) => {
 	const cli = buildCLI(argv);
 
 	const invalidOptionsMessage = checkInvalidCLIOptions(meowOptions.flags, cli.flags);
@@ -442,75 +442,73 @@ module.exports = (argv) => {
 	if (cli.flags.help) {
 		cli.showHelp(0);
 
-		return Promise.resolve();
+		return;
 	}
 
 	if (cli.flags.version) {
 		cli.showVersion();
 
-		return Promise.resolve();
+		return;
 	}
 
 	if (cli.flags.allowEmptyInput) {
 		optionsBase.allowEmptyInput = cli.flags.allowEmptyInput;
 	}
 
-	return Promise.resolve()
-		.then(
-			/**
-			 * @returns {Promise<OptionBaseType>}
-			 */
-			() => {
-				// Add input/code into options
-				if (cli.input.length) {
-					return Promise.resolve({ ...optionsBase, files: /** @type {string} */ (cli.input) });
-				}
+	// Add input/code into options
+	/** @type {OptionBaseType} */
+	const options = cli.input.length
+		? {
+				...optionsBase,
+				files: /** @type {string} */ (cli.input),
+		  }
+		: await getStdin().then((stdin) => {
+				return {
+					...optionsBase,
+					code: stdin,
+				};
+		  });
 
-				return getStdin().then((stdin) => ({ ...optionsBase, code: stdin }));
-			},
-		)
-		.then((options) => {
-			if (cli.flags.printConfig) {
-				return printConfig(options)
-					.then((config) => {
-						process.stdout.write(JSON.stringify(config, null, '  '));
-					})
-					.catch(handleError);
-			}
+	if (cli.flags.printConfig) {
+		return printConfig(options)
+			.then((config) => {
+				process.stdout.write(JSON.stringify(config, null, '  '));
+			})
+			.catch(handleError);
+	}
 
-			if (!options.files && !options.code && !cli.flags.stdin) {
-				cli.showHelp();
+	if (!options.files && !options.code && !cli.flags.stdin) {
+		cli.showHelp();
 
+		return;
+	}
+
+	return standalone(options)
+		.then((linted) => {
+			if (!linted.output) {
 				return;
 			}
 
-			return standalone(options)
-				.then((linted) => {
-					if (!linted.output) {
-						return;
-					}
+			process.stdout.write(linted.output);
 
-					process.stdout.write(linted.output);
+			if (options.outputFile) {
+				writeOutputFile(linted.output, options.outputFile).catch(handleError);
+			}
 
-					if (options.outputFile) {
-						writeOutputFile(linted.output, options.outputFile).catch(handleError);
-					}
+			if (linted.errored) {
+				process.exitCode = EXIT_CODE_ERROR;
+			} else if (maxWarnings !== undefined && linted.maxWarningsExceeded) {
+				const foundWarnings = linted.maxWarningsExceeded.foundWarnings;
 
-					if (linted.errored) {
-						process.exitCode = EXIT_CODE_ERROR;
-					} else if (maxWarnings !== undefined && linted.maxWarningsExceeded) {
-						const foundWarnings = linted.maxWarningsExceeded.foundWarnings;
-
-						process.stderr.write(
-							`${EOL}${chalk.red(`Max warnings exceeded: `)}${foundWarnings} found. ${chalk.dim(
-								`${maxWarnings} allowed${EOL}${EOL}`,
-							)}`,
-						);
-						process.exitCode = EXIT_CODE_ERROR;
-					}
-				})
-				.catch(handleError);
-		});
+				process.stderr.write(
+					`${EOL}${chalk.red(`Max warnings exceeded: `)}${foundWarnings} found. ${chalk.dim(
+						`${maxWarnings} allowed${EOL}${EOL}`,
+					)}`,
+				);
+				process.exitCode = EXIT_CODE_ERROR;
+			}
+		})
+		.catch(handleError);
 };
 
 /**

--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -29,7 +29,7 @@ module.exports = function createStylelint(options = {}) {
 	stylelint._extendExplorer = cosmiconfig(null, {
 		transform: augmentConfig.augmentConfigExtended.bind(
 			null,
-			/** @type{StylelintInternalApi} */ (stylelint),
+			/** @type {StylelintInternalApi} */ (stylelint),
 		),
 		stopDir: STOP_DIR,
 	});
@@ -38,22 +38,22 @@ module.exports = function createStylelint(options = {}) {
 	stylelint._postcssResultCache = new Map();
 	stylelint._createStylelintResult = createStylelintResult.bind(
 		null,
-		/** @type{StylelintInternalApi} */ (stylelint),
+		/** @type {StylelintInternalApi} */ (stylelint),
 	);
 	stylelint._getPostcssResult = getPostcssResult.bind(
 		null,
-		/** @type{StylelintInternalApi} */ (stylelint),
+		/** @type {StylelintInternalApi} */ (stylelint),
 	);
-	stylelint._lintSource = lintSource.bind(null, /** @type{StylelintInternalApi} */ (stylelint));
+	stylelint._lintSource = lintSource.bind(null, /** @type {StylelintInternalApi} */ (stylelint));
 
 	stylelint.getConfigForFile = getConfigForFile.bind(
 		null,
-		/** @type{StylelintInternalApi} */ (stylelint),
+		/** @type {StylelintInternalApi} */ (stylelint),
 	);
 	stylelint.isPathIgnored = isPathIgnored.bind(
 		null,
-		/** @type{StylelintInternalApi} */ (stylelint),
+		/** @type {StylelintInternalApi} */ (stylelint),
 	);
 
-	return /** @type{StylelintInternalApi} */ (stylelint);
+	return /** @type {StylelintInternalApi} */ (stylelint);
 };

--- a/lib/createStylelintResult.js
+++ b/lib/createStylelintResult.js
@@ -12,7 +12,7 @@ const createPartialStylelintResult = require('./createPartialStylelintResult');
  * @param {import('stylelint').StylelintCssSyntaxError} [cssSyntaxError]
  * @return {Promise<StylelintResult>}
  */
-module.exports = function createStylelintResult(
+module.exports = async function createStylelintResult(
 	stylelint,
 	postcssResult,
 	filePath,
@@ -20,26 +20,22 @@ module.exports = function createStylelintResult(
 ) {
 	let stylelintResult = createPartialStylelintResult(postcssResult, cssSyntaxError);
 
-	return stylelint.getConfigForFile(filePath, filePath).then((configForFile) => {
-		// TODO TYPES handle possible null here
-		const config =
-			/** @type {{ config: import('stylelint').StylelintConfig, filepath: string }} */ (
-				configForFile
-			).config;
-		const file = stylelintResult.source || (cssSyntaxError && cssSyntaxError.file);
+	const configForFile = await stylelint.getConfigForFile(filePath, filePath);
 
-		if (config.resultProcessors) {
-			config.resultProcessors.forEach((resultProcessor) => {
-				// Result processors might just mutate the result object,
-				// or might return a new one
-				const returned = resultProcessor(stylelintResult, file);
+	const config = configForFile === null ? {} : configForFile.config;
+	const file = stylelintResult.source || (cssSyntaxError && cssSyntaxError.file);
 
-				if (returned) {
-					stylelintResult = returned;
-				}
-			});
-		}
+	if (config.resultProcessors) {
+		config.resultProcessors.forEach((resultProcessor) => {
+			// Result processors might just mutate the result object,
+			// or might return a new one
+			const returned = resultProcessor(stylelintResult, file);
 
-		return stylelintResult;
-	});
+			if (returned) {
+				stylelintResult = returned;
+			}
+		});
+	}
+
+	return stylelintResult;
 };

--- a/lib/descriptionlessDisables.js
+++ b/lib/descriptionlessDisables.js
@@ -11,7 +11,7 @@ const validateDisableSettings = require('./validateDisableSettings');
 /**
  * @param {import('stylelint').StylelintResult[]} results
  */
-module.exports = function (results) {
+module.exports = function descriptionlessDisables(results) {
 	results.forEach((result) => {
 		const settings = validateDisableSettings(
 			result._postcssResult,

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -19,7 +19,7 @@ const STOP_DIR = IS_TEST ? path.resolve(__dirname, '..') : undefined;
  * @param {string} [filePath]
  * @returns {ConfigPromise}
  */
-module.exports = function getConfigForFile(stylelint, searchPath = process.cwd(), filePath) {
+module.exports = async function getConfigForFile(stylelint, searchPath = process.cwd(), filePath) {
 	const optionsConfig = stylelint._options.config;
 
 	if (optionsConfig !== undefined) {
@@ -56,22 +56,17 @@ module.exports = function getConfigForFile(stylelint, searchPath = process.cwd()
 		? configExplorer.load(stylelint._options.configFile)
 		: configExplorer.search(searchPath);
 
-	return /** @type {ConfigPromise} */ (
-		searchForConfig
-			.then((config) => {
-				// If no config was found, try looking from process.cwd
-				if (!config) return configExplorer.search(process.cwd());
+	let config = await searchForConfig;
 
-				return config;
-			})
-			.then((config) => {
-				if (!config) {
-					const ending = searchPath ? ` for ${searchPath}` : '';
+	if (!config) {
+		config = await configExplorer.search(process.cwd());
+	}
 
-					throw configurationError(`No configuration provided${ending}`);
-				}
+	if (!config) {
+		return Promise.reject(
+			configurationError(`No configuration provided${searchPath ? ` for ${searchPath}` : ''}`),
+		);
+	}
 
-				return config;
-			})
-	);
+	return config;
 };

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -19,73 +19,65 @@ const postcssProcessor = postcss();
  *
  * @returns {Promise<Result>}
  */
-module.exports = function getPostcssResult(stylelint, options = {}) {
+module.exports = async function getPostcssResult(stylelint, options = {}) {
 	const cached = options.filePath ? stylelint._postcssResultCache.get(options.filePath) : undefined;
 
-	if (cached) return Promise.resolve(cached);
+	if (cached) {
+		return cached;
+	}
 
-	/** @type {Promise<string> | undefined} */
+	if (stylelint._options.syntax) {
+		return Promise.reject(
+			new Error(
+				'The "syntax" (--syntax) option has been removed. Install the appropriate syntax and use the "customSyntax" (--custom-syntax) option instead',
+			),
+		);
+	}
+
+	let syntax = options.customSyntax
+		? getCustomSyntax(options.customSyntax)
+		: cssSyntax(stylelint, options.filePath);
+
+	const postcssOptions = {
+		from: options.filePath,
+		syntax,
+	};
+
+	/** @type {string | undefined} */
 	let getCode;
 
 	if (options.code !== undefined) {
-		getCode = Promise.resolve(options.code);
+		getCode = options.code;
 	} else if (options.filePath) {
-		getCode = fs.readFile(options.filePath, 'utf8');
+		getCode = await fs.readFile(options.filePath, 'utf8');
 	}
 
-	if (!getCode) {
-		throw new Error('code or filePath required');
+	if (getCode === undefined) {
+		return Promise.reject(new Error('code or filePath required'));
 	}
 
-	return getCode
-		.then((code) => {
-			if (stylelint._options.syntax) {
-				throw new Error(
-					'The "syntax" (--syntax) option has been removed. Install the appropriate syntax and use the "customSyntax" (--custom-syntax) option instead',
-				);
-			}
+	if (options.codeProcessors && options.codeProcessors.length) {
+		if (stylelint._options.fix) {
+			console.warn(
+				'Autofix is incompatible with processors and will be disabled. Are you sure you need a processor?',
+			);
+			stylelint._options.fix = false;
+		}
 
-			/** @type {Syntax | null} */
-			let syntax = null;
+		const sourceName = options.code ? options.codeFilename : options.filePath;
 
-			if (options.customSyntax) {
-				syntax = getCustomSyntax(options.customSyntax);
-			} else {
-				syntax = cssSyntax(stylelint, options.filePath);
-			}
-
-			const postcssOptions = {
-				from: options.filePath,
-				syntax,
-			};
-
-			const source = options.code ? options.codeFilename : options.filePath;
-			let preProcessedCode = code;
-
-			if (options.codeProcessors && options.codeProcessors.length) {
-				if (stylelint._options.fix) {
-					console.warn(
-						'Autofix is incompatible with processors and will be disabled. Are you sure you need a processor?',
-					);
-					stylelint._options.fix = false;
-				}
-
-				options.codeProcessors.forEach((codeProcessor) => {
-					preProcessedCode = codeProcessor(preProcessedCode, source);
-				});
-			}
-
-			const result = new LazyResult(postcssProcessor, preProcessedCode, postcssOptions);
-
-			return result;
-		})
-		.then((postcssResult) => {
-			if (options.filePath) {
-				stylelint._postcssResultCache.set(options.filePath, postcssResult);
-			}
-
-			return postcssResult;
+		options.codeProcessors.forEach((codeProcessor) => {
+			getCode = codeProcessor(getCode, sourceName);
 		});
+	}
+
+	const postcssResult = await new LazyResult(postcssProcessor, getCode, postcssOptions);
+
+	if (options.filePath) {
+		stylelint._postcssResultCache.set(options.filePath, postcssResult);
+	}
+
+	return postcssResult;
 };
 
 /**

--- a/lib/invalidScopeDisables.js
+++ b/lib/invalidScopeDisables.js
@@ -8,7 +8,7 @@ const validateDisableSettings = require('./validateDisableSettings');
 /**
  * @param {import('stylelint').StylelintResult[]} results
  */
-module.exports = function (results) {
+module.exports = function invalidScopeDisables(results) {
 	results.forEach((result) => {
 		const settings = validateDisableSettings(result._postcssResult, 'reportInvalidScopeDisables');
 

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -14,35 +14,35 @@ const slash = require('slash');
  * @param {string} [filePath]
  * @return {Promise<boolean>}
  */
-module.exports = function isPathIgnored(stylelint, filePath) {
+module.exports = async function isPathIgnored(stylelint, filePath) {
 	if (!filePath) {
-		return Promise.resolve(false);
+		return false;
 	}
 
 	const cwd = process.cwd();
 	const ignorer = getFileIgnorer(stylelint._options);
 
-	return stylelint.getConfigForFile(filePath, filePath).then((result) => {
-		if (!result) {
-			return true;
-		}
+	const result = await stylelint.getConfigForFile(filePath, filePath);
 
-		// Glob patterns for micromatch should be in POSIX-style
-		const ignoreFiles = /** @type {Array<string>} */ (result.config.ignoreFiles || []).map(slash);
+	if (!result) {
+		return true;
+	}
 
-		const absoluteFilePath = path.isAbsolute(filePath)
-			? filePath
-			: path.resolve(process.cwd(), filePath);
+	// Glob patterns for micromatch should be in POSIX-style
+	const ignoreFiles = /** @type {Array<string>} */ (result.config.ignoreFiles || []).map(slash);
 
-		if (micromatch([absoluteFilePath], ignoreFiles).length) {
-			return true;
-		}
+	const absoluteFilePath = path.isAbsolute(filePath)
+		? filePath
+		: path.resolve(process.cwd(), filePath);
 
-		// Check filePath with .stylelintignore file
-		if (filterFilePaths(ignorer, [path.relative(cwd, absoluteFilePath)]).length === 0) {
-			return true;
-		}
+	if (micromatch([absoluteFilePath], ignoreFiles).length) {
+		return true;
+	}
 
-		return false;
-	});
+	// Check filePath with .stylelintignore file
+	if (filterFilePaths(ignorer, [path.relative(cwd, absoluteFilePath)]).length === 0) {
+		return true;
+	}
+
+	return false;
 };

--- a/lib/lintSource.js
+++ b/lib/lintSource.js
@@ -17,7 +17,7 @@ const path = require('path');
  * @param {Options} options
  * @returns {Promise<PostcssResult>}
  */
-module.exports = function lintSource(stylelint, options = {}) {
+module.exports = async function lintSource(stylelint, options = {}) {
 	if (!options.filePath && options.code === undefined && !options.existingPostcssResult) {
 		return Promise.reject(new Error('You must provide filePath, code, or existingPostcssResult'));
 	}
@@ -34,74 +34,60 @@ module.exports = function lintSource(stylelint, options = {}) {
 		return Promise.reject(new Error('filePath must be an absolute path'));
 	}
 
-	const getIsIgnored = stylelint.isPathIgnored(inputFilePath).catch((err) => {
+	const isIgnored = await stylelint.isPathIgnored(inputFilePath).catch((err) => {
 		if (isCodeNotFile && isPathNotFoundError(err)) return false;
 
 		throw err;
 	});
 
-	return getIsIgnored.then((isIgnored) => {
-		if (isIgnored) {
-			/** @type {PostcssResult} */
+	if (isIgnored) {
+		return options.existingPostcssResult
+			? Object.assign(options.existingPostcssResult, {
+					stylelint: createEmptyStylelintPostcssResult(),
+			  })
+			: createEmptyPostcssResult(inputFilePath);
+	}
 
-			return options.existingPostcssResult
-				? Object.assign(options.existingPostcssResult, {
-						stylelint: createEmptyStylelintPostcssResult(),
-				  })
-				: createEmptyPostcssResult(inputFilePath);
-		}
+	const configSearchPath = stylelint._options.configFile || inputFilePath;
 
-		const configSearchPath = stylelint._options.configFile || inputFilePath;
-
-		const getConfig = stylelint.getConfigForFile(configSearchPath, inputFilePath).catch((err) => {
+	const configForFile = await stylelint
+		.getConfigForFile(configSearchPath, inputFilePath)
+		.catch((err) => {
 			if (isCodeNotFile && isPathNotFoundError(err))
 				return stylelint.getConfigForFile(process.cwd());
 
 			throw err;
 		});
 
-		return getConfig.then((result) => {
-			if (!result) {
-				throw new Error('Config file not found');
-			}
+	if (!configForFile) {
+		return Promise.reject(new Error('Config file not found'));
+	}
 
-			const config = result.config;
-			const existingPostcssResult = options.existingPostcssResult;
-			const stylelintResult = {
-				ruleSeverities: {},
-				customMessages: {},
-				disabledRanges: {},
-			};
+	const config = configForFile.config;
+	const existingPostcssResult = options.existingPostcssResult;
+	const stylelintResult = {
+		ruleSeverities: {},
+		customMessages: {},
+		disabledRanges: {},
+	};
 
-			if (existingPostcssResult) {
-				const stylelintPostcssResult = Object.assign(existingPostcssResult, {
-					stylelint: stylelintResult,
-				});
+	const postcssResult =
+		existingPostcssResult ||
+		(await stylelint._getPostcssResult({
+			code: options.code,
+			codeFilename: options.codeFilename,
+			filePath: inputFilePath,
+			codeProcessors: config.codeProcessors,
+			customSyntax: config.customSyntax,
+		}));
 
-				return lintPostcssResult(stylelint._options, stylelintPostcssResult, config).then(
-					() => stylelintPostcssResult,
-				);
-			}
-
-			return stylelint
-				._getPostcssResult({
-					code: options.code,
-					codeFilename: options.codeFilename,
-					filePath: inputFilePath,
-					codeProcessors: config.codeProcessors,
-					customSyntax: config.customSyntax,
-				})
-				.then((postcssResult) => {
-					const stylelintPostcssResult = Object.assign(postcssResult, {
-						stylelint: stylelintResult,
-					});
-
-					return lintPostcssResult(stylelint._options, stylelintPostcssResult, config).then(
-						() => stylelintPostcssResult,
-					);
-				});
-		});
+	const stylelintPostcssResult = Object.assign(postcssResult, {
+		stylelint: stylelintResult,
 	});
+
+	await lintPostcssResult(stylelint._options, stylelintPostcssResult, config);
+
+	return stylelintPostcssResult;
 };
 
 /**

--- a/lib/needlessDisables.js
+++ b/lib/needlessDisables.js
@@ -12,7 +12,7 @@ const validateDisableSettings = require('./validateDisableSettings');
 /**
  * @param {import('stylelint').StylelintResult[]} results
  */
-module.exports = function (results) {
+module.exports = function needlessDisables(results) {
 	results.forEach((result) => {
 		const settings = validateDisableSettings(result._postcssResult, 'reportNeedlessDisables');
 

--- a/lib/normalizeAllRuleSettings.js
+++ b/lib/normalizeAllRuleSettings.js
@@ -11,22 +11,22 @@ const rules = require('./rules');
  * @return {StylelintConfig}
  */
 function normalizeAllRuleSettings(config) {
+	if (!config.rules) return config;
+
 	/** @type {StylelintConfigRules} */
 	const normalizedRules = {};
-
-	if (!config.rules) return config;
 
 	for (const [ruleName, rawRuleSettings] of Object.entries(config.rules)) {
 		const rule = rules[ruleName] || (config.pluginFunctions && config.pluginFunctions[ruleName]);
 
-		if (!rule) {
-			normalizedRules[ruleName] = [];
-		} else {
+		if (rule) {
 			normalizedRules[ruleName] = normalizeRuleSettings(
 				rawRuleSettings,
 				ruleName,
 				rule.primaryOptionArray,
 			);
+		} else {
+			normalizedRules[ruleName] = [];
 		}
 	}
 

--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -23,7 +23,7 @@ const { isPlainObject } = require('is-plain-object');
  * @param {boolean} [primaryOptionArray] If primaryOptionArray is not provided, we try to get it from the rules themselves, which will not work for plugins
  * @return {[T] | [T, O] | null}
  */
-module.exports = function (
+module.exports = function normalizeRuleSettings(
 	rawSettings,
 	ruleName,
 	// If primaryOptionArray is not provided, we try to get it from the

--- a/lib/prepareReturnValue.js
+++ b/lib/prepareReturnValue.js
@@ -7,19 +7,17 @@ const reportDisables = require('./reportDisables');
 
 /** @typedef {import('stylelint').Formatter} Formatter */
 /** @typedef {import('stylelint').StylelintResult} StylelintResult */
-/** @typedef {import('stylelint').StylelintStandaloneOptions} StylelintStandaloneOptions */
+/** @typedef {import('stylelint').StylelintStandaloneOptions["maxWarnings"]} maxWarnings */
 /** @typedef {import('stylelint').StylelintStandaloneReturnValue} StylelintStandaloneReturnValue */
 
 /**
  * @param {StylelintResult[]} stylelintResults
- * @param {StylelintStandaloneOptions} options
+ * @param {maxWarnings} maxWarnings
  * @param {Formatter} formatter
  *
  * @returns {StylelintStandaloneReturnValue}
  */
-function prepareReturnValue(stylelintResults, options, formatter) {
-	const { maxWarnings } = options;
-
+function prepareReturnValue(stylelintResults, maxWarnings, formatter) {
 	reportDisables(stylelintResults);
 	needlessDisables(stylelintResults);
 	invalidScopeDisables(stylelintResults);

--- a/lib/printConfig.js
+++ b/lib/printConfig.js
@@ -10,14 +10,14 @@ const path = require('path');
  * @param {import('stylelint').StylelintStandaloneOptions} options
  * @returns {Promise<StylelintConfig | null>}
  */
-module.exports = function printConfig(options) {
-	const code = options.code;
-	const config = options.config;
-	const configBasedir = options.configBasedir;
-	const configFile = options.configFile;
-	const globbyOptions = options.globbyOptions;
-	const files = options.files;
-
+module.exports = function printConfig({
+	code,
+	config,
+	configBasedir,
+	configFile,
+	globbyOptions,
+	files,
+}) {
 	const isCodeNotFile = code !== undefined;
 
 	if (!files || files.length !== 1 || isCodeNotFile) {

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -32,51 +32,59 @@ const writeFileAtomic = require('write-file-atomic');
  * @param {StylelintStandaloneOptions} options
  * @returns {Promise<StylelintStandaloneReturnValue>}
  */
-module.exports = function (options) {
-	const cacheLocation = options.cacheLocation;
-	const code = options.code;
-	const codeFilename = options.codeFilename;
-	const config = options.config;
-	const configBasedir = options.configBasedir;
-	const configFile = options.configFile;
-	const customSyntax = options.customSyntax;
-	const globbyOptions = options.globbyOptions;
-	const files = options.files;
-	const fix = options.fix;
-	const formatter = options.formatter;
-	const ignoreDisables = options.ignoreDisables;
-	const reportNeedlessDisables = options.reportNeedlessDisables;
-	const reportInvalidScopeDisables = options.reportInvalidScopeDisables;
-	const reportDescriptionlessDisables = options.reportDescriptionlessDisables;
-	const syntax = options.syntax;
-	const allowEmptyInput = options.allowEmptyInput || false;
-	const useCache = options.cache || false;
+module.exports = async function standalone({
+	allowEmptyInput = false,
+	cache: useCache = false,
+	cacheLocation,
+	code,
+	codeFilename,
+	config,
+	configBasedir,
+	configFile,
+	customSyntax,
+	disableDefaultIgnores,
+	files,
+	fix,
+	formatter,
+	globbyOptions,
+	ignoreDisables,
+	ignorePath = DEFAULT_IGNORE_FILENAME,
+	ignorePattern = [],
+	maxWarnings,
+	quiet,
+	reportDescriptionlessDisables,
+	reportInvalidScopeDisables,
+	reportNeedlessDisables,
+	syntax,
+}) {
 	/** @type {FileCache} */
 	let fileCache;
 	const startTime = Date.now();
 
+	const isValidCode = typeof code === 'string';
+
+	if ((!files && !isValidCode) || (files && (code || isValidCode))) {
+		return Promise.reject(
+			new Error('You must pass stylelint a `files` glob or a `code` string, though not both'),
+		);
+	}
+
 	// The ignorer will be used to filter file paths after the glob is checked,
 	// before any files are actually read
-	const ignoreFilePath = options.ignorePath || DEFAULT_IGNORE_FILENAME;
-	const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
-		? ignoreFilePath
-		: path.resolve(process.cwd(), ignoreFilePath);
+	const absoluteIgnoreFilePath = path.isAbsolute(ignorePath)
+		? ignorePath
+		: path.resolve(process.cwd(), ignorePath);
 	let ignoreText = '';
 
 	try {
 		ignoreText = fs.readFileSync(absoluteIgnoreFilePath, 'utf8');
 	} catch (readError) {
-		if (!isPathNotFoundError(readError)) throw readError;
+		if (!isPathNotFoundError(readError)) {
+			return Promise.reject(readError);
+		}
 	}
 
-	const ignorePattern = options.ignorePattern || [];
 	const ignorer = ignore().add(ignoreText).add(ignorePattern);
-
-	const isValidCode = typeof code === 'string';
-
-	if ((!files && !isValidCode) || (files && (code || isValidCode))) {
-		throw new Error('You must pass stylelint a `files` glob or a `code` string, though not both');
-	}
 
 	/** @type {Formatter} */
 	let formatterFunction;
@@ -92,13 +100,14 @@ module.exports = function (options) {
 		configFile,
 		configBasedir,
 		ignoreDisables,
-		ignorePath: ignoreFilePath,
+		ignorePath,
 		reportNeedlessDisables,
 		reportInvalidScopeDisables,
 		reportDescriptionlessDisables,
 		syntax,
 		customSyntax,
 		fix,
+		quiet,
 	});
 
 	if (!files) {
@@ -112,71 +121,44 @@ module.exports = function (options) {
 			absoluteCodeFilename &&
 			!filterFilePaths(ignorer, [path.relative(process.cwd(), absoluteCodeFilename)]).length
 		) {
-			return Promise.resolve(prepareReturnValue([], options, formatterFunction));
+			return prepareReturnValue([], maxWarnings, formatterFunction);
 		}
 
-		return stylelint
-			._lintSource({
+		let stylelintResult;
+
+		try {
+			const postcssResult = await stylelint._lintSource({
 				code,
 				codeFilename: absoluteCodeFilename,
-			})
-			.then((postcssResult) => {
-				// Check for file existence
-				return /** @type {Promise<void>} */ (
-					new Promise((resolve, reject) => {
-						if (!absoluteCodeFilename) {
-							reject();
-
-							return;
-						}
-
-						fs.stat(absoluteCodeFilename, (err) => {
-							if (err) {
-								reject();
-							} else {
-								resolve();
-							}
-						});
-					})
-				)
-					.then(() => {
-						return stylelint._createStylelintResult(postcssResult, absoluteCodeFilename);
-					})
-					.catch(() => {
-						return stylelint._createStylelintResult(postcssResult);
-					});
-			})
-			.catch((error) => handleError(stylelint, error))
-			.then((stylelintResult) => {
-				const postcssResult = stylelintResult._postcssResult;
-				const returnValue = prepareReturnValue([stylelintResult], options, formatterFunction);
-
-				if (
-					options.fix &&
-					postcssResult &&
-					!postcssResult.stylelint.ignored &&
-					!postcssResult.stylelint.ruleDisableFix
-				) {
-					if (!postcssResult.stylelint.disableWritingFix) {
-						// If we're fixing, the output should be the fixed code
-						returnValue.output = postcssResult.root.toString(postcssResult.opts.syntax);
-					} else {
-						// If the writing of the fix is disabled, the input code is returned as-is
-						returnValue.output = code;
-					}
-				}
-
-				return returnValue;
 			});
+
+			stylelintResult = await stylelint._createStylelintResult(postcssResult, absoluteCodeFilename);
+		} catch (error) {
+			stylelintResult = await handleError(stylelint, error);
+		}
+
+		const postcssResult = stylelintResult._postcssResult;
+		const returnValue = prepareReturnValue([stylelintResult], maxWarnings, formatterFunction);
+
+		if (
+			fix &&
+			postcssResult &&
+			!postcssResult.stylelint.ignored &&
+			!postcssResult.stylelint.ruleDisableFix
+		) {
+			if (!postcssResult.stylelint.disableWritingFix) {
+				// If we're fixing, the output should be the fixed code
+				returnValue.output = postcssResult.root.toString(postcssResult.opts.syntax);
+			} else {
+				// If the writing of the fix is disabled, the input code is returned as-is
+				returnValue.output = code;
+			}
+		}
+
+		return returnValue;
 	}
 
-	let fileList = files;
-
-	if (typeof fileList === 'string') {
-		fileList = [fileList];
-	}
-
-	fileList = fileList.map((entry) => {
+	let fileList = [files].flat().map((entry) => {
 		const cwd = (globbyOptions && globbyOptions.cwd) || process.cwd();
 		const absolutePath = !path.isAbsolute(entry) ? path.join(cwd, entry) : path.normalize(entry);
 
@@ -188,7 +170,7 @@ module.exports = function (options) {
 		return entry;
 	});
 
-	if (!options.disableDefaultIgnores) {
+	if (!disableDefaultIgnores) {
 		fileList = fileList.concat(ALWAYS_IGNORED_GLOBS.map((glob) => `!${glob}`));
 	}
 
@@ -204,98 +186,89 @@ module.exports = function (options) {
 		fileCache.destroy();
 	}
 
-	return globby(fileList, globbyOptions)
-		.then((filePaths) => {
-			// The ignorer filter needs to check paths relative to cwd
-			filePaths = filterFilePaths(
-				ignorer,
-				filePaths.map((p) => path.relative(process.cwd(), p)),
-			);
+	let filePaths = await globby(fileList, globbyOptions);
 
-			if (!filePaths.length) {
-				if (!allowEmptyInput) {
-					throw new NoFilesFoundError(fileList);
+	// The ignorer filter needs to check paths relative to cwd
+	filePaths = filterFilePaths(
+		ignorer,
+		filePaths.map((p) => path.relative(process.cwd(), p)),
+	);
+
+	let stylelintResults;
+
+	if (filePaths.length) {
+		const cwd = (globbyOptions && globbyOptions.cwd) || process.cwd();
+		let absoluteFilePaths = filePaths.map((filePath) => {
+			const absoluteFilepath = !path.isAbsolute(filePath)
+				? path.join(cwd, filePath)
+				: path.normalize(filePath);
+
+			return absoluteFilepath;
+		});
+
+		if (useCache) {
+			absoluteFilePaths = absoluteFilePaths.filter(fileCache.hasFileChanged.bind(fileCache));
+		}
+
+		const getStylelintResults = absoluteFilePaths.map(async (absoluteFilepath) => {
+			debug(`Processing ${absoluteFilepath}`);
+
+			try {
+				const postcssResult = await stylelint._lintSource({
+					filePath: absoluteFilepath,
+				});
+
+				if (postcssResult.stylelint.stylelintError && useCache) {
+					debug(`${absoluteFilepath} contains linting errors and will not be cached.`);
+					fileCache.removeEntry(absoluteFilepath);
 				}
 
-				return Promise.all([]);
+				/**
+				 * If we're fixing, save the file with changed code
+				 */
+				if (
+					postcssResult.root &&
+					postcssResult.opts &&
+					!postcssResult.stylelint.ignored &&
+					fix &&
+					!postcssResult.stylelint.disableWritingFix
+				) {
+					const fixedCss = postcssResult.root.toString(postcssResult.opts.syntax);
+
+					if (
+						postcssResult.root &&
+						postcssResult.root.source &&
+						postcssResult.root.source.input.css !== fixedCss
+					) {
+						await writeFileAtomic(absoluteFilepath, fixedCss);
+					}
+				}
+
+				return stylelint._createStylelintResult(postcssResult, absoluteFilepath);
+			} catch (error) {
+				// On any error, we should not cache the lint result
+				fileCache.removeEntry(absoluteFilepath);
+
+				return handleError(stylelint, error, absoluteFilepath);
 			}
-
-			const cwd = (globbyOptions && globbyOptions.cwd) || process.cwd();
-			let absoluteFilePaths = filePaths.map((filePath) => {
-				const absoluteFilepath = !path.isAbsolute(filePath)
-					? path.join(cwd, filePath)
-					: path.normalize(filePath);
-
-				return absoluteFilepath;
-			});
-
-			if (useCache) {
-				absoluteFilePaths = absoluteFilePaths.filter(fileCache.hasFileChanged.bind(fileCache));
-			}
-
-			const getStylelintResults = absoluteFilePaths.map((absoluteFilepath) => {
-				debug(`Processing ${absoluteFilepath}`);
-
-				return stylelint
-					._lintSource({
-						filePath: absoluteFilepath,
-					})
-					.then((postcssResult) => {
-						if (postcssResult.stylelint.stylelintError && useCache) {
-							debug(`${absoluteFilepath} contains linting errors and will not be cached.`);
-							fileCache.removeEntry(absoluteFilepath);
-						}
-
-						/**
-						 * If we're fixing, save the file with changed code
-						 * @type {Promise<Error | void>}
-						 */
-						let fixFile = Promise.resolve();
-
-						if (
-							postcssResult.root &&
-							postcssResult.opts &&
-							!postcssResult.stylelint.ignored &&
-							!postcssResult.stylelint.ruleDisableFix &&
-							options.fix &&
-							!postcssResult.stylelint.disableWritingFix
-						) {
-							const fixedCss = postcssResult.root.toString(postcssResult.opts.syntax);
-
-							if (
-								postcssResult.root &&
-								postcssResult.root.source &&
-								postcssResult.root.source.input.css !== fixedCss
-							) {
-								fixFile = writeFileAtomic(absoluteFilepath, fixedCss);
-							}
-						}
-
-						return fixFile.then(() =>
-							stylelint._createStylelintResult(postcssResult, absoluteFilepath),
-						);
-					})
-					.catch((error) => {
-						// On any error, we should not cache the lint result
-						fileCache.removeEntry(absoluteFilepath);
-
-						return handleError(stylelint, error, absoluteFilepath);
-					});
-			});
-
-			return Promise.all(getStylelintResults);
-		})
-		.then((stylelintResults) => {
-			if (useCache) {
-				fileCache.reconcile();
-			}
-
-			const rtn = prepareReturnValue(stylelintResults, options, formatterFunction);
-
-			debug(`Linting complete in ${Date.now() - startTime}ms`);
-
-			return rtn;
 		});
+
+		stylelintResults = await Promise.all(getStylelintResults);
+	} else if (allowEmptyInput) {
+		stylelintResults = await Promise.all([]);
+	} else {
+		stylelintResults = await Promise.reject(new NoFilesFoundError(fileList));
+	}
+
+	if (useCache) {
+		fileCache.reconcile();
+	}
+
+	const result = prepareReturnValue(stylelintResults, maxWarnings, formatterFunction);
+
+	debug(`Linting complete in ${Date.now() - startTime}ms`);
+
+	return result;
 };
 
 /**

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -213,7 +213,6 @@ declare module 'stylelint' {
 		config?: StylelintConfig;
 		configFile?: string;
 		configBasedir?: string;
-		printConfig?: string;
 		ignoreDisables?: boolean;
 		ignorePath?: string;
 		ignorePattern?: string[];
@@ -221,6 +220,7 @@ declare module 'stylelint' {
 		reportNeedlessDisables?: boolean;
 		reportInvalidScopeDisables?: boolean;
 		maxWarnings?: number;
+		/** @deprecated Use `customSyntax` instead. */
 		syntax?: string;
 		customSyntax?: CustomSyntax;
 		formatter?: FormatterIdentifier;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #5529, but not closes it.

> Is there anything in the PR that needs further explanation?

Refactored as much as possible to async-await in core. Also noticed some improvements to code.

Accidentally found that `quite` flag in Node.js API didn't work. It's probably worked only in CLI only for a long time, even thought stylelint have it since [v2.0.0](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md#200). This option wasn't even documented. I fixed it and added tests. *UPD:* found that there is an issue #4476 :)
