### PR TITLE
Refactor to fix `cosmiconfig` type error

### DIFF
--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -15,7 +15,7 @@ const path = require('path');
 /** @typedef {import('stylelint').StylelintConfigOverride} StylelintConfigOverride */
 /** @typedef {import('stylelint').StylelintInternalApi} StylelintInternalApi */
 /** @typedef {import('stylelint').StylelintConfig} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} CosmiconfigResult */
+/** @typedef {import('stylelint').StylelintCosmiconfigResult} StylelintCosmiconfigResult */
 
 /**
  * - Merges config and stylelint options
@@ -49,8 +49,8 @@ async function augmentConfigBasic(stylelint, config, configDir, allowOverrides, 
  * but do not need the full treatment. Things like pluginFunctions
  * will be resolved and added by the parent config.
  * @param {StylelintInternalApi} stylelint
- * @param {CosmiconfigResult} [cosmiconfigResult]
- * @returns {Promise<CosmiconfigResult | null>}
+ * @param {StylelintCosmiconfigResult} [cosmiconfigResult]
+ * @returns {Promise<StylelintCosmiconfigResult>}
  */
 async function augmentConfigExtended(stylelint, cosmiconfigResult) {
 	if (!cosmiconfigResult) {
@@ -71,8 +71,8 @@ async function augmentConfigExtended(stylelint, cosmiconfigResult) {
 /**
  * @param {StylelintInternalApi} stylelint
  * @param {string} [filePath]
- * @param {CosmiconfigResult} [cosmiconfigResult]
- * @returns {Promise<CosmiconfigResult | null>}
+ * @param {StylelintCosmiconfigResult} [cosmiconfigResult]
+ * @returns {Promise<StylelintCosmiconfigResult>}
  */
 async function augmentConfigFull(stylelint, filePath, cosmiconfigResult) {
 	if (!cosmiconfigResult) {
@@ -183,7 +183,7 @@ async function extendConfig(stylelint, config, configDir) {
  * @param {StylelintInternalApi} stylelint
  * @param {string} configDir
  * @param {string} extendLookup
- * @return {Promise<CosmiconfigResult | null>}
+ * @return {Promise<StylelintCosmiconfigResult>}
  */
 function loadExtendedConfig(stylelint, configDir, extendLookup) {
 	const extendPath = getModulePath(configDir, extendLookup);

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -10,8 +10,8 @@ const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
 /** @typedef {import('stylelint').StylelintInternalApi} StylelintInternalApi */
 /** @typedef {import('stylelint').StylelintConfig} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} CosmiconfigResult */
-/** @typedef {Promise<CosmiconfigResult | null>} ConfigPromise  */
+/** @typedef {import('stylelint').StylelintCosmiconfigResult} StylelintCosmiconfigResult */
+/** @typedef {Promise<StylelintCosmiconfigResult>} ConfigPromise  */
 
 /**
  * @param {StylelintInternalApi} stylelint
@@ -46,8 +46,6 @@ module.exports = async function getConfigForFile(stylelint, searchPath = process
 	}
 
 	const configExplorer = cosmiconfig('stylelint', {
-		// @ts-ignore TODO TYPES found out which cosmiconfig types are valid
-		// transform: augmentConfigFull.bind(null, stylelint, filePath),
 		transform: (cosmiconfigResult) => augmentConfigFull(stylelint, filePath, cosmiconfigResult),
 		stopDir: STOP_DIR,
 	});

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'stylelint' {
 	import { Comment, Result, Message, Root, Syntax, WarningOptions, Warning } from 'postcss';
 	import { GlobbyOptions } from 'globby';
+	import { CosmiconfigResult } from 'cosmiconfig/dist/types';
 
 	export type Severity = 'warning' | 'error';
 
@@ -66,7 +67,7 @@ declare module 'stylelint' {
 	}[keyof T];
 	export type DisablePropertyName = PropertyNamesOfType<StylelintConfig, DisableSettings>;
 
-	export type CosmiconfigResult = { config: StylelintConfig; filepath: string };
+	export type StylelintCosmiconfigResult = (CosmiconfigResult & { config: StylelintConfig }) | null;
 
 	export type DisabledRange = {
 		comment: Comment;
@@ -183,8 +184,8 @@ declare module 'stylelint' {
 	export type StylelintInternalApi = {
 		_options: StylelintStandaloneOptions;
 		_extendExplorer: {
-			search: (s: string) => Promise<null | CosmiconfigResult>;
-			load: (s: string) => Promise<null | CosmiconfigResult>;
+			search: (s: string) => Promise<StylelintCosmiconfigResult>;
+			load: (s: string) => Promise<StylelintCosmiconfigResult>;
 		};
 		_configCache: Map<string, Object>;
 		_specifiedConfigCache: Map<StylelintConfig, Object>;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This refactoring does:
- fix the `// @ts-ignore` comment for `cosmiconfig`
- improve the `CosmiconfigResult` type renaming `StylelintCosmiconfigResult`

See also <https://github.com/davidtheclark/cosmiconfig/blob/v7.0.1/src/types.ts#L6-L10>

