### PR TITLE
Add support for `meta.url` to enable links in terminal

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -9,6 +9,7 @@ We recommend your plugin adheres to [Stylelint's conventions](rules.md) for:
 - messages
 - tests
 - docs
+- metadata
 
 ## The anatomy of a plugin
 
@@ -20,6 +21,10 @@ const ruleName = "plugin/foo-bar";
 const messages = stylelint.utils.ruleMessages(ruleName, {
   expected: "Expected ..."
 });
+const meta = {
+  url: "https://github.com/foo-org/stylelint-foo/blob/main/src/rules/foo-bar/README.md"
+  // deprecated: true,
+};
 
 module.exports = stylelint.createPlugin(
   ruleName,
@@ -47,6 +52,7 @@ module.exports = stylelint.createPlugin(
 
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;
+module.exports.meta = meta;
 ```
 
 Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`, to ensure it never clashes with the built-in rules. If your plugin provides only a single rule or you can't think of a good namespace, you can use `plugin/my-rule`. _You should document your plugin's rule name (and namespace) because users need to use them in their config._
@@ -79,6 +85,9 @@ const ruleName = "plugin/foo-bar-async";
 const messages = stylelint.utils.ruleMessages(ruleName, {
   expected: "Expected ..."
 });
+const meta = {
+  /* .. */
+};
 
 module.exports = stylelint.createPlugin(
   ruleName,
@@ -112,6 +121,7 @@ module.exports = stylelint.createPlugin(
 
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;
+module.exports.meta = meta;
 ```
 
 ## Testing

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -195,7 +195,7 @@ You should:
 Deprecating rules doesn't happen very often. When you do, you must:
 
 1. Point the `stylelintReference` link to the specific version of the rule README on the GitHub website, so that it is always accessible.
-2. Add the appropriate meta data to mark the rule as deprecated.
+2. Add the appropriate metadata to mark the rule as deprecated like `rule.meta = { deprecated: true }`.
 
 ## Improve the performance of a rule
 

--- a/lib/rules/__tests__/index.test.js
+++ b/lib/rules/__tests__/index.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const rules = require('..');
+
+describe('rules', () => {
+	for (const [ruleName, rule] of Object.entries(rules)) {
+		test(`the "${ruleName}" rule has metadata`, () => {
+			expect(rule.meta).toBeTruthy();
+			expect(rule.meta.url).toMatch(/^https:\/\/stylelint\.io\/.+/);
+		});
+	}
+});

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (unfixed, fixed) => `Expected "${unfixed}" to be "${fixed}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/alpha-value-notation',
+};
+
 const ALPHA_PROPS = new Set(['opacity', 'shape-image-threshold']);
 const ALPHA_FUNCS = new Set(['hsl', 'hsla', 'hwb', 'lab', 'lch', 'rgb', 'rgba']);
 
@@ -193,4 +197,5 @@ function isNumber(value) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-allowed-list/index.js
+++ b/lib/rules/at-rule-allowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected at-rule "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	// To allow for just a string as a parameter (not only arrays of strings)
@@ -56,4 +60,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-disallowed-list/index.js
+++ b/lib/rules/at-rule-disallowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected at-rule "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	// To allow for just a string as a parameter (not only arrays of strings)
@@ -56,4 +60,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -23,6 +23,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before at-rule',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -164,4 +168,5 @@ function isAtRuleAfterSameNameAtRule(atRule) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-name-case/index.js
+++ b/lib/rules/at-rule-name-case/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-name-case',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondary, context) => {
 	return (root, result) => {
@@ -57,4 +61,5 @@ const rule = (primary, _secondary, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-name-newline-after/index.js
+++ b/lib/rules/at-rule-name-newline-after/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	expectedAfter: (name) => `Expected newline after at-rule name "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-name-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -36,4 +40,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-name-space-after/index.js
+++ b/lib/rules/at-rule-name-space-after/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	expectedAfter: (name) => `Expected single space after at-rule name "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-name-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondary, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -43,4 +47,5 @@ const rule = (primary, _secondary, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-no-unknown/index.js
+++ b/lib/rules/at-rule-no-unknown/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (atRule) => `Unexpected unknown at-rule "${atRule}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-no-unknown',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -63,4 +67,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-no-vendor-prefix/index.js
+++ b/lib/rules/at-rule-no-vendor-prefix/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (p) => `Unexpected vendor-prefixed at-rule "@${p}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondary, context) => {
 	return (root, result) => {
@@ -54,4 +58,5 @@ const rule = (primary, _secondary, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-property-required-list/index.js
+++ b/lib/rules/at-rule-property-required-list/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (property, atRule) => `Expected property "${property}" for at-rule "${atRule}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-property-required-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -64,5 +68,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
-
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-semicolon-newline-after/index.js
+++ b/lib/rules/at-rule-semicolon-newline-after/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	expectedAfter: () => 'Expected newline after ";"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondary, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -74,4 +78,5 @@ const rule = (primary, _secondary, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/at-rule-semicolon-space-before/index.js
+++ b/lib/rules/at-rule-semicolon-space-before/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ";"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/at-rule-semicolon-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -59,4 +63,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before closing brace',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -119,4 +123,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "}" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -142,4 +146,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-closing-brace-newline-before/index.js
+++ b/lib/rules/block-closing-brace-newline-before/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: 'Unexpected whitespace before "}" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -122,4 +126,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-closing-brace-space-after/index.js
+++ b/lib/rules/block-closing-brace-space-after/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "}" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -87,4 +91,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-closing-brace-space-before/index.js
+++ b/lib/rules/block-closing-brace-space-before/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "}" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -99,4 +103,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-no-empty',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -82,4 +86,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-opening-brace-newline-after/index.js
+++ b/lib/rules/block-opening-brace-newline-after/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "{" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -172,4 +176,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-opening-brace-newline-before/index.js
+++ b/lib/rules/block-opening-brace-newline-before/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "{" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -110,4 +114,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-opening-brace-space-after/index.js
+++ b/lib/rules/block-opening-brace-space-after/index.js
@@ -21,6 +21,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "{" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -106,4 +110,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -22,6 +22,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "{" of a multi-line block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -129,4 +133,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/color-function-notation/index.js
+++ b/lib/rules/color-function-notation/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (primary) => `Expected ${primary} color-function notation`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/color-function-notation',
+};
+
 const LEGACY_FUNCS = new Set(['rgba', 'hsla']);
 const LEGACY_NOTATION_FUNCS = new Set(['rgb', 'rgba', 'hsl', 'hsla']);
 
@@ -119,4 +123,5 @@ function hasCommas(node) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/color-hex-alpha/index.js
+++ b/lib/rules/color-hex-alpha/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	unexpected: (hex) => `Unexpected alpha channel in "${hex}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/color-hex-alpha',
+};
+
 const HEX = /^#(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
 
 /** @type {import('stylelint').Rule} */
@@ -74,4 +78,5 @@ function hasAlphaChannel(hex) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/color-hex-case',
+};
+
 const HEX = /^#[0-9A-Za-z]+/;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
@@ -84,4 +88,5 @@ function isHexColor({ type, value }) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/color-hex-length',
+};
+
 const HEX = /^#[0-9A-Za-z]+/;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
@@ -131,4 +135,5 @@ function isHexColor({ type, value }) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (named) => `Unexpected named color "${named}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/color-named',
+};
+
 // Todo tested on case insensitivity
 const NODE_TYPES = new Set(['word', 'function']);
 
@@ -149,4 +153,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/color-no-hex/index.js
+++ b/lib/rules/color-no-hex/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (hex) => `Unexpected hex color "${hex}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/color-no-hex',
+};
+
 const HEX = /^#[0-9A-Za-z]+/;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
@@ -62,4 +66,5 @@ function isHexColor({ type, value }) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/color-no-invalid-hex/index.js
+++ b/lib/rules/color-no-invalid-hex/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (hex) => `Unexpected invalid hex color "${hex}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/color-no-invalid-hex',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -55,4 +59,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -21,6 +21,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before comment',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/comment-empty-line-before',
+};
+
 const stylelintCommandPrefix = 'stylelint-';
 
 /** @type {import('stylelint').Rule} */
@@ -125,4 +129,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/comment-no-empty/index.js
+++ b/lib/rules/comment-no-empty/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty comment',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/comment-no-empty',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -43,4 +47,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/comment-pattern/index.js
+++ b/lib/rules/comment-pattern/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (pattern) => `Expected comment to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/comment-pattern',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -44,4 +48,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/comment-whitespace-inside/index.js
+++ b/lib/rules/comment-whitespace-inside/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before "*/"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/comment-whitespace-inside',
+};
+
 /**
  * @param {import('postcss').Comment} comment
  */
@@ -128,4 +132,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/comment-word-disallowed-list/index.js
+++ b/lib/rules/comment-word-disallowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (pattern) => `Unexpected word matching pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/comment-word-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -55,4 +59,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/custom-media-pattern/index.js
+++ b/lib/rules/custom-media-pattern/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (pattern) => `Expected custom media query name to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/custom-media-pattern',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -54,4 +58,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -23,6 +23,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before custom property',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -134,4 +138,5 @@ function isAfterCustomProperty(decl) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/custom-property-no-missing-var-function/index.js
+++ b/lib/rules/custom-property-no-missing-var-function/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (customProperty) => `Unexpected missing var function for "${customProperty}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/custom-property-no-missing-var-function',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -73,4 +77,5 @@ function isVarFunction({ type, value }) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (pattern) => `Expected custom property name to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/custom-property-pattern',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -49,4 +53,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after "!"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-bang-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -81,4 +85,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-bang-space-before/index.js
+++ b/lib/rules/declaration-bang-space-before/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before "!"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-bang-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -82,4 +86,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected duplicate "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-custom-properties',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -57,4 +61,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-no-duplicate-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected duplicate "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-properties',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -149,4 +153,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (props) => `Expected shorthand property "${props}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-no-redundant-longhand-properties',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -102,4 +106,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (shorthand, original) => `Unexpected shorthand "${shorthand}" after "${original}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -58,4 +62,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-semicolon-newline-after/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected newline after ";" in a multi-line declaration block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -97,4 +101,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-semicolon-newline-before/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-before/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace before ";" in a multi-line declaration block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -65,4 +69,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-semicolon-space-after/index.js
+++ b/lib/rules/declaration-block-semicolon-space-after/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace after ";" in a single-line declaration block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -87,4 +91,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 		'Unexpected whitespace before ";" in a single-line declaration block',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -94,4 +98,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-single-line-max-declarations/index.js
+++ b/lib/rules/declaration-block-single-line-max-declarations/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} ${max === 1 ? 'declaration' : 'declarations'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -54,4 +58,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected trailing semicolon',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -135,4 +139,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-colon-newline-after/index.js
+++ b/lib/rules/declaration-colon-newline-after/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	expectedAfterMultiLine: () => 'Expected newline after ":" with a multi-line declaration',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -87,4 +91,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-colon-space-after/index.js
+++ b/lib/rules/declaration-colon-space-after/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	expectedAfterSingleLine: () => 'Expected single space after ":" with a single-line declaration',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-colon-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -63,4 +67,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ":"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-colon-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -62,4 +66,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -24,6 +24,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before declaration',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-empty-line-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -146,4 +150,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-no-important/index.js
+++ b/lib/rules/declaration-no-important/index.js
@@ -10,6 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected !important',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-no-important',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -37,4 +41,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-unit-allowed-list',
+};
+
 /** @type {import('stylelint').Rule<Record<string, string[]>>} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -96,4 +100,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, unit) => `Unexpected unit "${unit}" for property "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-unit-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule<Record<string, string[]>>} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -78,4 +82,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-value-allowed-list',
+};
+
 /** @type {import('stylelint').Rule<Record<string, (string | RegExp)[]>>} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -60,4 +64,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, value) => `Unexpected value "${value}" for property "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-value-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule<Record<string, (string | RegExp)[]>>} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -60,4 +64,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (family) => `Unexpected quotes around "${family}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/font-family-name-quotes',
+};
+
 /**
  * @param {string} font
  * @returns {boolean}
@@ -166,4 +170,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/font-family-no-duplicate-names/index.js
+++ b/lib/rules/font-family-no-duplicate-names/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected duplicate name ${name}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names',
+};
+
 /**
  * @param {import('postcss-value-parser').Node} node
  */
@@ -107,4 +111,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected missing generic font family',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword',
+};
+
 /**
  * @param {import('postcss-value-parser').Node} node
  * @returns {boolean}
@@ -103,4 +107,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	invalidNamed: (name) => `Unexpected invalid font-weight name "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/font-weight-notation',
+};
+
 const INHERIT_KEYWORD = 'inherit';
 const INITIAL_KEYWORD = 'initial';
 const NORMAL_KEYWORD = 'normal';
@@ -163,4 +167,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-allowed-list/index.js
+++ b/lib/rules/function-allowed-list/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected function "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const list = [primary].flat();
@@ -62,4 +66,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	expectedOperatorBeforeSign: (operator) => `Expected an operator before sign "${operator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator',
+};
+
 const OPERATORS = new Set(['*', '/', '+', '-']);
 const OPERATOR_REGEX = /[*/+-]/;
 
