### PR TITLE
Pre-work to update to ESLint 8

### DIFF
--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -290,7 +290,7 @@ describe('CLI', () => {
 			fixturesPath('empty-block-with-disables.css'),
 		]);
 
-		expect(process.exitCode).toEqual(1);
+		expect(process.exitCode).toBe(1);
 
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(process.stderr.write).toHaveBeenCalledWith(
@@ -307,7 +307,7 @@ describe('CLI', () => {
 			fixturesPath('empty-block.css'),
 		]);
 
-		expect(process.exitCode).toEqual(2);
+		expect(process.exitCode).toBe(2);
 
 		expect(process.stdout.write).toHaveBeenCalledTimes(1);
 		const output = JSON.parse(process.stdout.write.mock.calls[0][0]);
@@ -329,7 +329,7 @@ describe('CLI', () => {
 			fixturesPath('empty-block.css'),
 		]);
 
-		expect(process.exitCode).toEqual(2);
+		expect(process.exitCode).toBe(2);
 
 		expect(process.stdout.write).toHaveBeenCalledTimes(0);
 	});

--- a/lib/__tests__/standalone-globs.test.js
+++ b/lib/__tests__/standalone-globs.test.js
@@ -38,7 +38,7 @@ describe('standalone globbing', () => {
 			});
 
 			expect(results).toHaveLength(1);
