### PR TITLE
Refactor to improve types for `selector-(class|combinator|descendant|disallowed|id)-*` rules

### DIFF
--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isKeyframeSelector = require('../../utils/isKeyframeSelector');
@@ -19,19 +17,20 @@ const messages = ruleMessages(ruleName, {
 		`Expected class selector ".${selectorValue}" to match pattern "${pattern}"`,
 });
 
-function rule(pattern, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: pattern,
+				actual: primary,
 				possible: [isRegExp, isString],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
-					resolveNestedSelectors: isBoolean,
+					resolveNestedSelectors: [isBoolean],
 				},
 				optional: true,
 			},
@@ -41,8 +40,11 @@ function rule(pattern, options) {
 			return;
 		}
 
-		const shouldResolveNestedSelectors = options && options.resolveNestedSelectors;
-		const normalizedPattern = isString(pattern) ? new RegExp(pattern) : pattern;
+		/** @type {boolean} */
+		const shouldResolveNestedSelectors =
+			secondaryOptions && secondaryOptions.resolveNestedSelectors;
+		/** @type {RegExp} */
+		const normalizedPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkRules((ruleNode) => {
 			const selector = ruleNode.selector;
@@ -70,6 +72,10 @@ function rule(pattern, options) {
 			}
 		});
 
+		/**
+		 * @param {import('postcss-selector-parser').Root} fullSelector
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(fullSelector, ruleNode) {
 			fullSelector.walkClasses((classNode) => {
 				const value = classNode.value;
@@ -82,18 +88,23 @@ function rule(pattern, options) {
 				report({
 					result,
 					ruleName,
-					message: messages.expected(value, pattern),
+					message: messages.expected(value, primary),
 					node: ruleNode,
 					index: sourceIndex,
 				});
 			});
 		}
 	};
-}
+};
 
-// An "interpolating ampersand" means an "&" used to interpolate
-// within another simple selector, rather than an "&" that
-// stands on its own as a simple selector
+/**
+ * An "interpolating ampersand" means an "&" used to interpolate
+ * within another simple selector, rather than an "&" that
+ * stands on its own as a simple selector.
+ *
+ * @param {string} selector
+ * @returns {boolean}
+ */
 function hasInterpolatingAmpersand(selector) {
 	for (let i = 0, l = selector.length; i < l; i++) {
 		if (selector[i] !== '&') {
@@ -112,6 +123,10 @@ function hasInterpolatingAmpersand(selector) {
 	return false;
 }
 
+/**
+ * @param {string} x
+ * @returns {boolean}
+ */
 function isCombinator(x) {
 	return /[\s+>~]/.test(x);
 }

--- a/lib/rules/selector-combinator-allowed-list/index.js
+++ b/lib/rules/selector-combinator-allowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxCombinator = require('../../utils/isStandardSyntaxCombinator');
@@ -16,10 +14,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
-function rule(list) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
+			actual: primary,
 			possible: [isString],
 		});
 
@@ -42,7 +41,7 @@ function rule(list) {
 
 					const value = normalizeCombinator(combinatorNode.value);
 
-					if (list.includes(value)) {
+					if (primary.includes(value)) {
 						return;
 					}
 
@@ -57,8 +56,12 @@ function rule(list) {
 			});
 		});
 	};
-}
+};
 
+/**
+ * @param {string} value
+ * @returns {string}
+ */
 function normalizeCombinator(value) {
 	return value.replace(/\s+/g, ' ');
 }

--- a/lib/rules/selector-combinator-disallowed-list/index.js
+++ b/lib/rules/selector-combinator-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxCombinator = require('../../utils/isStandardSyntaxCombinator');
@@ -16,10 +14,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (combinator) => `Unexpected combinator "${combinator}"`,
 });
 
-function rule(list) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: list,
+			actual: primary,
 			possible: [isString],
 		});
 
