### PR TITLE
Refactor to improve types for `validateTypes` and `whitespaceChecker`

### DIFF
--- a/lib/utils/__tests__/validateTypes.test.js
+++ b/lib/utils/__tests__/validateTypes.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const {
+	isBoolean,
+	isFunction,
+	isNullish,
+	isNumber,
+	isRegExp,
+	isString,
+	isPlainObject,
+} = require('../validateTypes');
+
+describe('isBoolean()', () => {
+	it('returns true when a boolean value is specified', () => {
+		expect(isBoolean(true)).toBe(true);
+	});
+
+	it('returns true when a Boolean object is specified', () => {
+		expect(isBoolean(new Boolean(true))).toBe(true);
+	});
+
+	it('returns false when a boolean value is not specified', () => {
+		expect(isBoolean(null)).toBe(false);
+	});
+});
+
+describe('isFunction()', () => {
+	it('returns true when a function value is specified', () => {
+		expect(isFunction(() => 1)).toBe(true);
+	});
+
+	it('returns true when a Function object is specified', () => {
+		expect(isFunction(new Function())).toBe(true);
+	});
+
+	it('returns false when a function value is specified', () => {
+		expect(isFunction(null)).toBe(false);
+	});
+});
+
+describe('isNullish()', () => {
+	it('returns true when null is specified', () => {
+		expect(isNullish(null)).toBe(true);
+	});
+
+	it('returns true when undefined is specified', () => {
+		expect(isNullish(undefined)).toBe(true);
+	});
+
+	it('returns false when neither null nor undefined is specified', () => {
+		expect(isNullish('')).toBe(false);
+	});
+});
+
+describe('isNumber()', () => {
+	it('returns true when a number value is specified', () => {
+		expect(isNumber(1)).toBe(true);
+	});
+
+	it('returns true when a Number object is specified', () => {
+		expect(isNumber(new Number(1))).toBe(true);
+	});
+
+	it('returns false when a number value is not specified', () => {
+		expect(isNumber(null)).toBe(false);
+	});
+});
+
+describe('isRegExp()', () => {
+	it('returns true when a regexp value is specified', () => {
+		expect(isRegExp(/a/)).toBe(true);
+	});
+
+	it('returns false when a regexp value is not specified', () => {
+		expect(isRegExp(null)).toBe(false);
+	});
+});
+
+describe('isString()', () => {
+	it('returns true when a string value is specified', () => {
+		expect(isString('')).toBe(true);
+	});
+
+	it('returns true when a String object is specified', () => {
+		expect(isString(new String(''))).toBe(true);
+	});
+
+	it('returns false when a string value is not specified', () => {
+		expect(isString(null)).toBe(false);
+	});
+});
+
+describe('isPlainObject()', () => {
+	it('returns true when a plain object is specified', () => {
+		expect(isPlainObject({})).toBe(true);
+	});
+
+	it('returns false when a plain object is not specified', () => {
+		expect(isPlainObject(null)).toBe(false);
+	});
+});

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -12,6 +12,25 @@ function isBoolean(value) {
 }
 
 /**
+ * Checks if the value is a function or a Function object.
+ * @param {unknown} value
+ * @returns {value is Function}
+ */
+function isFunction(value) {
+	return typeof value === 'function' || value instanceof Function;
+}
+
+/**
+ * Checks if the value is *nullish*.
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/Nullish
+ * @param {unknown} value
+ * @returns {value is null | undefined}
+ */
+function isNullish(value) {
+	return value == null;
+}
+
+/**
  * Checks if the value is a number or a Number object.
  * @param {unknown} value
  * @returns {value is number}
@@ -21,7 +40,7 @@ function isNumber(value) {
 }
 
 /**
- * Checks if the value is a RegExp object.
+ * Checks if the value is a regular expression.
  * @param {unknown} value
  * @returns {value is RegExp}
  */
