### PR TITLE
Add "empty functions" to commonly overlooked edge cases

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -130,6 +130,7 @@ You should ask yourself how does your rule handle:
 - variables (e.g. `var(--custom-property)`)?
 - CSS strings (e.g. `content: "anything goes";`)?
 - CSS comments (e.g. `/* anything goes */`)?
+- empty functions (e.g. `var()`)?
 - `url()` functions, including data URIs (e.g. `url(anything/goes.jpg)`)?
 - vendor prefixes (e.g. `@-webkit-keyframes name {}`)?
 - case sensitivity (e.g. `@KEYFRAMES name {}`)?


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

A follow-up to #5972 and #5982. From the former:

> Follow-up PR to add "empty functions" to [commonly overlooked edge cases](https://stylelint.io/developer-guide/rules#commonly-overlooked-edge-cases).

---

> Is there anything in the PR that needs further explanation?

N/A - pretty trivial. Let me know if a different example/location is preferred.
