### PR TITLE
updates globby to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "file-entry-cache": "^6.0.1",
     "get-stdin": "^8.0.0",
     "global-modules": "^2.0.0",
-    "globby": "^11.0.4",
+    "globby": "^12.0.2",
     "globjoin": "^0.1.4",
     "html-tags": "^3.1.0",
     "ignore": "^5.1.9",


### PR DESCRIPTION
updates globby which uses glob-parent 6.0.1 which fixes an Improper Regular Expression DoS vulnerability 