### PR TITLE
Refactor to improve types for `StylelintInternalApi`

### DIFF
--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -16,43 +16,29 @@ const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 /**
  * The stylelint "internal API" is passed among functions
  * so that methods on a stylelint instance can invoke
- * each other while sharing options and caches
+ * each other while sharing options and caches.
+ *
  * @param {import('stylelint').StylelintStandaloneOptions} options
  * @returns {StylelintInternalApi}
  */
 module.exports = function createStylelint(options = {}) {
-	/** @type {Partial<StylelintInternalApi>} */
+	/** @type {StylelintInternalApi} */
+	// @ts-expect-error -- TS2740: Type '{ _options: StylelintStandaloneOptions; }' is missing the following properties from type 'StylelintInternalApi'
 	const stylelint = { _options: options };
 
-	// @ts-ignore TODO TYPES found out which cosmiconfig types are valid
-	stylelint._extendExplorer = cosmiconfig(null, {
-		transform: augmentConfig.augmentConfigExtended.bind(
-			null,
-			/** @type {StylelintInternalApi} */ (stylelint),
-		),
+	stylelint._extendExplorer = cosmiconfig('', {
+		transform: augmentConfig.augmentConfigExtended.bind(null, stylelint),
 		stopDir: STOP_DIR,
 	});
 
 	stylelint._specifiedConfigCache = new Map();
 	stylelint._postcssResultCache = new Map();
-	stylelint._createStylelintResult = createStylelintResult.bind(
-		null,
-		/** @type {StylelintInternalApi} */ (stylelint),
-	);
-	stylelint._getPostcssResult = getPostcssResult.bind(
-		null,
-		/** @type {StylelintInternalApi} */ (stylelint),
-	);
-	stylelint._lintSource = lintSource.bind(null, /** @type {StylelintInternalApi} */ (stylelint));
+	stylelint._createStylelintResult = createStylelintResult.bind(null, stylelint);
+	stylelint._getPostcssResult = getPostcssResult.bind(null, stylelint);
+	stylelint._lintSource = lintSource.bind(null, stylelint);
 
-	stylelint.getConfigForFile = getConfigForFile.bind(
-		null,
-		/** @type {StylelintInternalApi} */ (stylelint),
-	);
-	stylelint.isPathIgnored = isPathIgnored.bind(
-		null,
-		/** @type {StylelintInternalApi} */ (stylelint),
-	);
+	stylelint.getConfigForFile = getConfigForFile.bind(null, stylelint);
+	stylelint.isPathIgnored = isPathIgnored.bind(null, stylelint);
 
-	return /** @type {StylelintInternalApi} */ (stylelint);
+	return stylelint;
 };

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -11,21 +11,18 @@ const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 /** @typedef {import('stylelint').StylelintInternalApi} StylelintInternalApi */
 /** @typedef {import('stylelint').StylelintConfig} StylelintConfig */
 /** @typedef {import('stylelint').StylelintCosmiconfigResult} StylelintCosmiconfigResult */
-/** @typedef {Promise<StylelintCosmiconfigResult>} ConfigPromise  */
 
 /**
  * @param {StylelintInternalApi} stylelint
  * @param {string} [searchPath]
  * @param {string} [filePath]
- * @returns {ConfigPromise}
+ * @returns {Promise<StylelintCosmiconfigResult>}
  */
 module.exports = async function getConfigForFile(stylelint, searchPath = process.cwd(), filePath) {
 	const optionsConfig = stylelint._options.config;
 
 	if (optionsConfig !== undefined) {
-		const cached = /** @type {ConfigPromise} */ (
-			stylelint._specifiedConfigCache.get(optionsConfig)
-		);
+		const cached = stylelint._specifiedConfigCache.get(optionsConfig);
 
 		// If config has overrides the resulting config might be different for some files.
 		// Cache results only if resulted config is the same for all linted files.
@@ -50,11 +47,9 @@ module.exports = async function getConfigForFile(stylelint, searchPath = process
 		stopDir: STOP_DIR,
 	});
 
-	const searchForConfig = stylelint._options.configFile
-		? configExplorer.load(stylelint._options.configFile)
-		: configExplorer.search(searchPath);
-
-	let config = await searchForConfig;
+	let config = stylelint._options.configFile
+		? await configExplorer.load(stylelint._options.configFile)
+		: await configExplorer.search(searchPath);
 
 	if (!config) {
 		config = await configExplorer.search(process.cwd());

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -147,11 +147,12 @@ module.exports = async function standalone({
 			!postcssResult.stylelint.ignored &&
 			!postcssResult.stylelint.ruleDisableFix
 		) {
-			returnValue.output = !postcssResult.stylelint.disableWritingFix
-				? // If we're fixing, the output should be the fixed code
-				  postcssResult.root.toString(postcssResult.opts.syntax)
-				: // If the writing of the fix is disabled, the input code is returned as-is
-				  code;
+			returnValue.output =
+				!postcssResult.stylelint.disableWritingFix && postcssResult.opts
+					? // If we're fixing, the output should be the fixed code
+					  postcssResult.root.toString(postcssResult.opts.syntax)
+					: // If the writing of the fix is disabled, the input code is returned as-is
+					  code;
 		}
 
 		return returnValue;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'stylelint' {
 	import { Comment, Result, Message, Root, Syntax, WarningOptions, Warning } from 'postcss';
 	import { GlobbyOptions } from 'globby';
-	import { CosmiconfigResult } from 'cosmiconfig/dist/types';
+	import { cosmiconfig } from 'cosmiconfig';
 
 	export type Severity = 'warning' | 'error';
 
@@ -67,7 +67,12 @@ declare module 'stylelint' {
 	}[keyof T];
 	export type DisablePropertyName = PropertyNamesOfType<StylelintConfig, DisableSettings>;
 
-	export type StylelintCosmiconfigResult = (CosmiconfigResult & { config: StylelintConfig }) | null;
+	// This type has the same properties as `CosmiconfigResult` from `cosmiconfig`.
+	export type StylelintCosmiconfigResult = {
+		config: StylelintConfig;
+		filepath: string;
+		isEmpty?: boolean;
+	} | null;
 
 	export type DisabledRange = {
 		comment: Comment;
@@ -183,25 +188,22 @@ declare module 'stylelint' {
 
 	export type StylelintInternalApi = {
 		_options: StylelintStandaloneOptions;
-		_extendExplorer: {
-			search: (s: string) => Promise<StylelintCosmiconfigResult>;
-			load: (s: string) => Promise<StylelintCosmiconfigResult>;
-		};
-		_configCache: Map<string, Object>;
-		_specifiedConfigCache: Map<StylelintConfig, Object>;
+		_extendExplorer: ReturnType<typeof cosmiconfig>;
+		_specifiedConfigCache: Map<StylelintConfig, Promise<StylelintCosmiconfigResult>>;
 		_postcssResultCache: Map<string, Result>;
 
 		_getPostcssResult: (options?: GetPostcssOptions) => Promise<Result>;
 		_lintSource: (options: GetLintSourceOptions) => Promise<PostcssResult>;
-		_createStylelintResult: Function;
-		_createEmptyPostcssResult?: Function;
+		_createStylelintResult: (
+			postcssResult: PostcssResult,
+			filePath?: string,
+		) => Promise<StylelintResult>;
 
 		getConfigForFile: (
 			searchPath?: string,
 			filePath?: string,
-		) => Promise<{ config: StylelintConfig; filepath: string } | null>;
+		) => Promise<StylelintCosmiconfigResult>;
 		isPathIgnored: (s?: string) => Promise<boolean>;
-		lintSource: Function;
 	};
 
 	export type StylelintStandaloneOptions = {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This refactoring mainly improves the `StylelintInternalApi` type:
- remove needless properties
- make some properties stricter
- remove extra type annotations
