### PR TITLE
Fix false positives with `:nth-child` in `selector-max-specificity` rule

### DIFF
--- a/lib/rules/selector-max-specificity/__tests__/index.js
+++ b/lib/rules/selector-max-specificity/__tests__/index.js
@@ -63,6 +63,9 @@ testRule({
 		{
 			code: ':is(.ab) {}',
 		},
+		{
+			code: ':nth-child(2n + 1) {}',
+		},
 	],
 
 	reject: [
@@ -117,6 +120,18 @@ testRule({
 		{
 			code: ':is(.ab .ab) {}',
 			message: messages.expected(':is(.ab .ab)', '0,1,0'),
+			line: 1,
+			column: 1,
+		},
+		{
+			code: '.foo:nth-child(2n + 1) {}',
+			message: messages.expected('.foo:nth-child(2n + 1)', '0,1,0'),
+			line: 1,
+			column: 1,
+		},
+		{
+			code: ':nth-child(2n + 1 of .foo) {}',
+			message: messages.expected(':nth-child(2n + 1 of .foo)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
@@ -390,6 +405,10 @@ testRule({
 		},
 		{
 			code: 'my-tag.a {}',
+		},
+		{
+			code: ':nth-child(even of my-tag) {}',
+			skip: true, // TODO: We need to support `<complex-selector-list>` in `ignoreSelectors`.
 		},
 	],
 

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -122,6 +122,9 @@ const rule = (primary, secondaryOptions) => {
 
 			if (optionsMatches(secondaryOptions, 'ignoreSelectors', ownValue)) {
 				ownSpecificity = zeroSpecificity();
+			} else if (keywordSets.aNPlusBOfSNotationPseudoClasses.has(ownValue.replace(/^:/, ''))) {
+				// TODO: We need to support `<complex-selector-list>` in `ignoreSelectors`. E.g. `:nth-child(even of .foo)`.
+				return selectorSpecificity(node);
 			} else {
 				ownSpecificity = selectorSpecificity(node.clone({ nodes: [] }));
 			}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6139

> Is there anything in the PR that needs further explanation?

This pull request aims to fix a `TypeError` raised when parsing `:nth-child` (or `:nth-last-child`) pseudo-classes without arguments in the `selector-max-specificity` rule.

Even if the `@csstools/selector-specificity` package would be updated to parse `:nth-child` without errors (see csstools/postcss-plugins#439), please note that it's necessary Stylelint may have own logic processing `:nth-child(...)`, in order to support `<complex-selector-list>` with the `ignoreSelectors` option, e.g. `:nth-child(even of .foo)`.

See also [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#syntax):

```
:nth-child( <nth> [ of <complex-selector-list> ]? )
```

