### PR TITLE
Refactor requires of custom syntaxes in tests

### DIFF
--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
 const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
@@ -324,7 +323,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['number'],
 	fix: true,
 
@@ -359,7 +358,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['percentage'],
 	fix: true,
 

--- a/lib/rules/at-rule-allowed-list/__tests__/index.js
+++ b/lib/rules/at-rule-allowed-list/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -152,7 +150,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['keyframes'],
 	skipBasicChecks: true,
 

--- a/lib/rules/at-rule-disallowed-list/__tests__/index.js
+++ b/lib/rules/at-rule-disallowed-list/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -160,7 +158,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['keyframes'],
 
 	accept: [

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
 const stripIndent = require('common-tags').stripIndent;
 
 const mergeTestDescriptions = require('../../../testUtils/mergeTestDescriptions');
@@ -1285,7 +1284,7 @@ testRule(
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 
 	accept: [

--- a/lib/rules/at-rule-name-case/__tests__/index.js
+++ b/lib/rules/at-rule-name-case/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -276,7 +274,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['lower'],
 	skipBasicChecks: true,
 

--- a/lib/rules/at-rule-name-newline-after/__tests__/index.js
+++ b/lib/rules/at-rule-name-newline-after/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -187,7 +184,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 	skipBasicChecks: true,
 
@@ -228,7 +225,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['always'],
 	skipBasicChecks: true,
 

--- a/lib/rules/at-rule-name-space-after/__tests__/index.js
+++ b/lib/rules/at-rule-name-space-after/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -215,7 +212,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 
 	accept: [
@@ -255,7 +252,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['always'],
 
 	accept: [

--- a/lib/rules/at-rule-no-unknown/__tests__/index.js
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -180,7 +178,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: [true],
 
 	accept: [

--- a/lib/rules/at-rule-semicolon-newline-after/__tests__/index.js
+++ b/lib/rules/at-rule-semicolon-newline-after/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -129,7 +127,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 	accept: [
 		{

--- a/lib/rules/at-rule-semicolon-space-before/__tests__/index.js
+++ b/lib/rules/at-rule-semicolon-space-before/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -151,7 +149,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 	skipBasicChecks: true,
 

--- a/lib/rules/block-no-empty/__tests__/index.js
+++ b/lib/rules/block-no-empty/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-const sugarss = require('sugarss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -179,7 +176,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: sugarss,
+	customSyntax: 'sugarss',
 
 	reject: [
 		{
@@ -201,7 +198,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -225,7 +222,7 @@ testRule({
 		},
 	],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/color-function-notation/__tests__/index.js
+++ b/lib/rules/color-function-notation/__tests__/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
 const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
@@ -371,7 +370,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['modern'],
 	fix: true,
 
@@ -422,7 +421,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['legacy'],
 
 	accept: [

--- a/lib/rules/color-hex-alpha/__tests__/index.js
+++ b/lib/rules/color-hex-alpha/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -68,7 +66,7 @@ testRule({
 testRule({
 	ruleName,
 	config: 'always',
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -169,7 +169,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['lower'],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 	accept: [
 		{
@@ -259,7 +259,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['upper'],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 	accept: [
 		{

--- a/lib/rules/color-hex-length/__tests__/index.js
+++ b/lib/rules/color-hex-length/__tests__/index.js
@@ -191,7 +191,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['short'],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [
@@ -288,7 +288,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['long'],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [

--- a/lib/rules/color-no-hex/__tests__/index.js
+++ b/lib/rules/color-no-hex/__tests__/index.js
@@ -99,7 +99,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/color-no-invalid-hex/__tests__/index.js
+++ b/lib/rules/color-no-invalid-hex/__tests__/index.js
@@ -115,7 +115,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-const sugarss = require('sugarss');
-
 const mergeTestDescriptions = require('../../../testUtils/mergeTestDescriptions');
 const { messages, ruleName } = require('..');
 
@@ -267,7 +263,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -285,7 +281,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: sugarss,
+	customSyntax: 'sugarss',
 	skipBasicChecks: true,
 	fix: true,
 
@@ -300,7 +296,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [
@@ -318,7 +314,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [

--- a/lib/rules/comment-no-empty/__tests__/index.js
+++ b/lib/rules/comment-no-empty/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -62,7 +60,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/comment-pattern/__tests__/index.js
+++ b/lib/rules/comment-pattern/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -71,7 +69,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [/foo-.+/],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/comment-whitespace-inside/__tests__/index.js
+++ b/lib/rules/comment-whitespace-inside/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -240,7 +237,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -254,7 +251,7 @@ testRule({
 	ruleName,
 	config: ['never'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -268,7 +265,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -282,7 +279,7 @@ testRule({
 	ruleName,
 	config: ['never'],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/comment-word-disallowed-list/__tests__/index.js
+++ b/lib/rules/comment-word-disallowed-list/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -221,7 +218,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [['/^TODO:/', 'bad-word']],
 
 	accept: [
@@ -266,7 +263,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['/^TODO:/', 'bad-word'],
 
 	accept: [

--- a/lib/rules/declaration-bang-space-before/__tests__/index.js
+++ b/lib/rules/declaration-bang-space-before/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssSass = require('postcss-sass');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -199,7 +197,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssSass,
+	customSyntax: 'postcss-sass',
 	skipBasicChecks: true,
 	fix: true,
 
@@ -217,7 +215,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: postcssSass,
+	customSyntax: 'postcss-sass',
 	skipBasicChecks: true,
 	fix: true,
 

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -84,7 +82,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	accept: [
 		{
@@ -129,7 +127,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -270,7 +268,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	accept: [
 		{
@@ -308,7 +306,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -113,7 +111,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	accept: [
 		{
@@ -143,7 +141,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -91,7 +89,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	accept: [
 		{
@@ -124,7 +122,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-single-line-max-declarations/__tests__/index.js
+++ b/lib/rules/declaration-block-single-line-max-declarations/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -91,7 +89,7 @@ testRule({
 	ruleName,
 	config: [2],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -155,7 +153,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -192,7 +190,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -230,7 +228,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['always'],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [

--- a/lib/rules/declaration-empty-line-before/__tests__/index.js
+++ b/lib/rules/declaration-empty-line-before/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
 const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
@@ -105,7 +102,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -155,7 +152,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [
@@ -551,7 +548,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always', { except: ['after-declaration'] }],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -592,7 +589,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always', { except: ['after-declaration'] }],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [
@@ -904,7 +901,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 	accept: [
 		{
@@ -961,7 +958,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always', { ignore: ['inside-single-line-block'] }],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [

--- a/lib/rules/font-weight-notation/__tests__/index.js
+++ b/lib/rules/font-weight-notation/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -370,7 +368,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['numeric'],
 
 	accept: [

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -479,7 +477,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	reject: [

--- a/lib/rules/function-comma-newline-after/__tests__/index.js
+++ b/lib/rules/function-comma-newline-after/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -136,7 +134,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -297,7 +295,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always-multi-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -415,7 +413,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never-multi-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/function-comma-newline-before/__tests__/index.js
+++ b/lib/rules/function-comma-newline-before/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -109,7 +107,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -214,7 +212,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always-multi-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -311,7 +309,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never-multi-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/function-comma-space-after/__tests__/index.js
+++ b/lib/rules/function-comma-space-after/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -153,7 +151,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -304,7 +302,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -389,7 +387,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always-single-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -471,7 +469,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never-single-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/function-comma-space-before/__tests__/index.js
+++ b/lib/rules/function-comma-space-before/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -110,7 +108,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -221,7 +219,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -304,7 +302,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always-single-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -377,7 +375,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never-single-line'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -250,7 +248,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/function-url-no-scheme-relative/__tests__/index.js
+++ b/lib/rules/function-url-no-scheme-relative/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -121,7 +119,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	reject: [
 		{
@@ -143,7 +141,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -617,7 +615,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	reject: [
 		{
@@ -639,7 +637,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: ['always'],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/function-whitespace-after/__tests__/index.js
+++ b/lib/rules/function-whitespace-after/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -277,7 +274,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -302,7 +299,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	reject: [
 		{
@@ -321,7 +318,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [
@@ -348,7 +345,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [

--- a/lib/rules/hue-degree-notation/__tests__/index.js
+++ b/lib/rules/hue-degree-notation/__tests__/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
 const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
@@ -200,7 +199,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['angle'],
 	fix: true,
 
@@ -226,7 +225,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['number'],
 	fix: true,
 

--- a/lib/rules/indentation/__tests__/functions.js
+++ b/lib/rules/indentation/__tests__/functions.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -757,7 +755,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [2],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	skipBasicChecks: true,
 	// fix: true,
 

--- a/lib/rules/indentation/__tests__/html.js
+++ b/lib/rules/indentation/__tests__/html.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
 	ruleName,
 	config: ['tab'],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [
@@ -194,7 +192,7 @@ a {
 testRule({
 	ruleName,
 	config: [2],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [
@@ -249,7 +247,7 @@ testRule({
 			baseIndentLevel: 1,
 		},
 	],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [
@@ -394,7 +392,7 @@ testRule({
 			baseIndentLevel: 0,
 		},
 	],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [
@@ -489,7 +487,7 @@ testRule({
 			baseIndentLevel: 1,
 		},
 	],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [

--- a/lib/rules/indentation/__tests__/javascript.js
+++ b/lib/rules/indentation/__tests__/javascript.js
@@ -6,7 +6,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [2],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [
@@ -139,7 +139,7 @@ testRule({
 			baseIndentLevel: 1,
 		},
 	],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [
@@ -201,7 +201,7 @@ testRule({
 			baseIndentLevel: 0,
 		},
 	],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [

--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -632,7 +629,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	reject: [
 		{
@@ -661,7 +658,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	accept: [
 		{
 			code: '@variable: 0px;',

--- a/lib/rules/max-empty-lines/__tests__/index.js
+++ b/lib/rules/max-empty-lines/__tests__/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const postcssScss = require('postcss-scss');
-const sugarss = require('sugarss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -155,7 +151,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [1],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [
@@ -273,7 +269,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [1],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	fix: true,
 
 	accept: [
@@ -450,7 +446,7 @@ testRule({
 	ruleName,
 	config: [2],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -494,7 +490,7 @@ testRule({
 	ruleName,
 	config: [2],
 	skipBasicChecks: true,
-	customSyntax: sugarss,
+	customSyntax: 'sugarss',
 	fix: true,
 
 	accept: [

--- a/lib/rules/max-line-length/__tests__/index.js
+++ b/lib/rules/max-line-length/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 const testUrl = 'somethingsomething something\tsomething';
@@ -230,7 +227,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [20],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	accept: [
 		{
@@ -282,7 +279,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [20],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{
@@ -314,7 +311,7 @@ export default styled.div\`
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [20],
 
 	reject: [

--- a/lib/rules/max-nesting-depth/__tests__/index.js
+++ b/lib/rules/max-nesting-depth/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -255,7 +253,7 @@ testRule({
 	ruleName,
 	config: [1],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/media-feature-name-allowed-list/__tests__/index.js
+++ b/lib/rules/media-feature-name-allowed-list/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -134,7 +131,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['max-width', 'orientation'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -149,7 +146,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['max-width'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/media-feature-name-case/__tests__/index.js
+++ b/lib/rules/media-feature-name-case/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -172,7 +169,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['lower'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [
@@ -228,7 +225,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['lower'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -443,7 +440,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['upper'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [
@@ -499,7 +496,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['upper'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [

--- a/lib/rules/media-feature-name-disallowed-list/__tests__/index.js
+++ b/lib/rules/media-feature-name-disallowed-list/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -141,7 +138,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['feature-name'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -156,7 +153,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['feature-name', 'width'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/media-feature-name-no-unknown/__tests__/index.js
+++ b/lib/rules/media-feature-name-no-unknown/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -113,7 +110,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -140,7 +137,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/media-query-list-comma-newline-after/__tests__/index.js
+++ b/lib/rules/media-query-list-comma-newline-after/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -426,7 +423,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['always'],
 
 	accept: [
@@ -444,7 +441,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 
 	accept: [

--- a/lib/rules/no-descending-specificity/__tests__/index.js
+++ b/lib/rules/no-descending-specificity/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-const postcssLess = require('postcss-less');
 const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
@@ -164,7 +162,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [true],
 
 	accept: [
@@ -176,7 +174,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: [true],
 
 	accept: [
@@ -193,7 +191,7 @@ testRule({
 testRule({
 	skip: true,
 	ruleName,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	config: [true],
 
 	accept: [

--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -276,7 +276,7 @@ it('with postcss-import and duplicates across files, no warnings', () => {
 testRule({
 	skip: true,
 	ruleName,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	config: [true],
 
 	accept: [

--- a/lib/rules/no-empty-source/__tests__/index.js
+++ b/lib/rules/no-empty-source/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -97,7 +95,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	skipBasicChecks: true,
 
 	accept: [

--- a/lib/rules/no-eol-whitespace/__tests__/index.js
+++ b/lib/rules/no-eol-whitespace/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -517,7 +514,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -576,12 +573,12 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [
 		{
-			code: `<div> /* After this comment we have eol whitespace */ 
+			code: `<div> /* After this comment we have eol whitespace */
 <style>
 a {
   color: red;
@@ -594,24 +591,10 @@ a {
 
 	reject: [
 		{
-			code: `<div>
-<style>
-a {
-  color: red; 
-}
-</style>
-
-</div>`,
-			fixed: `<div>
-<style>
-a {
-  color: red;
-}
-</style>
-
-</div>`,
+			code: '<style>\na {\n  color: red; \n}\n</style>',
+			fixed: '<style>\na {\n  color: red;\n}\n</style>',
 			message: messages.rejected,
-			line: 4,
+			line: 3,
 			column: 14,
 		},
 	],
@@ -665,7 +648,7 @@ testRule({
 testRule({
 	skip: true,
 	ruleName,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 	config: [true],
 
 	accept: [

--- a/lib/rules/no-extra-semicolons/__tests__/index.js
+++ b/lib/rules/no-extra-semicolons/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -952,7 +949,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	fix: true,
 
 	accept: [
@@ -1008,7 +1005,7 @@ a {
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [

--- a/lib/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -67,7 +64,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -81,7 +78,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -95,7 +92,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -109,7 +106,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/no-invalid-position-at-import-rule/__tests__/index.js
+++ b/lib/rules/no-invalid-position-at-import-rule/__tests__/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
 const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
@@ -169,7 +168,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const sugarss = require('sugarss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -75,7 +72,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 
 	accept: [
 		{
@@ -113,7 +110,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{
@@ -131,7 +128,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: sugarss,
+	customSyntax: 'sugarss',
 	fix: true,
 
 	accept: [

--- a/lib/rules/property-case/__tests__/index.js
+++ b/lib/rules/property-case/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -175,7 +172,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['lower'],
 	fix: true,
 
@@ -299,7 +296,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['lower'],
 	fix: true,
 
@@ -579,7 +576,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['upper'],
 	fix: true,
 
@@ -703,7 +700,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['upper'],
 	fix: true,
 

--- a/lib/rules/property-no-unknown/__tests__/index.js
+++ b/lib/rules/property-no-unknown/__tests__/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -80,7 +76,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [true],
 
 	accept: [
@@ -105,7 +101,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: [true],
 
 	accept: [
@@ -282,7 +278,7 @@ testRule({
 	skip: true,
 	ruleName,
 	config: [true],
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{
@@ -342,7 +338,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	accept: [
 		{
 			code: '<a style="{{rule}}: 1">',

--- a/lib/rules/rule-empty-line-before/__tests__/index.js
+++ b/lib/rules/rule-empty-line-before/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -800,7 +798,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 	fix: true,
 

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -275,7 +272,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -293,7 +290,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -311,7 +308,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['always'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -329,7 +326,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['never'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-class-pattern/__tests__/index.js
+++ b/lib/rules/selector-class-pattern/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 const basicAZTestsAccept = {
@@ -189,7 +186,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [/^[A-Z]+$/, { resolveNestedSelectors: true }],
 
 	accept: [
@@ -214,7 +211,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: [/^[A-Z]+$/],
 
 	accept: [

--- a/lib/rules/selector-combinator-space-after/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-after/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -525,7 +522,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 	fix: true,
 
@@ -548,7 +545,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['always'],
 	fix: true,
 
@@ -566,7 +563,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['never'],
 	fix: true,
 

--- a/lib/rules/selector-combinator-space-before/__tests__/index.js
+++ b/lib/rules/selector-combinator-space-before/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -435,7 +432,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['always'],
 	fix: true,
 
@@ -458,7 +455,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['always'],
 	fix: true,
 
@@ -491,7 +488,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['never'],
 	fix: true,
 

--- a/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -156,7 +153,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -168,7 +165,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-id-pattern/__tests__/index.js
+++ b/lib/rules/selector-id-pattern/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 const basicAZTests = {
@@ -89,7 +87,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [/^[A-Z]+$/],
 
 	accept: [

--- a/lib/rules/selector-list-comma-newline-after/__tests__/index.js
+++ b/lib/rules/selector-list-comma-newline-after/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -346,7 +343,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -377,7 +374,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [

--- a/lib/rules/selector-list-comma-space-after/__tests__/index.js
+++ b/lib/rules/selector-list-comma-space-after/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -384,7 +382,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-attribute/__tests__/index.js
+++ b/lib/rules/selector-max-attribute/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 // Sanity checks
@@ -229,7 +227,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [0],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-class/__tests__/index.js
+++ b/lib/rules/selector-max-class/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 // Sanity checks
@@ -153,7 +150,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [0],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -188,7 +185,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [0],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-combinators/__tests__/index.js
+++ b/lib/rules/selector-max-combinators/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 // Sanity checks
@@ -200,7 +197,7 @@ testRule({
 	ruleName,
 	config: [0],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -304,7 +301,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-compound-selectors/__tests__/index.js
+++ b/lib/rules/selector-max-compound-selectors/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 // Testing plain selectors, different combinators
@@ -278,7 +275,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [1],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -337,7 +334,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [1],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-id/__tests__/index.js
+++ b/lib/rules/selector-max-id/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 // Sanity checks
@@ -263,7 +260,7 @@ testRule({
 	ruleName,
 	config: [0],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -385,7 +382,7 @@ testRule({
 	ruleName,
 	config: [0],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -419,7 +416,7 @@ testRule({
 	ruleName,
 	config: [2],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-pseudo-class/__tests__/index.js
+++ b/lib/rules/selector-max-pseudo-class/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -66,7 +64,7 @@ testRule({
 	ruleName,
 	config: [0],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [],
 
@@ -180,7 +178,7 @@ testRule({
 	ruleName,
 	config: [1],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [],
 

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -267,7 +264,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['0,1,1'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -335,7 +332,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['0,3,0'],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -347,7 +344,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['0,1,1'],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-type/__tests__/index.js
+++ b/lib/rules/selector-max-type/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 // Sanity checks
@@ -522,7 +519,7 @@ testRule({
 	ruleName,
 	config: [0],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -599,7 +596,7 @@ testRule({
 	ruleName,
 	config: [0],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-max-universal/__tests__/index.js
+++ b/lib/rules/selector-max-universal/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 // Sanity checks
@@ -204,7 +202,7 @@ testRule({
 	ruleName,
 	config: [0],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	reject: [
 		{

--- a/lib/rules/selector-nested-pattern/__tests__/index.js
+++ b/lib/rules/selector-nested-pattern/__tests__/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
 const stripIndent = require('common-tags').stripIndent;
 
 const { messages, ruleName } = require('..');
@@ -147,7 +146,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [/^[A-Z]+$/],
 
 	accept: [

--- a/lib/rules/selector-no-qualifying-type/__tests__/index.js
+++ b/lib/rules/selector-no-qualifying-type/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -2044,7 +2041,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: [true],
 
 	accept: [
@@ -2140,7 +2137,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [true],
 
 	accept: [

--- a/lib/rules/selector-pseudo-class-allowed-list/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-allowed-list/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -159,7 +157,7 @@ testRule({
 	ruleName,
 	config: ['hover'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-class-case/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-case/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -637,7 +635,7 @@ testRule({
 	ruleName,
 	config: ['lower'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -907,7 +905,7 @@ testRule({
 	ruleName,
 	config: ['upper'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-class-disallowed-list/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-disallowed-list/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -210,7 +208,7 @@ testRule({
 	ruleName,
 	config: ['variable'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -220,7 +217,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -242,7 +239,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-element-allowed-list/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-allowed-list/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -103,7 +101,7 @@ testRule({
 	ruleName,
 	config: ['before'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-element-case/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-case/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -291,7 +289,7 @@ testRule({
 	ruleName,
 	config: ['lower'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -580,7 +578,7 @@ testRule({
 	ruleName,
 	config: ['upper'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-element-disallowed-list/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-disallowed-list/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -89,7 +87,7 @@ testRule({
 	ruleName,
 	config: ['before'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -161,7 +159,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{

--- a/lib/rules/selector-type-case/__tests__/index.js
+++ b/lib/rules/selector-type-case/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -287,7 +285,7 @@ testRule({
 	ruleName,
 	config: ['upper'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [

--- a/lib/rules/selector-type-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -218,7 +215,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 
 	accept: [
 		{
@@ -238,7 +235,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 
 	accept: [
 		{
@@ -453,7 +450,7 @@ testRule({
 	ruleName,
 	config: [true],
 	skipBasicChecks: true,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -363,7 +360,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 	accept: [
 		{
@@ -384,7 +381,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 	accept: [
 		{

--- a/lib/rules/string-no-newline/__tests__/index.js
+++ b/lib/rules/string-no-newline/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -74,7 +71,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	skipBasicChecks: true,
 
 	accept: [
@@ -87,7 +84,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	skipBasicChecks: true,
 
 	accept: [

--- a/lib/rules/string-quotes/__tests__/index.js
+++ b/lib/rules/string-quotes/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -256,7 +253,7 @@ testRule({
 	ruleName,
 	config: ['double'],
 	skipBasicChecks: true,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 	accept: [
 		{
@@ -293,7 +290,7 @@ testRule({
 	ruleName,
 	config: ['double'],
 	skipBasicChecks: true,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 	accept: [
 		{

--- a/lib/rules/unicode-bom/__tests__/index.js
+++ b/lib/rules/unicode-bom/__tests__/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const postcssHtml = require('postcss-html')();
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -66,7 +64,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	config: ['always'],
 	skipBasicChecks: true,
 
@@ -92,7 +90,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssHtml,
+	customSyntax: 'postcss-html',
 	config: ['never'],
 	skipBasicChecks: true,
 
@@ -121,7 +119,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	skipBasicChecks: true,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{
@@ -140,7 +138,7 @@ testRule({
 	ruleName,
 	config: ['never'],
 	skipBasicChecks: true,
-	syntax: 'css-in-js',
+	customSyntax: 'postcss-css-in-js',
 
 	accept: [
 		{

--- a/lib/rules/unit-case/__tests__/index.js
+++ b/lib/rules/unit-case/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -291,7 +288,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['lower'],
 	fix: true,
 
@@ -389,7 +386,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['lower'],
 	fix: true,
 
@@ -621,7 +618,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['upper'],
 	fix: true,
 
@@ -719,7 +716,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['upper'],
 	fix: true,
 

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -425,7 +422,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: [true],
 
 	accept: [
@@ -467,7 +464,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: [true],
 
 	accept: [

--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -683,7 +680,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['lower'],
 	fix: true,
 
@@ -857,7 +854,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['lower'],
 	fix: true,
 
@@ -1641,7 +1638,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['upper'],
 	fix: true,
 
@@ -1811,7 +1808,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	config: ['upper'],
 	fix: true,
 
@@ -2158,7 +2155,7 @@ testRule({
 
 testRule({
 	ruleName,
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	config: ['lower', { ignoreProperties: ['$fontFamily'] }],
 	fix: true,
 

--- a/lib/rules/value-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/value-no-vendor-prefix/__tests__/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const postcssLess = require('postcss-less');
-const postcssScss = require('postcss-scss');
-
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -104,7 +101,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssScss,
+	customSyntax: 'postcss-scss',
 	fix: true,
 
 	accept: [
@@ -126,7 +123,7 @@ testRule({
 testRule({
 	ruleName,
 	config: [true],
-	customSyntax: postcssLess,
+	customSyntax: 'postcss-less',
 	fix: true,
 
 	accept: [


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

I figured we'd get this in while we've no conflicting pull requests.

In our tests, we sometimes require a custom syntax and in other times we use a string. This pull request uses strings consistently as they allow us to add self-contained `testRule`s for custom syntaxes.
