### PR TITLE
fix: only SCSS nested properties not parsable

### DIFF
--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -360,3 +360,24 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	customSyntax: 'postcss-less',
+	config: [true],
+
+	accept: [
+		{
+			code: `@alert-prefix-cls: ~'@{ant-prefix}-alert';
+
+.@{alert-prefix-cls} {
+	&-success {
+    .@{alert-prefix-cls}-icon {
+      color: @alert-success-icon-color;
+    }
+  }
+}`,
+			description: 'Non standard Less interpolation',
+		},
+	],
+});

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -5,7 +5,6 @@ const selectorParser = require('postcss-selector-parser');
 
 const findAtRuleContext = require('../../utils/findAtRuleContext');
 const isKeyframeRule = require('../../utils/isKeyframeRule');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
 const nodeContextLookup = require('../../utils/nodeContextLookup');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
@@ -23,6 +22,16 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/no-duplicate-selectors',
 };
+
+/**
+ * We're not using `isStandardSyntaxSelector` because the selector actually can be parsable
+ *
+ * @param {string} selector
+ * @returns {boolean}
+ */
+const isParsableSelector = (selector) =>
+	// SCSS nested properties
+	!selector.endsWith(':');
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
@@ -64,13 +73,11 @@ const rule = (primary, secondaryOptions) => {
 			const resolvedSelectorList = [
 				...new Set(
 					ruleNode.selectors.flatMap((selector) => {
-						return isStandardSyntaxSelector(selector)
-							? resolvedNestedSelector(selector, ruleNode)
-							: [];
+						return isParsableSelector(selector) ? resolvedNestedSelector(selector, ruleNode) : [];
 					}),
 				),
 			];
-			const normalizedSelectorList = resolvedSelectorList.map((selector) => normalize(selector));
+			const normalizedSelectorList = resolvedSelectorList.map(normalize);
 
 			// Sort the selectors list so that the order of the constituents
 			// doesn't matter
@@ -128,7 +135,7 @@ const rule = (primary, secondaryOptions) => {
 
 			// Or complain if one selector list contains the same selector more than once
 			for (const selector of ruleNode.selectors) {
-				if (!isStandardSyntaxSelector(selector)) {
+				if (!isParsableSelector(selector)) {
 					continue;
 				}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6110

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
