### PR TITLE
Fix importing `css-functions-list` for `function-no-unknown` rule

### DIFF
--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const fs = require('fs');
-const { URL } = require('url');
 const valueParser = require('postcss-value-parser');
-const functionsListPath = require('css-functions-list');
+
+// TODO: Importing just `css-functions-list` can cause a problem in a certain environment. See #5904.
+const functionsList = require('css-functions-list/cjs/index.json');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -43,9 +43,6 @@ const rule = (primary, secondaryOptions) => {
 		if (!validOptions) {
 			return;
 		}
-
-		const path = new URL(functionsListPath.toString(), 'file://');
-		const functionsList = JSON.parse(fs.readFileSync(path, 'utf8'));
 
 		root.walkDecls((decl) => {
 			const { value } = decl;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5904 (probably)

> Is there anything in the PR that needs further explanation?

This PR is a kind of hack. Usually, importing a package internally is not recommended.
Also, this hack may become a problem when we will migrate to ESM.
