### PR TITLE
Fix custom syntax require error handling

### DIFF
--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -93,10 +93,15 @@ function getCustomSyntax(customSyntax) {
 	if (typeof customSyntax === 'string') {
 		try {
 			resolved = require(customSyntax);
-		} catch {
-			throw new Error(
-				`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.`,
-			);
+		} catch (error) {
+			// @ts-expect-error -- TS2571: Object is of type 'unknown'.
+			if (error && typeof error === 'object' && error.code === 'MODULE_NOT_FOUND') {
+				throw new Error(
+					`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.`,
+				);
+			}
+
+			throw error;
 		}
 
 		/*


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- See #5632
- See stylelint-scss/stylelint-config-standard-scss#2

> Is there anything in the PR that needs further explanation?

Node.js `require()` may cause other errors than `MODULE_NOT_FOUND`. This change aims to throw such errors.
See also: <https://nodejs.org/api/errors.html#errors_module_not_found>
