### PR TITLE
Add shorthand properties reference to public API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const report = require('./utils/report');
 const resolveConfig = require('./resolveConfig');
 const ruleMessages = require('./utils/ruleMessages');
 const rules = require('./rules');
-const shorthandData = require('./reference/shorthandData');
+const { longhandSubPropertiesOfShorthandProperties } = require('./reference/properties');
 const standalone = require('./standalone');
 const validateOptions = require('./utils/validateOptions');
 
@@ -28,7 +28,7 @@ const stylelint = Object.assign(postcssPlugin, {
 		checkAgainstRule,
 	},
 	reference: {
-		shorthandData,
+		longhandSubPropertiesOfShorthandProperties,
 	},
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,11 +6,12 @@ const createStylelint = require('./createStylelint');
 const formatters = require('./formatters');
 const postcssPlugin = require('./postcssPlugin');
 const report = require('./utils/report');
+const resolveConfig = require('./resolveConfig');
 const ruleMessages = require('./utils/ruleMessages');
 const rules = require('./rules');
+const shorthandData = require('./reference/shorthandData');
 const standalone = require('./standalone');
 const validateOptions = require('./utils/validateOptions');
-const resolveConfig = require('./resolveConfig');
 
 /** @type {import('stylelint').PublicApi} */
 const stylelint = Object.assign(postcssPlugin, {
@@ -25,6 +26,9 @@ const stylelint = Object.assign(postcssPlugin, {
 		ruleMessages,
 		validateOptions,
 		checkAgainstRule,
+	},
+	reference: {
+		shorthandData,
 	},
 });
 

--- a/lib/reference/properties.js
+++ b/lib/reference/properties.js
@@ -1,7 +1,7 @@
 'use strict';
 
-/** @type {import('stylelint').ShorthandData} */
-const shorthandData = {
+/** @type {import('stylelint').LonghandSubPropertiesOfShorthandProperties} */
+const longhandSubPropertiesOfShorthandProperties = {
 	margin: new Set(['margin-top', 'margin-bottom', 'margin-left', 'margin-right']),
 	padding: new Set(['padding-top', 'padding-bottom', 'padding-left', 'padding-right']),
 	background: new Set([
@@ -147,4 +147,6 @@ const shorthandData = {
 	]),
 };
 
-module.exports = shorthandData;
+module.exports = {
+	longhandSubPropertiesOfShorthandProperties,
+};

--- a/lib/reference/properties.js
+++ b/lib/reference/properties.js
@@ -1,239 +1,351 @@
 'use strict';
 
 /** @type {import('stylelint').LonghandSubPropertiesOfShorthandProperties} */
-const longhandSubPropertiesOfShorthandProperties = {
-	/* eslint sort-keys: 'error' */
-	animation: new Set([
-		'animation-name',
-		'animation-duration',
-		'animation-timing-function',
-		'animation-delay',
-		'animation-iteration-count',
-		'animation-direction',
-		'animation-fill-mode',
-		'animation-play-state',
-	]),
-	background: new Set([
-		'background-image',
-		'background-size',
-		'background-position',
-		'background-repeat',
-		'background-origin',
-		'background-clip',
-		'background-attachment',
-		'background-color',
-	]),
-	border: new Set([
-		'border-top-width',
-		'border-bottom-width',
-		'border-left-width',
-		'border-right-width',
-		'border-top-style',
-		'border-bottom-style',
-		'border-left-style',
-		'border-right-style',
-		'border-top-color',
-		'border-bottom-color',
-		'border-left-color',
-		'border-right-color',
-	]),
-	'border-block-end': new Set([
-		'border-block-end-width',
-		'border-block-end-style',
-		'border-block-end-color',
-	]),
-	'border-block-start': new Set([
-		'border-block-start-width',
-		'border-block-start-style',
-		'border-block-start-color',
-	]),
-	'border-bottom': new Set([
-		// prettier-ignore
-		'border-bottom-width',
-		'border-bottom-style',
-		'border-bottom-color',
-	]),
-	'border-color': new Set([
-		'border-top-color',
-		'border-bottom-color',
-		'border-left-color',
-		'border-right-color',
-	]),
-	'border-image': new Set([
-		'border-image-source',
-		'border-image-slice',
-		'border-image-width',
-		'border-image-outset',
-		'border-image-repeat',
-	]),
-	'border-inline-end': new Set([
-		'border-inline-end-width',
-		'border-inline-end-style',
-		'border-inline-end-color',
-	]),
-	'border-inline-start': new Set([
-		'border-inline-start-width',
-		'border-inline-start-style',
-		'border-inline-start-color',
-	]),
-	'border-left': new Set([
-		// prettier-ignore
-		'border-left-width',
-		'border-left-style',
-		'border-left-color',
-	]),
-	'border-radius': new Set([
-		'border-top-right-radius',
-		'border-top-left-radius',
-		'border-bottom-right-radius',
-		'border-bottom-left-radius',
-	]),
-	'border-right': new Set([
-		// prettier-ignore
-		'border-right-width',
-		'border-right-style',
-		'border-right-color',
-	]),
-	'border-style': new Set([
-		'border-top-style',
-		'border-bottom-style',
-		'border-left-style',
-		'border-right-style',
-	]),
-	'border-top': new Set([
-		// prettier-ignore
-		'border-top-width',
-		'border-top-style',
-		'border-top-color',
-	]),
-	'border-width': new Set([
-		'border-top-width',
-		'border-bottom-width',
-		'border-left-width',
-		'border-right-width',
-	]),
-	'column-rule': new Set([
-		// prettier-ignore
-		'column-rule-width',
-		'column-rule-style',
-		'column-rule-color',
-	]),
-	columns: new Set([
-		// prettier-ignore
-		'column-width',
-		'column-count',
-	]),
-	flex: new Set([
-		// prettier-ignore
-		'flex-grow',
-		'flex-shrink',
-		'flex-basis',
-	]),
-	'flex-flow': new Set([
-		// prettier-ignore
-		'flex-direction',
-		'flex-wrap',
-	]),
-	font: new Set([
-		'font-style',
-		'font-variant',
-		'font-weight',
-		'font-stretch',
-		'font-size',
-		'font-family',
-		'line-height',
-	]),
-	grid: new Set([
-		'grid-template-rows',
-		'grid-template-columns',
-		'grid-template-areas',
-		'grid-auto-rows',
-		'grid-auto-columns',
-		'grid-auto-flow',
-		'grid-column-gap',
-		'grid-row-gap',
-	]),
-	'grid-area': new Set([
-		// prettier-ignore
-		'grid-row-start',
-		'grid-column-start',
-		'grid-row-end',
-		'grid-column-end',
-	]),
-	'grid-column': new Set([
-		// prettier-ignore
-		'grid-column-start',
-		'grid-column-end',
-	]),
-	'grid-gap': new Set([
-		// prettier-ignore
-		'grid-row-gap',
-		'grid-column-gap',
-	]),
-	'grid-row': new Set([
-		// prettier-ignore
-		'grid-row-start',
-		'grid-row-end',
-	]),
-	'grid-template': new Set([
-		// prettier-ignore
-		'grid-template-columns',
-		'grid-template-rows',
-		'grid-template-areas',
-	]),
-	'list-style': new Set([
-		// prettier-ignore
-		'list-style-type',
-		'list-style-position',
-		'list-style-image',
-	]),
-	margin: new Set([
-		// prettier-ignore
-		'margin-top',
-		'margin-bottom',
-		'margin-left',
-		'margin-right',
-	]),
-	mask: new Set([
-		'mask-image',
-		'mask-mode',
-		'mask-position',
-		'mask-size',
-		'mask-repeat',
-		'mask-origin',
-		'mask-clip',
-		'mask-composite',
-	]),
-	outline: new Set([
-		// prettier-ignore
-		'outline-color',
-		'outline-style',
-		'outline-width',
-	]),
-	padding: new Set([
-		// prettier-ignore
-		'padding-top',
-		'padding-bottom',
-		'padding-left',
-		'padding-right',
-	]),
-	'text-decoration': new Set([
-		'text-decoration-color',
-		'text-decoration-style',
-		'text-decoration-line',
-	]),
-	'text-emphasis': new Set([
-		// prettier-ignore
-		'text-emphasis-style',
-		'text-emphasis-color',
-	]),
-	transition: new Set([
-		'transition-delay',
-		'transition-duration',
-		'transition-property',
-		'transition-timing-function',
-	]),
-};
+const longhandSubPropertiesOfShorthandProperties = new Map([
+	// Sort alphabetically
+	[
+		'animation',
+		new Set([
+			'animation-name',
+			'animation-duration',
+			'animation-timing-function',
+			'animation-delay',
+			'animation-iteration-count',
+			'animation-direction',
+			'animation-fill-mode',
+			'animation-play-state',
+		]),
+	],
+	[
+		'background',
+		new Set([
+			'background-image',
+			'background-size',
+			'background-position',
+			'background-repeat',
+			'background-origin',
+			'background-clip',
+			'background-attachment',
+			'background-color',
+		]),
+	],
+	[
+		'border',
+		new Set([
+			'border-top-width',
+			'border-bottom-width',
+			'border-left-width',
+			'border-right-width',
+			'border-top-style',
+			'border-bottom-style',
+			'border-left-style',
+			'border-right-style',
+			'border-top-color',
+			'border-bottom-color',
+			'border-left-color',
+			'border-right-color',
+		]),
+	],
+	[
+		'border-block-end',
+		new Set([
+			// prettier-ignore
+			'border-block-end-width',
+			'border-block-end-style',
+			'border-block-end-color',
+		]),
+	],
+	[
+		'border-block-start',
+		new Set([
+			// prettier-ignore
+			'border-block-start-width',
+			'border-block-start-style',
+			'border-block-start-color',
+		]),
+	],
+	[
+		'border-bottom',
+		new Set([
+			// prettier-ignore
+			'border-bottom-width',
+			'border-bottom-style',
+			'border-bottom-color',
+		]),
+	],
+	[
+		'border-color',
+		new Set([
+			// prettier-ignore
+			'border-top-color',
+			'border-bottom-color',
+			'border-left-color',
+			'border-right-color',
+		]),
+	],
+	[
+		'border-image',
+		new Set([
+			'border-image-source',
+			'border-image-slice',
+			'border-image-width',
+			'border-image-outset',
+			'border-image-repeat',
+		]),
+	],
+	[
+		'border-inline-end',
+		new Set([
+			// prettier-ignore
+			'border-inline-end-width',
+			'border-inline-end-style',
+			'border-inline-end-color',
+		]),
+	],
+	[
+		'border-inline-start',
+		new Set([
+			'border-inline-start-width',
+			'border-inline-start-style',
+			'border-inline-start-color',
+		]),
+	],
+	[
+		'border-left',
+		new Set([
+			// prettier-ignore
+			'border-left-width',
+			'border-left-style',
+			'border-left-color',
+		]),
+	],
+	[
+		'border-radius',
+		new Set([
+			'border-top-right-radius',
+			'border-top-left-radius',
+			'border-bottom-right-radius',
+			'border-bottom-left-radius',
+		]),
+	],
+	[
+		'border-right',
+		new Set([
+			// prettier-ignore
+			'border-right-width',
+			'border-right-style',
+			'border-right-color',
+		]),
+	],
+	[
+		'border-style',
+		new Set([
+			// prettier-ignore
+			'border-top-style',
+			'border-bottom-style',
+			'border-left-style',
+			'border-right-style',
+		]),
+	],
+	[
+		'border-top',
+		new Set([
+			// prettier-ignore
+			'border-top-width',
+			'border-top-style',
+			'border-top-color',
+		]),
+	],
+	[
+		'border-width',
+		new Set([
+			// prettier-ignore
+			'border-top-width',
+			'border-bottom-width',
+			'border-left-width',
+			'border-right-width',
+		]),
+	],
+	[
+		'column-rule',
+		new Set([
+			// prettier-ignore
+			'column-rule-width',
+			'column-rule-style',
+			'column-rule-color',
+		]),
+	],
+	[
+		'columns',
+		new Set([
+			// prettier-ignore
+			'column-width',
+			'column-count',
+		]),
+	],
+	[
+		'flex',
+		new Set([
+			// prettier-ignore
+			'flex-grow',
+			'flex-shrink',
+			'flex-basis',
+		]),
+	],
+	[
+		'flex-flow',
+		new Set([
+			// prettier-ignore
+			'flex-direction',
+			'flex-wrap',
+		]),
+	],
+	[
+		'font',
+		new Set([
+			'font-style',
+			'font-variant',
+			'font-weight',
+			'font-stretch',
+			'font-size',
+			'font-family',
+			'line-height',
+		]),
+	],
+	[
+		'grid',
+		new Set([
+			'grid-template-rows',
+			'grid-template-columns',
+			'grid-template-areas',
+			'grid-auto-rows',
+			'grid-auto-columns',
+			'grid-auto-flow',
+			'grid-column-gap',
+			'grid-row-gap',
+		]),
+	],
+	[
+		'grid-area',
+		new Set([
+			// prettier-ignore
+			'grid-row-start',
+			'grid-column-start',
+			'grid-row-end',
+			'grid-column-end',
+		]),
+	],
+	[
+		'grid-column',
+		new Set([
+			// prettier-ignore
+			'grid-column-start',
+			'grid-column-end',
+		]),
+	],
+	[
+		'grid-gap',
+		new Set([
+			// prettier-ignore
+			'grid-row-gap',
+			'grid-column-gap',
+		]),
+	],
+	[
+		'grid-row',
+		new Set([
+			// prettier-ignore
+			'grid-row-start',
+			'grid-row-end',
+		]),
+	],
+	[
+		'grid-template',
+		new Set([
+			// prettier-ignore
+			'grid-template-columns',
+			'grid-template-rows',
+			'grid-template-areas',
+		]),
+	],
+	[
+		'list-style',
+		new Set([
+			// prettier-ignore
+			'list-style-type',
+			'list-style-position',
+			'list-style-image',
+		]),
+	],
+	[
+		'margin',
+		new Set([
+			// prettier-ignore
+			'margin-top',
+			'margin-bottom',
+			'margin-left',
+			'margin-right',
+		]),
+	],
+	[
+		'mask',
+		new Set([
+			'mask-image',
+			'mask-mode',
+			'mask-position',
+			'mask-size',
+			'mask-repeat',
+			'mask-origin',
+			'mask-clip',
+			'mask-composite',
+		]),
+	],
+	[
+		'outline',
+		new Set([
+			// prettier-ignore
+			'outline-color',
+			'outline-style',
+			'outline-width',
+		]),
+	],
+	[
+		'padding',
+		new Set([
+			// prettier-ignore
+			'padding-top',
+			'padding-bottom',
+			'padding-left',
+			'padding-right',
+		]),
+	],
+	[
+		'text-decoration',
+		new Set([
+			// prettier-ignore
+			'text-decoration-color',
+			'text-decoration-style',
+			'text-decoration-line',
+		]),
+	],
+	[
+		'text-emphasis',
+		new Set([
+			// prettier-ignore
+			'text-emphasis-style',
+			'text-emphasis-color',
+		]),
+	],
+	[
+		'transition',
+		new Set([
+			'transition-delay',
+			'transition-duration',
+			'transition-property',
+			'transition-timing-function',
+		]),
+	],
+]);
 
 module.exports = {
 	longhandSubPropertiesOfShorthandProperties,

--- a/lib/reference/properties.js
+++ b/lib/reference/properties.js
@@ -2,8 +2,17 @@
 
 /** @type {import('stylelint').LonghandSubPropertiesOfShorthandProperties} */
 const longhandSubPropertiesOfShorthandProperties = {
-	margin: new Set(['margin-top', 'margin-bottom', 'margin-left', 'margin-right']),
-	padding: new Set(['padding-top', 'padding-bottom', 'padding-left', 'padding-right']),
+	/* eslint sort-keys: 'error' */
+	animation: new Set([
+		'animation-name',
+		'animation-duration',
+		'animation-timing-function',
+		'animation-delay',
+		'animation-iteration-count',
+		'animation-direction',
+		'animation-fill-mode',
+		'animation-play-state',
+	]),
 	background: new Set([
 		'background-image',
 		'background-size',
@@ -13,15 +22,6 @@ const longhandSubPropertiesOfShorthandProperties = {
 		'background-clip',
 		'background-attachment',
 		'background-color',
-	]),
-	font: new Set([
-		'font-style',
-		'font-variant',
-		'font-weight',
-		'font-stretch',
-		'font-size',
-		'font-family',
-		'line-height',
 	]),
 	border: new Set([
 		'border-top-width',
@@ -37,51 +37,6 @@ const longhandSubPropertiesOfShorthandProperties = {
 		'border-left-color',
 		'border-right-color',
 	]),
-	'border-top': new Set(['border-top-width', 'border-top-style', 'border-top-color']),
-	'border-bottom': new Set(['border-bottom-width', 'border-bottom-style', 'border-bottom-color']),
-	'border-left': new Set(['border-left-width', 'border-left-style', 'border-left-color']),
-	'border-right': new Set(['border-right-width', 'border-right-style', 'border-right-color']),
-	'border-width': new Set([
-		'border-top-width',
-		'border-bottom-width',
-		'border-left-width',
-		'border-right-width',
-	]),
-	'border-style': new Set([
-		'border-top-style',
-		'border-bottom-style',
-		'border-left-style',
-		'border-right-style',
-	]),
-	'border-color': new Set([
-		'border-top-color',
-		'border-bottom-color',
-		'border-left-color',
-		'border-right-color',
-	]),
-	'list-style': new Set(['list-style-type', 'list-style-position', 'list-style-image']),
-	'border-radius': new Set([
-		'border-top-right-radius',
-		'border-top-left-radius',
-		'border-bottom-right-radius',
-		'border-bottom-left-radius',
-	]),
-	transition: new Set([
-		'transition-delay',
-		'transition-duration',
-		'transition-property',
-		'transition-timing-function',
-	]),
-	animation: new Set([
-		'animation-name',
-		'animation-duration',
-		'animation-timing-function',
-		'animation-delay',
-		'animation-iteration-count',
-		'animation-direction',
-		'animation-fill-mode',
-		'animation-play-state',
-	]),
 	'border-block-end': new Set([
 		'border-block-end-width',
 		'border-block-end-style',
@@ -91,6 +46,18 @@ const longhandSubPropertiesOfShorthandProperties = {
 		'border-block-start-width',
 		'border-block-start-style',
 		'border-block-start-color',
+	]),
+	'border-bottom': new Set([
+		// prettier-ignore
+		'border-bottom-width',
+		'border-bottom-style',
+		'border-bottom-color',
+	]),
+	'border-color': new Set([
+		'border-top-color',
+		'border-bottom-color',
+		'border-left-color',
+		'border-right-color',
 	]),
 	'border-image': new Set([
 		'border-image-source',
@@ -109,10 +76,73 @@ const longhandSubPropertiesOfShorthandProperties = {
 		'border-inline-start-style',
 		'border-inline-start-color',
 	]),
-	'column-rule': new Set(['column-rule-width', 'column-rule-style', 'column-rule-color']),
-	columns: new Set(['column-width', 'column-count']),
-	flex: new Set(['flex-grow', 'flex-shrink', 'flex-basis']),
-	'flex-flow': new Set(['flex-direction', 'flex-wrap']),
+	'border-left': new Set([
+		// prettier-ignore
+		'border-left-width',
+		'border-left-style',
+		'border-left-color',
+	]),
+	'border-radius': new Set([
+		'border-top-right-radius',
+		'border-top-left-radius',
+		'border-bottom-right-radius',
+		'border-bottom-left-radius',
+	]),
+	'border-right': new Set([
+		// prettier-ignore
+		'border-right-width',
+		'border-right-style',
+		'border-right-color',
+	]),
+	'border-style': new Set([
+		'border-top-style',
+		'border-bottom-style',
+		'border-left-style',
+		'border-right-style',
+	]),
+	'border-top': new Set([
+		// prettier-ignore
+		'border-top-width',
+		'border-top-style',
+		'border-top-color',
+	]),
+	'border-width': new Set([
+		'border-top-width',
+		'border-bottom-width',
+		'border-left-width',
+		'border-right-width',
+	]),
+	'column-rule': new Set([
+		// prettier-ignore
+		'column-rule-width',
+		'column-rule-style',
+		'column-rule-color',
+	]),
+	columns: new Set([
+		// prettier-ignore
+		'column-width',
+		'column-count',
+	]),
+	flex: new Set([
+		// prettier-ignore
+		'flex-grow',
+		'flex-shrink',
+		'flex-basis',
+	]),
+	'flex-flow': new Set([
+		// prettier-ignore
+		'flex-direction',
+		'flex-wrap',
+	]),
+	font: new Set([
+		'font-style',
+		'font-variant',
+		'font-weight',
+		'font-stretch',
+		'font-size',
+		'font-family',
+		'line-height',
+	]),
 	grid: new Set([
 		'grid-template-rows',
 		'grid-template-columns',
@@ -123,18 +153,47 @@ const longhandSubPropertiesOfShorthandProperties = {
 		'grid-column-gap',
 		'grid-row-gap',
 	]),
-	'grid-area': new Set(['grid-row-start', 'grid-column-start', 'grid-row-end', 'grid-column-end']),
-	'grid-column': new Set(['grid-column-start', 'grid-column-end']),
-	'grid-gap': new Set(['grid-row-gap', 'grid-column-gap']),
-	'grid-row': new Set(['grid-row-start', 'grid-row-end']),
-	'grid-template': new Set(['grid-template-columns', 'grid-template-rows', 'grid-template-areas']),
-	outline: new Set(['outline-color', 'outline-style', 'outline-width']),
-	'text-decoration': new Set([
-		'text-decoration-color',
-		'text-decoration-style',
-		'text-decoration-line',
+	'grid-area': new Set([
+		// prettier-ignore
+		'grid-row-start',
+		'grid-column-start',
+		'grid-row-end',
+		'grid-column-end',
 	]),
-	'text-emphasis': new Set(['text-emphasis-style', 'text-emphasis-color']),
+	'grid-column': new Set([
+		// prettier-ignore
+		'grid-column-start',
+		'grid-column-end',
+	]),
+	'grid-gap': new Set([
+		// prettier-ignore
+		'grid-row-gap',
+		'grid-column-gap',
+	]),
+	'grid-row': new Set([
+		// prettier-ignore
+		'grid-row-start',
+		'grid-row-end',
+	]),
+	'grid-template': new Set([
+		// prettier-ignore
+		'grid-template-columns',
+		'grid-template-rows',
+		'grid-template-areas',
+	]),
+	'list-style': new Set([
+		// prettier-ignore
+		'list-style-type',
+		'list-style-position',
+		'list-style-image',
+	]),
+	margin: new Set([
+		// prettier-ignore
+		'margin-top',
+		'margin-bottom',
+		'margin-left',
+		'margin-right',
+	]),
 	mask: new Set([
 		'mask-image',
 		'mask-mode',
@@ -144,6 +203,35 @@ const longhandSubPropertiesOfShorthandProperties = {
 		'mask-origin',
 		'mask-clip',
 		'mask-composite',
+	]),
+	outline: new Set([
+		// prettier-ignore
+		'outline-color',
+		'outline-style',
+		'outline-width',
+	]),
+	padding: new Set([
+		// prettier-ignore
+		'padding-top',
+		'padding-bottom',
+		'padding-left',
+		'padding-right',
+	]),
+	'text-decoration': new Set([
+		'text-decoration-color',
+		'text-decoration-style',
+		'text-decoration-line',
+	]),
+	'text-emphasis': new Set([
+		// prettier-ignore
+		'text-emphasis-style',
+		'text-emphasis-color',
+	]),
+	transition: new Set([
+		'transition-delay',
+		'transition-duration',
+		'transition-property',
+		'transition-timing-function',
 	]),
 };
 

--- a/lib/reference/shorthandData.js
+++ b/lib/reference/shorthandData.js
@@ -1,6 +1,7 @@
 'use strict';
 
-module.exports = {
+/** @type {import('stylelint').ShorthandData} */
+const shorthandData = {
 	margin: new Set(['margin-top', 'margin-bottom', 'margin-left', 'margin-right']),
 	padding: new Set(['padding-top', 'padding-bottom', 'padding-left', 'padding-right']),
 	background: new Set([
@@ -145,3 +146,5 @@ module.exports = {
 		'mask-composite',
 	]),
 };
+
+module.exports = shorthandData;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -40,31 +40,32 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		const longhandProperties = Object.entries(longhandSubPropertiesOfShorthandProperties).reduce(
-			(/** @type {Record<string, string[]>} */ longhandProps, [key, values]) => {
-				if (optionsMatches(secondaryOptions, 'ignoreShorthands', key)) {
-					return longhandProps;
-				}
+		/** @type {Map<string, string[]>} */
+		const longhandToShorthands = new Map();
 
-				for (const value of values) {
-					(longhandProps[value] || (longhandProps[value] = [])).push(key);
-				}
+		for (const [shorthand, longhandProps] of longhandSubPropertiesOfShorthandProperties.entries()) {
+			if (optionsMatches(secondaryOptions, 'ignoreShorthands', shorthand)) {
+				continue;
+			}
 
-				return longhandProps;
-			},
-			{},
-		);
+			for (const longhand of longhandProps) {
+				const shorthands = longhandToShorthands.get(longhand) || [];
+
+				shorthands.push(shorthand);
+				longhandToShorthands.set(longhand, shorthands);
+			}
+		}
 
 		eachDeclarationBlock(root, (eachDecl) => {
-			/** @type {Record<string, string[]>} */
-			const longhandDeclarations = {};
+			/** @type {Map<string, string[]>} */
+			const longhandDeclarations = new Map();
 
 			eachDecl((decl) => {
 				const prop = decl.prop.toLowerCase();
 				const unprefixedProp = vendor.unprefixed(prop);
 				const prefix = vendor.prefix(prop);
 
-				const shorthandProperties = longhandProperties[unprefixedProp];
+				const shorthandProperties = longhandToShorthands.get(unprefixedProp);
 
 				if (!shorthandProperties) {
 					return;
@@ -72,17 +73,14 @@ const rule = (primary, secondaryOptions) => {
 
 				for (const shorthandProperty of shorthandProperties) {
 					const prefixedShorthandProperty = prefix + shorthandProperty;
-					let longhandDeclaration = longhandDeclarations[prefixedShorthandProperty];
-
-					if (!longhandDeclaration) {
-						longhandDeclaration = longhandDeclarations[prefixedShorthandProperty] = [];
-					}
+					const longhandDeclaration = longhandDeclarations.get(prefixedShorthandProperty) || [];
 
 					longhandDeclaration.push(prop);
+					longhandDeclarations.set(prefixedShorthandProperty, longhandDeclaration);
 
-					const shorthandProps = /** @type {Record<string, Set<string>>} */ (
+					const shorthandProps = /** @type {Map<string, Set<string>>} */ (
 						longhandSubPropertiesOfShorthandProperties
-					)[shorthandProperty];
+					).get(shorthandProperty);
 					const prefixedShorthandData = Array.from(shorthandProps || []).map(
 						(item) => prefix + item,
 					);

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -5,7 +5,7 @@ const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
-const shorthandData = require('../../reference/shorthandData');
+const { longhandSubPropertiesOfShorthandProperties } = require('../../reference/properties');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
 const { isRegExp, isString } = require('../../utils/validateTypes');
@@ -40,7 +40,7 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		const longhandProperties = Object.entries(shorthandData).reduce(
+		const longhandProperties = Object.entries(longhandSubPropertiesOfShorthandProperties).reduce(
 			(/** @type {Record<string, string[]>} */ longhandProps, [key, values]) => {
 				if (optionsMatches(secondaryOptions, 'ignoreShorthands', key)) {
 					return longhandProps;
@@ -80,9 +80,9 @@ const rule = (primary, secondaryOptions) => {
 
 					longhandDeclaration.push(prop);
 
-					const shorthandProps = /** @type {Record<string, Set<string>>} */ (shorthandData)[
-						shorthandProperty
-					];
+					const shorthandProps = /** @type {Record<string, Set<string>>} */ (
+						longhandSubPropertiesOfShorthandProperties
+					)[shorthandProperty];
 					const prefixedShorthandData = Array.from(shorthandProps || []).map(
 						(item) => prefix + item,
 					);

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -35,9 +35,9 @@ const rule = (primary) => {
 				const unprefixedProp = vendor.unprefixed(prop).toLowerCase();
 				const prefix = vendor.prefix(prop).toLowerCase();
 
-				const overrideables = /** @type {Record<string, Set<string>>} */ (
+				const overrideables = /** @type {Map<string, Set<string>>} */ (
 					longhandSubPropertiesOfShorthandProperties
-				)[unprefixedProp];
+				).get(unprefixedProp);
 
 				if (!overrideables) {
 					declarations[prop.toLowerCase()] = prop;

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -27,8 +27,8 @@ const rule = (primary) => {
 		}
 
 		eachDeclarationBlock(root, (eachDecl) => {
-			/** @type {Record<string, string>} */
-			const declarations = {};
+			/** @type {Map<string, string>} */
+			const declarations = new Map();
 
 			eachDecl((decl) => {
 				const prop = decl.prop;
@@ -40,13 +40,15 @@ const rule = (primary) => {
 				).get(unprefixedProp);
 
 				if (!overrideables) {
-					declarations[prop.toLowerCase()] = prop;
+					declarations.set(prop.toLowerCase(), prop);
 
 					return;
 				}
 
 				for (const longhandProp of overrideables) {
-					if (!Object.prototype.hasOwnProperty.call(declarations, prefix + longhandProp)) {
+					const declaration = declarations.get(prefix + longhandProp);
+
+					if (!declaration) {
 						continue;
 					}
 
@@ -54,7 +56,7 @@ const rule = (primary) => {
 						ruleName,
 						result,
 						node: decl,
-						message: messages.rejected(prop, declarations[prefix + longhandProp] || ''),
+						message: messages.rejected(prop, declaration || ''),
 						word: prop,
 					});
 				}

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/index.js
@@ -3,7 +3,7 @@
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
-const shorthandData = require('../../reference/shorthandData');
+const { longhandSubPropertiesOfShorthandProperties } = require('../../reference/properties');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
 
@@ -35,9 +35,9 @@ const rule = (primary) => {
 				const unprefixedProp = vendor.unprefixed(prop).toLowerCase();
 				const prefix = vendor.prefix(prop).toLowerCase();
 
-				const overrideables = /** @type {Record<string, Set<string>>} */ (shorthandData)[
-					unprefixedProp
-				];
+				const overrideables = /** @type {Record<string, Set<string>>} */ (
+					longhandSubPropertiesOfShorthandProperties
+				)[unprefixedProp];
 
 				if (!overrideables) {
 					declarations[prop.toLowerCase()] = prop;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -383,7 +383,7 @@ declare module 'stylelint' {
 			line?: number;
 		};
 
-		export type LonghandSubPropertiesOfShorthandProperties = Record<
+		export type LonghandSubPropertiesOfShorthandProperties = ReadonlyMap<
 			| 'animation'
 			| 'background'
 			| 'border'

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -379,6 +379,44 @@ declare module 'stylelint' {
 			line?: number;
 		};
 
+		export type ShorthandData = {
+			margin: Set<string>;
+			padding: Set<string>;
+			background: Set<string>;
+			font: Set<string>;
+			border: Set<string>;
+			'border-top': Set<string>;
+			'border-bottom': Set<string>;
+			'border-left': Set<string>;
+			'border-right': Set<string>;
+			'border-width': Set<string>;
+			'border-style': Set<string>;
+			'border-color': Set<string>;
+			'list-style': Set<string>;
+			'border-radius': Set<string>;
+			transition: Set<string>;
+			animation: Set<string>;
+			'border-block-end': Set<string>;
+			'border-block-start': Set<string>;
+			'border-image': Set<string>;
+			'border-inline-end': Set<string>;
+			'border-inline-start': Set<string>;
+			'column-rule': Set<string>;
+			columns: Set<string>;
+			flex: Set<string>;
+			'flex-flow': Set<string>;
+			grid: Set<string>;
+			'grid-area': Set<string>;
+			'grid-column': Set<string>;
+			'grid-gap': Set<string>;
+			'grid-row': Set<string>;
+			'grid-template': Set<string>;
+			outline: Set<string>;
+			'text-decoration': Set<string>;
+			'text-emphasis': Set<string>;
+			mask: Set<string>;
+		};
+
 		export type PublicApi = PostCSS.PluginCreator<PostcssPluginOptions> & {
 			/**
 			 * Runs stylelint with the given options and returns a Promise that
@@ -454,6 +492,12 @@ declare module 'stylelint' {
 					options: { ruleName: string; ruleSettings: ConfigRuleSettings<T, O>; root: PostCSS.Root },
 					callback: (warning: PostCSS.Warning) => void,
 				) => void;
+			};
+			reference: {
+				/**
+				 * Shorthand properties having longhand sub-properties.
+				 */
+				shorthandData: ShorthandData;
 			};
 		};
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -383,43 +383,44 @@ declare module 'stylelint' {
 			line?: number;
 		};
 
-		export type LonghandSubPropertiesOfShorthandProperties = {
-			animation: Set<string>;
-			background: Set<string>;
-			border: Set<string>;
-			'border-block-end': Set<string>;
-			'border-block-start': Set<string>;
-			'border-bottom': Set<string>;
-			'border-color': Set<string>;
-			'border-image': Set<string>;
-			'border-inline-end': Set<string>;
-			'border-inline-start': Set<string>;
-			'border-left': Set<string>;
-			'border-radius': Set<string>;
-			'border-right': Set<string>;
-			'border-style': Set<string>;
-			'border-top': Set<string>;
-			'border-width': Set<string>;
-			'column-rule': Set<string>;
-			columns: Set<string>;
-			flex: Set<string>;
-			'flex-flow': Set<string>;
-			font: Set<string>;
-			grid: Set<string>;
-			'grid-area': Set<string>;
-			'grid-column': Set<string>;
-			'grid-gap': Set<string>;
-			'grid-row': Set<string>;
-			'grid-template': Set<string>;
-			'list-style': Set<string>;
-			margin: Set<string>;
-			mask: Set<string>;
-			outline: Set<string>;
-			padding: Set<string>;
-			'text-decoration': Set<string>;
-			'text-emphasis': Set<string>;
-			transition: Set<string>;
-		};
+		export type LonghandSubPropertiesOfShorthandProperties = Record<
+			| 'animation'
+			| 'background'
+			| 'border'
+			| 'border-block-end'
+			| 'border-block-start'
+			| 'border-bottom'
+			| 'border-color'
+			| 'border-image'
+			| 'border-inline-end'
+			| 'border-inline-start'
+			| 'border-left'
+			| 'border-radius'
+			| 'border-right'
+			| 'border-style'
+			| 'border-top'
+			| 'border-width'
+			| 'column-rule'
+			| 'columns'
+			| 'flex'
+			| 'flex-flow'
+			| 'font'
+			| 'grid'
+			| 'grid-area'
+			| 'grid-column'
+			| 'grid-gap'
+			| 'grid-row'
+			| 'grid-template'
+			| 'list-style'
+			| 'margin'
+			| 'mask'
+			| 'outline'
+			| 'padding'
+			| 'text-decoration'
+			| 'text-emphasis'
+			| 'transition',
+			Set<string>
+		>;
 
 		export type PublicApi = PostCSS.PluginCreator<PostcssPluginOptions> & {
 			/**

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -379,7 +379,7 @@ declare module 'stylelint' {
 			line?: number;
 		};
 
-		export type ShorthandData = {
+		export type LonghandSubPropertiesOfShorthandProperties = {
 			animation: Set<string>;
 			background: Set<string>;
 			border: Set<string>;
@@ -494,10 +494,7 @@ declare module 'stylelint' {
 				) => void;
 			};
 			reference: {
-				/**
-				 * Shorthand properties having longhand sub-properties.
-				 */
-				shorthandData: ShorthandData;
+				longhandSubPropertiesOfShorthandProperties: LonghandSubPropertiesOfShorthandProperties;
 			};
 		};
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -419,7 +419,7 @@ declare module 'stylelint' {
 			| 'text-decoration'
 			| 'text-emphasis'
 			| 'transition',
-			Set<string>
+			ReadonlySet<string>
 		>;
 
 		export type PublicApi = PostCSS.PluginCreator<PostcssPluginOptions> & {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -380,41 +380,41 @@ declare module 'stylelint' {
 		};
 
 		export type ShorthandData = {
-			margin: Set<string>;
-			padding: Set<string>;
-			background: Set<string>;
-			font: Set<string>;
-			border: Set<string>;
-			'border-top': Set<string>;
-			'border-bottom': Set<string>;
-			'border-left': Set<string>;
-			'border-right': Set<string>;
-			'border-width': Set<string>;
-			'border-style': Set<string>;
-			'border-color': Set<string>;
-			'list-style': Set<string>;
-			'border-radius': Set<string>;
-			transition: Set<string>;
 			animation: Set<string>;
+			background: Set<string>;
+			border: Set<string>;
 			'border-block-end': Set<string>;
 			'border-block-start': Set<string>;
+			'border-bottom': Set<string>;
+			'border-color': Set<string>;
 			'border-image': Set<string>;
 			'border-inline-end': Set<string>;
 			'border-inline-start': Set<string>;
+			'border-left': Set<string>;
+			'border-radius': Set<string>;
+			'border-right': Set<string>;
+			'border-style': Set<string>;
+			'border-top': Set<string>;
+			'border-width': Set<string>;
 			'column-rule': Set<string>;
 			columns: Set<string>;
 			flex: Set<string>;
 			'flex-flow': Set<string>;
+			font: Set<string>;
 			grid: Set<string>;
 			'grid-area': Set<string>;
 			'grid-column': Set<string>;
 			'grid-gap': Set<string>;
 			'grid-row': Set<string>;
 			'grid-template': Set<string>;
+			'list-style': Set<string>;
+			margin: Set<string>;
+			mask: Set<string>;
 			outline: Set<string>;
+			padding: Set<string>;
 			'text-decoration': Set<string>;
 			'text-emphasis': Set<string>;
-			mask: Set<string>;
+			transition: Set<string>;
 		};
 
 		export type PublicApi = PostCSS.PluginCreator<PostcssPluginOptions> & {

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -132,7 +132,11 @@ messages.warning('some string');
 // @ts-expect-error Null is not allowed in `RuleMessageFunc` parameters.
 messages.warning(null);
 
-const shorthandSubProps: Set<string> | undefined =
+const shorthandSubProps: ReadonlySet<string> | undefined =
 	stylelint.reference.longhandSubPropertiesOfShorthandProperties.get('border-color');
-// @ts-expect-error -- Modification is not allowed due to readonly.
-stylelint.reference.longhandSubPropertiesOfShorthandProperties.delete('border-color');
+// @ts-expect-error -- Readonly.
+shorthandSubProps.clear();
+// @ts-expect-error -- Readonly.
+stylelint.reference.longhandSubPropertiesOfShorthandProperties.clear();
+// @ts-expect-error -- Unknown key.
+stylelint.reference.longhandSubPropertiesOfShorthandProperties.get('unknown-property');

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -132,4 +132,5 @@ messages.warning('some string');
 // @ts-expect-error Null is not allowed in `RuleMessageFunc` parameters.
 messages.warning(null);
 
-const shorthandSubProps: Set<string> = stylelint.reference.shorthandData['border-color'];
+const shorthandSubProps: Set<string> =
+	stylelint.reference.longhandSubPropertiesOfShorthandProperties['border-color'];

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -131,3 +131,5 @@ messages.warning('some string');
 
 // @ts-expect-error Null is not allowed in `RuleMessageFunc` parameters.
 messages.warning(null);
+
+const shorthandSubProps: Set<string> = stylelint.reference.shorthandData['border-color'];

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -132,5 +132,7 @@ messages.warning('some string');
 // @ts-expect-error Null is not allowed in `RuleMessageFunc` parameters.
 messages.warning(null);
 
-const shorthandSubProps: Set<string> =
-	stylelint.reference.longhandSubPropertiesOfShorthandProperties['border-color'];
+const shorthandSubProps: Set<string> | undefined =
+	stylelint.reference.longhandSubPropertiesOfShorthandProperties.get('border-color');
+// @ts-expect-error -- Modification is not allowed due to readonly.
+stylelint.reference.longhandSubPropertiesOfShorthandProperties.delete('border-color');


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- Closes #6151
- #6152

> Is there anything in the PR that needs further explanation?

This pull request is following the suggestion below by @jeddy3 in <https://github.com/stylelint/stylelint/issues/6151#issuecomment-1160488202>:

> - align and expose data as it's requested (starting with the shorthand data)

The type definition is generated by the following script:

```js
const shorthandData = require("./lib/reference/shorthandData")
console.log('export type ShorthandData = {')
for (const key of Object.keys(shorthandData).sort()) {
	console.log(`\t'${key}': Set<string>;`)
}
console.log('};')
```