@@ -42,7 +41,7 @@ function rule(list) {
 
 					const value = normalizeCombinator(combinatorNode.value);
 
-					if (!list.includes(value)) {
+					if (!primary.includes(value)) {
 						return;
 					}
 
@@ -57,8 +56,12 @@ function rule(list) {
 			});
 		});
 	};
-}
+};
 
+/**
+ * @param {string} value
+ * @returns {string}
+ */
 function normalizeCombinator(value) {
 	return value.replace(/\s+/g, ' ');
 }

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const ruleMessages = require('../../utils/ruleMessages');
@@ -14,12 +12,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfter: (combinator) => `Unexpected whitespace after "${combinator}"`,
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -35,22 +34,24 @@ function rule(expectation, options, context) {
 			checkedRuleName: ruleName,
 			fix: context.fix
 				? (combinator) => {
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							combinator.spaces.after = ' ';
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							combinator.spaces.after = '';
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const ruleMessages = require('../../utils/ruleMessages');
@@ -14,12 +12,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBefore: (combinator) => `Unexpected whitespace before "${combinator}"`,
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never'],
 		});
 
@@ -35,22 +34,24 @@ function rule(expectation, options, context) {
 			checkedRuleName: ruleName,
 			fix: context.fix
 				? (combinator) => {
-						if (expectation === 'always') {
+						if (primary === 'always') {
 							combinator.spaces.before = ' ';
 
 							return true;
 						}
 
-						if (expectation === 'never') {
+						if (primary === 'never') {
 							combinator.spaces.before = '';
 
 							return true;
 						}
+
+						return false;
 				  }
 				: null,
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -14,10 +12,11 @@ const messages = ruleMessages(ruleName, {
 	rejected: (nonSpaceCharacter) => `Unexpected "${nonSpaceCharacter}"`,
 });
 
-function rule(expectation, options, context) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 		});
 
 		if (!validOptions) {
@@ -52,6 +51,7 @@ function rule(expectation, options, context) {
 					) {
 						if (context.fix && /^\s+$/.test(value)) {
 							hasFixed = true;
+							// @ts-expect-error -- TS2339: Property 'raws' does not exist on type 'Combinator'.
 							combinatorNode.raws.value = ' ';
 							combinatorNode.rawSpaceBefore = combinatorNode.rawSpaceBefore.replace(/^\s+/, '');
 							combinatorNode.rawSpaceAfter = combinatorNode.rawSpaceAfter.replace(/\s+$/, '');
@@ -70,7 +70,7 @@ function rule(expectation, options, context) {
 				});
 			});
 
-			if (hasFixed) {
+			if (hasFixed && fixedSelector) {
 				if (!ruleNode.raws.selector) {
 					ruleNode.selector = fixedSelector;
 				} else {
@@ -79,7 +79,7 @@ function rule(expectation, options, context) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -51,7 +51,9 @@ const rule = (primary, _secondaryOptions, context) => {
 					) {
 						if (context.fix && /^\s+$/.test(value)) {
 							hasFixed = true;
-							// @ts-expect-error -- TS2339: Property 'raws' does not exist on type 'Combinator'.
+
+							if (!combinatorNode.raws) combinatorNode.raws = {};
+
 							combinatorNode.raws.value = ' ';
 							combinatorNode.rawSpaceBefore = combinatorNode.rawSpaceBefore.replace(/^\s+/, '');
 							combinatorNode.rawSpaceAfter = combinatorNode.rawSpaceAfter.replace(/\s+$/, '');

--- a/lib/rules/selector-disallowed-list/index.js
+++ b/lib/rules/selector-disallowed-list/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -15,8 +13,9 @@ const messages = ruleMessages(ruleName, {
 	rejected: (selector) => `Unexpected selector "${selector}"`,
 });
 
-function rule(listInput) {
-	const list = [listInput].flat();
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
+	const list = [primary].flat();
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -47,7 +46,7 @@ function rule(listInput) {
 			});
 		});
 	};
-}
+};
 
 rule.primaryOptionArray = true;
 

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -16,10 +14,11 @@ const messages = ruleMessages(ruleName, {
 		`Expected ID selector "#${selectorValue}" to match pattern "${pattern}"`,
 });
 
-function rule(pattern) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: pattern,
+			actual: primary,
 			possible: [isRegExp, isString],
 		});
 