@@ -316,4 +320,5 @@ function isSingleSpace(node) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-comma-newline-after/index.js
+++ b/lib/rules/function-comma-newline-after/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line function',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-comma-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -50,4 +54,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-comma-newline-before/index.js
+++ b/lib/rules/function-comma-newline-before/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line function',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-comma-newline-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -50,4 +54,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-comma-space-after/index.js
+++ b/lib/rules/function-comma-space-after/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line function',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-comma-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -51,4 +55,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-comma-space-before/index.js
+++ b/lib/rules/function-comma-space-before/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line function',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-comma-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -51,4 +55,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-disallowed-list/index.js
+++ b/lib/rules/function-disallowed-list/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected function "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -60,4 +64,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected nonstandard direction',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction',
+};
+
 /**
  * @param {string} source
  * @param {boolean} withToPrefix
@@ -110,4 +114,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-max-empty-lines/index.js
+++ b/lib/rules/function-max-empty-lines/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-max-empty-lines',
+};
+
 /**
  * @param {import('postcss').Declaration} decl
  */
@@ -103,4 +107,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-name-case',
+};
+
 const mapLowercaseFunctionNamesToCamelCase = new Map();
 
 for (const func of keywordSets.camelCaseFunctionNames) {
@@ -107,4 +111,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-parentheses-newline-inside/index.js
+++ b/lib/rules/function-parentheses-newline-inside/index.js
@@ -21,6 +21,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosingMultiLine: 'Unexpected whitespace before ")" in a multi-line function',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -266,4 +270,5 @@ function fixAfterForNever(valueNode) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-parentheses-space-inside/index.js
+++ b/lib/rules/function-parentheses-space-inside/index.js
@@ -23,6 +23,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosingSingleLine: 'Unexpected whitespace before ")" in a single-line function',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -165,4 +169,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-url-no-scheme-relative/index.js
+++ b/lib/rules/function-url-no-scheme-relative/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected scheme-relative url',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-url-no-scheme-relative',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -43,4 +47,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (functionName) => `Unexpected quotes around "${functionName}" function argument`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-url-quotes',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -126,4 +130,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-url-scheme-allowed-list/index.js
+++ b/lib/rules/function-url-scheme-allowed-list/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (scheme) => `Unexpected URL scheme "${scheme}:"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-url-scheme-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -62,4 +66,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-url-scheme-disallowed-list/index.js
+++ b/lib/rules/function-url-scheme-disallowed-list/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (scheme) => `Unexpected URL scheme "${scheme}:"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-url-scheme-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -62,4 +66,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected whitespace after ")"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/function-whitespace-after',
+};
+
 const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([')', ',', '}', ':', '/', undefined]);
 
 /** @type {import('stylelint').Rule} */
