### PR TITLE
corrected a typo in combine.md

### DIFF
--- a/docs/user-guide/rules/combine.md
+++ b/docs/user-guide/rules/combine.md
@@ -28,7 +28,7 @@ For example, this is the complete set of `value-list-comma-*` rules and their op
 
 - `value-list-comma-space-after`: `"always"|"never"|"always-single-line"|"never-single-line"`
 - `value-list-comma-space-before`: `"always"|"never"|"always-single-line"|"never-single-line"`
-- `value-list-comma-newline-after`: `"always"|"always-multi-line|"never-multi-line"`
+- `value-list-comma-newline-after`: `"always"|"always-multi-line"|"never-multi-line"`
 - `value-list-comma-newline-before`: `"always"|"always-multi-line"|"never-multi-line"`
 
 Where `*-multi-line` and `*-single-line` are in reference to the value list (the _thing_). For example, given:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5796 
> Is there anything in the PR that needs further explanation?

Changed - `value-list-comma-newline-after`: `"always"|"always-multi-line|"never-multi-line"` to - `value-list-comma-newline-after`: `"always"|"always-multi-line"|"never-multi-line"` in combine.md
