### PR TITLE
Add `ConfigurationError` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Added: `rule-selector-property-disallowed-list` rule ([#5679](https://github.com/stylelint/stylelint/pull/5679)).
 - Added: `ignore: ["consecutive-duplicates-with-same-prefixless-values"]` to `declaration-block-no-duplicate-properties` ([#5609](https://github.com/stylelint/stylelint/pull/5609)).
 - Added: `ignorePseudoClasses: []` to `max-nesting-depth` ([#5620](https://github.com/stylelint/stylelint/pull/5620)).
+- Added: `ConfigurationError` type ([#5696](https://github.com/stylelint/stylelint/pull/5696)).
 - Fixed: `color-function-notation` false positives for hex colours ([#5650](https://github.com/stylelint/stylelint/pull/5650)).
 - Fixed: `declaration-empty-line-before` false positives for values wrapped in parentheses ([#5680](https://github.com/stylelint/stylelint/pull/5680)).
 

--- a/lib/utils/configurationError.js
+++ b/lib/utils/configurationError.js
@@ -1,13 +1,14 @@
 'use strict';
 
+/** @typedef {import('stylelint').ConfigurationError} ConfigurationError */
+
 /**
  * Create configurationError from text and set CLI exit code
  * @param {string} text
- * @returns {Object}
+ * @returns {ConfigurationError}
  */
-module.exports = function (text) /* Object */ {
-	/** @type {Error & {code?: number}} */
-	const err = new Error(text);
+module.exports = function (text) {
+	const err = /** @type {ConfigurationError} */ (new Error(text));
 
 	err.code = 78;
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -69,6 +69,8 @@ declare module 'stylelint' {
 			isEmpty?: boolean;
 		} | null;
 
+		export type ConfigurationError = Error & { code: 78 };
+
 		export type DisabledRange = {
 			comment: PostCSS.Comment;
 			start: number;


### PR DESCRIPTION
Adds the ConfigurationError type. Currently, we [define this type downstream](https://github.com/stylelint/vscode-stylelint/blob/77c0719/types/index.d.ts#L68-L73) since it isn't defined in Stylelint, but it really belongs here.