### PR TITLE
Fix missing word in `time-min-milliseconds` doc

### DIFF
--- a/lib/rules/time-min-milliseconds/README.md
+++ b/lib/rules/time-min-milliseconds/README.md
@@ -69,7 +69,7 @@ Ignore time values for an animation or transition delay.
 
 For example, with a minimum of `200` milliseconds.
 
-The following is _not_ considered a problem:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
