### PR TITLE
Refactor to adhere to lint checks

### DIFF
--- a/lib/__tests__/integration.test.js
+++ b/lib/__tests__/integration.test.js
@@ -89,10 +89,11 @@ describe('integration test expecting warnings', () => {
 		const errors = result.messages.filter((msg) => msg.rule === 'color-no-invalid-hex');
 
 		expect(errors).toHaveLength(2);
-		errors.forEach((error) => {
+
+		for (const error of errors) {
 			expect(error.text).toBe('You made a mistake');
 			expect(error.severity).toBe('warning');
-		});
+		}
 	});
 
 	it('function-disallowed-list - array primary option', () => {

--- a/lib/__tests__/standalone-syntax.test.js
+++ b/lib/__tests__/standalone-syntax.test.js
@@ -24,19 +24,20 @@ it('standalone with postcss-safe-parser', () => {
 		expect(results).toHaveLength(6);
 
 		const safeParserExtensionsTest = /\.(?:css|pcss|postcss)$/i;
+		const filteredResults = results.filter(
+			(result) => !safeParserExtensionsTest.test(result.source),
+		);
 
-		results
-			.filter((result) => !safeParserExtensionsTest.test(result.source))
-			.forEach((result) => {
-				expect(result.warnings).toHaveLength(1);
+		for (const result of filteredResults) {
+			expect(result.warnings).toHaveLength(1);
 
-				const error = result.warnings[0];
+			const error = result.warnings[0];
 
-				expect(error.line).toBe(1);
-				expect(error.column).toBe(1);
-				expect(error.rule).toBe('CssSyntaxError');
-				expect(error.severity).toBe('error');
-			});
+			expect(error.line).toBe(1);
+			expect(error.column).toBe(1);
+			expect(error.rule).toBe('CssSyntaxError');
+			expect(error.severity).toBe('error');
+		}
 
 		return Promise.all(
 			results

--- a/lib/assignDisabledRanges.js
+++ b/lib/assignDisabledRanges.js
@@ -134,9 +134,9 @@ module.exports = function assignDisabledRanges(root, result) {
 			const line = comment.source.start.line;
 			const description = getDescription(comment.text);
 
-			getCommandRules(disableLineCommand, comment.text).forEach((ruleName) => {
+			for (const ruleName of getCommandRules(disableLineCommand, comment.text)) {
 				disableLine(comment, line, ruleName, description);
-			});
+			}
 		}
 	}
 
@@ -148,9 +148,9 @@ module.exports = function assignDisabledRanges(root, result) {
 			const line = comment.source.end.line;
 			const description = getDescription(comment.text);
 
-			getCommandRules(disableNextLineCommand, comment.text).forEach((ruleName) => {
+			for (const ruleName of getCommandRules(disableNextLineCommand, comment.text)) {
 				disableLine(comment, line + 1, ruleName, description);
-			});
+			}
 		}
 	}
 
@@ -168,14 +168,14 @@ module.exports = function assignDisabledRanges(root, result) {
 		}
 
 		if (ruleName === ALL_RULES) {
-			Object.keys(disabledRanges).forEach((disabledRuleName) => {
-				if (ruleIsDisabled(disabledRuleName)) return;
+			for (const disabledRuleName of Object.keys(disabledRanges)) {
+				if (ruleIsDisabled(disabledRuleName)) continue;
 
 				const strict = disabledRuleName === ALL_RULES;
 
 				startDisabledRange(comment, line, disabledRuleName, strict, description);
 				endDisabledRange(line, disabledRuleName, strict);
-			});
+			}
 		} else {
 			if (ruleIsDisabled(ruleName)) {
 				throw comment.error(`"${ruleName}" has already been disabled`, {
@@ -194,7 +194,7 @@ module.exports = function assignDisabledRanges(root, result) {
 	function processDisableCommand(comment) {
 		const description = getDescription(comment.text);
 
-		getCommandRules(disableCommand, comment.text).forEach((ruleToDisable) => {
+		for (const ruleToDisable of getCommandRules(disableCommand, comment.text)) {
 			const isAllRules = ruleToDisable === ALL_RULES;
 
 			if (ruleIsDisabled(ruleToDisable)) {
@@ -212,21 +212,21 @@ module.exports = function assignDisabledRanges(root, result) {
 				const line = comment.source.start.line;
 
 				if (isAllRules) {
-					Object.keys(disabledRanges).forEach((ruleName) => {
+					for (const ruleName of Object.keys(disabledRanges)) {
 						startDisabledRange(comment, line, ruleName, ruleName === ALL_RULES, description);
-					});
+					}
 				} else {
 					startDisabledRange(comment, line, ruleToDisable, true, description);
 				}
 			}
-		});
+		}
 	}
 
 	/**
 	 * @param {PostcssComment} comment
 	 */
 	function processEnableCommand(comment) {
-		getCommandRules(enableCommand, comment.text).forEach((ruleToEnable) => {
+		for (const ruleToEnable of getCommandRules(enableCommand, comment.text)) {
 			// TODO TYPES
 			// need fallback if endLine will be undefined
 			const endLine = /** @type {number} */ (
@@ -244,15 +244,15 @@ module.exports = function assignDisabledRanges(root, result) {
 					});
 				}
 
-				Object.entries(disabledRanges).forEach(([ruleName, ranges]) => {
+				for (const [ruleName, ranges] of Object.entries(disabledRanges)) {
 					const lastRange = ranges[ranges.length - 1];
 
 					if (!lastRange || !lastRange.end) {
 						endDisabledRange(endLine, ruleName, ruleName === ALL_RULES);
 					}
-				});
+				}
 
-				return;
+				continue;
 			}
 
 			if (ruleIsDisabled(ALL_RULES) && disabledRanges[ruleToEnable] === undefined) {
@@ -272,19 +272,19 @@ module.exports = function assignDisabledRanges(root, result) {
 
 				endDisabledRange(endLine, ruleToEnable, true);
 
-				return;
+				continue;
 			}
 
 			if (ruleIsDisabled(ruleToEnable)) {
 				endDisabledRange(endLine, ruleToEnable, true);
 
-				return;
+				continue;
 			}
 
 			throw comment.error(`"${ruleToEnable}" has not been disabled`, {
 				plugin: 'stylelint',
 			});
-		});
+		}
 	}
 
 	/**

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -295,7 +295,7 @@ function addPluginFunctions(config) {
 		// or an array of them
 		const normalizedPluginImport = [pluginImport].flat();
 
-		normalizedPluginImport.forEach((pluginRuleDefinition) => {
+		for (const pluginRuleDefinition of normalizedPluginImport) {
 			if (!pluginRuleDefinition.ruleName) {
 				throw configurationError(
 					`stylelint requires plugins to expose a ruleName. The plugin "${pluginLookup}" is not doing this, so will not work with stylelint. Please file an issue with the plugin.`,
@@ -309,7 +309,7 @@ function addPluginFunctions(config) {
 			}
 
 			pluginFunctions[pluginRuleDefinition.ruleName] = pluginRuleDefinition.rule;
-		});
+		}
 	}
 
 	config.pluginFunctions = pluginFunctions;
@@ -344,7 +344,7 @@ function addProcessorFunctions(config) {
 	/** @type {StylelintResultProcessor[]} */
 	const resultProcessors = [];
 
-	[config.processors].flat().forEach((processorConfig) => {
+	for (const processorConfig of [config.processors].flat()) {
 		const processorKey = JSON.stringify(processorConfig);
 
 		let initializedProcessor;
@@ -369,7 +369,7 @@ function addProcessorFunctions(config) {
 		if (initializedProcessor && initializedProcessor.result) {
 			resultProcessors.push(initializedProcessor.result);
 		}
-	});
+	}
 
 	config.codeProcessors = codeProcessors;
 	config.resultProcessors = resultProcessors;

--- a/lib/descriptionlessDisables.js
+++ b/lib/descriptionlessDisables.js
@@ -12,13 +12,13 @@ const validateDisableSettings = require('./validateDisableSettings');
  * @param {import('stylelint').LintResult[]} results
  */
 module.exports = function descriptionlessDisables(results) {
-	results.forEach((result) => {
+	for (const result of results) {
 		const settings = validateDisableSettings(
 			result._postcssResult,
 			'reportDescriptionlessDisables',
 		);
 
-		if (!settings) return;
+		if (!settings) continue;
 
 		const [enabled, options, stylelintResult] = settings;
 
@@ -27,11 +27,11 @@ module.exports = function descriptionlessDisables(results) {
 		/** @type {Set<PostcssComment>} */
 		const alreadyReported = new Set();
 
-		Object.keys(rangeData).forEach((rule) => {
-			rangeData[rule].forEach((range) => {
-				if (range.description) return;
+		for (const rule of Object.keys(rangeData)) {
+			for (const range of rangeData[rule]) {
+				if (range.description) continue;
 
-				if (alreadyReported.has(range.comment)) return;
+				if (alreadyReported.has(range.comment)) continue;
 
 				if (enabled === optionsMatches(options, 'except', rule)) {
 					// An 'all' rule will get copied for each individual rule. If the
@@ -40,14 +40,14 @@ module.exports = function descriptionlessDisables(results) {
 					// the comment as already reported.
 					if (!enabled && rule === 'all') alreadyReported.add(range.comment);
 
-					return;
+					continue;
 				}
 
 				alreadyReported.add(range.comment);
 
 				// If the comment doesn't have a location, we can't report a useful error.
 				// In practice we expect all comments to have locations, though.
-				if (!range.comment.source || !range.comment.source.start) return;
+				if (!range.comment.source || !range.comment.source.start) continue;
 
 				result.warnings.push({
 					text: `Disable for "${rule}" is missing a description`,
@@ -56,7 +56,7 @@ module.exports = function descriptionlessDisables(results) {
 					column: range.comment.source.start.column,
 					severity: options.severity,
 				});
-			});
-		});
-	});
+			}
+		}
+	}
 };

--- a/lib/formatters/__tests__/prepareFormatterOutput.js
+++ b/lib/formatters/__tests__/prepareFormatterOutput.js
@@ -12,9 +12,9 @@ symbolConversions.set('✖', '×');
 module.exports = function (results, formatter) {
 	let output = stripAnsi(formatter(results)).trim();
 
-	symbolConversions.forEach((win, nix) => {
+	for (const [nix, win] of symbolConversions.entries()) {
 		output = output.replace(new RegExp(nix, 'g'), win);
-	});
+	}
 
 	return output;
 };

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -239,15 +239,14 @@ module.exports = function (results) {
 	output = results.reduce((accum, result) => {
 		// Treat parseErrors as warnings
 		if (result.parseErrors) {
-			result.parseErrors.forEach((error) =>
+			for (const error of result.parseErrors)
 				result.warnings.push({
 					line: error.line,
 					column: error.column,
 					rule: error.stylelintType,
 					severity: 'error',
 					text: `${error.text} (${error.stylelintType})`,
-				}),
-			);
+				});
 		}
 
 		accum += formatter(result.warnings, result.source || '');

--- a/lib/formatters/tapFormatter.js
+++ b/lib/formatters/tapFormatter.js
@@ -6,7 +6,7 @@
 const tapFormatter = (results) => {
 	const lines = [`TAP version 13\n1..${results.length}`];
 
-	results.forEach((result, index) => {
+	for (const [index, result] of results.entries()) {
 		lines.push(
 			`${result.errored ? 'not ok' : 'ok'} ${index + 1} - ${result.ignored ? 'ignored ' : ''}${
 				result.source
@@ -16,7 +16,7 @@ const tapFormatter = (results) => {
 		if (result.warnings.length > 0) {
 			lines.push('---', 'messages:');
 
-			result.warnings.forEach((warning) => {
+			for (const warning of result.warnings) {
 				lines.push(
 					` - message: "${warning.text}"`,
 					`   severity: ${warning.severity}`,
@@ -25,11 +25,11 @@ const tapFormatter = (results) => {
 					`     column: ${warning.column}`,
 					`     ruleId: ${warning.rule}`,
 				);
-			});
+			}
 
 			lines.push('---');
 		}
-	});
+	}
 
 	lines.push('');
 

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -23,7 +23,8 @@ module.exports = function (results) {
 		: results.length;
 
 	output += underline(`${checkedDisplay} ${sourceWord} checked\n`);
-	results.forEach((result) => {
+
+	for (const result of results) {
 		let formatting = green;
 
 		if (result.errored) {
@@ -41,7 +42,7 @@ module.exports = function (results) {
 		}
 
 		output += formatting(` ${sourceText}\n`);
-	});
+	}
 
 	const warnings = results.flatMap((r) => r.warnings);
 	const warningsBySeverity = groupBy(warnings, (w) => w.severity);

--- a/lib/invalidScopeDisables.js
+++ b/lib/invalidScopeDisables.js
@@ -9,10 +9,10 @@ const validateDisableSettings = require('./validateDisableSettings');
  * @param {import('stylelint').LintResult[]} results
  */
 module.exports = function invalidScopeDisables(results) {
-	results.forEach((result) => {
+	for (const result of results) {
 		const settings = validateDisableSettings(result._postcssResult, 'reportInvalidScopeDisables');
 
-		if (!settings) return;
+		if (!settings) continue;
 
 		const [enabled, options, stylelintResult] = settings;
 
@@ -25,17 +25,17 @@ module.exports = function invalidScopeDisables(results) {
 		const rangeData = stylelintResult.disabledRanges;
 		const disabledRules = Object.keys(rangeData);
 
-		disabledRules.forEach((rule) => {
-			if (usedRules.has(rule)) return;
+		for (const rule of disabledRules) {
+			if (usedRules.has(rule)) continue;
 
-			if (enabled === optionsMatches(options, 'except', rule)) return;
+			if (enabled === optionsMatches(options, 'except', rule)) continue;
 
-			rangeData[rule].forEach((range) => {
-				if (!range.strictStart && !range.strictEnd) return;
+			for (const range of rangeData[rule]) {
+				if (!range.strictStart && !range.strictEnd) continue;
 
 				// If the comment doesn't have a location, we can't report a useful error.
 				// In practice we expect all comments to have locations, though.
-				if (!range.comment.source || !range.comment.source.start) return;
+				if (!range.comment.source || !range.comment.source.start) continue;
 
 				result.warnings.push({
 					text: `Rule "${rule}" isn't enabled`,
@@ -44,7 +44,7 @@ module.exports = function invalidScopeDisables(results) {
 					column: range.comment.source.start.column,
 					severity: options.severity,
 				});
-			});
-		});
-	});
+			}
+		}
+	}
 };

--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -60,7 +60,7 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 		  )
 		: [];
 
-	rules.forEach((ruleName) => {
+	for (const ruleName of rules) {
 		const ruleFunction =
 			rulesOrder[ruleName] || (config.pluginFunctions && config.pluginFunctions[ruleName]);
 
@@ -73,13 +73,13 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 				),
 			);
 
-			return;
+			continue;
 		}
 
 		const ruleSettings = config.rules && config.rules[ruleName];
 
 		if (ruleSettings === null || ruleSettings[0] === null) {
-			return;
+			continue;
 		}
 
 		const primaryOption = ruleSettings[0];
@@ -113,7 +113,7 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 				),
 			),
 		);
-	});
+	}
 
 	return Promise.all(performRules);
 }

