### PR TITLE
Fix false positives for SVG type selectors in selector-type-case (#5712)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .coverage
 .eslintcache
 yarn.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules
 .coverage
 .eslintcache
 yarn.lock
-.idea

--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -679,6 +679,42 @@ keywordSets.nonStandardHtmlTags = new Set([
 	'xmp',
 ]);
 
+// extracted from https://developer.mozilla.org/en-US/docs/Web/SVG/Element
+keywordSets.validMixedCaseSvgElements = new Set([
+	'animateMotion',
+	'animateTransform',
+	'clipPath',
+	'feBlend',
+	'feColorMatrix',
+	'feComponentTransfer',
+	'feComposite',
+	'feConvolveMatrix',
+	'feDiffuseLighting',
+	'feDisplacementMap',
+	'feDistantLight',
+	'feDropShadow',
+	'feFlood',
+	'feFuncA',
+	'feFuncB',
+	'feFuncG',
+	'feFuncR',
+	'feGaussianBlur',
+	'feImage',
+	'feMerge',
+	'feMergeNode',
+	'feMorphology',
+	'feOffset',
+	'fePointLight',
+	'feSpecularLighting',
+	'feSpotLight',
+	'feTile',
+	'feTurbulence',
+	'foreignObject',
+	'linearGradient',
+	'radialGradient',
+	'textPath',
+]);
+
 /**
  * @param {(string[] | Set<string>)[]} args
  */

--- a/lib/rules/selector-type-case/__tests__/index.js
+++ b/lib/rules/selector-type-case/__tests__/index.js
@@ -95,6 +95,14 @@ testRule({
 			code: 'a /*comments */\n b {}',
 			description: 'comments in the selector',
 		},
+		{
+			code: 'foreignObject {}',
+			description: 'valid mixed-case svg elements',
+		},
+		{
+			code: 'html textPath { fill: red; }',
+			description: 'valid mixed-case svg elements',
+		},
 	],
 
 	reject: [

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -11,6 +11,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const { isString } = require('../../utils/validateTypes');
+const keywordSets = require('../../reference/keywordSets');
 
 const ruleName = 'selector-type-case';
 
@@ -56,6 +57,10 @@ function rule(expectation, options, context) {
 			parseSelector(selector, result, ruleNode, (selectorAST) => {
 				selectorAST.walkTags((tag) => {
 					if (!isStandardSyntaxTypeSelector(tag)) {
+						return;
+					}
+
+					if (keywordSets.validMixedCaseSvgElements.has(tag.value)) {
 						return;
 					}
 


### PR DESCRIPTION
[SVG elements](https://developer.mozilla.org/en-US/docs/Web/SVG/Element) with mixed case (e.g. "foreignObject") should be ignored by the "selector-type-case" rule.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5712

> Is there anything in the PR that needs further explanation?

Added `.idea` to `.gitignore`. Let me know if a separate PR should be done for this.