### PR TITLE
Fix end positions for `no-invalid-*`

### DIFF
--- a/lib/rules/no-invalid-double-slash-comments/__tests__/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/__tests__/index.js
@@ -28,6 +28,8 @@ testRule({
 			message: messages.rejected,
 			line: 1,
 			column: 1,
+			endLine: 1,
+			endColumn: 22,
 		},
 		{
 			code: 'a {\n//color: pink;\n}',
@@ -35,6 +37,8 @@ testRule({
 			message: messages.rejected,
 			line: 2,
 			column: 1,
+			endLine: 2,
+			endColumn: 14,
 		},
 		{
 			code: '//a { color: pink; }',
@@ -42,6 +46,8 @@ testRule({
 			message: messages.rejected,
 			line: 1,
 			column: 1,
+			endLine: 1,
+			endColumn: 21,
 		},
 		{
 			code: 'a, //div { color: pink; }',
@@ -49,6 +55,8 @@ testRule({
 			message: messages.rejected,
 			line: 1,
 			column: 1,
+			endLine: 1,
+			endColumn: 26,
 		},
 		{
 			code: '//@media { }',
@@ -56,6 +64,8 @@ testRule({
 			message: messages.rejected,
 			line: 1,
 			column: 1,
+			endLine: 1,
+			endColumn: 13,
 		},
 	],
 });

--- a/lib/rules/no-invalid-double-slash-comments/index.js
+++ b/lib/rules/no-invalid-double-slash-comments/index.js
@@ -30,6 +30,7 @@ const rule = (primary) => {
 					node: decl,
 					result,
 					ruleName,
+					word: decl.toString(),
 				});
 			}
 		});
@@ -42,6 +43,7 @@ const rule = (primary) => {
 						node: ruleNode,
 						result,
 						ruleName,
+						word: ruleNode.toString(),
 					});
 				}
 			}

--- a/lib/rules/no-invalid-position-at-import-rule/__tests__/index.js
+++ b/lib/rules/no-invalid-position-at-import-rule/__tests__/index.js
@@ -57,6 +57,8 @@ testRule({
 			description: '@import after selector',
 			line: 2,
 			column: 1,
+			endLine: 2,
+			endColumn: 18,
 		},
 		{
 			code: stripIndent`
@@ -67,6 +69,8 @@ testRule({
 			description: '@import after another at-rule',
 			line: 2,
 			column: 1,
+			endLine: 2,
+			endColumn: 23,
 		},
 		{
 			code: stripIndent`
@@ -77,6 +81,8 @@ testRule({
 			description: 'case insensitive',
 			line: 2,
 			column: 1,
+			endLine: 2,
+			endColumn: 23,
 		},
 		{
 			code: stripIndent`
@@ -88,6 +94,8 @@ testRule({
 			description: 'only second @import reported',
 			line: 3,
 			column: 1,
+			endLine: 3,
+			endColumn: 18,
 		},
 		{
 			code: stripIndent`
@@ -100,11 +108,15 @@ testRule({
 					message: messages.rejected,
 					line: 2,
 					column: 1,
+					endLine: 2,
+					endColumn: 18,
 				},
 				{
 					message: messages.rejected,
 					line: 3,
 					column: 1,
+					endLine: 3,
+					endColumn: 18,
 				},
 			],
 			description: 'all @import reported',

--- a/lib/rules/no-invalid-position-at-import-rule/index.js
+++ b/lib/rules/no-invalid-position-at-import-rule/index.js
@@ -62,6 +62,7 @@ const rule = (primary, options) => {
 					node,
 					result,
 					ruleName,
+					word: node.toString(),
 				});
 			}
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of the umbrella issue #5694.

> Is there anything in the PR that needs further explanation?

For `no-invalid-double-slash-comments`, there was one test case I was confused about:

```js
code: 'a, //div { color: pink; }',
description: 'between rules',
message: messages.rejected,
line: 1,
column: 1,
endLine: 1,
endColumn: 26,
```

I haven't changed the behaviour of this test case, but to me I'm not sure why it's `column: 1` - the comment starts at index `4` (where the double-slash is). I might be misunderstanding how this rule works, though!