### PR TITLE
Refactor to use PostCSS `Container` type for more flexibility

### DIFF
--- a/lib/utils/beforeBlockString.js
+++ b/lib/utils/beforeBlockString.js
@@ -1,10 +1,9 @@
 'use strict';
 
-/** @typedef {import('postcss').Rule} Rule */
-/** @typedef {import('postcss').AtRule} AtRule */
+const { isAtRule, isRule } = require('./typeGuards');
 
 /**
- * @param {Rule | AtRule} statement
+ * @param {import('postcss').Container} statement
  * @returns {string}
  */
 module.exports = function beforeBlockString(statement, { noRawBefore } = { noRawBefore: false }) {
@@ -16,15 +15,12 @@ module.exports = function beforeBlockString(statement, { noRawBefore } = { noRaw
 		result += before;
 	}
 
-	switch (statement.type) {
-		case 'rule':
-			result += statement.selector;
-			break;
-		case 'atrule':
-			result += `@${statement.name}${statement.raws.afterName || ''}${statement.params}`;
-			break;
-		default:
-			return '';
+	if (isRule(statement)) {
+		result += statement.selector;
+	} else if (isAtRule(statement)) {
+		result += `@${statement.name}${statement.raws.afterName || ''}${statement.params}`;
+	} else {
+		return '';
 	}
 
 	result += statement.raws.between || '';

--- a/lib/utils/blockString.js
+++ b/lib/utils/blockString.js
@@ -4,15 +4,12 @@ const beforeBlockString = require('./beforeBlockString');
 const hasBlock = require('./hasBlock');
 const rawNodeString = require('./rawNodeString');
 
-/** @typedef {import('postcss').Rule} Rule */
-/** @typedef {import('postcss').AtRule} AtRule */
-
 /**
  * Return a CSS statement's block -- the string that starts and `{` and ends with `}`.
  *
  * If the statement has no block (e.g. `@import url(foo.css);`), returns an empty string.
  *
- * @param {Rule | AtRule} statement - postcss rule or at-rule node
+ * @param {import('postcss').Container} statement
  * @returns {string}
  */
 module.exports = function blockString(statement) {

--- a/lib/utils/hasBlock.js
+++ b/lib/utils/hasBlock.js
@@ -3,9 +3,9 @@
 /**
  * Check if a statement has an block (empty or otherwise).
  *
- * @param {import('postcss').Rule | import('postcss').AtRule} statement - postcss rule or at-rule node
+ * @param {import('postcss').Container} statement
  * @return {boolean} True if `statement` has a block (empty or otherwise)
  */
-module.exports = function (statement) {
+module.exports = function hasBlock(statement) {
 	return statement.nodes !== undefined;
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes the type error on #5689

> Is there anything in the PR that needs further explanation?

Instead of `import('postcss').Rule | import('postcss').AtRule`, this refactoring uses the `import('postcss').Container` type.
This type includes also `import('postcss').Root` so has more flexibility. 

See the type definitions of PostCSS below:

- `Container` - https://github.com/postcss/postcss/blob/77c2e73/lib/container.d.ts#L23-L30
- `AtRule` - https://github.com/postcss/postcss/blob/77c2e73/lib/at-rule.d.ts#L73
- `Rule` - https://github.com/postcss/postcss/blob/77c2e73/lib/rule.d.ts#L66
- `Root` - https://github.com/postcss/postcss/blob/77c2e73/lib/root.d.ts#L51
