### PR TITLE
Fix false positives for `:is()` and `:where()` in `*-specificity`

### DIFF
--- a/lib/rules/no-descending-specificity/__tests__/index.js
+++ b/lib/rules/no-descending-specificity/__tests__/index.js
@@ -91,6 +91,9 @@ testRule({
 		{
 			code: 'p::-moz-focus-inner {} p {}',
 		},
+		{
+			code: ':where(a :is(b, i)) {} :where(a) {}',
+		},
 	],
 
 	reject: [

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -109,7 +109,7 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			/** @type {Array<{ selector: string, specificity: import('@bramus/specificity').Specificity }>} */
+			/** @type {Array<{ selector: string, specificity: Specificity }>} */
 			const priorComparableSelectors = comparisonContext.get(referenceSelectorNode);
 
 			for (const priorEntry of priorComparableSelectors) {

--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const resolvedNestedSelector = require('postcss-resolve-nested-selector');
-const specificity = require('specificity');
+const Specificity = require('@bramus/specificity').default;
 
 const findAtRuleContext = require('../../utils/findAtRuleContext');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
@@ -97,10 +97,10 @@ const rule = (primary, secondaryOptions) => {
 		function checkSelector(selectorNode, ruleNode, comparisonContext) {
 			const selector = selectorNode.toString();
 			const referenceSelectorNode = lastCompoundSelectorWithoutPseudoClasses(selectorNode);
-			const calculatedSpecificity = specificity.calculate(selector);
+			const calculatedSpecificity = Specificity.calculate(selector);
 
 			assert(calculatedSpecificity[0]);
-			const selectorSpecificity = calculatedSpecificity[0].specificityArray;
+			const selectorSpecificity = calculatedSpecificity[0];
 			const entry = { selector, specificity: selectorSpecificity };
 
 			if (!comparisonContext.has(referenceSelectorNode)) {
@@ -109,11 +109,11 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			/** @type {Array<{ selector: string, specificity: import('specificity').SpecificityArray }>} */
+			/** @type {Array<{ selector: string, specificity: import('@bramus/specificity').Specificity }>} */
 			const priorComparableSelectors = comparisonContext.get(referenceSelectorNode);
 
 			for (const priorEntry of priorComparableSelectors) {
-				if (specificity.compare(selectorSpecificity, priorEntry.specificity) === -1) {
+				if (selectorSpecificity.isLessThan(priorEntry.specificity)) {
 					report({
 						ruleName,
 						result,

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -98,7 +98,7 @@ Given:
 [
   "0,2,0",
   {
-    "ignoreSelectors": [":global", ":local", "/my-/"]
+    "ignoreSelectors": [":global", ":local", "/^my-/"]
   }
 ]
 ```
@@ -112,12 +112,17 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-:local(.foo.bar)
+:local(.foo.bar) {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-:local(.foo, :global(.bar).baz)
+:local(.foo, :global(.bar).baz) {}
+```
+
+<!-- prettier-ignore -->
+```css
+my-element.foo.bar {}
 ```
 
 The following patterns are considered problems:
@@ -129,10 +134,15 @@ The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
-:local(.foo.bar.baz)
+:local(.foo.bar.baz) {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-:local(.foo, :global(.bar), .foo.bar.baz)
+:local(.foo, :global(.bar), .foo.bar.baz) {}
+```
+
+<!-- prettier-ignore -->
+```css
+my-element.foo.bar.baz {}
 ```

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -57,6 +57,12 @@ testRule({
 		{
 			code: '.foo(@a, @b) {\n&.bar {}}',
 		},
+		{
+			code: ':where(.ab .ab) {}',
+		},
+		{
+			code: ':is(.ab) {}',
+		},
 	],
 
 	reject: [
@@ -105,6 +111,12 @@ testRule({
 		{
 			code: ':matches(.b, .c.d) {}',
 			message: messages.expected(':matches(.b, .c.d)', '0,1,0'),
+			line: 1,
+			column: 1,
+		},
+		{
+			code: ':is(.ab .ab) {}',
+			message: messages.expected(':is(.ab .ab)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
@@ -417,6 +429,7 @@ testRule({
 			message: messages.expected(':local(.b, .c.d)', '0,1,0'),
 			line: 1,
 			column: 1,
+			only: !true,
 		},
 		{
 			code: 'my-tag.a.b {}',

--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -429,7 +429,6 @@ testRule({
 			message: messages.expected(':local(.b, .c.d)', '0,1,0'),
 			line: 1,
 			column: 1,
-			only: !true,
 		},
 		{
 			code: 'my-tag.a.b {}',

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -11,7 +11,7 @@ const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isRegExp, isString, assert, assertNumber } = require('../../utils/validateTypes');
+const { isRegExp, isString, assertNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-max-specificity';
 
@@ -84,11 +84,7 @@ const rule = (primary, secondaryOptions) => {
 				return zeroSpecificity();
 			}
 
-			const calculatedSpecificity = Specificity.calculate(selector);
-
-			assert(calculatedSpecificity[0]);
-
-			return calculatedSpecificity[0];
+			return specificitySum(Specificity.calculate(selector));
 		};
 
 		/**
@@ -114,11 +110,19 @@ const rule = (primary, secondaryOptions) => {
 			// `node.toString()` includes children which should be processed separately,
 			// so use `node.value` instead
 			const ownValue = node.value;
-			const ownSpecificity =
-				ownValue === ':not' || ownValue === ':matches'
-					? // :not and :matches don't add specificity themselves, but their children do
-					  zeroSpecificity()
-					: simpleSpecificity(ownValue);
+
+			if (ownValue === ':where') {
+				return zeroSpecificity();
+			}
+
+			let ownSpecificity;
+
+			if ([':not', ':matches', ':is'].includes(ownValue)) {
+				// these don't add specificity themselves, but their children do
+				ownSpecificity = zeroSpecificity();
+			} else {
+				ownSpecificity = simpleSpecificity(ownValue);
+			}
 
 			return specificitySum([ownSpecificity, maxChildSpecificity(node)]);
 		};

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -1,16 +1,17 @@
 'use strict';
 
+const resolvedNestedSelector = require('postcss-resolve-nested-selector');
+const Specificity = require('@bramus/specificity').default;
+
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
 const keywordSets = require('../../reference/keywordSets');
 const optionsMatches = require('../../utils/optionsMatches');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
-const resolvedNestedSelector = require('postcss-resolve-nested-selector');
 const ruleMessages = require('../../utils/ruleMessages');
-const specificity = require('specificity');
 const validateOptions = require('../../utils/validateOptions');
-const { isRegExp, isString, assert } = require('../../utils/validateTypes');
+const { isRegExp, isString, assert, assertNumber } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-max-specificity';
 
@@ -22,33 +23,31 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-max-specificity',
 };
 
-/** @typedef {import('specificity').SpecificityArray} SpecificityArray */
-
 /**
- * Return an array representation of zero specificity. We need a new array each time so that it can mutated.
+ * Return a zero specificity. We need a new instance each time so that it can mutated.
  *
- * @returns {SpecificityArray}
+ * @returns {Specificity}
  */
-const zeroSpecificity = () => [0, 0, 0, 0];
+const zeroSpecificity = () => new Specificity({ a: 0, b: 0, c: 0 });
 
 /**
- * Calculate the sum of given array of specificity arrays.
+ * Calculate the sum of given array of specificities.
  *
- * @param {SpecificityArray[]} specificities
+ * @param {Specificity[]} specificities
  */
 const specificitySum = (specificities) => {
-	const sum = zeroSpecificity();
+	let [a, b, c] = [0, 0, 0];
 
-	for (const specificityArray of specificities) {
-		for (const [i, value] of specificityArray.entries()) {
-			sum[i] += value;
-		}
+	for (const spec of specificities) {
+		a += spec.a;
+		b += spec.b;
+		c += spec.c;
 	}
 
-	return sum;
+	return new Specificity({ a, b, c });
 };
 
-/** @type {import('stylelint').Rule} */
+/** @type {import('stylelint').Rule<string>} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -78,38 +77,38 @@ const rule = (primary, secondaryOptions) => {
 		 * Calculate the specificity of a simple selector (type, attribute, class, ID, or pseudos's own value).
 		 *
 		 * @param {string} selector
-		 * @returns {SpecificityArray}
+		 * @returns {Specificity}
 		 */
 		const simpleSpecificity = (selector) => {
 			if (optionsMatches(secondaryOptions, 'ignoreSelectors', selector)) {
 				return zeroSpecificity();
 			}
 
-			const calculatedSpecificity = specificity.calculate(selector);
+			const calculatedSpecificity = Specificity.calculate(selector);
 
 			assert(calculatedSpecificity[0]);
 
-			return calculatedSpecificity[0].specificityArray;
+			return calculatedSpecificity[0];
 		};
 
 		/**
 		 * Calculate the the specificity of the most specific direct child.
 		 *
 		 * @param {import('postcss-selector-parser').Container<unknown>} node
-		 * @returns {SpecificityArray}
+		 * @returns {Specificity}
 		 */
 		const maxChildSpecificity = (node) =>
 			node.reduce((maxSpec, child) => {
 				const childSpecificity = nodeSpecificity(child); // eslint-disable-line no-use-before-define
 
-				return specificity.compare(childSpecificity, maxSpec) === 1 ? childSpecificity : maxSpec;
+				return childSpecificity.isGreaterThan(maxSpec) ? childSpecificity : maxSpec;
 			}, zeroSpecificity());
 
 		/**
 		 * Calculate the specificity of a pseudo selector including own value and children.
 		 *
 		 * @param {import('postcss-selector-parser').Pseudo} node
-		 * @returns {SpecificityArray}
+		 * @returns {Specificity}
 		 */
 		const pseudoSpecificity = (node) => {
 			// `node.toString()` includes children which should be processed separately,
@@ -153,7 +152,7 @@ const rule = (primary, secondaryOptions) => {
 		 * Calculate the specificity of a node parsed by `postcss-selector-parser`.
 		 *
 		 * @param {import('postcss-selector-parser').Node} node
-		 * @returns {SpecificityArray}
+		 * @returns {Specificity}
 		 */
 		const nodeSpecificity = (node) => {
 			if (shouldSkipPseudoClassArgument(node)) {
@@ -176,13 +175,14 @@ const rule = (primary, secondaryOptions) => {
 			}
 		};
 
-		/** @type {[number, number, number]} */
-		const primaryNumbers = primary
-			.split(',')
-			.map((/** @type {string} */ s) => Number.parseFloat(s));
+		const [a, b, c] = primary.split(',').map((s) => Number.parseFloat(s));
 
-		/** @type {SpecificityArray} */
-		const maxSpecificityArray = [0, ...primaryNumbers];
+		assertNumber(a);
+		assertNumber(b);
+		assertNumber(c);
+
+		/** @type {Specificity} */
+		const maxSpecificity = new Specificity({ a, b, c });
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {
@@ -192,32 +192,23 @@ const rule = (primary, secondaryOptions) => {
 			// Using `.selectors` gets us each selector in the eventuality we have a comma separated set
 			for (const selector of ruleNode.selectors) {
 				for (const resolvedSelector of resolvedNestedSelector(selector, ruleNode)) {
-					try {
-						// Skip non-standard syntax selectors
-						if (!isStandardSyntaxSelector(resolvedSelector)) {
-							continue;
-						}
-
-						parseSelector(resolvedSelector, result, ruleNode, (selectorTree) => {
-							// Check if the selector specificity exceeds the allowed maximum
-							if (
-								specificity.compare(maxChildSpecificity(selectorTree), maxSpecificityArray) === 1
-							) {
-								report({
-									ruleName,
-									result,
-									node: ruleNode,
-									message: messages.expected(resolvedSelector, primary),
-									word: selector,
-								});
-							}
-						});
-					} catch {
-						result.warn('Cannot parse selector', {
-							node: ruleNode,
-							stylelintType: 'parseError',
-						});
+					// Skip non-standard syntax selectors
+					if (!isStandardSyntaxSelector(resolvedSelector)) {
+						continue;
 					}
+
+					parseSelector(resolvedSelector, result, ruleNode, (selectorTree) => {
+						// Check if the selector specificity exceeds the allowed maximum
+						if (maxChildSpecificity(selectorTree).isGreaterThan(maxSpecificity)) {
+							report({
+								ruleName,
+								result,
+								node: ruleNode,
+								message: messages.expected(resolvedSelector, primary),
+								word: selector,
+							});
+						}
+					});
 				}
 			}
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "14.8.2",
       "license": "MIT",
       "dependencies": {
-        "@bramus/specificity": "^2.1.0",
+        "@bramus/specificity": "github:bramus/specificity",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.2",
         "cosmiconfig": "^7.0.1",
@@ -664,8 +664,8 @@
     },
     "node_modules/@bramus/specificity": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.1.0.tgz",
-      "integrity": "sha512-uR7qeHyVrz5L+USibpf8l17GhOBtYWdAwyQcDfzt/hU3Y772H4r0BiVzf1674/ZP/tDRZPpgiOmUfKCu+4+9Pw==",
+      "resolved": "git+ssh://git@github.com/bramus/specificity.git#09b42a46dce1928947af94a13b2b17deaf64394a",
+      "license": "MIT",
       "dependencies": {
         "css-tree": "^2.1.0"
       },
@@ -13044,9 +13044,8 @@
       "dev": true
     },
     "@bramus/specificity": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.1.0.tgz",
-      "integrity": "sha512-uR7qeHyVrz5L+USibpf8l17GhOBtYWdAwyQcDfzt/hU3Y772H4r0BiVzf1674/ZP/tDRZPpgiOmUfKCu+4+9Pw==",
+      "version": "git+ssh://git@github.com/bramus/specificity.git#09b42a46dce1928947af94a13b2b17deaf64394a",
+      "from": "@bramus/specificity@github:bramus/specificity",
       "requires": {
         "css-tree": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "14.8.2",
       "license": "MIT",
       "dependencies": {
+        "@bramus/specificity": "^2.1.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.2",
         "cosmiconfig": "^7.0.1",
@@ -660,6 +661,17 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.1.0.tgz",
+      "integrity": "sha512-uR7qeHyVrz5L+USibpf8l17GhOBtYWdAwyQcDfzt/hU3Y772H4r0BiVzf1674/ZP/tDRZPpgiOmUfKCu+4+9Pw==",
+      "dependencies": {
+        "css-tree": "^2.1.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -2652,6 +2664,19 @@
       "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw==",
       "engines": {
         "node": ">=12.22"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.1.0.tgz",
+      "integrity": "sha512-PcysZRzToBbrpoUrZ9qfblRIRf8zbEAkU0AIpQFtgkFK0vSbzOmBCvdSAx2Zg7Xx5wiYJKUKk0NMP7kxevie/A==",
+      "dependencies": {
+        "mdn-data": "2.0.27",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -7158,6 +7183,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.27.tgz",
+      "integrity": "sha512-kwqO0I0jtWr25KcfLm9pia8vLZ8qoAKhWZuZMbneJq3jjBD3gl5nZs8l8Tu3ZBlBAHVQtDur9rdDGyvtfVraHQ=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -13013,6 +13043,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bramus/specificity": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.1.0.tgz",
+      "integrity": "sha512-uR7qeHyVrz5L+USibpf8l17GhOBtYWdAwyQcDfzt/hU3Y772H4r0BiVzf1674/ZP/tDRZPpgiOmUfKCu+4+9Pw==",
+      "requires": {
+        "css-tree": "^2.1.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -14587,6 +14625,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.0.1.tgz",
       "integrity": "sha512-PriDuifDt4u4rkDgnqRCLnjfMatufLmWNfQnGCq34xZwpY3oabwhB9SqRBmuvWUgndbemCFlKqg+nO7C2q0SBw=="
+    },
+    "css-tree": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.1.0.tgz",
+      "integrity": "sha512-PcysZRzToBbrpoUrZ9qfblRIRf8zbEAkU0AIpQFtgkFK0vSbzOmBCvdSAx2Zg7Xx5wiYJKUKk0NMP7kxevie/A==",
+      "requires": {
+        "mdn-data": "2.0.27",
+        "source-map-js": "^1.0.1"
+      }
     },
     "cssesc": {
       "version": "3.0.0",
@@ -17883,6 +17930,11 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
       "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
       "dev": true
+    },
+    "mdn-data": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.27.tgz",
+      "integrity": "sha512-kwqO0I0jtWr25KcfLm9pia8vLZ8qoAKhWZuZMbneJq3jjBD3gl5nZs8l8Tu3ZBlBAHVQtDur9rdDGyvtfVraHQ=="
     },
     "memorystream": {
       "version": "0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "postcss-selector-parser": "^6.0.10",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
-        "specificity": "^0.4.1",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
@@ -11166,14 +11165,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
     },
-    "node_modules/specificity": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
-      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
-      "bin": {
-        "specificity": "bin/specificity"
-      }
-    },
     "node_modules/split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -20836,11 +20827,6 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
-    },
-    "specificity": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
-      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg=="
     },
     "split": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "postcss-selector-parser": "^6.0.10",
     "postcss-value-parser": "^4.2.0",
     "resolve-from": "^5.0.0",
-    "specificity": "^0.4.1",
     "string-width": "^4.2.3",
     "strip-ansi": "^6.0.1",
     "style-search": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     ]
   },
   "dependencies": {
-    "@bramus/specificity": "^2.1.0",
+    "@bramus/specificity": "github:bramus/specificity",
     "balanced-match": "^2.0.0",
     "colord": "^2.9.2",
     "cosmiconfig": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     ]
   },
   "dependencies": {
+    "@bramus/specificity": "^2.1.0",
     "balanced-match": "^2.0.0",
     "colord": "^2.9.2",
     "cosmiconfig": "^7.0.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5065

> Is there anything in the PR that needs further explanation?

This pull request does:

- fix false positives in [`no-descending-specificity`](https://stylelint.io/user-guide/rules/list/no-descending-specificity) and [`selector-max-specificity`](https://stylelint.io/user-guide/rules/list/selector-max-specificity)
- install the [`@bramus/specificity`](https://github.com/bramus/specificity) package
```shell
npm i @bramus/specificity
```
- uninstall the [`specificity`](https://github.com/keeganstreet/specificity) package that is no longer needed:
```shell
npm rm specificity
```

