### PR TITLE
Fix end positions for `at-rule-no-unknown`

### DIFF
--- a/lib/rules/at-rule-no-unknown/__tests__/index.js
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.js
@@ -90,6 +90,8 @@ testRule({
 			message: messages.rejected('@unknown-at-rule'),
 			line: 1,
 			column: 1,
+			endLine: 1,
+			endColumn: 17,
 		},
 	],
 });

--- a/lib/rules/at-rule-no-unknown/index.js
+++ b/lib/rules/at-rule-no-unknown/index.js
@@ -55,11 +55,14 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
+			const atName = `@${name}`;
+
 			report({
-				message: messages.rejected(`@${name}`),
+				message: messages.rejected(atName),
 				node: atRule,
 				ruleName,
 				result,
+				word: atName,
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5694

> Is there anything in the PR that needs further explanation?

I think the range should be at an at-rule name, not an at-rule block. E.g.,

```css
    @unknown (max-width: 960px) {}
/** ↑------↑ */
```