@@ -179,4 +183,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (unfixed, fixed) => `Expected "${unfixed}" to be "${fixed}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/hue-degree-notation',
+};
+
 const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];
 const HUE_THIRD_ARG_FUNCS = ['lch'];
 const HUE_FUNCS = new Set([...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS]);
@@ -135,4 +139,5 @@ function isNumber(value) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (x) => `Expected indentation of ${x}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/indentation',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions = {}, context) => {
 	return (root, result) => {
@@ -719,4 +723,5 @@ function replaceIndentation(input, searchString, replaceString, startIndex) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/keyframe-declaration-no-important/index.js
+++ b/lib/rules/keyframe-declaration-no-important/index.js
@@ -10,6 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected !important',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -39,4 +43,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/keyframes-name-pattern/index.js
+++ b/lib/rules/keyframes-name-pattern/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected keyframe name "${keyframeName}" to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/keyframes-name-pattern',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -47,4 +51,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -24,6 +24,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected unit',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/length-zero-no-unit',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -209,4 +213,5 @@ function isZero(number) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/linebreaks/index.js
+++ b/lib/rules/linebreaks/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (linebreak) => `Expected linebreak to be ${linebreak}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/linebreaks',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -124,4 +128,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/max-empty-lines',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	let emptyLines = 0;
@@ -209,4 +213,5 @@ function isEofNode(document, root) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected line length to be no more than ${max} ${max === 1 ? 'character' : 'characters'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/max-line-length',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -191,4 +195,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (depth) => `Expected nesting depth to be no more than ${depth}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/max-nesting-depth',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	/**
@@ -157,4 +161,5 @@ function extractPseudoRule(selector) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-colon-space-after/index.js
+++ b/lib/rules/media-feature-colon-space-after/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after ":"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -77,4 +81,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-colon-space-before/index.js
+++ b/lib/rules/media-feature-colon-space-before/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before ":"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -77,4 +81,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-name-allowed-list/index.js
+++ b/lib/rules/media-feature-name-allowed-list/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected media feature name "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -72,4 +76,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-case',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -95,4 +99,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-name-disallowed-list/index.js
+++ b/lib/rules/media-feature-name-disallowed-list/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected media feature name "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -72,4 +76,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-name-no-unknown/index.js
+++ b/lib/rules/media-feature-name-no-unknown/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (mediaFeatureName) => `Unexpected unknown media feature name "${mediaFeatureName}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -84,4 +88,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected vendor-prefix',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-no-vendor-prefix',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -54,4 +58,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name, value) => `Unexpected value "${value}" for name "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-value-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -98,4 +102,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-parentheses-space-inside/index.js
+++ b/lib/rules/media-feature-parentheses-space-inside/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before ")"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -102,4 +106,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-range-operator-space-after/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: () => 'Unexpected whitespace after range operator',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -94,4 +98,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-feature-range-operator-space-before/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: () => 'Unexpected whitespace before range operator',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -94,4 +98,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-query-list-comma-newline-after/index.js
+++ b/lib/rules/media-query-list-comma-newline-after/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -83,4 +87,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-query-list-comma-newline-before/index.js
+++ b/lib/rules/media-query-list-comma-newline-before/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -38,4 +42,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -79,4 +83,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/media-query-list-comma-space-before/index.js
+++ b/lib/rules/media-query-list-comma-space-before/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -79,4 +83,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expectedRectangle: (name) => `Expected single filled-in rectangle for "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/named-grid-areas-no-invalid',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -85,4 +89,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (b, a) => `Expected selector "${b}" to come before selector "${a}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-descending-specificity',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -146,4 +150,5 @@ function lastCompoundSelectorWithoutPseudoClasses(selectorNode) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (atImport) => `Unexpected duplicate @import rule ${atImport}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -66,4 +70,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 		`Unexpected duplicate selector "${selector}", first used at line ${firstDuplicateLine}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-duplicate-selectors',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -153,4 +157,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-empty-first-line/index.js
+++ b/lib/rules/no-empty-first-line/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-empty-first-line',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -54,4 +58,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-empty-source/index.js
+++ b/lib/rules/no-empty-source/index.js
@@ -10,6 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty source',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-empty-source',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -36,4 +40,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected whitespace at end of line',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-eol-whitespace',
+};
+
 const whitespacesToReject = new Set([' ', '\t']);
 
 /**
@@ -292,4 +296,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected extra semicolon',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-extra-semicolons',
+};
+
 /**
  * @param {import('postcss').Node} node
  * @returns {number}
@@ -233,4 +237,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-invalid-double-slash-comments/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/index.js
@@ -10,6 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected double-slash CSS comment',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -47,4 +51,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-invalid-position-at-import-rule/index.js
+++ b/lib/rules/no-invalid-position-at-import-rule/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected invalid position @import rule',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-invalid-position-at-import-rule',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, options) => {
 	return (root, result) => {
@@ -66,4 +70,5 @@ const rule = (primary, options) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-irregular-whitespace/index.js
+++ b/lib/rules/no-irregular-whitespace/index.js
@@ -10,6 +10,10 @@ const messages = ruleMessages(ruleName, {
 	unexpected: 'Unexpected irregular whitespace',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-irregular-whitespace',
+};
+
 const IRREGULAR_WHITESPACES = [
 	'\u000B', // Line Tabulation (\v) - <VT>
 	'\u000C', // Form Feed (\f) - <FF>
@@ -103,4 +107,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-missing-end-of-source-newline/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/index.js
@@ -10,6 +10,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected missing end-of-source newline',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -53,4 +57,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/no-unknown-animations/index.js
+++ b/lib/rules/no-unknown-animations/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (animationName) => `Unexpected unknown animation name "${animationName}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/no-unknown-animations',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -60,4 +64,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected leading zero',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/number-leading-zero',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -188,4 +192,5 @@ function removeLeadingZeros(input, startIndex, endIndex) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (number, precision) => `Expected "${number}" to be "${number.toFixed(precision)}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/number-max-precision',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -111,4 +115,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected trailing zero(s)',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -130,4 +134,5 @@ function removeTrailingZeros(input, startIndex, endIndex) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/property-allowed-list/index.js
+++ b/lib/rules/property-allowed-list/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected property "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/property-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -56,4 +60,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/property-case/index.js
+++ b/lib/rules/property-case/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/property-case',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -59,4 +63,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/property-disallowed-list/index.js
+++ b/lib/rules/property-disallowed-list/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected property "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/property-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -56,4 +60,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/property-no-unknown/index.js
+++ b/lib/rules/property-no-unknown/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected unknown property "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/property-no-unknown',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	const allValidProperties = new Set(properties);
@@ -110,4 +114,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/property-no-vendor-prefix/index.js
+++ b/lib/rules/property-no-vendor-prefix/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property) => `Unexpected vendor-prefix "${property}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -72,4 +76,5 @@ const rule = (primary, secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -21,6 +21,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected empty line before rule',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/rule-empty-line-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
@@ -153,4 +157,5 @@ function isAfterRule(ruleNode) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (property, selector) => `Unexpected property "${property}" for selector "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/rule-selector-property-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -63,4 +67,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-attribute-brackets-space-inside/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before "]"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -199,4 +203,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-attribute-name-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-name-disallowed-list/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (name) => `Unexpected name "${name}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-name-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const list = [primary].flat();
@@ -62,4 +66,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-attribute-operator-allowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-allowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (operator) => `Unexpected operator "${operator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-operator-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const list = [primary].flat();
@@ -61,4 +65,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-attribute-operator-disallowed-list/index.js
+++ b/lib/rules/selector-attribute-operator-disallowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (operator) => `Unexpected operator "${operator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-operator-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const list = [primary].flat();
@@ -61,4 +65,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-attribute-operator-space-after/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: (operator) => `Unexpected whitespace after "${operator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -100,4 +104,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-attribute-operator-space-before/index.js
+++ b/lib/rules/selector-attribute-operator-space-before/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: (operator) => `Unexpected whitespace before "${operator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -76,4 +80,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (value) => `Unexpected quotes around "${value}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-quotes',
+};
+
 const acceptedQuoteMark = '"';
 
 /** @type {import('stylelint').Rule} */
