### PR TITLE
Refactor to improve some function types

### DIFF
--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -16,6 +16,8 @@ const path = require('path');
 /** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
 /** @typedef {import('stylelint').Config} StylelintConfig */
 /** @typedef {import('stylelint').CosmiconfigResult} StylelintCosmiconfigResult */
+/** @typedef {import('stylelint').CodeProcessor} StylelintCodeProcessor */
+/** @typedef {import('stylelint').ResultProcessor} StylelintResultProcessor */
 
 /**
  * - Merges config and stylelint options
@@ -337,9 +339,9 @@ const processorCache = new Map();
 function addProcessorFunctions(config) {
 	if (!config.processors) return config;
 
-	/** @type {Array<Function>} */
+	/** @type {StylelintCodeProcessor[]} */
 	const codeProcessors = [];
-	/** @type {Array<Function>} */
+	/** @type {StylelintResultProcessor[]} */
 	const resultProcessors = [];
 
 	[config.processors].flat().forEach((processorConfig) => {

--- a/lib/createStylelintResult.js
+++ b/lib/createStylelintResult.js
@@ -26,7 +26,7 @@ module.exports = async function createStylelintResult(
 	const file = stylelintResult.source || (cssSyntaxError && cssSyntaxError.file);
 
 	if (config.resultProcessors) {
-		config.resultProcessors.forEach((resultProcessor) => {
+		for (const resultProcessor of config.resultProcessors) {
 			// Result processors might just mutate the result object,
 			// or might return a new one
 			const returned = resultProcessor(stylelintResult, file);
@@ -34,7 +34,7 @@ module.exports = async function createStylelintResult(
 			if (returned) {
 				stylelintResult = returned;
 			}
-		});
+		}
 	}
 
 	return stylelintResult;

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -69,9 +69,9 @@ module.exports = async function getPostcssResult(stylelint, options = {}) {
 
 		const sourceName = options.code ? options.codeFilename : options.filePath;
 
-		options.codeProcessors.forEach((codeProcessor) => {
+		for (const codeProcessor of options.codeProcessors) {
 			getCode = codeProcessor(getCode, sourceName);
-		});
+		}
 	}
 
 	const postcssResult = await new LazyResult(postcssProcessor, getCode, postcssOptions);

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -30,6 +30,8 @@ declare module 'stylelint' {
 		};
 		export type DisableSettings = ConfigRuleSettings<boolean, DisableOptions>;
 
+		export type ResultProcessor = (result: LintResult, file: string | undefined) => LintResult;
+
 		export type Config = {
 			extends?: ConfigExtends;
 			plugins?: ConfigPlugins;
@@ -41,8 +43,8 @@ declare module 'stylelint' {
 			ignoreFiles?: ConfigIgnoreFiles;
 			ignorePatterns?: string;
 			rules?: ConfigRules;
-			codeProcessors?: Function[];
-			resultProcessors?: Function[];
+			codeProcessors?: CodeProcessor[];
+			resultProcessors?: ResultProcessor[];
 			quiet?: boolean;
 			defaultSeverity?: Severity;
 			ignoreDisables?: DisableSettings;
@@ -161,11 +163,13 @@ declare module 'stylelint' {
 
 		export type Plugin<P = any, S = any> = RuleBase<P, S>;
 
+		export type CodeProcessor = (code: string, file: string | undefined) => string;
+
 		export type GetPostcssOptions = {
 			code?: string;
 			codeFilename?: string;
 			filePath?: string;
-			codeProcessors?: Function[];
+			codeProcessors?: CodeProcessor[];
 			syntax?: string;
 			customSyntax?: CustomSyntax;
 		};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This PR should resolve the type error in #5652.

> Is there anything in the PR that needs further explanation?

This change adds 2 function types: `CodeProcessor` and `ResultProcessor`.
These can provide better type-checking.
