### PR TITLE
Fix showing of incorrect missing package in customSyntax require handling 

### DIFF
--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -102,7 +102,6 @@ function getCustomSyntax(customSyntax) {
 				// @ts-expect-error -- TS2571: Object is of type 'unknown'.
 				error.message.includes(customSyntax)
 			) {
-				console.error('Stylelint MODULE_NOT_FOUND', error);
 
 				throw new Error(
 					`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.\n\nCaused by: ${error}`,

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -102,7 +102,6 @@ function getCustomSyntax(customSyntax) {
 				// @ts-expect-error -- TS2571: Object is of type 'unknown'.
 				error.message.includes(customSyntax)
 			) {
-
 				throw new Error(
 					`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.\n\nCaused by: ${error}`,
 				);

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -94,8 +94,16 @@ function getCustomSyntax(customSyntax) {
 		try {
 			resolved = require(customSyntax);
 		} catch (error) {
-			// @ts-expect-error -- TS2571: Object is of type 'unknown'.
-			if (error && typeof error === 'object' && error.code === 'MODULE_NOT_FOUND') {
+			if (
+				error &&
+				typeof error === 'object' &&
+				// @ts-expect-error -- TS2571: Object is of type 'unknown'.
+				error.code === 'MODULE_NOT_FOUND' &&
+				// @ts-expect-error -- TS2571: Object is of type 'unknown'.
+				error.message.includes(customSyntax)
+			) {
+				console.error('Stylelint MODULE_NOT_FOUND', error);
+
 				throw new Error(
 					`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.`,
 				);

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -105,7 +105,7 @@ function getCustomSyntax(customSyntax) {
 				console.error('Stylelint MODULE_NOT_FOUND', error);
 
 				throw new Error(
-					`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.`,
+					`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.\n\nCaused by: ${error}`,
 				);
 			}
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #5761

> Is there anything in the PR that needs further explanation?

I'm not sure if the added `console.error` is beneficial. What are your thoughts? 