-			expect(results[0].errored).toEqual(true);
+			expect(results[0].errored).toBe(true);
 			expect(results[0].warnings[0]).toEqual(
 				expect.objectContaining({
 					rule: 'block-no-empty',
@@ -58,7 +58,7 @@ describe('standalone globbing', () => {
 		});
 
 		expect(results).toHaveLength(1);
-		expect(results[0].errored).toEqual(true);
+		expect(results[0].errored).toBe(true);
 		expect(results[0].warnings[0]).toEqual(
 			expect.objectContaining({
 				rule: 'block-no-empty',
@@ -77,7 +77,7 @@ describe('standalone globbing', () => {
 		});
 
 		expect(results).toHaveLength(1);
-		expect(results[0].errored).toEqual(true);
+		expect(results[0].errored).toBe(true);
 		expect(results[0].warnings[0]).toEqual(
 			expect.objectContaining({
 				rule: 'block-no-empty',
@@ -103,7 +103,7 @@ describe('standalone globbing', () => {
 		expect(results[0].source).toEqual(expect.stringContaining('lint-this-file.css'));
 
 		expect(results).toHaveLength(1);
-		expect(results[0].errored).toEqual(true);
+		expect(results[0].errored).toBe(true);
 		expect(results[0].warnings[0]).toEqual(
 			expect.objectContaining({
 				rule: 'block-no-empty',
@@ -131,7 +131,7 @@ describe('standalone globbing', () => {
 			});
 
 			expect(results).toHaveLength(1);
-			expect(results[0].errored).toEqual(true);
+			expect(results[0].errored).toBe(true);
 			expect(results[0].warnings[0]).toEqual(
 				expect.objectContaining({
 					rule: 'block-no-empty',
@@ -155,7 +155,7 @@ describe('standalone globbing', () => {
 			});
 
 			expect(results).toHaveLength(1);
-			expect(results[0].errored).toEqual(true);
+			expect(results[0].errored).toBe(true);
 			expect(results[0].warnings[0]).toEqual(
 				expect.objectContaining({
 					rule: 'block-no-empty',
@@ -180,7 +180,7 @@ describe('standalone globbing', () => {
 			});
 
 			expect(results).toHaveLength(1);
-			expect(results[0].errored).toEqual(true);
+			expect(results[0].errored).toBe(true);
 			expect(results[0].warnings[0]).toEqual(
 				expect.objectContaining({
 					rule: 'block-no-empty',
@@ -209,7 +209,7 @@ describe('standalone globbing', () => {
 		// 	});
 
 		// 	expect(results).toHaveLength(1);
-		// 	expect(results[0].errored).toEqual(true);
+		// 	expect(results[0].errored).toBe(true);
 		// 	expect(results[0].warnings[0]).toEqual(
 		// 		expect.objectContaining({
 		// 			rule: 'block-no-empty',

--- a/lib/__tests__/writeOutputFile.test.js
+++ b/lib/__tests__/writeOutputFile.test.js
@@ -10,7 +10,7 @@ describe('writeOutputFile', () => {
 
 		await writeOutputFile('test content', filePath);
 
-		expect((await fs.readFile(filePath)).toString()).toEqual('test content');
+		expect((await fs.readFile(filePath)).toString()).toBe('test content');
 
 		await fs.unlink(filePath);
 	});
@@ -20,7 +20,7 @@ describe('writeOutputFile', () => {
 
 		await writeOutputFile('test content', filePath);
 
-		expect((await fs.readFile(filePath)).toString()).toEqual('test content');
+		expect((await fs.readFile(filePath)).toString()).toBe('test content');
 
 		await fs.rmdir(path.dirname(filePath), { recursive: true });
 	});

--- a/lib/rules/named-grid-areas-no-invalid/utils/__tests__/isRectangular.test.js
+++ b/lib/rules/named-grid-areas-no-invalid/utils/__tests__/isRectangular.test.js
@@ -10,7 +10,7 @@ describe('isRectangular is', () => {
 				['a', 'a', '.'],
 				['.', 'b', 'c'],
 			]),
-		).toEqual(true);
+		).toBe(true);
 	});
 
 	test('false when not-rectangular', () => {
@@ -20,6 +20,6 @@ describe('isRectangular is', () => {
 				['a', 'a'],
 				['.', 'b', 'a'],
 			]),
-		).toEqual(false);
+		).toBe(false);
 	});
 });

--- a/lib/utils/__tests__/validateOptions.test.js
+++ b/lib/utils/__tests__/validateOptions.test.js
@@ -23,7 +23,7 @@ describe('validateOptions for primary options', () => {
 			actual: 'd',
 		});
 		expect(result.warn).toHaveBeenCalledTimes(1);
-		expect(result.warn.mock.calls[0][0]).toEqual('Invalid option value "d" for rule "foo"');
+		expect(result.warn.mock.calls[0][0]).toBe('Invalid option value "d" for rule "foo"');
 	});
 
 	it('passing boolean equivalence', () => {
@@ -40,7 +40,7 @@ describe('validateOptions for primary options', () => {
 			actual: 'a',
 		});
 		expect(result.warn).toHaveBeenCalledTimes(1);
-		expect(result.warn.mock.calls[0][0]).toEqual('Invalid option value "a" for rule "foo"');
+		expect(result.warn.mock.calls[0][0]).toBe('Invalid option value "a" for rule "foo"');
 	});
 
 	it('passing evaluation', () => {
@@ -57,7 +57,7 @@ describe('validateOptions for primary options', () => {
 			actual: 1,
 		});
 		expect(result.warn).toHaveBeenCalledTimes(1);
-		expect(result.warn.mock.calls[0][0]).toEqual('Invalid option value "1" for rule "bar"');
+		expect(result.warn.mock.calls[0][0]).toBe('Invalid option value "1" for rule "bar"');
 	});
 
 	it('undefined `actual` with `possible` values and no `optional` option', () => {
@@ -66,7 +66,7 @@ describe('validateOptions for primary options', () => {
 			actual: undefined,
 		});
 		expect(result.warn).toHaveBeenCalledTimes(1);
-		expect(result.warn.mock.calls[0][0]).toEqual('Expected option value for rule "foo"');
+		expect(result.warn.mock.calls[0][0]).toBe('Expected option value for rule "foo"');
 	});
 });
 
@@ -98,10 +98,10 @@ describe('validateOptions for secondary options objects', () => {
 			actual: { foo: 'neveer', bar: false },
 		});
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
-		expect(result.warn.mock.calls[0][0]).toEqual(
+		expect(result.warn.mock.calls[0][0]).toBe(
 			'Invalid value "neveer" for option "foo" of rule "bar"',
 		);
-		expect(result.warn.mock.calls[1][0]).toEqual(
+		expect(result.warn.mock.calls[1][0]).toBe(
 			'Invalid value "false" for option "bar" of rule "bar"',
 		);
 		result.warn.mockClear();
@@ -111,7 +111,7 @@ describe('validateOptions for secondary options objects', () => {
 			actual: { foo: 'never', barr: 1 },
 		});
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
-		expect(result.warn.mock.calls[0][0]).toEqual('Invalid option name "barr" for rule "bar"');
+		expect(result.warn.mock.calls[0][0]).toBe('Invalid option name "barr" for rule "bar"');
 	});
 
 	it('undefined `actual` with `possible` values and an `optional` option', () => {
@@ -129,7 +129,7 @@ describe('validateOptions for secondary options objects', () => {
 			actual: 2,
 		});
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
-		expect(result.warn.mock.calls[0][0]).toEqual(
+		expect(result.warn.mock.calls[0][0]).toBe(
 			'Invalid option value 2 for rule "foo": should be an object',
 		);
 	});
@@ -141,7 +141,7 @@ describe('validateOptions for secondary options objects', () => {
 		});
 
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
-		expect(result.warn.mock.calls[0][0]).toEqual(
+		expect(result.warn.mock.calls[0][0]).toBe(
 			'Incorrect configuration for rule "foo". Rule should have "possible" values for options validation',
 		);
 	});
@@ -165,9 +165,7 @@ it('validateOptions for secondary options objects with subarrays', () => {
 		actual: { bar: ['one', 'three', 'floor'] },
 	});
 	expect(result.warn.mock.calls[0]).toHaveLength(2);
-	expect(result.warn.mock.calls[0][0]).toEqual(
-		'Invalid value "floor" for option "bar" of rule "foo"',
-	);
+	expect(result.warn.mock.calls[0][0]).toBe('Invalid value "floor" for option "bar" of rule "foo"');
 });
 
 describe('validateOptions for `*-no-*` rule with no valid options', () => {
@@ -193,7 +191,7 @@ describe('validateOptions for `*-no-*` rule with no valid options', () => {
 			actual: 'foo',
 		});
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
-		expect(result.warn.mock.calls[0][0]).toEqual(
+		expect(result.warn.mock.calls[0][0]).toBe(
 			'Unexpected option value "foo" for rule "no-dancing"',
 		);
 		result.warn.mockClear();
@@ -202,7 +200,7 @@ describe('validateOptions for `*-no-*` rule with no valid options', () => {
 			actual: false,
 		});
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
-		expect(result.warn.mock.calls[0][0]).toEqual(
+		expect(result.warn.mock.calls[0][0]).toBe(
 			'Unexpected option value "false" for rule "no-dancing"',
 		);
 	});
@@ -242,8 +240,8 @@ it('validateOptions for multiple actual/possible pairs, checking return value', 
 
 	expect(invalidOptions).toBe(false);
 	expect(result.warn.mock.calls[0]).toHaveLength(2);
-	expect(result.warn.mock.calls[0][0]).toEqual('Invalid option value "onne" for rule "foo"');
-	expect(result.warn.mock.calls[1][0]).toEqual('Invalid option value "threee" for rule "foo"');
+	expect(result.warn.mock.calls[0][0]).toBe('Invalid option value "onne" for rule "foo"');
+	expect(result.warn.mock.calls[1][0]).toBe('Invalid option value "threee" for rule "foo"');
 });
 
 describe("validateOptions with a function for 'possible'", () => {
@@ -312,7 +310,7 @@ describe("validateOptions with a function for 'possible'", () => {
 
 		expect(invalidObject).toBe(false);
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
-		expect(result.warn.mock.calls[0][0]).toEqual(
+		expect(result.warn.mock.calls[0][0]).toBe(
 			'Invalid option "{"properties":["one"]}" for rule foo',
 		);
 	});

--- a/lib/utils/__tests__/vendor.test.js
+++ b/lib/utils/__tests__/vendor.test.js
@@ -5,13 +5,13 @@ const vendor = require('../vendor');
 const VALUE = '-1px -1px 1px rgba(0, 0, 0, 0.2) inset';
 
 it('returns prefix', () => {
-	expect(vendor.prefix('-moz-color')).toEqual('-moz-');
-	expect(vendor.prefix('color')).toEqual('');
-	expect(vendor.prefix(VALUE)).toEqual('');
+	expect(vendor.prefix('-moz-color')).toBe('-moz-');
+	expect(vendor.prefix('color')).toBe('');
+	expect(vendor.prefix(VALUE)).toBe('');
 });
 
 it('returns unprefixed version', () => {
-	expect(vendor.unprefixed('-moz-color')).toEqual('color');
-	expect(vendor.unprefixed('color')).toEqual('color');
-	expect(vendor.unprefixed(VALUE)).toEqual(VALUE);
+	expect(vendor.unprefixed('-moz-color')).toBe('color');
+	expect(vendor.unprefixed('color')).toBe('color');
+	expect(vendor.unprefixed(VALUE)).toBe(VALUE);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "common-tags": "^1.8.0",
         "deepmerge": "^4.2.2",
         "eslint": "^7.32.0",
-        "eslint-config-stylelint": "^14.0.0",
+        "eslint-config-stylelint": "^15.0.0",
         "got": "^11.8.2",
         "husky": "^7.0.4",
         "jest": "^27.3.1",
@@ -1534,59 +1534,17 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
+      "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "5.3.0",
+        "@typescript-eslint/visitor-keys": "5.3.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1594,12 +1552,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
+      "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
       "dev": true,
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1607,21 +1565,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
+      "integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
+        "@typescript-eslint/types": "5.3.0",
+        "@typescript-eslint/visitor-keys": "5.3.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1634,20 +1592,29 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
+      "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.3.0",
+        "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+      "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/abab": {
@@ -3233,16 +3200,81 @@
       }
     },
     "node_modules/eslint-config-stylelint": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-14.0.0.tgz",
-      "integrity": "sha512-/HAEjiNNVOvSAs4J+z9G/Ybk8G8/nLy8hjzISHDZU27Cnx2BwAGFdqXnStucER8rkVnaaFyEM7p+GIC2Zzp6dA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-15.0.0.tgz",
+      "integrity": "sha512-RQSkNgtCyAlf6yLVTbxHgHTCu3OPTx1LaihYKeLa3OPYUKytIb8f0H6I5+1DC6v2T8THUNDEVdQPYuZTGmBRkg==",
       "dev": true,
       "dependencies": {
         "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-jest": "^24.4.0",
+        "eslint-plugin-jest": "^25.2.2",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-regexp": "^1.1.0"
+        "eslint-plugin-regexp": "^1.5.0"
+      }
+    },
+    "node_modules/eslint-config-stylelint/node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
+      "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.3.0",
+        "@typescript-eslint/types": "5.3.0",
+        "@typescript-eslint/typescript-estree": "5.3.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/eslint-config-stylelint/node_modules/eslint-plugin-jest": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.3.tgz",
+      "integrity": "sha512-Yoa0at3euTjERDvPGPWiItY1uuqKYQ5Ov2SmkSLmKRq9OFiVdEehw0rWuK4PA538k7CNqnvmkztjAB9l+HJ7kQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-stylelint/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -3262,55 +3294,6 @@
       },
       "peerDependencies": {
         "eslint": ">=4.19.1"
-      }
-    },
-    "node_modules/eslint-plugin-eslint-comments": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
-      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "ignore": "^5.0.5"
-      },
-      "engines": {
-        "node": ">=6.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=4.19.1"
-      }
-    },
-    "node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/eslint-plugin-jest": {
-      "version": "24.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
-      "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">= 4",
-        "eslint": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-plugin-node": {
@@ -14111,70 +14094,53 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        }
-      }
-    },
     "@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.0.tgz",
+      "integrity": "sha512-22Uic9oRlTsPppy5Tcwfj+QET5RWEnZ5414Prby465XxQrQFZ6nnm5KnXgnsAJefG4hEgMnaxTB3kNEyjdjj6A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
+        "@typescript-eslint/types": "5.3.0",
+        "@typescript-eslint/visitor-keys": "5.3.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.0.tgz",
+      "integrity": "sha512-fce5pG41/w8O6ahQEhXmMV+xuh4+GayzqEogN24EK+vECA3I6pUwKuLi5QbXO721EMitpQne5VKXofPonYlAQg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.0.tgz",
+      "integrity": "sha512-FJ0nqcaUOpn/6Z4Jwbtf+o0valjBLkqc3MWkMvrhA2TvzFXtcclIM8F4MBEmYa2kgcI8EZeSAzwoSrIC8JYkug==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
+        "@typescript-eslint/types": "5.3.0",
+        "@typescript-eslint/visitor-keys": "5.3.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.0.tgz",
+      "integrity": "sha512-oVIAfIQuq0x2TFDNLVavUn548WL+7hdhxYn+9j3YdJJXB7mH9dAmZNJsPDa7Jc+B9WGqoiex7GUDbyMxV0a/aw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.3.0",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
+          "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
+          "dev": true
+        }
       }
     },
     "abab": {
@@ -15366,16 +15332,49 @@
       "requires": {}
     },
     "eslint-config-stylelint": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-14.0.0.tgz",
-      "integrity": "sha512-/HAEjiNNVOvSAs4J+z9G/Ybk8G8/nLy8hjzISHDZU27Cnx2BwAGFdqXnStucER8rkVnaaFyEM7p+GIC2Zzp6dA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-15.0.0.tgz",
+      "integrity": "sha512-RQSkNgtCyAlf6yLVTbxHgHTCu3OPTx1LaihYKeLa3OPYUKytIb8f0H6I5+1DC6v2T8THUNDEVdQPYuZTGmBRkg==",
       "dev": true,
       "requires": {
         "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-eslint-comments": "^3.2.0",
-        "eslint-plugin-jest": "^24.4.0",
+        "eslint-plugin-jest": "^25.2.2",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-regexp": "^1.1.0"
+        "eslint-plugin-regexp": "^1.5.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
+          "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.3.0",
+            "@typescript-eslint/types": "5.3.0",
+            "@typescript-eslint/typescript-estree": "5.3.0",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "eslint-plugin-jest": {
+          "version": "25.2.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.3.tgz",
+          "integrity": "sha512-Yoa0at3euTjERDvPGPWiItY1uuqKYQ5Ov2SmkSLmKRq9OFiVdEehw0rWuK4PA538k7CNqnvmkztjAB9l+HJ7kQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/experimental-utils": "^5.0.0"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-es": {
@@ -15386,33 +15385,6 @@
       "requires": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
-      }
-    },
-    "eslint-plugin-eslint-comments": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
-      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "ignore": "^5.0.5"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-jest": {
-      "version": "24.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.7.0.tgz",
-      "integrity": "sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "^4.0.1"
       }
     },
     "eslint-plugin-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "deepmerge": "^4.2.2",
         "eslint": "^7.32.0",
         "eslint-config-stylelint": "^15.0.0",
+        "eslint-plugin-jest": "^25.2.3",
         "got": "^11.8.2",
         "husky": "^7.0.4",
         "jest": "^27.3.1",
@@ -777,9 +778,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1533,6 +1534,48 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
+      "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.3.0",
+        "@typescript-eslint/types": "5.3.0",
+        "@typescript-eslint/typescript-estree": "5.3.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.3.0",
@@ -3211,31 +3254,26 @@
         "eslint-plugin-regexp": "^1.5.0"
       }
     },
-    "node_modules/eslint-config-stylelint/node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
-      "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
+    "node_modules/eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
       "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.3.0",
-        "@typescript-eslint/types": "5.3.0",
-        "@typescript-eslint/typescript-estree": "5.3.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=8.10.0"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
+        "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": ">=4.19.1"
       }
     },