--- a/lib/needlessDisables.js
+++ b/lib/needlessDisables.js
@@ -13,16 +13,16 @@ const validateDisableSettings = require('./validateDisableSettings');
  * @param {import('stylelint').LintResult[]} results
  */
 module.exports = function needlessDisables(results) {
-	results.forEach((result) => {
+	for (const result of results) {
 		const settings = validateDisableSettings(result._postcssResult, 'reportNeedlessDisables');
 
-		if (!settings) return;
+		if (!settings) continue;
 
 		const [enabled, options, stylelintResult] = settings;
 
 		const rangeData = stylelintResult.disabledRanges;
 
-		if (!rangeData) return;
+		if (!rangeData) continue;
 
 		const disabledWarnings = stylelintResult.disabledWarnings || [];
 
@@ -81,7 +81,7 @@ module.exports = function needlessDisables(results) {
 				});
 			}
 		}
-	});
+	}
 };
 
 /**

--- a/lib/reportDisables.js
+++ b/lib/reportDisables.js
@@ -12,25 +12,25 @@
  * @param {StylelintResult[]} results
  */
 module.exports = function (results) {
-	results.forEach((result) => {
+	for (const result of results) {
 		// File with `CssSyntaxError` don't have `_postcssResult`s.
 		if (!result._postcssResult) {
-			return;
+			continue;
 		}
 
 		/** @type {{[ruleName: string]: Array<RangeType>}} */
 		const rangeData = result._postcssResult.stylelint.disabledRanges;
 
-		if (!rangeData) return;
+		if (!rangeData) continue;
 
 		const config = result._postcssResult.stylelint.config;
 
-		if (!config || !config.rules) return;
+		if (!config || !config.rules) continue;
 
 		// If no rules actually disallow disables, don't bother looking for ranges
 		// that correspond to disabled rules.
-		if (!Object.values(config.rules).some(reportDisablesForRule)) {
-			return;
+		if (!Object.values(config.rules).some((rule) => reportDisablesForRule(rule))) {
+			continue;
 		}
 
 		for (const [rule, ranges] of Object.entries(rangeData)) {
@@ -50,7 +50,7 @@ module.exports = function (results) {
 				});
 			}
 		}
-	});
+	}
 };
 
 /**

--- a/lib/reportUnknownRuleNames.js
+++ b/lib/reportUnknownRuleNames.js
@@ -17,13 +17,13 @@ function extractSuggestions(ruleName) {
 		suggestions[i] = [];
 	}
 
-	Object.keys(rules).forEach((existRuleName) => {
+	for (const existRuleName of Object.keys(rules)) {
 		const distance = levenshtein.distance(existRuleName, ruleName);
 
 		if (distance <= MAX_LEVENSHTEIN_DISTANCE) {
 			suggestions[distance - 1].push(existRuleName);
 		}
-	});
+	}
 
 	/** @type {string[]} */
 	let result = [];

