### PR TITLE
Fix typo / inconsistency in stylelint.rules API docs for plugins

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -286,7 +286,7 @@ Here's an example of a plugin that runs `declaration-no-important` only if there
 
 ```js
 module.exports = stylelint.createPlugin(ruleName, function (expectation) {
-  const runColorHexCase =
+  const runDeclarationNoImportant =
     stylelint.rules["declaration-no-important"](expectation);
 
   return (root, result) => {
@@ -294,7 +294,7 @@ module.exports = stylelint.createPlugin(ruleName, function (expectation) {
       return;
     }
 
-    runColorHexCase(root, result);
+    runDeclarationNoImportant(root, result);
   };
 });
 ```


### PR DESCRIPTION
I think the snippet is understandable even with the typo, but worth fixing nonetheless.