### PR TITLE
 Add support for vendor prefixes in ﻿`property-*-list`

### DIFF
--- a/lib/rules/property-allowed-list/README.md
+++ b/lib/rules/property-allowed-list/README.md
@@ -13,7 +13,7 @@ This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /properties/, "regex"]|"property"|"/regex/"|/regex/`
+`array|string|regex`: `["array", "of", /properties/, "regex"]|"property"|"/regex/"|/regex/`
 
 If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 

--- a/lib/rules/property-allowed-list/__tests__/index.js
+++ b/lib/rules/property-allowed-list/__tests__/index.js
@@ -166,3 +166,39 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+
+	config: ['-webkit-text-stroke'],
+
+	accept: [
+		{
+			code: 'a { -webkit-text-stroke: 2px red; }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { text-stroke: 2px red; }',
+			message: messages.rejected('text-stroke'),
+			line: 1,
+			column: 5,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+
+	config: ['text-stroke'],
+
+	accept: [
+		{
+			code: 'a { -webkit-text-stroke: 2px red; }',
+		},
+		{
+			code: 'a { text-stroke: 2px red; }',
+		},
+	],
+});

--- a/lib/rules/property-allowed-list/index.js
+++ b/lib/rules/property-allowed-list/index.js
@@ -42,7 +42,8 @@ const rule = (primary) => {
 				return;
 			}
 
-			if (matchesStringOrRegExp(vendor.unprefixed(prop), primary)) {
+			// either the prefix or unprefixed version is in the list
+			if (matchesStringOrRegExp([prop, vendor.unprefixed(prop)], primary)) {
 				return;
 			}
 

--- a/lib/rules/property-disallowed-list/README.md
+++ b/lib/rules/property-disallowed-list/README.md
@@ -11,7 +11,7 @@ a { text-rendering: optimizeLegibility; }
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /properties/, "regex"]|"property"|"/regex/"|/regex/`
+`array|string|regex`: `["array", "of", /properties/, "regex"]|"property"|"/regex/"|/regex/`
 
 If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 

--- a/lib/rules/property-disallowed-list/__tests__/index.js
+++ b/lib/rules/property-disallowed-list/__tests__/index.js
@@ -157,3 +157,45 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+
+	config: ['-webkit-text-stroke'],
+
+	accept: [
+		{
+			code: 'a { text-stroke: 2px red; }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { -webkit-text-stroke: 2px red; }',
+			message: messages.rejected('-webkit-text-stroke'),
+			line: 1,
+			column: 5,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+
+	config: ['text-stroke'],
+
+	reject: [
+		{
+			code: 'a { -webkit-text-stroke: 2px red; }',
+			message: messages.rejected('-webkit-text-stroke'),
+			line: 1,
+			column: 5,
+		},
+		{
+			code: 'a { text-stroke: 2px red; }',
+			message: messages.rejected('text-stroke'),
+			line: 1,
+			column: 5,
+		},
+	],
+});

--- a/lib/rules/property-disallowed-list/index.js
+++ b/lib/rules/property-disallowed-list/index.js
@@ -42,7 +42,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			// either the prefix or unprefixed version is in the disallowed list
+			// either the prefix or unprefixed version is in the list
 			if (!matchesStringOrRegExp([prop, vendor.unprefixed(prop)], primary)) {
 				return;
 			}

--- a/lib/rules/property-disallowed-list/index.js
+++ b/lib/rules/property-disallowed-list/index.js
@@ -42,7 +42,8 @@ const rule = (primary) => {
 				return;
 			}
 
-			if (!matchesStringOrRegExp(vendor.unprefixed(prop), primary)) {
+			// either the prefix or unprefixed version is in the disallowed list
+			if (!matchesStringOrRegExp([prop, vendor.unprefixed(prop)], primary)) {
 				return;
 			}
 

--- a/lib/utils/matchesStringOrRegExp.js
+++ b/lib/utils/matchesStringOrRegExp.js
@@ -8,7 +8,7 @@
  * Any strings starting and ending with `/` are interpreted
  * as regular expressions.
  *
- * @param {string} input
+ * @param {string | Array<string>} input
  * @param {string | RegExp | Array<string | RegExp>} comparison
  *
  * @returns {false | {match: string, pattern: (string | RegExp), substring: string}}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/5981

> Is there anything in the PR that needs further explanation?

The parameter types for matchesStringOrRegExp had to be fixed. It didn't include Array<string>.