--- a/lib/rules/at-rule-property-required-list/index.js
+++ b/lib/rules/at-rule-property-required-list/index.js
@@ -39,7 +39,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			list[atRuleName].forEach((property) => {
+			for (const property of list[atRuleName]) {
 				const propertyName = property.toLowerCase();
 
 				const hasProperty = nodes.find(
@@ -47,16 +47,17 @@ const rule = (primary) => {
 				);
 
 				if (hasProperty) {
-					return;
+					continue;
 				}
 
-				return report({
+				report({
 					message: messages.expected(propertyName, atRuleName),
 					node: atRule,
 					result,
 					ruleName,
 				});
-			});
+				continue;
+			}
 		});
 	};
 };

--- a/lib/rules/block-opening-brace-newline-after/index.js
+++ b/lib/rules/block-opening-brace-newline-after/index.js
@@ -105,9 +105,10 @@ const rule = (primary, _secondaryOptions, context) => {
 
 						if (primary === 'never-multi-line') {
 							// Restore the `before` of the node next to the comment node.
-							backupCommentNextBefores.forEach((before, node) => {
+							for (const [node, before] of backupCommentNextBefores.entries()) {
 								node.raws.before = before;
-							});
+							}
+
 							backupCommentNextBefores.clear();
 
 							// Fix
@@ -147,9 +148,9 @@ const rule = (primary, _secondaryOptions, context) => {
 			});
 
 			// Restore the `before` of the node next to the comment node.
-			backupCommentNextBefores.forEach((before, node) => {
+			for (const [node, before] of backupCommentNextBefores.entries()) {
 				node.raws.before = before;
-			});
+			}
 		}
 	};
 };

