### PR TITLE
Fix typo in `no-duplicate-selectors` doc

### DIFF
--- a/lib/rules/no-duplicate-selectors/README.md
+++ b/lib/rules/no-duplicate-selectors/README.md
@@ -5,7 +5,7 @@ Disallow duplicate selectors within a stylesheet.
 <!-- prettier-ignore -->
 ```css
     .foo {} .bar {} .foo {}
-/** ↑              ↑
+/** ↑               ↑
  * These duplicates */
 ```
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

This change just corrects the position of `↑`.
