### PR TITLE
Fix missing heading in `selector-max-id` doc

### DIFF
--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -75,6 +75,8 @@ The following patterns are _not_ considered problems:
 #foo #bar:not(#baz) {}
 ```
 
+## Optional secondary options
+
 ### `ignoreContextFunctionalPseudoClasses: ["/regex/", /regex/, "non-regex"]`
 
 Ignore selectors inside of specified [functional pseudo-classes](https://drafts.csswg.org/selectors-4/#pseudo-classes) that provide [evaluation contexts](https://drafts.csswg.org/selectors-4/#specificity-rules).


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
