### PR TITLE
Add rule metadata to public `LinterResult` API

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -56,6 +56,12 @@ And the second argument (`returnValue`) is an object (type `LinterResult`) with 
     // Present if Stylelint was configured with a `maxWarnings` count
     "maxWarnings": 10,
     "foundWarnings": 15
+  },
+  "ruleMetadata": {
+    "block-no-empty": {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty"
+    },
+    // other rules...
   }
 }
 ```

--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.js
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.js
@@ -70,6 +70,7 @@ describe('stylelintignore', () => {
 				output: '[]',
 				reportedDisables: [],
 				results: [],
+				ruleMetadata: {},
 			});
 		});
 
@@ -106,6 +107,7 @@ describe('stylelintignore', () => {
 				output: '[]',
 				reportedDisables: [],
 				results: [],
+				ruleMetadata: {},
 			});
 		});
 
@@ -122,6 +124,7 @@ describe('stylelintignore', () => {
 				output: '[]',
 				reportedDisables: [],
 				results: [],
+				ruleMetadata: {},
 			});
 		});
 	});
@@ -185,6 +188,7 @@ describe('stylelintignore with options.cwd', () => {
 				output: '[]',
 				reportedDisables: [],
 				results: [],
+				ruleMetadata: {},
 			});
 		});
 
@@ -223,6 +227,7 @@ describe('stylelintignore with options.cwd', () => {
 				output: '[]',
 				reportedDisables: [],
 				results: [],
+				ruleMetadata: {},
 			});
 		});
 
@@ -240,6 +245,7 @@ describe('stylelintignore with options.cwd', () => {
 				output: '[]',
 				reportedDisables: [],
 				results: [],
+				ruleMetadata: {},
 			});
 		});
 	});

--- a/lib/formatters/__tests__/githubFormatter.test.js
+++ b/lib/formatters/__tests__/githubFormatter.test.js
@@ -31,8 +31,14 @@ test('githubFormatter', () => {
 			],
 		},
 	];
+	const returnValue = {
+		ruleMetadata: {
+			foo: { url: 'https://stylelint.io/rules/foo' },
+			bar: {},
+		},
+	};
 
-	expect(githubFormatter(results))
-		.toBe(`::error file=path/to/file.css,line=1,col=2,endLine=1,endColumn=5,title=Stylelint problem::Unexpected "foo" (foo)
+	expect(githubFormatter(results, returnValue))
+		.toBe(`::error file=path/to/file.css,line=1,col=2,endLine=1,endColumn=5,title=Stylelint problem::Unexpected "foo" (foo) - https://stylelint.io/rules/foo
 ::warning file=a.css,line=10,col=20,title=Stylelint problem::Unexpected "bar" (bar)`);
 });

