### PR TITLE
Fix parseError for double-slash comments within selector lists in no-descending-specificity

### DIFF
--- a/lib/rules/no-descending-specificity/__tests__/index.js
+++ b/lib/rules/no-descending-specificity/__tests__/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const postcssScss = require('postcss-scss');
+const postcssLess = require('postcss-less');
+const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
 
@@ -168,6 +170,22 @@ testRule({
 	accept: [
 		{
 			code: '.foo { &--a, &--a#{&}--b {  div {} } }',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	customSyntax: postcssLess,
+	config: [true],
+
+	accept: [
+		{
+			code: stripIndent`
+				a,
+				// comment2
+				b {}
+			`,
 		},
 	],
 });

--- a/lib/utils/__tests__/isStandardSyntaxSelector.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxSelector.test.js
@@ -80,7 +80,10 @@ describe('isStandardSyntaxSelector', () => {
 		expect(isStandardSyntaxSelector('.foo(@a)')).toBeFalsy();
 		expect(isStandardSyntaxSelector('.foo(@a: 5px)')).toBeFalsy();
 	});
-
+	it('SCSS or Less comments', () => {
+		expect(isStandardSyntaxSelector('a\n// comment\nb')).toBeFalsy();
+		expect(isStandardSyntaxSelector('a\n//comment\nb')).toBeFalsy();
+	});
 	it('ERB templates', () => {
 		// E. g. like in https://github.com/stylelint/stylelint/issues/4489
 		expect(isStandardSyntaxSelector('<% COLORS.each do |color| %>\na')).toBe(false);

--- a/lib/utils/isStandardSyntaxSelector.js
+++ b/lib/utils/isStandardSyntaxSelector.js
@@ -49,5 +49,10 @@ module.exports = function (selector) {
 		return false;
 	}
 
+	//  SCSS and Less comments
+	if (selector.includes('//')) {
+		return false;
+	}
+
 	return true;
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5739

> Is there anything in the PR that needs further explanation?

The following triggered a parse error in the selector parser.

```less
a,
// comment2
b {}
```