--- a/lib/rules/color-named/generateColorFuncs.js
+++ b/lib/rules/color-named/generateColorFuncs.js
@@ -178,7 +178,7 @@ function generateColorFuncs(hexString) {
 
 	const rgb = [0, 0, 0];
 
-	for (let i = 0; i < 3; i += 1) {
+	for (let i = 0; i < 3; i++) {
 		rgb[i] = Number.parseInt(hexString.substr(2 * i + 1, 2), 16);
 	}
 

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -54,14 +54,14 @@ const rule = (primary, secondaryOptions) => {
 		/** @type {Record<string, { hex: string[], func: string[] }>} */
 		const namedColorData = {};
 
-		namedColors.forEach((name) => {
+		for (const name of namedColors) {
 			const hex = namedColorDataHex[name];
 
 			namedColorData[name] = {
 				hex,
 				func: generateColorFuncs(hex[0]),
 			};
-		});
+		}
 
 		root.walkDecls((decl) => {
 			if (propertySets.acceptCustomIdents.has(decl.prop)) {

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -42,9 +42,9 @@ const rule = (primary, secondaryOptions) => {
 					return longhandProps;
 				}
 
-				values.forEach((value) => {
+				for (const value of values) {
 					(longhandProps[value] || (longhandProps[value] = [])).push(key);
-				});
+				}
 
 				return longhandProps;
 			},
@@ -66,7 +66,7 @@ const rule = (primary, secondaryOptions) => {
 					return;
 				}
 
-				shorthandProperties.forEach((shorthandProperty) => {
+				for (const shorthandProperty of shorthandProperties) {
 					const prefixedShorthandProperty = prefix + shorthandProperty;
 
 					if (!longhandDeclarations[prefixedShorthandProperty]) {
@@ -85,7 +85,7 @@ const rule = (primary, secondaryOptions) => {
 							longhandDeclarations[prefixedShorthandProperty].sort(),
 						)
 					) {
-						return;
+						continue;
 					}
 
 					report({
@@ -94,7 +94,7 @@ const rule = (primary, secondaryOptions) => {
 						node: decl,
 						message: messages.expected(prefixedShorthandProperty),
 					});
-				});
+				}
 			});
 		});
 	};

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -39,9 +39,9 @@ const rule = (primary) => {
 					return;
 				}
 
-				overrideables.forEach((longhandProp) => {
+				for (const longhandProp of overrideables) {
 					if (!Object.prototype.hasOwnProperty.call(declarations, prefix + longhandProp)) {
-						return;
+						continue;
 					}
 
 					report({
@@ -50,7 +50,7 @@ const rule = (primary) => {
 						node: decl,
 						message: messages.rejected(prop, declarations[prefix + longhandProp]),
 					});
-				});
+				}
 			});
 		});
 	};

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -75,7 +75,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			fontFamilies.forEach((fontFamilyNode) => {
+			for (const fontFamilyNode of fontFamilies) {
 				let rawFamily = fontFamilyNode.value;
 
 				if ('quote' in fontFamilyNode) {
@@ -83,7 +83,7 @@ const rule = (primary) => {
 				}
 
 				checkFamilyName(rawFamily, decl);
-			});
+			}
 		});
 
 		/**

--- a/lib/rules/font-family-no-duplicate-names/index.js
+++ b/lib/rules/font-family-no-duplicate-names/index.js
@@ -51,11 +51,11 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			fontFamilies.forEach((fontFamilyNode) => {
+			for (const fontFamilyNode of fontFamilies) {
 				const family = fontFamilyNode.value.trim();
 
 				if (optionsMatches(secondaryOptions, 'ignoreFontFamilyNames', family)) {
-					return;
+					continue;
 				}
 
 				if (isFamilyNameKeyword(fontFamilyNode)) {
@@ -66,12 +66,12 @@ const rule = (primary, secondaryOptions) => {
 							decl,
 						);
 
-						return;
+						continue;
 					}
 
 					keywords.add(family);
 
-					return;
+					continue;
 				}
 
 				if (familyNames.has(family)) {
@@ -81,11 +81,11 @@ const rule = (primary, secondaryOptions) => {
 						decl,
 					);
 
-					return;
+					continue;
 				}
 
 				familyNames.add(family);
-			});
+			}
 		});
 
 		/**

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -78,7 +78,7 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			if (fontFamilies.some(isFamilyNameKeyword)) {
+			if (fontFamilies.some((node) => isFamilyNameKeyword(node))) {
 				return;
 			}
 

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -65,7 +65,7 @@ const rule = (primary, secondaryOptions) => {
 			// We do not need to more carefully distinguish font-weight
 			// numbers from unitless line-heights because line-heights in
 			// `font` values need to be part of a font-size/line-height pair
-			const hasNumericFontWeight = valueList.some(isNumbery);
+			const hasNumericFontWeight = valueList.some((value) => isNumbery(value));
 
 			for (const value of postcss.list.space(decl.value)) {
 				if (
@@ -116,7 +116,7 @@ const rule = (primary, secondaryOptions) => {
 				if (parent && isAtRule(parent) && parent.name.toLowerCase() === 'font-face') {
 					const weightValueNumbers = postcss.list.space(weightValue);
 
-					if (!weightValueNumbers.every(isNumbery)) {
+					if (!weightValueNumbers.every((value) => isNumbery(value))) {
 						return complain(messages.expected('numeric'));
 					}
 

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -237,11 +237,9 @@ const rule = (primary, _secondaryOptions, context) => {
 			 * @param {import('postcss-value-parser').Node[]} nodes
 			 */
 			function checkWords(nodes) {
-				if (checkForOperatorInFirstNode(nodes)) return;
+				if (checkForOperatorInFirstNode(nodes) || checkForOperatorInLastNode(nodes)) return;
 
-				if (checkForOperatorInLastNode(nodes)) return;
-
-				nodes.forEach((node, index) => {
+				for (const [index, node] of nodes.entries()) {
 					const lastChar = node.value.slice(-1);
 					const firstChar = node.value.slice(0, 1);
 
@@ -250,7 +248,7 @@ const rule = (primary, _secondaryOptions, context) => {
 							if (context.fix) {
 								node.value = `${node.value.slice(0, -1)} ${lastChar}`;
 
-								return;
+								continue;
 							}
 
 							complain(messages.expectedBefore(lastChar), decl, node.sourceIndex);
@@ -258,13 +256,13 @@ const rule = (primary, _secondaryOptions, context) => {
 							if (context.fix) {
 								node.value = `${firstChar} ${node.value.slice(1)}`;
 
-								return;
+								continue;
 							}
 
 							complain(messages.expectedOperatorBeforeSign(firstChar), decl, node.sourceIndex);
 						}
 					}
-				});
+				}
 			}
 
 			parsedValue.walk((node) => {

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -20,9 +20,9 @@ const messages = ruleMessages(ruleName, {
 
 const mapLowercaseFunctionNamesToCamelCase = new Map();
 
-keywordSets.camelCaseFunctionNames.forEach((func) => {
+for (const func of keywordSets.camelCaseFunctionNames) {
 	mapLowercaseFunctionNamesToCamelCase.set(func.toLowerCase(), func);
-});
+}
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {

--- a/lib/rules/functionCommaSpaceChecker.js
+++ b/lib/rules/functionCommaSpaceChecker.js
@@ -74,9 +74,9 @@ module.exports = function functionCommaSpaceChecker(opts) {
 			/** @type {{ commaNode: ValueParserDivNode, checkIndex: number, nodeIndex: number }[]} */
 			const commaDataList = [];
 
-			valueNode.nodes.forEach((node, nodeIndex) => {
+			for (const [nodeIndex, node] of valueNode.nodes.entries()) {
 				if (node.type !== 'div' || node.value !== ',') {
-					return;
+					continue;
 				}
 
 				const checkIndex = getCommaCheckIndex(node, nodeIndex);
@@ -86,7 +86,7 @@ module.exports = function functionCommaSpaceChecker(opts) {
 					checkIndex,
 					nodeIndex,
 				});
-			});
+			}
 
 			for (const { commaNode, checkIndex, nodeIndex } of commaDataList) {
 				opts.locationChecker({

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -388,14 +388,14 @@ const rule = (primary, secondaryOptions = {}, context) => {
 
 			if (fixPositions.length) {
 				if (isRule(node)) {
-					fixPositions.forEach((fixPosition) => {
+					for (const fixPosition of fixPositions) {
 						node.selector = replaceIndentation(
 							node.selector,
 							fixPosition.currentIndentation,
 							fixPosition.expectedIndentation,
 							fixPosition.startIndex,
 						);
-					});
+					}
 				}
 
 				if (isDeclaration(node)) {
@@ -406,7 +406,7 @@ const rule = (primary, secondaryOptions = {}, context) => {
 						throw new TypeError('The `between` property must be a string');
 					}
 
-					fixPositions.forEach((fixPosition) => {
+					for (const fixPosition of fixPositions) {
 						if (fixPosition.startIndex < declProp.length + declBetween.length) {
 							node.raws.between = replaceIndentation(
 								declBetween,
@@ -422,7 +422,7 @@ const rule = (primary, secondaryOptions = {}, context) => {
 								fixPosition.startIndex - declProp.length - declBetween.length,
 							);
 						}
-					});
+					}
 				}
 
 				if (isAtRule(node)) {
@@ -434,7 +434,7 @@ const rule = (primary, secondaryOptions = {}, context) => {
 						throw new TypeError('The `afterName` property must be a string');
 					}
 
-					fixPositions.forEach((fixPosition) => {
+					for (const fixPosition of fixPositions) {
 						// 1 — it's a @ length
 						if (fixPosition.startIndex < 1 + atRuleName.length + atRuleAfterName.length) {
 							node.raws.afterName = replaceIndentation(
@@ -451,7 +451,7 @@ const rule = (primary, secondaryOptions = {}, context) => {
 								fixPosition.startIndex - atRuleName.length - atRuleAfterName.length - 1,
 							);
 						}
-					});
+					}
 				}
 			}
 		}
@@ -559,9 +559,9 @@ function inferDocIndentSize(document, space) {
 			lastLeadingSpacesLength = leadingSpacesLength;
 		};
 
-		indents.forEach((leadingSpaces) => {
+		for (const leadingSpaces of indents) {
 			vote(leadingSpaces.length);
-		});
+		}
 
 		let bestScore = 0;
 
@@ -619,7 +619,7 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 		const indents = source.match(/^[ \t]*(?=\S)/gm);
 
 		if (indents) {
-			return Math.min(...indents.map(getIndentLevel));
+			return Math.min(...indents.map((indent) => getIndentLevel(indent)));
 		}
 
 		newBaseIndentLevel = 1;
@@ -683,7 +683,7 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 	}
 
 	if (indents.length) {
-		return Math.max(...indents.map(getIndentLevel)) + newBaseIndentLevel;
+		return Math.max(...indents.map((indent) => getIndentLevel(indent))) + newBaseIndentLevel;
 	}
 
 	return newBaseIndentLevel;

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -55,14 +55,14 @@ const rule = (primary, secondaryOptions, context) => {
 		let skippedSubStrings = [];
 		let skippedSubStringsIndex = 0;
 
-		EXCLUDED_PATTERNS.forEach((pattern) =>
-			execall(pattern, rootString).forEach((match) => {
+		for (const pattern of EXCLUDED_PATTERNS)
+			for (const match of execall(pattern, rootString)) {
 				const subMatch = match.subMatches[0] || '';
 				const startOfSubString = match.index + match.match.indexOf(subMatch);
 
-				return skippedSubStrings.push([startOfSubString, startOfSubString + subMatch.length]);
-			}),
-		);
+				skippedSubStrings.push([startOfSubString, startOfSubString + subMatch.length]);
+				continue;
+			}
 
 		skippedSubStrings = skippedSubStrings.sort((a, b) => a[0] - b[0]);
 

--- a/lib/rules/media-feature-colon-space-after/index.js
+++ b/lib/rules/media-feature-colon-space-after/index.js
@@ -51,28 +51,26 @@ const rule = (primary, _secondaryOptions, context) => {
 		});
 
 		if (fixData) {
-			fixData.forEach((colonIndices, atRule) => {
+			for (const [atRule, colonIndices] of fixData.entries()) {
 				let params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
-				colonIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeColon = params.slice(0, index + 1);
-						const afterColon = params.slice(index + 1);
+				for (const index of colonIndices.sort((a, b) => b - a)) {
+					const beforeColon = params.slice(0, index + 1);
+					const afterColon = params.slice(index + 1);
 
-						if (primary === 'always') {
-							params = beforeColon + afterColon.replace(/^\s*/, ' ');
-						} else if (primary === 'never') {
-							params = beforeColon + afterColon.replace(/^\s*/, '');
-						}
-					});
+					if (primary === 'always') {
+						params = beforeColon + afterColon.replace(/^\s*/, ' ');
+					} else if (primary === 'never') {
+						params = beforeColon + afterColon.replace(/^\s*/, '');
+					}
+				}
 
 				if (atRule.raws.params) {
 					atRule.raws.params.raw = params;
 				} else {
 					atRule.params = params;
 				}
-			});
+			}
 		}
 	};
 };

--- a/lib/rules/media-feature-colon-space-before/index.js
+++ b/lib/rules/media-feature-colon-space-before/index.js
@@ -51,28 +51,26 @@ const rule = (primary, _secondaryOptions, context) => {
 		});
 
 		if (fixData) {
-			fixData.forEach((colonIndices, atRule) => {
+			for (const [atRule, colonIndices] of fixData.entries()) {
 				let params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
-				colonIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeColon = params.slice(0, index);
-						const afterColon = params.slice(index);
+				for (const index of colonIndices.sort((a, b) => b - a)) {
+					const beforeColon = params.slice(0, index);
+					const afterColon = params.slice(index);
 
-						if (primary === 'always') {
-							params = beforeColon.replace(/\s*$/, ' ') + afterColon;
-						} else if (primary === 'never') {
-							params = beforeColon.replace(/\s*$/, '') + afterColon;
-						}
-					});
+					if (primary === 'always') {
+						params = beforeColon.replace(/\s*$/, ' ') + afterColon;
+					} else if (primary === 'never') {
+						params = beforeColon.replace(/\s*$/, '') + afterColon;
+					}
+				}
 
 				if (atRule.raws.params) {
 					atRule.raws.params.raw = params;
 				} else {
 					atRule.params = params;
 				}
-			});
+			}
 		}
 	};
 };

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.js
@@ -39,7 +39,7 @@ const rule = (primary, _secondaryOptions, context) => {
 				return;
 			}
 
-			matches.forEach((match) => {
+			for (const match of matches) {
 				report({
 					message: messages.rejected,
 					node: atRule,
@@ -47,7 +47,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					result,
 					ruleName,
 				});
-			});
+			}
 		});
 	};
 };

--- a/lib/rules/media-feature-parentheses-space-inside/index.js
+++ b/lib/rules/media-feature-parentheses-space-inside/index.js
@@ -86,7 +86,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					return;
 				}
 
-				problems.forEach((err) => {
+				for (const err of problems) {
 					report({
 						message: err.message,
 						node: atRule,
@@ -94,7 +94,7 @@ const rule = (primary, _secondaryOptions, context) => {
 						result,
 						ruleName,
 					});
-				});
+				}
 			}
 		});
 	};

