### PR TITLE
Refactor to improve types for `number-*` rules

### DIFF
--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -1,13 +1,12 @@
-// @ts-nocheck
-
 'use strict';
+
+const valueParser = require('postcss-value-parser');
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const valueParser = require('postcss-value-parser');
 
 const ruleName = 'number-leading-zero';
 
@@ -16,10 +15,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected leading zero',
 });
 
-function rule(expectation, secondary, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -32,13 +32,19 @@ function rule(expectation, secondary, context) {
 				return;
 			}
 
-			check(atRule, atRule.params, atRuleParamIndex);
+			check(atRule, atRule.params);
 		});
 
-		root.walkDecls((decl) => check(decl, decl.value, declarationValueIndex));
+		root.walkDecls((decl) => check(decl, decl.value));
 
-		function check(node, value, getIndex) {
+		/**
+		 * @param {import('postcss').AtRule | import('postcss').Declaration} node
+		 * @param {string} value
+		 */
+		function check(node, value) {
+			/** @type {Array<{ startIndex: number, endIndex: number }>} */
 			const neverFixPositions = [];
+			/** @type {Array<{ index: number }>} */
 			const alwaysFixPositions = [];
 
 			// Get out quickly if there are no periods
@@ -57,8 +63,11 @@ function rule(expectation, secondary, context) {
 					return;
 				}
 
+				const baseIndex =
+					node.type === 'atrule' ? atRuleParamIndex(node) : declarationValueIndex(node);
+
 				// Check leading zero
-				if (expectation === 'always') {
+				if (primary === 'always') {
 					const match = /(?:\D|^)(\.\d+)/.exec(valueNode.value);
 
 					if (match === null) {
@@ -80,10 +89,10 @@ function rule(expectation, secondary, context) {
 						return;
 					}
 
-					complain(messages.expected, node, getIndex(node) + index);
+					complain(messages.expected, node, baseIndex + index);
 				}
 
-				if (expectation === 'never') {
+				if (primary === 'never') {
 					const match = /(?:\D|^)(0+)(\.\d+)/.exec(valueNode.value);
 
 					if (match === null) {
@@ -107,7 +116,7 @@ function rule(expectation, secondary, context) {
 						return;
 					}
 
-					complain(messages.rejected, node, getIndex(node) + index);
+					complain(messages.rejected, node, baseIndex + index);
 				}
 			});
 
@@ -137,6 +146,11 @@ function rule(expectation, secondary, context) {
 			}
 		}
 
+		/**
+		 * @param {string} message
+		 * @param {import('postcss').Node} node
+		 * @param {number} index
+		 */
 		function complain(message, node, index) {
 			report({
 				result,
@@ -147,13 +161,24 @@ function rule(expectation, secondary, context) {
 			});
 		}
 	};
-}
+};
 
+/**
+ * @param {string} input
+ * @param {number} index
+ * @returns {string}
+ */
 function addLeadingZero(input, index) {
 	// eslint-disable-next-line prefer-template
 	return input.slice(0, index) + '0' + input.slice(index);
 }
 
+/**
+ * @param {string} input
+ * @param {number} startIndex
+ * @param {number} endIndex
+ * @returns {string}
+ */
 function removeLeadingZeros(input, startIndex, endIndex) {
 	return input.slice(0, startIndex) + input.slice(endIndex);
 }

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -63,9 +63,6 @@ const rule = (primary, _secondaryOptions, context) => {
 					return;
 				}
 
-				const baseIndex =
-					node.type === 'atrule' ? atRuleParamIndex(node) : declarationValueIndex(node);
-
 				// Check leading zero
 				if (primary === 'always') {
 					const match = /(?:\D|^)(\.\d+)/.exec(valueNode.value);
@@ -88,6 +85,9 @@ const rule = (primary, _secondaryOptions, context) => {
 
 						return;
 					}
+
+					const baseIndex =
+						node.type === 'atrule' ? atRuleParamIndex(node) : declarationValueIndex(node);
 
 					complain(messages.expected, node, baseIndex + index);
 				}
@@ -115,6 +115,9 @@ const rule = (primary, _secondaryOptions, context) => {
 
 						return;
 					}
+
+					const baseIndex =
+						node.type === 'atrule' ? atRuleParamIndex(node) : declarationValueIndex(node);
 
 					complain(messages.rejected, node, baseIndex + index);
 				}

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -1,6 +1,6 @@
-// @ts-nocheck
-
 'use strict';
+
+const valueParser = require('postcss-value-parser');
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -11,26 +11,25 @@ const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const { isNumber, isRegExp, isString } = require('../../utils/validateTypes');
 
-const valueParser = require('postcss-value-parser');
-
 const ruleName = 'number-max-precision';
 
 const messages = ruleMessages(ruleName, {
 	expected: (number, precision) => `Expected "${number}" to be "${number.toFixed(precision)}"`,
 });
 
