### PR TITLE
Refactor to improve types for `selector-list-*` rules

### DIFF
--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -17,12 +15,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterMultiLine: () => 'Unexpected whitespace after "," in a multi-line list',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -40,6 +39,7 @@ function rule(expectation, options, context) {
 			// b {}
 			const selector = ruleNode.raws.selector ? ruleNode.raws.selector.raw : ruleNode.selector;
 
+			/** @type {number[]} */
 			const fixIndices = [];
 
 			styleSearch(
@@ -91,9 +91,9 @@ function rule(expectation, options, context) {
 					const beforeSelector = fixedSelector.slice(0, index);
 					let afterSelector = fixedSelector.slice(index);
 
-					if (expectation.startsWith('always')) {
+					if (primary.startsWith('always')) {
 						afterSelector = context.newline + afterSelector;
-					} else if (expectation.startsWith('never-multi-line')) {
+					} else if (primary.startsWith('never-multi-line')) {
 						afterSelector = afterSelector.replace(/^\s*/, '');
 					}
 
@@ -108,7 +108,7 @@ function rule(expectation, options, context) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const ruleMessages = require('../../utils/ruleMessages');
@@ -15,12 +13,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeMultiLine: () => 'Unexpected whitespace before "," in a multi-line list',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('newline', expectation, messages);
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('newline', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'always-multi-line', 'never-multi-line'],
 		});
 
@@ -28,6 +27,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		/** @type {Map<import('postcss').Rule, number[]> | undefined} */
 		let fixData;
 
 		selectorListCommaWhitespaceChecker({
@@ -56,7 +56,7 @@ function rule(expectation, options, context) {
 					let beforeSelector = selector.slice(0, index);
 					const afterSelector = selector.slice(index);
 
-					if (expectation.startsWith('always')) {
+					if (primary.startsWith('always')) {
 						const spaceIndex = beforeSelector.search(/\s+$/);
 
 						if (spaceIndex >= 0) {
@@ -67,7 +67,7 @@ function rule(expectation, options, context) {
 						} else {
 							beforeSelector += context.newline;
 						}
-					} else if (expectation === 'never-multi-line') {
+					} else if (primary === 'never-multi-line') {
 						beforeSelector = beforeSelector.replace(/\s*$/, '');
 					}
 
@@ -82,7 +82,7 @@ function rule(expectation, options, context) {
 			}
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-list-comma-space-after/index.js
+++ b/lib/rules/selector-list-comma-space-after/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const ruleMessages = require('../../utils/ruleMessages');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedAfterSingleLine: () => 'Unexpected whitespace after "," in a single-line list',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never', 'always-single-line', 'never-single-line'],
 		});
 
@@ -29,6 +28,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		/** @type {Map<import('postcss').Rule, number[]> | undefined} */
 		let fixData;
 
 		selectorListCommaWhitespaceChecker({
@@ -57,9 +57,9 @@ function rule(expectation, options, context) {
 					const beforeSelector = selector.slice(0, index + 1);
 					let afterSelector = selector.slice(index + 1);
 
-					if (expectation.startsWith('always')) {
+					if (primary.startsWith('always')) {
 						afterSelector = afterSelector.replace(/^\s*/, ' ');
-					} else if (expectation.startsWith('never')) {
+					} else if (primary.startsWith('never')) {
 						afterSelector = afterSelector.replace(/^\s*/, '');
 					}
 
@@ -74,7 +74,7 @@ function rule(expectation, options, context) {
 			}
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const ruleMessages = require('../../utils/ruleMessages');
@@ -16,12 +14,13 @@ const messages = ruleMessages(ruleName, {
 	rejectedBeforeSingleLine: () => 'Unexpected whitespace before "," in a single-line list',
 });
 
-function rule(expectation, options, context) {
-	const checker = whitespaceChecker('space', expectation, messages);
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const checker = whitespaceChecker('space', primary, messages);
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: expectation,
+			actual: primary,
 			possible: ['always', 'never', 'always-single-line', 'never-single-line'],
 		});
 
@@ -29,6 +28,7 @@ function rule(expectation, options, context) {
 			return;
 		}
 
+		/** @type {Map<import('postcss').Rule, number[]> | undefined} */
 		let fixData;
 
 		selectorListCommaWhitespaceChecker({
@@ -57,9 +57,9 @@ function rule(expectation, options, context) {
 					let beforeSelector = selector.slice(0, index);
 					const afterSelector = selector.slice(index);
 
-					if (expectation.includes('always')) {
+					if (primary.includes('always')) {
 						beforeSelector = beforeSelector.replace(/\s*$/, ' ');
-					} else if (expectation.includes('never')) {
+					} else if (primary.includes('never')) {
 						beforeSelector = beforeSelector.replace(/\s*$/, '');
 					}
 
@@ -74,7 +74,7 @@ function rule(expectation, options, context) {
 			}
 		}
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selectorListCommaWhitespaceChecker.js
+++ b/lib/rules/selectorListCommaWhitespaceChecker.js
@@ -1,12 +1,20 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../utils/isStandardSyntaxRule');
 const report = require('../utils/report');
 const styleSearch = require('style-search');
 
-module.exports = function (opts) {
+/**
+ * @param {{
+ *   root: import('postcss').Root,
+ *   result: import('stylelint').PostcssResult,
+ *   locationChecker: (opts: { source: string, index: number, err: (msg: string) => void }) => void,
+ *   checkedRuleName: string,
+ *   fix: ((rule: import('postcss').Rule, index: number) => boolean) | null,
+ * }} opts
+ * @returns {void}
+ */
+module.exports = function selectorListCommaWhitespaceChecker(opts) {
 	opts.root.walkRules((rule) => {
 		if (!isStandardSyntaxRule(rule)) {
 			return;
@@ -26,17 +34,22 @@ module.exports = function (opts) {
 		);
 	});
 
+	/**
+	 * @param {string} source
+	 * @param {number} index
+	 * @param {import('postcss').Rule} node
+	 */
 	function checkDelimiter(source, index, node) {
 		opts.locationChecker({
 			source,
 			index,
-			err: (m) => {
+			err: (message) => {
 				if (opts.fix && opts.fix(node, index)) {
 					return;
 				}
 
 				report({
-					message: m,
+					message,
 					node,
 					index,
 					result: opts.result,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
- Improve the code a bit for type safety.

