### PR TITLE
Update CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Stylelint
 
-[![npm version](https://img.shields.io/npm/v/stylelint)](https://www.npmjs.com/package/stylelint) [![Build Status](https://img.shields.io/github/workflow/status/stylelint/stylelint/Testing/main?label=CI&logo=github)](https://github.com/stylelint/stylelint/actions/workflows/testing.yml?query=branch%3Amain) [![npm downloads](https://img.shields.io/npm/dm/stylelint)](https://npmcharts.com/compare/stylelint?minimal=true)
+[![npm version](https://img.shields.io/npm/v/stylelint)](https://www.npmjs.com/package/stylelint)
+[![Build Status](https://github.com/stylelint/stylelint/workflows/Testing/badge.svg)](https://github.com/stylelint/stylelint/actions/workflows/testing.yml?query=branch%3Amain)
+[![npm downloads](https://img.shields.io/npm/dm/stylelint)](https://npmcharts.com/compare/stylelint?minimal=true)
 
 A mighty, modern linter that helps you avoid errors and enforce conventions in your styles.
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Badges.

> Is there anything in the PR that needs further explanation?

No.

### Changes

This is a workaround to fix the badge in https://stylelint.io homepage. I replaced the sheids.io badge with the GitHub one. As you can see, the URL of the new badge is from GitHub.

The weird backslash `\` in the badge comes from the Remark library. Seems there are some bugs when Remark trying to parse the  `&` in `![](https://example.com?query1=string1&query2=string2)`.

We can update the workflow name in https://github.com/stylelint/stylelint/blob/main/.github/workflows/testing.yml#L1 if you want to keep the `CI` on the badge. That's up to you.

### Preview

| Before | After |
| :-: | :-: |
| ![](https://user-images.githubusercontent.com/8186898/148226715-f9eb5e12-f9f8-456f-b782-3f5ebc23b96d.png) | ![](https://user-images.githubusercontent.com/8186898/148226801-181db530-5ff1-45db-98cf-4e50f140711a.png) | 

