### PR TITLE
Refactor to improve types for `selector-attribute-*` rules

### DIFF
--- a/lib/rules/selector-attribute-brackets-space-inside/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -18,10 +16,11 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before "]"',
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -49,7 +48,7 @@ function rule(expectation, options, context) {
 						const nextCharIsSpace = attributeSelectorString[match.startIndex + 1] === ' ';
 						const index = attributeNode.sourceIndex + match.startIndex + 1;
 
-						if (nextCharIsSpace && expectation === 'never') {
+						if (nextCharIsSpace && primary === 'never') {
 							if (context.fix) {
 								hasFixed = true;
 								fixBefore(attributeNode);
@@ -60,7 +59,7 @@ function rule(expectation, options, context) {
 							complain(messages.rejectedOpening, index);
 						}
 
-						if (!nextCharIsSpace && expectation === 'always') {
+						if (!nextCharIsSpace && primary === 'always') {
 							if (context.fix) {
 								hasFixed = true;
 								fixBefore(attributeNode);
@@ -76,7 +75,7 @@ function rule(expectation, options, context) {
 						const prevCharIsSpace = attributeSelectorString[match.startIndex - 1] === ' ';
 						const index = attributeNode.sourceIndex + match.startIndex - 1;
 
-						if (prevCharIsSpace && expectation === 'never') {
+						if (prevCharIsSpace && primary === 'never') {
 							if (context.fix) {
 								hasFixed = true;
 								fixAfter(attributeNode);
@@ -87,7 +86,7 @@ function rule(expectation, options, context) {
 							complain(messages.rejectedClosing, index);
 						}
 
-						if (!prevCharIsSpace && expectation === 'always') {
+						if (!prevCharIsSpace && primary === 'always') {
 							if (context.fix) {
 								hasFixed = true;
 								fixAfter(attributeNode);
@@ -101,7 +100,7 @@ function rule(expectation, options, context) {
 				});
 			});
 
-			if (hasFixed) {
+			if (hasFixed && fixedSelector) {
 				if (!ruleNode.raws.selector) {
 					ruleNode.selector = fixedSelector;
 				} else {
@@ -109,6 +108,10 @@ function rule(expectation, options, context) {
 				}
 			}
 
+			/**
+			 * @param {string} message
+			 * @param {number} index
+			 */
 			function complain(message, index) {
 				report({
 					message,
@@ -121,16 +124,19 @@ function rule(expectation, options, context) {
 		});
 	};
 
+	/**
+	 * @param {import('postcss-selector-parser').Attribute} attributeNode
+	 */
 	function fixBefore(attributeNode) {
-		const rawAttrBefore =
-			attributeNode.raws.spaces &&
-			attributeNode.raws.spaces.attribute &&
-			attributeNode.raws.spaces.attribute.before;
+		const spacesAttribute = attributeNode.raws.spaces && attributeNode.raws.spaces.attribute;
+		const rawAttrBefore = spacesAttribute && spacesAttribute.before;
+
+		/** @type {{ attrBefore: string, setAttrBefore: (fixed: string) => void }} */
 		const { attrBefore, setAttrBefore } = rawAttrBefore
 			? {
 					attrBefore: rawAttrBefore,
 					setAttrBefore(fixed) {
-						attributeNode.raws.spaces.attribute.before = fixed;
+						spacesAttribute.before = fixed;
 					},
 			  }
 			: {
@@ -143,49 +149,53 @@ function rule(expectation, options, context) {
 					},
 			  };
 
-		if (expectation === 'always') {
+		if (primary === 'always') {
 			setAttrBefore(attrBefore.replace(/^\s*/, ' '));
-		} else if (expectation === 'never') {
+		} else if (primary === 'never') {
 			setAttrBefore(attrBefore.replace(/^\s*/, ''));
 		}
 	}
 
+	/**
+	 * @param {import('postcss-selector-parser').Attribute} attributeNode
+	 */
 	function fixAfter(attributeNode) {
-		let key;
+		const key = attributeNode.operator
+			? attributeNode.insensitive
+				? 'insensitive'
+				: 'value'
+			: 'attribute';
 
-		if (attributeNode.operator) {
-			key = attributeNode.insensitive ? 'insensitive' : 'value';
-		} else {
-			key = 'attribute';
-		}
+		const rawSpaces = attributeNode.raws.spaces && attributeNode.raws.spaces[key];
+		const rawAfter = rawSpaces && rawSpaces.after;
 
-		const rawAfter =
-			attributeNode.raws.spaces &&
-			attributeNode.raws.spaces[key] &&
-			attributeNode.raws.spaces[key].after;
+		const spaces = attributeNode.spaces[key];
+
+		/** @type {{ after: string, setAfter: (fixed: string) => void }} */
 		const { after, setAfter } = rawAfter
 			? {
 					after: rawAfter,
 					setAfter(fixed) {
-						attributeNode.raws.spaces[key].after = fixed;
+						rawSpaces.after = fixed;
 					},
 			  }
 			: {
-					after: (attributeNode.spaces[key] && attributeNode.spaces[key].after) || '',
+					after: (spaces && spaces.after) || '',
 					setAfter(fixed) {
 						if (!attributeNode.spaces[key]) attributeNode.spaces[key] = {};
 
+						// @ts-expect-error -- TS2532: Object is possibly 'undefined'.
 						attributeNode.spaces[key].after = fixed;
 					},
 			  };
 
-		if (expectation === 'always') {
+		if (primary === 'always') {
 			setAfter(after.replace(/\s*$/, ' '));
-		} else if (expectation === 'never') {
+		} else if (primary === 'never') {
 			setAfter(after.replace(/\s*$/, ''));
 		}
 	}
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-attribute-name-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-name-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -16,8 +14,9 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected name "${name}"`,
 });
 
-function rule(listInput) {
-	const list = [listInput].flat();
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
+	const list = [primary].flat();
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -57,7 +56,7 @@ function rule(listInput) {
 			});
 		});
 	};
-}
+};
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-attribute-operator-allowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-allowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -15,8 +13,9 @@ const messages = ruleMessages(ruleName, {
 	rejected: (operator) => `Unexpected operator "${operator}"`,
 });
 
-function rule(listInput) {
-	const list = [listInput].flat();
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
+	const list = [primary].flat();
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -56,7 +55,7 @@ function rule(listInput) {
 			});
 		});
 	};
-}
+};
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-attribute-operator-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -15,8 +13,9 @@ const messages = ruleMessages(ruleName, {
 	rejected: (operator) => `Unexpected operator "${operator}"`,
 });
 
-function rule(listInput) {
-	const list = [listInput].flat();
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
+	const list = [primary].flat();
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -56,7 +55,7 @@ function rule(listInput) {
 			});
 		});
 	};
-}
+};
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-attribute-operator-space-after/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const ruleMessages = require('../../utils/ruleMessages');
@@ -14,11 +12,12 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: (operator) => `Unexpected whitespace after "${operator}"`,
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
-		const checker = whitespaceChecker('space', expectation, messages);
+		const checker = whitespaceChecker('space', primary, messages);
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -34,12 +33,15 @@ function rule(expectation, options, context) {
 			checkBeforeOperator: false,
 			fix: context.fix
 				? (attributeNode) => {
+						/** @type {{ operatorAfter: string, setOperatorAfter: (fixed: string) => void }} */
 						const { operatorAfter, setOperatorAfter } = (() => {
 							const rawOperator = attributeNode.raws.operator;
 
 							if (rawOperator) {
 								return {
-									operatorAfter: rawOperator.slice(attributeNode.operator.length),
+									operatorAfter: rawOperator.slice(
+										attributeNode.operator ? attributeNode.operator.length : 0,
+									),
 									setOperatorAfter(fixed) {
 										delete attributeNode.raws.operator;
 
@@ -53,16 +55,15 @@ function rule(expectation, options, context) {
 								};
 							}
 
-							const rawOperatorAfter =
-								attributeNode.raws.spaces &&
-								attributeNode.raws.spaces.operator &&
-								attributeNode.raws.spaces.operator.after;
+							const rawSpacesOperator =
+								attributeNode.raws.spaces && attributeNode.raws.spaces.operator;
+							const rawOperatorAfter = rawSpacesOperator && rawSpacesOperator.after;
 
 							if (rawOperatorAfter) {
 								return {
 									operatorAfter: rawOperatorAfter,
 									setOperatorAfter(fixed) {
-										attributeNode.raws.spaces.operator.after = fixed;
+										rawSpacesOperator.after = fixed;
 									},
 								};
 							}
@@ -78,22 +79,24 @@ function rule(expectation, options, context) {
 							};
 						})();
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							setOperatorAfter(operatorAfter.replace(/^\s*/, ' '));
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							setOperatorAfter(operatorAfter.replace(/^\s*/, ''));
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-attribute-operator-space-before/index.js
+++ b/lib/rules/selector-attribute-operator-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const ruleMessages = require('../../utils/ruleMessages');
@@ -14,12 +12,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: (operator) => `Unexpected whitespace before "${operator}"`,
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -35,15 +34,15 @@ function rule(expectation, options, context) {
 			checkBeforeOperator: true,
 			fix: context.fix
 				? (attributeNode) => {
-						const rawAttrAfter =
-							attributeNode.raws.spaces &&
-							attributeNode.raws.spaces.attribute &&
-							attributeNode.raws.spaces.attribute.after;
+						const rawAttr = attributeNode.raws.spaces && attributeNode.raws.spaces.attribute;
+						const rawAttrAfter = rawAttr && rawAttr.after;
+
+						/** @type {{ attrAfter: string, setAttrAfter: (fixed: string) => void }} */
 						const { attrAfter, setAttrAfter } = rawAttrAfter
 							? {
 									attrAfter: rawAttrAfter,
 									setAttrAfter(fixed) {
-										attributeNode.raws.spaces.attribute.after = fixed;
+										rawAttr.after = fixed;
 									},
 							  }
 							: {
@@ -56,22 +55,24 @@ function rule(expectation, options, context) {
 									},
 							  };
 
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							setAttrAfter(attrAfter.replace(/\s*$/, ' '));
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							setAttrAfter(attrAfter.replace(/\s*$/, ''));
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const getRuleSelector = require('../../utils/getRuleSelector');
@@ -18,10 +16,11 @@ const messages = ruleMessages(ruleName, {
 
 const acceptedQuoteMark = '"';
 
-function rule(expectation, secondary, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -46,7 +45,7 @@ function rule(expectation, secondary, context) {
 						return;
 					}
 
-					if (!attributeNode.quoted && expectation === 'always') {
+					if (!attributeNode.quoted && primary === 'always') {
 						if (context.fix) {
 							selectorFixed = true;
 							attributeNode.quoteMark = acceptedQuoteMark;
@@ -58,7 +57,7 @@ function rule(expectation, secondary, context) {
 						}
 					}
 
-					if (attributeNode.quoted && expectation === 'never') {
+					if (attributeNode.quoted && primary === 'never') {
 						if (context.fix) {
 							selectorFixed = true;
 							attributeNode.quoteMark = null;
@@ -76,6 +75,10 @@ function rule(expectation, secondary, context) {
 				}
 			});
 
+			/**
+			 * @param {string} message
+			 * @param {number} index
+			 */
 			function complain(message, index) {
 				report({
 					message,
@@ -87,7 +90,7 @@ function rule(expectation, secondary, context) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selectorAttributeOperatorSpaceChecker.js
+++ b/lib/rules/selectorAttributeOperatorSpaceChecker.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../utils/isStandardSyntaxRule');
@@ -7,7 +5,18 @@ const parseSelector = require('../utils/parseSelector');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function (options) {
+/**
+ * @param {{
+ *   root: import('postcss').Root,
+ *   result: import('stylelint').PostcssResult,
+ *   locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
+ *   checkedRuleName: string,
+ *   checkBeforeOperator: boolean,
+ *   fix: ((attributeNode: import('postcss-selector-parser').Attribute) => boolean) | null,
+ * }} options
+ * @returns {void}
+ */
+module.exports = function selectorAttributeOperatorSpaceChecker(options) {
 	options.root.walkRules((rule) => {
 		if (!isStandardSyntaxRule(rule)) {
 			return;
@@ -38,7 +47,7 @@ module.exports = function (options) {
 			});
 		});
 
-		if (hasFixed) {
+		if (hasFixed && fixedSelector) {
 			if (!rule.raws.selector) {
 				rule.selector = fixedSelector;
 			} else {
@@ -46,11 +55,18 @@ module.exports = function (options) {
 			}
 		}
 
+		/**
+		 * @param {string} source
+		 * @param {number} index
+		 * @param {import('postcss').Node} node
+		 * @param {import('postcss-selector-parser').Attribute} attributeNode
+		 * @param {string} operator
+		 */
 		function checkOperator(source, index, node, attributeNode, operator) {
 			options.locationChecker({
 				source,
 				index,
-				err: (m) => {
+				err: (msg) => {
 					if (options.fix && options.fix(attributeNode)) {
 						hasFixed = true;
 
@@ -58,7 +74,7 @@ module.exports = function (options) {
 					}
 
 					report({
-						message: m.replace(
+						message: msg.replace(
 							options.checkBeforeOperator ? operator[0] : operator[operator.length - 1],
 							operator,
 						),

--- a/lib/utils/parseSelector.js
+++ b/lib/utils/parseSelector.js
@@ -7,6 +7,7 @@ const selectorParser = require('postcss-selector-parser');
  * @param {import('stylelint').PostcssResult} result
  * @param {import('postcss').Node} node
  * @param {(root: import('postcss-selector-parser').Root) => void} callback
+ * @returns {string | undefined}
  */
 module.exports = function parseSelector(selector, result, node, callback) {
 	try {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?


- Remove `// @ts-nocheck` to enable type-checking.
- Improve the code a bit for type safety.
