### PR TITLE
Refactor to improve type-check for `selector-not-notation`

### DIFF
--- a/lib/rules/selector-not-notation/index.js
+++ b/lib/rules/selector-not-notation/index.js
@@ -52,7 +52,8 @@ const isNot = (node) =>
 const isSimple = (list) => {
 	if (list.length > 1) return false;
 
-	const [first, second] = list[0].nodes; // list is never empty
+	assert(list[0], 'list is never empty');
+	const [first, second] = list[0].nodes;
 
 	if (!first) return true;
 
@@ -99,7 +100,9 @@ const rule = (primary, _, context) => {
 						const mustFix =
 							context.fix &&
 							selectors.length > 1 &&
-							(!selectors[1].nodes.length || selectors.every(({ nodes }) => nodes.length === 1));
+							selectors[1] &&
+							(selectors[1].nodes.length === 0 ||
+								selectors.every(({ nodes }) => nodes.length === 1));
 
 						if (mustFix) return fixSimple(pseudo);
 					}
@@ -126,8 +129,9 @@ const rule = (primary, _, context) => {
  */
 function fixSimple(not) {
 	const simpleSelectors = not.nodes
-		.filter(({ nodes }) => isSimpleSelector(nodes[0]))
+		.filter(({ nodes }) => nodes[0] && isSimpleSelector(nodes[0]))
 		.map((s) => {
+			assert(s.nodes[0]);
 			s.nodes[0].rawSpaceBefore = '';
 			s.nodes[0].rawSpaceAfter = '';
 
@@ -154,6 +158,7 @@ function fixSimple(not) {
 function fixComplex(previousNot) {
 	const indentAndTrimRight = (/** @type {Selector[]} */ selectors) => {
 		for (const s of selectors) {
+			assert(s.nodes[0]);
 			s.nodes[0].rawSpaceBefore = ' ';
 			s.nodes[0].rawSpaceAfter = '';
 		}
@@ -161,8 +166,9 @@ function fixComplex(previousNot) {
 	const [head, ...tail] = previousNot.nodes;
 	let node = previousNot.next();
 
-	if (!head.nodes.length) return;
+	if (head == null || head.nodes.length === 0) return;
 
+	assert(head.nodes[0]);
 	head.nodes[0].rawSpaceBefore = '';
 	head.nodes[0].rawSpaceAfter = '';
 	indentAndTrimRight(tail);

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -69,11 +69,17 @@ function isPlainObject(value) {
 /**
  * Assert that the value is truthy.
  * @param {unknown} value
+ * @param {string} [message]
  * @returns {asserts value}
  */
-function assert(value) {
-	// eslint-disable-next-line no-console
-	console.assert(value);
+function assert(value, message = undefined) {
+	if (message) {
+		// eslint-disable-next-line no-console
+		console.assert(value, message);
+	} else {
+		// eslint-disable-next-line no-console
+		console.assert(value);
+	}
 }
 
 /**


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #5983

> Is there anything in the PR that needs further explanation?

We can confirm the improvements via the following command:

```shell
npm run lint:types -- --noUncheckedIndexedAccess | grep selector-not-notation
```

