### PR TITLE
Refactor to replace `matchesStringOrRegExp` with `optionsMatches`

### DIFF
--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -4,7 +4,7 @@ const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const keywordSets = require('../../reference/keywordSets');
-const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
+const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
@@ -63,9 +63,7 @@ const rule = (primary, secondaryOptions, context) => {
 				const functionName = node.value;
 				const functionNameLowerCase = functionName.toLowerCase();
 
-				const ignoreFunctions = (secondaryOptions && secondaryOptions.ignoreFunctions) || [];
-
-				if (ignoreFunctions.length > 0 && matchesStringOrRegExp(functionName, ignoreFunctions)) {
+				if (optionsMatches(secondaryOptions, 'ignoreFunctions', functionName)) {
 					return;
 				}
 

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -7,7 +7,7 @@ const isCounterIncrementCustomIdentValue = require('../../utils/isCounterIncreme
 const isCounterResetCustomIdentValue = require('../../utils/isCounterResetCustomIdentValue');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const keywordSets = require('../../reference/keywordSets');
-const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
+const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -92,12 +92,9 @@ const rule = (primary, secondaryOptions, context) => {
 
 				// ignore keywords within ignoreFunctions functions
 
-				const ignoreFunctions = (secondaryOptions && secondaryOptions.ignoreFunctions) || [];
-
 				if (
 					node.type === 'function' &&
-					ignoreFunctions.length > 0 &&
-					matchesStringOrRegExp(valueLowerCase, ignoreFunctions)
+					optionsMatches(secondaryOptions, 'ignoreFunctions', valueLowerCase)
 				) {
 					return false;
 				}
@@ -186,14 +183,11 @@ const rule = (primary, secondaryOptions, context) => {
 					return;
 				}
 
-				const ignoreKeywords = (secondaryOptions && secondaryOptions.ignoreKeywords) || [];
-				const ignoreProperties = (secondaryOptions && secondaryOptions.ignoreProperties) || [];
-
-				if (ignoreKeywords.length > 0 && matchesStringOrRegExp(keyword, ignoreKeywords)) {
+				if (optionsMatches(secondaryOptions, 'ignoreKeywords', keyword)) {
 					return;
 				}
 
-				if (ignoreProperties.length > 0 && matchesStringOrRegExp(prop, ignoreProperties)) {
+				if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) {
 					return;
 				}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, just a small refactoring.

> Is there anything in the PR that needs further explanation?

`optionsMatches` makes the code simpler in some cases.
