### PR TITLE
Refactor to replace `style-search` for `rangeContextNodeParser()`

### DIFF
--- a/lib/rules/rangeContextNodeParser.js
+++ b/lib/rules/rangeContextNodeParser.js
@@ -1,80 +1,59 @@
 'use strict';
 
-const styleSearch = require('style-search');
+const valueParser = require('postcss-value-parser');
 
-const rangeOperators = ['>=', '<=', '>', '<', '='];
+const rangeOperators = new Set(['>=', '<=', '>', '<', '=']);
 
 /**
- * @param {import('postcss-media-query-parser').Node} node
+ * @param {string} name
+ * @returns {boolean}
  */
-function getRangeContextOperators(node) {
-	/** @type {string[]} */
-	const operators = [];
+function isRangeContextName(name) {
+	// When the node is like "(width > 10em)" or "(10em < width)"
+	// Regex is needed because the name can either be in the first or second position
+	return /^(?!--)\D/.test(name) || /^--./.test(name);
+}
 
-	const source = node.value;
+/**
+ * @typedef {{ value: string, sourceIndex: number }} RangeContextNode
+ *
+ * @param {import('postcss-media-query-parser').Node} node
+ * @returns {{ name: RangeContextNode, values: RangeContextNode[] }}
+ */
+module.exports = function rangeContextNodeParser(node) {
+	/** @type {import('postcss-value-parser').WordNode | undefined} */
+	let nameNode;
 
-	styleSearch({ source, target: rangeOperators }, (match) => {
-		const before = source[match.startIndex - 1];
+	/** @type {import('postcss-value-parser').WordNode[]} */
+	const valueNodes = [];
 
-		if (before === '>' || before === '<') {
+	valueParser(node.value).walk((valueNode) => {
+		if (valueNode.type !== 'word') return;
+
+		if (rangeOperators.has(valueNode.value)) return;
+
+		if (nameNode == null && isRangeContextName(valueNode.value)) {
+			nameNode = valueNode;
+
 			return;
 		}
 
-		operators.push(match.target);
+		valueNodes.push(valueNode);
 	});
 
-	// Sorting helps when using the operators to split
-	// E.g. for "(10em < width <= 50em)" this returns ["<=", "<"]
-	return operators.sort((a, b) => b.length - a.length);
-}
-
-/**
- * @param {string[]} parsedNode
- */
-function getRangeContextName(parsedNode) {
-	// When the node is like "(10em < width < 50em)"
-	// The parsedNode is ["10em", "width", "50em"] - the name is always in the second position
-	if (parsedNode.length === 3) {
-		return parsedNode[1];
+	if (nameNode == null) {
+		throw new Error(`The context name must be present: ${node.value}`);
 	}
 
-	// When the node is like "(width > 10em)" or "(10em < width)"
-	// Regex is needed because the name can either be in the first or second position
-	return parsedNode.find((value) => value.match(/^(?!--)\D+/) || value.match(/^(--).+/));
-}
-
-/**
- * @param {import('postcss-media-query-parser').Node} node
- * @returns {{ name: { value: string, sourceIndex: number }, values: Array<{ value: string, sourceIndex: number }> }}
- */
-module.exports = function rangeContextNodeParser(node) {
-	const nodeValue = node.value;
-
-	const operators = getRangeContextOperators(node);
-
-	// Remove spaces and parentheses and split by the operators
-	const parsedMedia = nodeValue.replace(/[()\s]/g, '').split(new RegExp(operators.join('|')));
-
-	const name = getRangeContextName(parsedMedia);
-
-	if (name == null) throw new Error('The context name must be present');
-
-	const nameObj = {
-		value: name,
-		sourceIndex: node.sourceIndex + nodeValue.indexOf(name),
-	};
-
-	const values = parsedMedia
-		.filter((parsedValue) => parsedValue !== name)
-		.map((value) => {
-			return {
-				value,
-				sourceIndex: node.sourceIndex + nodeValue.indexOf(value),
-			};
-		});
-
 	return {
-		name: nameObj,
-		values,
+		name: {
+			value: nameNode.value,
+			sourceIndex: node.sourceIndex + nameNode.sourceIndex,
+		},
+
+		values: valueNodes.map((valueNode) => ({
+			value: valueNode.value,
+			sourceIndex: node.sourceIndex + valueNode.sourceIndex,
+		})),
 	};
 };

--- a/lib/rules/rangeContextNodeParser.js
+++ b/lib/rules/rangeContextNodeParser.js
@@ -2,6 +2,8 @@
 
 const valueParser = require('postcss-value-parser');
 
+const { assert } = require('../utils/validateTypes');
+
 const rangeOperators = new Set(['>=', '<=', '>', '<', '=']);
 
 /**
@@ -41,9 +43,7 @@ module.exports = function rangeContextNodeParser(node) {
 		valueNodes.push(valueNode);
 	});
 
-	if (nameNode == null) {
-		throw new Error(`The context name must be present: ${node.value}`);
-	}
+	assert(nameNode);
 
 	return {
 		name: {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5499

> Is there anything in the PR that needs further explanation?

Replacing `style-search` with `postcss-value-parser`.
