### PR TITLE
Refactor to replace `style-search` for `value-no-vendor-prefix` rule

### DIFF
--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -56,7 +56,7 @@ const rule = (primary, secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
-			const value = decl.value;
+			const { value } = decl;
 
 			if (
 				!isStandardSyntaxDeclaration(decl) ||

--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -1,15 +1,17 @@
 'use strict';
 
+const valueParser = require('postcss-value-parser');
+
 const isAutoprefixable = require('../../utils/isAutoprefixable');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
-const styleSearch = require('style-search');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isString, assert } = require('../../utils/validateTypes');
+const { isString } = require('../../utils/validateTypes');
 
 const ruleName = 'value-no-vendor-prefix';
 
@@ -22,6 +24,16 @@ const meta = {
 };
 
 const valuePrefixes = ['-webkit-', '-moz-', '-ms-', '-o-'];
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+const hasPrefix = (value) => {
+	const lowerValue = value.toLowerCase();
+
+	return valuePrefixes.some((prefix) => lowerValue.startsWith(prefix));
+};
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
@@ -44,49 +56,47 @@ const rule = (primary, secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
+			const value = decl.value;
+
 			if (
 				!isStandardSyntaxDeclaration(decl) ||
 				!isStandardSyntaxProperty(decl.prop) ||
-				!decl.value.startsWith('-')
+				!value.startsWith('-')
 			) {
 				return;
 			}
 
-			const prop = decl.prop;
-			const value = decl.value;
-			const unprefixedValue = vendor.unprefixed(value);
-
-			//return early if value is to be ignored
-			if (optionsMatches(secondaryOptions, 'ignoreValues', unprefixedValue)) {
+			if (optionsMatches(secondaryOptions, 'ignoreValues', vendor.unprefixed(value))) {
 				return;
 			}
 
-			// Search the full declaration in order to get an accurate index
+			const parsedValue = valueParser(value);
 
-			styleSearch({ source: value.toLowerCase(), target: valuePrefixes }, (match) => {
-				const fullIdentifierMatch = /^(-[a-z-]+)\b/i.exec(value.slice(match.startIndex));
+			parsedValue.walk((node) => {
+				if (!hasPrefix(node.value)) {
+					return;
+				}
 
-				assert(fullIdentifierMatch);
-				const fullIdentifier = fullIdentifierMatch[1];
-
-				if (!isAutoprefixable.propertyValue(fullIdentifier)) {
+				if (!isAutoprefixable.propertyValue(node.value)) {
 					return;
 				}
 
 				if (context.fix) {
-					decl.value = isAutoprefixable.unprefix(decl.value);
+					node.value = isAutoprefixable.unprefix(node.value);
 
 					return;
 				}
 
 				report({
-					message: messages.rejected(fullIdentifier),
+					message: messages.rejected(node.value),
 					node: decl,
-					index: prop.length + (decl.raws.between || '').length + match.startIndex,
+					index: decl.prop.length + (decl.raws.between || '').length + node.sourceIndex,
 					result,
 					ruleName,
 				});
 			});
+
+			setDeclarationValue(decl, parsedValue.toString());
 		});
 	};
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- Part of #5499

> Is there anything in the PR that needs further explanation?

Replacing `style-search` with [`postcss-value-parser`](https://github.com/TrySound/postcss-value-parser).
