### PR TITLE
Fix ENOENT and TypeErrors in `function-no-unknown`

### DIFF
--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs');
-const { URL } = require('url');
 const valueParser = require('postcss-value-parser');
 const functionsListPath = require('css-functions-list');
 
@@ -44,8 +43,7 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		const path = new URL(functionsListPath.toString(), 'file://');
-		const functionsList = JSON.parse(fs.readFileSync(path, 'utf8'));
+		const functionsList = JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "balanced-match": "^2.0.0",
         "colord": "^2.9.2",
         "cosmiconfig": "^7.0.1",
-        "css-functions-list": "^3.0.0",
+        "css-functions-list": "^3.0.1",
         "debug": "^4.3.3",
         "execall": "^2.0.0",
         "fast-glob": "^3.2.11",
@@ -2704,9 +2704,9 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.0.tgz",
-      "integrity": "sha512-rfwhBOvXVFcKrSwmLxD8JQyuEEy/3g3Y9FMI2l6iV558Coeo1ucXypXb4rwrVpk5Osh5ViXp2DTgafw8WxglhQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+      "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
       "engines": {
         "node": ">=12.22"
       }
@@ -15192,9 +15192,9 @@
       "dev": true
     },
     "css-functions-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.0.tgz",
-      "integrity": "sha512-rfwhBOvXVFcKrSwmLxD8JQyuEEy/3g3Y9FMI2l6iV558Coeo1ucXypXb4rwrVpk5Osh5ViXp2DTgafw8WxglhQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
+      "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw=="
     },
     "cssesc": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "balanced-match": "^2.0.0",
     "colord": "^2.9.2",
     "cosmiconfig": "^7.0.1",
-    "css-functions-list": "^3.0.0",
+    "css-functions-list": "^3.0.1",
     "debug": "^4.3.3",
     "execall": "^2.0.0",
     "fast-glob": "^3.2.11",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- Closes #5904
- Closes #5918

> Is there anything in the PR that needs further explanation?

This change bumps `css-functions-list` from 3.0.0 to 3.0.1.
See https://github.com/niksy/css-functions-list/releases/tag/v3.0.1

```shell
npm i css-functions-list
```

`css-functions-list@3.0.1` improves handling paths on Windows. So, it's no longer necessary to use `URL` in our code.