### PR TITLE
Use Prettier cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   ],
   "scripts": {
     "benchmark-rule": "node scripts/benchmark-rule.mjs",
-    "format": "prettier . --write",
+    "format": "prettier . --write --cache",
     "jest": "jest",
     "lint": "npm-run-all --parallel --continue-on-error lint:*",
-    "lint:formatting": "prettier . --check",
+    "lint:formatting": "prettier . --check --cache",
     "lint:js": "eslint . --cache --max-warnings=0",
     "lint:md": "remark . --quiet --frail",
     "lint:types": "tsc",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This pull request uses the new `--cache` option since Prettier 2.7.
See https://prettier.io/blog/2022/06/14/2.7.0.html

By default, Prettier saves cache in `node_modules/.cache/prettier`, which has no effect on CI.

Demo on my local machine (the second has cache):

```console
$ time npm run lint:formatting
...
npm run lint:formatting  9.27s user 0.50s system 172% cpu 5.656 total

$ time npm run lint:formatting
...
npm run lint:formatting  1.32s user 0.26s system 125% cpu 1.261 total
```
