### PR TITLE
Downgrade npm to 8.3 as workaround

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,9 @@ jobs:
           cache: npm
 
       - name: Install latest npm
-        run: npm install --global npm@latest
+        run: npm install --global npm@8.3
+        # TODO: npm@8.4 is broken on Windows. See https://github.com/npm/cli/issues/4341
+        # run: npm install --global npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Currently, our CI jobs for Windows fail due to npm@8.4 (see <https://github.com/npm/cli/issues/4341>). So this change downgrades to npm@8.3 as a workaround.

E.g. https://github.com/npm/cli/issues/4341
