### PR TITLE
Fix exit code when nothing is passed to stylelint command

### DIFF
--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -174,7 +174,7 @@ describe('CLI', () => {
 	it('basic', async () => {
 		await cli([]);
 
-		expect(process.exit).toHaveBeenCalledWith(2);
+		expect(process.exit).toHaveBeenCalledWith(0);
 
 		expect(console.log).toHaveBeenCalledTimes(1);
 		expect(console.log).toHaveBeenCalledWith(

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -476,7 +476,7 @@ module.exports = async (argv) => {
 	}
 
 	if (!options.files && !options.code && !cli.flags.stdin) {
-		cli.showHelp();
+		cli.showHelp(0);
 
 		return;
 	}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5150.

> Is there anything in the PR that needs further explanation?

Seems *too simple* - am I missing something?

Also, is this a breaking change? I did change the behaviour that was captured in a test.
