### PR TITLE
Fix false positives for non-standard variables in `function-calc-no-unspaced-operator`

### DIFF
--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -116,6 +116,18 @@ testRule({
 			description: 'Less variable syntax',
 		},
 		{
+			code: 'a { top: calc(@x-y * 2); }',
+			description: 'Less variable syntax with hyphens',
+		},
+		{
+			code: 'a { top: calc(-@x-y * 2); }',
+			description: 'Less variable syntax with hyphens and a unary operator',
+		},
+		{
+			code: 'a { top: calc(100% * @x-y); }',
+			description: 'Less variable syntax with hyphens at the end',
+		},
+		{
 			code: 'a { top: calc($x-y-z - 2rem); }',
 			description: 'postcss-simple-vars and SCSS variable with hyphens',
 		},
@@ -126,6 +138,18 @@ testRule({
 		{
 			code: 'a { top: calc(100% - #{$foo}); }',
 			description: 'Scss interpolation',
+		},
+		{
+			code: 'a { top: calc(#{$foo-bar} * 5); }',
+			description: 'Scss interpolation with hyphens',
+		},
+		{
+			code: 'a { top: calc(-#{$foo-bar} * 5); }',
+			description: 'Scss interpolation with hyphens and a unary operator',
+		},
+		{
+			code: 'a { top: calc(100% * #{$foo-bar}); }',
+			description: 'Scss interpolation with hyphens at the end',
 		},
 		{
 			code: 'a { top: calc(100% - #{map-get($container-max-widths, xl)}); }',

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -4,6 +4,7 @@ const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
@@ -165,6 +166,8 @@ const rule = (primary, _secondaryOptions, context) => {
 				assert(firstNode);
 
 				if (firstNode.type !== 'word') return false;
+
+				if (!isStandardSyntaxValue(firstNode.value)) return false;
 
 				const operatorIndex = firstNode.value.search(OPERATOR_REGEX);
 				const operator = firstNode.value.slice(operatorIndex, operatorIndex + 1);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6052

> Is there anything in the PR that needs further explanation?

This pull request aims to fix false positives for non-standard variables (e.g. SCSS, Less, and so on.) in the `function-calc-no-unspaced-operator` rule.

I think [`isStandardSyntaxValue()`](https://github.com/stylelint/stylelint/blob/e017583128863ee75634cb15e721779163b571e5/lib/utils/isStandardSyntaxValue.js) is more appropriate than [`isStandardSyntaxMathFunction()`](https://github.com/stylelint/stylelint/blob/e017583128863ee75634cb15e721779163b571e5/lib/utils/isStandardSyntaxMathFunction.js) suggested on <https://github.com/stylelint/stylelint/issues/6052#issuecomment-1114004679> because `isStandardSyntaxMathFunction()` fails the cases using non-standard variables. E.g.

https://github.com/stylelint/stylelint/blob/e017583128863ee75634cb15e721779163b571e5/lib/rules/function-calc-no-unspaced-operator/__tests__/index.js#L535-L543
