### PR TITLE
Fix rule message function type to not require users to handle all kind of arguments

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -137,7 +137,15 @@ declare module 'stylelint' {
 			newline?: string | undefined;
 		};
 
-		export type RuleMessageFunc = (...args: (string | number | boolean | RegExp)[]) => string;
+		// Note: With strict function types enabled, function signatures are checked contravariantly.
+		// This means that it would not be possible for rule authors to narrow the message function
+		// parameters to e.g. just `string`. Declaring the type for rule message functions through
+		// method declarations tricks TypeScript into bivariant signature checking. More details can
+		// be found here: https://stackoverflow.com/questions/52667959/what-is-the-purpose-of-bivariancehack-in-typescript-types.
+		// and in the original discussion: https://github.com/stylelint/stylelint/pull/6147#issuecomment-1155337016.
+		export type RuleMessageFunc = {
+			bivariance(...args: (string | number | boolean | RegExp)[]): string;
+		}['bivariance'];
 
 		export type RuleMessages = { [message: string]: string | RuleMessageFunc };
 

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -82,6 +82,7 @@ const ruleName = 'sample-rule';
 const messages = stylelint.utils.ruleMessages(ruleName, {
 	problem: 'This a rule problem message',
 	warning: (reason) => `This is not allowed because ${reason}`,
+	withNarrowedParam: (mixinName: string) => `Mixin not allowed: ${mixinName}`,
 });
 const problemMessage: string = messages.problem;
 const problemFunc: (...reason: string[]) => string = messages.warning;
@@ -115,3 +116,18 @@ const testPlugin: Plugin = (options) => {
 };
 
 stylelint.createPlugin(ruleName, testPlugin);
+
+messages.withNarrowedParam('should work');
+
+// @ts-expect-error Boolean should not be allowed here.
+messages.withNarrowedParam(true);
+// @ts-expect-error Expected a required parameter.
+messages.withNarrowedParam();
+
+// For non-explicit parameters, boolean, strings etc. are always allowed.
+// Not `null` for example though.
+messages.warning(true);
+messages.warning('some string');
+
+// @ts-expect-error Null is not allowed in `RuleMessageFunc` parameters.
+messages.warning(null);


### PR DESCRIPTION
Currently, users writing custom rules and using `RuleMessageFunc` are required to handle all kinds of parameters with TypeScript's strict mode enabled. e.g.

```ts
const messages = utils.ruleMessages(ruleName, {
  invalid: (rule: string) =>
    `Failed to extract namespace from ${rule}. material/no-unused-` +
    `imports Stylelint rule likely needs to be updated.`,
});
```

results in

```
tools/stylelint/no-unused-import.ts:7:12 - error TS2322: Type '(rule: string) => string' is not assignable to type 'string | RuleMessageFunc'.
  Type '(rule: string) => string' is not assignable to type 'RuleMessageFunc'.
    Types of parameters 'rule' and 'args' are incompatible.
      Type 'string | number | boolean | RegExp' is not assignable to type 'string'.

7   invalid: (rule: string) =>
             ~~~~~~~~~~~~~~~~~
8     `Failed to extract namespace from ${rule}. material/no-unused-` +
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
9     `imports Stylelint rule likely needs to be updated.`,
```

This can be observed in my small playground as well:

https://www.typescriptlang.org/play?#code/C4TwDgpgBASgrgGwgWQgZzQQwOYQGJwB2AxlALxQAUAdLZgE7ZoBcVaw9AlodlAD6wI2AKIAPMAEoA2gF0J5AHxR2XHgG4AUBoBmRYsE4B7QlAC2IABIQEkepV0lW8JKgw58e+QG8AvlvNWNhB2lPSIEABymKYQrCrc2PJkSgAGAILAUGFIUAAkXtmR0RA+UJxoUNqYnAgJAIQpEmpAA

Not specifying any type constraints, allows the user to choose the quantity and types of arguments themselves.  TypeScript will still be able to narrow the function type when it is re-exposed through the generic in `utils.ruleMessages`.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

See description above
