### PR TITLE
fix: ignore non-standard selectors for rule no-duplicate-selectors

### DIFF
--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -349,7 +349,6 @@ testRule({
 });
 
 testRule({
-	skip: true,
 	ruleName,
 	customSyntax: 'postcss-scss',
 	config: [true],

--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -347,3 +347,17 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	skip: true,
+	ruleName,
+	customSyntax: 'postcss-scss',
+	config: [true],
+
+	accept: [
+		{
+			code: 'a { background: { color: red } }',
+			description: 'Non standard SCSS nested property',
+		},
+	],
+});

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -5,6 +5,7 @@ const selectorParser = require('postcss-selector-parser');
 
 const findAtRuleContext = require('../../utils/findAtRuleContext');
 const isKeyframeRule = require('../../utils/isKeyframeRule');
+const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
 const nodeContextLookup = require('../../utils/nodeContextLookup');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
@@ -62,7 +63,11 @@ const rule = (primary, secondaryOptions) => {
 			);
 			const resolvedSelectorList = [
 				...new Set(
-					ruleNode.selectors.flatMap((selector) => resolvedNestedSelector(selector, ruleNode)),
+					ruleNode.selectors.flatMap((selector) => {
+						return isStandardSyntaxSelector(selector)
+							? resolvedNestedSelector(selector, ruleNode)
+							: [];
+					}),
 				),
 			];
 			const normalizedSelectorList = resolvedSelectorList.map((selector) => normalize(selector));

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -128,6 +128,10 @@ const rule = (primary, secondaryOptions) => {
 
 			// Or complain if one selector list contains the same selector more than once
 			for (const selector of ruleNode.selectors) {
+				if (!isStandardSyntaxSelector(selector)) {
+					continue;
+				}
+
 				const normalized = normalize(selector);
 
 				if (presentedSelectors.has(normalized)) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6103

> Is there anything in the PR that needs further explanation?

<del>

I'm getting the following error, so I have to add `skip: true` like the other test case for `postcss-css-in-js` above in the same test file:

```log
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'nodes' -> object with constructor 'Array'
    |     index 0 -> object with constructor 'Object'
    --- property 'parent' closes the circle
    at stringify (<anonymous>)
    at writeChannelMessage (node:internal/child_process/serialization:127:20)
    at process.target._send (node:internal/child_process:839:17)
    at process.target.send (node:internal/child_process:739:19)
    at reportSuccess (/Users/JounQin/Workspaces/GitHub/stylelint/node_modules/jest-worker/build/workers/processChild.js:59:11)
```

</del>