-function rule(precision, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: precision,
+				actual: primary,
 				possible: [isNumber],
 			},
 			{
 				optional: true,
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreProperties: [isString, isRegExp],
 					ignoreUnits: [isString, isRegExp],
@@ -47,27 +46,31 @@ function rule(precision, options) {
 				return;
 			}
 
-			check(atRule, atRule.params, atRuleParamIndex);
+			check(atRule, atRule.params);
 		});
 
-		root.walkDecls((decl) => check(decl, decl.value, declarationValueIndex));
+		root.walkDecls((decl) => check(decl, decl.value));
 
-		function check(node, value, getIndex) {
+		/**
+		 * @param {import('postcss').AtRule | import('postcss').Declaration} node
+		 * @param {string} value
+		 */
+		function check(node, value) {
 			// Get out quickly if there are no periods
 			if (!value.includes('.')) {
 				return;
 			}
 
-			const prop = node.prop;
+			const prop = 'prop' in node ? node.prop : undefined;
 
-			if (optionsMatches(options, 'ignoreProperties', prop)) {
+			if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) {
 				return;
 			}
 
 			valueParser(value).walk((valueNode) => {
 				const unit = getUnitFromValueNode(valueNode);
 
-				if (optionsMatches(options, 'ignoreUnits', unit)) {
+				if (optionsMatches(secondaryOptions, 'ignoreUnits', unit)) {
 					return;
 				}
 
@@ -87,21 +90,24 @@ function rule(precision, options) {
 					return;
 				}
 
-				if (match[1].length <= precision) {
+				if (match[1].length <= primary) {
 					return;
 				}
+
+				const baseIndex =
+					node.type === 'atrule' ? atRuleParamIndex(node) : declarationValueIndex(node);
 
 				report({
 					result,
 					ruleName,
 					node,
-					index: getIndex(node) + valueNode.sourceIndex + match.index,
-					message: messages.expected(Number.parseFloat(match[0]), precision),
+					index: baseIndex + valueNode.sourceIndex + match.index,
+					message: messages.expected(Number.parseFloat(match[0]), primary),
 				});
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -122,6 +122,7 @@ const rule = (primary, _secondaryOptions, context) => {
  * @param {string} input
  * @param {number} startIndex
  * @param {number} endIndex
+ * @returns {string}
  */
 function removeTrailingZeros(input, startIndex, endIndex) {
 	return input.slice(0, startIndex) + input.slice(endIndex);

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -1,13 +1,12 @@
-// @ts-nocheck
-
 'use strict';
+
+const valueParser = require('postcss-value-parser');
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const valueParser = require('postcss-value-parser');
 
 const ruleName = 'number-no-trailing-zeros';
 
@@ -15,9 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected trailing zero(s)',
 });
 
-function rule(actual, secondary, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, { actual });
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
 		if (!validOptions) {
 			return;
@@ -28,12 +28,17 @@ function rule(actual, secondary, context) {
 				return;
 			}
 
-			check(atRule, atRule.params, atRuleParamIndex);
+			check(atRule, atRule.params);
 		});
 
-		root.walkDecls((decl) => check(decl, decl.value, declarationValueIndex));
+		root.walkDecls((decl) => check(decl, decl.value));
 
-		function check(node, value, getIndex) {
+		/**
+		 * @param {import('postcss').AtRule | import('postcss').Declaration} node
+		 * @param {string} value
+		 */
+		function check(node, value) {
+			/** @type {Array<{ startIndex: number, endIndex: number }>} */
 			const fixPositions = [];
 
 			// Get out quickly if there are no periods
@@ -84,11 +89,14 @@ function rule(actual, secondary, context) {
 					return;
 				}
 
+				const baseIndex =
+					node.type === 'atrule' ? atRuleParamIndex(node) : declarationValueIndex(node);
+
 				report({
 					message: messages.rejected,
 					node,
 					// this is the index of the _first_ trailing zero
-					index: getIndex(node) + index,
+					index: baseIndex + index,
 					result,
 					ruleName,
 				});
@@ -108,8 +116,13 @@ function rule(actual, secondary, context) {
 			}
 		}
 	};
-}
+};
 
+/**
+ * @param {string} input
+ * @param {number} startIndex
+ * @param {number} endIndex
+ */
 function removeTrailingZeros(input, startIndex, endIndex) {
 	return input.slice(0, startIndex) + input.slice(endIndex);
 }

--- a/lib/utils/optionsMatches.js
+++ b/lib/utils/optionsMatches.js
@@ -8,7 +8,7 @@ const matchesStringOrRegExp = require('./matchesStringOrRegExp');
  *
  * @param {{ [x: string]: any; }} options
  * @param {string} propertyName
- * @param {string} input
+ * @param {unknown} input
  *
  * @returns {boolean}
  */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
- Improve the code a bit for type-safety.