### PR TITLE
Update migration guide for Vue, HTML and markdown.

### DIFF
--- a/docs/migration-guide/to-14.md
+++ b/docs/migration-guide/to-14.md
@@ -42,6 +42,11 @@ Then, update your [configuration object](../user-guide/configure.md) to use it:
 
 This shared config extends Stylelint to be compatible with SCSS. It configures the [built-in rules](../user-guide/rules/list.md) for SCSS, and includes the [postcss-scss syntax](https://www.npmjs.com/package/postcss-scss) and [stylelint-scss plugin](https://www.npmjs.com/package/stylelint-scss) (a collection of rules specific to SCSS).
 
+There are other shared configs provided for each language:
+
+- [stylelint-config-recommended-vue](https://www.npmjs.com/package/stylelint-config-recommended-vue) ... Shared config for Vue.
+- [stylelint-config-html](https://www.npmjs.com/package/stylelint-config-html) ... Shared config that enables parsing for HTML, XML, Vue, Svelte, and PHP.
+
 If a shared config isn't available for your perferred language or library, then you can install the appropriate [PostCSS syntax](https://github.com/postcss/postcss#syntaxes) yourself and use the [`customSyntax` option](../user-guide/usage/options.md#customSyntax), which is now available in the configuration object.
 
 For example, to lint [SugarSS](https://github.com/postcss/sugarss).
@@ -71,7 +76,7 @@ For other languages and embedded styles, we suggest the following [PostCSS synta
 - HTML, XML and HTML-like embeds (`.html`, `.xml`, `.svelte`, `.vue` etc.) use [postcss-html](https://www.npmjs.com/package/postcss-html)
 - Markdown embeds (`.md`, `.markdown` etc.) use [postcss-markdown](https://www.npmjs.com/package/postcss-markdown)
 
-(The [postcss-markdown](https://www.npmjs.com/package/postcss-markdown) package needs a maintainer (see [this issue](https://github.com/stylelint/stylelint/issues/5583)). The [@stylelint/postcss-css-in-js](https://www.npmjs.com/package/@stylelint/postcss-css-in-js) package [has issues](https://github.com/stylelint/stylelint/issues/4574). It will likely to be deprecated in the future in favor of smaller syntaxes that focus on only one library (see [this issue](https://github.com/stylelint/postcss-css-in-js/issues/225))).
+(The [@stylelint/postcss-css-in-js](https://www.npmjs.com/package/@stylelint/postcss-css-in-js) package [has issues](https://github.com/stylelint/stylelint/issues/4574). It will likely to be deprecated in the future in favor of smaller syntaxes that focus on only one library (see [this issue](https://github.com/stylelint/postcss-css-in-js/issues/225))).
 
 If you lint more than one styling language, then you can use the new [`overrides` property](../user-guide/configure.md#overrides). For example, to lint both CSS and [SugarSS](https://github.com/postcss/sugarss) you can update your configuration object to include:
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5583

> Is there anything in the PR that needs further explanation?

This PR updates the migration guide.

I have released a shared config for Vue and HTML  (and HTML-like). So I have added to let you know about it.


- [stylelint-config-recommended-vue](https://www.npmjs.com/package/stylelint-config-recommended-vue)
- [stylelint-config-html](https://www.npmjs.com/package/stylelint-config-html)

Also, since I released v1 of [postcss-markdown], I remove the document about seeking for a maintainer of [postcss-markdown].
Also, I think we can probably close #5583.

[postcss-markdown]: https://www.npmjs.com/package/postcss-markdown



