### PR TITLE
Fix clarity of invalid option warning message for objects

### DIFF
--- a/lib/utils/__tests__/validateOptions.test.js
+++ b/lib/utils/__tests__/validateOptions.test.js
@@ -130,7 +130,7 @@ describe('validateOptions for secondary options objects', () => {
 		});
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
 		expect(result.warn.mock.calls[0][0]).toBe(
-			'Invalid option value 2 for rule "foo": should be an object',
+			'Invalid option value "2" for rule "foo": should be an object',
 		);
 	});
 
@@ -162,10 +162,12 @@ it('validateOptions for secondary options objects with subarrays', () => {
 
 	validateOptions(result, 'foo', {
 		possible: schema,
-		actual: { bar: ['one', 'three', 'floor'] },
+		actual: { bar: ['one', 'three', { floor: 1 }] },
 	});
 	expect(result.warn.mock.calls[0]).toHaveLength(2);
-	expect(result.warn.mock.calls[0][0]).toBe('Invalid value "floor" for option "bar" of rule "foo"');
+	expect(result.warn.mock.calls[0][0]).toBe(
+		'Invalid value "{"floor":1}" for option "bar" of rule "foo"',
+	);
 });
 
 describe('validateOptions for `*-no-*` rule with no valid options', () => {
@@ -186,7 +188,7 @@ describe('validateOptions for `*-no-*` rule with no valid options', () => {
 		expect(result.warn).toHaveBeenCalledTimes(0);
 	});
 
-	it('with options', () => {
+	it('with options (string)', () => {
 		validateOptions(result, 'no-dancing', {
 			actual: 'foo',
 		});
@@ -194,14 +196,25 @@ describe('validateOptions for `*-no-*` rule with no valid options', () => {
 		expect(result.warn.mock.calls[0][0]).toBe(
 			'Unexpected option value "foo" for rule "no-dancing"',
 		);
-		result.warn.mockClear();
+	});
 
+	it('with options (boolean)', () => {
 		validateOptions(result, 'no-dancing', {
 			actual: false,
 		});
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
 		expect(result.warn.mock.calls[0][0]).toBe(
 			'Unexpected option value "false" for rule "no-dancing"',
+		);
+	});
+
+	it('with options (object)', () => {
+		validateOptions(result, 'no-dancing', {
+			actual: { bar: 1 },
+		});
+		expect(result.warn.mock.calls[0]).toHaveLength(2);
+		expect(result.warn.mock.calls[0][0]).toBe(
+			'Unexpected option value "{"bar":1}" for rule "no-dancing"',
 		);
 	});
 });
@@ -234,14 +247,14 @@ it('validateOptions for multiple actual/possible pairs, checking return value', 
 		},
 		{
 			possible: ['three', 'four'],
-			actual: 'threee',
+			actual: { threee: 1 },
 		},
 	);
 
 	expect(invalidOptions).toBe(false);
 	expect(result.warn.mock.calls[0]).toHaveLength(2);
 	expect(result.warn.mock.calls[0][0]).toBe('Invalid option value "onne" for rule "foo"');
-	expect(result.warn.mock.calls[1][0]).toBe('Invalid option value "threee" for rule "foo"');
+	expect(result.warn.mock.calls[1][0]).toBe('Invalid option value "{"threee":1}" for rule "foo"');
 });
 
 describe("validateOptions with a function for 'possible'", () => {
@@ -311,7 +324,7 @@ describe("validateOptions with a function for 'possible'", () => {
 		expect(invalidObject).toBe(false);
 		expect(result.warn.mock.calls[0]).toHaveLength(2);
 		expect(result.warn.mock.calls[0][0]).toBe(
-			'Invalid option "{"properties":["one"]}" for rule foo',
+			'Invalid option "{"properties":["one"]}" for rule "foo"',
 		);
 	});
 });

--- a/lib/utils/validateOptions.js
+++ b/lib/utils/validateOptions.js
@@ -96,14 +96,14 @@ function validate(opts, ruleName, complain) {
 			return;
 		}
 
-		complain(`Unexpected option value "${String(actual)}" for rule "${ruleName}"`);
+		complain(`Unexpected option value ${stringify(actual)} for rule "${ruleName}"`);
 
 		return;
 	}
 
 	if (typeof possible === 'function') {
 		if (!possible(actual)) {
-			complain(`Invalid option "${JSON.stringify(actual)}" for rule ${ruleName}`);
+			complain(`Invalid option ${stringify(actual)} for rule "${ruleName}"`);
 		}
 
 		return;
@@ -116,7 +116,7 @@ function validate(opts, ruleName, complain) {
 				continue;
 			}
 
-			complain(`Invalid option value "${String(a)}" for rule "${ruleName}"`);
+			complain(`Invalid option value ${stringify(a)} for rule "${ruleName}"`);
 		}
 
 		return;
@@ -125,7 +125,7 @@ function validate(opts, ruleName, complain) {
 	// If actual is NOT an object ...
 	if (!isPlainObject(actual) || typeof actual !== 'object' || actual == null) {
 		complain(
-			`Invalid option value ${JSON.stringify(actual)} for rule "${ruleName}": should be an object`,
+			`Invalid option value ${stringify(actual)} for rule "${ruleName}": should be an object`,
 		);
 
 		return;
@@ -149,7 +149,7 @@ function validate(opts, ruleName, complain) {
 				continue;
 			}
 
-			complain(`Invalid value "${a}" for option "${optionName}" of rule "${ruleName}"`);
+			complain(`Invalid value ${stringify(a)} for option "${optionName}" of rule "${ruleName}"`);
 		}
 	}
 }
@@ -171,6 +171,18 @@ function isValid(possible, actual) {
 	}
 
 	return false;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function stringify(value) {
+	if (typeof value === 'string') {
+		return `"${value}"`;
+	}
+
+	return `"${JSON.stringify(value)}"`;
 }
 
 module.exports = /** @type {typeof import('stylelint').utils.validateOptions} */ (validateOptions);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

When an object is embedded into a message, it's not user-friendly. E.g.

```
Invalid option value "[object Object]" for rule "foo"
```
