### PR TITLE
Fix support for HTML files in declaration-empty-line-before

### DIFF
--- a/lib/rules/declaration-empty-line-before/__tests__/index.js
+++ b/lib/rules/declaration-empty-line-before/__tests__/index.js
@@ -902,7 +902,6 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: ['always'],
 	customSyntax: postcssHtml,
@@ -960,7 +959,6 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	config: ['always', { ignore: ['inside-single-line-block'] }],
 	customSyntax: postcssHtml,

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -15,7 +15,7 @@ const removeEmptyLinesBefore = require('../../utils/removeEmptyLinesBefore');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isAtRule, isRule } = require('../../utils/typeGuards');
+const { isAtRule, isRule, isRoot } = require('../../utils/typeGuards');
 
 const ruleName = 'declaration-empty-line-before';
 
@@ -66,7 +66,7 @@ const rule = (primary, secondaryOptions, context) => {
 				return;
 			}
 
-			if (!isAtRule(parent) && !isRule(parent)) {
+			if (!isAtRule(parent) && !isRule(parent) && !isRoot(parent)) {
 				return;
 			}
 


### PR DESCRIPTION
This is taken out of #5657 to be able to merge the agreed-on parts ahead of other stuff.

The first 3 commits are from that yet unmerged PR right now, the change is only in the 4th commit. After re-enabling those tests by replacing the `syntax: 'html'` with `customSyntax`, those two tests would still fail and were left skipped in #5657.

The fix seems simple enough, but needs some improvement regarding typescript typing.