### PR TITLE
Refactor to replace `__dirname` with `process.cwd()` in runtime code

### DIFF
--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -6,11 +6,10 @@ const getConfigForFile = require('./getConfigForFile');
 const getPostcssResult = require('./getPostcssResult');
 const isPathIgnored = require('./isPathIgnored');
 const lintSource = require('./lintSource');
-const path = require('path');
 const { cosmiconfig } = require('cosmiconfig');
 
 const IS_TEST = process.env.NODE_ENV === 'test';
-const STOP_DIR = IS_TEST ? path.resolve(__dirname, '..') : undefined;
+const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
 /** @typedef {import('stylelint').StylelintInternalApi} StylelintInternalApi */
 

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -6,7 +6,7 @@ const { augmentConfigFull } = require('./augmentConfig');
 const { cosmiconfig } = require('cosmiconfig');
 
 const IS_TEST = process.env.NODE_ENV === 'test';
-const STOP_DIR = IS_TEST ? path.resolve(__dirname, '..') : undefined;
+const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
 /** @typedef {import('stylelint').StylelintInternalApi} StylelintInternalApi */
 /** @typedef {import('stylelint').StylelintConfig} StylelintConfig */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/issues/5291#issuecomment-921846766

> Is there anything in the PR that needs further explanation?

This change aims to make the ESM migration easier.
`__dirname` is used only for testing, so I think there are no problems to replace it.


