### PR TITLE
Migrate Coveralls to Codecov

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,10 +46,8 @@ jobs:
         run: npm run jest -- --coverage
         if: startsWith(matrix.os, 'ubuntu') && matrix.node == 16
 
-      - name: Run Coveralls
-        # TODO: use version tag when available
-        uses: coverallsapp/github-action@1.1.3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
         if: startsWith(matrix.os, 'ubuntu') && matrix.node == 16
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./.coverage/lcov.info
+          files: ./.coverage/lcov.info

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5748

> Is there anything in the PR that needs further explanation?

This change aims to migrate Coveralls to Codecov as a test coverage SaaS.
See also:
- https://github.com/codecov/codecov-action
- https://github.com/apps/codecov
