### PR TITLE
Fix false positives for arealess templates in named-grid-areas-no-invalid

### DIFF
--- a/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/__tests__/index.js
@@ -10,6 +10,9 @@ testRule({
 
 	accept: [
 		{
+			code: 'a { grid-template-areas: 1fr / auto 1fr auto; }',
+		},
+		{
 			code: 'a { grid-template-areas: "a a a" "b b b"; }',
 		},
 		{

--- a/lib/rules/named-grid-areas-no-invalid/index.js
+++ b/lib/rules/named-grid-areas-no-invalid/index.js
@@ -58,6 +58,8 @@ const rule = (primary) => {
 
 			if (reportSent) return;
 
+			if (areas.length === 0) return;
+
 			if (!isRectangular(areas)) {
 				complain(messages.expectedSameNumber());
 


### PR DESCRIPTION

> Which issue, if any, is this issue related to?

Closes #6041 

> Is there anything in the PR that needs further explanation?

Quick fix where we avoid further checks on areas if there aren't any.
