### PR TITLE
fix: `no-duplicate-selectors` false positives for SCSS/Less nested interpolations

### DIFF
--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -371,5 +371,9 @@ testRule({
 			code: '.@{foo} { .@{foo}-bar {} }',
 			description: 'Non standard Less nested interpolation',
 		},
+		{
+			code: '.@{foo} { &:last-child { &, & > .@{foo}-bar {} } }',
+			description: 'Non standard Less nested interpolation (2',
+		},
 	],
 });

--- a/lib/rules/no-duplicate-selectors/__tests__/index.js
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.js
@@ -358,6 +358,14 @@ testRule({
 			code: 'a { background: { color: red } }',
 			description: 'Non standard SCSS nested property',
 		},
+		{
+			code: '.#{foo} { &:last-child { &, & > .#{foo}-bar {} } }',
+			description: 'Non standard SCSS nested interpolation',
+		},
+		{
+			code: 'a { b, .#{var} {} b {} }',
+			description: 'Non standard SCSS nested interpolation (2',
+		},
 	],
 });
 
@@ -374,6 +382,10 @@ testRule({
 		{
 			code: '.@{foo} { &:last-child { &, & > .@{foo}-bar {} } }',
 			description: 'Non standard Less nested interpolation (2',
+		},
+		{
+			code: 'a { b, .@{var} {} b {} }',
+			description: 'Non standard Less nested interpolation (3',
 		},
 	],
 });

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -63,17 +63,13 @@ const rule = (primary, secondaryOptions) => {
 			);
 			const resolvedSelectorList = [
 				...new Set(
-					ruleNode.selectors
-						.flatMap((selector) => resolvedNestedSelector(selector, ruleNode))
-						.filter(isStandardSyntaxSelector),
+					ruleNode.selectors.flatMap((selector) => resolvedNestedSelector(selector, ruleNode)),
 				),
 			];
 
-			if (resolvedSelectorList.length === 0) {
-				return;
-			}
-
-			const normalizedSelectorList = resolvedSelectorList.map(normalize);
+			const normalizedSelectorList = resolvedSelectorList.map((selector) => {
+				return isStandardSyntaxSelector(selector) ? normalize(selector) : selector;
+			});
 
 			// Sort the selectors list so that the order of the constituents
 			// doesn't matter
@@ -131,11 +127,7 @@ const rule = (primary, secondaryOptions) => {
 
 			// Or complain if one selector list contains the same selector more than once
 			for (const selector of ruleNode.selectors) {
-				if (!isStandardSyntaxSelector(selector)) {
-					continue;
-				}
-
-				const normalized = normalize(selector);
+				const normalized = isStandardSyntaxSelector(selector) ? normalize(selector) : selector;
 
 				if (presentedSelectors.has(normalized)) {
 					if (reportedSelectors.has(normalized)) {

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -67,9 +67,7 @@ const rule = (primary, secondaryOptions) => {
 				),
 			];
 
-			const normalizedSelectorList = resolvedSelectorList.map((selector) => {
-				return isStandardSyntaxSelector(selector) ? normalize(selector) : selector;
-			});
+			const normalizedSelectorList = resolvedSelectorList.map(normalize);
 
 			// Sort the selectors list so that the order of the constituents
 			// doesn't matter
@@ -127,7 +125,7 @@ const rule = (primary, secondaryOptions) => {
 
 			// Or complain if one selector list contains the same selector more than once
 			for (const selector of ruleNode.selectors) {
-				const normalized = isStandardSyntaxSelector(selector) ? normalize(selector) : selector;
+				const normalized = normalize(selector);
 
 				if (presentedSelectors.has(normalized)) {
 					if (reportedSelectors.has(normalized)) {
@@ -165,6 +163,10 @@ const rule = (primary, secondaryOptions) => {
  * @returns {string}
  */
 function normalize(selector) {
+	if (!isStandardSyntaxSelector(selector)) {
+		return selector;
+	}
+
 	return selectorParser().processSync(selector, { lossless: false });
 }
 

--- a/lib/rules/no-duplicate-selectors/index.js
+++ b/lib/rules/no-duplicate-selectors/index.js
@@ -63,11 +63,9 @@ const rule = (primary, secondaryOptions) => {
 			);
 			const resolvedSelectorList = [
 				...new Set(
-					ruleNode.selectors.flatMap((selector) => {
-						return isStandardSyntaxSelector(selector)
-							? resolvedNestedSelector(selector, ruleNode)
-							: [];
-					}),
+					ruleNode.selectors
+						.flatMap((selector) => resolvedNestedSelector(selector, ruleNode))
+						.filter(isStandardSyntaxSelector),
 				),
 			];
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes [#6110#issuecomment-1137211409](https://github.com/stylelint/stylelint/issues/6110#issuecomment-1137211409)

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
