### PR TITLE
Refactor to improve types for `selector-max-*` rules

### DIFF
--- a/lib/rules/selector-max-attribute/index.js
+++ b/lib/rules/selector-max-attribute/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
@@ -22,17 +20,18 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
-function rule(max, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: max,
+				actual: primary,
 				possible: isNonNegativeInteger,
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreAttributes: [isString, isRegExp],
 				},
@@ -44,6 +43,10 @@ function rule(max, options) {
 			return;
 		}
 
+		/**
+		 * @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors and context functional pseudo-classes
@@ -56,7 +59,7 @@ function rule(max, options) {
 					return total;
 				}
 
-				if (optionsMatches(options, 'ignoreAttributes', childNode.attribute)) {
+				if (optionsMatches(secondaryOptions, 'ignoreAttributes', childNode.attribute)) {
 					// it's an attribute that is supposed to be ignored
 					return total;
 				}
@@ -66,13 +69,15 @@ function rule(max, options) {
 				return total;
 			}, 0);
 
-			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
+			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > primary) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
@@ -91,7 +96,7 @@ function rule(max, options) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-class/index.js
+++ b/lib/rules/selector-max-class/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
@@ -18,10 +16,11 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} ${max === 1 ? 'class' : 'classes'}`,
 });
 
-function rule(max) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: max,
+			actual: primary,
 			possible: isNonNegativeInteger,
 		});
 
@@ -29,6 +28,10 @@ function rule(max) {
 			return;
 		}
 
+		/**
+		 *  @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 *  @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors and context functional pseudo-classes
@@ -41,13 +44,15 @@ function rule(max) {
 				return total;
 			}, 0);
 
-			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
+			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > primary) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
@@ -66,7 +71,7 @@ function rule(max) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-combinators/index.js
+++ b/lib/rules/selector-max-combinators/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger');
@@ -19,10 +17,11 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
-function rule(max) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: max,
+			actual: primary,
 			possible: isNonNegativeInteger,
 		});
 
@@ -30,6 +29,10 @@ function rule(max) {
 			return;
 		}
 
+		/**
+		 * @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors
@@ -42,13 +45,15 @@ function rule(max) {
 				return total;
 			}, 0);
 
-			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
+			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > primary) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
@@ -67,7 +72,7 @@ function rule(max) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-compound-selectors/index.js
+++ b/lib/rules/selector-max-compound-selectors/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
@@ -20,10 +18,11 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
-function rule(max) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: max,
+			actual: primary,
 			possible: isNonNegativeInteger,
 		});
 
@@ -31,7 +30,12 @@ function rule(max) {
 			return;
 		}
 
-		// Finds actual selectors in selectorNode object and checks them
+		/**
+		 * Finds actual selectors in selectorNode object and checks them.
+		 *
+		 * @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			let compoundCount = 1;
 
@@ -47,13 +51,19 @@ function rule(max) {
 				}
 			});
 
-			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && compoundCount > max) {
+			if (
+				selectorNode.type !== 'root' &&
+				selectorNode.type !== 'pseudo' &&
+				compoundCount > primary
+			) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
@@ -72,7 +82,7 @@ function rule(max) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-empty-lines/index.js
+++ b/lib/rules/selector-max-empty-lines/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const report = require('../../utils/report');
@@ -13,12 +11,13 @@ const messages = ruleMessages(ruleName, {
 	expected: (max) => `Expected no more than ${max} empty ${max === 1 ? 'line' : 'lines'}`,
 });
 
-function rule(max, options, context) {
-	const maxAdjacentNewlines = max + 1;
+/** @type {import('stylelint').Rule} */
+const rule = (primary, _secondaryOptions, context) => {
+	const maxAdjacentNewlines = primary + 1;
 
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: max,
+			actual: primary,
 			possible: isNumber,
 		});
 
