### PR TITLE
lint script: add `--continue-on-error`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "benchmark-rule": "node scripts/benchmark-rule.js",
     "format": "prettier . --write",
     "jest": "jest",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "npm-run-all --parallel --continue-on-error lint:*",
     "lint:formatting": "prettier . --check",
     "lint:js": "eslint . --cache --max-warnings=0",
     "lint:md": "remark . --quiet --frail",


### PR DESCRIPTION
This allows the other scripts to finish instead of the process exiting when any error is first encountered in any of the scripts.

BTW @jeddy3 the v14 isn't protected, not sure if it's intentional :)