### PR TITLE
Refactor to remove `slash` package

### DIFF
--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -5,8 +5,8 @@ const getModulePath = require('./utils/getModulePath');
 const globjoin = require('globjoin');
 const micromatch = require('micromatch');
 const normalizeAllRuleSettings = require('./normalizeAllRuleSettings');
+const normalizePath = require('normalize-path');
 const path = require('path');
-const slash = require('slash');
 
 /** @typedef {import('stylelint').StylelintConfigPlugins} StylelintConfigPlugins */
 /** @typedef {import('stylelint').StylelintConfigProcessor} StylelintConfigProcessor */
@@ -427,7 +427,7 @@ function applyOverrides(fullConfig, configDir, filePath) {
 				return globjoin(configDir, glob);
 			})
 			// Glob patterns for micromatch should be in POSIX-style
-			.map(slash);
+			.map((s) => normalizePath(s));
 
 		if (micromatch.isMatch(filePath, filesGlobs)) {
 			config = mergeConfigs(config, configOverrides);

--- a/lib/isPathIgnored.js
+++ b/lib/isPathIgnored.js
@@ -3,8 +3,8 @@
 const filterFilePaths = require('./utils/filterFilePaths');
 const getFileIgnorer = require('./utils/getFileIgnorer');
 const micromatch = require('micromatch');
+const normalizePath = require('normalize-path');
 const path = require('path');
-const slash = require('slash');
 
 /**
  * To find out if a path is ignored, we need to load the config,
@@ -28,7 +28,9 @@ module.exports = function isPathIgnored(stylelint, filePath) {
 		}
 
 		// Glob patterns for micromatch should be in POSIX-style
-		const ignoreFiles = /** @type {Array<string>} */ (result.config.ignoreFiles || []).map(slash);
+		const ignoreFiles = /** @type {Array<string>} */ (result.config.ignoreFiles || []).map((s) =>
+			normalizePath(s),
+		);
 
 		const absoluteFilePath = path.isAbsolute(filePath)
 			? filePath

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "postcss-selector-parser": "^6.0.6",
         "postcss-value-parser": "^4.1.0",
         "resolve-from": "^5.0.0",
-        "slash": "^3.0.0",
         "specificity": "^0.4.1",
         "string-width": "^4.2.2",
         "strip-ansi": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "postcss-selector-parser": "^6.0.6",
     "postcss-value-parser": "^4.1.0",
     "resolve-from": "^5.0.0",
-    "slash": "^3.0.0",
     "specificity": "^0.4.1",
     "string-width": "^4.2.2",
     "strip-ansi": "^6.0.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/pull/5541#issuecomment-921656346

> Is there anything in the PR that needs further explanation?

This change replaces the [`slash`](https://github.com/sindresorhus/slash) package with the [`normalize-path`](https://github.com/jonschlinkert/normalize-path) package. It just removes `slash`.
