### PR TITLE
Document autofix behaviour better for `*-no-vendor-prefix`

### DIFF
--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -5,7 +5,7 @@ Disallow vendor prefixes for at-rules.
 <!-- prettier-ignore -->
 ```css
     @-webkit-keyframes { 0% { top: 0; } }
-/**  ↑
+/**   ↑
  * This prefix */
 ```
 

--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -11,7 +11,7 @@ Disallow vendor prefixes for at-rules.
 
 This rule ignores non-standard vendor-prefixed at-rules that aren't handled by [Autoprefixer](https://github.com/postcss/autoprefixer).
 
-The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate at-rules produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
 ## Options
 

--- a/lib/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/lib/rules/media-feature-name-no-vendor-prefix/README.md
@@ -6,7 +6,7 @@ Disallow vendor prefixes for media feature names.
 ```css
 @media (-webkit-min-device-pixel-ratio: 1) {}
 /**      ↑
- * This prefixe */
+ * This prefix */
 ```
 
 This rule ignores non-standard vendor-prefixed media feature names that aren't handled by [Autoprefixer](https://github.com/postcss/autoprefixer).

--- a/lib/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/lib/rules/media-feature-name-no-vendor-prefix/README.md
@@ -11,7 +11,7 @@ Disallow vendor prefixes for media feature names.
 
 This rule ignores non-standard vendor-prefixed media feature names that aren't handled by [Autoprefixer](https://github.com/postcss/autoprefixer).
 
-The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate media feature names produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
 ## Options
 

--- a/lib/rules/property-no-vendor-prefix/README.md
+++ b/lib/rules/property-no-vendor-prefix/README.md
@@ -11,7 +11,7 @@ a { -webkit-transform: scale(1); }
 
 This rule ignores non-standard vendor-prefixed properties that aren't handled by [Autoprefixer](https://github.com/postcss/autoprefixer).
 
-The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate properties produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
 ## Options
 

--- a/lib/rules/selector-no-vendor-prefix/README.md
+++ b/lib/rules/selector-no-vendor-prefix/README.md
@@ -11,7 +11,7 @@ input::-moz-placeholder {}
 
 This rule ignores non-standard vendor-prefixed selectors that aren't handled by [Autoprefixer](https://github.com/postcss/autoprefixer).
 
-The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate selectors produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
 ## Options
 

--- a/lib/rules/value-no-vendor-prefix/README.md
+++ b/lib/rules/value-no-vendor-prefix/README.md
@@ -5,8 +5,8 @@ Disallow vendor prefixes for values.
 <!-- prettier-ignore -->
 ```css
 a { display: -webkit-flex; }
-/**          ↑
- *  These prefixes */
+/**           ↑
+ *  This prefix */
 ```
 
 This rule ignores non-standard vendor-prefixed values that aren't handled by [Autoprefixer](https://github.com/postcss/autoprefixer).

--- a/lib/rules/value-no-vendor-prefix/README.md
+++ b/lib/rules/value-no-vendor-prefix/README.md
@@ -11,7 +11,7 @@ a { display: -webkit-flex; }
 
 This rule ignores non-standard vendor-prefixed values that aren't handled by [Autoprefixer](https://github.com/postcss/autoprefixer).
 
-The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate values produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
 ## Options
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5664.

> Is there anything in the PR that needs further explanation?

I've applied the change to all 5 rules that have `*-no-vendor-prefix`. A bit unsure if the language makes sense for the `value-no-vendor-prefix` rule - is it possible for there to be duplicate values (I'm not sure what a duplicate value use-case would look like)? Happy to adjust this if there is better wording.