@@ -49,7 +48,7 @@ function rule(max, options, context) {
 				violatedCRLFNewLinesRegex.test(selector)
 			) {
 				report({
-					message: messages.expected(max),
+					message: messages.expected(primary),
 					node: ruleNode,
 					index: 0,
 					result,
@@ -58,7 +57,7 @@ function rule(max, options, context) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-id/index.js
+++ b/lib/rules/selector-max-id/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
@@ -20,17 +18,18 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} ID ${max === 1 ? 'selector' : 'selectors'}`,
 });
 
-function rule(max, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: max,
+				actual: primary,
 				possible: isNonNegativeInteger,
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreContextFunctionalPseudoClasses: [isString, isRegExp],
 				},
@@ -42,6 +41,10 @@ function rule(max, options) {
 			return;
 		}
 
+		/**
+		 * @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors and context functional pseudo-classes that are not part of ignored functional pseudo-classes
@@ -58,21 +61,27 @@ function rule(max, options) {
 				return total;
 			}, 0);
 
-			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
+			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > primary) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
 
+		/**
+		 * @param {import('postcss-selector-parser').Node} node
+		 * @returns {boolean}
+		 */
 		function isIgnoredContextFunctionalPseudoClass(node) {
 			return (
 				node.type === 'pseudo' &&
-				optionsMatches(options, 'ignoreContextFunctionalPseudoClasses', node.value)
+				optionsMatches(secondaryOptions, 'ignoreContextFunctionalPseudoClasses', node.value)
 			);
 		}
 
@@ -90,7 +99,7 @@ function rule(max, options) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-pseudo-class/index.js
+++ b/lib/rules/selector-max-pseudo-class/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
@@ -19,10 +17,11 @@ const messages = ruleMessages(ruleName, {
 		`Expected "${selector}" to have no more than ${max} pseudo-${max === 1 ? 'class' : 'classes'}`,
 });
 
-function rule(max) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: max,
+			actual: primary,
 			possible: isNonNegativeInteger,
 		});
 
@@ -30,6 +29,10 @@ function rule(max) {
 			return;
 		}
 
+		/**
+		 * @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors and context functional pseudo-classes
@@ -53,13 +56,15 @@ function rule(max) {
 				return total;
 			}, 0);
 
-			if (count > max) {
+			if (count > primary) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
@@ -71,14 +76,14 @@ function rule(max) {
 
 			for (const selector of ruleNode.selectors) {
 				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
-					parseSelector(resolvedSelector, result, rule, (selectorTree) => {
+					parseSelector(resolvedSelector, result, ruleNode, (selectorTree) => {
 						checkSelector(selectorTree, ruleNode);
 					});
 				}
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -20,10 +18,20 @@ const messages = ruleMessages(ruleName, {
 	expected: (selector, max) => `Expected "${selector}" to have a specificity no more than "${max}"`,
 });
 
-// Return an array representation of zero specificity. We need a new array each time so that it can mutated
+/** @typedef {import('specificity').SpecificityArray} SpecificityArray */
+
+/**
+ * Return an array representation of zero specificity. We need a new array each time so that it can mutated.
+ *
+ * @returns {SpecificityArray}
+ */
 const zeroSpecificity = () => [0, 0, 0, 0];
 
-// Calculate the sum of given array of specificity arrays
+/**
+ * Calculate the sum of given array of specificity arrays.
+ *
+ * @param {SpecificityArray[]} specificities
+ */
 const specificitySum = (specificities) => {
 	const sum = zeroSpecificity();
 
@@ -36,20 +44,21 @@ const specificitySum = (specificities) => {
 	return sum;
 };
 
-function rule(max, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: max,
+				actual: primary,
 				possible: [
 					// Check that the max specificity is in the form "a,b,c"
-					(spec) => /^\d+,\d+,\d+$/.test(spec),
+					(spec) => isString(spec) && /^\d+,\d+,\d+$/.test(spec),
 				],
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignoreSelectors: [isString, isRegExp],
 				},
@@ -61,16 +70,26 @@ function rule(max, options) {
 			return;
 		}
 
-		// Calculate the specificity of a simple selector (type, attribute, class, ID, or pseudos's own value)
+		/**
+		 * Calculate the specificity of a simple selector (type, attribute, class, ID, or pseudos's own value).
+		 *
+		 * @param {string} selector
+		 * @returns {SpecificityArray}
+		 */
 		const simpleSpecificity = (selector) => {
-			if (optionsMatches(options, 'ignoreSelectors', selector)) {
+			if (optionsMatches(secondaryOptions, 'ignoreSelectors', selector)) {
 				return zeroSpecificity();
 			}
 
 			return specificity.calculate(selector)[0].specificityArray;
 		};
 
-		// Calculate the the specificity of the most specific direct child
+		/**
+		 * Calculate the the specificity of the most specific direct child.
+		 *
+		 * @param {import('postcss-selector-parser').Container<unknown>} node
+		 * @returns {SpecificityArray}
+		 */
 		const maxChildSpecificity = (node) =>
 			node.reduce((maxSpec, child) => {
 				const childSpecificity = nodeSpecificity(child); // eslint-disable-line no-use-before-define
@@ -78,7 +97,12 @@ function rule(max, options) {
 				return specificity.compare(childSpecificity, maxSpec) === 1 ? childSpecificity : maxSpec;
 			}, zeroSpecificity());
 
-		// Calculate the specificity of a pseudo selector including own value and children
+		/**
+		 * Calculate the specificity of a pseudo selector including own value and children.
+		 *
+		 * @param {import('postcss-selector-parser').Pseudo} node
+		 * @returns {SpecificityArray}
+		 */
 		const pseudoSpecificity = (node) => {
 			// `node.toString()` includes children which should be processed separately,
 			// so use `node.value` instead
@@ -92,12 +116,16 @@ function rule(max, options) {
 			return specificitySum([ownSpecificity, maxChildSpecificity(node)]);
 		};
 
+		/**
+		 * @param {import('postcss-selector-parser').Node} node
+		 * @returns {boolean}
+		 */
 		const shouldSkipPseudoClassArgument = (node) => {
 			// postcss-selector-parser includes the arguments to nth-child() functions
 			// as "tags", so we need to ignore them ourselves.
 			// The fake-tag's "parent" is actually a selector node, whose parent
 			// should be the :nth-child pseudo node.
-			const parentNode = node.parent.parent;
+			const parentNode = node.parent && node.parent.parent;
 
 			if (parentNode && parentNode.value) {
 				const parentNodeValue = parentNode.value;
@@ -113,7 +141,12 @@ function rule(max, options) {
 			return false;
 		};
 
-		// Calculate the specificity of a node parsed by `postcss-selector-parser`
+		/**
+		 * Calculate the specificity of a node parsed by `postcss-selector-parser`.
+		 *
+		 * @param {import('postcss-selector-parser').Node} node
+		 * @returns {SpecificityArray}
+		 */
 		const nodeSpecificity = (node) => {
 			if (shouldSkipPseudoClassArgument(node)) {
 				return zeroSpecificity();
@@ -135,7 +168,13 @@ function rule(max, options) {
 			}
 		};
 
-		const maxSpecificityArray = `0,${max}`.split(',').map((s) => Number.parseFloat(s));
+		/** @type {[number, number, number]} */
+		const primaryNumbers = primary
+			.split(',')
+			.map((/** @type {string} */ s) => Number.parseFloat(s));
+
+		/** @type {SpecificityArray} */
+		const maxSpecificityArray = [0, ...primaryNumbers];
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {
@@ -160,7 +199,7 @@ function rule(max, options) {
 									ruleName,
 									result,
 									node: ruleNode,
-									message: messages.expected(resolvedSelector, max),
+									message: messages.expected(resolvedSelector, primary),
 									word: selector,
 								});
 							}
@@ -175,7 +214,7 @@ function rule(max, options) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/selector-max-type/index.js
+++ b/lib/rules/selector-max-type/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass');
@@ -26,17 +24,18 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
-function rule(max, options) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
 			ruleName,
 			{
-				actual: max,
+				actual: primary,
 				possible: isNonNegativeInteger,
 			},
 			{
-				actual: options,
+				actual: secondaryOptions,
 				possible: {
 					ignore: ['descendant', 'child', 'compounded', 'next-sibling'],
 					ignoreTypes: [isString, isRegExp],
@@ -49,11 +48,15 @@ function rule(max, options) {
 			return;
 		}
 
-		const ignoreDescendant = optionsMatches(options, 'ignore', 'descendant');
-		const ignoreChild = optionsMatches(options, 'ignore', 'child');
-		const ignoreCompounded = optionsMatches(options, 'ignore', 'compounded');
-		const ignoreNextSibling = optionsMatches(options, 'ignore', 'next-sibling');
+		const ignoreDescendant = optionsMatches(secondaryOptions, 'ignore', 'descendant');
+		const ignoreChild = optionsMatches(secondaryOptions, 'ignore', 'child');
+		const ignoreCompounded = optionsMatches(secondaryOptions, 'ignore', 'compounded');
+		const ignoreNextSibling = optionsMatches(secondaryOptions, 'ignore', 'next-sibling');
 
+		/**
+		 * @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors and context functional pseudo-classes
@@ -61,7 +64,7 @@ function rule(max, options) {
 					checkSelector(childNode, ruleNode);
 				}
 
-				if (optionsMatches(options, 'ignoreTypes', childNode.value)) {
+				if (optionsMatches(secondaryOptions, 'ignoreTypes', childNode.value)) {
 					return total;
 				}
 
@@ -85,16 +88,18 @@ function rule(max, options) {
 					return total;
 				}
 
-				return total + (childNode.type === 'tag');
+				return childNode.type === 'tag' ? total + 1 : total;
 			}, 0);
 
-			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
+			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > primary) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
@@ -123,20 +128,38 @@ function rule(max, options) {
 			}
 		});
 	};
-}
+};
 
+/** @typedef {import('postcss-selector-parser').Node} SelectorNode */
+
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function hasDescendantCombinatorBefore(node) {
+	if (!node.parent) return false;
+
 	const nodeIndex = node.parent.nodes.indexOf(node);
 
 	return node.parent.nodes.slice(0, nodeIndex).some((n) => isDescendantCombinator(n));
 }
 
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function hasChildCombinatorBefore(node) {
+	if (!node.parent) return false;
+
 	const nodeIndex = node.parent.nodes.indexOf(node);
 
 	return node.parent.nodes.slice(0, nodeIndex).some((n) => isChildCombinator(n));
 }
 
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function hasCompoundSelector(node) {
 	if (node.prev() && !isCombinator(node.prev())) {
 		return true;
@@ -145,28 +168,48 @@ function hasCompoundSelector(node) {
 	return node.next() && !isCombinator(node.next());
 }
 
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function hasNextSiblingCombinator(node) {
 	return node.prev() && isNextSiblingCombinator(node.prev());
 }
 
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function isCombinator(node) {
 	if (!node) return false;
 
 	return node.type === 'combinator';
 }
 
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function isDescendantCombinator(node) {
 	if (!node) return false;
 
-	return isCombinator(node) && isOnlyWhitespace(node.value);
+	return isCombinator(node) && isString(node.value) && isOnlyWhitespace(node.value);
 }
 
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function isChildCombinator(node) {
 	if (!node) return false;
 
 	return isCombinator(node) && node.value === '>';
 }
 
+/**
+ * @param {SelectorNode} node
+ * @returns {boolean}
+ */
 function isNextSiblingCombinator(node) {
 	return isCombinator(node) && node.value === '+';
 }

--- a/lib/rules/selector-max-universal/index.js
+++ b/lib/rules/selector-max-universal/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 'use strict';
 
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger');
@@ -20,10 +18,11 @@ const messages = ruleMessages(ruleName, {
 		}`,
 });
 