--- a/lib/formatters/__tests__/prepareFormatterOutput.js
+++ b/lib/formatters/__tests__/prepareFormatterOutput.js
@@ -10,7 +10,10 @@ symbolConversions.set('⚠', '‼');
 symbolConversions.set('✖', '×');
 
 module.exports = function (results, formatter) {
-	let output = stripAnsi(formatter(results)).trim();
+	const returnValue = {
+		ruleMetadata: {},
+	};
+	let output = stripAnsi(formatter(results, returnValue)).trim();
 
 	for (const [nix, win] of symbolConversions.entries()) {
 		output = output.replace(new RegExp(nix, 'g'), win);

--- a/lib/formatters/githubFormatter.js
+++ b/lib/formatters/githubFormatter.js
@@ -5,16 +5,32 @@
  *
  * @type {import('stylelint').Formatter}
  */
-module.exports = function githubFormatter(results) {
+module.exports = function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';
+	const metadata = returnValue.ruleMetadata;
 
 	return results
 		.flatMap(({ source, warnings }) =>
-			warnings.map(({ line, column, endLine, endColumn, text, severity }) => {
+			warnings.map(({ line, column, endLine, endColumn, text, severity, rule }) => {
+				const msg = buildMessage(text, metadata[rule]);
+
 				return endLine === undefined
-					? `::${severity} file=${source},line=${line},col=${column},title=${title}::${text}`
-					: `::${severity} file=${source},line=${line},col=${column},endLine=${endLine},endColumn=${endColumn},title=${title}::${text}`;
+					? `::${severity} file=${source},line=${line},col=${column},title=${title}::${msg}`
+					: `::${severity} file=${source},line=${line},col=${column},endLine=${endLine},endColumn=${endColumn},title=${title}::${msg}`;
 			}),
 		)
 		.join('\n');
 };
+
+/**
+ * @param {string} msg
+ * @param {Partial<import('stylelint').RuleMeta> | undefined} metadata
+ * @returns {string}
+ */
+function buildMessage(msg, metadata) {
+	if (!metadata) return msg;
+
+	if (!metadata.url) return msg;
+
+	return `${msg} - ${metadata.url}`;
+}

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -10,11 +10,12 @@ const terminalLink = require('./terminalLink');
 /** @typedef {import('stylelint').LintResult} LintResult */
 /** @typedef {import('stylelint').Warning} Warning */
 /** @typedef {import('stylelint').Severity} Severity */
+/** @typedef {import('stylelint').RuleMeta} RuleMeta */
 
 /**
  * @type {Formatter}
  */
-module.exports = function (results, returnValue) {
+module.exports = function verboseFormatter(results, returnValue) {
 	let output = stringFormatter(results, returnValue);
 
 	if (output === '') {
@@ -54,7 +55,6 @@ module.exports = function (results, returnValue) {
 		output += '\n0 problems found\n';
 	} else {
 		const warningsBySeverity = groupBy(warnings, (w) => w.severity);
-		const metadata = ruleMetadata(results);
 
 		/**
 		 * @param {Severity} severity
@@ -68,6 +68,7 @@ module.exports = function (results, returnValue) {
 			output += underline(`${problems.length} ${pluralize(severity, problems.length)} found\n`);
 
 			const problemsByRule = groupBy(problems, (w) => w.rule);
+			const metadata = returnValue.ruleMetadata;
 
 			for (const [rule, list] of Object.entries(problemsByRule)) {
 				output += dim(` ${ruleLink(rule, metadata[rule])}: ${list.length}\n`);
@@ -118,24 +119,8 @@ function fileLink(source) {
 }
 
 /**
- * @param {LintResult[]} results
- * @returns {Record<string, { url?: string }>}
- */
-function ruleMetadata(results) {
-	const firstResult = results[0];
-
-	return (
-		(firstResult &&
-			firstResult._postcssResult &&
-			firstResult._postcssResult.stylelint &&
-			firstResult._postcssResult.stylelint.ruleMetadata) ||
-		{}
-	);
-}
-
-/**
  * @param {string} rule
- * @param {{ url?: string } | undefined} metadata
+ * @param {Partial<RuleMeta> | undefined} metadata
  * @returns {string}
  */
 function ruleLink(rule, metadata) {

--- a/lib/prepareReturnValue.js
+++ b/lib/prepareReturnValue.js
@@ -18,7 +18,7 @@ const reportDisables = require('./reportDisables');
  *
  * @returns {LinterResult}
  */
-function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
+module.exports = function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
 	reportDisables(stylelintResults);
 	needlessDisables(stylelintResults);
 	invalidScopeDisables(stylelintResults);
@@ -38,6 +38,7 @@ function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
 		results: [],
 		output: '',
 		reportedDisables: [],
+		ruleMetadata: getRuleMetadata(stylelintResults),
 	};
 
 	if (maxWarnings !== undefined) {
@@ -52,6 +53,17 @@ function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
 	returnValue.results = stylelintResults;
 
 	return returnValue;
-}
+};
 
-module.exports = prepareReturnValue;
+/**
+ * @param {StylelintResult[]} lintResults
+ */
+function getRuleMetadata(lintResults) {
+	const [lintResult] = lintResults;
+
+	if (lintResult === undefined) return {};
+
+	if (lintResult._postcssResult === undefined) return {};
+
+	return lintResult._postcssResult.stylelint.ruleMetadata;
+}

--- a/system-tests/001/__snapshots__/fs.test.js.snap
+++ b/system-tests/001/__snapshots__/fs.test.js.snap
@@ -24,5 +24,295 @@ Object {
       "warnings": Array [],
     },
   ],
+  "ruleMetadata": Object {
+    "at-rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
+    },
+    "at-rule-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
+    },
+    "at-rule-name-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
+    },
+    "at-rule-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
+    },
+    "at-rule-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
+    },
+    "block-closing-brace-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
+    },
+    "block-closing-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
+    },
+    "block-closing-brace-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
+    },
+    "block-closing-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
+    },
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+    "block-opening-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
+    },
+    "block-opening-brace-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
+    },
+    "block-opening-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
+    },
+    "color-hex-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
+    },
+    "color-hex-length": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
+    },
+    "color-no-invalid-hex": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
+    },
+    "comment-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
+    },
+    "comment-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
+    },
+    "comment-whitespace-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
+    },
+    "custom-property-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
+    },
+    "declaration-bang-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
+    },
+    "declaration-bang-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
+    },
+    "declaration-block-no-duplicate-properties": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-properties",
+    },
+    "declaration-block-no-shorthand-property-overrides": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
+    },
+    "declaration-block-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
+    },
+    "declaration-block-semicolon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
+    },
+    "declaration-block-semicolon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
+    },
+    "declaration-block-single-line-max-declarations": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
+    },
+    "declaration-block-trailing-semicolon": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
+    },
+    "declaration-colon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
+    },
+    "declaration-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
+    },
+    "declaration-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
+    },
+    "declaration-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
+    },
+    "font-family-no-duplicate-names": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names",
+    },
+    "font-family-no-missing-generic-family-keyword": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
+    },
+    "function-calc-no-unspaced-operator": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
+    },
+    "function-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
+    },
+    "function-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
+    },
+    "function-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
+    },
+    "function-linear-gradient-no-nonstandard-direction": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
+    },
+    "function-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
+    },
+    "function-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
+    },
+    "function-parentheses-newline-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
+    },
+    "function-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
+    },
+    "function-whitespace-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
+    },
+    "indentation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/indentation",
+    },
+    "keyframe-declaration-no-important": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
+    },
+    "length-zero-no-unit": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
+    },
+    "max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
+    },
+    "media-feature-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
+    },
+    "media-feature-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
+    },
+    "media-feature-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
+    },
+    "media-feature-name-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
+    },
+    "media-feature-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
+    },
+    "media-feature-range-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
+    },
+    "media-feature-range-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
+    },
+    "media-query-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
+    },
+    "media-query-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
+    },
+    "media-query-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
+    },
+    "no-duplicate-at-import-rules": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules",
+    },
+    "no-duplicate-selectors": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-selectors",
+    },
+    "no-empty-source": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
+    },
+    "no-eol-whitespace": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
+    },
+    "no-extra-semicolons": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
+    },
+    "no-invalid-double-slash-comments": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
+    },
+    "no-missing-end-of-source-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
+    },
+    "number-leading-zero": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
+    },
+    "number-no-trailing-zeros": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
+    },
+    "property-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-case",
+    },
+    "property-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
+    },
+    "rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
+    },
+    "selector-attribute-brackets-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
+    },
+    "selector-attribute-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
+    },
+    "selector-attribute-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
+    },
+    "selector-combinator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
+    },
+    "selector-combinator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
+    },
+    "selector-descendant-combinator-no-non-space": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
+    },
+    "selector-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
+    },
+    "selector-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
+    },
+    "selector-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
+    },
+    "selector-pseudo-class-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
+    },
+    "selector-pseudo-class-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
+    },
+    "selector-pseudo-class-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
+    },
+    "selector-pseudo-element-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
+    },
+    "selector-pseudo-element-colon-notation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
+    },
+    "selector-pseudo-element-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
+    },
+    "selector-type-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
+    },
+    "selector-type-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-no-unknown",
+    },
+    "string-no-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
+    },
+    "unit-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-case",
+    },
+    "unit-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
+    },
+    "value-keyword-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
+    },
+    "value-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
+    },
+    "value-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
+    },
+    "value-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
+    },
+    "value-list-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
+    },
+  },
 }
 `;

--- a/system-tests/001/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/001/__snapshots__/no-fs.test.js.snap
@@ -24,5 +24,295 @@ Object {
       "warnings": Array [],
     },
   ],
+  "ruleMetadata": Object {
+    "at-rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
+    },
+    "at-rule-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
+    },
+    "at-rule-name-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
+    },
+    "at-rule-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
+    },
+    "at-rule-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
+    },
+    "block-closing-brace-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
+    },
+    "block-closing-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
+    },
+    "block-closing-brace-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
+    },
+    "block-closing-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
+    },
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+    "block-opening-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
+    },
+    "block-opening-brace-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
+    },
+    "block-opening-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
+    },
+    "color-hex-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
+    },
+    "color-hex-length": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
+    },
+    "color-no-invalid-hex": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
+    },
+    "comment-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
+    },
+    "comment-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
+    },
+    "comment-whitespace-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
+    },
+    "custom-property-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
+    },
+    "declaration-bang-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
+    },
+    "declaration-bang-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
+    },
+    "declaration-block-no-duplicate-properties": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-properties",
+    },
+    "declaration-block-no-shorthand-property-overrides": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
+    },
+    "declaration-block-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
+    },
+    "declaration-block-semicolon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
+    },
+    "declaration-block-semicolon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
+    },
+    "declaration-block-single-line-max-declarations": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
+    },
+    "declaration-block-trailing-semicolon": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
+    },
+    "declaration-colon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
+    },
+    "declaration-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
+    },
+    "declaration-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
+    },
+    "declaration-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
+    },
+    "font-family-no-duplicate-names": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names",
+    },
+    "font-family-no-missing-generic-family-keyword": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
+    },
+    "function-calc-no-unspaced-operator": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
+    },
+    "function-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
+    },
+    "function-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
+    },
+    "function-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
+    },
+    "function-linear-gradient-no-nonstandard-direction": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
+    },
+    "function-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
+    },
+    "function-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
+    },
+    "function-parentheses-newline-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
+    },
+    "function-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
+    },
+    "function-whitespace-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
+    },
+    "indentation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/indentation",
+    },
+    "keyframe-declaration-no-important": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
+    },
+    "length-zero-no-unit": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
+    },
+    "max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
+    },
+    "media-feature-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
+    },
+    "media-feature-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
+    },
+    "media-feature-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
+    },
+    "media-feature-name-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
+    },
+    "media-feature-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
+    },
+    "media-feature-range-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
+    },
+    "media-feature-range-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
+    },
+    "media-query-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
+    },
+    "media-query-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
+    },
+    "media-query-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
+    },
+    "no-duplicate-at-import-rules": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules",
+    },
+    "no-duplicate-selectors": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-selectors",
+    },
+    "no-empty-source": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
+    },
+    "no-eol-whitespace": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
+    },
+    "no-extra-semicolons": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
+    },
+    "no-invalid-double-slash-comments": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
+    },
+    "no-missing-end-of-source-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
+    },
+    "number-leading-zero": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
+    },
+    "number-no-trailing-zeros": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
+    },
+    "property-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-case",
+    },
+    "property-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
+    },
+    "rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
+    },
+    "selector-attribute-brackets-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
+    },
+    "selector-attribute-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
+    },
+    "selector-attribute-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
+    },
+    "selector-combinator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
+    },
+    "selector-combinator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
+    },
+    "selector-descendant-combinator-no-non-space": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
+    },
+    "selector-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
+    },
+    "selector-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
+    },
+    "selector-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
+    },
+    "selector-pseudo-class-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
+    },
+    "selector-pseudo-class-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
+    },
+    "selector-pseudo-class-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
+    },
+    "selector-pseudo-element-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
+    },
+    "selector-pseudo-element-colon-notation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
+    },
+    "selector-pseudo-element-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
+    },
+    "selector-type-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
+    },
+    "selector-type-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-no-unknown",
+    },
+    "string-no-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
+    },
+    "unit-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-case",
+    },
+    "unit-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
+    },
+    "value-keyword-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
+    },
+    "value-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
+    },
+    "value-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
+    },
+    "value-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
+    },
+    "value-list-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
+    },
+  },
 }
 `;

