### PR TITLE
Refactor to remove `execall` dependency

### DIFF
--- a/lib/__tests__/fixtures/processor-fenced-blocks.js
+++ b/lib/__tests__/fixtures/processor-fenced-blocks.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const execall = require('execall');
-
 module.exports = function (options = {}) {
 	const specialMessage = options.specialMessage || 'was processed';
 
 	return {
 		code(input) {
-			const blocks = execall(/```start([\s\S]+?)```end/g, input);
-			const toLint = blocks.map((match) => match.subMatches[0]).join('\n\n');
+			const blocks = [...input.matchAll(/```start([\s\S]+?)```end/g)];
+			const toLint = blocks.map((match) => match[1]).join('\n\n');
 
 			return toLint;
 		},

--- a/lib/__tests__/fixtures/processor-triple-question-marks.js
+++ b/lib/__tests__/fixtures/processor-triple-question-marks.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const execall = require('execall');
-
 module.exports = function () {
 	let found = false;
 
 	return {
 		code(input) {
-			const blocks = execall(/\?{3}start([\s\S]+?)\?{3}end/g, input);
-			const toLint = blocks.map((match) => match.subMatches[0]).join('\n\n');
+			const blocks = [...input.matchAll(/\?{3}start([\s\S]+?)\?{3}end/g)];
+			const toLint = blocks.map((match) => match[1]).join('\n\n');
 
 			if (toLint.length > 0) {
 				found = true;

--- a/lib/rules/max-line-length/index.js
+++ b/lib/rules/max-line-length/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const execall = require('execall');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -9,10 +8,6 @@ const validateOptions = require('../../utils/validateOptions');
 const { isNumber, isRegExp, isString, assert } = require('../../utils/validateTypes');
 
 const ruleName = 'max-line-length';
-const EXCLUDED_PATTERNS = [
-	/url\(\s*(\S.*\S)\s*\)/gi, // allow tab, whitespace in url content
-	/@import\s+(['"].*['"])/gi,
-];
 
 const messages = ruleMessages(ruleName, {
 	expected: (max) =>
@@ -51,6 +46,11 @@ const rule = (primary, secondaryOptions, context) => {
 			throw new Error('The root node must have a source');
 		}
 
+		const EXCLUDED_PATTERNS = [
+			/url\(\s*(\S.*\S)\s*\)/gi, // allow tab, whitespace in url content
+			/@import\s+(['"].*['"])/gi,
+		];
+
 		const ignoreNonComments = optionsMatches(secondaryOptions, 'ignore', 'non-comments');
 		const ignoreComments = optionsMatches(secondaryOptions, 'ignore', 'comments');
 		const rootString = context.fix ? root.toString() : root.source.input.css;
@@ -59,14 +59,14 @@ const rule = (primary, secondaryOptions, context) => {
 		let skippedSubStrings = [];
 		let skippedSubStringsIndex = 0;
 
-		for (const pattern of EXCLUDED_PATTERNS)
-			for (const match of execall(pattern, rootString)) {
-				const subMatch = match.subMatches[0] || '';
-				const startOfSubString = match.index + match.match.indexOf(subMatch);
+		for (const pattern of EXCLUDED_PATTERNS) {
+			for (const match of rootString.matchAll(pattern)) {
+				const subMatch = match[1] || '';
+				const startOfSubString = (match.index || 0) + (match[0] || '').indexOf(subMatch);
 
 				skippedSubStrings.push([startOfSubString, startOfSubString + subMatch.length]);
-				continue;
 			}
+		}
 
 		skippedSubStrings = skippedSubStrings.sort((a, b) => a[0] - b[0]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "cosmiconfig": "^7.0.1",
         "css-functions-list": "^3.1.0",
         "debug": "^4.3.4",
-        "execall": "^2.0.0",
         "fast-glob": "^3.2.11",
         "fastest-levenshtein": "^1.0.12",
         "file-entry-cache": "^6.0.1",
@@ -2567,17 +2566,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "node_modules/clone-regexp": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
-      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
-      "dependencies": {
-        "is-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -3620,17 +3608,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execall": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
-      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
-      "dependencies": {
-        "clone-regexp": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/exit": {
@@ -5189,14 +5166,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-regexp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
-      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-scoped": {
@@ -15024,14 +14993,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "clone-regexp": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
-      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
-      "requires": {
-        "is-regexp": "^2.0.0"
-      }
-    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -15787,14 +15748,6 @@
         "onetime": "^5.1.2",
         "signal-exit": "^3.0.3",
         "strip-final-newline": "^2.0.0"
-      }
-    },
-    "execall": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
-      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
-      "requires": {
-        "clone-regexp": "^2.1.0"
       }
     },
     "exit": {
@@ -16927,11 +16880,6 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-regexp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
-      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA=="
     },
     "is-scoped": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "cosmiconfig": "^7.0.1",
     "css-functions-list": "^3.1.0",
     "debug": "^4.3.4",
-    "execall": "^2.0.0",
     "fast-glob": "^3.2.11",
     "fastest-levenshtein": "^1.0.12",
     "file-entry-cache": "^6.0.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

We can replace `execall` with `String.prototype.matchAll()` which has been supported since Node.js v12.

See also:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
- https://github.com/sindresorhus/execall

FYI. We have supported Node.js v12+:

https://github.com/stylelint/stylelint/blob/0ffb27fa2dc01d46f9df96e5f2c9377b00b30a46/package.json#L192-L194