### PR TITLE
Add Node.js 18 to CI matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16]
+        node: [12, 14, 16, 18]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js 18 recently [has been released](https://nodejs.org/uk/blog/announcements/v18-release-announce/). This version will be LTS in October 2022.

<img width="540" alt="image" src="https://user-images.githubusercontent.com/473530/164274613-3f96ecfb-6531-4ef5-a556-e86cf41ca549.png">
