### PR TITLE
Replace violation with problem in docs and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project are documented in this file.
 - Added: `ignoreProperties: []` to `number-max-precision` ([#5421](https://github.com/stylelint/stylelint/pull/5421)).
 - Added: TypeScript type definitions ([#5582](https://github.com/stylelint/stylelint/pull/5582)).
 - Fixed: "No files matching the pattern" when using backslash paths on Windows ([#5386](https://github.com/stylelint/stylelint/pull/5386)).
-- Fixed: `function-url-quotes` violation messages to be consistent with other `*-quotes` rules ([#5488](https://github.com/stylelint/stylelint/pull/5488)).
+- Fixed: `function-url-quotes` problem messages to be consistent with other `*-quotes` rules ([#5488](https://github.com/stylelint/stylelint/pull/5488)).
 - Fixed: `length-zero-no-unit` false positives for `flex` property ([#5315](https://github.com/stylelint/stylelint/pull/5315)).
 - Fixed: `media-feature-name-no-unknown` false positives for `prefers-contrast` ([#5428](https://github.com/stylelint/stylelint/pull/5428)).
 - Fixed: `property-no-unknown` false positives for Less maps ([#5381](https://github.com/stylelint/stylelint/pull/5381)).
@@ -84,7 +84,7 @@ All notable changes to this project are documented in this file.
 - Added: `selector-attribute-name-disallowed-list` rule ([#4992](https://github.com/stylelint/stylelint/pull/4992)).
 - Added: `ignoreAtRules[]` to `property-no-unknown` ([#4965](https://github.com/stylelint/stylelint/pull/4965)).
 - Fixed: `*-notation` false negatives for dollar variables ([#5031](https://github.com/stylelint/stylelint/pull/5031)).
-- Fixed: `*-pattern` missing configured pattern in violation messages ([#4975](https://github.com/stylelint/stylelint/pull/4975)).
+- Fixed: `*-pattern` missing configured pattern in problem messages ([#4975](https://github.com/stylelint/stylelint/pull/4975)).
 
 ## 13.7.2
 
@@ -262,7 +262,7 @@ All notable changes to this project are documented in this file.
 ## 11.0.0
 
 - Changed: `--report-needless-disables` CLI flag now reports needless disables and runs linting ([#4151](https://github.com/stylelint/stylelint/pull/4151)).
-- Changed: display a violation at 1:1 for each file instead of throwing an error on unrecognised rules ([#4237](https://github.com/stylelint/stylelint/pull/4237)).
+- Changed: display a problem at 1:1 for each file instead of throwing an error on unrecognised rules ([#4237](https://github.com/stylelint/stylelint/pull/4237)).
 - Changed: always return `stylelintError` as a boolean ([#4174](https://github.com/stylelint/stylelint/pull/4174)).
 - Deprecated: `createRuleTester` API ([#4279](https://github.com/stylelint/stylelint/pull/4279)).
 - Added: `--reportInvalidScopeDisables` CLI flag ([#4181](https://github.com/stylelint/stylelint/pull/4181)).
@@ -274,7 +274,7 @@ All notable changes to this project are documented in this file.
 - Added: `ignoreSelectors: []` to `property-no-unknown` ([#4275](https://github.com/stylelint/stylelint/pull/4275)).
 - Fixed: Babel user configuration interfering with CSS-in-JS parser ([#4164](https://github.com/stylelint/stylelint/pull/4164)).
 - Fixed: PostCSS plugin ignoring .stylelintignore ([#4186](https://github.com/stylelint/stylelint/pull/4186)).
-- Fixed: `*-max-empty-lines` to only report one violation per function, selector, value list ([#4260](https://github.com/stylelint/stylelint/pull/4260)).
+- Fixed: `*-max-empty-lines` to only report one problem per function, selector, value list ([#4260](https://github.com/stylelint/stylelint/pull/4260)).
 - Fixed: `block-no-empty` crash for `@import` statements ([#4110](https://github.com/stylelint/stylelint/pull/4110)).
 - Fixed: `indentation` false positives for `<style>` tag with multiline attributes ([#4177](https://github.com/stylelint/stylelint/pull/4177)).
 - Fixed: `length-zero-no-unit` false positives for inside calc function ([#4175](https://github.com/stylelint/stylelint/pull/4175)).
@@ -587,7 +587,7 @@ All notable changes to this project are documented in this file.
 - Fixed: `indentation` false positives for Less parametric mixins with rule block/snippet ([#2744](https://github.com/stylelint/stylelint/pull/2744)).
 - Fixed: `no-empty-source` compatability with `postcss-html` custom syntax ([#2798](https://github.com/stylelint/stylelint/issues/2798)).
 - Fixed: `no-extra-semicolons` false negatives where instances were not detected when followed by multiple comments ([#2678](https://github.com/stylelint/stylelint/issues/2678)).
-- Fixed: `selector-max-specificity` cannot parse selector violation for Less mixins ([#2677](https://github.com/stylelint/stylelint/pull/2677)).
+- Fixed: `selector-max-specificity` cannot parse selector problem for Less mixins ([#2677](https://github.com/stylelint/stylelint/pull/2677)).
 
 ## 8.0.0
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It's mighty as it:
 - understands **modern** CSS syntax and features
 - has over **170 built-in rules** to catch errors and enforce conventions
 - supports **plugins** so you can create your own rules
-- automatically **fixes** the majority of stylistic violations
+- automatically **fixes** the majority of stylistic problems
 - is **well tested** with over 15000 unit tests
 - supports **shareable configs** that you can extend or create
 - is **unopinionated** so that you can customize it to your exact needs

--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -19,7 +19,7 @@ Where the first argument (`results`) is an array of Stylelint result objects (ty
   "source": "path/to/file.css", // The filepath or PostCSS identifier like <input css 1>
   "errored": true, // This is `true` if at least one rule with an "error"-level severity triggered a warning
   "warnings": [
-    // Array of rule violation warning objects, each like the following ...
+    // Array of rule problem warning objects, each like the following ...
     {
       "line": 3,
       "column": 12,

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -206,7 +206,7 @@ Stylelint exposes some useful utilities.
 
 ### `stylelint.utils.report`
 
-Adds violations from your plugin to the list of violations that Stylelint will report to the user.
+Adds problems from your plugin to the list of problems that Stylelint will report to the user.
 
 Use `stylelint.utils.report` to ensure your plugin respects disabled ranges and other possible future features of stylelint. _Do not use PostCSS's `node.warn()` method directly._
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -77,7 +77,7 @@ There is one caveat here: If your rule accepts a primary option array, it cannot
 
 ### Add autofix
 
-Depending on the rule, it might be possible to automatically fix the rule's violations by mutating the PostCSS AST (Abstract Syntax Tree) using the [PostCSS API](http://api.postcss.org/).
+Depending on the rule, it might be possible to automatically fix the rule's problems by mutating the PostCSS AST (Abstract Syntax Tree) using the [PostCSS API](http://api.postcss.org/).
 
 Add `context` variable to rule parameters:
 
@@ -109,8 +109,8 @@ report(/* .. */);
 
 Each rule must have tests that cover all patterns that:
 
-- are considered violations
-- should _not_ be considered violations
+- are considered problems
+- should _not_ be considered problems
 
 Write as many as you can stand to.
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -176,7 +176,7 @@ For example:
 }
 ```
 
-Reporters may use these severity levels to display violations or exit the process differently.
+Reporters may use these severity levels to display problems or exit the process differently.
 
 ## `extends`
 

--- a/docs/user-guide/errors.md
+++ b/docs/user-guide/errors.md
@@ -1,6 +1,6 @@
 # Errors & warnings
 
-In addition to rule violations, Stylelint surfaces the following errors and warnings:
+In addition to rule problems, Stylelint surfaces the following errors and warnings:
 
 ## CSS syntax error
 

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -122,4 +122,4 @@ You don't have to use the [Command Line Interface](usage/cli.md); you can also u
 - [Node API](usage/node-api.md)
 - [PostCSS plugin](usage/postcss-plugin.md)
 
-There are also integrations for [editors](integrations/editor.md), [task-runners](integrations/task-runner.md) and [others](integrations/other.md) too. Our [offical extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) is a popular choice that lets you see violations inline in your editor.
+There are also integrations for [editors](integrations/editor.md), [task-runners](integrations/task-runner.md) and [others](integrations/other.md) too. Our [offical extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) is a popular choice that lets you see problems inline in your editor.

--- a/docs/user-guide/rules/about.md
+++ b/docs/user-guide/rules/about.md
@@ -184,8 +184,8 @@ Each rule is accompanied by a README in the following format:
 3. Prototypical code example.
 4. Expanded description (if necessary).
 5. Options.
-6. Example patterns that are considered violations (for each option value).
-7. Example patterns that are _not_ considered violations (for each option value).
+6. Example patterns that are considered problems (for each option value).
+7. Example patterns that are _not_ considered problems (for each option value).
 8. Optional options (if applicable).
 
 The single-line description is in the form of:
@@ -195,9 +195,9 @@ The single-line description is in the form of:
 - "Require ..." for rules that accept `"always"` and `"never"` options
 - "Specify ..." for everything else
 
-## Violation messages
+## Problem messages
 
-Each rule produces violation messages in these forms:
+Each rule produces problem messages in these forms:
 
 - "Expected \[something\] \[in some context\]"
 - "Unexpected \[something\] \[in some context\]"

--- a/docs/user-guide/usage/cli.md
+++ b/docs/user-guide/usage/cli.md
@@ -46,7 +46,7 @@ Disable the default ignores. Stylelint will not automatically ignore the content
 
 ### `--fix`
 
-Automatically fix, where possible, violations reported by rules. [More info](options.md#fix).
+Automatically fix, where possible, problems reported by rules. [More info](options.md#fix).
 
 ### `--formatter, -f` | `--custom-formatter`
 
@@ -78,7 +78,7 @@ Print the configuration for the given path. Stylelint outputs the configuration 
 
 ### `--quiet, -q`
 
-Only register violations for rules with an "error"-level severity (ignore "warning"-level). [More info](options.md#quiet).
+Only register problems for rules with an "error"-level severity (ignore "warning"-level). [More info](options.md#quiet).
 
 ### `--report-descriptionless-disables, --rdd`
 
@@ -187,5 +187,5 @@ stylelint -f verbose "foo/**/*.css"
 The CLI can exit the process with the following exit codes:
 
 - `1` - something unknown went wrong
-- `2` - there was at least one rule violation or CLI flag error
+- `2` - there was at least one rule problem or CLI flag error
 - `78` - there was some problem with the configuration file

--- a/docs/user-guide/usage/node-api.md
+++ b/docs/user-guide/usage/node-api.md
@@ -44,11 +44,11 @@ For more detail usage, see [Globby Guide](https://github.com/sindresorhus/globby
 
 ### `errored`
 
-Boolean. If `true`, at least one rule with an "error"-level severity registered a violation.
+Boolean. If `true`, at least one rule with an "error"-level severity registered a problem.
 
 ### `output`
 
-A string displaying the formatted violations (using the default formatter or whichever you passed).
+A string displaying the formatted problems (using the default formatter or whichever you passed).
 
 ### `postcssResults`
 

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -26,13 +26,13 @@ Absolute path to the directory that relative paths defining "extends" and "plugi
 
 CLI flag: `--fix`
 
-Automatically fix, where possible, violations reported by rules.
+Automatically fix, where possible, problems reported by rules.
 
 For CSS with standard syntax, Stylelint uses [postcss-safe-parser](https://github.com/postcss/postcss-safe-parser) to fix syntax errors.
 
 If a source contains a:
 
-- scoped disable comment, e.g. `/* stylelint-disable indentation */`, any violations reported by the scoped rules will not be automatically fixed anywhere in the source
+- scoped disable comment, e.g. `/* stylelint-disable indentation */`, any problems reported by the scoped rules will not be automatically fixed anywhere in the source
 - unscoped disable comment, i.e. `/* stylelint-disable */`, the entirety of source will not be automatically fixed
 
 This limitation in being tracked in [issue #2643](https://github.com/stylelint/stylelint/issues/2643).
@@ -156,13 +156,13 @@ But, the following patterns (`stylelint-disable -- <description>`) are _not_ rep
 
 <!-- prettier-ignore -->
 ```css
-/* stylelint-disable -- This violation is ignorable. */
+/* stylelint-disable -- This problem is ignorable. */
 a {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-/* stylelint-disable-next-line block-no-empty -- This violation is ignorable. */
+/* stylelint-disable-next-line block-no-empty -- This problem is ignorable. */
 a {}
 ```
 
@@ -190,4 +190,4 @@ If using `code` or `stdin` to pass a source string directly, you can use `codeFi
 
 CLI flag: `--quiet`
 
-Only register violations for rules with an "error"-level severity (ignore "warning"-level).
+Only register problems for rules with an "error"-level severity (ignore "warning"-level).

--- a/lib/__tests__/__snapshots__/cli.test.js.snap
+++ b/lib/__tests__/__snapshots__/cli.test.js.snap
@@ -49,7 +49,7 @@ exports[`CLI --help 1`] = `
 
     --fix
 
-      Automatically fix violations of certain rules.
+      Automatically fix problems of certain rules.
 
     --custom-syntax
 
@@ -97,7 +97,7 @@ exports[`CLI --help 1`] = `
 
     --quiet, -q
 
-      Only register violations for rules with an \\"error\\"-level severity (ignore
+      Only register problems for rules with an \\"error\\"-level severity (ignore
       \\"warning\\"-level).
 
     --color

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -132,7 +132,7 @@ const meowOptions = {
 
       --fix
 
-        Automatically fix violations of certain rules.
+        Automatically fix problems of certain rules.
 
       --custom-syntax
 
@@ -180,7 +180,7 @@ const meowOptions = {
 
       --quiet, -q
 
-        Only register violations for rules with an "error"-level severity (ignore
+        Only register problems for rules with an "error"-level severity (ignore
         "warning"-level).
 
       --color

--- a/lib/rules/alpha-value-notation/README.md
+++ b/lib/rules/alpha-value-notation/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Alpha-values _must always_ use the number notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { opacity: 50% }
 a { color: rgb(0 0 0 / 50%) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a { color: rgb(0 0 0 / 0.5) }
 
 Alpha-values _must always_ use percentage notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a { opacity: 0.5 }
 a { color: rgb(0 0 0 / 0.5) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -85,7 +85,7 @@ Given:
 ["opacity"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ a { opacity: 50% }
 a { color: rgb(0 0 0 / 0.5) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["extend", "keyframes"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["extend", "keyframes"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -42,7 +42,7 @@ a { @extend placeholder; }
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -26,7 +26,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be an empty line before at-rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -39,7 +39,7 @@ a {}
 @media {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ a {}
 
 There _must never_ be an empty line before at-rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ a {}
 @media {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -86,7 +86,7 @@ This means that you can group your at-rules by name.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -117,7 +117,7 @@ Reverse the primary option for at-rules that are inside a block.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -134,7 +134,7 @@ b {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -159,7 +159,7 @@ Shared-line comments do not affect this option.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -197,7 +197,7 @@ Shared-line comments do not affect this option.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -208,7 +208,7 @@ The following patterns are considered violations:
 @media print {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -232,7 +232,7 @@ Reverse the primary option for at-rules that are nested and the first child of t
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -248,7 +248,7 @@ b {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -272,7 +272,7 @@ Ignore at-rules that follow a comment.
 
 Shared-line comments do not trigger this option.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -300,7 +300,7 @@ Ignore at-rules that are nested and the first child of their parent node.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -317,7 +317,7 @@ Ignore at-rules that are inside a block.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -352,7 +352,7 @@ This means that you can group your blockless at-rules by name.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -381,7 +381,7 @@ Ignore blockless at-rules that follow another blockless at-rule.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -412,7 +412,7 @@ Given:
 ["import"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-name-case/README.md
+++ b/lib/rules/at-rule-name-case/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ The following patterns are considered violations:
 @MEDIA (min-width: 50em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -65,7 +65,7 @@ The following patterns are _not_ considered violations:
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ The following patterns are considered violations:
 @media (min-width: 50em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-name-newline-after/README.md
+++ b/lib/rules/at-rule-name-newline-after/README.md
@@ -18,7 +18,7 @@ Require a newline after at-rule names.
 
 There _must always_ be a newline after at-rule names.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
   (orientation: landscape) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ The following patterns are _not_ considered violations:
 
 There _must always_ be a newline after at-rule names in at-rules with multi-line parameters.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,7 +77,7 @@ The following patterns are considered violations:
  (orientation: landscape) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-name-space-after/README.md
+++ b/lib/rules/at-rule-name-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after at-rule names.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -42,7 +42,7 @@ The following patterns are considered violations:
 (min-width: 700px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ The following patterns are _not_ considered violations:
 
 There _must always_ be a single space after at-rule names in single-line declaration blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -80,7 +80,7 @@ The following patterns are considered violations:
 @media  (min-width: 700px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -15,14 +15,14 @@ This rule considers at-rules defined in the CSS Specifications, up to and includ
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 @unknown {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -56,7 +56,7 @@ Given:
 ["/^--my-/", "--custom"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ The following patterns are considered violations:
 @-ms-viewport { orientation: landscape; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -21,7 +21,7 @@ Given:
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-semicolon-newline-after/README.md
+++ b/lib/rules/at-rule-semicolon-newline-after/README.md
@@ -29,7 +29,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the semicolon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ The following patterns are considered violations:
 @import url("x.css"); a {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/at-rule-semicolon-space-before/README.md
+++ b/lib/rules/at-rule-semicolon-space-before/README.md
@@ -17,14 +17,14 @@ Require a single space or disallow whitespace before the semicolons of at-rules.
 
 There _must always_ be a single space before the semicolons.
 
-The following pattern is considered a violation:
+The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
 ```css
 @import "components/buttons";
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -35,14 +35,14 @@ The following pattern is _not_ considered a violation:
 
 There _must never_ be a single space before the semicolons.
 
-The following pattern is considered a violation:
+The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
 ```css
 @import "components/buttons" ;
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-closing-brace-empty-line-before/README.md
+++ b/lib/rules/block-closing-brace-empty-line-before/README.md
@@ -20,7 +20,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `always-multi-line`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -46,7 +46,7 @@ a { color: pink; }
 
 ### `never`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -56,7 +56,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -78,7 +78,7 @@ When a rule is nested, `after-closing-brace` brace will reverse the primary opti
 
 For example, with `"never"` and `except: ["after-closing-brace"]`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -110,7 +110,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -155,7 +155,7 @@ The following patterns are _not_ considered violations:
 
 For example, with `"always-multi-line"` and `except: ["after-closing-brace"]`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -193,7 +193,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-closing-brace-newline-after/README.md
+++ b/lib/rules/block-closing-brace-newline-after/README.md
@@ -42,7 +42,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the closing brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -55,7 +55,7 @@ a { color: pink;
 } b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -67,14 +67,14 @@ b { color: red; }
 
 There _must always_ be a newline after the closing brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; } b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -92,14 +92,14 @@ b { color: red; }
 
 There _must never_ be whitespace after the closing brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; } b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -116,7 +116,7 @@ a { color: pink;
 
 There _must always_ be a newline after the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -124,7 +124,7 @@ a { color: pink;
 }b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -142,7 +142,7 @@ b { color: red; }
 
 There _must never_ be whitespace after the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -150,7 +150,7 @@ a { color: pink;
 } b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -177,7 +177,7 @@ Given:
 ["if", "else"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-closing-brace-newline-before/README.md
+++ b/lib/rules/block-closing-brace-newline-before/README.md
@@ -20,14 +20,14 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline before the closing brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink;}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -46,7 +46,7 @@ color: pink;
 
 There _must always_ be a newline before the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ a {
 color: pink;}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -71,7 +71,7 @@ a { color: pink;
 
 There _must never_ be whitespace before the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,7 +79,7 @@ a {
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-closing-brace-space-after/README.md
+++ b/lib/rules/block-closing-brace-space-after/README.md
@@ -30,7 +30,7 @@ This rule allows a trailing semicolon after the closing brace of a block. For ex
 
 There _must always_ be a single space after the closing brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -43,7 +43,7 @@ a { color: pink; }
 b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ a { color: pink; } b { color: red; }
 
 There _must never_ be whitespace after the closing brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -67,7 +67,7 @@ a { color: pink; }
 b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -84,14 +84,14 @@ a { color: pink;
 
 There _must always_ be a single space after the closing brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; }b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -108,14 +108,14 @@ a { color: pink;
 
 There _must never_ be whitespace after the closing brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; } b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -132,7 +132,7 @@ a { color: pink;
 
 There _must always_ be a single space after the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -140,7 +140,7 @@ a { color: pink;
 }b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -157,7 +157,7 @@ a { color: pink;
 
 There _must never_ be whitespace after the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -165,7 +165,7 @@ a { color: pink;
 } b { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-closing-brace-space-before/README.md
+++ b/lib/rules/block-closing-brace-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the closing brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a
 { color: pink;}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ color: pink; }
 
 There _must never_ be whitespace before the closing brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ a
 { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,14 +79,14 @@ color: pink;}
 
 There _must always_ be a single space before the closing brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink;}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -103,14 +103,14 @@ color: pink;}
 
 There _must never_ be whitespace before the closing brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -127,7 +127,7 @@ color: pink; }
 
 There _must always_ be a single space before the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -135,7 +135,7 @@ a {
 color: pink;}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -152,7 +152,7 @@ color: pink; }
 
 There _must never_ be whitespace before the closing brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -160,7 +160,7 @@ a {
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-no-empty/README.md
+++ b/lib/rules/block-no-empty/README.md
@@ -13,7 +13,7 @@ Disallow empty blocks.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a { }
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -56,7 +56,7 @@ a {
 
 Exclude comments from being treated as content inside of a block.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-opening-brace-newline-after/README.md
+++ b/lib/rules/block-opening-brace-newline-after/README.md
@@ -31,7 +31,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the opening brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ a{ /* end-of-line comment
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -78,7 +78,7 @@ a { /* end-of-line comment */
 
 There _must always_ be a newline after the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -86,7 +86,7 @@ a{color: pink;
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -103,7 +103,7 @@ color: pink; }
 
 There _must never_ be whitespace after the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -111,7 +111,7 @@ a { color: pink;
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-opening-brace-newline-before/README.md
+++ b/lib/rules/block-opening-brace-newline-before/README.md
@@ -22,7 +22,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline before the opening brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -35,7 +35,7 @@ a{ color: pink;
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,14 +62,14 @@ a /* foo */
 
 There _must always_ be a newline before the opening brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a{ color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -87,14 +87,14 @@ color: pink; }
 
 There _must never_ be whitespace before the opening brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -111,7 +111,7 @@ color: pink; }
 
 There _must always_ be a newline before the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -125,7 +125,7 @@ a {
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -154,7 +154,7 @@ color: pink; }
 
 There _must never_ be whitespace before the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -162,7 +162,7 @@ a {
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-opening-brace-space-after/README.md
+++ b/lib/rules/block-opening-brace-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the opening brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a {
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { color: pink;
 
 There _must never_ be whitespace after the opening brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ a {
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,14 +79,14 @@ a
 
 There _must always_ be a single space after the opening brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a {color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -103,14 +103,14 @@ a {color: pink;
 
 There _must never_ be whitespace after the opening brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -127,7 +127,7 @@ a { color: pink;
 
 There _must always_ be a single space after the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -135,7 +135,7 @@ a {color: pink;
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -152,7 +152,7 @@ a { color: pink;
 
 There _must never_ be whitespace after the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -160,7 +160,7 @@ a { color: pink;
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/block-opening-brace-space-before/README.md
+++ b/lib/rules/block-opening-brace-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the opening brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a
 { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ color: pink; }
 
 There _must never_ be whitespace before the opening brace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ a
 { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,14 +79,14 @@ color: pink; }
 
 There _must always_ be a single space before the opening brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a{ color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -103,14 +103,14 @@ color: pink; }
 
 There _must never_ be whitespace before the opening brace in single-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -127,7 +127,7 @@ color: pink; }
 
 There _must always_ be a single space before the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -135,7 +135,7 @@ a{
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -152,7 +152,7 @@ color: pink; }
 
 There _must never_ be whitespace before the opening brace in multi-line blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -160,7 +160,7 @@ a {
 color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -183,7 +183,7 @@ Given:
 ["/fo/"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -204,7 +204,7 @@ Given:
 [":root"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/color-function-notation/README.md
+++ b/lib/rules/color-function-notation/README.md
@@ -23,7 +23,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Applicable color-functions _must always_ use modern notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -45,7 +45,7 @@ a { color: hsla(270, 60%, 50%, 15%) }
 a { color: hsl(.75turn, 60%, 70%) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -71,7 +71,7 @@ a { color: hsl(.75turn 60% 70%) }
 
 Applicable color-functions _must always_ use the legacy notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -93,7 +93,7 @@ a { color: hsl(270 60% 50% / 15%) }
 a { color: hsl(.75turn 60% 70%) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/color-hex-alpha/README.md
+++ b/lib/rules/color-hex-alpha/README.md
@@ -15,7 +15,7 @@ a { color: #fffa }
 
 ### `"always"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -27,7 +27,7 @@ a { color: #fff; }
 a { color: #ffffff; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ a { color: #ffffffaa; }
 
 ### `"never"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -53,7 +53,7 @@ a { color: #fffa; }
 a { color: #ffffffaa; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/color-hex-case/README.md
+++ b/lib/rules/color-hex-case/README.md
@@ -17,14 +17,14 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: #FFF; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,14 +38,14 @@ a { color: #fff; }
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: #fff; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/color-hex-length/README.md
+++ b/lib/rules/color-hex-length/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"short"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ a { color: #ffffff; }
 a { color: #ffffffaa; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -48,7 +48,7 @@ a { color: #a4a4a4; }
 
 ### `"long"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -60,7 +60,7 @@ a { color: #fff; }
 a { color: #fffa; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -21,7 +21,7 @@ Colors _must always_, where possible, be named.
 
 This will complain if a hex (3, 4, 6 and 8 digit), `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()` or `gray()` color can be represented as a named color.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -68,7 +68,7 @@ a { color: hwb(0, 0%, 100%); }
 a { color: gray(0); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -89,7 +89,7 @@ a { color: rgb(0, 0, 0, 0.5); }
 
 Colors _must never_ be named.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -101,7 +101,7 @@ a { color: black; }
 a { color: white; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -126,7 +126,7 @@ Ignore colors that are inside a function.
 
 For example, with `"never"`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -152,7 +152,7 @@ Given:
 ["/^my-/", "composes"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -13,7 +13,7 @@ a { color: #333 }
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -30,7 +30,7 @@ a { color: #fff1aa; }
 a { color: #123456aa; }
 ```
 
-Hex values that are not valid also cause violations:
+Hex values that are not valid also cause problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -42,7 +42,7 @@ a { color: #foobar; }
 a { color: #0000000000000000; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/color-no-invalid-hex/README.md
+++ b/lib/rules/color-no-invalid-hex/README.md
@@ -15,7 +15,7 @@ Longhand hex colors can be either 6 or 8 (with alpha channel) hexadecimal charac
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a { color: #fff1az; }
 a { color: #12345aa; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -28,7 +28,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be an empty line before comments.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ a {}
 /* comment */
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ a {} /* comment */
 
 There _must never_ be an empty line before comments.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ a {}
 /* comment */
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -84,7 +84,7 @@ Reverse the primary option for comments that are nested and the first child of t
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -95,7 +95,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -113,7 +113,7 @@ Ignore comments that follow another comment.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -144,7 +144,7 @@ Ignore comments that deliver commands to stylelint, e.g. `/* stylelint-disable c
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -155,7 +155,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -176,7 +176,7 @@ For example, with `"always"` and given:
 ["/^ignore/", "string-ignore"]
 ```
 
-The following comments are _not_ considered violations:
+The following comments are _not_ considered problems:
 
 ```css
 :root {

--- a/lib/rules/comment-no-empty/README.md
+++ b/lib/rules/comment-no-empty/README.md
@@ -17,7 +17,7 @@ This rule ignores SCSS-like comments.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ The following patterns are considered violations:
  */
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -21,7 +21,7 @@ Given the string:
 "foo .+"
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ The following patterns are considered violations:
 a { color: red; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/comment-whitespace-inside/README.md
+++ b/lib/rules/comment-whitespace-inside/README.md
@@ -23,7 +23,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be whitespace inside the markers.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ The following patterns are considered violations:
 /** comment**/
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -69,7 +69,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace on the inside the markers.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -86,7 +86,7 @@ The following patterns are considered violations:
 /** comment**/
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -23,7 +23,7 @@ Given:
 ["/^TODO:/", "badword"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ The following patterns are considered violations:
 /* some badword */
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -21,14 +21,14 @@ Given the string:
 "foo-.+"
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 @custom-media --bar (min-width: 30em);
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -21,7 +21,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"always"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a {
 
 ### `"never"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -69,7 +69,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -100,7 +100,7 @@ Shared-line comments do not trigger this option.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -122,7 +122,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -152,7 +152,7 @@ Shared-line comments do not affect this option.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -174,7 +174,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -200,7 +200,7 @@ Reverse the primary option for custom properties that are nested and the first c
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -212,7 +212,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -231,7 +231,7 @@ Ignore custom properties that follow a comment.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -247,7 +247,7 @@ Ignore custom properties that are nested and the first child of their parent nod
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -264,7 +264,7 @@ Ignore custom properties that are inside single-line blocks.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/custom-property-no-missing-var-function/README.md
+++ b/lib/rules/custom-property-no-missing-var-function/README.md
@@ -16,7 +16,7 @@ This rule only reports custom properties that are defined within the same source
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -30,7 +30,7 @@ a { color: --foo; }
 a { color: --foo; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -21,14 +21,14 @@ Given the string:
 "foo-.+"
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 :root { --boo-bar: 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-bang-space-after/README.md
+++ b/lib/rules/declaration-bang-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the bang.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { color: pink !important; }
 a { color: pink      !important; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a { color: pink! important; }
 
 There _must never_ be whitespace after the bang.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a { color: pink ! important; }
 a { color: pink! important; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-bang-space-before/README.md
+++ b/lib/rules/declaration-bang-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the bang.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { color: pink!important; }
 a { color: pink  ! important; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,14 +47,14 @@ a { color:pink ! important; }
 
 There _must never_ be whitespace before the bang.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color : pink !important; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
@@ -15,7 +15,7 @@ This rule is case-sensitive.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -27,7 +27,7 @@ a { --custom-property: pink; --custom-property: orange; }
 a { --custom-property: pink; background: orange; --custom-property: orange }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-no-duplicate-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-properties/README.md
@@ -15,7 +15,7 @@ This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -27,7 +27,7 @@ a { color: pink; color: orange; }
 a { color: pink; background: orange; color: orange }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ Ignore consecutive duplicated properties.
 
 They can prove to be useful fallbacks for older browsers.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -58,7 +58,7 @@ p {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ Ignore consecutive duplicated properties with different values.
 
 Including duplicate properties (fallbacks) is useful to deal with older browsers support for CSS properties. E.g. using `px` units when `rem` isn't available.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ p {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -118,7 +118,7 @@ Given:
 ["color", "/background-/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -130,7 +130,7 @@ a { color: pink; background: orange; background: white; }
 a { background: orange; color: pink; background: white; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -62,7 +62,7 @@ This rule complains when the following shorthand properties can be used:
 - `text-emphasis`
 - `mask`
 
-**Please note** that properties are considered to be redundant if they may be written shorthand according to the specification, **regardless of the behavior of any individual browser**. For example, due to Internet Explorer's implementation of Flexbox, [it may not be possible to use the shorthand property `flex`](https://github.com/philipwalton/flexbugs#flexbug-8), but the longhand form is still considered a violation.
+**Please note** that properties are considered to be redundant if they may be written shorthand according to the specification, **regardless of the behavior of any individual browser**. For example, due to Internet Explorer's implementation of Flexbox, [it may not be possible to use the shorthand property `flex`](https://github.com/philipwalton/flexbugs#flexbug-8), but the longhand form is still considered a problem.
 
 Flexbox-related properties can be ignored using `ignoreShorthands: ["/flex/"]` (see below).
 
@@ -70,7 +70,7 @@ Flexbox-related properties can be ignored using `ignoreShorthands: ["/flex/"]` (
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -105,7 +105,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -155,7 +155,7 @@ Given:
 ["padding", "/border/"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
@@ -15,7 +15,7 @@ In almost every case, this is just an authorial oversight. For more about this b
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-semicolon-newline-after/README.md
+++ b/lib/rules/declaration-block-semicolon-newline-after/README.md
@@ -39,7 +39,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the semicolon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -55,7 +55,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,7 +77,7 @@ a {
 
 There _must always_ be a newline after the semicolon in multi-line rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -86,7 +86,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -110,7 +110,7 @@ a {
 
 There _must never_ be whitespace after the semicolon in multi-line rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -120,7 +120,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-semicolon-newline-before/README.md
+++ b/lib/rules/declaration-block-semicolon-newline-before/README.md
@@ -22,7 +22,7 @@ This rule ignores semicolons that are preceded by Less mixins.
 
 There _must always_ be a newline before the semicolons.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -56,7 +56,7 @@ a {
 
 There _must always_ be a newline before the semicolons in multi-line rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -65,7 +65,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -89,7 +89,7 @@ a {
 
 There _must never_ be whitespace before the semicolons in multi-line rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -99,7 +99,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-semicolon-space-after/README.md
+++ b/lib/rules/declaration-block-semicolon-space-after/README.md
@@ -26,7 +26,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the semicolon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ a { color: pink; top: 0; }
 
 There _must never_ be whitespace after the semicolon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,7 +77,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -98,14 +98,14 @@ a { color: pink;top: 0; }
 
 There _must always_ be a single space after the semicolon in single-line declaration blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink;top: 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -124,14 +124,14 @@ a {
 
 There _must never_ be whitespace after the semicolon in single-line declaration blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; top: 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-semicolon-space-before/README.md
+++ b/lib/rules/declaration-block-semicolon-space-before/README.md
@@ -21,7 +21,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the semicolons.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ a { color: pink; }
 a { color: pink; top: 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { color: pink ; top: 0 ; }
 
 There _must never_ be whitespace before the semicolons.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ a { color: pink ; }
 a { color: pink ; top: 0 ; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,14 +77,14 @@ a { color: pink; top: 0; }
 
 There _must always_ be a single space before the semicolons in single-line declaration blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -105,14 +105,14 @@ a { color: pink ; top: 0 ; }
 
 There _must never_ be whitespace before the semicolons in single-line declaration blocks.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink ; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-single-line-max-declarations/README.md
+++ b/lib/rules/declaration-block-single-line-max-declarations/README.md
@@ -15,7 +15,7 @@ a { color: pink; top: 0; }
 
 For example, with `1`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -28,7 +28,7 @@ a,
 b { color: pink; top: 3px; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-trailing-semicolon/README.md
+++ b/lib/rules/declaration-block-trailing-semicolon/README.md
@@ -27,7 +27,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a trailing semicolon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -44,7 +44,7 @@ a { background: orange; color: pink }
 a { @include foo }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -65,7 +65,7 @@ a { @include foo; }
 
 There _must never_ be a trailing semicolon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,7 +77,7 @@ a { color: pink; }
 a { background: orange; color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -95,7 +95,7 @@ a { background: orange; color: pink }
 
 Ignore declaration blocks that contain a single declaration.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-colon-newline-after/README.md
+++ b/lib/rules/declaration-colon-newline-after/README.md
@@ -23,7 +23,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -35,7 +35,7 @@ a { color:pink; }
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a {
 
 There _must always_ be a newline after the colon _if the declaration's value is multi-line_.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-colon-space-after/README.md
+++ b/lib/rules/declaration-colon-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { color :pink }
 a { color:pink }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a { color: pink }
 
 There _must never_ be whitespace after the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a { color : pink }
 a { color: pink }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ a { color:pink }
 
 There _must always_ be a single space after the colon _if the declaration's value is single-line_.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -84,7 +84,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-colon-space-before/README.md
+++ b/lib/rules/declaration-colon-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { color: pink }
 a { color:pink }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a { color :pink }
 
 There _must never_ be whitespace before the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a { color : pink }
 a { color :pink }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-empty-line-before/README.md
+++ b/lib/rules/declaration-empty-line-before/README.md
@@ -23,7 +23,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"always"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -64,7 +64,7 @@ a {
 
 ### `"never"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -85,7 +85,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -115,7 +115,7 @@ Shared-line comments do not trigger this option.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -134,7 +134,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -163,7 +163,7 @@ Shared-line comments do not affect this option.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -185,7 +185,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -211,7 +211,7 @@ Reverse the primary option for declarations that are nested and the first child 
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -223,7 +223,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -242,7 +242,7 @@ Ignore declarations that follow a comment.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -258,7 +258,7 @@ Ignore declarations that follow another declaration.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -297,7 +297,7 @@ Ignore declarations that are nested and the first child of their parent node.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -314,7 +314,7 @@ Ignore declarations that are inside single-line blocks.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-no-important/README.md
+++ b/lib/rules/declaration-no-important/README.md
@@ -15,7 +15,7 @@ If you always want `!important` in your declarations, e.g. if you're writing [us
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a { color: pink ! important; }
 a { color: pink!important; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -25,7 +25,7 @@ Given:
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ a { animation-duration: 500ms; }
 a { line-height: 13px; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -104,7 +104,7 @@ For example, given:
 ]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -24,7 +24,7 @@ Given:
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -46,7 +46,7 @@ a { -webkit-animation: animation-name 5s ease; }
 a { animation-duration: 5s; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -31,7 +31,7 @@ Given:
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -58,7 +58,7 @@ a { color: pink; }
 a { background-color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -30,7 +30,7 @@ Given:
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -67,7 +67,7 @@ a { animation-timing-function: ease-in-out; }
 a { -webkit-animation-timing-function: ease-in-out; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/font-family-name-quotes/README.md
+++ b/lib/rules/font-family-name-quotes/README.md
@@ -32,7 +32,7 @@ For more on these subtleties, read ["Unquoted font family names in CSS"](https:/
 
 Expect quotes around every font family name that is not a keyword.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { font-family: Times New Roman, Times, serif; }
 a { font: 1em Arial, sans-serif; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -70,7 +70,7 @@ a { font: 1em 'Arial', sans-serif; }
 
 Expect quotes only when quotes are _required_ according to the criteria above, and disallow quotes in all other cases.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -87,7 +87,7 @@ a { font-family: 'Times New Roman', Times, serif; }
 a { font: 1em "Arial", sans-serif; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -118,7 +118,7 @@ a { font: 1em Arial, sans-serif; }
 
 Expect quotes only when quotes are _recommended_ according to the criteria above, and disallow quotes in all other cases. (This includes all cases where quotes are _required_, as well.)
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -140,7 +140,7 @@ a { font-family: 'Arial', sans-serif; }
 a { font: 1em Times New Roman, Times, serif; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/font-family-no-duplicate-names/README.md
+++ b/lib/rules/font-family-no-duplicate-names/README.md
@@ -19,7 +19,7 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ a { font: 1em "Arial", 'Arial', sans-serif; }
 a { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif, sans-serif; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ Given:
 ["/^My Font /", "monospace"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -20,7 +20,7 @@ This rule checks the `font` and `font-family` properties.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a { font-family: Helvetica, Arial, Verdana, Tahoma; }
 a { font: 1em/1.3 Times; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -74,14 +74,14 @@ Given:
 ["custom-font"]
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css
 a { font-family: custom-font; }
 ```
 
-The following pattern is considered a violation:
+The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/font-weight-notation/README.md
+++ b/lib/rules/font-weight-notation/README.md
@@ -25,7 +25,7 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 `font-weight` values _must always_ be numbers.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -37,7 +37,7 @@ a { font-weight: bold; }
 a { font: italic normal 20px sans-serif; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -55,7 +55,7 @@ a { font: italic 400 20px; }
 
 This means that only `400` and `700` will be rejected, because those are the only numbers with keyword equivalents (`normal` and `bold`).
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -67,7 +67,7 @@ a { font-weight: 700; }
 a { font: italic 400 20px sans-serif; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -85,7 +85,7 @@ a { font: italic normal 20px sans-serif; }
 
 Ignore the [_relative_](https://drafts.csswg.org/css-fonts/#font-weight-prop) keyword names of `bolder` and `lighter`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-allowed-list/README.md
+++ b/lib/rules/function-allowed-list/README.md
@@ -21,7 +21,7 @@ Given:
 ["scale", "rgba", "linear-gradient"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -44,7 +44,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-calc-no-unspaced-operator/README.md
+++ b/lib/rules/function-calc-no-unspaced-operator/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ a { top: calc(1px+2px); }
 a { top: calc(1px+ 2px); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-comma-newline-after/README.md
+++ b/lib/rules/function-comma-newline-after/README.md
@@ -20,7 +20,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,7 +38,7 @@ a { transform: translate(1
   ,1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ a {
 
 There _must always_ be a newline after the commas in multi-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -60,7 +60,7 @@ a { transform: translate(1
   ,1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -84,7 +84,7 @@ a {
 
 There _must never_ be whitespace after the commas in multi-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -92,7 +92,7 @@ a { transform: translate(1
   , 1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-comma-newline-before/README.md
+++ b/lib/rules/function-comma-newline-before/README.md
@@ -20,7 +20,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,7 +38,7 @@ a { transform: translate(1,
   1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -60,7 +60,7 @@ a {
 
 There _must always_ be a newline before the commas in multi-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -68,7 +68,7 @@ a { transform: translate(1,
   1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -100,7 +100,7 @@ a {
 
 There _must never_ be whitespace before the commas in multi-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -108,7 +108,7 @@ a { transform: translate(1 ,
   1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-comma-space-after/README.md
+++ b/lib/rules/function-comma-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { transform: translate(1,1) }
 a { transform: translate(1 ,1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a { transform: translate(1 , 1) }
 
 There _must never_ be whitespace after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a { transform: translate(1, 1) }
 a { transform: translate(1 , 1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ a { transform: translate(1 ,1) }
 
 There _must always_ be a single space after the commas in single-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -87,7 +87,7 @@ a { transform: translate(1,1) }
 a { transform: translate(1 ,1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -111,7 +111,7 @@ a {
 
 There _must never_ be whitespace after the commas in single-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -123,7 +123,7 @@ a { transform: translate(1, 1) }
 a { transform: translate(1 , 1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-comma-space-before/README.md
+++ b/lib/rules/function-comma-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { transform: translate(1,1) }
 a { transform: translate(1, 1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a { transform: translate(1 , 1) }
 
 There _must never_ be whitespace before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a { transform: translate(1 ,1) }
 a { transform: translate(1 , 1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ a { transform: translate(1, 1) }
 
 There _must always_ be a single space before the commas in single-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -87,7 +87,7 @@ a { transform: translate(1,1) }
 a { transform: translate(1, 1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -111,7 +111,7 @@ a {
 
 There _must never_ be whitespace before the commas in single-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -123,7 +123,7 @@ a { transform: translate(1 ,1) }
 a { transform: translate(1 , 1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-disallowed-list/README.md
+++ b/lib/rules/function-disallowed-list/README.md
@@ -21,7 +21,7 @@ Given:
 ["scale", "rgba", "linear-gradient"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -44,7 +44,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
@@ -21,7 +21,7 @@ A common mistake (matching outdated non-standard syntax) is to use just a side-o
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -48,7 +48,7 @@ The following patterns are considered violations:
 .foo { background: linear-gradient(to top top, #fff, #000); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-max-empty-lines/README.md
+++ b/lib/rules/function-max-empty-lines/README.md
@@ -26,7 +26,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 For example, with `0`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -64,7 +64,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-name-case/README.md
+++ b/lib/rules/function-name-case/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -67,7 +67,7 @@ a {
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -127,7 +127,7 @@ Given:
 ["some-function", "/^get.*$/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -157,7 +157,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-parentheses-newline-inside/README.md
+++ b/lib/rules/function-parentheses-newline-inside/README.md
@@ -24,7 +24,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline inside the parentheses.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,7 +38,7 @@ a { transform: translate(1,
   ); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ a {
 
 There _must always_ be a newline inside the parentheses of multi-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -71,7 +71,7 @@ a { transform: translate(1,
   1) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -104,7 +104,7 @@ a {
 
 ### `"never-multi-line"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -125,7 +125,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-parentheses-space-inside/README.md
+++ b/lib/rules/function-parentheses-space-inside/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space inside of the parentheses.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { transform: translate(1, 1); }
 a { transform: translate(1, 1 ); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -42,7 +42,7 @@ a { transform: translate( 1, 1 ); }
 
 There _must never_ be whitespace on the inside of the parentheses.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ a { transform: translate( 1, 1 ); }
 a { transform: translate(1, 1 ); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -65,7 +65,7 @@ a { transform: translate(1, 1); }
 
 There _must always_ be a single space inside the parentheses of single-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,7 +77,7 @@ a { transform: translate(1, 1) }
 a { transform: translate(1, 1 ) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -104,7 +104,7 @@ a {
 
 There _must never_ be whitespace inside the parentheses of single-line functions.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -116,7 +116,7 @@ a { transform: translate( 1, 1 ) }
 a { transform: translate(1, 1 ) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-url-no-scheme-relative/README.md
+++ b/lib/rules/function-url-no-scheme-relative/README.md
@@ -17,7 +17,7 @@ This rule ignores url arguments that are variables (`$sass`, `@less`, `--custom-
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -26,7 +26,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-url-quotes/README.md
+++ b/lib/rules/function-url-quotes/README.md
@@ -17,7 +17,7 @@ a { background: url("x.jpg") }
 
 Urls _must always_ be quoted.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -39,7 +39,7 @@ The following patterns are considered violations:
 @-moz-document url-prefix() {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -70,7 +70,7 @@ a { background: url('x.jpg'); }
 
 Urls _must never_ be quoted.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -87,7 +87,7 @@ a { background: url('x.jpg'); }
 @font-face { font-family: "foo"; src: url('foo.ttf'); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -112,7 +112,7 @@ Reverse the primary option for functions that have no arguments.
 
 For example, with `"always"`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-url-scheme-allowed-list/README.md
+++ b/lib/rules/function-url-scheme-allowed-list/README.md
@@ -26,14 +26,14 @@ Given:
 ["data", "/^http/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { background-image: url('file://file.jpg'); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-url-scheme-disallowed-list/README.md
+++ b/lib/rules/function-url-scheme-disallowed-list/README.md
@@ -26,7 +26,7 @@ Given:
 ["ftp", "/^http/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -43,7 +43,7 @@ a { background-image: url('http://www.example.com/file.jpg'); }
 a { background-image: url('https://www.example.com/file.jpg'); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/function-whitespace-after/README.md
+++ b/lib/rules/function-whitespace-after/README.md
@@ -21,14 +21,14 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be whitespace after the function.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { transform: translate(1, 1)scale(3); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -65,14 +65,14 @@ a { padding: calc(1 * 2px), calc(2 * 5px); }
 
 There _must never_ be whitespace after the function.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { transform: translate(1, 1) scale(3); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/hue-degree-notation/README.md
+++ b/lib/rules/hue-degree-notation/README.md
@@ -21,7 +21,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Degree hues _must always_ use angle notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ a { color: hsl(198 28% 50%) }
 a { color: lch(56.29% 19.86 10 / 15%) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { color: lch(56.29% 19.86 10deg / 15%) }
 
 Degree hues _must always_ use the number notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ a { color: hsl(198deg 28% 50%) }
 a { color: lch(56.29% 19.86 10deg / 15%) }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/indentation/README.md
+++ b/lib/rules/indentation/README.md
@@ -24,7 +24,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Always indent at-rules, rules, comments, declarations, inside parentheses and multi-line values by 2 spaces.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -95,7 +95,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -211,7 +211,7 @@ If `true`, the closing brace of a block (rule or at-rule) will be expected at th
 
 For example, with `indentClosingBrace: true`.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -229,7 +229,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -253,7 +253,7 @@ Do _not_ indent for these things.
 
 For example, with `2`.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -267,7 +267,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -289,7 +289,7 @@ Ignore the indentation inside parentheses.
 
 For example, with `2`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -309,7 +309,7 @@ Ignore the indentation of at-rule params.
 
 For example, with `2`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -325,7 +325,7 @@ Ignore the indentation of values.
 
 For example, with `2`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/keyframe-declaration-no-important/README.md
+++ b/lib/rules/keyframe-declaration-no-important/README.md
@@ -18,7 +18,7 @@ Using `!important` within keyframes declarations is [completely ignored in some 
 
 ### `true`
 
-The following patterns is considered a violation:
+The following patterns is considered a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ The following patterns is considered a violation:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/keyframes-name-pattern/README.md
+++ b/lib/rules/keyframes-name-pattern/README.md
@@ -21,7 +21,7 @@ Given the string:
 "foo-.+"
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,7 +38,7 @@ The following patterns are considered violations:
 @keyframes FOO-bar {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/length-zero-no-unit/README.md
+++ b/lib/rules/length-zero-no-unit/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { top: 0px }
 a { top: 0.000em }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ a { top: 1.001vh }
 
 Ignore units for zero length in custom properties.
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -76,7 +76,7 @@ Given:
 ["var", "/^--/"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/linebreaks/README.md
+++ b/lib/rules/linebreaks/README.md
@@ -12,10 +12,10 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Linebreaks _must always_ be LF (`\n`).
 
-Lines with CRLF linebreaks are considered violations.
+Lines with CRLF linebreaks are considered problems.
 
 ### `"windows"`
 
 Linebreaks _must always_ be CRLF (`\r\n`).
 
-Lines with LF linebreaks are considered violations.
+Lines with LF linebreaks are considered problems.

--- a/lib/rules/max-empty-lines/README.md
+++ b/lib/rules/max-empty-lines/README.md
@@ -20,7 +20,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a {}
 b {}
 ```
 
-Comment strings are also checked -- so the following is a violation:
+Comment strings are also checked -- so the following is a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -44,7 +44,7 @@ Comment strings are also checked -- so the following is a violation:
  */
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ Only enforce the adjacent empty lines limit for lines that are not comments.
 
 For example, with `2` adjacent empty lines:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -87,7 +87,7 @@ a {}
 b {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -105,7 +105,7 @@ const rule = (primary, secondaryOptions, context) => {
 		 */
 		function checkMatch(source, matchStartIndex, matchEndIndex, node) {
 			const eof = matchEndIndex === source.length;
-			let violation = false;
+			let problem = false;
 
 			// Additional check for beginning of file
 			if (!matchStartIndex || lastIndex === matchStartIndex) {
@@ -116,11 +116,11 @@ const rule = (primary, secondaryOptions, context) => {
 
 			lastIndex = matchEndIndex;
 
-			if (emptyLines > primary) violation = true;
+			if (emptyLines > primary) problem = true;
 
-			if (!eof && !violation) return;
+			if (!eof && !problem) return;
 
-			if (violation) {
+			if (problem) {
 				report({
 					message: messages.expected(primary),
 					node,

--- a/lib/rules/max-line-length/README.md
+++ b/lib/rules/max-line-length/README.md
@@ -11,7 +11,7 @@ a { color: red }
 
 Lines that exceed the maximum length but contain no whitespace (other than at the beginning of the line) are ignored.
 
-When evaluating the line length, the arguments of any `url(...)` functions are excluded from the calculation, because typically you have no control over the length of these arguments. This means that long `url()` functions should not contribute to violations.
+When evaluating the line length, the arguments of any `url(...)` functions are excluded from the calculation, because typically you have no control over the length of these arguments. This means that long `url()` functions should not contribute to problems.
 
 ## Options
 
@@ -19,7 +19,7 @@ When evaluating the line length, the arguments of any `url(...)` functions are e
 
 For example, with `20`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -60,9 +60,9 @@ This does not apply to comments that are stuck in between other stuff, only to l
 
 For example, with a maximum length of `30`.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
-Each have only one violation.
+Each have only one problem.
 
 <!-- prettier-ignore -->
 ```css
@@ -90,7 +90,7 @@ This also applies to comments that are between code on the same line.
 
 For example, with a maximum length of `30`.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -102,7 +102,7 @@ a { color: pink; } /* comment that is too long */
 a { /* this comment is too long for the max length */ }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -130,7 +130,7 @@ Given:
 "/^@import\\s+/"
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -143,7 +143,7 @@ Given the following, with a maximum length of `20`.
 ["/https?://[0-9,a-z]*.*/"];
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -53,7 +53,7 @@ This rule integrates into Stylelint's core the functionality of the (now depreca
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,7 +77,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -109,7 +109,7 @@ Ignore at-rules that only wrap other rules, and do not themselves have declarati
 
 For example, with `1`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 As the at-rules have a declarations blocks.
 
@@ -131,7 +131,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 As all of the following `.foo` rules would have a nesting depth of just 1.
 
@@ -166,7 +166,7 @@ Ignore rules where the first selector in each selector list item is a pseudo-cla
 
 For example, with `1`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -214,7 +214,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 As all of the following pseudoclasses rules would have a nesting depth of just 1.
 
@@ -288,7 +288,7 @@ For example, with `1` and given:
 ["/^--my-/", "media"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -334,7 +334,7 @@ a {
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-colon-space-after/README.md
+++ b/lib/rules/media-feature-colon-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 @media (max-width :600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace after the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ The following patterns are considered violations:
 @media (max-width : 600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-colon-space-before/README.md
+++ b/lib/rules/media-feature-colon-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 @media (max-width: 600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace before the colon.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ The following patterns are considered violations:
 @media (max-width : 600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-name-allowed-list/README.md
+++ b/lib/rules/media-feature-name-allowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["max-width", "/^my-/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ The following patterns are considered violations:
 @media (10em < min-width < 50em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-name-case/README.md
+++ b/lib/rules/media-feature-name-case/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -39,7 +39,7 @@ The following patterns are considered violations:
 @media (WIDTH > 10em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ The following patterns are _not_ considered violations:
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -85,7 +85,7 @@ The following patterns are considered violations:
 @media (10em < width <= 50em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-name-disallowed-list/README.md
+++ b/lib/rules/media-feature-name-disallowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["max-width", "/^my-/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ The following patterns are considered violations:
 @media (10em < my-height < 50em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-name-no-unknown/README.md
+++ b/lib/rules/media-feature-name-no-unknown/README.md
@@ -17,7 +17,7 @@ This rule ignores vendor-prefixed media feature names.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -34,7 +34,7 @@ The following patterns are considered violations:
 @media screen and (unknown > 10px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -71,7 +71,7 @@ Given:
 ["/^my-/", "custom"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/lib/rules/media-feature-name-no-vendor-prefix/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -34,7 +34,7 @@ The following patterns are considered violations:
 @media (-o-max-device-pixel-ratio: 1/1) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-name-value-allowed-list/README.md
+++ b/lib/rules/media-feature-name-value-allowed-list/README.md
@@ -34,7 +34,7 @@ Given:
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ The following patterns are considered violations:
 @media screen and (min-width > 1000px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-parentheses-space-inside/README.md
+++ b/lib/rules/media-feature-parentheses-space-inside/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space inside the parentheses.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 @media (max-width: 300px ) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -42,7 +42,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace on the inside the parentheses.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ The following patterns are considered violations:
 @media ( max-width: 300px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-parentheses-space-inside/index.js
+++ b/lib/rules/media-feature-parentheses-space-inside/index.js
@@ -33,7 +33,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			const params = (atRule.raws.params && atRule.raws.params.raw) || atRule.params;
 			const indexBoost = atRuleParamIndex(atRule);
 			/** @type {Array<{ message: string, index: number }>} */
-			const violations = [];
+			const problems = [];
 
 			const parsedParams = valueParser(params).walk((node) => {
 				if (node.type === 'function') {
@@ -43,7 +43,7 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (/[ \t]/.test(node.before)) {
 							if (context.fix) node.before = '';
 
-							violations.push({
+							problems.push({
 								message: messages.rejectedOpening,
 								index: node.sourceIndex + 1 + indexBoost,
 							});
@@ -52,7 +52,7 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (/[ \t]/.test(node.after)) {
 							if (context.fix) node.after = '';
 
-							violations.push({
+							problems.push({
 								message: messages.rejectedClosing,
 								index: node.sourceIndex - 2 + len + indexBoost,
 							});
@@ -61,7 +61,7 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (node.before === '') {
 							if (context.fix) node.before = ' ';
 
-							violations.push({
+							problems.push({
 								message: messages.expectedOpening,
 								index: node.sourceIndex + 1 + indexBoost,
 							});
@@ -70,7 +70,7 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (node.after === '') {
 							if (context.fix) node.after = ' ';
 
-							violations.push({
+							problems.push({
 								message: messages.expectedClosing,
 								index: node.sourceIndex - 2 + len + indexBoost,
 							});
@@ -79,14 +79,14 @@ const rule = (primary, _secondaryOptions, context) => {
 				}
 			});
 
-			if (violations.length) {
+			if (problems.length) {
 				if (context.fix) {
 					atRule.params = parsedParams.toString();
 
 					return;
 				}
 
-				violations.forEach((err) => {
+				problems.forEach((err) => {
 					report({
 						message: err.message,
 						node: atRule,

--- a/lib/rules/media-feature-range-operator-space-after/README.md
+++ b/lib/rules/media-feature-range-operator-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the range operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 @media (width >=600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace after the range operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ The following patterns are considered violations:
 @media (width >= 600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-feature-range-operator-space-before/README.md
+++ b/lib/rules/media-feature-range-operator-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the range operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 @media (width>= 600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace before the range operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ The following patterns are considered violations:
 @media (width >= 600px) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-query-list-comma-newline-after/README.md
+++ b/lib/rules/media-query-list-comma-newline-after/README.md
@@ -20,7 +20,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ The following patterns are considered violations:
 , projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ projection and (color) {}
 
 There _must always_ be a newline after the commas in multi-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -60,7 +60,7 @@ The following patterns are considered violations:
 , projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -84,7 +84,7 @@ projection and (color) {}
 
 There _must never_ be whitespace after the commas in multi-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -99,7 +99,7 @@ projection and (color) {}
 projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-query-list-comma-newline-before/README.md
+++ b/lib/rules/media-query-list-comma-newline-before/README.md
@@ -18,7 +18,7 @@ Require a newline or disallow whitespace before the commas of media query lists.
 
 There _must always_ be a newline before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -50,7 +50,7 @@ projection and (color) {}
 
 There _must always_ be a newline before the commas in multi-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -58,7 +58,7 @@ The following patterns are considered violations:
 projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -82,7 +82,7 @@ projection and (color) {}
 
 There _must never_ be whitespace before the commas in multi-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ The following patterns are considered violations:
 projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-query-list-comma-space-after/README.md
+++ b/lib/rules/media-query-list-comma-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ The following patterns are considered violations:
 ,projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ The following patterns are considered violations:
 , projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,14 +79,14 @@ The following patterns are _not_ considered violations:
 
 There _must always_ be a single space after the commas in single-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 @media screen and (color),projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -109,14 +109,14 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace after the commas in single-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 @media screen and (color), projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/media-query-list-comma-space-before/README.md
+++ b/lib/rules/media-query-list-comma-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ The following patterns are considered violations:
 ,projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ projection and (color) {}
 
 There _must never_ be whitespace before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ The following patterns are considered violations:
 , projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,14 +79,14 @@ projection and (color) {}
 
 There _must always_ be a single space before the commas in single-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 @media screen and (color),projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -109,14 +109,14 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace before the commas in single-line media query lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 @media screen and (color) , projection and (color) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -22,7 +22,7 @@ And all named grid areas that spans multiple grid cells must form a single fille
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ a { grid-template-areas: "a a a"
                          "b b a"; }
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -54,7 +54,7 @@ It may be possible to restructure your CSS to remove the error, otherwise it is 
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -90,7 +90,7 @@ b {}
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -146,7 +146,7 @@ a {}
 
 Ignores selectors within list of selectors.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -157,7 +157,7 @@ h3 {}
 a {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-duplicate-at-import-rules/README.md
+++ b/lib/rules/no-duplicate-at-import-rules/README.md
@@ -14,7 +14,7 @@ Disallow duplicate `@import` rules within a stylesheet.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ The following patterns are considered violations:
 @import url(a.css);
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-duplicate-selectors/README.md
+++ b/lib/rules/no-duplicate-selectors/README.md
@@ -20,13 +20,13 @@ The same selector _is_ allowed to repeat in the following circumstances:
 - The duplicates are determined to originate in different stylesheets, e.g. you have concatenated or compiled files in a way that produces sourcemaps for PostCSS to read, e.g. postcss-import.
 - The duplicates are in rules with different parent nodes, e.g. inside and outside of a media query.
 
-This rule resolves nested selectors. So `a b {} a { & b {} }` counts as a violation, because the resolved selectors end up with a duplicate.
+This rule resolves nested selectors. So `a b {} a { & b {} }` counts as a problem, because the resolved selectors end up with a duplicate.
 
 ## Options
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,7 +79,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -121,7 +121,7 @@ This option will also disallow duplicate selectors within selector lists.
 
 For example, with `true`.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-empty-first-line/README.md
+++ b/lib/rules/no-empty-first-line/README.md
@@ -18,7 +18,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -26,7 +26,7 @@ The following patterns are considered violations:
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-empty-source/README.md
+++ b/lib/rules/no-empty-source/README.md
@@ -15,7 +15,7 @@ A source containing only whitespace is considered empty.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ The following patterns are considered violations:
 \n
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-eol-whitespace/README.md
+++ b/lib/rules/no-eol-whitespace/README.md
@@ -15,7 +15,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -27,7 +27,7 @@ a { color: pink; }·
 a { color: pink; }····
 ```
 
-Comment strings are also checked -- so the following is a violation:
+Comment strings are also checked -- so the following is a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -35,7 +35,7 @@ Comment strings are also checked -- so the following is a violation:
  * something else */
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -56,7 +56,7 @@ a { color: pink; }
 
 Allow end-of-line whitespace for lines that are only whitespace, "empty" lines.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-extra-semicolons/README.md
+++ b/lib/rules/no-extra-semicolons/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ b {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-invalid-double-slash-comments/README.md
+++ b/lib/rules/no-invalid-double-slash-comments/README.md
@@ -17,7 +17,7 @@ If you are using a preprocessor that allows `//` single-line comments (e.g. Sass
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -39,7 +39,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-invalid-position-at-import-rule/README.md
+++ b/lib/rules/no-invalid-position-at-import-rule/README.md
@@ -16,7 +16,7 @@ Any `@import` rules must precede all other valid at-rules and style rules in a s
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -30,7 +30,7 @@ a {}
 @import 'foo.css';
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -60,7 +60,7 @@ Given:
 ["/^--my-/", "--custom"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-irregular-whitespace/README.md
+++ b/lib/rules/no-irregular-whitespace/README.md
@@ -13,14 +13,14 @@ Disallow irregular whitespaces.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 .firstClass .secondClass {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-missing-end-of-source-newline/README.md
+++ b/lib/rules/no-missing-end-of-source-newline/README.md
@@ -10,7 +10,7 @@ Disallow missing end-of-source newlines.
  * This newline */
 ```
 
-Completely empty files are not considered violations.
+Completely empty files are not considered problems.
 
 The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
 
@@ -18,14 +18,14 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/no-unknown-animations/README.md
+++ b/lib/rules/no-unknown-animations/README.md
@@ -19,7 +19,7 @@ This rule considers the identifiers of `@keyframes` rules defined within the sam
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { animation-name: jump; }
 @keyframes fancy-slide {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/number-leading-zero/README.md
+++ b/lib/rules/number-leading-zero/README.md
@@ -21,7 +21,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a leading zero.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ a { line-height: .5; }
 a { transform: translate(2px, .4px); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { transform: translate(2px, 0.4px); }
 
 There _must never_ be a leading zero.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ a { line-height: 0.5; }
 a { transform: translate(2px, 0.4px); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/number-max-precision/README.md
+++ b/lib/rules/number-max-precision/README.md
@@ -15,7 +15,7 @@ a { top: 3.245634px; }
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a { top: 3.245634px; }
 @media (min-width: 3.234em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -58,14 +58,14 @@ Given:
 ["transition"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { top: 10.5px; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -84,7 +84,7 @@ Given:
 ["/^my-/", "%"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -101,7 +101,7 @@ a { top: 3.245634px; }
 @media (min-width: 3.234em) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/number-no-trailing-zeros/README.md
+++ b/lib/rules/number-no-trailing-zeros/README.md
@@ -15,7 +15,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -27,7 +27,7 @@ a { top: 1.0px }
 a { top: 1.01000px }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/property-allowed-list/README.md
+++ b/lib/rules/property-allowed-list/README.md
@@ -23,7 +23,7 @@ Given:
 ["display", "animation", "/^background/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -43,7 +43,7 @@ a {
 a { borkgrund: orange; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/property-case/README.md
+++ b/lib/rules/property-case/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -93,7 +93,7 @@ a {
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -137,7 +137,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/property-disallowed-list/README.md
+++ b/lib/rules/property-disallowed-list/README.md
@@ -21,7 +21,7 @@ Given:
 ["text-rendering", "animation", "/^background/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ a { background: pink; }
 a { background-size: cover; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -22,7 +22,7 @@ Use option `checkPrefixed` described below to turn on checking of vendor-prefixe
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,7 +38,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -85,7 +85,7 @@ Given:
 ["/^my-/", "custom"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -118,7 +118,7 @@ Given:
 [":root"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -137,7 +137,7 @@ Given:
 ["supports"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -154,7 +154,7 @@ If `true`, this rule will check vendor-prefixed properties.
 
 For example with `true`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -170,7 +170,7 @@ a {
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/property-no-vendor-prefix/README.md
+++ b/lib/rules/property-no-vendor-prefix/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ a { -webkit-transform: scale(1); }
 a { -moz-columns: 2; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -57,7 +57,7 @@ Given:
 ["transform", "columns"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/rule-empty-line-before/README.md
+++ b/lib/rules/rule-empty-line-before/README.md
@@ -23,7 +23,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be an empty line before rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ a {}
 b {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ b {}
 
 There _must never_ be an empty line before rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -58,7 +58,7 @@ a {}
 b {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ b {}
 
 There _must always_ be an empty line before multi-line rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -87,7 +87,7 @@ b {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -104,7 +104,7 @@ b {
 
 There _must never_ be an empty line before multi-line rules.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -117,7 +117,7 @@ b {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -139,7 +139,7 @@ Reverse the primary option for rules that follow another rule.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -148,7 +148,7 @@ a {}
 b {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -162,7 +162,7 @@ Reverse the primary option for rules that follow a single-line comment.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -171,7 +171,7 @@ The following patterns are considered violations:
 a {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -185,7 +185,7 @@ Reverse the primary option for rules that are inside a block and follow another 
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -197,7 +197,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -214,7 +214,7 @@ Reverse the primary option for rules that are inside a block.
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -228,7 +228,7 @@ a {
 
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -246,7 +246,7 @@ Reverse the primary option for rules that are nested and the first child of thei
 
 For example, with `"always"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -258,7 +258,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -277,7 +277,7 @@ Ignore rules that follow a comment.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -291,7 +291,7 @@ Ignore rules that are nested and the first child of their parent node.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -308,7 +308,7 @@ Ignore rules that are inside a block.
 
 For example, with `"always"`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-attribute-brackets-space-inside/README.md
+++ b/lib/rules/selector-attribute-brackets-space-inside/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space inside the brackets.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ The following patterns are considered violations:
 [target=_blank ] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -67,7 +67,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be whitespace on the inside the brackets.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -99,7 +99,7 @@ The following patterns are considered violations:
 [ target=_blank ] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-attribute-name-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-name-disallowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["class", "id", "/^data-/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ The following patterns are considered violations:
 [data-foo*="bar"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-attribute-operator-allowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-allowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["=", "|="]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ The following patterns are considered violations:
 [class^="top"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-attribute-operator-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-disallowed-list/README.md
@@ -19,14 +19,14 @@ Given:
 ["*="]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 [class*="test"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-attribute-operator-space-after/README.md
+++ b/lib/rules/selector-attribute-operator-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ The following patterns are considered violations:
 [target ="_blank"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -92,7 +92,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be a single space after the operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -124,7 +124,7 @@ The following patterns are considered violations:
 [target = "_blank"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-attribute-operator-space-before/README.md
+++ b/lib/rules/selector-attribute-operator-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ The following patterns are considered violations:
 [target= "_blank"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -92,7 +92,7 @@ The following patterns are _not_ considered violations:
 
 There _must never_ be a single space before the operator.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -124,7 +124,7 @@ The following patterns are considered violations:
 [target = "_blank"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-attribute-quotes/README.md
+++ b/lib/rules/selector-attribute-quotes/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Attribute values _must always_ be quoted.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 [class^=top] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ The following patterns are _not_ considered violations:
 
 Attribute values _must never_ be quoted.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -84,7 +84,7 @@ The following patterns are considered violations:
 [data-attribute='component'] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -27,7 +27,7 @@ Given the string:
 "foo-[a-z]+";
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -44,7 +44,7 @@ The following patterns are considered violations:
 div > #zing + .foo-BAR {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -80,7 +80,7 @@ Given the string:
 "^[A-Z]+$"
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -89,7 +89,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-combinator-allowed-list/README.md
+++ b/lib/rules/selector-combinator-allowed-list/README.md
@@ -23,7 +23,7 @@ Given:
 [">", " "]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -35,7 +35,7 @@ a + b {}
 a ~ b {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-combinator-disallowed-list/README.md
+++ b/lib/rules/selector-combinator-disallowed-list/README.md
@@ -23,7 +23,7 @@ Given:
 [">", " "]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ a
 b {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-combinator-space-after/README.md
+++ b/lib/rules/selector-combinator-space-after/README.md
@@ -25,7 +25,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the combinators.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -37,7 +37,7 @@ a +b { color: pink; }
 a>b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -53,7 +53,7 @@ a> b { color: pink; }
 
 There _must never_ be whitespace after the combinators.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -65,7 +65,7 @@ a + b { color: pink; }
 a> b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-combinator-space-before/README.md
+++ b/lib/rules/selector-combinator-space-before/README.md
@@ -25,7 +25,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the combinators.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -37,7 +37,7 @@ a+ b { color: pink; }
 a>b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -53,7 +53,7 @@ a >b { color: pink; }
 
 There _must never_ be whitespace before the combinators.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -65,7 +65,7 @@ a + b { color: pink; }
 a >b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-descendant-combinator-no-non-space/README.md
+++ b/lib/rules/selector-descendant-combinator-no-non-space/README.md
@@ -19,7 +19,7 @@ This rule currently ignores selectors containing comments.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ The following patterns are considered violations:
 .bar {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -21,7 +21,7 @@ Given:
 ["a > .foo", "/\\[data-.+]/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,7 +38,7 @@ a[data-auto="1"] {}
 .foo, [data-auto="1"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-id-pattern/README.md
+++ b/lib/rules/selector-id-pattern/README.md
@@ -23,7 +23,7 @@ Given the string:
 "foo-[a-z]+"
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ The following patterns are considered violations:
 div > .zing + #foo-BAR {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-list-comma-newline-after/README.md
+++ b/lib/rules/selector-list-comma-newline-after/README.md
@@ -28,7 +28,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ a
 , b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -60,7 +60,7 @@ b { color: pink; }
 
 There _must always_ be a newline after the commas in multi-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -68,7 +68,7 @@ a
 , b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -92,7 +92,7 @@ b { color: pink; }
 
 There _must never_ be whitespace after the commas in multi-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -106,7 +106,7 @@ a,
 b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-list-comma-newline-before/README.md
+++ b/lib/rules/selector-list-comma-newline-before/README.md
@@ -20,7 +20,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ a,
 b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ a
 
 There _must always_ be a newline before the commas in multi-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a,
 b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -83,7 +83,7 @@ b { color: pink; }
 
 There _must never_ be whitespace before the commas in multi-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -98,7 +98,7 @@ a
 b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-list-comma-space-after/README.md
+++ b/lib/rules/selector-list-comma-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a,b { color: pink; }
 a ,b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a , b { color: pink; }
 
 There _must never_ be whitespace after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a, b { color: pink; }
 a , b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,14 +75,14 @@ a ,b { color: pink; }
 
 There _must always_ be a single space after the commas in single-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a,b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -94,14 +94,14 @@ a
 
 There _must never_ be a single space after the commas in single-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a, b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-list-comma-space-before/README.md
+++ b/lib/rules/selector-list-comma-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a,b { color: pink; }
 a, b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a , b { color: pink; }
 
 There _must never_ be whitespace before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -59,7 +59,7 @@ a ,b { color: pink; }
 a , b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,14 +75,14 @@ a, b { color: pink; }
 
 There _must always_ be a single space before the commas in single-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a,b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -94,14 +94,14 @@ b { color: pink; }
 
 There _must never_ be a single space before the commas in single-line selector lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a ,b { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -19,7 +19,7 @@ The `:not()` pseudo-class is also evaluated separately. The rule processes the a
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -58,7 +58,7 @@ The following patterns are considered violations:
 input:not([type="text"][data-attribute="value"][disabled]) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -100,7 +100,7 @@ Given:
 
 For example, with `0`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-class/README.md
+++ b/lib/rules/selector-max-class/README.md
@@ -20,7 +20,7 @@ The `:not()` pseudo-class is also evaluated separately. The rule processes the a
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -34,7 +34,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-combinators/README.md
+++ b/lib/rules/selector-max-combinators/README.md
@@ -17,7 +17,7 @@ This rule resolves nested selectors before counting the number of combinators se
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ a b {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-compound-selectors/README.md
+++ b/lib/rules/selector-max-compound-selectors/README.md
@@ -22,7 +22,7 @@ This rule resolves nested selectors before counting the depth of a selector. Eac
 
 For example, with `3`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-empty-lines/README.md
+++ b/lib/rules/selector-max-empty-lines/README.md
@@ -21,7 +21,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 For example, with `0`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ b {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -19,7 +19,7 @@ The `:not()` pseudo-class is also evaluated separately. The rule processes the a
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -85,14 +85,14 @@ Given:
 [":not", "/^:(h|H)as$/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a:matches(#foo) {}
 ```
 
-While the following patters are _not_ considered violations:
+While the following patters are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-pseudo-class/README.md
+++ b/lib/rules/selector-max-pseudo-class/README.md
@@ -20,7 +20,7 @@ The content of the `:not()` pseudo-class is also evaluated separately. The rule 
 
 For example, with `1`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a:first-child:focus {}
 .foo .bar:first-child:hover {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -23,7 +23,7 @@ Format is `"id,class,type"`, as laid out in the [W3C selector spec](https://draf
 
 For example, with `"0,2,0"`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -103,7 +103,7 @@ Given:
 ]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -120,7 +120,7 @@ The following patterns are _not_ considered violations:
 :local(.foo, :global(.bar).baz)
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-type/README.md
+++ b/lib/rules/selector-max-type/README.md
@@ -19,7 +19,7 @@ The `:not()` pseudo-class is also evaluated separately. The rule processes the a
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ div a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -85,7 +85,7 @@ Discount child type selectors.
 
 For example, with `2`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -103,7 +103,7 @@ Discount compounded type selectors -- i.e. type selectors chained with other sel
 
 For example, with `2`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -121,7 +121,7 @@ Discount descendant type selectors.
 
 For example, with `2`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -139,7 +139,7 @@ Discount next-sibling type selectors.
 
 For example, with `2`:
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -161,7 +161,7 @@ Given:
 
 For example, with `2`.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-universal/README.md
+++ b/lib/rules/selector-max-universal/README.md
@@ -19,7 +19,7 @@ The logical combinations pseudo-class (e.g. `:not`, `:has`) is also evaluated se
 
 For example, with `2`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ The following patterns are considered violations:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-nested-pattern/README.md
+++ b/lib/rules/selector-nested-pattern/README.md
@@ -28,7 +28,7 @@ Given the string:
 "^&:(?:hover|focus)$"
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-no-qualifying-type/README.md
+++ b/lib/rules/selector-no-qualifying-type/README.md
@@ -15,7 +15,7 @@ A type selector is "qualifying" when it is compounded with (chained to) another 
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -38,7 +38,7 @@ input[type='button'] {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -69,7 +69,7 @@ input {
 
 Allow attribute selectors qualified by type.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -82,7 +82,7 @@ input[type='button'] {
 
 Allow class selectors qualified by type.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -95,7 +95,7 @@ a.foo {
 
 Allow ID selectors qualified by type.
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-no-vendor-prefix/README.md
+++ b/lib/rules/selector-no-vendor-prefix/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ input::-moz-placeholder {}
 :-webkit-full-screen a {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -53,7 +53,7 @@ Given:
 ["::-webkit-input-placeholder", "/-moz-.*/"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-class-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-allowed-list/README.md
@@ -23,7 +23,7 @@ Given:
 ["hover", "/^nth-/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -35,7 +35,7 @@ a:focus {}
 a:first-of-type {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-class-case/README.md
+++ b/lib/rules/selector-pseudo-class-case/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -44,7 +44,7 @@ a:HOVER {}
 :-MS-INPUT-PLACEHOLDER {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -63,7 +63,7 @@ a:hover {}
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -90,7 +90,7 @@ a:hover {}
 :-ms-input-placeholder {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-class-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-disallowed-list/README.md
@@ -23,7 +23,7 @@ Given:
 ["hover", "/^nth-/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -40,7 +40,7 @@ a:nth-of-type(5) {}
 a:nth-child(2) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-class-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-class-no-unknown/README.md
@@ -17,7 +17,7 @@ This rule ignores vendor-prefixed pseudo-class selectors.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -34,7 +34,7 @@ a:UNKNOWN {}
 a:hoverr {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -66,7 +66,7 @@ Given:
 ["/^my-/", "pseudo-class"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/README.md
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space inside the parentheses.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ input:not([type="submit"]) {}
 input:not([type="submit"] ) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -42,7 +42,7 @@ input:not( [type="submit"] ) {}
 
 There _must never_ be whitespace on the inside the parentheses.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ input:not( [type="submit"] ) {}
 input:not( [type="submit"]) {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-element-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-allowed-list/README.md
@@ -24,7 +24,7 @@ Given:
 ["before", "/^my-/i"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ a::after {}
 a::not-my-pseudo-element {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-element-case/README.md
+++ b/lib/rules/selector-pseudo-element-case/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ a::BEFORE {}
 input::-MOZ-PLACEHOLDER {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -73,7 +73,7 @@ input::-moz-placeholder {}
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -110,7 +110,7 @@ a::before {}
 input::-moz-placeholder {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-element-colon-notation/README.md
+++ b/lib/rules/selector-pseudo-element-colon-notation/README.md
@@ -23,7 +23,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Applicable pseudo-elements _must always_ use the single colon notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -45,7 +45,7 @@ a::first-letter { color: pink; }
 a::first-line { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -81,7 +81,7 @@ li::marker { font-variant-numeric: tabular-nums; }
 
 Applicable pseudo-elements _must always_ use the double colon notation.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -103,7 +103,7 @@ a:first-letter { color: pink; }
 a:first-line { color: pink; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-element-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-disallowed-list/README.md
@@ -24,7 +24,7 @@ Given:
 ["before", "/^my-/i"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -41,7 +41,7 @@ a::my-pseudo-element {}
 a::MY-OTHER-pseudo-element {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-pseudo-element-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-element-no-unknown/README.md
@@ -17,7 +17,7 @@ This rule ignores vendor-prefixed pseudo-element selectors.
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -34,7 +34,7 @@ a::PSEUDO {}
 a::element {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -66,7 +66,7 @@ Given:
 ["/^my-/", "pseudo-element"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-type-case/README.md
+++ b/lib/rules/selector-type-case/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -29,7 +29,7 @@ A {}
 LI {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -43,7 +43,7 @@ li {}
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -55,7 +55,7 @@ a {}
 li {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -77,7 +77,7 @@ Given:
 ["$childClass", "/(p|P)arent.*/"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-type-no-unknown/README.md
+++ b/lib/rules/selector-type-no-unknown/README.md
@@ -15,7 +15,7 @@ This rule considers tags defined in the HTML, SVG, and MathML specifications to 
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -27,7 +27,7 @@ unknown {}
 tag {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ li > a {}
 
 Allow custom elements.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -64,7 +64,7 @@ unknown {}
 x-Foo {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,14 +75,14 @@ x-foo {}
 
 Allow unknown type selectors if they belong to the default namespace.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 namespace|unknown {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ Given:
 ["/^my-/", "custom-namespace"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -122,7 +122,7 @@ Given:
 ["/^my-/", "custom-type"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/shorthand-property-no-redundant-values/README.md
+++ b/lib/rules/shorthand-property-no-redundant-values/README.md
@@ -25,7 +25,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -52,7 +52,7 @@ a { border-radius: 1px 2px 1px 2px; }
 a { -webkit-border-radius: 1px 1px 1px 1px; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/string-no-newline/README.md
+++ b/lib/rules/string-no-newline/README.md
@@ -18,7 +18,7 @@ a {
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -43,7 +43,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/string-quotes/README.md
+++ b/lib/rules/string-quotes/README.md
@@ -35,7 +35,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 Strings _must always_ be wrapped with single quotes.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -47,7 +47,7 @@ a { content: "x"; }
 a[id="foo"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -68,7 +68,7 @@ a { content: "x'y'z"; }
 
 Strings _must always_ be wrapped with double quotes.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -80,7 +80,7 @@ a { content: 'x'; }
 a[id='foo'] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -105,7 +105,7 @@ Allows strings to use single-quotes or double-quotes so long as the string conta
 
 For example, with `"single", { "avoidEscape" : false }`.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -117,7 +117,7 @@ a { content: "x'y'z"; }
 a[id="foo'bar'baz"] {}
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/time-min-milliseconds/README.md
+++ b/lib/rules/time-min-milliseconds/README.md
@@ -17,7 +17,7 @@ This rule checks positive numbers in `transition-duration`, `transition-delay`, 
 
 For example, with `100`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -39,7 +39,7 @@ a { transition: background-color 6ms linear; }
 a { animation-delay: 0.01s; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -69,7 +69,7 @@ Ignore time values for an animation or transition delay.
 
 For example, with a minimum of `200` milliseconds.
 
-The following is _not_ considered a violation:
+The following is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/unicode-bom/README.md
+++ b/lib/rules/unicode-bom/README.md
@@ -8,14 +8,14 @@ Require or disallow the Unicode Byte Order Mark.
 
 ### `"always"`
 
-The following pattern is considered a violation:
+The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
 ```css
 a {}
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -25,7 +25,7 @@ a {}
 
 ### `"never"`
 
-The following pattern is considered a violation:
+The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ U+FEFF
 a {}
 ```
 
-The following pattern is _not_ considered a violation:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/unit-allowed-list/README.md
+++ b/lib/rules/unit-allowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["px", "em", "deg"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ a { font-size: 10rem; }
 a { animation: animation-name 5s ease; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -80,7 +80,7 @@ Given:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ a { border-bottom-width: 6rem; }
 a { width: 100%; }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/unit-case/README.md
+++ b/lib/rules/unit-case/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -54,7 +54,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -72,7 +72,7 @@ a {
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -109,7 +109,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -28,7 +28,7 @@ function rule(expectation, options, context) {
 		}
 
 		function check(node, checkedValue, getIndex) {
-			const violations = [];
+			const problems = [];
 
 			function processValue(valueNode) {
 				const unit = getUnitFromValueNode(valueNode);
@@ -43,7 +43,7 @@ function rule(expectation, options, context) {
 					return false;
 				}
 
-				violations.push({
+				problems.push({
 					index: getIndex(node) + valueNode.sourceIndex,
 					message: messages.expected(unit, expectedUnit),
 				});
@@ -77,7 +77,7 @@ function rule(expectation, options, context) {
 				}
 			});
 
-			if (violations.length) {
+			if (problems.length) {
 				if (context.fix) {
 					if (node.name === 'media') {
 						node.params = parsedValue.toString();
@@ -85,7 +85,7 @@ function rule(expectation, options, context) {
 						node.value = parsedValue.toString();
 					}
 				} else {
-					violations.forEach((err) => {
+					problems.forEach((err) => {
 						report({
 							index: err.index,
 							message: err.message,

--- a/lib/rules/unit-disallowed-list/README.md
+++ b/lib/rules/unit-disallowed-list/README.md
@@ -19,7 +19,7 @@ Given:
 ["px", "em", "deg"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -36,7 +36,7 @@ a { font-size: 10em; }
 a { transform: rotate(30deg); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ Given:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -92,7 +92,7 @@ a { border-bottom-width: 6px; }
 a { width: 100vmin; }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -124,7 +124,7 @@ Given:
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -141,7 +141,7 @@ The following patterns are _not_ considered violations:
 @media not (resolution: 300dpi) {}
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/unit-disallowed-list/index.js
+++ b/lib/rules/unit-disallowed-list/index.js
@@ -56,7 +56,7 @@ function rule(listInput, options) {
 		function check(node, nodeIndex, valueNode, input, option) {
 			const unit = getUnitFromValueNode(valueNode);
 
-			// There is not unit or it is not configured as a violation
+			// There is not unit or it is not configured as a problem
 			if (!unit || (unit && !list.includes(unit.toLowerCase()))) {
 				return;
 			}

--- a/lib/rules/unit-no-unknown/README.md
+++ b/lib/rules/unit-no-unknown/README.md
@@ -15,7 +15,7 @@ This rule considers units defined in the CSS Specifications, up to and including
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -71,7 +71,7 @@ Given:
 ["/^my-/", "custom"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -102,7 +102,7 @@ Given:
 ["image-set", "/^my-/", "/^YOUR-/i"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/value-keyword-case/README.md
+++ b/lib/rules/value-keyword-case/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `"lower"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -67,7 +67,7 @@ a {
 
 ### `"upper"`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -97,7 +97,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -127,7 +127,7 @@ Given:
 ["Block", "/^(f|F)lex$/"]
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -157,7 +157,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -197,7 +197,7 @@ For example, with `"lower"`.
 ["/^(b|B)ackground$/", "display"];
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -213,7 +213,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -267,7 +267,7 @@ For example, with `"upper"`.
 ["/^(f|F)oo$/", "t"];
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -282,7 +282,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/value-list-comma-newline-after/README.md
+++ b/lib/rules/value-list-comma-newline-after/README.md
@@ -20,7 +20,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a newline after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -33,7 +33,7 @@ a { background-size: 0
       , 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -45,7 +45,7 @@ a { background-size: 0,
 
 There _must always_ be a newline after the commas in multi-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -53,7 +53,7 @@ a { background-size: 0
     , 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -75,7 +75,7 @@ a { background-size: 0,
 
 There _must never_ be whitespace after the commas in multi-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -83,7 +83,7 @@ a { background-size: 0
       , 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/value-list-comma-newline-before/README.md
+++ b/lib/rules/value-list-comma-newline-before/README.md
@@ -18,7 +18,7 @@ Require a newline or disallow whitespace before the commas of value lists.
 
 There _must always_ be a newline before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -31,7 +31,7 @@ a { background-size: 0,
       0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -43,7 +43,7 @@ a { background-size: 0
 
 There _must always_ be a newline before the commas in multi-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -51,7 +51,7 @@ a { background-size: 0,
       0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -73,7 +73,7 @@ a { background-size: 0
 
 There _must never_ be whitespace before the commas in multi-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -81,7 +81,7 @@ a { background-size: 0
       , 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/value-list-comma-space-after/README.md
+++ b/lib/rules/value-list-comma-space-after/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a { background-size: 0
       , 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { background-size: 0
 
 There _must never_ be whitespace after the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ a { background-size: 0 ,
       0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,14 +79,14 @@ a { background-size: 0
 
 There _must always_ be a single space after the commas in single-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { background-size: 0,0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -109,14 +109,14 @@ a { background-size: 0
 
 There _must never_ be whitespace after the commas in single-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { background-size: 0, 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/value-list-comma-space-before/README.md
+++ b/lib/rules/value-list-comma-space-before/README.md
@@ -19,7 +19,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 There _must always_ be a single space before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -32,7 +32,7 @@ a { background-size: 0
       , 0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -49,7 +49,7 @@ a { background-size: 0 ,
 
 There _must never_ be whitespace before the commas.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -62,7 +62,7 @@ a { background-size: 0 ,
       0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -79,14 +79,14 @@ a { background-size: 0,
 
 There _must always_ be a single space before the commas in single-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { background-size: 0,0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -109,14 +109,14 @@ a { background-size: 0
 
 There _must never_ be whitespace before the commas in single-line value lists.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 a { background-size: 0 ,0; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/value-list-max-empty-lines/README.md
+++ b/lib/rules/value-list-max-empty-lines/README.md
@@ -22,7 +22,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 For example, with `0`:
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -66,7 +66,7 @@ a {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/value-no-vendor-prefix/README.md
+++ b/lib/rules/value-no-vendor-prefix/README.md
@@ -17,7 +17,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ### `true`
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -34,7 +34,7 @@ a { max-width: -moz-max-content; }
 a { background: -webkit-linear-gradient(bottom, #000, #fff); }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -61,7 +61,7 @@ Given:
 ["grab", "max-content"]
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -1,29 +1,29 @@
 'use strict';
 
-/** @typedef {import('stylelint').Violation} Violation */
+/** @typedef {import('stylelint').Problem} Problem */
 
 /**
- * Report a violation.
+ * Report a problem.
  *
  * This function accounts for `disabledRanges` attached to the result.
- * That is, if the reported violation is within a disabledRange,
+ * That is, if the reported problem is within a disabledRange,
  * it is ignored. Otherwise, it is attached to the result as a
  * postcss warning.
  *
  * It also accounts for the rule's severity.
  *
  * You *must* pass *either* a node or a line number.
- * @param {Violation} violation
+ * @param {Problem} problem
  * @returns {void}
  */
-function report(violation) {
-	const ruleName = violation.ruleName;
-	const result = violation.result;
-	const message = violation.message;
-	const line = violation.line;
-	const node = violation.node;
-	const index = violation.index;
-	const word = violation.word;
+function report(problem) {
+	const ruleName = problem.ruleName;
+	const result = problem.result;
+	const message = problem.message;
+	const line = problem.line;
+	const node = problem.node;
+	const index = problem.index;
+	const word = problem.word;
 
 	result.stylelint = result.stylelint || {
 		ruleSeverities: {},
@@ -47,7 +47,7 @@ function report(violation) {
 
 		for (const range of ranges) {
 			if (
-				// If the violation is within a disabledRange,
+				// If the problem is within a disabledRange,
 				// and that disabledRange's rules include this one,
 				// do not register a warning
 				range.start <= startLine &&

--- a/lib/utils/ruleMessages.js
+++ b/lib/utils/ruleMessages.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Given an object of violation messages, return another
+ * Given an object of problem messages, return another
  * that provides the same messages postfixed with the rule
  * that has been violated.
  *

--- a/lib/utils/whitespaceChecker.js
+++ b/lib/utils/whitespaceChecker.js
@@ -28,10 +28,10 @@ const isWhitespace = require('./isWhitespace');
  * @typedef {Object} WhitespaceCheckerArgs
  * @property {string} source - The source string
  * @property {number} index - The index of the character to check before
- * @property {(message: string) => void} err - If a violation is found, this callback
+ * @property {(message: string) => void} err - If a problem is found, this callback
  *   will be invoked with the relevant warning message.
- *   Typically this callback will report() the violation.
- * @property {string} [errTarget] - If a violation is found, this string
+ *   Typically this callback will report() the problem.
+ * @property {string} [errTarget] - If a problem is found, this string
  *   will be sent to the relevant warning message.
  * @property {string} [lineCheckStr] - Single- and multi-line checkers
  *   will use this string to determine whether they should proceed,

--- a/system-tests/002/stylesheet.scss
+++ b/system-tests/002/stylesheet.scss
@@ -1,5 +1,5 @@
 // https://github.com/twbs/bootstrap/blob/master/scss/_buttons.scss
-// Violation lines added at lines 80 and 119
+// Problem lines added at lines 80 and 119
 
 //
 // Base styles

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -274,7 +274,7 @@ declare module 'stylelint' {
 			invalidScopeDisables?: DisableOptionsReport;
 		};
 
-		export type Violation = {
+		export type Problem = {
 			ruleName: string;
 			result: PostcssResult;
 			message: string;
@@ -310,10 +310,10 @@ declare module 'stylelint' {
 			createLinter: (options: LinterOptions) => InternalApi;
 			utils: {
 				/**
-				 * Report a violation.
+				 * Report a problem.
 				 *
 				 * This function accounts for `disabledRanges` attached to the result.
-				 * That is, if the reported violation is within a disabledRange,
+				 * That is, if the reported problem is within a disabledRange,
 				 * it is ignored. Otherwise, it is attached to the result as a
 				 * postcss warning.
 				 *
@@ -321,9 +321,9 @@ declare module 'stylelint' {
 				 *
 				 * You *must* pass *either* a node or a line number.
 				 */
-				report: (violation: Violation) => void;
+				report: (problem: Problem) => void;
 				/**
-				 * Given an object of violation messages, return another
+				 * Given an object of problem messages, return another
 				 * that provides the same messages postfixed with the rule
 				 * that has been violated.
 				 */

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -56,11 +56,11 @@ const formatter: FormatterType = 'json';
 
 const ruleName = 'sample-rule';
 const messages = stylelint.utils.ruleMessages(ruleName, {
-	violation: 'This a rule violation message',
+	problem: 'This a rule problem message',
 	warning: (reason: string) => `This is not allowed because ${reason}`,
 });
-const violationMessage: string = messages.violation;
-const violationFunc: (reason: string) => string = messages.warning;
+const problemMessage: string = messages.problem;
+const problemFunc: (reason: string) => string = messages.warning;
 
 const testPlugin: Plugin = (options) => {
 	return (root, result) => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/5591

> Is there anything in the PR that needs further explanation?

It was a quick find-and-replace job. We're dotting the i's and crossing the t's now for the release.

Related website commit: https://github.com/stylelint/stylelint.io/pull/227/commits/0af080f7b4ca1494bc82328ae26d3e27ecb597c3

FYI @adalinesimonian, this touches on your types added in https://github.com/stylelint/stylelint/pull/5582.
