### PR TITLE
Document no-extra-semicolons as stylistic

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -83,7 +83,6 @@ Within each cateogory, the rules are grouped by the [_thing_](http://apps.workfl
 - [`no-duplicate-at-import-rules`](../../../lib/rules/no-duplicate-at-import-rules/README.md): Disallow duplicate `@import` rules within a stylesheet.
 - [`no-duplicate-selectors`](../../../lib/rules/no-duplicate-selectors/README.md): Disallow duplicate selectors within a stylesheet.
 - [`no-empty-source`](../../../lib/rules/no-empty-source/README.md): Disallow empty sources.
-- [`no-extra-semicolons`](../../../lib/rules/no-extra-semicolons/README.md): Disallow extra semicolons (Autofixable).
 - [`no-invalid-double-slash-comments`](../../../lib/rules/no-invalid-double-slash-comments/README.md): Disallow double-slash comments (`//...`) which are not supported by CSS.
 - [`no-invalid-position-at-import-rule`](../../../lib/rules/no-invalid-position-at-import-rule/README.md): Disallow invalid position `@import` rules within a stylesheet.
 
@@ -396,3 +395,4 @@ We have frozen these rules, and we will deprecate then remove them in future rel
 - [`no-eol-whitespace`](../../../lib/rules/no-eol-whitespace/README.md): Disallow end-of-line whitespace (Autofixable).
 - [`no-missing-end-of-source-newline`](../../../lib/rules/no-missing-end-of-source-newline/README.md): Disallow missing end-of-source newlines (Autofixable).
 - [`no-empty-first-line`](../../../lib/rules/no-empty-first-line/README.md): Disallow empty first lines (Autofixable).
+- [`no-extra-semicolons`](../../../lib/rules/no-extra-semicolons/README.md): Disallow extra semicolons (Autofixable).


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/issues/5674
Ref: https://github.com/stylelint/stylelint/issues/5153

> Is there anything in the PR that needs further explanation?

A pretty printer like Prettier [seems to address is](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeAzjAngGzgPgB0oACEgQxOBIG4SATJEgIzppoF9izUB6TXARAAaEBAAOMAJbR0yUOQBOiiAHcACkoRyU5HKvJY5o5ovJgA1nBgBlcgFs4AGSlQ4yAGZ70cE2cvWNuLmrgDmyDCKAK6+IHD2zHD09ElO5FChUeShcABiEIr25DDSGcgg5FEwECIgABYw9jgA6nVS8OjBYHA22u1SAG7tWOVg6MYgrj6KMOpmoUWe3rEAVugAHjZheACKURDwSzg+osGK0+UNTbXiiq4wzVL0MHXIABwADKcqPs1m4uVbnBpgN3KIAI77eBzCQ6CroAC0biSSVqijgkKk6Lm2UWSC8x1iPnsUgi0SJ2zgewO7nxy1EMHIzEez1eSAATAyzFIcGEAMIQex4uLoACstSiPgAKkydASTiABjEAJJQFKwGxgO6SACCaps2DwRx8HA4QA).