@@ -94,4 +98,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected class selector ".${selectorValue}" to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-class-pattern',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -133,4 +137,5 @@ function isCombinator(x) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected class selector ".${selectorValue}" to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-class-pattern',
+};
+
 function rule(pattern, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -118,4 +122,5 @@ function isCombinator(x) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-allowed-list/index.js
+++ b/lib/rules/selector-combinator-allowed-list/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-allowed-list',
+};
+
 function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -67,4 +71,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-allowed-list/index.js
+++ b/lib/rules/selector-combinator-allowed-list/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-allowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -70,4 +74,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-disallowed-list/index.js
+++ b/lib/rules/selector-combinator-disallowed-list/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-disallowed-list',
+};
+
 function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -67,4 +71,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-disallowed-list/index.js
+++ b/lib/rules/selector-combinator-disallowed-list/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -70,4 +74,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: (combinator) => `Unexpected whitespace after "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -55,4 +59,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: (combinator) => `Unexpected whitespace after "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-space-after',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
@@ -54,4 +58,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: (combinator) => `Unexpected whitespace before "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-space-before',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
@@ -54,4 +58,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: (combinator) => `Unexpected whitespace before "${combinator}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -55,4 +59,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -12,6 +12,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (nonSpaceCharacter) => `Unexpected "${nonSpaceCharacter}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
@@ -85,4 +89,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (nonSpaceCharacter) => `Unexpected "${nonSpaceCharacter}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space',
+};
+
 function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -83,4 +87,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-disallowed-list/index.js
+++ b/lib/rules/selector-disallowed-list/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected selector "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-disallowed-list',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	const list = [primary].flat();
@@ -52,4 +56,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-disallowed-list/index.js
+++ b/lib/rules/selector-disallowed-list/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected selector "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-disallowed-list',
+};
+
 function rule(listInput) {
 	const list = [listInput].flat();
 
@@ -53,4 +57,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected ID selector "#${selectorValue}" to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-id-pattern',
+};
+
 function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -64,4 +68,5 @@ function rule(pattern) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected ID selector "#${selectorValue}" to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-id-pattern',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -64,4 +68,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
@@ -112,4 +116,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -112,4 +116,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('newline', primary, messages);
@@ -86,4 +90,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
@@ -86,4 +90,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-space-after/index.js
+++ b/lib/rules/selector-list-comma-space-after/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-space-after',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
@@ -78,4 +82,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-space-after/index.js
+++ b/lib/rules/selector-list-comma-space-after/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-space-after',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -78,4 +82,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -14,6 +14,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const checker = whitespaceChecker('space', primary, messages);
@@ -78,4 +82,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
@@ -78,4 +82,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-attribute',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -100,4 +104,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -22,6 +22,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-attribute',
+};
+
 function rule(max, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -95,4 +99,5 @@ function rule(max, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-class/index.js
+++ b/lib/rules/selector-max-class/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} ${max === 1 ? 'class' : 'classes'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-class',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -75,4 +79,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-class/index.js
+++ b/lib/rules/selector-max-class/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} ${max === 1 ? 'class' : 'classes'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-class',
+};
+
 function rule(max) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -70,4 +74,5 @@ function rule(max) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-combinators/index.js
+++ b/lib/rules/selector-max-combinators/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-combinators',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -76,4 +80,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-combinators/index.js
+++ b/lib/rules/selector-max-combinators/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-combinators',
+};
+
 function rule(max) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -71,4 +75,5 @@ function rule(max) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-compound-selectors',
+};
+
 function rule(max) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -76,4 +80,5 @@ function rule(max) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-compound-selectors',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -86,4 +90,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-empty-lines/index.js
+++ b/lib/rules/selector-max-empty-lines/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-empty-lines',
+};
+
 function rule(max, options, context) {
 	const maxAdjacentNewlines = max + 1;
 
@@ -62,4 +66,5 @@ function rule(max, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-empty-lines/index.js
+++ b/lib/rules/selector-max-empty-lines/index.js
@@ -11,6 +11,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-empty-lines',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
 	const maxAdjacentNewlines = primary + 1;
@@ -61,4 +65,5 @@ const rule = (primary, _secondaryOptions, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} ID ${max === 1 ? 'selector' : 'selectors'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-id',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -103,4 +107,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} ID ${max === 1 ? 'selector' : 'selectors'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-id',
+};
+
 function rule(max, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -94,4 +98,5 @@ function rule(max, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-pseudo-class/index.js
+++ b/lib/rules/selector-max-pseudo-class/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} pseudo-${max === 1 ? 'class' : 'classes'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-pseudo-class',
+};
+
 function rule(max) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -82,4 +86,5 @@ function rule(max) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-pseudo-class/index.js
+++ b/lib/rules/selector-max-pseudo-class/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} pseudo-${max === 1 ? 'class' : 'classes'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-pseudo-class',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -87,4 +91,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (selector, max) => `Expected "${selector}" to have a specificity no more than "${max}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-specificity',
+};
+
 /** @typedef {import('specificity').SpecificityArray} SpecificityArray */
 
 /**
@@ -218,4 +222,5 @@ const rule = (primary, secondaryOptions) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (selector, max) => `Expected "${selector}" to have a specificity no more than "${max}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-specificity',
+};
+
 // Return an array representation of zero specificity. We need a new array each time so that it can mutated
 const zeroSpecificity = () => [0, 0, 0, 0];
 
@@ -179,4 +183,5 @@ function rule(max, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -26,6 +26,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-type',
+};
+
 function rule(max, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -173,4 +177,5 @@ function isNextSiblingCombinator(node) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -24,6 +24,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-type',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -216,4 +220,5 @@ function isNextSiblingCombinator(node) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-universal/index.js
+++ b/lib/rules/selector-max-universal/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-universal',
+};
+
 function rule(max) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -83,4 +87,5 @@ function rule(max) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-max-universal/index.js
+++ b/lib/rules/selector-max-universal/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-max-universal',
+};
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -89,4 +93,5 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-nested-pattern/index.js
+++ b/lib/rules/selector-nested-pattern/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 		`Expected nested selector "${selector}" to match pattern "${pattern}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-nested-pattern',
+};
+
 function rule(pattern) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -55,4 +59,5 @@ function rule(pattern) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-no-qualifying-type/index.js
+++ b/lib/rules/selector-no-qualifying-type/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected qualifying type selector',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type',
+};
+
 const selectorCharacters = ['#', '.', '['];
 
 function isSelectorCharacters(value) {
@@ -131,4 +135,5 @@ function rule(enabled, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-no-vendor-prefix/index.js
+++ b/lib/rules/selector-no-vendor-prefix/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected vendor-prefix "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-no-vendor-prefix',
+};
+
 function rule(actual, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -72,4 +76,5 @@ function rule(actual, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-class-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-allowed-list/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-class "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-class-allowed-list',
+};
+
 function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -71,4 +75,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-class-case/index.js
+++ b/lib/rules/selector-pseudo-class-case/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case',
+};
+
 function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -94,4 +98,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-class-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-class-disallowed-list/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-class "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-class-disallowed-list',
+};
+
 function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -72,4 +76,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -22,6 +22,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected unknown pseudo-class selector "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown',
+};
+
 function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -154,4 +158,5 @@ function rule(actual, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedClosing: 'Unexpected whitespace before ")"',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside',
+};
+
 function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -138,4 +142,5 @@ function stringifyProperty(node, propName) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-element-allowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-allowed-list/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-element "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-element-allowed-list',
+};
+
 function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -71,4 +75,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-element-case/index.js
+++ b/lib/rules/selector-pseudo-element-case/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case',
+};
+
 function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -81,4 +85,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (q) => `Expected ${q} colon pseudo-element notation`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation',
+};
+
 function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -91,4 +95,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-element-disallowed-list/index.js
+++ b/lib/rules/selector-pseudo-element-disallowed-list/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected pseudo-element "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-element-disallowed-list',
+};
+
 function rule(list) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -71,4 +75,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected unknown pseudo-element selector "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown',
+};
+
 function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -89,4 +93,5 @@ function rule(actual, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-type-case',
+};
+
 function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -109,4 +113,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/selector-type-no-unknown/index.js
+++ b/lib/rules/selector-type-no-unknown/index.js
@@ -23,6 +23,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected unknown type selector "${selector}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-type-no-unknown',
+};
+
 function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -112,4 +116,5 @@ function rule(actual, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -17,6 +17,10 @@ const messages = ruleMessages(ruleName, {
 		`Unexpected longhand value '${unexpected}' instead of '${expected}'`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values',
+};
+
 const propertiesWithShorthandNotation = new Set([
 	'margin',
 	'padding',
@@ -134,4 +138,5 @@ function rule(actual, secondary, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/string-no-newline/index.js
+++ b/lib/rules/string-no-newline/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected newline in string',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/string-no-newline',
+};
+
 function rule(actual) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual });
@@ -121,4 +125,5 @@ function rule(actual) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (q) => `Expected ${q} quotes`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/string-quotes',
+};
+
 const singleQuote = `'`;
 const doubleQuote = `"`;
 
@@ -217,4 +221,5 @@ function replaceQuote(string, index, replace) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/time-min-milliseconds/index.js
+++ b/lib/rules/time-min-milliseconds/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (time) => `Expected a minimum of ${time} milliseconds`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/time-min-milliseconds',
+};
+
 const DELAY_PROPERTIES = new Set(['animation-delay', 'transition-delay']);
 
 function rule(minimum, options) {
@@ -139,4 +143,5 @@ function rule(minimum, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/unicode-bom/index.js
+++ b/lib/rules/unicode-bom/index.js
@@ -13,6 +13,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: 'Unexpected Unicode BOM',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/unicode-bom',
+};
+
 function rule(expectation) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -56,4 +60,5 @@ function rule(expectation) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/unit-allowed-list/index.js
+++ b/lib/rules/unit-allowed-list/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (unit) => `Unexpected unit "${unit}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/unit-allowed-list',
+};
+
 function rule(listInput, options) {
 	const list = [listInput].flat();
 
@@ -82,4 +86,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -16,6 +16,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/unit-case',
+};
+
 function rule(expectation, options, context) {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -111,4 +115,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/unit-disallowed-list/index.js
+++ b/lib/rules/unit-disallowed-list/index.js
@@ -20,6 +20,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (unit) => `Unexpected unit "${unit}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/unit-disallowed-list',
+};
+
 // a function to retrieve only the media feature name
 // could be externalized in an utils function if needed in other code
 const getMediaFeatureName = (mediaFeatureNode) => {
@@ -122,4 +126,5 @@ rule.primaryOptionArray = true;
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -23,6 +23,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (unit) => `Unexpected unknown unit "${unit}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/unit-no-unknown',
+};
+
 function rule(actual, options) {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -148,4 +152,5 @@ function rule(actual, options) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -22,6 +22,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/value-keyword-case',
+};
+
 // Operators are interpreted as "words" by the value parser, so we want to make sure to ignore them.
 const ignoredCharacters = new Set(['+', '-', '/', '*', '%']);
 const gridRowProps = new Set(['grid-row', 'grid-row-start', 'grid-row-end']);
@@ -233,4 +237,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -18,6 +18,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
@@ -94,4 +98,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/value-list-comma-newline-before/index.js
+++ b/lib/rules/value-list-comma-newline-before/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/value-list-comma-newline-before',
+};
+
 function rule(expectation) {
 	const checker = whitespaceChecker('newline', expectation, messages);
 
@@ -39,4 +43,5 @@ function rule(expectation) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/value-list-comma-space-after/index.js
+++ b/lib/rules/value-list-comma-space-after/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/value-list-comma-space-after',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
@@ -81,4 +85,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/value-list-comma-space-before/index.js
+++ b/lib/rules/value-list-comma-space-before/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/value-list-comma-space-before',
+};
+
 function rule(expectation, options, context) {
 	const checker = whitespaceChecker('space', expectation, messages);
 
@@ -81,4 +85,5 @@ function rule(expectation, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/value-list-max-empty-lines/index.js
+++ b/lib/rules/value-list-max-empty-lines/index.js
@@ -15,6 +15,10 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines',
+};
+
 function rule(max, options, context) {
 	const maxAdjacentNewlines = max + 1;
 
@@ -57,4 +61,5 @@ function rule(max, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -19,6 +19,10 @@ const messages = ruleMessages(ruleName, {
 	rejected: (value) => `Unexpected vendor-prefix "${value}"`,
 });
 
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix',
+};
+
 const valuePrefixes = ['-webkit-', '-moz-', '-ms-', '-o-'];
 
 function rule(actual, options, context) {
@@ -87,4 +91,5 @@ function rule(actual, options, context) {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = meta;
 module.exports = rule;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -160,6 +160,7 @@ declare module 'stylelint' {
 		export type Rule<P = any, S = any> = RuleBase<P, S> & {
 			ruleName: string;
 			messages: RuleMessages;
+			meta: { url: string; deprecated?: boolean };
 			primaryOptionArray?: boolean;
 		};
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -160,8 +160,8 @@ declare module 'stylelint' {
 		export type Rule<P = any, S = any> = RuleBase<P, S> & {
 			ruleName: string;
 			messages: RuleMessages;
-			meta: { url: string; deprecated?: boolean };
 			primaryOptionArray?: boolean;
+			meta?: { url: string; deprecated?: boolean };
 		};
 
 		export type Plugin<P = any, S = any> = RuleBase<P, S>;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5842
Related to https://github.com/stylelint/stylelint/pull/5835#discussion_r785246463

> Is there anything in the PR that needs further explanation?

This pull request adds the `meta.url` property to all built-in rules. For automation, I use a temporary script as below:

Run:

```console
$ cd stylelint
$ node add-meta-to-stylelint-rules.js
...
$ npm run format
```

Script:

```js
// add-meta-to-stylelint-rules.js
const fs = require('fs');
const globby = require('globby');

const files = globby.sync('lib/rules/*/index.js');

for (const file of files) {
	const content = fs.readFileSync(file).toString();

	const rule = file.replace(/lib\/rules\/([^/]+)\/index.js/, '$1');

	let newContent = content.replace(
		'module.exports = rule;',
		'rule.meta = meta;\nmodule.exports = rule;',
	);

	newContent = newContent.replace(
		/(const messages = ruleMessages\(.+?\);)/s,
		`$1

const meta = {
	url: 'https://stylelint.io/user-guide/rules/list/${rule}',
};`,
	);

	fs.writeFileSync(file, newContent);

	console.log(`${file} (${rule}) updated`); // eslint-disable-line no-console
}
```

