### PR TITLE
Fix false positives for values wrapped in parentheses in declaration-empty-line-before

### DIFF
--- a/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
@@ -138,16 +138,29 @@ describe('isStandardSyntaxDeclaration', () => {
 	it('less map', () => {
 		expect(isStandardSyntaxDeclaration(lessDecl('@map: { key: value; }'))).toBe(false);
 	});
+
 	it('scss map declaration', () => {
 		expect(isStandardSyntaxDeclaration(scssDecl('$foo: (key: value, key2: value2)'))).toBe(false);
 	});
+
 	it('scss map declaration with quotes', () => {
 		expect(isStandardSyntaxDeclaration(scssDecl('$foo: ("key": value, "key2": value2)'))).toBe(
 			false,
 		);
 	});
+
 	it('scss list declaration', () => {
 		expect(isStandardSyntaxDeclaration(scssDecl('$foo: (value, value2)'))).toBe(false);
+	});
+
+	it('scss pure value in parentheses', () => {
+		expect(isStandardSyntaxDeclaration(scssDecl('a { height: (0) }'))).toBe(true);
+	});
+
+	it('scss complex value in parentheses', () => {
+		expect(isStandardSyntaxDeclaration(scssDecl('a { height: (3px + 5px) * (2px + 4px) }'))).toBe(
+			true,
+		);
 	});
 });
 

--- a/lib/utils/isStandardSyntaxDeclaration.js
+++ b/lib/utils/isStandardSyntaxDeclaration.js
@@ -18,7 +18,6 @@ function isStandardSyntaxLang(lang) {
 module.exports = function (decl) {
 	const prop = decl.prop;
 	const parent = decl.parent;
-	const value = decl.value;
 
 	// Declarations belong in a declaration block or standard CSS source
 	if (
@@ -32,13 +31,8 @@ module.exports = function (decl) {
 		return false;
 	}
 
-	// SCSS var
+	// SCSS var; covers map and list declarations
 	if (isScssVariable(prop)) {
-		return false;
-	}
-
-	// SCSS map and list declarations
-	if (prop.startsWith('$') && value.startsWith('(') && value.endsWith(')')) {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxDeclaration.js
+++ b/lib/utils/isStandardSyntaxDeclaration.js
@@ -38,7 +38,7 @@ module.exports = function (decl) {
 	}
 
 	// SCSS map and list declarations
-	if (value.startsWith('(') && value.endsWith(')')) {
+	if (prop.startsWith('$') && value.startsWith('(') && value.endsWith(')')) {
 		return false;
 	}
 


### PR DESCRIPTION
Closes #5639.
Adds a condition to the SCSS maps & lists check to ensure it's not used in cases like `height: (0);`.