### PR TITLE
Add `github-actions` configuration for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
       - 'pr: dependencies'
     versioning-strategy: increase
     target-branch: 'v14' # TODO: Remove when releasing v14.
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - 'pr: dependencies'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

With various updates to Dependabot coming in Stylelint projects, this might be helpful in ensuring the GitHub Actions we use are updated when new releases are released. I suspect this would be most valuable if a security release of a GitHub Action is released we'd get a PR for it relatively quickly.

> Which issue, if any, is this issue related to?

None, as it's a build tooling update.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