--- a/system-tests/002/__snapshots__/fs.test.js.snap
+++ b/system-tests/002/__snapshots__/fs.test.js.snap
@@ -80,5 +80,112 @@ Object {
       ],
     },
   ],
+  "ruleMetadata": Object {
+    "at-rule-name-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
+    },
+    "at-rule-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix",
+    },
+    "at-rule-semicolon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-space-before",
+    },
+    "color-named": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-named",
+    },
+    "declaration-block-semicolon-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-before",
+    },
+    "declaration-no-important": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-no-important",
+    },
+    "font-family-name-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-name-quotes",
+    },
+    "font-weight-notation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-weight-notation",
+    },
+    "function-url-no-scheme-relative": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-url-no-scheme-relative",
+    },
+    "function-url-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-url-quotes",
+    },
+    "max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
+    },
+    "media-feature-name-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-vendor-prefix",
+    },
+    "number-leading-zero": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
+    },
+    "property-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix",
+    },
+    "selector-attribute-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-quotes",
+    },
+    "selector-class-pattern": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-class-pattern",
+    },
+    "selector-list-comma-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before",
+    },
+    "selector-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-after",
+    },
+    "selector-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
+    },
+    "selector-max-attribute": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-attribute",
+    },
+    "selector-max-class": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-class",
+    },
+    "selector-max-combinators": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-combinators",
+    },
+    "selector-max-compound-selectors": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-compound-selectors",
+    },
+    "selector-max-id": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-id",
+    },
+    "selector-max-type": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-type",
+    },
+    "selector-max-universal": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-universal",
+    },
+    "selector-no-qualifying-type": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type",
+    },
+    "selector-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-no-vendor-prefix",
+    },
+    "shorthand-property-no-redundant-values": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values",
+    },
+    "string-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/string-quotes",
+    },
+    "unicode-bom": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unicode-bom",
+    },
+    "value-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
+    },
+    "value-list-comma-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-before",
+    },
+    "value-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
+    },
+    "value-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix",
+    },
+  },
 }
 `;

--- a/system-tests/002/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/002/__snapshots__/no-fs.test.js.snap
@@ -80,5 +80,112 @@ Object {
       ],
     },
   ],
+  "ruleMetadata": Object {
+    "at-rule-name-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
+    },
+    "at-rule-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix",
+    },
+    "at-rule-semicolon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-space-before",
+    },
+    "color-named": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-named",
+    },
+    "declaration-block-semicolon-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-before",
+    },
+    "declaration-no-important": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-no-important",
+    },
+    "font-family-name-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-name-quotes",
+    },
+    "font-weight-notation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-weight-notation",
+    },
+    "function-url-no-scheme-relative": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-url-no-scheme-relative",
+    },
+    "function-url-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-url-quotes",
+    },
+    "max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
+    },
+    "media-feature-name-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-vendor-prefix",
+    },
+    "number-leading-zero": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
+    },
+    "property-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix",
+    },
+    "selector-attribute-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-quotes",
+    },
+    "selector-class-pattern": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-class-pattern",
+    },
+    "selector-list-comma-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before",
+    },
+    "selector-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-after",
+    },
+    "selector-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
+    },
+    "selector-max-attribute": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-attribute",
+    },
+    "selector-max-class": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-class",
+    },
+    "selector-max-combinators": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-combinators",
+    },
+    "selector-max-compound-selectors": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-compound-selectors",
+    },
+    "selector-max-id": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-id",
+    },
+    "selector-max-type": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-type",
+    },
+    "selector-max-universal": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-universal",
+    },
+    "selector-no-qualifying-type": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type",
+    },
+    "selector-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-no-vendor-prefix",
+    },
+    "shorthand-property-no-redundant-values": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values",
+    },
+    "string-quotes": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/string-quotes",
+    },
+    "unicode-bom": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unicode-bom",
+    },
+    "value-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
+    },
+    "value-list-comma-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-before",
+    },
+    "value-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
+    },
+    "value-no-vendor-prefix": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix",
+    },
+  },
 }
 `;

