### PR TITLE
Add uninherited templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/REPORT_A_DOCS_ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_DOCS_ISSUE.yml
@@ -1,0 +1,20 @@
+name: "📝 Report a docs issue"
+description: "Is something wrong, confusing or missing in the docs?"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to file a docs issue!
+  - type: textarea
+    id: describe-issue
+    attributes:
+      label: "Describe the documentation issue"
+    validations:
+      required: true
+  - type: textarea
+    id: what-solution
+    attributes:
+      label: "What solution would you like to see?"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/REPORT_A_DOCS_ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_DOCS_ISSUE.yml
@@ -1,5 +1,5 @@
-name: "📝 Report a docs issue"
-description: "Is something wrong, confusing or missing in the docs?"
+name: '📝 Report a docs issue'
+description: 'Is something wrong, confusing or missing in the docs?'
 labels: []
 body:
   - type: markdown
@@ -9,12 +9,12 @@ body:
   - type: textarea
     id: describe-issue
     attributes:
-      label: "Describe the documentation issue"
+      label: 'Describe the documentation issue'
     validations:
       required: true
   - type: textarea
     id: what-solution
     attributes:
-      label: "What solution would you like to see?"
+      label: 'What solution would you like to see?'
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.yml
+++ b/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.yml
@@ -1,5 +1,5 @@
-name: "🚀 Request a feature"
-description: "Do you want to suggest a new feature?"
+name: '🚀 Request a feature'
+description: 'Do you want to suggest a new feature?'
 labels: []
 body:
   - type: markdown
@@ -9,12 +9,12 @@ body:
   - type: textarea
     id: what-problem
     attributes:
-      label: "What is the problem you're trying to solve?"
+      label: 'What is the problem you're trying to solve?'
     validations:
       required: true
   - type: textarea
     id: what-solution
     attributes:
-      label: "What solution would you like to see?"
+      label: 'What solution would you like to see?'
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.yml
+++ b/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.yml
@@ -1,0 +1,20 @@
+name: "🚀 Request a feature"
+description: "Do you want to suggest a new feature?"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to request a feature!
+  - type: textarea
+    id: what-problem
+    attributes:
+      label: "What is the problem you're trying to solve?"
+    validations:
+      required: true
+  - type: textarea
+    id: what-solution
+    attributes:
+      label: "What solution would you like to see?"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.yml
+++ b/.github/ISSUE_TEMPLATE/REQUEST_A_FEATURE.yml
@@ -9,7 +9,7 @@ body:
   - type: textarea
     id: what-problem
     attributes:
-      label: 'What is the problem you're trying to solve?'
+      label: "What is the problem you're trying to solve?"
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/.github/tree/main/.github/ISSUE_TEMPLATE

> Is there anything in the PR that needs further explanation?

Sadly, the other templates aren't inherited if we override one of them. Although, It makes sense that this is the behaviour.

I'm going to quick merge this to fix up the template choice menu.