--- a/lib/rules/media-feature-range-operator-space-after/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/index.js
@@ -41,18 +41,16 @@ const rule = (primary, _secondaryOptions, context) => {
 			if (fixOperatorIndices.length) {
 				let params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
-				fixOperatorIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeOperator = params.slice(0, index + 1);
-						const afterOperator = params.slice(index + 1);
+				for (const index of fixOperatorIndices.sort((a, b) => b - a)) {
+					const beforeOperator = params.slice(0, index + 1);
+					const afterOperator = params.slice(index + 1);
 
-						if (primary === 'always') {
-							params = beforeOperator + afterOperator.replace(/^\s*/, ' ');
-						} else if (primary === 'never') {
-							params = beforeOperator + afterOperator.replace(/^\s*/, '');
-						}
-					});
+					if (primary === 'always') {
+						params = beforeOperator + afterOperator.replace(/^\s*/, ' ');
+					} else if (primary === 'never') {
+						params = beforeOperator + afterOperator.replace(/^\s*/, '');
+					}
+				}
 
 				if (atRule.raws.params) {
 					atRule.raws.params.raw = params;

--- a/lib/rules/media-feature-range-operator-space-before/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/index.js
@@ -41,18 +41,16 @@ const rule = (primary, _secondaryOptions, context) => {
 			if (fixOperatorIndices.length) {
 				let params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
-				fixOperatorIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeOperator = params.slice(0, index);
-						const afterOperator = params.slice(index);
+				for (const index of fixOperatorIndices.sort((a, b) => b - a)) {
+					const beforeOperator = params.slice(0, index);
+					const afterOperator = params.slice(index);
 
-						if (primary === 'always') {
-							params = beforeOperator.replace(/\s*$/, ' ') + afterOperator;
-						} else if (primary === 'never') {
-							params = beforeOperator.replace(/\s*$/, '') + afterOperator;
-						}
-					});
+					if (primary === 'always') {
+						params = beforeOperator.replace(/\s*$/, ' ') + afterOperator;
+					} else if (primary === 'never') {
+						params = beforeOperator.replace(/\s*$/, '') + afterOperator;
+					}
+				}
 
 				if (atRule.raws.params) {
 					atRule.raws.params.raw = params;

--- a/lib/rules/media-query-list-comma-newline-after/index.js
+++ b/lib/rules/media-query-list-comma-newline-after/index.js
@@ -55,30 +55,28 @@ const rule = (primary, _secondaryOptions, context) => {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, atRule) => {
+			for (const [atRule, commaIndices] of fixData.entries()) {
 				let params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeComma = params.slice(0, index + 1);
-						const afterComma = params.slice(index + 1);
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					const beforeComma = params.slice(0, index + 1);
+					const afterComma = params.slice(index + 1);
 
-						if (primary.startsWith('always')) {
-							params = /^\s*\n/.test(afterComma)
-								? beforeComma + afterComma.replace(/^[^\S\r\n]*/, '')
-								: beforeComma + context.newline + afterComma;
-						} else if (primary.startsWith('never')) {
-							params = beforeComma + afterComma.replace(/^\s*/, '');
-						}
-					});
+					if (primary.startsWith('always')) {
+						params = /^\s*\n/.test(afterComma)
+							? beforeComma + afterComma.replace(/^[^\S\r\n]*/, '')
+							: beforeComma + context.newline + afterComma;
+					} else if (primary.startsWith('never')) {
+						params = beforeComma + afterComma.replace(/^\s*/, '');
+					}
+				}
 
 				if (atRule.raws.params) {
 					atRule.raws.params.raw = params;
 				} else {
 					atRule.params = params;
 				}
-			});
+			}
 		}
 	};
 };

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -53,28 +53,26 @@ const rule = (primary, _secondaryOptions, context) => {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, atRule) => {
+			for (const [atRule, commaIndices] of fixData.entries()) {
 				let params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeComma = params.slice(0, index + 1);
-						const afterComma = params.slice(index + 1);
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					const beforeComma = params.slice(0, index + 1);
+					const afterComma = params.slice(index + 1);
 
-						if (primary.startsWith('always')) {
-							params = beforeComma + afterComma.replace(/^\s*/, ' ');
-						} else if (primary.startsWith('never')) {
-							params = beforeComma + afterComma.replace(/^\s*/, '');
-						}
-					});
+					if (primary.startsWith('always')) {
+						params = beforeComma + afterComma.replace(/^\s*/, ' ');
+					} else if (primary.startsWith('never')) {
+						params = beforeComma + afterComma.replace(/^\s*/, '');
+					}
+				}
 
 				if (atRule.raws.params) {
 					atRule.raws.params.raw = params;
 				} else {
 					atRule.params = params;
 				}
-			});
+			}
 		}
 	};
 };

--- a/lib/rules/media-query-list-comma-space-before/index.js
+++ b/lib/rules/media-query-list-comma-space-before/index.js
@@ -53,28 +53,26 @@ const rule = (primary, _secondaryOptions, context) => {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, atRule) => {
+			for (const [atRule, commaIndices] of fixData.entries()) {
 				let params = atRule.raws.params ? atRule.raws.params.raw : atRule.params;
 
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeComma = params.slice(0, index);
-						const afterComma = params.slice(index);
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					const beforeComma = params.slice(0, index);
+					const afterComma = params.slice(index);
 
-						if (primary.startsWith('always')) {
-							params = beforeComma.replace(/\s*$/, ' ') + afterComma;
-						} else if (primary.startsWith('never')) {
-							params = beforeComma.replace(/\s*$/, '') + afterComma;
-						}
-					});
+					if (primary.startsWith('always')) {
+						params = beforeComma.replace(/\s*$/, ' ') + afterComma;
+					} else if (primary.startsWith('never')) {
+						params = beforeComma.replace(/\s*$/, '') + afterComma;
+					}
+				}
 
 				if (atRule.raws.params) {
 					atRule.raws.params.raw = params;
 				} else {
 					atRule.params = params;
 				}
-			});
+			}
 		}
 	};
 };

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -62,9 +62,9 @@ const rule = (primary) => {
 
 			const notContiguousOrRectangular = findNotContiguousOrRectangular(areas);
 
-			notContiguousOrRectangular.sort().forEach((name) => {
+			for (const name of notContiguousOrRectangular.sort()) {
 				complain(messages.expectedRectangle(name));
-			});
+			}
 
 			/**
 			 * @param {string} message

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -62,19 +62,19 @@ const rule = (primary, secondaryOptions) => {
 				findAtRuleContext(ruleNode),
 			);
 
-			ruleNode.selectors.forEach((selector) => {
+			for (const selector of ruleNode.selectors) {
 				const trimSelector = selector.trim();
 
 				// Ignore `.selector, { }`
 				if (trimSelector === '') {
-					return;
+					continue;
 				}
 
 				// The edge-case of duplicate selectors will act acceptably
 				const index = ruleNode.selector.indexOf(trimSelector);
 
 				// Resolve any nested selectors before checking
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					parseSelector(resolvedSelector, result, ruleNode, (s) => {
 						if (!isStandardSyntaxSelector(resolvedSelector)) {
 							return;
@@ -82,8 +82,8 @@ const rule = (primary, secondaryOptions) => {
 
 						checkSelector(s, ruleNode, index, comparisonContext);
 					});
-				});
-			});
+				}
+			}
 		});
 
 		/**
@@ -107,7 +107,7 @@ const rule = (primary, secondaryOptions) => {
 			/** @type {Array<{ selector: string, specificity: import('specificity').SpecificityArray }>} */
 			const priorComparableSelectors = comparisonContext.get(referenceSelectorNode);
 
-			priorComparableSelectors.forEach((priorEntry) => {
+			for (const priorEntry of priorComparableSelectors) {
 				if (specificity.compare(selectorSpecificity, priorEntry.specificity) === -1) {
 					report({
 						ruleName,
@@ -117,7 +117,7 @@ const rule = (primary, secondaryOptions) => {
 						index: sourceIndex,
 					});
 				}
-			});
+			}
 
 			priorComparableSelectors.push(entry);
 		}

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -60,7 +60,9 @@ const rule = (primary, secondaryOptions) => {
 					ruleNode.selectors.flatMap((selector) => resolvedNestedSelector(selector, ruleNode)),
 				),
 			];
-			const normalizedSelectorList = resolvedSelectorList.map(normalizeSelector);
+			const normalizedSelectorList = resolvedSelectorList.map((selector) =>
+				normalizeSelector(selector),
+			);
 
 			// Sort the selectors list so that the order of the constituents
 			// doesn't matter
