### PR TITLE
Refactor to use `Set` for `shorthandData` and `mathFunctions` types

### DIFF
--- a/lib/reference/mathFunctions.js
+++ b/lib/reference/mathFunctions.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = ['calc', 'clamp', 'max', 'min'];
+module.exports = new Set(['calc', 'clamp', 'max', 'min']);

--- a/lib/reference/shorthandData.js
+++ b/lib/reference/shorthandData.js
@@ -1,10 +1,9 @@
 'use strict';
 
-/** @type {Record<string, string[]>} */
 module.exports = {
-	margin: ['margin-top', 'margin-bottom', 'margin-left', 'margin-right'],
-	padding: ['padding-top', 'padding-bottom', 'padding-left', 'padding-right'],
-	background: [
+	margin: new Set(['margin-top', 'margin-bottom', 'margin-left', 'margin-right']),
+	padding: new Set(['padding-top', 'padding-bottom', 'padding-left', 'padding-right']),
+	background: new Set([
 		'background-image',
 		'background-size',
 		'background-position',
@@ -13,8 +12,8 @@ module.exports = {
 		'background-clip',
 		'background-attachment',
 		'background-color',
-	],
-	font: [
+	]),
+	font: new Set([
 		'font-style',
 		'font-variant',
 		'font-weight',
@@ -22,8 +21,8 @@ module.exports = {
 		'font-size',
 		'font-family',
 		'line-height',
-	],
-	border: [
+	]),
+	border: new Set([
 		'border-top-width',
 		'border-bottom-width',
 		'border-left-width',
@@ -36,43 +35,43 @@ module.exports = {
 		'border-bottom-color',
 		'border-left-color',
 		'border-right-color',
-	],
-	'border-top': ['border-top-width', 'border-top-style', 'border-top-color'],
-	'border-bottom': ['border-bottom-width', 'border-bottom-style', 'border-bottom-color'],
-	'border-left': ['border-left-width', 'border-left-style', 'border-left-color'],
-	'border-right': ['border-right-width', 'border-right-style', 'border-right-color'],
-	'border-width': [
+	]),
+	'border-top': new Set(['border-top-width', 'border-top-style', 'border-top-color']),
+	'border-bottom': new Set(['border-bottom-width', 'border-bottom-style', 'border-bottom-color']),
+	'border-left': new Set(['border-left-width', 'border-left-style', 'border-left-color']),
+	'border-right': new Set(['border-right-width', 'border-right-style', 'border-right-color']),
+	'border-width': new Set([
 		'border-top-width',
 		'border-bottom-width',
 		'border-left-width',
 		'border-right-width',
-	],
-	'border-style': [
+	]),
+	'border-style': new Set([
 		'border-top-style',
 		'border-bottom-style',
 		'border-left-style',
 		'border-right-style',
-	],
-	'border-color': [
+	]),
+	'border-color': new Set([
 		'border-top-color',
 		'border-bottom-color',
 		'border-left-color',
 		'border-right-color',
-	],
-	'list-style': ['list-style-type', 'list-style-position', 'list-style-image'],
-	'border-radius': [
+	]),
+	'list-style': new Set(['list-style-type', 'list-style-position', 'list-style-image']),
+	'border-radius': new Set([
 		'border-top-right-radius',
 		'border-top-left-radius',
 		'border-bottom-right-radius',
 		'border-bottom-left-radius',
-	],
-	transition: [
+	]),
+	transition: new Set([
 		'transition-delay',
 		'transition-duration',
 		'transition-property',
 		'transition-timing-function',
-	],
-	animation: [
+	]),
+	animation: new Set([
 		'animation-name',
 		'animation-duration',
 		'animation-timing-function',
@@ -81,39 +80,39 @@ module.exports = {
 		'animation-direction',
 		'animation-fill-mode',
 		'animation-play-state',
-	],
-	'border-block-end': [
+	]),
+	'border-block-end': new Set([
 		'border-block-end-width',
 		'border-block-end-style',
 		'border-block-end-color',
-	],
-	'border-block-start': [
+	]),
+	'border-block-start': new Set([
 		'border-block-start-width',
 		'border-block-start-style',
 		'border-block-start-color',
-	],
-	'border-image': [
+	]),
+	'border-image': new Set([
 		'border-image-source',
 		'border-image-slice',
 		'border-image-width',
 		'border-image-outset',
 		'border-image-repeat',
-	],
-	'border-inline-end': [
+	]),
+	'border-inline-end': new Set([
 		'border-inline-end-width',
 		'border-inline-end-style',
 		'border-inline-end-color',
-	],
-	'border-inline-start': [
+	]),
+	'border-inline-start': new Set([
 		'border-inline-start-width',
 		'border-inline-start-style',
 		'border-inline-start-color',
-	],
-	'column-rule': ['column-rule-width', 'column-rule-style', 'column-rule-color'],
-	columns: ['column-width', 'column-count'],
-	flex: ['flex-grow', 'flex-shrink', 'flex-basis'],
-	'flex-flow': ['flex-direction', 'flex-wrap'],
-	grid: [
+	]),
+	'column-rule': new Set(['column-rule-width', 'column-rule-style', 'column-rule-color']),
+	columns: new Set(['column-width', 'column-count']),
+	flex: new Set(['flex-grow', 'flex-shrink', 'flex-basis']),
+	'flex-flow': new Set(['flex-direction', 'flex-wrap']),
+	grid: new Set([
 		'grid-template-rows',
 		'grid-template-columns',
 		'grid-template-areas',
@@ -122,16 +121,20 @@ module.exports = {
 		'grid-auto-flow',
 		'grid-column-gap',
 		'grid-row-gap',
-	],
-	'grid-area': ['grid-row-start', 'grid-column-start', 'grid-row-end', 'grid-column-end'],
-	'grid-column': ['grid-column-start', 'grid-column-end'],
-	'grid-gap': ['grid-row-gap', 'grid-column-gap'],
-	'grid-row': ['grid-row-start', 'grid-row-end'],
-	'grid-template': ['grid-template-columns', 'grid-template-rows', 'grid-template-areas'],
-	outline: ['outline-color', 'outline-style', 'outline-width'],
-	'text-decoration': ['text-decoration-color', 'text-decoration-style', 'text-decoration-line'],
-	'text-emphasis': ['text-emphasis-style', 'text-emphasis-color'],
-	mask: [
+	]),
+	'grid-area': new Set(['grid-row-start', 'grid-column-start', 'grid-row-end', 'grid-column-end']),
+	'grid-column': new Set(['grid-column-start', 'grid-column-end']),
+	'grid-gap': new Set(['grid-row-gap', 'grid-column-gap']),
+	'grid-row': new Set(['grid-row-start', 'grid-row-end']),
+	'grid-template': new Set(['grid-template-columns', 'grid-template-rows', 'grid-template-areas']),
+	outline: new Set(['outline-color', 'outline-style', 'outline-width']),
+	'text-decoration': new Set([
+		'text-decoration-color',
+		'text-decoration-style',
+		'text-decoration-line',
+	]),
+	'text-emphasis': new Set(['text-emphasis-style', 'text-emphasis-color']),
+	mask: new Set([
 		'mask-image',
 		'mask-mode',
 		'mask-position',
@@ -140,5 +143,5 @@ module.exports = {
 		'mask-origin',
 		'mask-clip',
 		'mask-composite',
-	],
+	]),
 };

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -80,7 +80,10 @@ const rule = (primary, secondaryOptions) => {
 
 					longhandDeclaration.push(prop);
 
-					const prefixedShorthandData = (shorthandData[shorthandProperty] || []).map(
+					const shorthandProps = /** @type {Record<string, Set<string>>} */ (shorthandData)[
+						shorthandProperty
+					];
+					const prefixedShorthandData = Array.from(shorthandProps || []).map(
 						(item) => prefix + item,
 					);
 

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -32,10 +32,12 @@ const rule = (primary) => {
 
 			eachDecl((decl) => {
 				const prop = decl.prop;
-				const unprefixedProp = vendor.unprefixed(prop);
+				const unprefixedProp = vendor.unprefixed(prop).toLowerCase();
 				const prefix = vendor.prefix(prop).toLowerCase();
 
-				const overrideables = shorthandData[unprefixedProp.toLowerCase()];
+				const overrideables = /** @type {Record<string, Set<string>>} */ (shorthandData)[
+					unprefixedProp
+				];
 
 				if (!overrideables) {
 					declarations[prop.toLowerCase()] = prop;

--- a/lib/utils/isMathFunction.js
+++ b/lib/utils/isMathFunction.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const MATH_FUNCTIONS = require('../reference/mathFunctions');
+const mathFunctions = require('../reference/mathFunctions');
 
 /**
  * Check whether a node is math function
@@ -9,5 +9,5 @@ const MATH_FUNCTIONS = require('../reference/mathFunctions');
  * @return {boolean} If `true`, the node is math function
  */
 module.exports = function isMathFunction(node) {
-	return node.type === 'function' && MATH_FUNCTIONS.includes(node.value.toLowerCase());
+	return node.type === 'function' && mathFunctions.has(node.value.toLowerCase());
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/issues/6151#issuecomment-1161953568

> Is there anything in the PR that needs further explanation?

This pull request is prepared for #6151, unifying reference data structures.