@@ -27,7 +26,8 @@ function rule(pattern) {
 			return;
 		}
 
-		const normalizedPattern = isString(pattern) ? new RegExp(pattern) : pattern;
+		/** @type {RegExp} */
+		const normalizedPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {
@@ -52,7 +52,7 @@ function rule(pattern) {
 					report({
 						result,
 						ruleName,
-						message: messages.expected(value, pattern),
+						message: messages.expected(value, primary),
 						node: ruleNode,
 						index: sourceIndex,
 					});
@@ -60,7 +60,7 @@ function rule(pattern) {
 			});
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selectorCombinatorSpaceChecker.js
+++ b/lib/rules/selectorCombinatorSpaceChecker.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxCombinator = require('../utils/isStandardSyntaxCombinator');
@@ -7,7 +5,20 @@ const isStandardSyntaxRule = require('../utils/isStandardSyntaxRule');
 const parseSelector = require('../utils/parseSelector');
 const report = require('../utils/report');
 
-module.exports = function (opts) {
+/**
+ * @typedef {(args: { source: string, index: number, errTarget: string, err: (message: string) => void }) => void} LocationChecker
+ *
+ * @param {{
+ *   root: import('postcss').Root,
+ *   result: import('stylelint').PostcssResult,
+ *   locationChecker: LocationChecker,
+ *   locationType: 'before' | 'after',
+ *   checkedRuleName: string,
+ *   fix: ((combinator: import('postcss-selector-parser').Combinator) => boolean) | null,
+ * }} opts
+ * @returns {void}
+ */
+module.exports = function selectorCombinatorSpaceChecker(opts) {
 	let hasFixed;
 
 	opts.root.walkRules((rule) => {
@@ -53,7 +64,7 @@ module.exports = function (opts) {
 			});
 		});
 
-		if (hasFixed) {
+		if (hasFixed && fixedSelector) {
 			if (!rule.raws.selector) {
 				rule.selector = fixedSelector;
 			} else {
@@ -62,12 +73,19 @@ module.exports = function (opts) {
 		}
 	});
 
+	/**
+	 * @param {string} source
+	 * @param {import('postcss-selector-parser').Combinator} combinator
+	 * @param {number} index
+	 * @param {import('postcss').Node} node
+	 * @param {number} sourceIndex
+	 */
 	function check(source, combinator, index, node, sourceIndex) {
 		opts.locationChecker({
 			source,
 			index,
 			errTarget: combinator.value,
-			err: (m) => {
+			err: (message) => {
 				if (opts.fix && opts.fix(combinator)) {
 					hasFixed = true;
 
@@ -75,7 +93,7 @@ module.exports = function (opts) {
 				}
 
 				report({
-					message: m,
+					message,
 					node,
 					index: sourceIndex,
 					result: opts.result,

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.8",
+        "postcss-selector-parser": "^6.0.9",
         "postcss-value-parser": "^4.1.0",
         "resolve-from": "^5.0.0",
         "specificity": "^0.4.1",
@@ -9438,9 +9438,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
-      "integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+      "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -19912,9 +19912,9 @@
       "requires": {}
     },
     "postcss-selector-parser": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
-      "integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+      "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "postcss-media-query-parser": "^0.2.3",
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-safe-parser": "^6.0.0",
-    "postcss-selector-parser": "^6.0.8",
+    "postcss-selector-parser": "^6.0.9",
     "postcss-value-parser": "^4.1.0",
     "resolve-from": "^5.0.0",
     "specificity": "^0.4.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
- Improve the code a bit for type safety.
