### PR TITLE
Refactor `cli.js` a bit

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -318,8 +318,6 @@ const meowOptions = {
 			type: 'boolean',
 		},
 	},
-	pkg: require('../package.json'),
-	argv: /** @type {string[]} */ ([]),
 };
 
 /**
@@ -527,7 +525,7 @@ function handleError(err) {
  * @returns {CLIOptions}
  */
 function buildCLI(argv) {
-	// @ts-ignore TODO TYPES
+	// @ts-expect-error -- TODO TYPES
 	return meow({ ...meowOptions, argv });
 }
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Removing the extra `require` may make the ESM migration easier. See <https://github.com/stylelint/stylelint/issues/5291#issuecomment-920778090>.

> Is there anything in the PR that needs further explanation?

- Remove the `pkg` option of `meow`. By default, `meow` finds the closest `package.json`.
  See <https://github.com/sindresorhus/meow/blob/v9.0.0/readme.md#pkg>
- Change `@ts-ignore` to `@ts-expect-error`.

