### PR TITLE
Refactor for better type-checking

### DIFF
--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -221,7 +221,7 @@ function formatter(messages, source) {
 			 * @param {string} el
 			 * @returns {string}
 			 */
-			(el) => el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => dim(`${p1}:${p2}`)),
+			(el) => el.replace(/(\d+)\s+(\d+)/, (_m, p1, p2) => dim(`${p1}:${p2}`)),
 		)
 		.join('\n');
 

--- a/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/isRectangular.js
@@ -6,7 +6,7 @@
  * @returns {boolean}
  */
 function isRectangular(areas) {
-	return areas.every((row, i, arr) => row.length === arr[0].length);
+	return areas.every((row, _i, arr) => row.length === arr[0].length);
 }
 
 module.exports = isRectangular;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
 		"checkJs": true,
 		"noEmit": true,
 		"strict": true,
-		"noImplicitThis": true,
-		"alwaysStrict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUnusedParameters": true,
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
 		"typeRoots": ["./types", "./node_modules/@types"]


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- Related to #4496

> Is there anything in the PR that needs further explanation?

This change aims to improve type-checking and refactor `tsconfig.json`:

- Add `noFallthroughCasesInSwitch`. This aims to prevent a *fallthrough* bug.
- Add `noUnusedParameters`. This aims to improve readability. If you'd like to avoid the error, add a prefix `_`.
- Remove `noImplicitThis` and `alwaysStrict`. These are enabled by `strict: true`.

See <https://www.typescriptlang.org/tsconfig>
