### PR TITLE
Refactor to fix `@ts-ignore` in `isStandardSyntaxDeclaration()`

### DIFF
--- a/lib/utils/isStandardSyntaxDeclaration.js
+++ b/lib/utils/isStandardSyntaxDeclaration.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const isScssVariable = require('./isScssVariable');
-const { isRoot } = require('./typeGuards');
+const { isRoot, isRule } = require('./typeGuards');
 
 /**
  * @param {string} [lang]
@@ -54,11 +54,10 @@ module.exports = function (decl) {
 
 	// Sass nested properties (e.g. border: { style: solid; color: red; })
 	if (
-		// @ts-ignore TODO TYPES selector does not exists
+		parent &&
+		isRule(parent) &&
 		parent.selector &&
-		// @ts-ignore
 		parent.selector[parent.selector.length - 1] === ':' &&
-		// @ts-ignore
 		parent.selector.substring(0, 2) !== '--'
 	) {
 		return false;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
