### PR TITLE
Refactor to add missing radix

### DIFF
--- a/lib/utils/isCounterIncrementCustomIdentValue.js
+++ b/lib/utils/isCounterIncrementCustomIdentValue.js
@@ -12,7 +12,7 @@ module.exports = function (value) {
 
 	if (
 		keywordSets.counterIncrementKeywords.has(valueLowerCase) ||
-		Number.isFinite(Number.parseInt(valueLowerCase))
+		Number.isFinite(Number.parseInt(valueLowerCase, 10))
 	) {
 		return false;
 	}

--- a/lib/utils/isCounterResetCustomIdentValue.js
+++ b/lib/utils/isCounterResetCustomIdentValue.js
@@ -12,7 +12,7 @@ module.exports = function (value) {
 
 	if (
 		keywordSets.counterResetKeywords.has(valueLowerCase) ||
-		Number.isFinite(Number.parseInt(valueLowerCase))
+		Number.isFinite(Number.parseInt(valueLowerCase, 10))
 	) {
 		return false;
 	}


### PR DESCRIPTION
I believe `10` is meant to be used here. Either way, I think the ESLint config should have the rule enabled to catch these :)