### PR TITLE
Fix invalid option warnings for strings in `*-list` 

### DIFF
--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -11,7 +11,7 @@ Specify a list of required properties for an at-rule.
 
 ## Options
 
-`object`: `{ "at-rule-name": ["array", "of", "properties"] }`
+`object`: `{ "at-rule-name": ["array", "of", "properties"]|"property" }`
 
 Given:
 

--- a/lib/rules/at-rule-property-required-list/__tests__/index.js
+++ b/lib/rules/at-rule-property-required-list/__tests__/index.js
@@ -6,7 +6,7 @@ testRule({
 	ruleName,
 	config: {
 		'font-face': ['font-display', 'font-family'],
-		page: ['margin'],
+		page: 'margin',
 	},
 
 	accept: [

--- a/lib/rules/at-rule-property-required-list/index.js
+++ b/lib/rules/at-rule-property-required-list/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const flattenArray = require('../../utils/flattenArray');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -17,7 +18,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/at-rule-property-required-list',
 };
 
-/** @type {import('stylelint').Rule<Record<string, string[]>>} */
+/** @type {import('stylelint').Rule<Record<string, string | string[]>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -36,12 +37,13 @@ const rule = (primary) => {
 
 			const { name, nodes } = atRule;
 			const atRuleName = name.toLowerCase();
+			const propList = flattenArray(primary[atRuleName]);
 
-			if (!primary[atRuleName]) {
+			if (!propList) {
 				return;
 			}
 
-			for (const property of primary[atRuleName]) {
+			for (const property of propList) {
 				const propertyName = property.toLowerCase();
 
 				const hasProperty = nodes.find(

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -11,7 +11,7 @@ a { width: 100px; }
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "units"] }`
+`object`: `{ "unprefixed-property-name": ["array", "of", "units"]|"unit" }`
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
@@ -20,7 +20,7 @@ Given:
 ```json
 {
   "font-size": ["em", "px"],
-  "/^animation/": ["s"],
+  "/^animation/": "s",
   "line-height": []
 }
 ```

--- a/lib/rules/declaration-property-unit-allowed-list/__tests__/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/__tests__/index.js
@@ -8,7 +8,7 @@ testRule({
 	config: [
 		{
 			'font-size': ['px', 'em'],
-			margin: ['em'],
+			margin: 'em',
 			'background-position': ['%'],
 			animation: ['s'],
 			'line-height': [],

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -3,6 +3,7 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const flattenArray = require('../../utils/flattenArray');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const optionsMatches = require('../../utils/optionsMatches');
@@ -23,7 +24,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-unit-allowed-list',
 };
 
-/** @type {import('stylelint').Rule<Record<string, string[]>>} */
+/** @type {import('stylelint').Rule<Record<string, string | string[]>>} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -60,7 +61,7 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			const propList = primary[propKey];
+			const propList = flattenArray(primary[propKey]);
 
 			if (!propList) {
 				return;
@@ -84,7 +85,7 @@ const rule = (primary, secondaryOptions) => {
 
 				const unit = getUnitFromValueNode(node);
 
-				if (!unit || (unit && propList.indexOf(unit.toLowerCase())) !== -1) {
+				if (!unit || (unit && propList.includes(unit.toLowerCase()))) {
 					return;
 				}
 

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -11,7 +11,7 @@ a { width: 100px; }
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "units"] }`
+`object`: `{ "unprefixed-property-name": ["array", "of", "units"]|"unit" }`
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
@@ -20,7 +20,7 @@ Given:
 ```json
 {
   "font-size": ["em", "px"],
-  "/^animation/": ["s"]
+  "/^animation/": "s"
 }
 ```
 

--- a/lib/rules/declaration-property-unit-disallowed-list/__tests__/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/__tests__/index.js
@@ -8,7 +8,7 @@ testRule({
 	config: [
 		{
 			'font-size': ['px', 'em'],
-			margin: ['em'],
+			margin: 'em',
 			'background-position': ['%'],
 			animation: ['s'],
 		},

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -3,6 +3,7 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const flattenArray = require('../../utils/flattenArray');
 const getUnitFromValueNode = require('../../utils/getUnitFromValueNode');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
@@ -22,7 +23,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-unit-disallowed-list',
 };
 
-/** @type {import('stylelint').Rule<Record<string, string[]>>} */
+/** @type {import('stylelint').Rule<Record<string, string | string[]>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -48,7 +49,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			const propList = primary[propKey];
+			const propList = flattenArray(primary[propKey]);
 
 			if (!propList) {
 				return;

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -11,7 +11,7 @@ a { text-transform: uppercase; }
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "values"], "unprefixed-property-name": ["/regex/", "non-regex", /regex/] }`
+`object`: `{ "unprefixed-property-name": ["array", "of", "values", "/regex/", /regex/]|"value"|"/regex/"|/regex/ }`
 
 If a property name is found in the object, only the listed property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 
@@ -26,7 +26,7 @@ Given:
 ```json
 {
   "transform": ["/scale/"],
-  "whitespace": ["nowrap"],
+  "whitespace": "nowrap",
   "/color/": ["/^green/"]
 }
 ```

--- a/lib/rules/declaration-property-value-allowed-list/__tests__/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/__tests__/index.js
@@ -8,7 +8,7 @@ testRule({
 	config: [
 		{
 			transform: ['/scale/'],
-			whitespace: ['nowrap'],
+			whitespace: 'nowrap',
 			'/color/': ['/^green/'],
 		},
 	],

--- a/lib/rules/declaration-property-value-allowed-list/index.js
+++ b/lib/rules/declaration-property-value-allowed-list/index.js
@@ -20,12 +20,12 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-value-allowed-list',
 };
 
-/** @type {import('stylelint').Rule<Record<string, (string | RegExp)[]>>} */
+/** @type {import('stylelint').Rule<Record<string, string | RegExp | Array<string | RegExp>>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
-			possible: [validateObjectWithArrayProps([isString, isRegExp])],
+			possible: [validateObjectWithArrayProps(isString, isRegExp)],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -11,7 +11,7 @@ a { text-transform: uppercase; }
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "values"], "unprefixed-property-name": ["/regex/", "non-regex", /regex/] }`
+`object`: `{ "unprefixed-property-name": ["array", "of", "values", "/regex/", /regex/]|"value"|"/regex/"|/regex/ }`
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
@@ -24,7 +24,7 @@ Given:
 ```json
 {
   "transform": ["/scale3d/", "/rotate3d/", "/translate3d/"],
-  "position": ["fixed"],
+  "position": "fixed",
   "color": ["/^green/"],
   "/^animation/": ["/ease/"]
 }

--- a/lib/rules/declaration-property-value-disallowed-list/__tests__/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/__tests__/index.js
@@ -8,7 +8,7 @@ testRule({
 	config: [
 		{
 			// regular string
-			'text-transform': ['uppercase'],
+			'text-transform': 'uppercase',
 			// regexes
 			transform: ['/scale3d/', '/rotate3d/', '/translate3d/'],
 			// mixed string and regex

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -20,12 +20,12 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-property-value-disallowed-list',
 };
 
-/** @type {import('stylelint').Rule<Record<string, (string | RegExp)[]>>} */
+/** @type {import('stylelint').Rule<Record<string, string | RegExp | Array<string | RegExp>>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
-			possible: [validateObjectWithArrayProps([isString, isRegExp])],
+			possible: [validateObjectWithArrayProps(isString, isRegExp)],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/media-feature-name-value-allowed-list/README.md
+++ b/lib/rules/media-feature-name-value-allowed-list/README.md
@@ -11,26 +11,20 @@ Specify a list of allowed media feature name and value pairs.
 
 ## Options
 
-```js
-{
-  "unprefixed-media-feature-name": ["array", "of", "values"],
-  "/unprefixed-media-feature-name/": ["/regex/", "non-regex", /real-regex/]
-}
-```
+`object`: `{ "unprefixed-media-feature-name": ["array", "of", "values", "/regex/", /regex/]|"value"|"/regex/"|/regex/ }`
 
 If a media feature name is found in the object, only its allowed-listed values are
 allowed. If the media feature name is not included in the object, anything goes.
 
 If a name or value is surrounded with `/` (e.g. `"/width$/"`), it is interpreted
-as a regular expression. For example, `/width$/` will match `max-width` and
-`min-width`.
+as a regular expression. For example, `/width$/` will match `max-width` and `min-width`.
 
 Given:
 
 ```json
 {
   "min-width": ["768px", "1024px"],
-  "/resolution/": ["/dpcm$/"]
+  "/resolution/": "/dpcm$/"
 }
 ```
 

--- a/lib/rules/media-feature-name-value-allowed-list/__tests__/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/__tests__/index.js
@@ -7,7 +7,7 @@ testRule({
 	config: [
 		{
 			'min-width': ['768px', '$sm'],
-			'/resolution/': ['/dpcm$/'], // Only dpcm unit
+			'/resolution/': '/dpcm$/', // Only dpcm unit
 			color: [], // Test boolean context
 			width: [], // Test range context
 		},

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -24,12 +24,12 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-value-allowed-list',
 };
 
-/** @type {import('stylelint').Rule<Record<string, Array<string | RegExp>>>} */
+/** @type {import('stylelint').Rule<Record<string, string | RegExp | Array<string | RegExp>>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
-			possible: [validateObjectWithArrayProps([isString, isRegExp])],
+			possible: [validateObjectWithArrayProps(isString, isRegExp)],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -11,7 +11,7 @@ Specify a list of disallowed properties for selectors within rules.
 
 ## Options
 
-`object`: `{ "selector": ["array", "of", "properties"]`
+`object`: `{ "selector": ["array", "of", "properties", "/regex/", /regex/]|"property"|"/regex/"|/regex/`
 
 If a selector name is surrounded with `"/"` (e.g. `"/anchor/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of all the potential anchors: `/anchor/` will match `.anchor`, `[data-anchor]`, etc.
 
@@ -22,7 +22,7 @@ Given:
 ```json
 {
   "a": ["color", "/margin/"],
-  "/foo/": ["/size/"]
+  "/foo/": "/size/"
 }
 ```
 

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
@@ -6,7 +6,7 @@ testRule({
 	ruleName,
 	config: {
 		a: ['color', '/margin/'],
-		'/foo/': ['/size/'],
+		'/foo/': '/size/',
 	},
 
 	accept: [

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -18,12 +18,12 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/rule-selector-property-disallowed-list',
 };
 
-/** @type {import('stylelint').Rule<Record<string, Array<string | RegExp>>>} */
+/** @type {import('stylelint').Rule<Record<string, string | RegExp | Array<string | RegExp>>>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
-			possible: [validateObjectWithArrayProps([isString, isRegExp])],
+			possible: [validateObjectWithArrayProps(isString, isRegExp)],
 		});
 
 		if (!validOptions) {

--- a/lib/rules/unit-allowed-list/README.md
+++ b/lib/rules/unit-allowed-list/README.md
@@ -65,7 +65,7 @@ a { transform: rotate(30deg); }
 
 ## Optional secondary options
 
-### `ignoreProperties: { unit: ["property", "/regex/", /regex/] }`
+### `ignoreProperties: { "unit": ["property", "/regex/", /regex/]|"property"|"/regex/"|/regex/ }`
 
 Ignore units in the values of declarations with the specified properties.
 
@@ -114,7 +114,7 @@ a { -moz-border-radius-topright: 20rem; }
 a { height: 100%; }
 ```
 
-### `ignoreFunctions: ["/regex/", /regex/, "string"]`
+### `ignoreFunctions: ["function", "/regex/", /regex/]|"function"|"/regex/"|/regex/`
 
 Ignore units that are inside of the specified functions.
 

--- a/lib/rules/unit-allowed-list/__tests__/index.js
+++ b/lib/rules/unit-allowed-list/__tests__/index.js
@@ -236,7 +236,7 @@ testRule({
 testRule({
 	ruleName,
 
-	config: ['px'],
+	config: 'px',
 
 	accept: [
 		{
@@ -324,7 +324,7 @@ testRule({
 		{
 			ignoreProperties: {
 				rem: ['line-height', 'margin', /^border/],
-				'%': ['width', 'height'],
+				'%': 'width',
 			},
 		},
 	],
@@ -351,11 +351,11 @@ testRule({
 testRule({
 	ruleName,
 
-	config: [['px', 'em'], { ignoreFunctions: ['hsl', '/^rgb/', /-gradient$/] }],
+	config: ['em', { ignoreFunctions: ['hsl', '/^rgb/', /-gradient$/] }],
 
 	accept: [
 		{
-			code: 'a { border: 1px solid hsl(20deg 0% 20% / 80%); }',
+			code: 'a { border: 1em solid hsl(20deg 0% 20% / 80%); }',
 			description: 'color functions',
 		},
 		{
@@ -378,6 +378,25 @@ testRule({
 		{
 			code: 'a { border: 1rem solid rgb(0, 0, 0) }',
 			message: messages.rejected('rem'),
+		},
+	],
+});
+
+testRule({
+	ruleName,
+
+	config: ['em', { ignoreFunctions: 'hsl' }],
+
+	accept: [
+		{
+			code: 'a { border: 1em solid hsl(20deg 0% 20% / 80%); }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { border: 1em solid hsla(162deg, 51, 35, 0.8); }',
+			message: messages.rejected('deg'),
 		},
 	],
 });

--- a/lib/rules/unit-allowed-list/index.js
+++ b/lib/rules/unit-allowed-list/index.js
@@ -38,7 +38,7 @@ const rule = (primary, secondaryOptions) => {
 				actual: secondaryOptions,
 				possible: {
 					ignoreFunctions: [isString, isRegExp],
-					ignoreProperties: [validateObjectWithArrayProps([isString, isRegExp])],
+					ignoreProperties: [validateObjectWithArrayProps(isString, isRegExp)],
 				},
 			},
 		);

--- a/lib/rules/unit-disallowed-list/README.md
+++ b/lib/rules/unit-disallowed-list/README.md
@@ -60,7 +60,7 @@ a { animation: animation-name 5s ease; }
 
 ## Optional secondary options
 
-### `ignoreProperties: { unit: ["property", "/regex/", /regex/] }`
+### `ignoreProperties: { "unit": ["property", "/regex/", /regex/]|"property"|"/regex/"|/regex/ }`
 
 Ignore units in the values of declarations with the specified properties.
 
@@ -71,7 +71,7 @@ Given:
 ```json
 {
   "px": ["font-size", "/^border/"],
-  "vmin": ["width"]
+  "vmin": "width"
 }
 ```
 
@@ -109,7 +109,7 @@ a { -moz-border-radius-topright: 40px; }
 a { height: 100vmin; }
 ```
 
-### `ignoreMediaFeatureNames: { unit: ["property", "/regex/", /regex/] }`
+### `ignoreMediaFeatureNames: { "unit": ["property", "/regex/", /regex/]|"property"|"/regex/"|/regex/ }`
 
 Ignore units for specific feature names.
 
@@ -120,7 +120,7 @@ Given:
 ```json
 {
   "px": ["min-width", "/height$/"],
-  "dpi": ["resolution"]
+  "dpi": "resolution"
 }
 ```
 

--- a/lib/rules/unit-disallowed-list/__tests__/index.js
+++ b/lib/rules/unit-disallowed-list/__tests__/index.js
@@ -232,7 +232,7 @@ testRule({
 testRule({
 	ruleName,
 
-	config: ['px'],
+	config: 'px',
 
 	accept: [
 		{
@@ -320,7 +320,7 @@ testRule({
 		{
 			ignoreProperties: {
 				px: ['font-size', 'margin', /^border/],
-				vmin: ['width', 'height'],
+				vmin: 'width',
 			},
 		},
 	],
@@ -511,7 +511,7 @@ testRule({
 		{
 			ignoreMediaFeatureNames: {
 				px: ['min-width', 'height'],
-				dpi: ['min-resolution', 'resolution'],
+				dpi: 'min-resolution',
 				'%': ['width', /^min/],
 			},
 		},

--- a/lib/rules/unit-disallowed-list/index.js
+++ b/lib/rules/unit-disallowed-list/index.js
@@ -53,8 +53,8 @@ const rule = (primary, secondaryOptions) => {
 				optional: true,
 				actual: secondaryOptions,
 				possible: {
-					ignoreProperties: [validateObjectWithArrayProps([isString, isRegExp])],
-					ignoreMediaFeatureNames: [validateObjectWithArrayProps([isString, isRegExp])],
+					ignoreProperties: [validateObjectWithArrayProps(isString, isRegExp)],
+					ignoreMediaFeatureNames: [validateObjectWithArrayProps(isString, isRegExp)],
 				},
 			},
 		);

--- a/lib/utils/__tests__/flattenArray.test.js
+++ b/lib/utils/__tests__/flattenArray.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const flattenArray = require('../flattenArray');
+
+test('accept undefined', () => {
+	expect(flattenArray(undefined)).toBeUndefined();
+});
+
+test('accept null', () => {
+	expect(flattenArray(null)).toBeUndefined();
+});
+
+test('accept a single value', () => {
+	expect(flattenArray(1)).toEqual([1]);
+});
+
+test('accept an array with a single value', () => {
+	expect(flattenArray([1])).toEqual([1]);
+});
+
+test('accept an array with multiple values', () => {
+	expect(flattenArray([1, 2])).toEqual([1, 2]);
+});
+
+test('accept an empty array', () => {
+	expect(flattenArray([])).toEqual([]);
+});

--- a/lib/utils/__tests__/validateObjectWithArrayProps.test.js
+++ b/lib/utils/__tests__/validateObjectWithArrayProps.test.js
@@ -8,22 +8,13 @@ describe('validateObjectWithArrayProps', () => {
 	});
 
 	describe('returned validator', () => {
-		const validator = validateObjectWithArrayProps((x) => x);
+		const validator = validateObjectWithArrayProps((x) => x > 0);
 
-		it('should return false if any of the object properties are not an array', () => {
+		it('should return false if any of the object properties do not satisfy the validator', () => {
 			expect(
 				validator({
 					arrayProp: [1, 2],
-					nonArrayProp: 3,
-				}),
-			).toBeFalsy();
-		});
-
-		it('should return false if any of the object properties array values do not pass the test', () => {
-			expect(
-				validator({
-					arrayProp: [1, 2],
-					nonArrayProp: [0, 3],
+					nonArrayProp: 0,
 				}),
 			).toBeFalsy();
 		});
@@ -32,29 +23,32 @@ describe('validateObjectWithArrayProps', () => {
 			expect(
 				validator({
 					arrayProp: [1, 2],
-					nonArrayProp: [3, 4],
+					nonArrayProp: 3,
 				}),
 			).toBeTruthy();
 		});
 	});
 
 	describe('returned validator with array', () => {
-		const validator = validateObjectWithArrayProps([(x) => x > 0, (x) => x < 0]);
+		const validator = validateObjectWithArrayProps(
+			(x) => x > 0,
+			(x) => x < 0,
+		);
 
 		it('should accept an array of validators, any of which can return true', () => {
 			expect(
 				validator({
-					arrayProp: [1, 2],
-					nonArrayProp: [-1, 3],
+					arrayProp: [1, -1],
+					nonArrayProp: 3,
 				}),
 			).toBeTruthy();
 		});
 
-		it('should be false if none of the validators are true for any value', () => {
+		it('should return false if none of the validators are true for any value', () => {
 			expect(
 				validator({
-					arrayProp: [1, 2],
-					nonArrayProp: [-1, 0],
+					arrayProp: [1, -1],
+					nonArrayProp: 0,
 				}),
 			).toBeFalsy();
 		});

--- a/lib/utils/flattenArray.js
+++ b/lib/utils/flattenArray.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Convert the specified value to an array. If an array is specified, the array is returned as-is.
+ *
+ * @template T
+ * @param {T | T[] | undefined | null} value
+ * @returns {T[] | undefined}
+ */
+module.exports = function flattenArray(value) {
+	if (value == null) {
+		return;
+	}
+
+	return Array.isArray(value) ? value : [value];
+};

--- a/lib/utils/validateObjectWithArrayProps.js
+++ b/lib/utils/validateObjectWithArrayProps.js
@@ -3,41 +3,29 @@
 const { isPlainObject } = require('./validateTypes');
 
 /**
- * Check whether the variable is an object and all its properties are arrays of values
+ * Check whether the variable is an object and all its properties are one or more values
  * that satisfy the specified validator(s):
  *
  * @example
  * ignoreProperties = {
  *   value1: ["item11", "item12", "item13"],
- *   value2: ["item21", "item22", "item23"],
- *   value3: ["item31", "item32", "item33"],
+ *   value2: "item2",
  * };
  * validateObjectWithArrayProps(isString)(ignoreProperties);
  * //=> true
  *
- * @template {(value: unknown) => boolean} Validator
- * @param {Validator | Validator[]} validator
- * @returns {(value: unknown) => boolean}
+ * @typedef {(value: unknown) => boolean} Validator
+ * @param {...Validator} validators
+ * @returns {Validator}
  */
-module.exports = function validateObjectWithArrayProps(validator) {
+module.exports = function validateObjectWithArrayProps(...validators) {
 	return (value) => {
 		if (!isPlainObject(value)) {
 			return false;
 		}
 
-		return Object.values(value).every((array) => {
-			if (!Array.isArray(array)) {
-				return false;
-			}
-
-			// Make sure the array items are strings
-			return array.every((item) => {
-				if (Array.isArray(validator)) {
-					return validator.some((v) => v(item));
-				}
-
-				return validator(item);
-			});
-		});
+		return Object.values(value)
+			.flat()
+			.every((item) => validators.some((v) => v(item)));
 	};
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5933

> Is there anything in the PR that needs further explanation?

This pull request does:

- loosen up the `validateObjectWithArrayProps()` utility to accept also a single value not only an array. E.g.
    ```js
    validateObjectWithArrayProps({ foo: [1, 2], bar: 3 }) //=> true
    ```
- fix or update the undocumented behavior of all rules using `validateObjectWithArrayProps()`