@@ -116,12 +118,12 @@ const rule = (primary, secondaryOptions) => {
 			const reportedSelectors = new Set();
 
 			// Or complain if one selector list contains the same selector more than once
-			ruleNode.selectors.forEach((selector) => {
+			for (const selector of ruleNode.selectors) {
 				const normalized = normalizeSelector(selector);
 
 				if (presentedSelectors.has(normalized)) {
 					if (reportedSelectors.has(normalized)) {
-						return;
+						continue;
 					}
 
 					report({
@@ -134,7 +136,7 @@ const rule = (primary, secondaryOptions) => {
 				} else {
 					presentedSelectors.add(normalized);
 				}
-			});
+			}
 
 			if (shouldDisallowDuplicateInList) {
 				for (const selector of selectorListParsed) {

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -193,9 +193,9 @@ function rule(actual, options, context) {
 		}
 
 		function removeIndices(str, indices) {
-			indices.reverse().forEach((index) => {
+			for (const index of indices.reverse()) {
 				str = str.slice(0, index) + str.slice(index + 1);
-			});
+			}
 
 			return str;
 		}

--- a/lib/rules/no-invalid-double-slash-comments/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/index.js
@@ -32,7 +32,7 @@ function rule(actual) {
 		});
 
 		root.walkRules((ruleNode) => {
-			ruleNode.selectors.forEach((selector) => {
+			for (const selector of ruleNode.selectors) {
 				if (selector.startsWith('//')) {
 					report({
 						message: messages.rejected,
@@ -41,7 +41,7 @@ function rule(actual) {
 						ruleName,
 					});
 				}
-			});
+			}
 		});
 	};
 }

--- a/lib/rules/no-irregular-whitespace/index.js
+++ b/lib/rules/no-irregular-whitespace/index.js
@@ -77,12 +77,12 @@ const generateNodeValidator = (nodeSchema, validator) => {
 	const allKeys = Object.keys(nodeSchema);
 	const validatorForKey = {};
 
-	allKeys.forEach((key) => {
+	for (const key of allKeys) {
 		if (typeof nodeSchema[key] === 'string') validatorForKey[key] = validator;
 
 		if (typeof nodeSchema[key] === 'object')
 			validatorForKey[key] = generateNodeValidator(nodeSchema[key], validator);
-	});
+	}
 
 	// This will be called many times, so it's optimized for performance and not readibility.
 	// Surprisingly, this seem to be slightly faster then concatenating the params and running the validator once.

--- a/lib/rules/no-unknown-animations/index.js
+++ b/lib/rules/no-unknown-animations/index.js
@@ -37,13 +37,13 @@ function rule(actual) {
 					return;
 				}
 
-				animationNames.forEach((animationNameNode) => {
+				for (const animationNameNode of animationNames) {
 					if (keywordSets.animationNameKeywords.has(animationNameNode.value.toLowerCase())) {
-						return;
+						continue;
 					}
 
 					if (declaredAnimations.has(animationNameNode.value)) {
-						return;
+						continue;
 					}
 
 					report({
@@ -53,7 +53,7 @@ function rule(actual) {
 						node: decl,
 						index: declarationValueIndex(decl) + animationNameNode.sourceIndex,
 					});
-				});
+				}
 			}
 		});
 	};

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -112,7 +112,7 @@ function rule(expectation, secondary, context) {
 			});
 
 			if (alwaysFixPositions.length) {
-				alwaysFixPositions.forEach((fixPosition) => {
+				for (const fixPosition of alwaysFixPositions) {
 					const index = fixPosition.index;
 
 					if (node.type === 'atrule') {
@@ -120,11 +120,11 @@ function rule(expectation, secondary, context) {
 					} else {
 						node.value = addLeadingZero(node.value, index);
 					}
-				});
+				}
 			}
 
 			if (neverFixPositions.length) {
-				neverFixPositions.forEach((fixPosition) => {
+				for (const fixPosition of neverFixPositions) {
 					const startIndex = fixPosition.startIndex;
 					const endIndex = fixPosition.endIndex;
 
@@ -133,7 +133,7 @@ function rule(expectation, secondary, context) {
 					} else {
 						node.value = removeLeadingZeros(node.value, startIndex, endIndex);
 					}
-				});
+				}
 			}
 		}
 

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -95,7 +95,7 @@ function rule(actual, secondary, context) {
 			});
 
 			if (fixPositions.length) {
-				fixPositions.forEach((fixPosition) => {
+				for (const fixPosition of fixPositions) {
 					const startIndex = fixPosition.startIndex;
 					const endIndex = fixPosition.endIndex;
 
@@ -104,7 +104,7 @@ function rule(actual, secondary, context) {
 					} else {
 						node.value = removeTrailingZeros(node.value, startIndex, endIndex);
 					}
-				});
+				}
 			}
 		}
 	};

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -58,13 +58,13 @@ function rule(pattern, options) {
 
 			// Only bother resolving selectors that have an interpolating &
 			if (shouldResolveNestedSelectors && hasInterpolatingAmpersand(selector)) {
-				resolveNestedSelector(selector, ruleNode).forEach((nestedSelector) => {
+				for (const nestedSelector of resolveNestedSelector(selector, ruleNode)) {
 					if (!isStandardSyntaxSelector(nestedSelector)) {
-						return;
+						continue;
 					}
 
 					parseSelector(nestedSelector, result, ruleNode, (s) => checkSelector(s, ruleNode));
-				});
+				}
 			} else {
 				parseSelector(selector, result, ruleNode, (s) => checkSelector(s, ruleNode));
 			}

--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -87,20 +87,18 @@ function rule(expectation, options, context) {
 			if (fixIndices.length) {
 				let fixedSelector = selector;
 
-				fixIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeSelector = fixedSelector.slice(0, index);
-						let afterSelector = fixedSelector.slice(index);
+				for (const index of fixIndices.sort((a, b) => b - a)) {
+					const beforeSelector = fixedSelector.slice(0, index);
+					let afterSelector = fixedSelector.slice(index);
 
-						if (expectation.startsWith('always')) {
-							afterSelector = context.newline + afterSelector;
-						} else if (expectation.startsWith('never-multi-line')) {
-							afterSelector = afterSelector.replace(/^\s*/, '');
-						}
+					if (expectation.startsWith('always')) {
+						afterSelector = context.newline + afterSelector;
+					} else if (expectation.startsWith('never-multi-line')) {
+						afterSelector = afterSelector.replace(/^\s*/, '');
+					}
 
-						fixedSelector = beforeSelector + afterSelector;
-					});
+					fixedSelector = beforeSelector + afterSelector;
+				}
 
 				if (ruleNode.raws.selector) {
 					ruleNode.raws.selector.raw = fixedSelector;

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -49,39 +49,37 @@ function rule(expectation, options, context) {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, ruleNode) => {
+			for (const [ruleNode, commaIndices] of fixData.entries()) {
 				let selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						let beforeSelector = selector.slice(0, index);
-						const afterSelector = selector.slice(index);
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					let beforeSelector = selector.slice(0, index);
+					const afterSelector = selector.slice(index);
 
-						if (expectation.startsWith('always')) {
-							const spaceIndex = beforeSelector.search(/\s+$/);
+					if (expectation.startsWith('always')) {
+						const spaceIndex = beforeSelector.search(/\s+$/);
 
-							if (spaceIndex >= 0) {
-								beforeSelector =
-									beforeSelector.slice(0, spaceIndex) +
-									context.newline +
-									beforeSelector.slice(spaceIndex);
-							} else {
-								beforeSelector += context.newline;
-							}
-						} else if (expectation === 'never-multi-line') {
-							beforeSelector = beforeSelector.replace(/\s*$/, '');
+						if (spaceIndex >= 0) {
+							beforeSelector =
+								beforeSelector.slice(0, spaceIndex) +
+								context.newline +
+								beforeSelector.slice(spaceIndex);
+						} else {
+							beforeSelector += context.newline;
 						}
+					} else if (expectation === 'never-multi-line') {
+						beforeSelector = beforeSelector.replace(/\s*$/, '');
+					}
 
-						selector = beforeSelector + afterSelector;
-					});
+					selector = beforeSelector + afterSelector;
+				}
 
 				if (ruleNode.raws.selector) {
 					ruleNode.raws.selector.raw = selector;
 				} else {
 					ruleNode.selector = selector;
 				}
-			});
+			}
 		}
 	};
 }

--- a/lib/rules/selector-list-comma-space-after/index.js
+++ b/lib/rules/selector-list-comma-space-after/index.js
@@ -50,30 +50,28 @@ function rule(expectation, options, context) {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, ruleNode) => {
+			for (const [ruleNode, commaIndices] of fixData.entries()) {
 				let selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const beforeSelector = selector.slice(0, index + 1);
-						let afterSelector = selector.slice(index + 1);
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					const beforeSelector = selector.slice(0, index + 1);
+					let afterSelector = selector.slice(index + 1);
 
-						if (expectation.startsWith('always')) {
-							afterSelector = afterSelector.replace(/^\s*/, ' ');
-						} else if (expectation.startsWith('never')) {
-							afterSelector = afterSelector.replace(/^\s*/, '');
-						}
+					if (expectation.startsWith('always')) {
+						afterSelector = afterSelector.replace(/^\s*/, ' ');
+					} else if (expectation.startsWith('never')) {
+						afterSelector = afterSelector.replace(/^\s*/, '');
+					}
 
-						selector = beforeSelector + afterSelector;
-					});
+					selector = beforeSelector + afterSelector;
+				}
 
 				if (ruleNode.raws.selector) {
 					ruleNode.raws.selector.raw = selector;
 				} else {
 					ruleNode.selector = selector;
 				}
