### PR TITLE
Fix TypeError error "Cannot destructure property..." in custom-property-pattern

### DIFF
--- a/lib/rules/custom-property-pattern/__tests__/index.js
+++ b/lib/rules/custom-property-pattern/__tests__/index.js
@@ -19,6 +19,10 @@ testRule({
 		{
 			code: ':root { --foo-sub-color: #f00; } a { color: var(--foo-color, var(--foo-sub-color)); }',
 		},
+		{
+			code: 'a { --foo-color: var(); }',
+			description: 'empty function',
+		},
 	],
 
 	reject: [

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -58,6 +58,8 @@ const rule = (primary) => {
 
 				const { nodes, sourceIndex } = node;
 
+				if (nodes.length === 0) return;
+
 				const { value: firstNodeValue } = nodes[0];
 
 				if (check(firstNodeValue)) return;

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -58,11 +58,9 @@ const rule = (primary) => {
 
 				const { nodes, sourceIndex } = node;
 
-				if (nodes.length === 0) return;
+				const firstNode = nodes[0];
 
-				const { value: firstNodeValue } = nodes[0];
-
-				if (check(firstNodeValue)) return;
+				if (!firstNode || check(firstNode.value)) return;
 
 				complain(declarationValueIndex(decl) + sourceIndex, decl);
 			});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5972.

> Is there anything in the PR that needs further explanation?

In the issue description, @jeddy3 mentions to check if `nodes` exists before restructuring. My understanding is that `nodes` will always exist, and the bug arises from if the array is empty (and thus, `nodes[0]` doesn't exist). ~~So, this approach checks if `nodes` is an empty array, and returns early if so.~~ So, this approach checks if `nodes[0]` exists instead.

I've also added a test case (that previously failed with the same error, and now is resolved).