-function rule(max) {
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
-			actual: max,
+			actual: primary,
 			possible: isNonNegativeInteger,
 		});
 
@@ -31,6 +30,10 @@ function rule(max) {
 			return;
 		}
 
+		/**
+		 * @param {import('postcss-selector-parser').Container<unknown>} selectorNode
+		 * @param {import('postcss').Rule} ruleNode
+		 */
 		function checkSelector(selectorNode, ruleNode) {
 			const count = selectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors
@@ -44,13 +47,15 @@ function rule(max) {
 				return total;
 			}, 0);
 
-			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > max) {
+			if (selectorNode.type !== 'root' && selectorNode.type !== 'pseudo' && count > primary) {
+				const selector = selectorNode.toString();
+
 				report({
 					ruleName,
 					result,
 					node: ruleNode,
-					message: messages.expected(selectorNode, max),
-					word: selectorNode,
+					message: messages.expected(selector, primary),
+					word: selector,
 				});
 			}
 		}
@@ -60,6 +65,7 @@ function rule(max) {
 				return;
 			}
 
+			/** @type {string[]} */
 			const selectors = [];
 
 			selectorParser()
@@ -79,7 +85,7 @@ function rule(max) {
 			}
 		});
 	};
-}
+};
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/utils/isContextFunctionalPseudoClass.js
+++ b/lib/utils/isContextFunctionalPseudoClass.js
@@ -6,8 +6,8 @@ const keywordSets = require('../reference/keywordSets');
  * Check whether a node is a context-functional pseudo-class (i.e. either a logical combination
  * or a 'aNPlusBOfSNotationPseudoClasses' / tree-structural pseudo-class)
  *
- * @param {import('postcss-selector-parser').Pseudo} node postcss-selector-parser node (of type pseudo)
- * @return {boolean} If `true`, the node is a context-functional pseudo-class
+ * @param {import('postcss-selector-parser').Node} node - postcss-selector-parser node (of type pseudo)
+ * @return {node is import('postcss-selector-parser').Pseudo} If `true`, the node is a context-functional pseudo-class
  */
 module.exports = function isContextFunctionalPseudoClass(node) {
 	if (node.type === 'pseudo') {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4496

> Is there anything in the PR that needs further explanation?

- Remove `// @ts-nocheck` to enable type-checking.
- Improve the code a bit for type safety.