--- a/system-tests/003/__snapshots__/fs.test.js.snap
+++ b/system-tests/003/__snapshots__/fs.test.js.snap
@@ -44,5 +44,298 @@ Object {
       ],
     },
   ],
+  "ruleMetadata": Object {
+    "at-rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
+    },
+    "at-rule-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
+    },
+    "at-rule-name-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
+    },
+    "at-rule-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
+    },
+    "at-rule-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
+    },
+    "block-closing-brace-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
+    },
+    "block-closing-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
+    },
+    "block-closing-brace-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
+    },
+    "block-closing-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
+    },
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+    "block-opening-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
+    },
+    "block-opening-brace-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
+    },
+    "block-opening-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
+    },
+    "color-hex-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
+    },
+    "color-hex-length": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
+    },
+    "color-no-invalid-hex": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
+    },
+    "comment-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
+    },
+    "comment-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
+    },
+    "comment-whitespace-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
+    },
+    "custom-property-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
+    },
+    "declaration-bang-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
+    },
+    "declaration-bang-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
+    },
+    "declaration-block-no-duplicate-properties": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-properties",
+    },
+    "declaration-block-no-shorthand-property-overrides": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
+    },
+    "declaration-block-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
+    },
+    "declaration-block-semicolon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
+    },
+    "declaration-block-semicolon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
+    },
+    "declaration-block-single-line-max-declarations": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
+    },
+    "declaration-block-trailing-semicolon": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
+    },
+    "declaration-colon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
+    },
+    "declaration-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
+    },
+    "declaration-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
+    },
+    "declaration-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
+    },
+    "font-family-no-duplicate-names": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names",
+    },
+    "font-family-no-missing-generic-family-keyword": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
+    },
+    "function-calc-no-unspaced-operator": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
+    },
+    "function-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
+    },
+    "function-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
+    },
+    "function-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
+    },
+    "function-linear-gradient-no-nonstandard-direction": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
+    },
+    "function-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
+    },
+    "function-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
+    },
+    "function-parentheses-newline-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
+    },
+    "function-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
+    },
+    "function-whitespace-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
+    },
+    "indentation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/indentation",
+    },
+    "keyframe-declaration-no-important": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
+    },
+    "length-zero-no-unit": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
+    },
+    "max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
+    },
+    "media-feature-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
+    },
+    "media-feature-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
+    },
+    "media-feature-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
+    },
+    "media-feature-name-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
+    },
+    "media-feature-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
+    },
+    "media-feature-range-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
+    },
+    "media-feature-range-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
+    },
+    "media-query-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
+    },
+    "media-query-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
+    },
+    "media-query-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
+    },
+    "no-descending-specificity": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-descending-specificity",
+    },
+    "no-duplicate-at-import-rules": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules",
+    },
+    "no-duplicate-selectors": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-selectors",
+    },
+    "no-empty-source": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
+    },
+    "no-eol-whitespace": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
+    },
+    "no-extra-semicolons": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
+    },
+    "no-invalid-double-slash-comments": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
+    },
+    "no-missing-end-of-source-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
+    },
+    "number-leading-zero": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
+    },
+    "number-no-trailing-zeros": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
+    },
+    "property-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-case",
+    },
+    "property-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
+    },
+    "rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
+    },
+    "selector-attribute-brackets-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
+    },
+    "selector-attribute-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
+    },
+    "selector-attribute-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
+    },
+    "selector-combinator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
+    },
+    "selector-combinator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
+    },
+    "selector-descendant-combinator-no-non-space": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
+    },
+    "selector-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
+    },
+    "selector-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
+    },
+    "selector-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
+    },
+    "selector-pseudo-class-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
+    },
+    "selector-pseudo-class-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
+    },
+    "selector-pseudo-class-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
+    },
+    "selector-pseudo-element-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
+    },
+    "selector-pseudo-element-colon-notation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
+    },
+    "selector-pseudo-element-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
+    },
+    "selector-type-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
+    },
+    "selector-type-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-no-unknown",
+    },
+    "string-no-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
+    },
+    "unit-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-case",
+    },
+    "unit-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
+    },
+    "value-keyword-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
+    },
+    "value-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
+    },
+    "value-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
+    },
+    "value-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
+    },
+    "value-list-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
+    },
+  },
 }
 `;

--- a/system-tests/003/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/003/__snapshots__/no-fs.test.js.snap
@@ -236,5 +236,298 @@ footer a:visited {
       ],
     },
   ],
+  "ruleMetadata": Object {
+    "at-rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
+    },
+    "at-rule-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
+    },
+    "at-rule-name-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
+    },
+    "at-rule-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
+    },
+    "at-rule-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
+    },
+    "block-closing-brace-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
+    },
+    "block-closing-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
+    },
+    "block-closing-brace-newline-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
+    },
+    "block-closing-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
+    },
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+    "block-opening-brace-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
+    },
+    "block-opening-brace-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
+    },
+    "block-opening-brace-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
+    },
+    "color-hex-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
+    },
+    "color-hex-length": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
+    },
+    "color-no-invalid-hex": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
+    },
+    "comment-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
+    },
+    "comment-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
+    },
+    "comment-whitespace-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
+    },
+    "custom-property-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
+    },
+    "declaration-bang-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
+    },
+    "declaration-bang-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
+    },
+    "declaration-block-no-duplicate-properties": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-properties",
+    },
+    "declaration-block-no-shorthand-property-overrides": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
+    },
+    "declaration-block-semicolon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
+    },
+    "declaration-block-semicolon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
+    },
+    "declaration-block-semicolon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
+    },
+    "declaration-block-single-line-max-declarations": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
+    },
+    "declaration-block-trailing-semicolon": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
+    },
+    "declaration-colon-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
+    },
+    "declaration-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
+    },
+    "declaration-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
+    },
+    "declaration-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
+    },
+    "font-family-no-duplicate-names": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names",
+    },
+    "font-family-no-missing-generic-family-keyword": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
+    },
+    "function-calc-no-unspaced-operator": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
+    },
+    "function-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
+    },
+    "function-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
+    },
+    "function-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
+    },
+    "function-linear-gradient-no-nonstandard-direction": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
+    },
+    "function-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
+    },
+    "function-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
+    },
+    "function-parentheses-newline-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
+    },
+    "function-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
+    },
+    "function-whitespace-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
+    },
+    "indentation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/indentation",
+    },
+    "keyframe-declaration-no-important": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
+    },
+    "length-zero-no-unit": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
+    },
+    "max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
+    },
+    "media-feature-colon-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
+    },
+    "media-feature-colon-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
+    },
+    "media-feature-name-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
+    },
+    "media-feature-name-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
+    },
+    "media-feature-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
+    },
+    "media-feature-range-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
+    },
+    "media-feature-range-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
+    },
+    "media-query-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
+    },
+    "media-query-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
+    },
+    "media-query-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
+    },
+    "no-descending-specificity": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-descending-specificity",
+    },
+    "no-duplicate-at-import-rules": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules",
+    },
+    "no-duplicate-selectors": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-duplicate-selectors",
+    },
+    "no-empty-source": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
+    },
+    "no-eol-whitespace": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
+    },
+    "no-extra-semicolons": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
+    },
+    "no-invalid-double-slash-comments": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
+    },
+    "no-missing-end-of-source-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
+    },
+    "number-leading-zero": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
+    },
+    "number-no-trailing-zeros": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
+    },
+    "property-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-case",
+    },
+    "property-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
+    },
+    "rule-empty-line-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
+    },
+    "selector-attribute-brackets-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
+    },
+    "selector-attribute-operator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
+    },
+    "selector-attribute-operator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
+    },
+    "selector-combinator-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
+    },
+    "selector-combinator-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
+    },
+    "selector-descendant-combinator-no-non-space": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
+    },
+    "selector-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
+    },
+    "selector-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
+    },
+    "selector-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
+    },
+    "selector-pseudo-class-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
+    },
+    "selector-pseudo-class-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
+    },
+    "selector-pseudo-class-parentheses-space-inside": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
+    },
+    "selector-pseudo-element-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
+    },
+    "selector-pseudo-element-colon-notation": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
+    },
+    "selector-pseudo-element-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
+    },
+    "selector-type-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
+    },
+    "selector-type-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/selector-type-no-unknown",
+    },
+    "string-no-newline": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
+    },
+    "unit-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-case",
+    },
+    "unit-no-unknown": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
+    },
+    "value-keyword-case": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
+    },
+    "value-list-comma-newline-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
+    },
+    "value-list-comma-space-after": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
+    },
+    "value-list-comma-space-before": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
+    },
+    "value-list-max-empty-lines": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
+    },
+  },
 }
 `;

