### PR TITLE
Fix false negatives for custom properties within var() in custom-property-pattern

### DIFF
--- a/lib/rules/custom-property-pattern/__tests__/index.js
+++ b/lib/rules/custom-property-pattern/__tests__/index.js
@@ -46,6 +46,19 @@ testRule({
 			line: 1,
 			column: 62,
 		},
+		{
+			code: ':root { --foo-color: #f00; } a { color: VAR(--boo-color)); }',
+			message: messages.expected(/foo-.+/),
+			line: 1,
+			column: 41,
+		},
+		{
+			code: ':root { --foo-color: #f00; } a { color: var(--boo-color), var(--boo-sub-color)); }',
+			warnings: [
+				{ message: messages.expected(/foo-.+/), line: 1, column: 41 },
+				{ message: messages.expected(/foo-.+/), line: 1, column: 59 },
+			],
+		},
 	],
 });
 

--- a/lib/rules/custom-property-pattern/__tests__/index.js
+++ b/lib/rules/custom-property-pattern/__tests__/index.js
@@ -25,18 +25,26 @@ testRule({
 		{
 			code: ':root { --boo-bar: 0; }',
 			message: messages.expected(/foo-.+/),
+			line: 1,
+			column: 9,
 		},
 		{
 			code: ':root { --foo-: 0; }',
 			message: messages.expected(/foo-.+/),
+			line: 1,
+			column: 9,
 		},
 		{
 			code: ':root { --foo-color: #f00; } a { color: var(--boo-color); }',
 			message: messages.expected(/foo-.+/),
+			line: 1,
+			column: 41,
 		},
 		{
 			code: ':root { --foo-sub-color: #f00; } a { color: var(--foo-color, var(--boo-sub-color)); }',
 			message: messages.expected(/foo-.+/),
+			line: 1,
+			column: 62,
 		},
 	],
 });
@@ -58,10 +66,14 @@ testRule({
 		{
 			code: ':root { --boo-bar: 0; }',
 			message: messages.expected('foo-.+'),
+			line: 1,
+			column: 9,
 		},
 		{
 			code: ':root { --foo-: 0; }',
 			message: messages.expected('foo-.+'),
+			line: 1,
+			column: 9,
 		},
 	],
 });
@@ -83,14 +95,20 @@ testRule({
 		{
 			code: ':root { --boo-Foo-bar: 0; }',
 			message: messages.expected(/^[A-Z][a-z]+-[a-z][a-zA-Z]+$/),
+			line: 1,
+			column: 9,
 		},
 		{
 			code: ':root { --foo-bar: 0; }',
 			message: messages.expected(/^[A-Z][a-z]+-[a-z][a-zA-Z]+$/),
+			line: 1,
+			column: 9,
 		},
 		{
 			code: ':root { --Foo-Bar: 0; }',
 			message: messages.expected(/^[A-Z][a-z]+-[a-z][a-zA-Z]+$/),
+			line: 1,
+			column: 9,
 		},
 	],
 });

--- a/lib/rules/custom-property-pattern/__tests__/index.js
+++ b/lib/rules/custom-property-pattern/__tests__/index.js
@@ -13,6 +13,12 @@ testRule({
 		{
 			code: ':root { --boo-foo-bar: 0; }',
 		},
+		{
+			code: ':root { --foo-color: #f00; } a { color: var(--foo-color); }',
+		},
+		{
+			code: ':root { --foo-sub-color: #f00; } a { color: var(--foo-color, var(--foo-sub-color)); }',
+		},
 	],
 
 	reject: [
@@ -22,6 +28,14 @@ testRule({
 		},
 		{
 			code: ':root { --foo-: 0; }',
+			message: messages.expected(/foo-.+/),
+		},
+		{
+			code: ':root { --foo-color: #f00; } a { color: var(--boo-color); }',
+			message: messages.expected(/foo-.+/),
+		},
+		{
+			code: ':root { --foo-sub-color: #f00; } a { color: var(--foo-color, var(--boo-sub-color)); }',
 			message: messages.expected(/foo-.+/),
 		},
 	],

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -41,7 +41,7 @@ const rule = (primary) => {
 			parsedValue.walk((node) => {
 				if (!isValueFunction(node)) return;
 
-				if (node.value !== 'var') return;
+				if (node.value.toLowerCase() !== 'var') return;
 
 				const { nodes, sourceIndex } = node;
 

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -47,7 +47,7 @@ const rule = (primary) => {
 
 				if (regexpPattern.test(nodes[0].value.slice(2))) return;
 
-				complain(messages.expected(primary), declarationValueIndex(decl) + sourceIndex, decl);
+				complain(declarationValueIndex(decl) + sourceIndex, decl);
 			});
 
 			if (!isCustomProperty(prop)) {
@@ -58,15 +58,14 @@ const rule = (primary) => {
 				return;
 			}
 
-			complain(messages.expected(primary), 0, decl);
+			complain(0, decl);
 		});
 
 		/**
-		 * @param {string} message
 		 * @param {number} index
 		 * @param {import('postcss').Declaration} decl
 		 */
-		function complain(message, index, decl) {
+		function complain(index, decl) {
 			report({
 				result,
 				ruleName,

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -70,7 +70,7 @@ const rule = (primary) => {
 			report({
 				result,
 				ruleName,
-				message,
+				message: messages.expected(primary),
 				node: decl,
 				index,
 			});

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -1,10 +1,13 @@
 'use strict';
 
+const valueParser = require('postcss-value-parser');
 const isCustomProperty = require('../../utils/isCustomProperty');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const declarationValueIndex = require('../../utils/declarationValueIndex');
 const { isRegExp, isString } = require('../../utils/validateTypes');
+const { isValueFunction } = require('../../utils/typeGuards');
 
 const ruleName = 'custom-property-pattern';
 
@@ -31,7 +34,21 @@ const rule = (primary) => {
 		const regexpPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkDecls((decl) => {
-			const prop = decl.prop;
+			const { prop, value } = decl;
+
+			const parsedValue = valueParser(value);
+
+			parsedValue.walk((node) => {
+				if (!isValueFunction(node)) return;
+
+				if (node.value !== 'var') return;
+
+				const { nodes, sourceIndex } = node;
+
+				if (regexpPattern.test(nodes[0].value.slice(2))) return;
+
+				complain(messages.expected(primary), declarationValueIndex(decl) + sourceIndex, decl);
+			});
 
 			if (!isCustomProperty(prop)) {
 				return;
@@ -41,13 +58,23 @@ const rule = (primary) => {
 				return;
 			}
 
+			complain(messages.expected(primary), 0, decl);
+		});
+
+		/**
+		 * @param {string} message
+		 * @param {number} index
+		 * @param {import('postcss').Declaration} decl
+		 */
+		function complain(message, index, decl) {
 			report({
-				message: messages.expected(primary),
-				node: decl,
 				result,
 				ruleName,
+				message,
+				node: decl,
+				index,
 			});
-		});
+		}
 	};
 };
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #3655

> Is there anything in the PR that needs further explanation?

The following problem has not been solved.
You will need to create another isuue.

> The following is a false positive (as it's invalid syntax) and should be ignored by this rule. We > can either squish that bug within this issue or create a separate issue for it.
>  ```--invalid-custom-property-variable: #fff;```

https://github.com/stylelint/stylelint/issues/3655#issuecomment-420942480

