### PR TITLE
Refactor to use markdown syntax for images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,23 +71,19 @@ Stylelint is maintained by volunteers. Without the code contributions from [all 
 
 ### Sponsors
 
-<object data="https://opencollective.com/stylelint/sponsors.svg?width=420&button=false" type="image/svg+xml">
-  <img src="https://opencollective.com/stylelint/sponsors.svg?width=840&button=false" />
-</object>
+[![Stylelint Sponsors](https://opencollective.com/stylelint/sponsors.svg?width=420&button=false)](https://opencollective.com/stylelint/sponsors.svg?width=420&button=false)
 
 Thank you to all our sponsors! [Become a sponsor](https://opencollective.com/stylelint).
 
 ### Backers
 
-<object data="https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false" type="image/svg+xml">
-  <img src="https://opencollective.com/stylelint/backers.svg?width=840&avatarHeight=48&button=false" />
-</object>
+[![Stylelint Backers](https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false)](https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false)
 
 Thank you to all our backers! [Become a backer](https://opencollective.com/stylelint).
 
 ### Website hosting
 
-<a href="https://www.netlify.com"><img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" /></a>
+[![Deploys by Netlify](https://www.netlify.com/img/global/badges/netlify-color-accent.svg)](https://www.netlify.com)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -71,13 +71,17 @@ Stylelint is maintained by volunteers. Without the code contributions from [all 
 
 ### Sponsors
 
-[![Stylelint Sponsors](https://opencollective.com/stylelint/sponsors.svg?width=420&button=false)](https://opencollective.com/stylelint/sponsors.svg?width=420&button=false)
+<object data="https://opencollective.com/stylelint/sponsors.svg?width=420&button=false" type="image/svg+xml">
+  <img src="https://opencollective.com/stylelint/sponsors.svg?width=840&button=false" />
+</object>
 
 Thank you to all our sponsors! [Become a sponsor](https://opencollective.com/stylelint).
 
 ### Backers
 
-[![Stylelint Backers](https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false)](https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false)
+<object data="https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false" type="image/svg+xml">
+  <img src="https://opencollective.com/stylelint/backers.svg?width=840&avatarHeight=48&button=false" />
+</object>
 
 Thank you to all our backers! [Become a backer](https://opencollective.com/stylelint).
 


### PR DESCRIPTION
This is documentation fixes. 

- [ ] Change **HTML** image, link and object to **Markdown** image + links
