### PR TITLE
Replace Coveralls with jest-coverage-report-action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,13 +43,8 @@ jobs:
         if: "!(startsWith(matrix.os, 'ubuntu') && matrix.node == 16)"
 
       - name: Test with coverage
-        run: npm run jest -- --coverage
-        if: startsWith(matrix.os, 'ubuntu') && matrix.node == 16
-
-      - name: Run Coveralls
-        # TODO: use version tag when available
-        uses: coverallsapp/github-action@1.1.3
+        uses: artaiomtr/jest-coverage-report-action@v2.0-rc.6x
         if: startsWith(matrix.os, 'ubuntu') && matrix.node == 16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./.coverage/lcov.info
+          skip-step: install

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
         if: "!(startsWith(matrix.os, 'ubuntu') && matrix.node == 16)"
 
       - name: Test with coverage
-        uses: artaiomtr/jest-coverage-report-action@v2.0-rc.6
+        uses: ArtiomTr/jest-coverage-report-action@v2.0-rc.6
         if: startsWith(matrix.os, 'ubuntu') && matrix.node == 16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
         if: "!(startsWith(matrix.os, 'ubuntu') && matrix.node == 16)"
 
       - name: Test with coverage
-        uses: artaiomtr/jest-coverage-report-action@v2.0-rc.6x
+        uses: artaiomtr/jest-coverage-report-action@v2.0-rc.6
         if: startsWith(matrix.os, 'ubuntu') && matrix.node == 16
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Currently, Coveralls does not work. This change replaces it with `jest-coverage-report-action`:
https://github.com/ArtiomTr/jest-coverage-report-action

Here is the latest build on Coveralls:
https://coveralls.io/builds/44570787
