### PR TITLE
Document new pre-commit integration

### DIFF
--- a/docs/user-guide/integrations/other.md
+++ b/docs/user-guide/integrations/other.md
@@ -11,7 +11,7 @@ Other integrations built and maintained by the community.
 
 ## Version Control
 
-- [Pre-commit](https://github.com/awebdeveloper/pre-commit-stylelint) - Git pre-commit hook for Stylelint
+- [pre-commit-stylelint](https://github.com/thibaudcolas/pre-commit-stylelint) - Mirrors all releases for the [pre-commit](https://pre-commit.com/) hooks framework
 
 ## Command Line Tools
 


### PR DESCRIPTION
Closes #5373. The integration should be working the same as before, the only difference is in how it’s installed. I’ve also spent more time to document common customisations in the README.

For people wanting to switch to this, here are [migration instructions](https://github.com/thibaudcolas/pre-commit-stylelint#migrating-from-awebdeveloperpre-commit-stylelint).