### PR TITLE
Refactor to getPostcssResult to remove unneeded variable fallback

### DIFF
--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -153,7 +153,6 @@ const previouslyInferedExtensions = {
  */
 function cssSyntax(stylelint, filePath) {
 	const fileExtension = filePath ? path.extname(filePath).slice(1).toLowerCase() : '';
-
 	const extensions = ['css', 'pcss', 'postcss'];
 
 	if (previouslyInferedExtensions[fileExtension]) {


### PR DESCRIPTION
`filePath` shouldn't be falsy here since it's already checked in the ternary.

Fixes one of the [LGTM](https://lgtm.com/projects/g/stylelint/stylelint/?mode=list) issues.