### PR TITLE
Refactor to replace deprecated `String.prototype.substr()`

### DIFF
--- a/lib/rules/comment-whitespace-inside/index.js
+++ b/lib/rules/comment-whitespace-inside/index.js
@@ -59,7 +59,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			}
 
 			const rawComment = comment.toString();
-			const firstFourChars = rawComment.substr(0, 4);
+			const firstFourChars = rawComment.slice(0, 4);
 
 			// Return early if sourcemap or copyright comment
 			if (/^\/\*[#!]\s/.test(firstFourChars)) {

--- a/lib/rules/comment-word-disallowed-list/index.js
+++ b/lib/rules/comment-word-disallowed-list/index.js
@@ -32,7 +32,7 @@ const rule = (primary) => {
 		root.walkComments((comment) => {
 			const text = comment.text;
 			const rawComment = comment.toString();
-			const firstFourChars = rawComment.substr(0, 4);
+			const firstFourChars = rawComment.slice(0, 4);
 
 			// Return early if sourcemap
 			if (firstFourChars === '/*# ') {

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -75,7 +75,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					return;
 				}
 
-				if (source.substr(index, 2) === '\r\n') {
+				if (source.slice(index, index + 2) === '\r\n') {
 					return;
 				}
 

--- a/lib/rules/max-line-length/__tests__/index.js
+++ b/lib/rules/max-line-length/__tests__/index.js
@@ -68,11 +68,11 @@ testRule({
 			code: '@import \'svg-something<id="horse">\' projection;',
 		},
 		{
-			code: `a {\n background-image:\nurl(\n${_21whitespaces.substr(0, 20)}"${testUrl}"\n); }`,
+			code: `a {\n background-image:\nurl(\n${_21whitespaces.slice(0, 20)}"${testUrl}"\n); }`,
 			description: 'exactly 20 whitespaces',
 		},
 		{
-			code: `a {\n background-image:\nurl(\n"${testUrl}"${_21whitespaces.substr(0, 20)}\n); }`,
+			code: `a {\n background-image:\nurl(\n"${testUrl}"${_21whitespaces.slice(0, 20)}\n); }`,
 			description: 'exactly 20 whitespaces',
 		},
 	],

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -156,7 +156,7 @@ const rule = (primary, secondaryOptions) => {
  * @returns {string | undefined}
  */
 function extractPseudoRule(selector) {
-	return selector.startsWith('&:') && selector[2] !== ':' ? selector.substr(2) : undefined;
+	return selector.startsWith('&:') && selector[2] !== ':' ? selector.slice(2) : undefined;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -53,7 +53,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					functionArguments: 'skip',
 				},
 				(match) => {
-					const nextChars = selector.substr(match.endIndex, selector.length - match.endIndex);
+					const nextChars = selector.slice(match.endIndex);
 
 					// If there's a // comment, that means there has to be a newline
 					// ending the comment so we're fine


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, it's just a small refactoring.

> Is there anything in the PR that needs further explanation?

The `String.prototype.substr()` method is deprecated.
This change replaces it with the `String.prototype.slice()` method.

See also:
- https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substr
- https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/slice

`substr()` will be not found after this change:

```console
$ git grep -w substr || echo 'no match'
no match
```