### PR TITLE
Fix typo in "About rules" doc

### DIFF
--- a/docs/user-guide/rules/about.md
+++ b/docs/user-guide/rules/about.md
@@ -85,7 +85,7 @@ Most rules require _or_ disallow something.
 
 For example, whether colors _must_ or _must not_ be named:
 
-- `color-named`: `string - "always-where-possible"|"never"`
+- `color-named`: `string` - `"always-where-possible"|"never"`
   - `"always-where-possible"` - colors _must always (where possible)_ be named
   - `"never"` - colors _must never_ be named
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

This change aims to keep consistency for the use of a rule's primary option type.
