### PR TITLE
Fix TypeError for baseIndentLevel: 1 option and vue file in indentation

### DIFF
--- a/lib/rules/declaration-bang-space-before/__tests__/index.js
+++ b/lib/rules/declaration-bang-space-before/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssSass = require('postcss-sass');
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -197,7 +199,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	syntax: 'sass',
+	customSyntax: postcssSass,
 	skipBasicChecks: true,
 	fix: true,
 
@@ -215,7 +217,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	syntax: 'sass',
+	customSyntax: postcssSass,
 	skipBasicChecks: true,
 	fix: true,
 

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -79,11 +81,10 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -265,11 +267,10 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -109,10 +111,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -87,10 +89,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	accept: [
 		{

--- a/lib/rules/declaration-empty-line-before/__tests__/index.js
+++ b/lib/rules/declaration-empty-line-before/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const postcssLess = require('postcss-less');
 const postcssScss = require('postcss-scss');
 const stripIndent = require('common-tags').stripIndent;
@@ -904,7 +905,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['always'],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 	accept: [
 		{
@@ -962,7 +963,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['always', { ignore: ['inside-single-line-block'] }],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [

--- a/lib/rules/function-url-no-scheme-relative/__tests__/index.js
+++ b/lib/rules/function-url-no-scheme-relative/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -117,10 +119,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	reject: [
 		{

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -613,10 +615,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: ['always'],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	reject: [
 		{

--- a/lib/rules/indentation/__tests__/html.js
+++ b/lib/rules/indentation/__tests__/html.js
@@ -1,12 +1,13 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
-	skip: true,
 	ruleName,
 	config: ['tab'],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [
@@ -191,10 +192,9 @@ a {
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [2],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [
@@ -242,7 +242,6 @@ a {
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [
 		'tab',
@@ -250,7 +249,7 @@ testRule({
 			baseIndentLevel: 1,
 		},
 	],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [
@@ -388,7 +387,6 @@ a {
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [
 		'tab',
@@ -396,7 +394,7 @@ testRule({
 			baseIndentLevel: 0,
 		},
 	],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [
@@ -484,7 +482,6 @@ a {
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [
 		2,
@@ -492,7 +489,7 @@ testRule({
 			baseIndentLevel: 1,
 		},
 	],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -664,7 +664,7 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 			if (document) {
 				const nextRoot = document.nodes[document.nodes.indexOf(root) + 1];
 
-				afterEnd = nextRoot ? nextRoot.raws.beforeStart : document.raws.afterEnd;
+				afterEnd = nextRoot ? nextRoot.raws.codeBefore : document.raws.codeAfter;
 			} else {
 				// Nested root node in css-in-js lang
 				const parent = root.parent;
@@ -673,13 +673,13 @@ function inferRootIndentLevel(root, baseIndentLevel, indentSize) {
 
 				const nextRoot = parent.nodes[parent.nodes.indexOf(root) + 1];
 
-				afterEnd = nextRoot ? nextRoot.raws.beforeStart : root.raws.afterEnd;
+				afterEnd = nextRoot ? nextRoot.raws.codeBefore : root.raws.codeAfter;
 			}
 		} else {
 			afterEnd = after;
 		}
 
-		indents.push(afterEnd.match(/^[ \t]*/)[0]);
+		if (afterEnd) indents.push(afterEnd.match(/^[ \t]*/)[0]);
 	}
 
 	if (indents.length) {

--- a/lib/rules/max-empty-lines/__tests__/index.js
+++ b/lib/rules/max-empty-lines/__tests__/index.js
@@ -162,9 +162,14 @@ testRule({
 		{
 			code: `<div>
 
+
+
+
 <style>
 /* horse */
 </style>
+
+
 
 </div>`,
 		},
@@ -207,6 +212,7 @@ a {color: pink;}
 <style>
 /* horse */
 
+
 </style>
 </div>`,
 			fixed: `<div>
@@ -222,6 +228,7 @@ a {color: pink;}
 
 		{
 			code: `<div style="color: pink;
+
 
 ">
 </div>`,
@@ -241,6 +248,7 @@ a {}
 </style>
 <style>
 a {}
+
 
 </style>
 </div>`,
@@ -273,9 +281,16 @@ testRule({
 			code: `
 import styled from 'styled-components';
 
+
+
+
+
 export default styled.div\`
   color: #00
 \`;
+
+
+
 
 `,
 		},
@@ -310,6 +325,7 @@ import styled from 'styled-components';
 export default styled.div\`
   /* horse */
 
+
   color: #00
 \`;
 `,
@@ -336,6 +352,7 @@ export const style1 = styled.div\`
 // styled style2
 export const style2 = styled.div\`
   color: #00
+
 
 \`;`,
 			fixed: `

--- a/lib/rules/max-empty-lines/__tests__/index.js
+++ b/lib/rules/max-empty-lines/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const postcssScss = require('postcss-scss');
 const sugarss = require('sugarss');
 
@@ -152,10 +153,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [1],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -195,15 +195,15 @@ function isEofNode(document, root) {
 
 	// @ts-expect-error -- TS2367: This condition will always return 'false' since the types 'Root' and 'ChildNode | undefined' have no overlap.
 	if (root === document.last) {
-		after = document.raws && document.raws.afterEnd;
+		after = document.raws && document.raws.codeAfter;
 	} else {
 		// @ts-expect-error -- TS2345: Argument of type 'Root' is not assignable to parameter of type 'number | ChildNode'.
 		const rootIndex = document.index(root);
 
 		const nextNode = document.nodes[rootIndex + 1];
 
-		// @ts-expect-error -- TS2339: Property 'beforeStart' does not exist on type 'AtRuleRaws | RuleRaws | DeclarationRaws | CommentRaws'.
-		after = nextNode && nextNode.raws && nextNode.raws.beforeStart;
+		// @ts-expect-error -- TS2339: Property 'codeBefore' does not exist on type 'CommentRaws'.
+		after = nextNode && nextNode.raws && nextNode.raws.codeBefore;
 	}
 
 	return !String(after).trim();

--- a/lib/rules/max-line-length/__tests__/index.js
+++ b/lib/rules/max-line-length/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const postcssScss = require('postcss-scss');
 
 const { messages, ruleName } = require('..');
@@ -227,10 +228,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [20],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	accept: [
 		{

--- a/lib/rules/no-empty-source/__tests__/index.js
+++ b/lib/rules/no-empty-source/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -93,10 +95,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	skipBasicChecks: true,
 
 	accept: [

--- a/lib/rules/no-eol-whitespace/__tests__/index.js
+++ b/lib/rules/no-eol-whitespace/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const postcssScss = require('postcss-scss');
 
 const { messages, ruleName } = require('..');
@@ -573,10 +574,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [

--- a/lib/rules/no-eol-whitespace/__tests__/index.js
+++ b/lib/rules/no-eol-whitespace/__tests__/index.js
@@ -581,7 +581,7 @@ testRule({
 
 	accept: [
 		{
-			code: `<div> /* After this comment we have eol whitespace */
+			code: `<div> /* After this comment we have eol whitespace */ 
 <style>
 a {
   color: red;
@@ -597,7 +597,7 @@ a {
 			code: `<div>
 <style>
 a {
-  color: red;
+  color: red; 
 }
 </style>
 

--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const postcssLess = require('postcss-less');
 
 const { messages, ruleName } = require('..');
@@ -949,10 +950,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	fix: true,
 
 	accept: [

--- a/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const sugarss = require('sugarss');
 
 const { messages, ruleName } = require('..');
@@ -71,11 +72,10 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	syntax: 'html',
+	customSyntax: postcssHtml,
 
 	accept: [
 		{

--- a/lib/rules/property-no-unknown/__tests__/index.js
+++ b/lib/rules/property-no-unknown/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const postcssLess = require('postcss-less');
 const postcssScss = require('postcss-scss');
 
@@ -339,10 +340,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	accept: [
 		{
 			code: '<a style="{{rule}}: 1">',

--- a/lib/rules/string-no-newline/__tests__/index.js
+++ b/lib/rules/string-no-newline/__tests__/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
 const postcssScss = require('postcss-scss');
 
 const { messages, ruleName } = require('..');
@@ -84,10 +85,9 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	skipBasicChecks: true,
 
 	accept: [

--- a/lib/rules/unicode-bom/__tests__/index.js
+++ b/lib/rules/unicode-bom/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcssHtml = require('postcss-html')();
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -63,9 +65,8 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	config: ['always'],
 	skipBasicChecks: true,
 
@@ -90,9 +91,8 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
-	syntax: 'html',
+	customSyntax: postcssHtml,
 	config: ['never'],
 	skipBasicChecks: true,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "lint-staged": "^11.2.4",
         "np": "^7.5.0",
         "npm-run-all": "^4.1.5",
+        "postcss-html": "^1.2.0",
         "postcss-import": "^14.0.2",
         "postcss-less": "^5.0.0",
         "postcss-sass": "^0.5.0",
@@ -2922,6 +2923,41 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
     "node_modules/domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2941,6 +2977,35 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-prop": {
@@ -3015,6 +3080,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -4354,6 +4431,25 @@
       "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.1.2.tgz",
+      "integrity": "sha512-d6cqsbJba2nRdg8WW2okyD4ceonFHn9jLFxhwlNcLhQWcFPdxXeJulgOLjLKtAK9T6ahd+GQNZwG9fjmGW7lyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -9278,6 +9374,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-html": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-1.2.0.tgz",
+      "integrity": "sha512-DEuVLHIf8wwqJtLAVGj0ol00PJFB9byPDZF+p56CAC5ktdlF9lFzLdhqbPxBza/jpBYwn17+fGeqvXxYh+h+CQ==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.2",
+        "postcss": "^8.3.11",
+        "postcss-safe-parser": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12 || >=14"
       }
     },
     "node_modules/postcss-import": {
@@ -15221,6 +15331,31 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "dev": true
+    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -15236,6 +15371,26 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "dot-prop": {
@@ -15293,6 +15448,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -16273,6 +16434,18 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
       "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+    },
+    "htmlparser2": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.1.2.tgz",
+      "integrity": "sha512-d6cqsbJba2nRdg8WW2okyD4ceonFHn9jLFxhwlNcLhQWcFPdxXeJulgOLjLKtAK9T6ahd+GQNZwG9fjmGW7lyg==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -19830,6 +20003,17 @@
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
         "source-map-js": "^0.6.2"
+      }
+    },
+    "postcss-html": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-1.2.0.tgz",
+      "integrity": "sha512-DEuVLHIf8wwqJtLAVGj0ol00PJFB9byPDZF+p56CAC5ktdlF9lFzLdhqbPxBza/jpBYwn17+fGeqvXxYh+h+CQ==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^7.1.2",
+        "postcss": "^8.3.11",
+        "postcss-safe-parser": "^6.0.0"
       }
     },
     "postcss-import": {

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "lint-staged": "^11.2.4",
     "np": "^7.5.0",
     "npm-run-all": "^4.1.5",
+    "postcss-html": "^1.2.0",
     "postcss-import": "^14.0.2",
     "postcss-less": "^5.0.0",
     "postcss-sass": "^0.5.0",


### PR DESCRIPTION
This is a follow up to issue #5289, because PR #5297 did not replace `syntax: 'html'` and `syntax: 'css-in-js'` in rules tests. Those test-cases were disabled instead, and some of those were broken at the same time by accidentally removing some whitespace, where it was required for the tests.

The first and second commits replace `syntax: ...` everywhere and remove the `skip: true` in those cases. The third commit brings back the accidentally removed whitespace. After that, a few tests still fail:
- the indentation and max-empty-lines rules were using `raws.beforeStart` and `raws.afterEnd`. Not sure where those came from (`postcss-syntax` maybe?), but it seems they should be replace with `raws.codeBefore` and `raws.codeAfter`. (fourth commit)
- the declaration-empty-line-before rule seems to need another check for `isRoot(parent)` - at least that fixed the failing test... (fifth commit). There's still some issue with typing, but I don't really know typescript well, yet, so I'd need some guidance there.

I guess those changes should have been part of #5304, but were not noticed because of the skipped tests.

---

I came here, because when migrating to stylelint 14 in a vue project using `postcss-html`, I had the following error thrown:
```
TypeError: Cannot read properties of undefined (reading 'match')
...
at inferRootIndentLevel (node_modules/stylelint/lib/rules/indentation/index.js:682:25)
```

This only happens when setting `baseIndentLevel` to something other than `auto`.

Closes https://github.com/stylelint/stylelint/issues/5677