### PR TITLE
Fix false positives for interpolation in `function-no-unknown`

### DIFF
--- a/lib/rules/function-no-unknown/__tests__/index.js
+++ b/lib/rules/function-no-unknown/__tests__/index.js
@@ -54,6 +54,9 @@ testRule({
 		{
 			code: 'a { $list: (list) }',
 		},
+		{
+			code: 'a { --primary-color: #{theme(1px)}; }',
+		},
 	],
 });
 

--- a/lib/utils/__tests__/isStandardSyntaxFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxFunction.test.js
@@ -20,6 +20,12 @@ describe('isStandardSyntaxFunction', () => {
 	it('scss map', () => {
 		expect(isStandardSyntaxFunction(func('a { $map: (key: value) }'))).toBe(false);
 	});
+
+	it('scss function in custom prop', () => {
+		expect(isStandardSyntaxFunction(func('a { --primary-color: #{darken(#fff, 0.2)} }'))).toBe(
+			false,
+		);
+	});
 });
 
 function func(css) {

--- a/lib/utils/isStandardSyntaxFunction.js
+++ b/lib/utils/isStandardSyntaxFunction.js
@@ -12,5 +12,9 @@ module.exports = function (node) {
 		return false;
 	}
 
+	if (node.value.startsWith('#{')) {
+		return false;
+	}
+
 	return true;
 };


### PR DESCRIPTION
This PR tweaks `function-no-unknown` so that `ignoreFunctions` are also supported in the custom properties syntax (e.g. `--primary-color: #{custom-mixin(#fff)};`

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes https://github.com/stylelint/stylelint/issues/5913

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
