### PR TITLE
Fix package size by excluding docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     "stylelint": "bin/stylelint.js"
   },
   "files": [
-    "{bin,lib}/**/*.js",
-    "types/stylelint/index.d.ts",
-    "!**/{__tests__,testUtils}/**"
+    "bin/**/*.js",
+    "lib/**/*.js",
+    "!**/__tests__/**",
+    "!lib/testUtils/**",
+    "types/stylelint/index.d.ts"
   ],
   "scripts": {
     "benchmark-rule": "node scripts/benchmark-rule.js",


### PR DESCRIPTION
Before:
total files:   572
package size:  260.0 kB
unpacked size: 1.4 MB

After:
total files:   356
package size:  149.1 kB
unpacked size: 780.9 kB

Basically, got rid of all docs and rules README.md files. Now, I know that it might have been intentional, but it makes a big difference. Also, I checked eslint and they don't include the docs either. After all, all this info is available in the repo and the website.

IMHO, at the end of the day, it's probably a good change that will help with the package size and/or install time.