### PR TITLE
Use dashed indents in examples of custom unit constructs

### DIFF
--- a/lib/rules/unit-no-unknown/README.md
+++ b/lib/rules/unit-no-unknown/README.md
@@ -68,7 +68,7 @@ a {
 Given:
 
 ```json
-["/^my-/", "custom"]
+["/^--foo-/", "--bar"]
 ```
 
 The following patterns are _not_ considered problems:
@@ -83,14 +83,14 @@ a {
 <!-- prettier-ignore -->
 ```css
 a {
-  width: 10my-unit;
+  width: 10--foo--baz;
 }
 ```
 
 <!-- prettier-ignore -->
 ```css
 a {
-  width: 10my-other-unit;
+  width: 10--bar;
 }
 ```
 

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -481,7 +481,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreUnits: ['pix', '/^my-/', '/^YOUR-/i'] }],
+	config: [true, { ignoreUnits: ['pix', '/^--my-/', '/^--YOUR-/i'] }],
 
 	accept: [
 		{
@@ -491,16 +491,16 @@ testRule({
 			code: 'a { margin: 10pix; }',
 		},
 		{
-			code: 'a { margin: 10my-unit; }',
+			code: 'a { margin: 10--my-unit; }',
 		},
 		{
-			code: 'a { margin: 10my-other-unit; }',
+			code: 'a { margin: 10--my-other-unit; }',
 		},
 		{
-			code: 'a { margin: 10YOUR-unit; }',
+			code: 'a { margin: 10--YOUR-unit; }',
 		},
 		{
-			code: 'a { margin: 10your-unit; }',
+			code: 'a { margin: 10--your-unit; }',
 		},
 	],
 
@@ -526,11 +526,11 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreUnits: [/^my-/] }],
+	config: [true, { ignoreUnits: [/^--my-/] }],
 
 	accept: [
 		{
-			code: 'a { margin: 10my-unit; }',
+			code: 'a { margin: 10--my-unit; }',
 		},
 	],
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of umbrella issue #5523.

> Is there anything in the PR that needs further explanation?

Tried to follow #5555 but used the foo, bar, baz naming conventions in the docs. Also updated tests to mostly match. Let me know if I should do something different.

In looking for custom unit constructs (mostly skimming the rule list), I only found them in `unit-no-unknown`. Let me know if I should add any others.
