### PR TITLE
Refactor `getFileIgnorer()` to reduce duplication

### DIFF
--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -202,6 +202,19 @@ test('specified `ignorePath` file ignoring one file using options.cwd', async ()
 	).rejects.toThrow(noFilesErrorMessage); // no files read
 });
 
+test('specified `ignorePath` directory, not a file', async () => {
+	process.chdir(__dirname);
+
+	await expect(
+		standalone({
+			files: [],
+			config: {},
+			ignorePath: '__snapshots__',
+			cwd: __dirname,
+		}),
+	).rejects.toThrow(/EISDIR/);
+});
+
 test('specified `ignorePattern` file ignoring one file', async () => {
 	const files = [fixtures('empty-block.css')];
 	const noFilesErrorMessage = new NoFilesFoundError(files);

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -1,25 +1,24 @@
 'use strict';
 
-const createStylelint = require('./createStylelint');
-const createStylelintResult = require('./createStylelintResult');
 const debug = require('debug')('stylelint:standalone');
 const fastGlob = require('fast-glob');
+const fs = require('fs');
+const globby = require('globby');
+const normalizePath = require('normalize-path');
+const path = require('path');
+
+const createStylelint = require('./createStylelint');
+const createStylelintResult = require('./createStylelintResult');
 const FileCache = require('./utils/FileCache');
 const filterFilePaths = require('./utils/filterFilePaths');
 const formatters = require('./formatters');
-const fs = require('fs');
+const getFileIgnorer = require('./utils/getFileIgnorer');
 const getFormatterOptionsText = require('./utils/getFormatterOptionsText');
-const globby = require('globby');
 const hash = require('./utils/hash');
-const isPathNotFoundError = require('./utils/isPathNotFoundError');
 const NoFilesFoundError = require('./utils/noFilesFoundError');
-const normalizePath = require('normalize-path');
-const path = require('path');
 const pkg = require('../package.json');
 const prepareReturnValue = require('./prepareReturnValue');
-const { default: ignore } = require('ignore');
 
-const DEFAULT_IGNORE_FILENAME = '.stylelintignore';
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 const writeFileAtomic = require('write-file-atomic');
 
@@ -51,8 +50,8 @@ async function standalone({
 	formatter,
 	globbyOptions,
 	ignoreDisables,
-	ignorePath = DEFAULT_IGNORE_FILENAME,
-	ignorePattern = [],
+	ignorePath,
+	ignorePattern,
 	maxWarnings,
 	quiet,
 	reportDescriptionlessDisables,
@@ -74,20 +73,15 @@ async function standalone({
 
 	// The ignorer will be used to filter file paths after the glob is checked,
 	// before any files are actually read
-	const absoluteIgnoreFilePath = path.isAbsolute(ignorePath)
-		? ignorePath
-		: path.resolve(cwd, ignorePath);
-	let ignoreText = '';
+
+	/** @type {import('ignore').Ignore} */
+	let ignorer;
 
 	try {
-		ignoreText = fs.readFileSync(absoluteIgnoreFilePath, 'utf8');
-	} catch (readError) {
-		if (!isPathNotFoundError(readError)) {
-			return Promise.reject(readError);
-		}
+		ignorer = getFileIgnorer({ cwd, ignorePath, ignorePattern });
+	} catch (error) {
+		return Promise.reject(error);
 	}
-
-	const ignorer = ignore().add(ignoreText).add(ignorePattern);
 
 	/** @type {Formatter} */
 	let formatterFunction;

--- a/lib/utils/getFileIgnorer.js
+++ b/lib/utils/getFileIgnorer.js
@@ -9,27 +9,26 @@ const isPathNotFoundError = require('./isPathNotFoundError');
 
 const DEFAULT_IGNORE_FILENAME = '.stylelintignore';
 
-/** @typedef {import('stylelint').LinterOptions} StylelintOptions */
-
 /**
- * @param {StylelintOptions} options
+ * @param {{ cwd: string, ignorePath?: string, ignorePattern?: string[] }} options
  * @return {import('ignore').Ignore}
  */
-module.exports = function (options) {
+module.exports = function getFileIgnorer(options) {
 	const ignoreFilePath = options.ignorePath || DEFAULT_IGNORE_FILENAME;
 	const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
 		? ignoreFilePath
-		: path.resolve(options.cwd || process.cwd(), ignoreFilePath);
+		: path.resolve(options.cwd, ignoreFilePath);
 	let ignoreText = '';
 
 	try {
 		ignoreText = fs.readFileSync(absoluteIgnoreFilePath, 'utf8');
 	} catch (readError) {
-		if (!isPathNotFoundError(readError)) throw readError;
+		if (!isPathNotFoundError(readError)) {
+			throw readError;
+		}
 	}
 
-	const ignorePattern = options.ignorePattern || [];
-	const ignorer = ignore().add(ignoreText).add(ignorePattern);
-
-	return ignorer;
+	return ignore()
+		.add(ignoreText)
+		.add(options.ignorePattern || []);
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR aims to reduce duplication using the `ignore` package. The duplication is in both `lib/standalone.js` and `lib/utils/getFileIgnorer.js`.
  
