### PR TITLE
Add support for `extends` in `overrides` config

### DIFF
--- a/lib/__tests__/fixtures/config-overrides/extends-in-overrides.json
+++ b/lib/__tests__/fixtures/config-overrides/extends-in-overrides.json
@@ -1,0 +1,8 @@
+{
+	"overrides": [
+		{
+			"files": ["*.css"],
+			"extends": "./extending-simple-rule.json"
+		}
+	]
+}

--- a/lib/__tests__/overrides.test.js
+++ b/lib/__tests__/overrides.test.js
@@ -83,6 +83,39 @@ describe('single input file. all overrides are matching', () => {
 		expect(linted.results[0].warnings[2].rule).toBe('block-no-empty');
 		expect(linted.results[0].warnings[3].rule).toBe('color-named');
 	});
+
+	it('override with extends', async () => {
+		const linted = await standalone({
+			files: [path.join(fixturesPath, 'style.css')],
+			configFile: path.join(fixturesPath, 'extends-in-overrides.json'),
+			configBasedir: fixturesPath,
+		});
+
+		expect(linted.results).toHaveLength(1);
+		expect(linted.results[0].warnings).toHaveLength(2);
+		expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
+		expect(linted.results[0].warnings[1].rule).toBe('color-named');
+	});
+
+	it('override with extends in overrides', async () => {
+		const linted = await standalone({
+			files: [path.join(fixturesPath, 'style.css')],
+			config: {
+				overrides: [
+					{
+						files: ['*.css'],
+						extends: [path.join(fixturesPath, 'extends-in-overrides.json')],
+					},
+				],
+			},
+			configBasedir: fixturesPath,
+		});
+
+		expect(linted.results).toHaveLength(1);
+		expect(linted.results[0].warnings).toHaveLength(2);
+		expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
+		expect(linted.results[0].warnings[1].rule).toBe('color-named');
+	});
 });
 
 it('override is not matching', async () => {

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -38,7 +38,10 @@ async function augmentConfigBasic(stylelint, config, configDir, allowOverrides, 
 	augmentedConfig = await extendConfig(stylelint, augmentedConfig, configDir);
 
 	if (filePath) {
-		augmentedConfig = applyOverrides(augmentedConfig, configDir, filePath);
+		while (augmentedConfig.overrides) {
+			augmentedConfig = applyOverrides(augmentedConfig, configDir, filePath);
+			augmentedConfig = await extendConfig(stylelint, augmentedConfig, configDir);
+		}
 	}
 
 	return absolutizePaths(augmentedConfig, configDir);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, but related to #3128.

> Is there anything in the PR that needs further explanation?

This PR adds support for `extends` in `overrides` config.

e.g.

```json
{
  "overrides": [
    {
      "files": ["*.scss"],
      "extends": "stylelint-config-recommended-scss"
    }
  ]
}
```

This option allows users to use config by language.
