### PR TITLE
Add rule-selector-property-disallowed-list

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -194,6 +194,10 @@ Grouped first by the following categories and then by the [_thing_](http://apps.
 - [`selector-pseudo-element-colon-notation`](../../../lib/rules/selector-pseudo-element-colon-notation/README.md): Specify single or double colon notation for applicable pseudo-elements (Autofixable).
 - [`selector-pseudo-element-disallowed-list`](../../../lib/rules/selector-pseudo-element-disallowed-list/README.md): Specify a list of disallowed pseudo-element selectors.
 
+### Rules
+
+- [`rule-selector-property-disallowed-list`](../../../lib/rules/rule-selector-property-disallowed-list/README.md): Specify a list of disallowed properties for selectors within rules.
+
 ### Media feature
 
 - [`media-feature-name-allowed-list`](../../../lib/rules/media-feature-name-allowed-list/README.md): Specify a list of allowed media feature names.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -235,6 +235,9 @@ const rules = {
 	'property-no-unknown': importLazy(() => require('./property-no-unknown'))(),
 	'property-no-vendor-prefix': importLazy(() => require('./property-no-vendor-prefix'))(),
 	'rule-empty-line-before': importLazy(() => require('./rule-empty-line-before'))(),
+	'rule-selector-property-disallowed-list': importLazy(() =>
+		require('./rule-selector-property-disallowed-list'),
+	)(),
 	'selector-attribute-brackets-space-inside': importLazy(() =>
 		require('./selector-attribute-brackets-space-inside'),
 	)(),

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -57,5 +57,5 @@ a { padding-top: 0px; }
 
 <!-- prettier-ignore -->
 ```css
-html[data-test] { background-color: red; }
+html[data-foo] { color: red; }
 ```

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -1,0 +1,62 @@
+# rule-selector-property-disallowed-list
+
+Specify a list of disallowed properties for selectors within rules.
+
+<!-- prettier-ignore -->
+```css
+    html.custom { background-color: red; }
+/** ↑             ↑
+ * Selector and property name */
+```
+
+## Options
+
+`object`: `{ "selector": ["array", "of", "properties"]`
+
+If a selector name is surrounded with `"/"` (e.g. `"/anchor/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of all the potential anchors: `/anchor/` will match `.anchor`, `[data-anchor]`, etc.
+
+The same goes for properties. Keep in mind that a regular expression value is matched against the entire property name, not specific parts of it. For example, a value like `"animation-duration"` will _not_ match `"/^duration/"` (notice beginning of the line boundary) but _will_ match `"/duration/"`.
+
+Given:
+
+```json
+{
+  "a": ["background-color"],
+  "html": ["/color/"],
+  "/test/": ["/size/"]
+}
+```
+
+The following patterns are considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { background-color: red; }
+```
+
+<!-- prettier-ignore -->
+```css
+html { background-color: red; }
+```
+
+<!-- prettier-ignore -->
+```css
+html[data-test] { font-size: 1px; }
+```
+
+The following patterns are _not_ considered violations:
+
+<!-- prettier-ignore -->
+```css
+a { background: red; color: red; }
+```
+
+<!-- prettier-ignore -->
+```css
+a[href="#"] { background-color: red; }
+```
+
+<!-- prettier-ignore -->
+```css
+html[data-test] { background-color: red; }
+```

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -21,9 +21,8 @@ Given:
 
 ```json
 {
-  "a": ["background-color"],
-  "html": ["/color/"],
-  "/test/": ["/size/"]
+  "a": ["color", "/margin/"],
+  "/foo/": ["/size/"]
 }
 ```
 

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -4,8 +4,8 @@ Specify a list of disallowed properties for selectors within rules.
 
 <!-- prettier-ignore -->
 ```css
-    html.custom { background-color: red; }
-/** ↑             ↑
+    a { color: red; }
+/** ↑          ↑
  * Selector and property name */
 ```
 

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -40,7 +40,7 @@ a { margin-top: 0px; }
 
 <!-- prettier-ignore -->
 ```css
-html[data-test] { font-size: 1px; }
+html[data-foo] { font-size: 1px; }
 ```
 
 The following patterns are _not_ considered violations:

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -52,7 +52,7 @@ a { background: red; }
 
 <!-- prettier-ignore -->
 ```css
-a[href="#"] { background-color: red; }
+a { padding-top: 0px; }
 ```
 
 <!-- prettier-ignore -->

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -31,7 +31,7 @@ The following patterns are considered violations:
 
 <!-- prettier-ignore -->
 ```css
-a { background-color: red; }
+a { color: red; }
 ```
 
 <!-- prettier-ignore -->

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -43,7 +43,7 @@ a { margin-top: 0px; }
 html[data-foo] { font-size: 1px; }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -35,7 +35,7 @@ a { color: red; }
 
 <!-- prettier-ignore -->
 ```css
-html { background-color: red; }
+a { margin-top: 0px; }
 ```
 
 <!-- prettier-ignore -->

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -26,7 +26,7 @@ Given:
 }
 ```
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -47,7 +47,7 @@ The following patterns are _not_ considered violations:
 
 <!-- prettier-ignore -->
 ```css
-a { background: red; color: red; }
+a { background: red; }
 ```
 
 <!-- prettier-ignore -->

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
@@ -5,8 +5,8 @@ const { messages, ruleName } = require('..');
 testRule({
 	ruleName,
 	config: {
-		a: ['color', "/margin/"],
-		'/test/': ['/size/'],
+		a: ['color', '/margin/'],
+		'/foo/': ['/size/'],
 	},
 
 	accept: [
@@ -14,46 +14,58 @@ testRule({
 			code: 'a { background: red; }',
 		},
 		{
-			code: 'a { color: red; }',
+			code: 'a { padding-top: 0px; }',
 		},
 		{
-			code: 'a { background: red; color: red; }',
+			code: 'a { background-color: red; }',
 		},
 		{
-			code: 'a[href="#"] { background-color: red; }',
+			code: 'a[href="#"] { color: red; }',
 		},
 		{
-			code: 'html.foo { background-color: red; }',
+			code: 'html.foo { color: red; }',
 		},
 		{
-			code: 'html[data-test] { background-color: red; }',
+			code: 'html[data-foo] { color: red; }',
 		},
 	],
 
 	reject: [
 		{
-			code: 'a { background-color: red; }',
-			message: messages.rejected('background-color', 'a'),
+			code: 'a { color: red; }',
+			message: messages.rejected('color', 'a'),
 			line: 1,
 			column: 5,
 		},
 		{
-			code: 'html { background-color: red; }',
-			message: messages.rejected('background-color', 'html'),
+			code: 'a { background: red; color: red; }',
+			message: messages.rejected('color', 'a'),
 			line: 1,
-			column: 8,
+			column: 22,
 		},
 		{
-			code: '[data-test] { font-size: 1rem; }',
-			message: messages.rejected('font-size', '[data-test]'),
+			code: 'a { margin-top: 0px; }',
+			message: messages.rejected('margin-top', 'a'),
 			line: 1,
-			column: 15,
+			column: 5,
 		},
 		{
-			code: 'html[data-test] { font-size: 1px; }',
-			message: messages.rejected('font-size', 'html[data-test]'),
+			code: 'a { color: red; margin-top: 0px; }',
+			message: messages.rejected('color', 'a'),
 			line: 1,
-			column: 19,
+			column: 5,
+		},
+		{
+			code: '[data-foo] { font-size: 1rem; }',
+			message: messages.rejected('font-size', '[data-foo]'),
+			line: 1,
+			column: 14,
+		},
+		{
+			code: 'html[data-foo] { font-size: 1px; }',
+			message: messages.rejected('font-size', 'html[data-foo]'),
+			line: 1,
+			column: 18,
 		},
 	],
 });

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { messages, ruleName } = require('..');
+
+testRule({
+	ruleName,
+	config: {
+		a: ['background-color'],
+		html: ['/color/'],
+		'/test/': ['/size/'],
+	},
+
+	accept: [
+		{
+			code: 'a { background: red; }',
+		},
+		{
+			code: 'a { color: red; }',
+		},
+		{
+			code: 'a { background: red; color: red; }',
+		},
+		{
+			code: 'a[href="#"] { background-color: red; }',
+		},
+		{
+			code: 'html.foo { background-color: red; }',
+		},
+		{
+			code: 'html[data-test] { background-color: red; }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { background-color: red; }',
+			message: messages.rejected('background-color', 'a'),
+			line: 1,
+			column: 5,
+		},
+		{
+			code: 'html { background-color: red; }',
+			message: messages.rejected('background-color', 'html'),
+			line: 1,
+			column: 8,
+		},
+		{
+			code: '[data-test] { font-size: 1rem; }',
+			message: messages.rejected('font-size', '[data-test]'),
+			line: 1,
+			column: 15,
+		},
+		{
+			code: 'html[data-test] { font-size: 1px; }',
+			message: messages.rejected('font-size', 'html[data-test]'),
+			line: 1,
+			column: 19,
+		},
+	],
+});

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
@@ -5,8 +5,7 @@ const { messages, ruleName } = require('..');
 testRule({
 	ruleName,
 	config: {
-		a: ['background-color'],
-		html: ['/color/'],
+		a: ['color', "/margin/"],
 		'/test/': ['/size/'],
 	},
 

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
@@ -51,7 +51,10 @@ testRule({
 		},
 		{
 			code: 'a { color: red; margin-top: 0px; }',
-			message: messages.rejected('color', 'a'),
+			warnings: [
+				{ message: messages.rejected('color', 'a'), line: 1, column: 5 },
+				{ message: messages.rejected('margin-top', 'a'), line: 1, column: 17 },
+			],
 			line: 1,
 			column: 5,
 		},

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -14,7 +14,7 @@ const messages = ruleMessages(ruleName, {
 });
 
 /** @type {import('stylelint').StylelintRule} */
-function rule(primary) {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -59,7 +59,7 @@ function rule(primary) {
 			}
 		});
 	};
-}
+};
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -15,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, selector) => `Unexpected property "${property}" for selector "${selector}"`,
 });
 
+/** @type {import('stylelint').StylelintRule} */
 function rule(primary) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -13,7 +13,7 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, selector) => `Unexpected property "${property}" for selector "${selector}"`,
 });
 
-/** @type {import('stylelint').StylelintRule} */
+/** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -53,8 +53,6 @@ const rule = (primary) => {
 						result,
 						ruleName,
 					});
-
-					break;
 				}
 			}
 		});

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -1,0 +1,69 @@
+// @ts-nocheck
+
+'use strict';
+
+const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
+const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
+const report = require('../../utils/report');
+const ruleMessages = require('../../utils/ruleMessages');
+const validateOptions = require('../../utils/validateOptions');
+const { isPlainObject } = require('is-plain-object');
+
+const ruleName = 'rule-selector-property-disallowed-list';
+
+const messages = ruleMessages(ruleName, {
+	rejected: (property, selector) => `Unexpected property "${property}" for selector "${selector}"`,
+});
+
+function rule(primary) {
+	return (root, result) => {
+		const validOptions = validateOptions(result, ruleName, {
+			actual: primary,
+			possible: [isPlainObject],
+		});
+
+		if (!validOptions) {
+			return;
+		}
+
+		const selectors = Object.keys(primary);
+
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) {
+				return;
+			}
+
+			const selectorKey = selectors.find((selector) =>
+				matchesStringOrRegExp(ruleNode.selector, selector),
+			);
+
+			if (!selectorKey) {
+				return;
+			}
+
+			const disallowedProperties = primary[selectorKey];
+
+			for (const node of ruleNode.nodes) {
+				const isDisallowedProperty =
+					node.type === 'decl' && matchesStringOrRegExp(node.prop, disallowedProperties);
+
+				if (isDisallowedProperty) {
+					report({
+						message: messages.rejected(node.prop, ruleNode.selector),
+						node,
+						result,
+						ruleName,
+					});
+
+					break;
+				}
+			}
+		});
+	};
+}
+
+rule.primaryOptionArray = true;
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+module.exports = rule;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

The new rule rule-selector-property-disallowed-list that is mentioned in #5433 has been added.

> Is there anything in the PR that needs further explanation?

@jeddy3 I see that the branch `v14` has been merged and my previous [PR #5489](https://github.com/stylelint/stylelint/pull/5489), targeted to that branch, has been closed. So, I am creating this one to the `main` branch. 

I made [the change](https://github.com/stylelint/stylelint/pull/5489#pullrequestreview-780769606) that you asked me to do in comments to the previous PR. Namely, added a new test which checks multiple errors in one CSS block.

---

Closes #5433 