### PR TITLE
Update README links for main

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ And can be extended to:
 
 ## Example output
 
-![Example](https://github.com/stylelint/stylelint/raw/master/example.png?raw=true)
+![Example](https://github.com/stylelint/stylelint/raw/main/example.png?raw=true)
 
 ## Guides
 
@@ -91,4 +91,4 @@ Thank you to all our backers! [Become a backer](https://opencollective.com/style
 
 ## License
 
-[The MIT License](https://raw.githubusercontent.com/stylelint/stylelint/master/LICENSE).
+[The MIT License](https://raw.githubusercontent.com/stylelint/stylelint/main/LICENSE).


### PR DESCRIPTION
Super excited for Stylelint v14 and the `master` -> `main` switch! This PR catches two links in the README that are now broken.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

"None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

"No, it's self-explanatory."
