### PR TITLE
Refactor to add type-guard of `isPlainObject()`

### DIFF
--- a/lib/normalizeRuleSettings.js
+++ b/lib/normalizeRuleSettings.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const rules = require('./rules');
-const { isPlainObject } = require('is-plain-object');
+const { isPlainObject } = require('./utils/validateTypes');
 
 // Rule settings can take a number of forms, e.g.
 // a. "rule-name": null

--- a/lib/rules/at-rule-property-required-list/index.js
+++ b/lib/rules/at-rule-property-required-list/index.js
@@ -4,7 +4,7 @@ const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isPlainObject } = require('is-plain-object');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'at-rule-property-required-list';
 
@@ -16,7 +16,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/at-rule-property-required-list',
 };
 
-/** @type {import('stylelint').Rule} */
+/** @type {import('stylelint').Rule<Record<string, string[]>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -28,9 +28,6 @@ const rule = (primary) => {
 			return;
 		}
 
-		/** @type {Record<string, string[]>} */
-		const list = primary;
-
 		root.walkAtRules((atRule) => {
 			if (!isStandardSyntaxAtRule(atRule)) {
 				return;
@@ -39,11 +36,11 @@ const rule = (primary) => {
 			const { name, nodes } = atRule;
 			const atRuleName = name.toLowerCase();
 
-			if (!list[atRuleName]) {
+			if (!primary[atRuleName]) {
 				return;
 			}
 
-			for (const property of list[atRuleName]) {
+			for (const property of primary[atRuleName]) {
 				const propertyName = property.toLowerCase();
 
 				const hasProperty = nodes.find(

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const valueParser = require('postcss-value-parser');
+
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
@@ -7,9 +9,8 @@ const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const valueParser = require('postcss-value-parser');
+const { isPlainObject } = require('../../utils/validateTypes');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-unit-allowed-list';
 

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -1,14 +1,15 @@
 'use strict';
 
+const valueParser = require('postcss-value-parser');
+
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const valueParser = require('postcss-value-parser');
+const { isPlainObject } = require('../../utils/validateTypes');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-unit-disallowed-list';
 

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -4,8 +4,8 @@ const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isPlainObject } = require('../../utils/validateTypes');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-value-allowed-list';
 

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -4,8 +4,8 @@ const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isPlainObject } = require('../../utils/validateTypes');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'declaration-property-value-disallowed-list';
 

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -1,15 +1,16 @@
 'use strict';
 
+const mediaParser = require('postcss-media-query-parser').default;
+
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
-const mediaParser = require('postcss-media-query-parser').default;
 const rangeContextNodeParser = require('../rangeContextNodeParser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const { isPlainObject } = require('../../utils/validateTypes');
 const vendor = require('../../utils/vendor');
-const { isPlainObject } = require('is-plain-object');
 
 const ruleName = 'media-feature-name-value-allowed-list';
 
@@ -21,7 +22,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-value-allowed-list',
 };
 
-/** @type {import('stylelint').Rule} */
+/** @type {import('stylelint').Rule<Record<string, Array<string | RegExp>>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -5,7 +5,7 @@ const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isPlainObject } = require('is-plain-object');
+const { isPlainObject } = require('../../utils/validateTypes');
 
 const ruleName = 'rule-selector-property-disallowed-list';
 
@@ -17,7 +17,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/rule-selector-property-disallowed-list',
 };
 
-/** @type {import('stylelint').Rule} */
+/** @type {import('stylelint').Rule<Record<string, Array<string | RegExp>>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {

--- a/lib/utils/validateObjectWithArrayProps.js
+++ b/lib/utils/validateObjectWithArrayProps.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isPlainObject } = require('is-plain-object');
+const { isPlainObject } = require('./validateTypes');
 
 /**
  * @template T
@@ -24,7 +24,7 @@ module.exports = (validator) => (value) => {
 		return false;
 	}
 
-	return Object.values(/** @type {Record<string, unknown>} */ (value)).every((array) => {
+	return Object.values(value).every((array) => {
 		if (!Array.isArray(array)) {
 			return false;
 		}

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const arrayEqual = require('./arrayEqual');
-const { isPlainObject } = require('is-plain-object');
+const { isPlainObject } = require('./validateTypes');
 
 const IGNORED_OPTIONS = new Set(['severity', 'message', 'reportDisables', 'disableFix']);
 

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isPlainObject: _isPlainObject } = require('is-plain-object');
+
 /**
  * Checks if the value is a boolean or a Boolean object.
  * @param {unknown} value
@@ -37,6 +39,15 @@ function isString(value) {
 }
 
 /**
+ * Checks if the value is a plain object.
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isPlainObject(value) {
+	return _isPlainObject(value);
+}
+
+/**
  * Assert that the value is truthy.
  * @param {unknown} value
  * @returns {asserts value}
@@ -71,6 +82,7 @@ module.exports = {
 	isNumber,
 	isRegExp,
 	isString,
+	isPlainObject,
 
 	assert,
 	assertNumber,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a refactoring.

> Is there anything in the PR that needs further explanation?

- Add a type-guard function `isPlainObject()` to our `validateTypes.js` module.
  - The new type-guard function uses internally the `is-plain-object` package.
- Use the new function via `validateTypes.js`, instead of directly using `is-plain-object`.
