### PR TITLE
Fix id links in documentation for the customSyntax feature

### DIFF
--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -265,7 +265,7 @@ A "plugin" can provide a single rule or a set of rules. If the plugin you use pr
 
 ## `customSyntax`
 
-Specify a custom syntax to use on your code. [More info](usage/options.md#customSyntax).
+Specify a custom syntax to use on your code. [More info](usage/options.md#customsyntax).
 
 ## `overrides`
 
@@ -391,7 +391,7 @@ _Note that this is not an efficient method for ignoring lots of files._ If you w
 
 Processors are functions built by the community that hook into Stylelint's pipeline, modifying code on its way into Stylelint and modifying results on their way out.
 
-**We discourage their use in favor of using the [`customSyntax` option](#customSyntax) as processors are incompatible with the [autofix feature](usage/options.md#fix).**
+**We discourage their use in favor of using the [`customSyntax` option](#customsyntax) as processors are incompatible with the [autofix feature](usage/options.md#fix).**
 
 To use one, add a `"processors"` array to your config, containing "locaters" identifying the processors you want to use. As with `extends`, above, a "locater" can be either an npm module name, an absolute path, or a path relative to the invoking configuration file.
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

This is a documentation fix to repair links that should link to [https://github.com/stylelint/stylelint/tree/main/docs](https://github.com/stylelint/stylelint/tree/main/docs), but currently links to the root directory of the page.


> Is there anything in the PR that needs further explanation?

It's self explanatory.