### PR TITLE
Jest: ignore __tests__ and testUtils from coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "collectCoverage": false,
     "collectCoverageFrom": [
       "lib/**/*.js",
-      "!lib/vendor/**/*.js"
+      "!lib/**/{__tests__,testUtils}/**/*.js"
     ],
     "coverageDirectory": "./.coverage/",
     "coverageReporters": [


### PR DESCRIPTION
Unsure if you all want these in the coverage report, so if you do, feel free to drop the PR :)