### PR TITLE
Fix typo in `keyframe-declaration-no-important` doc

### DIFF
--- a/lib/rules/keyframe-declaration-no-important/README.md
+++ b/lib/rules/keyframe-declaration-no-important/README.md
@@ -18,7 +18,7 @@ Using `!important` within keyframes declarations is [completely ignored in some 
 
 ### `true`
 
-The following patterns is considered a problem:
+The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
 ```css


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
