### PR TITLE
Replace "violations" with "problems" in `declaration-block-no-duplicate-properties` rule doc

### DIFF
--- a/lib/rules/declaration-block-no-duplicate-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-properties/README.md
@@ -114,7 +114,7 @@ Ignore consecutive duplicated properties with identical values, when ignoring th
 
 This option is useful to deal with draft CSS values while still being future proof. E.g. using `fit-content` and `-moz-fit-content`.
 
-The following patterns are considered violations:
+The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
@@ -135,7 +135,7 @@ p {
 }
 ```
 
-The following patterns are _not_ considered violations:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

To follow the decision in #5592. They were overlooked in #5609.