### PR TITLE
Fix `length-zero-no-unit` autofix for `.0` values

### DIFF
--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -674,6 +674,15 @@ testRule({
 			endColumn: 27,
 		},
 		{
+			code: 'a { right: .0rem; }',
+			fixed: 'a { right: 0; }',
+			message: messages.rejected,
+			line: 1,
+			column: 14,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
 			code: stripIndent`
  				a {
  					box-shadow: -0.25rem 0rem 0rem rgba(0, 0, 0, 0), /* comment */

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -81,7 +81,13 @@ const rule = (primary, secondaryOptions, context) => {
 			if (!isZero(number)) return;
 
 			if (context.fix) {
-				valueNode.value = number;
+				let regularNumber = number;
+
+				if (regularNumber.startsWith('.')) {
+					regularNumber = number.slice(1);
+				}
+
+				valueNode.value = regularNumber;
 				needsFix = true;
 
 				return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6074

> Is there anything in the PR that needs further explanation?

I tested these changes in the reproduction repository and
- works well with .0rem (.0rem -> 0)
- doesn't work with .0 (still .0 -> '')

So should we fix it for the second case? It doesn't seem to be the problem with this rule. @ybiquitous correct me if I'm wrong.