-			});
+			}
 		}
 	};
 }

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -50,30 +50,28 @@ function rule(expectation, options, context) {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, ruleNode) => {
+			for (const [ruleNode, commaIndices] of fixData.entries()) {
 				let selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						let beforeSelector = selector.slice(0, index);
-						const afterSelector = selector.slice(index);
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					let beforeSelector = selector.slice(0, index);
+					const afterSelector = selector.slice(index);
 
-						if (expectation.includes('always')) {
-							beforeSelector = beforeSelector.replace(/\s*$/, ' ');
-						} else if (expectation.includes('never')) {
-							beforeSelector = beforeSelector.replace(/\s*$/, '');
-						}
+					if (expectation.includes('always')) {
+						beforeSelector = beforeSelector.replace(/\s*$/, ' ');
+					} else if (expectation.includes('never')) {
+						beforeSelector = beforeSelector.replace(/\s*$/, '');
+					}
 
-						selector = beforeSelector + afterSelector;
-					});
+					selector = beforeSelector + afterSelector;
+				}
 
 				if (ruleNode.raws.selector) {
 					ruleNode.raws.selector.raw = selector;
 				} else {
 					ruleNode.selector = selector;
 				}
-			});
+			}
 		}
 	};
 }

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -61,7 +61,9 @@ function rule(max, options) {
 					return total;
 				}
 
-				return (total += 1);
+				total += 1;
+
+				return total;
 			}, 0);
 
 			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
@@ -80,13 +82,13 @@ function rule(max, options) {
 				return;
 			}
 
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					parseSelector(resolvedSelector, result, ruleNode, (container) =>
 						checkSelector(container, ruleNode),
 					);
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-max-class/index.js
+++ b/lib/rules/selector-max-class/index.js
@@ -36,7 +36,9 @@ function rule(max) {
 					checkSelector(childNode, ruleNode);
 				}
 
-				return (total += childNode.type === 'class' ? 1 : 0);
+				if (childNode.type === 'class') total += 1;
+
+				return total;
 			}, 0);
 
 			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
@@ -55,13 +57,13 @@ function rule(max) {
 				return;
 			}
 
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					parseSelector(resolvedSelector, result, ruleNode, (container) =>
 						checkSelector(container, ruleNode),
 					);
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-max-combinators/index.js
+++ b/lib/rules/selector-max-combinators/index.js
@@ -37,7 +37,9 @@ function rule(max) {
 					checkSelector(childNode, ruleNode);
 				}
 
-				return (total += childNode.type === 'combinator' ? 1 : 0);
+				if (childNode.type === 'combinator') total += 1;
+
+				return total;
 			}, 0);
 
 			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
@@ -56,13 +58,13 @@ function rule(max) {
 				return;
 			}
 
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					parseSelector(resolvedSelector, result, ruleNode, (container) =>
 						checkSelector(container, ruleNode),
 					);
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -64,12 +64,12 @@ function rule(max) {
 			}
 
 			// Using `.selectors` gets us each selector if there is a comma separated set
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					// Process each resolved selector with `checkSelector` via postcss-selector-parser
 					parseSelector(resolvedSelector, result, ruleNode, (s) => checkSelector(s, ruleNode));
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -53,7 +53,9 @@ function rule(max, options) {
 					checkSelector(childNode, ruleNode);
 				}
 
-				return (total += childNode.type === 'id' ? 1 : 0);
+				if (childNode.type === 'id') total += 1;
+
+				return total;
 			}, 0);
 
 			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
@@ -79,13 +81,13 @@ function rule(max, options) {
 				return;
 			}
 
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					parseSelector(resolvedSelector, result, ruleNode, (container) =>
 						checkSelector(container, ruleNode),
 					);
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-max-pseudo-class/index.js
+++ b/lib/rules/selector-max-pseudo-class/index.js
@@ -47,7 +47,7 @@ function rule(max) {
 				}
 
 				if (childNode.type === 'pseudo') {
-					return (total += 1);
+					total += 1;
 				}
 
 				return total;
@@ -69,13 +69,13 @@ function rule(max) {
 				return;
 			}
 
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					parseSelector(resolvedSelector, result, rule, (selectorTree) => {
 						checkSelector(selectorTree, ruleNode);
 					});
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -27,11 +27,11 @@ const zeroSpecificity = () => [0, 0, 0, 0];
 const specificitySum = (specificities) => {
 	const sum = zeroSpecificity();
 
-	specificities.forEach((specificityArray) => {
-		specificityArray.forEach((value, i) => {
+	for (const specificityArray of specificities) {
+		for (const [i, value] of specificityArray.entries()) {
 			sum[i] += value;
-		});
-	});
+		}
+	}
 
 	return sum;
 };
@@ -129,13 +129,13 @@ function rule(max, options) {
 					return pseudoSpecificity(node);
 				case 'selector':
 					// Calculate the sum of all the direct children
-					return specificitySum(node.map(nodeSpecificity));
+					return specificitySum(node.map((n) => nodeSpecificity(n)));
 				default:
 					return zeroSpecificity();
 			}
 		};
 
-		const maxSpecificityArray = `0,${max}`.split(',').map(parseFloat);
+		const maxSpecificityArray = `0,${max}`.split(',').map((s) => Number.parseFloat(s));
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {
@@ -143,12 +143,12 @@ function rule(max, options) {
 			}
 
 			// Using `.selectors` gets us each selector in the eventuality we have a comma separated set
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					try {
 						// Skip non-standard syntax selectors
 						if (!isStandardSyntaxSelector(resolvedSelector)) {
-							return;
+							continue;
 						}
 
 						parseSelector(resolvedSelector, result, ruleNode, (selectorTree) => {
@@ -171,8 +171,8 @@ function rule(max, options) {
 							stylelintType: 'parseError',
 						});
 					}
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -110,17 +110,17 @@ function rule(max, options) {
 				return;
 			}
 
-			ruleNode.selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of ruleNode.selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					if (!isStandardSyntaxSelector(resolvedSelector)) {
-						return;
+						continue;
 					}
 
 					parseSelector(resolvedSelector, result, ruleNode, (container) =>
 						checkSelector(container, ruleNode),
 					);
-				});
-			});
+				}
+			}
 		});
 	};
 }
@@ -128,13 +128,13 @@ function rule(max, options) {
 function hasDescendantCombinatorBefore(node) {
 	const nodeIndex = node.parent.nodes.indexOf(node);
 
-	return node.parent.nodes.slice(0, nodeIndex).some(isDescendantCombinator);
+	return node.parent.nodes.slice(0, nodeIndex).some((n) => isDescendantCombinator(n));
 }
 
 function hasChildCombinatorBefore(node) {
 	const nodeIndex = node.parent.nodes.indexOf(node);
 
-	return node.parent.nodes.slice(0, nodeIndex).some(isChildCombinator);
+	return node.parent.nodes.slice(0, nodeIndex).some((n) => isChildCombinator(n));
 }
 
 function hasCompoundSelector(node) {

--- a/lib/rules/selector-max-universal/index.js
+++ b/lib/rules/selector-max-universal/index.js
@@ -39,7 +39,9 @@ function rule(max) {
 					checkSelector(childNode, ruleNode);
 				}
 
-				return (total += childNode.type === 'universal' ? 1 : 0);
+				if (childNode.type === 'universal') total += 1;
+
+				return total;
 			}, 0);
 
 			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
@@ -68,13 +70,13 @@ function rule(max) {
 					}
 				});
 
-			selectors.forEach((selector) => {
-				resolvedNestedSelector(selector, ruleNode).forEach((resolvedSelector) => {
+			for (const selector of selectors) {
+				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
 					parseSelector(resolvedSelector, result, ruleNode, (container) =>
 						checkSelector(container, ruleNode),
 					);
-				});
-			});
+				}
+			}
 		});
 	};
 }

--- a/lib/rules/selector-no-qualifying-type/index.js
+++ b/lib/rules/selector-no-qualifying-type/index.js
@@ -89,7 +89,7 @@ function rule(enabled, options) {
 					const selectorNodes = getRightNodes(selector);
 					const index = selector.sourceIndex;
 
-					selectorNodes.forEach((selectorNode) => {
+					for (const selectorNode of selectorNodes) {
 						if (selectorNode.type === 'id' && !optionsMatches(options, 'ignore', 'id')) {
 							complain(index);
 						}
@@ -104,17 +104,17 @@ function rule(enabled, options) {
 						) {
 							complain(index);
 						}
-					});
+					}
 				});
 			}
 
-			resolvedNestedSelector(ruleNode.selector, ruleNode).forEach((resolvedSelector) => {
+			for (const resolvedSelector of resolvedNestedSelector(ruleNode.selector, ruleNode)) {
 				if (!isStandardSyntaxSelector(resolvedSelector)) {
-					return;
+					continue;
 				}
 
 				parseSelector(resolvedSelector, result, ruleNode, checkSelector);
-			});
+			}
 
 			function complain(index) {
 				report({

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -45,7 +45,7 @@ function rule(expectation, options, context) {
 						return;
 					}
 
-					const paramString = pseudoNode.map(String).join(',');
+					const paramString = pseudoNode.map((node) => String(node)).join(',');
 					const nextCharIsSpace = paramString.startsWith(' ');
 					const openIndex =
 						pseudoNode.sourceIndex + stringifyProperty(pseudoNode, 'value').length + 1;

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -78,12 +78,12 @@ function rule(expectation, options, context) {
 				const offset = expectedSingle ? 1 : 0;
 				const extraColon = expectedSingle ? '' : ':';
 
-				fixPositions.forEach((fixPosition) => {
+				for (const fixPosition of fixPositions) {
 					ruleNode.selector =
 						ruleNode.selector.substring(0, fixPosition.startIndex - offset) +
 						extraColon +
 						ruleNode.selector.substring(fixPosition.startIndex);
-				});
+				}
 			}
 		});
 	};

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -153,9 +153,9 @@ function rule(expectation, secondary, context) {
 				}
 			});
 
