### PR TITLE
Refactor to improve types for `ruleMessages()`

### DIFF
--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -10,7 +10,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
-const { isRegExp, isString } = require('../../utils/validateTypes');
+const { isRegExp, isString, assert } = require('../../utils/validateTypes');
 
 const ruleName = 'alpha-value-notation';
 
@@ -124,7 +124,7 @@ const rule = (primary, secondaryOptions, context) => {
 
 /**
  * @param {string} value
- * @returns {string | undefined}
+ * @returns {string}
  */
 function asPercentage(value) {
 	const number = Number(value);
@@ -134,12 +134,12 @@ function asPercentage(value) {
 
 /**
  * @param {string} value
- * @returns {string | undefined}
+ * @returns {string}
  */
 function asNumber(value) {
 	const dimension = valueParser.unit(value);
 
-	if (!dimension) return undefined;
+	assert(dimension);
 
 	const number = Number(dimension.number);
 

--- a/lib/rules/number-max-precision/__tests__/index.js
+++ b/lib/rules/number-max-precision/__tests__/index.js
@@ -52,19 +52,19 @@ testRule({
 	reject: [
 		{
 			code: 'a { top: 3.123%; }',
-			message: messages.expected(3.123, 2),
+			message: messages.expected(3.123, 3.12),
 			line: 1,
 			column: 10,
 		},
 		{
 			code: 'a { padding: 6.123% 3.1%; }',
-			message: messages.expected(6.123, 2),
+			message: messages.expected(6.123, 6.12),
 			line: 1,
 			column: 14,
 		},
 		{
 			code: '@media (min-width: 5.123em) {}',
-			message: messages.expected(5.123, 2),
+			message: messages.expected(5.123, 5.12),
 			line: 1,
 			column: 20,
 		},
@@ -108,19 +108,19 @@ testRule({
 	reject: [
 		{
 			code: 'a { top: 3.12345%; }',
-			message: messages.expected(3.12345, 4),
+			message: messages.expected(3.12345, 3.1235),
 			line: 1,
 			column: 10,
 		},
 		{
 			code: 'a { padding: 6.12345% 3.1234%; }',
-			message: messages.expected(6.12345, 4),
+			message: messages.expected(6.12345, 6.1235),
 			line: 1,
 			column: 14,
 		},
 		{
 			code: '@media (min-width: 5.12345em) {}',
-			message: messages.expected(5.12345, 4),
+			message: messages.expected(5.12345, 5.1235),
 			line: 1,
 			column: 20,
 		},
@@ -140,7 +140,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { top: 3.1%; }',
-			message: messages.expected(3.1, 0),
+			message: messages.expected(3.1, 3),
 			line: 1,
 			column: 10,
 		},
@@ -178,13 +178,13 @@ testRule({
 	reject: [
 		{
 			code: 'a { top: 3.1px; }',
-			message: messages.expected(3.1, 0),
+			message: messages.expected(3.1, 3),
 			line: 1,
 			column: 10,
 		},
 		{
 			code: 'a { top: 3.123em; }',
-			message: messages.expected(3.123, 0),
+			message: messages.expected(3.123, 3),
 			line: 1,
 			column: 10,
 		},
@@ -192,12 +192,12 @@ testRule({
 			code: 'a { padding: 6.123px 3.1234px; }',
 			warnings: [
 				{
-					message: messages.expected(6.123, 0),
+					message: messages.expected(6.123, 6),
 					line: 1,
 					column: 14,
 				},
 				{
-					message: messages.expected(3.1234, 0),
+					message: messages.expected(3.1234, 3),
 					line: 1,
 					column: 22,
 				},
@@ -205,7 +205,7 @@ testRule({
 		},
 		{
 			code: 'a { top: 6.123other-unit; }',
-			message: messages.expected(6.123, 0),
+			message: messages.expected(6.123, 6),
 			line: 1,
 			column: 10,
 		},
@@ -225,7 +225,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { top: 6.123other-unit; }',
-			message: messages.expected(6.123, 0),
+			message: messages.expected(6.123, 6),
 			line: 1,
 			column: 10,
 		},
@@ -248,13 +248,13 @@ testRule({
 	reject: [
 		{
 			code: 'a { top: 3.1px; }',
-			message: messages.expected(3.1, 0),
+			message: messages.expected(3.1, 3),
 			line: 1,
 			column: 10,
 		},
 		{
 			code: 'a { top: 3.123em; }',
-			message: messages.expected(3.123, 0),
+			message: messages.expected(3.123, 3),
 			line: 1,
 			column: 10,
 		},
@@ -262,12 +262,12 @@ testRule({
 			code: 'a { myprop: 6.123px 3.1234px; }',
 			warnings: [
 				{
-					message: messages.expected(6.123, 0),
+					message: messages.expected(6.123, 6),
 					line: 1,
 					column: 13,
 				},
 				{
-					message: messages.expected(3.1234, 0),
+					message: messages.expected(3.1234, 3),
 					line: 1,
 					column: 21,
 				},
@@ -304,13 +304,13 @@ testRule({
 	reject: [
 		{
 			code: 'a { top: 3.1px; }',
-			message: messages.expected(3.1, 0),
+			message: messages.expected(3.1, 3),
 			line: 1,
 			column: 10,
 		},
 		{
 			code: 'a { top: 3.123em; }',
-			message: messages.expected(3.123, 0),
+			message: messages.expected(3.123, 3),
 			line: 1,
 			column: 10,
 		},
@@ -318,12 +318,12 @@ testRule({
 			code: 'a { myprop: 6.123px 3.1234px; }',
 			warnings: [
 				{
-					message: messages.expected(6.123, 0),
+					message: messages.expected(6.123, 6),
 					line: 1,
 					column: 13,
 				},
 				{
-					message: messages.expected(3.1234, 0),
+					message: messages.expected(3.1234, 3),
 					line: 1,
 					column: 21,
 				},

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -14,7 +14,7 @@ const { isNumber, isRegExp, isString } = require('../../utils/validateTypes');
 const ruleName = 'number-max-precision';
 
 const messages = ruleMessages(ruleName, {
-	expected: (number, precision) => `Expected "${number}" to be "${number.toFixed(precision)}"`,
+	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 });
 
 const meta = {
@@ -100,13 +100,14 @@ const rule = (primary, secondaryOptions) => {
 
 				const baseIndex =
 					node.type === 'atrule' ? atRuleParamIndex(node) : declarationValueIndex(node);
+				const actual = Number.parseFloat(match[0]);
 
 				report({
 					result,
 					ruleName,
 					node,
 					index: baseIndex + valueNode.sourceIndex + match.index,
-					message: messages.expected(Number.parseFloat(match[0]), primary),
+					message: messages.expected(actual, actual.toFixed(primary)),
 				});
 			});
 		}

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -6,6 +6,7 @@ const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { assertString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-attribute-quotes';
 
@@ -54,6 +55,7 @@ const rule = (primary, _secondaryOptions, context) => {
 							selectorFixed = true;
 							attributeNode.quoteMark = acceptedQuoteMark;
 						} else {
+							assertString(attributeNode.value);
 							complain(
 								messages.expected(attributeNode.value),
 								attributeNode.sourceIndex + attributeNode.offsetOf('value'),
@@ -66,6 +68,7 @@ const rule = (primary, _secondaryOptions, context) => {
 							selectorFixed = true;
 							attributeNode.quoteMark = null;
 						} else {
+							assertString(attributeNode.value);
 							complain(
 								messages.rejected(attributeNode.value),
 								attributeNode.sourceIndex + attributeNode.offsetOf('value'),

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -137,7 +137,9 @@ declare module 'stylelint' {
 			newline?: string | undefined;
 		};
 
-		export type RuleMessages = { [message: string]: string | ((...args: any[]) => string) };
+		export type RuleMessageFunc = (...args: (string | number | boolean | RegExp)[]) => string;
+
+		export type RuleMessages = { [message: string]: string | RuleMessageFunc };
 
 		export type RuleOptionsPossibleFunc = (value: unknown) => boolean;
 

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -80,10 +80,10 @@ const formatter: FormatterType = 'json';
 const ruleName = 'sample-rule';
 const messages = stylelint.utils.ruleMessages(ruleName, {
 	problem: 'This a rule problem message',
-	warning: (reason: string) => `This is not allowed because ${reason}`,
+	warning: (reason) => `This is not allowed because ${reason}`,
 });
 const problemMessage: string = messages.problem;
-const problemFunc: (reason: string) => string = messages.warning;
+const problemFunc: (...reason: string[]) => string = messages.warning;
 
 const testPlugin: Plugin = (options) => {
 	return (root, result) => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Making the argument type more accurate. (avoiding `any`)
