### PR TITLE
Fix no-disable regression for some rules

### DIFF
--- a/lib/utils/__tests__/report.test.js
+++ b/lib/utils/__tests__/report.test.js
@@ -162,6 +162,28 @@ it('with relevant rule-specific disabledRange, among others', () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
+it('with relevant rule-specific disabledRange with range report', () => {
+	const v = {
+		ruleName: 'foo',
+		result: {
+			warn: jest.fn(),
+			stylelint: {
+				disabledRanges: {
+					all: [],
+					foo: [{ start: 2, end: 2 }],
+				},
+			},
+		},
+		message: 'bar',
+		node: {
+			rangeBy: () => ({ start: { line: 2, column: 1 }, end: { line: 5, column: 1 } }),
+		},
+	};
+
+	report(v);
+	expect(v.result.warn).toHaveBeenCalledTimes(0);
+});
+
 it("with quiet mode on and rule severity of 'warning'", () => {
 	const v = {
 		ruleName: 'foo',

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -28,12 +28,11 @@ module.exports = function report(problem) {
 		return;
 	}
 
-	const { start, end } = (node && node.rangeBy({ index, endIndex })) || {};
+	const { start } = (node && node.rangeBy({ index, endIndex })) || {};
 
 	// If a line is not passed, use the node.rangeBy method to get the
 	// line number that the complaint pertains to
 	const startLine = line || (start && start.line);
-	const endLine = line || (end && end.line);
 
 	if (!startLine) {
 		throw new Error('You must pass either a node or a line number');
@@ -50,7 +49,7 @@ module.exports = function report(problem) {
 				// and that disabledRange's rules include this one,
 				// do not register a warning
 				range.start <= startLine &&
-				(range.end === undefined || range.end >= (endLine || startLine)) &&
+				(range.end === undefined || range.end >= startLine) &&
 				(!range.rules || range.rules.includes(ruleName))
 			) {
 				// Collect disabled warnings


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6015

> Is there anything in the PR that needs further explanation?

This PR is modified so that stylelint-disable is enabled when the start line of the report matches.