-			fixPositions.forEach((fixIndex) => {
+			for (const fixIndex of fixPositions) {
 				ruleNode.selector = replaceQuote(ruleNode.selector, fixIndex, correctQuote);
-			});
+			}
 		}
 
 		function checkDeclOrAtRule(node, value, getIndex) {
@@ -200,13 +200,13 @@ function rule(expectation, secondary, context) {
 				}
 			});
 
-			fixPositions.forEach((fixIndex) => {
+			for (const fixIndex of fixPositions) {
 				if (node.type === 'atrule') {
 					node.params = replaceQuote(node.params, fixIndex, correctQuote);
 				} else {
 					node.value = replaceQuote(node.value, fixIndex, correctQuote);
 				}
-			});
+			}
 		}
 	};
 }

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -85,7 +85,7 @@ function rule(expectation, options, context) {
 						node.value = parsedValue.toString();
 					}
 				} else {
-					problems.forEach((err) => {
+					for (const err of problems) {
 						report({
 							index: err.index,
 							message: err.message,
@@ -93,7 +93,7 @@ function rule(expectation, options, context) {
 							result,
 							ruleName,
 						});
-					});
+					}
 				}
 			}
 		}

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -29,9 +29,9 @@ const gridColumnProps = new Set(['grid-column', 'grid-column-start', 'grid-colum
 
 const mapLowercaseKeywordsToCamelCase = new Map();
 
-keywordSets.camelCaseKeywords.forEach((func) => {
+for (const func of keywordSets.camelCaseKeywords) {
 	mapLowercaseKeywordsToCamelCase.set(func.toLowerCase(), func);
-});
+}
 
 function rule(expectation, options, context) {
 	return (root, result) => {

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -72,25 +72,22 @@ function rule(expectation, options, context) {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, decl) => {
-				commaIndices
-					.sort((a, b) => a - b)
-					.reverse()
-					.forEach((index) => {
-						const value = getDeclarationValue(decl);
-						const valueIndex = index - declarationValueIndex(decl);
-						const beforeValue = value.slice(0, valueIndex + 1);
-						let afterValue = value.slice(valueIndex + 1);
+			for (const [decl, commaIndices] of fixData.entries()) {
+				for (const index of commaIndices.sort((a, b) => a - b).reverse()) {
+					const value = getDeclarationValue(decl);
+					const valueIndex = index - declarationValueIndex(decl);
+					const beforeValue = value.slice(0, valueIndex + 1);
+					let afterValue = value.slice(valueIndex + 1);
 
-						if (expectation.startsWith('always')) {
-							afterValue = context.newline + afterValue;
-						} else if (expectation.startsWith('never-multi-line')) {
-							afterValue = afterValue.replace(/^\s*/, '');
-						}
+					if (expectation.startsWith('always')) {
+						afterValue = context.newline + afterValue;
+					} else if (expectation.startsWith('never-multi-line')) {
+						afterValue = afterValue.replace(/^\s*/, '');
+					}
 
-						setDeclarationValue(decl, beforeValue + afterValue);
-					});
-			});
+					setDeclarationValue(decl, beforeValue + afterValue);
+				}
+			}
 		}
 	};
 }

--- a/lib/rules/value-list-comma-space-after/index.js
+++ b/lib/rules/value-list-comma-space-after/index.js
@@ -59,24 +59,22 @@ function rule(expectation, options, context) {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, decl) => {
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const value = getDeclarationValue(decl);
-						const valueIndex = index - declarationValueIndex(decl);
-						const beforeValue = value.slice(0, valueIndex + 1);
-						let afterValue = value.slice(valueIndex + 1);
+			for (const [decl, commaIndices] of fixData.entries()) {
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					const value = getDeclarationValue(decl);
+					const valueIndex = index - declarationValueIndex(decl);
+					const beforeValue = value.slice(0, valueIndex + 1);
+					let afterValue = value.slice(valueIndex + 1);
 
-						if (expectation.startsWith('always')) {
-							afterValue = afterValue.replace(/^\s*/, ' ');
-						} else if (expectation.startsWith('never')) {
-							afterValue = afterValue.replace(/^\s*/, '');
-						}
+					if (expectation.startsWith('always')) {
+						afterValue = afterValue.replace(/^\s*/, ' ');
+					} else if (expectation.startsWith('never')) {
+						afterValue = afterValue.replace(/^\s*/, '');
+					}
 
-						setDeclarationValue(decl, beforeValue + afterValue);
-					});
-			});
+					setDeclarationValue(decl, beforeValue + afterValue);
+				}
+			}
 		}
 	};
 }

--- a/lib/rules/value-list-comma-space-before/index.js
+++ b/lib/rules/value-list-comma-space-before/index.js
@@ -59,24 +59,22 @@ function rule(expectation, options, context) {
 		});
 
 		if (fixData) {
-			fixData.forEach((commaIndices, decl) => {
-				commaIndices
-					.sort((a, b) => b - a)
-					.forEach((index) => {
-						const value = getDeclarationValue(decl);
-						const valueIndex = index - declarationValueIndex(decl);
-						let beforeValue = value.slice(0, valueIndex);
-						const afterValue = value.slice(valueIndex);
+			for (const [decl, commaIndices] of fixData.entries()) {
+				for (const index of commaIndices.sort((a, b) => b - a)) {
+					const value = getDeclarationValue(decl);
+					const valueIndex = index - declarationValueIndex(decl);
+					let beforeValue = value.slice(0, valueIndex);
+					const afterValue = value.slice(valueIndex);
 
-						if (expectation.startsWith('always')) {
-							beforeValue = beforeValue.replace(/\s*$/, ' ');
-						} else if (expectation.startsWith('never')) {
-							beforeValue = beforeValue.replace(/\s*$/, '');
-						}
+					if (expectation.startsWith('always')) {
+						beforeValue = beforeValue.replace(/\s*$/, ' ');
+					} else if (expectation.startsWith('never')) {
+						beforeValue = beforeValue.replace(/\s*$/, '');
+					}
 
-						setDeclarationValue(decl, beforeValue + afterValue);
-					});
-			});
+					setDeclarationValue(decl, beforeValue + afterValue);
+				}
+			}
 		}
 	};
 }

--- a/lib/utils/checkAgainstRule.js
+++ b/lib/utils/checkAgainstRule.js
@@ -48,7 +48,8 @@ function checkAgainstRule(options, callback) {
 		/** @type {O} */ (settings[1]),
 		{},
 	)(options.root, tmpPostcssResult);
-	tmpPostcssResult.warnings().forEach(callback);
+
+	for (const warning of tmpPostcssResult.warnings()) callback(warning);
 }
 
 module.exports = /** @type {typeof import('stylelint').utils.checkAgainstRule} */ (

--- a/lib/utils/checkInvalidCLIOptions.js
+++ b/lib/utils/checkInvalidCLIOptions.js
@@ -97,7 +97,7 @@ module.exports = function checkInvalidCLIOptions(allowedOptions, inputOptions) {
 
 	return Object.keys(inputOptions)
 		.filter((opt) => !allOptions.includes(opt))
-		.map(kebabCase)
+		.map((opt) => kebabCase(opt))
 		.reduce((msg, invalid) => {
 			// NOTE: No suggestion for shortcut options because it's too difficult
 			const suggestion = invalid.length >= 2 ? suggest(allOptions, invalid) : null;

--- a/lib/utils/eachDeclarationBlock.js
+++ b/lib/utils/eachDeclarationBlock.js
@@ -43,13 +43,13 @@ module.exports = function eachDeclarationBlock(root, callback) {
 			/** @type {Declaration[]} */
 			const decls = [];
 
-			statement.nodes.forEach((node) => {
+			for (const node of statement.nodes) {
 				if (node.type === 'decl') {
 					decls.push(node);
 				}
 
 				each(node);
-			});
+			}
 
 			if (decls.length) {
 				callback(decls.forEach.bind(decls));

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -32,9 +32,9 @@ const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables', 'disab
 function validateOptions(result, ruleName, ...optionDescriptions) {
 	let noErrors = true;
 
-	optionDescriptions.forEach((optionDescription) => {
+	for (const optionDescription of optionDescriptions) {
 		validate(optionDescription, ruleName, complain);
-	});
+	}
 
 	/**
 	 * @param {string} message


### PR DESCRIPTION
* use `for...of`
* fix a few return assignments
* fix a few array callback issues

The non-whitespace diff is cleaner to view: https://github.com/stylelint/stylelint/pull/5652/files?w=1

@jeddy3 @ybiquitous here it is. There's one type lint error. Feel free to adapt the patch.
