### PR TITLE
Refactor to improve types for `no-empty-*` rules

### DIFF
--- a/lib/rules/no-empty-first-line/index.js
+++ b/lib/rules/no-empty-first-line/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -13,15 +11,17 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line',
 });
 
-function rule(actual, _, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
+		// @ts-expect-error -- TS2339: Property 'inline' does not exist on type 'Source'. Property 'lang' does not exist on type 'Source'.
 		if (!validOptions || root.source.inline || root.source.lang === 'object-literal') {
 			return;
 		}
 
-		const rootString = context.fix ? root.toString() : root.source.input.css;
+		const rootString = context.fix ? root.toString() : (root.source && root.source.input.css) || '';
 
 		if (!rootString.trim()) {
 			return;
@@ -29,7 +29,15 @@ function rule(actual, _, context) {
 
 		if (noEmptyFirstLineTest.test(rootString)) {
 			if (context.fix) {
-				root.nodes[0].raws.before = root.first.raws.before.trimStart();
+				if (root.first == null) {
+					throw new Error('The root node must have the first node.');
+				}
+
+				if (root.first.raws.before == null) {
+					throw new Error('The first node must have spaces before.');
+				}
+
+				root.first.raws.before = root.first.raws.before.trimStart();
 
 				return;
 			}
@@ -42,7 +50,7 @@ function rule(actual, _, context) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-empty-source/index.js
+++ b/lib/rules/no-empty-source/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -12,15 +10,16 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty source',
 });
 
-function rule(actual, options, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
 		}
 
-		const rootString = context.fix ? root.toString() : root.source.input.css;
+		const rootString = context.fix ? root.toString() : (root.source && root.source.input.css) || '';
 
 		if (rootString.trim()) {
 			return;
@@ -33,7 +32,7 @@ function rule(actual, options, context) {
 			ruleName,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

This change removes `// @ts-nocheck` from the `no-empty-*` rules.
