### PR TITLE
Refactor to improve types for `no-irregular-whitespace` rule

### DIFF
--- a/lib/rules/no-irregular-whitespace/__tests__/index.js
+++ b/lib/rules/no-irregular-whitespace/__tests__/index.js
@@ -52,6 +52,20 @@ testRule({
 
 	reject: [
 		{
+			code: '@ charset "utf-8"',
+			description: 'irregular whitespace in at-rule',
+			message: messages.unexpected,
+			line: 1,
+			column: 2,
+		},
+		{
+			code: '@charset  "utf-8"',
+			description: 'irregular whitespace after at-rule',
+			message: messages.unexpected,
+			line: 1,
+			column: 9,
+		},
+		{
 			code: '.firstClass .secondClass { color: pink; }',
 			description: 'irregular whitespace in selector',
 			message: messages.unexpected,

--- a/lib/rules/no-irregular-whitespace/index.js
+++ b/lib/rules/no-irregular-whitespace/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -7,6 +5,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'no-irregular-whitespace';
+
 const messages = ruleMessages(ruleName, {
 	unexpected: 'Unexpected irregular whitespace',
 });
@@ -40,73 +39,31 @@ const IRREGULAR_WHITESPACES = [
 
 const IRREGULAR_WHITESPACES_PATTERN = new RegExp(`([${IRREGULAR_WHITESPACES.join('')}])`);
 
-const generateInvalidWhitespaceValidator = () => {
-	return (str) => typeof str === 'string' && IRREGULAR_WHITESPACES_PATTERN.exec(str);
+/**
+ * @param {string} str
+ * @returns {string | null}
+ */
+const findIrregularWhitespace = (str) => {
+	const result = IRREGULAR_WHITESPACES_PATTERN.exec(str);
+
+	return result ? result[1] : null;
 };
 
-const declarationSchema = {
-	prop: 'string',
-	value: 'string',
-	raws: {
-		before: 'string',
-		between: 'string',
-	},
-};
-
-const atRuleSchema = {
-	name: 'string',
-	params: 'string',
-	raws: {
-		before: 'string',
-		between: 'string',
-		afterName: 'string',
-		after: 'string',
-	},
-};
-
-const ruleSchema = {
-	selector: 'string',
-	raws: {
-		before: 'string',
-		between: 'string',
-		after: 'string',
-	},
-};
-
-const generateNodeValidator = (nodeSchema, validator) => {
-	const allKeys = Object.keys(nodeSchema);
-	const validatorForKey = {};
-
-	for (const key of allKeys) {
-		if (typeof nodeSchema[key] === 'string') validatorForKey[key] = validator;
-
-		if (typeof nodeSchema[key] === 'object')
-			validatorForKey[key] = generateNodeValidator(nodeSchema[key], validator);
-	}
-
-	// This will be called many times, so it's optimized for performance and not readibility.
-	// Surprisingly, this seem to be slightly faster then concatenating the params and running the validator once.
-	return (node) => {
-		for (const currentKey of allKeys) {
-			if (validatorForKey[currentKey](node[currentKey])) {
-				return validatorForKey[currentKey](node[currentKey]);
-			}
-		}
-	};
-};
-
-function rule(on) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual: on });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
 		}
 
-		const genericValidator = generateInvalidWhitespaceValidator();
-
-		const validate = (node, validator) => {
-			const issue = validator(node);
+		/**
+		 * @param {import('postcss').Node} node
+		 * @param {string | undefined} value
+		 */
+		const validate = (node, value) => {
+			const issue = value && findIrregularWhitespace(value);
 
 			if (issue) {
 				report({
@@ -114,20 +71,35 @@ function rule(on) {
 					result,
 					message: messages.unexpected,
 					node,
-					word: issue[1],
+					word: issue,
 				});
 			}
 		};
 
-		const atRuleValidator = generateNodeValidator(atRuleSchema, genericValidator);
-		const ruleValidator = generateNodeValidator(ruleSchema, genericValidator);
-		const declValidator = generateNodeValidator(declarationSchema, genericValidator);
+		root.walkAtRules((atRule) => {
+			validate(atRule, atRule.name);
+			validate(atRule, atRule.params);
+			validate(atRule, atRule.raws.before);
+			validate(atRule, atRule.raws.after);
+			validate(atRule, atRule.raws.afterName);
+			validate(atRule, atRule.raws.between);
+		});
 
-		root.walkAtRules((atRule) => validate(atRule, atRuleValidator));
-		root.walkRules((selector) => validate(selector, ruleValidator));
-		root.walkDecls((declaration) => validate(declaration, declValidator));
+		root.walkRules((ruleNode) => {
+			validate(ruleNode, ruleNode.selector);
+			validate(ruleNode, ruleNode.raws.before);
+			validate(ruleNode, ruleNode.raws.after);
+			validate(ruleNode, ruleNode.raws.between);
+		});
+
+		root.walkDecls((decl) => {
+			validate(decl, decl.prop);
+			validate(decl, decl.value);
+			validate(decl, decl.raws.before);
+			validate(decl, decl.raws.between);
+		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
- Convert the internal logic to a more type-safe way; not using `***Schema` objects for nodes, but accessing directly to each node's properties.