--- a/system-tests/004/__snapshots__/fs.test.js.snap
+++ b/system-tests/004/__snapshots__/fs.test.js.snap
@@ -44,6 +44,11 @@ Object {
       ],
     },
   ],
+  "ruleMetadata": Object {
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+  },
 }
 `;
 
@@ -71,5 +76,10 @@ Object {
       "warnings": Array [],
     },
   ],
+  "ruleMetadata": Object {
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+  },
 }
 `;

--- a/system-tests/004/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/004/__snapshots__/no-fs.test.js.snap
@@ -44,6 +44,11 @@ Object {
       ],
     },
   ],
+  "ruleMetadata": Object {
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+  },
 }
 `;
 
@@ -71,5 +76,10 @@ Object {
       "warnings": Array [],
     },
   ],
+  "ruleMetadata": Object {
+    "block-no-empty": Object {
+      "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
+    },
+  },
 }
 `;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -90,7 +90,7 @@ declare module 'stylelint' {
 		export type StylelintPostcssResult = {
 			ruleSeverities: { [ruleName: string]: Severity };
 			customMessages: { [ruleName: string]: any };
-			ruleMetadata: { [ruleName: string]: RuleMeta | {} };
+			ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
 			quiet?: boolean;
 			disabledRanges: DisabledRangeObject;
 			disabledWarnings?: DisabledWarning[];
@@ -126,7 +126,7 @@ declare module 'stylelint' {
 			warn(message: string, options?: WarningOptions): void;
 		};
 
-		export type Formatter = (results: LintResult[], returnValue?: LinterResult) => string;
+		export type Formatter = (results: LintResult[], returnValue: LinterResult) => string;
 
 		export type FormatterType =
 			| 'compact'
@@ -340,6 +340,10 @@ declare module 'stylelint' {
 			descriptionlessDisables?: DisableOptionsReport;
 			needlessDisables?: DisableOptionsReport;
 			invalidScopeDisables?: DisableOptionsReport;
+			/**
+			 * Each rule metadata by name.
+			 */
+			ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
 		};
 
 		export type Problem = {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6082

> Is there anything in the PR that needs further explanation?

This pull request adds a new property `ruleMetadata` to the `LinterResult` type as a public API. The new property should make it easier to write a custom formatter using rule metadata.


Also, this change includes:

- refactor the `verboseFormatter` code by using the new property
- add a rule URL to the `githubFormatter` output. See the [demo](https://github.com/ybiquitous/stylelint-github-actions-formatter/pull/3/files) and screenshot:
  - <img width="917" alt="Screen Shot 2022-06-22 at 0 37 33" src="https://user-images.githubusercontent.com/473530/174840473-f911c26f-2546-422e-9053-4cf5ec503e0b.png">



