### PR TITLE
Refactor to improve types for `property-*` rules

### DIFF
--- a/lib/rules/property-allowed-list/index.js
+++ b/lib/rules/property-allowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isCustomProperty = require('../../utils/isCustomProperty');
@@ -17,10 +15,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected property "${property}"`,
 });
 
-function rule(list) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
+			actual: primary,
 			possible: [isString, isRegExp],
 		});
 
@@ -39,7 +38,7 @@ function rule(list) {
 				return;
 			}
 
-			if (matchesStringOrRegExp(vendor.unprefixed(prop), list)) {
+			if (matchesStringOrRegExp(vendor.unprefixed(prop), primary)) {
 				return;
 			}
 
@@ -51,7 +50,7 @@ function rule(list) {
 			});
 		});
 	};
-}
+};
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/property-case/index.js
+++ b/lib/rules/property-case/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isCustomProperty = require('../../utils/isCustomProperty');
@@ -14,10 +12,11 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['lower', 'upper'],
 		});
 
@@ -36,7 +35,7 @@ function rule(expectation, options, context) {
 				return;
 			}
 
-			const expectedProp = expectation === 'lower' ? prop.toLowerCase() : prop.toUpperCase();
+			const expectedProp = primary === 'lower' ? prop.toLowerCase() : prop.toUpperCase();
 
 			if (prop === expectedProp) {
 				return;
@@ -56,7 +55,7 @@ function rule(expectation, options, context) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/property-disallowed-list/index.js
+++ b/lib/rules/property-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isCustomProperty = require('../../utils/isCustomProperty');
@@ -17,10 +15,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected property "${property}"`,
 });
 
-function rule(list) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
+			actual: primary,
 			possible: [isString, isRegExp],
 		});
 
@@ -39,7 +38,7 @@ function rule(list) {
 				return;
 			}
 
-			if (!matchesStringOrRegExp(vendor.unprefixed(prop), list)) {
+			if (!matchesStringOrRegExp(vendor.unprefixed(prop), primary)) {
 				return;
 			}
 
@@ -51,7 +50,7 @@ function rule(list) {
 			});
 		});
 	};
-}
+};
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isCustomProperty = require('../../utils/isCustomProperty');
@@ -9,6 +7,7 @@ const optionsMatches = require('../../utils/optionsMatches');
 const properties = require('known-css-properties').all;
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const { isAtRule, isRule } = require('../../utils/typeGuards');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
 const { isBoolean, isRegExp, isString } = require('../../utils/validateTypes');
@@ -19,19 +18,20 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected unknown property "${property}"`,
 });
 
-function rule(actual, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions) => {
 	const allValidProperties = new Set(properties);
 
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
-			{ actual },
+			{ actual: primary },
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreProperties: [isString, isRegExp],
-					checkPrefixed: isBoolean,
+					checkPrefixed: [isBoolean],
 					ignoreSelectors: [isString, isRegExp],
 					ignoreAtRules: [isString, isRegExp],
 				},
@@ -43,10 +43,13 @@ function rule(actual, options) {
 			return;
 		}
 
-		const shouldCheckPrefixed = options && options.checkPrefixed;
+		const shouldCheckPrefixed = secondaryOptions && secondaryOptions.checkPrefixed;
 
 		root.walkDecls(checkStatement);
 
+		/**
+		 * @param {import('postcss').Declaration} decl
+		 */
 		function checkStatement(decl) {
 			const prop = decl.prop;
 
@@ -66,22 +69,25 @@ function rule(actual, options) {
 				return;
 			}
 
-			if (optionsMatches(options, 'ignoreProperties', prop)) {
+			if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) {
 				return;
 			}
 
-			const { selector } = decl.parent;
+			const parent = decl.parent;
 
-			if (selector && optionsMatches(options, 'ignoreSelectors', selector)) {
+			if (
+				parent &&
+				isRule(parent) &&
+				optionsMatches(secondaryOptions, 'ignoreSelectors', parent.selector)
+			) {
 				return;
 			}
 
-			let node = decl.parent;
+			/** @type {import('postcss').Node | undefined} */
+			let node = parent;
 
 			while (node && node.type !== 'root') {
-				const { type, name } = node;
-
-				if (type === 'atrule' && optionsMatches(options, 'ignoreAtRules', name)) {
+				if (isAtRule(node) && optionsMatches(secondaryOptions, 'ignoreAtRules', node.name)) {
 					return;
 				}
 
@@ -100,7 +106,7 @@ function rule(actual, options) {
 			});
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/property-no-vendor-prefix/index.js
+++ b/lib/rules/property-no-vendor-prefix/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isAutoprefixable = require('../../utils/isAutoprefixable');
@@ -16,15 +14,16 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected vendor-prefix "${property}"`,
 });
 
-function rule(actual, options, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
-			{ actual },
+			{ actual: primary },
 			{
 				optional: true,
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreProperties: [isString, isRegExp],
 				},
@@ -40,7 +39,7 @@ function rule(actual, options, context) {
 			const unprefixedProp = vendor.unprefixed(prop);
 
 			//return early if property is to be ignored
-			if (optionsMatches(options, 'ignoreProperties', unprefixedProp)) {
+			if (optionsMatches(secondaryOptions, 'ignoreProperties', unprefixedProp)) {
 				return;
 			}
 
@@ -69,7 +68,7 @@ function rule(actual, options, context) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
- Improve the code a bit for type safety.
