### PR TITLE
Use arrow functions in docs

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -28,8 +28,8 @@ const meta = {
 
 module.exports = stylelint.createPlugin(
   ruleName,
-  function (primaryOption, secondaryOptionObject) {
-    return function (postcssRoot, postcssResult) {
+  (primaryOption, secondaryOptionObject) => {
+    return (postcssRoot, postcssResult) => {
       const validOptions = stylelint.utils.validateOptions(
         postcssResult,
         ruleName,
@@ -91,8 +91,8 @@ const meta = {
 
 module.exports = stylelint.createPlugin(
   ruleName,
-  function (primaryOption, secondaryOptionObject) {
-    return function (postcssRoot, postcssResult) {
+  (primaryOption, secondaryOptionObject) => {
+    return (postcssRoot, postcssResult) => {
       const validOptions = stylelint.utils.validateOptions(
         postcssResult,
         ruleName,
@@ -105,9 +105,9 @@ module.exports = stylelint.createPlugin(
         return;
       }
 
-      return new Promise(function (resolve) {
+      return new Promise((resolve) => {
         // some async operation
-        setTimeout(function () {
+        setTimeout(() => {
           // ... some logic ...
           stylelint.utils.report({
             /* .. */
@@ -250,7 +250,7 @@ const allowableAtRules = [
 ];
 
 function myPluginRule(primaryOption, secondaryOptionObject) {
-  return function (postcssRoot, postcssResult) {
+  return (postcssRoot, postcssResult) => {
     const defaultedOptions = Object.assign({}, secondaryOptionObject, {
       ignoreAtRules: allowableAtRules.concat(options.ignoreAtRules || [])
     });
@@ -289,7 +289,7 @@ All rules share a common signature. They are a function that accepts two argumen
 Here's an example of a plugin that runs `declaration-no-important` only if there is a special directive `@@check-declaration-no-important` somewhere in the stylesheet:
 
 ```js
-module.exports = stylelint.createPlugin(ruleName, function (expectation) {
+module.exports = stylelint.createPlugin(ruleName, (expectation) => {
   const runDeclarationNoImportant =
     stylelint.rules["declaration-no-important"](expectation);
 

--- a/docs/developer-guide/processors.md
+++ b/docs/developer-guide/processors.md
@@ -11,13 +11,13 @@ Processor modules are functions that accept an options object and return an obje
 
 ```js
 // my-processor.js
-module.exports = function (options) {
+module.exports = function myProcessor(options) {
   return {
-    code: function (input, filepath) {
+    code: (input, filepath) => {
       // ...
       return transformedCode;
     },
-    result: function (stylelintResult, filepath) {
+    result: (stylelintResult, filepath) => {
       // ...
       return transformedResult;
     }

--- a/docs/user-guide/usage/node-api.md
+++ b/docs/user-guide/usage/node-api.md
@@ -3,7 +3,7 @@
 The Stylelint module includes a `lint()` function that provides the Node.js API.
 
 ```js
-stylelint.lint(options).then(function (resultObject) {
+stylelint.lint(options).then((resultObject) => {
   /* .. */
 });
 ```
@@ -90,11 +90,11 @@ stylelint
     config: { rules: "color-no-invalid-hex" },
     files: "all/my/stylesheets/*.css"
   })
-  .then(function (data) {
+  .then((data) => {
     // do things with data.output, data.errored,
     // and data.results
   })
-  .catch(function (err) {
+  .catch((err) => {
     // do things with err e.g.
     console.error(err.stack);
   });
@@ -111,7 +111,7 @@ stylelint
     configBasedir: path.join(__dirname, "configs"),
     files: "all/my/stylesheets/*.css"
   })
-  .then(function () {
+  .then(() => {
     /* .. */
   });
 ```
@@ -127,7 +127,7 @@ stylelint
     config: myConfig,
     formatter: "verbose"
   })
-  .then(function () {
+  .then(() => {
     /* .. */
   });
 ```
@@ -141,11 +141,11 @@ stylelint
   .lint({
     config: myConfig,
     files: "all/my/stylesheets/*.scss",
-    formatter: function (stylelintResults) {
+    formatter: (stylelintResults) => {
       /* .. */
     }
   })
-  .then(function () {
+  .then(() => {
     /* .. */
   });
 ```
@@ -168,7 +168,7 @@ stylelint
       }
     }
   })
-  .then(function () {
+  .then(() => {
     /* .. */
   });
 ```
@@ -186,7 +186,7 @@ stylelint
     config: { rules: { "hue-degree-notation": "angle" } },
     fix: true
   })
-  .then(function () {
+  .then(() => {
     /* .. */
   });
 ```


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Arrow Function is now widely-used and becomes simpler code.
This change replaces `function` expressions with arrow functions in docs.

