### PR TITLE
Refactor to improve types for `no-missing-*` / `no-unknown-*` rules

### DIFF
--- a/lib/rules/no-missing-end-of-source-newline/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -12,14 +10,20 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected missing end-of-source newline',
 });
 
-function rule(primary, _, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { primary });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
 		}
 
+		if (root.source == null) {
+			throw new Error('The root node must have a source property');
+		}
+
+		// @ts-expect-error -- TS2339: Property 'inline' does not exist on type 'Source'.
 		if (root.source.inline || root.source.lang === 'object-literal') {
 			return;
 		}
@@ -45,7 +49,7 @@ function rule(primary, _, context) {
 			ruleName,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-unknown-animations/index.js
+++ b/lib/rules/no-unknown-animations/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -15,9 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (animationName) => `Unexpected unknown animation name "${animationName}"`,
 });
 
-function rule(actual) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -57,7 +56,7 @@ function rule(actual) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