@@ -58,6 +77,16 @@ function assert(value) {
 }
 
 /**
+ * Assert that the value is a function or a Function object.
+ * @param {unknown} value
+ * @returns {asserts value is Function}
+ */
+function assertFunction(value) {
+	// eslint-disable-next-line no-console
+	console.assert(isFunction(value), `"${value}" must be a function`);
+}
+
+/**
  * Assert that the value is a number or a Number object.
  * @param {unknown} value
  * @returns {asserts value is number}
@@ -79,12 +108,15 @@ function assertString(value) {
 
 module.exports = {
 	isBoolean,
+	isFunction,
+	isNullish,
 	isNumber,
 	isRegExp,
 	isString,
 	isPlainObject,
 
 	assert,
+	assertFunction,
 	assertNumber,
 	assertString,
 };

--- a/lib/utils/whitespaceChecker.js
+++ b/lib/utils/whitespaceChecker.js
@@ -3,6 +3,7 @@
 const configurationError = require('./configurationError');
 const isSingleLineString = require('./isSingleLineString');
 const isWhitespace = require('./isWhitespace');
+const { assertFunction, isNullish } = require('./validateTypes');
 
 /**
  * @typedef {(message: string) => string} MessageFunction
@@ -215,20 +216,20 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 		const oneCharBefore = source[index - 1];
 		const twoCharsBefore = source[index - 2];
 
-		if (!isValue(oneCharBefore)) {
+		if (isNullish(oneCharBefore)) {
 			return;
 		}
 
 		if (
 			targetWhitespace === 'space' &&
 			oneCharBefore === ' ' &&
-			(activeArgs.onlyOneChar || !isWhitespace(twoCharsBefore))
+			(activeArgs.onlyOneChar || isNullish(twoCharsBefore) || !isWhitespace(twoCharsBefore))
 		) {
 			return;
 		}
 
 		assertFunction(messageFunc);
-		activeArgs.err(messageFunc(activeArgs.errTarget || source[index]));
+		activeArgs.err(messageFunc(activeArgs.errTarget || source.charAt(index)));
 	}
 
 	function expectBeforeAllowingIndentation(messageFunc = messages.expectedBefore) {
@@ -251,7 +252,7 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 			}
 
 			assertFunction(messageFunc);
-			err(messageFunc(activeArgs.errTarget || source[index]));
+			err(messageFunc(activeArgs.errTarget || source.charAt(index)));
 
 			return;
 		}
@@ -264,9 +265,9 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 
 		const oneCharBefore = source[index - 1];
 
-		if (isValue(oneCharBefore) && isWhitespace(oneCharBefore)) {
+		if (!isNullish(oneCharBefore) && isWhitespace(oneCharBefore)) {
 			assertFunction(messageFunc);
-			activeArgs.err(messageFunc(activeArgs.errTarget || source[index]));
+			activeArgs.err(messageFunc(activeArgs.errTarget || source.charAt(index)));
 		}
 	}
 
@@ -284,8 +285,9 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 
 		const oneCharAfter = source[index + 1];
 		const twoCharsAfter = source[index + 2];
+		const threeCharsAfter = source[index + 3];
 
-		if (!isValue(oneCharAfter)) {
+		if (isNullish(oneCharAfter)) {
 			return;
 		}
 
@@ -294,13 +296,16 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 			if (
 				oneCharAfter === '\r' &&
 				twoCharsAfter === '\n' &&
-				(activeArgs.onlyOneChar || !isWhitespace(source[index + 3]))
+				(activeArgs.onlyOneChar || isNullish(threeCharsAfter) || !isWhitespace(threeCharsAfter))
 			) {
 				return;
 			}
 
 			// If index is followed by a Unix LF ...
-			if (oneCharAfter === '\n' && (activeArgs.onlyOneChar || !isWhitespace(twoCharsAfter))) {
+			if (
+				oneCharAfter === '\n' &&
+				(activeArgs.onlyOneChar || isNullish(twoCharsAfter) || !isWhitespace(twoCharsAfter))
+			) {
 				return;
 			}
 		}
@@ -308,13 +313,13 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 		if (
 			targetWhitespace === 'space' &&
 			oneCharAfter === ' ' &&
-			(activeArgs.onlyOneChar || !isWhitespace(twoCharsAfter))
+			(activeArgs.onlyOneChar || isNullish(twoCharsAfter) || !isWhitespace(twoCharsAfter))
 		) {
 			return;
 		}
 
 		assertFunction(messageFunc);
-		activeArgs.err(messageFunc(activeArgs.errTarget || source[index]));
+		activeArgs.err(messageFunc(activeArgs.errTarget || source.charAt(index)));
 	}
 
 	function rejectAfter(messageFunc = messages.rejectedAfter) {
@@ -324,9 +329,9 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 
 		const oneCharAfter = source[index + 1];
 
-		if (isValue(oneCharAfter) && isWhitespace(oneCharAfter)) {
+		if (!isNullish(oneCharAfter) && isWhitespace(oneCharAfter)) {
 			assertFunction(messageFunc);
-			activeArgs.err(messageFunc(activeArgs.errTarget || source[index]));
+			activeArgs.err(messageFunc(activeArgs.errTarget || source.charAt(index)));
 		}
 	}
 
@@ -337,20 +342,3 @@ module.exports = function whitespaceChecker(targetWhitespace, expectation, messa
 		afterOneOnly,
 	};
 };
-
-/**
- * @param {unknown} x
- */
-function isValue(x) {
-	return x !== undefined && x !== null;
-}
-
-/**
- * @param {unknown} x
- * @returns {asserts x is Function}
- */
-function assertFunction(x) {
-	if (typeof x !== 'function') {
-		throw new TypeError(`\`${x}\` must be a function`);
-	}
-}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5983

> Is there anything in the PR that needs further explanation?

This refactoring does the following:

- Move utility functions in `lib/utils/whitespaceChecker.js` to `lib/utils/validateTypes.js`
- Add new utility functions to `validateTypes.js`
- Add a unit test for `validateTypes.js`
- Resolve type errors in `whitespaceChecker.js` via the `noUncheckedIndexedAccess` TypeScript compiler option

We can see the error resolution via the following commands:

```console
$ git checkout tsconfig-noUncheckedIndexedAccess -- tsconfig.json

$ npm run lint:types
```
