### PR TITLE
Remove v14 CI triggers

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - master
       - '!dependabot/**'
-      - v14 # TODO: Remove when releasing v14.
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
       - master
-      - v14 # TODO: Remove when releasing v14.
   schedule:
     - cron: '0 7 * * 1'
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'dependabot/**'
-      - v14 # TODO: Remove when releasing v14.
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'dependabot/**'
-      - v14 # TODO: Remove when releasing v14.
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
> Is there anything in the PR that needs further explanation?

These are not needed anymore as we close to release and we have [regular PR](https://github.com/stylelint/stylelint/pull/5604) to `master`.
