### PR TITLE
Fix false negative about `-ms-linear-gradient` in `function-linear-gradient-no-nonstandard-direction`

### DIFF
--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -94,6 +94,9 @@ testRule({
 		{
 			code: '.foo { background: url(foo.png), -o-linear-gradient(bottom, #fff, #000 ), url(bar.png); }',
 		},
+		{
+			code: '.foo { background: url(foo.png), -ms-linear-gradient(bottom, #fff, #000 ), url(bar.png); }',
+		},
 	],
 
 	reject: [
@@ -288,6 +291,14 @@ testRule({
 			column: 53,
 			endLine: 1,
 			endColumn: 62,
+		},
+		{
+			code: '.foo { background: url(foo.png), -ms-linear-gradient(to bottom, #fff, #000), url(bar.png); }',
+			message: messages.rejected,
+			line: 1,
+			column: 54,
+			endLine: 1,
+			endColumn: 63,
 		},
 	],
 });

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -63,7 +63,7 @@ const rule = (primary) => {
 
 				functionArgumentsSearch(
 					valueParser.stringify(valueNode).toLowerCase(),
-					/^(-webkit-|-moz-|-o-)?linear-gradient$/i,
+					/^(-webkit-|-moz-|-o-|-ms-)?linear-gradient$/i,
 					(expression, expressionIndex) => {
 						const args = expression.split(',');
 						const firstArg = (args[0] || '').trim();


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Thanks to @Mouvedia (https://github.com/stylelint/stylelint/commit/4b0f57d7b491342af1370b6f1222cb84c115e10c#r71832295), I can open this pull request. Thank you.
