### PR TITLE
Unify wording in `comment-empty-line-before` doc

### DIFF
--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -176,7 +176,7 @@ For example, with `"always"` and given:
 ["/^ignore/", "string-ignore"]
 ```
 
-The following comments are _not_ considered problems:
+The following patterns are _not_ considered problems:
 
 ```css
 :root {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
