### PR TITLE
Fix `overrides` property ignoring dot directories

### DIFF
--- a/lib/__tests__/applyOverrides.test.js
+++ b/lib/__tests__/applyOverrides.test.js
@@ -99,6 +99,29 @@ describe('single matching override', () => {
 
 		expect(applied).toEqual(expectedConfig);
 	});
+
+	test('override with dot dir', () => {
+		const config = {
+			overrides: [
+				{
+					files: ['**/*.scss'],
+					customSyntax: 'postcss-scss',
+				},
+			],
+		};
+
+		const expectedConfig = {
+			customSyntax: 'postcss-scss',
+		};
+
+		const applied = applyOverrides(
+			config,
+			__dirname,
+			path.join(__dirname, '.dot-dir', 'style.scss'),
+		);
+
+		expect(applied).toEqual(expectedConfig);
+	});
 });
 
 describe('two matching overrides', () => {

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -415,7 +415,7 @@ function applyOverrides(fullConfig, configDir, filePath) {
 			// Glob patterns for micromatch should be in POSIX-style
 			.map((s) => normalizePath(s));
 
-		if (micromatch.isMatch(filePath, filesGlobs)) {
+		if (micromatch.isMatch(filePath, filesGlobs, { dot: true })) {
 			config = mergeConfigs(config, configOverrides);
 		}
 	}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5628

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
