### PR TITLE
Refactor to improve types for `no-invalid-*` rules

### DIFF
--- a/lib/rules/no-invalid-double-slash-comments/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -12,9 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected double-slash CSS comment',
 });
 
-function rule(actual) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -44,7 +43,7 @@ function rule(actual) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-invalid-position-at-import-rule/index.js
+++ b/lib/rules/no-invalid-position-at-import-rule/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected invalid position @import rule',
 });
 
-function rule(actual, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, options) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
-			{ actual },
+			{ actual: primary },
 			{
 				actual: options,
 				possible: {
@@ -38,7 +37,7 @@ function rule(actual, options) {
 		let invalidPosition = false;
 
 		root.walk((node) => {
-			const nodeName = node.name && node.name.toLowerCase();
+			const nodeName = ('name' in node && node.name && node.name.toLowerCase()) || '';
 
 			if (
 				(node.type === 'atrule' &&
@@ -63,7 +62,7 @@ function rule(actual, options) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
- Improve the code a bit for more type-consistency.