-    "node_modules/eslint-config-stylelint/node_modules/eslint-plugin-jest": {
+    "node_modules/eslint-plugin-jest": {
       "version": "25.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.3.tgz",
       "integrity": "sha512-Yoa0at3euTjERDvPGPWiItY1uuqKYQ5Ov2SmkSLmKRq9OFiVdEehw0rWuK4PA538k7CNqnvmkztjAB9l+HJ7kQ==",
@@ -3257,43 +3295,6 @@
         "jest": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-config-stylelint/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
-      "dev": true,
-      "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=4.19.1"
       }
     },
     "node_modules/eslint-plugin-node": {
@@ -13428,9 +13429,9 @@
       }
     },
     "@humanwhocodes/object-schema": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -14093,6 +14094,31 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
+      "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.3.0",
+        "@typescript-eslint/types": "5.3.0",
+        "@typescript-eslint/typescript-estree": "5.3.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
+      }
     },
     "@typescript-eslint/scope-manager": {
       "version": "5.3.0",
@@ -15341,40 +15367,6 @@
         "eslint-plugin-jest": "^25.2.2",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-regexp": "^1.5.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/experimental-utils": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.0.tgz",
-          "integrity": "sha512-NFVxYTjKj69qB0FM+piah1x3G/63WB8vCBMnlnEHUsiLzXSTWb9FmFn36FD9Zb4APKBLY3xRArOGSMQkuzTF1w==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "@typescript-eslint/scope-manager": "5.3.0",
-            "@typescript-eslint/types": "5.3.0",
-            "@typescript-eslint/typescript-estree": "5.3.0",
-            "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0"
-          }
-        },
-        "eslint-plugin-jest": {
-          "version": "25.2.3",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.3.tgz",
-          "integrity": "sha512-Yoa0at3euTjERDvPGPWiItY1uuqKYQ5Ov2SmkSLmKRq9OFiVdEehw0rWuK4PA538k7CNqnvmkztjAB9l+HJ7kQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/experimental-utils": "^5.0.0"
-          }
-        },
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        }
       }
     },
     "eslint-plugin-es": {
@@ -15385,6 +15377,15 @@
       "requires": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.3.tgz",
+      "integrity": "sha512-Yoa0at3euTjERDvPGPWiItY1uuqKYQ5Ov2SmkSLmKRq9OFiVdEehw0rWuK4PA538k7CNqnvmkztjAB9l+HJ7kQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.0.0"
       }
     },
     "eslint-plugin-node": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "common-tags": "^1.8.0",
     "deepmerge": "^4.2.2",
     "eslint": "^7.32.0",
-    "eslint-config-stylelint": "^14.0.0",
+    "eslint-config-stylelint": "^15.0.0",
     "got": "^11.8.2",
     "husky": "^7.0.4",
     "jest": "^27.3.1",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "deepmerge": "^4.2.2",
     "eslint": "^7.32.0",
     "eslint-config-stylelint": "^15.0.0",
+    "eslint-plugin-jest": "^25.2.3",
     "got": "^11.8.2",
     "husky": "^7.0.4",
     "jest": "^27.3.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Not an issue, but part of the discussion in #5645.

> Is there anything in the PR that needs further explanation?

This PR slightly took on scope creep (from the initial ask to just update `eslint-shared-config` to major version 15. Here's my thought process:

1. First, I bumped the above
2. Then, this causes an error with `eslint-plugin-jest`. I could resolve this by manually reinstalling it as a dev dependency. **I'm not sure if this is the right move**; if it isn't, let me know and I can move this commit out of the PR.
3. Finally, I address the newly enabled [`jest/prefer-to-be`](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/prefer-to-be.md) rule, which was a simple find-and-replace.

Let me know if we'd prefer dependabot to handle. I'm using node 16 to generate the new `package-lock`, and we stay on lockfile v2.
