### PR TITLE
Fix false positives for revert and revert-layer in font-family-no-missing-generic-family-keyword

### DIFF
--- a/lib/reference/keywordSets.js
+++ b/lib/reference/keywordSets.js
@@ -65,7 +65,7 @@ keywordSets.camelCaseFunctionNames = new Set([
 	'skewY',
 ]);
 
-keywordSets.basicKeywords = new Set(['initial', 'inherit', 'unset']);
+keywordSets.basicKeywords = new Set(['initial', 'inherit', 'revert', 'revert-layer', 'unset']);
 
 keywordSets.systemFontValues = uniteSets(keywordSets.basicKeywords, [
 	'caption',

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.js
@@ -96,6 +96,12 @@ testRule({
 		{
 			code: 'a { font-family: "font", var(--font); }',
 		},
+		{
+			code: 'a { font-family: revert }',
+		},
+		{
+			code: 'a { font-family: revert-layer }',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #5850

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
