### PR TITLE
Add `meta.fixable` property to each rule

### DIFF
--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -30,7 +30,7 @@ Within each cateogory, the rules are grouped by the [_thing_](http://apps.workfl
 
 ### Function
 
-- [`function-calc-no-unspaced-operator`](../../../lib/rules/function-calc-no-unspaced-operator/README.md): Disallow an unspaced operator within `calc` functions.
+- [`function-calc-no-unspaced-operator`](../../../lib/rules/function-calc-no-unspaced-operator/README.md): Disallow an unspaced operator within `calc` functions (Autofixable).
 - [`function-linear-gradient-no-nonstandard-direction`](../../../lib/rules/function-linear-gradient-no-nonstandard-direction/README.md): Disallow direction values in `linear-gradient()` calls that are not valid according to the [standard syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient#Syntax).
 - [`function-no-unknown`](../../../lib/rules/function-no-unknown/README.md): Disallow unknown functions.
 
@@ -140,7 +140,7 @@ Within each cateogory, the rules are grouped by the [_thing_](http://apps.workfl
 
 ### Keyframe selector
 
-- [`keyframe-selector-notation`](../../../lib/rules/keyframe-selector-notation/README.md): Specify keyword or percentage notation for keyframe selectors.
+- [`keyframe-selector-notation`](../../../lib/rules/keyframe-selector-notation/README.md): Specify keyword or percentage notation for keyframe selectors (Autofixable).
 
 ### Keyframes
 
@@ -196,7 +196,7 @@ Within each cateogory, the rules are grouped by the [_thing_](http://apps.workfl
 - [`selector-attribute-name-disallowed-list`](../../../lib/rules/selector-attribute-name-disallowed-list/README.md): Specify a list of disallowed attribute names.
 - [`selector-attribute-operator-allowed-list`](../../../lib/rules/selector-attribute-operator-allowed-list/README.md): Specify a list of allowed attribute operators.
 - [`selector-attribute-operator-disallowed-list`](../../../lib/rules/selector-attribute-operator-disallowed-list/README.md): Specify a list of disallowed attribute operators.
-- [`selector-attribute-quotes`](../../../lib/rules/selector-attribute-quotes/README.md): Require or disallow quotes for attribute values.
+- [`selector-attribute-quotes`](../../../lib/rules/selector-attribute-quotes/README.md): Require or disallow quotes for attribute values (Autofixable).
 - [`selector-class-pattern`](../../../lib/rules/selector-class-pattern/README.md): Specify a pattern for class selectors.
 - [`selector-combinator-allowed-list`](../../../lib/rules/selector-combinator-allowed-list/README.md): Specify a list of allowed combinators.
 - [`selector-combinator-disallowed-list`](../../../lib/rules/selector-combinator-disallowed-list/README.md): Specify a list of disallowed combinators.

--- a/lib/rules/__tests__/index.test.js
+++ b/lib/rules/__tests__/index.test.js
@@ -1,12 +1,30 @@
 'use strict';
 
+const fs = require('node:fs');
+const path = require('node:path');
+
 const rules = require('..');
 
-describe('rules', () => {
-	for (const [ruleName, rule] of Object.entries(rules)) {
-		test(`the "${ruleName}" rule has metadata`, () => {
-			expect(rule.meta).toBeTruthy();
-			expect(rule.meta.url).toMatch(/^https:\/\/stylelint\.io\/.+/);
-		});
-	}
+describe('all rules', () => {
+	test.each(Object.entries(rules))('"%s" should have metadata', (_name, rule) => {
+		expect(rule.meta).toBeTruthy();
+		expect(rule.meta.url).toMatch(/^https:\/\/stylelint\.io\/.+/);
+		expect([true, undefined]).toContain(rule.meta.fixable);
+	});
+});
+
+describe('fixable rules', () => {
+	const fixableRules = Object.entries(rules).filter(([, rule]) => rule.meta.fixable);
+
+	test.each(fixableRules)('"%s" should describe fixable in the doc', async (name) => {
+		const doc = await fs.promises.readFile(path.join('lib', 'rules', name, 'README.md'), 'utf8');
+
+		expect(doc).toMatch('`fix` option');
+	});
+
+	const rulesListDoc = fs.readFileSync(path.join('docs', 'user-guide', 'rules', 'list.md'), 'utf8');
+
+	test.each(fixableRules)('"%s" should describe fixable in the rule list doc', (name) => {
+		expect(rulesListDoc).toMatch(new RegExp(`^.+\\b${name}\\b.+\\(Autofixable\\)\\.$`, 'm'));
+	});
 });

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -20,6 +20,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/alpha-value-notation',
+	fixable: true,
 };
 
 const ALPHA_PROPS = new Set(['opacity', 'shape-image-threshold']);

--- a/lib/rules/at-rule-empty-line-before/index.js
+++ b/lib/rules/at-rule-empty-line-before/index.js
@@ -25,6 +25,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/at-rule-name-case/index.js
+++ b/lib/rules/at-rule-name-case/index.js
@@ -13,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/at-rule-name-case',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/at-rule-name-space-after/index.js
+++ b/lib/rules/at-rule-name-space-after/index.js
@@ -13,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/at-rule-name-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/at-rule-no-vendor-prefix/index.js
+++ b/lib/rules/at-rule-no-vendor-prefix/index.js
@@ -14,6 +14,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/at-rule-semicolon-newline-after/index.js
+++ b/lib/rules/at-rule-semicolon-newline-after/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-closing-brace-empty-line-before/index.js
+++ b/lib/rules/block-closing-brace-empty-line-before/index.js
@@ -21,6 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-closing-brace-newline-after/index.js
+++ b/lib/rules/block-closing-brace-newline-after/index.js
@@ -22,6 +22,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-closing-brace-newline-before/index.js
+++ b/lib/rules/block-closing-brace-newline-before/index.js
@@ -18,6 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-closing-brace-space-before/index.js
+++ b/lib/rules/block-closing-brace-space-before/index.js
@@ -21,6 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-opening-brace-newline-after/index.js
+++ b/lib/rules/block-opening-brace-newline-after/index.js
@@ -21,6 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-opening-brace-newline-before/index.js
+++ b/lib/rules/block-opening-brace-newline-before/index.js
@@ -21,6 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-opening-brace-space-after/index.js
+++ b/lib/rules/block-opening-brace-space-after/index.js
@@ -23,6 +23,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/block-opening-brace-space-before/index.js
+++ b/lib/rules/block-opening-brace-space-before/index.js
@@ -24,6 +24,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/color-function-notation/index.js
+++ b/lib/rules/color-function-notation/index.js
@@ -19,6 +19,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/color-function-notation',
+	fixable: true,
 };
 
 const LEGACY_FUNCS = new Set(['rgba', 'hsla']);

--- a/lib/rules/color-hex-case/index.js
+++ b/lib/rules/color-hex-case/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/color-hex-case',
+	fixable: true,
 };
 
 const HEX = /^#[0-9A-Za-z]+/;

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/color-hex-length',
+	fixable: true,
 };
 
 const HEX = /^#[0-9A-Za-z]+/;

--- a/lib/rules/comment-empty-line-before/index.js
+++ b/lib/rules/comment-empty-line-before/index.js
@@ -23,6 +23,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/comment-empty-line-before',
+	fixable: true,
 };
 
 const stylelintCommandPrefix = 'stylelint-';

--- a/lib/rules/comment-whitespace-inside/index.js
+++ b/lib/rules/comment-whitespace-inside/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/comment-whitespace-inside',
+	fixable: true,
 };
 
 /**

--- a/lib/rules/custom-property-empty-line-before/index.js
+++ b/lib/rules/custom-property-empty-line-before/index.js
@@ -25,6 +25,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-bang-space-after/index.js
+++ b/lib/rules/declaration-bang-space-after/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-bang-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-bang-space-before/index.js
+++ b/lib/rules/declaration-bang-space-before/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-bang-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-block-semicolon-newline-after/index.js
+++ b/lib/rules/declaration-block-semicolon-newline-after/index.js
@@ -19,6 +19,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-block-semicolon-space-after/index.js
+++ b/lib/rules/declaration-block-semicolon-space-after/index.js
@@ -21,6 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-block-semicolon-space-before/index.js
+++ b/lib/rules/declaration-block-semicolon-space-before/index.js
@@ -22,6 +22,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-block-trailing-semicolon/index.js
+++ b/lib/rules/declaration-block-trailing-semicolon/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-colon-newline-after/index.js
+++ b/lib/rules/declaration-colon-newline-after/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-colon-space-after/index.js
+++ b/lib/rules/declaration-colon-space-after/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-colon-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-colon-space-before/index.js
+++ b/lib/rules/declaration-colon-space-before/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-colon-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/declaration-empty-line-before/index.js
+++ b/lib/rules/declaration-empty-line-before/index.js
@@ -26,6 +26,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/declaration-empty-line-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/font-family-name-quotes',
+	fixable: true,
 };
 
 /**

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -21,6 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator',
+	fixable: true,
 };
 
 const OPERATORS = new Set(['+', '-']);

--- a/lib/rules/function-comma-newline-after/index.js
+++ b/lib/rules/function-comma-newline-after/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-comma-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/function-comma-newline-before/index.js
+++ b/lib/rules/function-comma-newline-before/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-comma-newline-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/function-comma-space-after/index.js
+++ b/lib/rules/function-comma-space-after/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-comma-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/function-comma-space-before/index.js
+++ b/lib/rules/function-comma-space-before/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-comma-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/function-max-empty-lines/index.js
+++ b/lib/rules/function-max-empty-lines/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-max-empty-lines',
+	fixable: true,
 };
 
 /**

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -20,6 +20,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-name-case',
+	fixable: true,
 };
 
 const mapLowercaseFunctionNamesToCamelCase = new Map();

--- a/lib/rules/function-parentheses-newline-inside/index.js
+++ b/lib/rules/function-parentheses-newline-inside/index.js
@@ -23,6 +23,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/function-parentheses-space-inside/index.js
+++ b/lib/rules/function-parentheses-space-inside/index.js
@@ -25,6 +25,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/function-whitespace-after/index.js
+++ b/lib/rules/function-whitespace-after/index.js
@@ -19,6 +19,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/function-whitespace-after',
+	fixable: true,
 };
 
 const ACCEPTABLE_AFTER_CLOSING_PAREN = new Set([')', ',', '}', ':', '/', undefined]);

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -18,6 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/hue-degree-notation',
+	fixable: true,
 };
 
 const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];

--- a/lib/rules/import-notation/README.md
+++ b/lib/rules/import-notation/README.md
@@ -9,6 +9,8 @@ Specify string or URL notation for `@import` rules.
  *      This notation */
 ```
 
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"string"|"url"`

--- a/lib/rules/import-notation/index.js
+++ b/lib/rules/import-notation/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/import-notation',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/indentation',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/keyframe-selector-notation/index.js
+++ b/lib/rules/keyframe-selector-notation/index.js
@@ -13,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/keyframe-selector-notation',
+	fixable: true,
 };
 
 const PERCENTAGE_SELECTORS = new Set(['0%', '100%']);

--- a/lib/rules/length-zero-no-unit/index.js
+++ b/lib/rules/length-zero-no-unit/index.js
@@ -26,6 +26,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/length-zero-no-unit',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/linebreaks/index.js
+++ b/lib/rules/linebreaks/index.js
@@ -13,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/linebreaks',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/max-empty-lines/index.js
+++ b/lib/rules/max-empty-lines/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/max-empty-lines',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-feature-colon-space-after/index.js
+++ b/lib/rules/media-feature-colon-space-after/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-feature-colon-space-before/index.js
+++ b/lib/rules/media-feature-colon-space-before/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -18,6 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-case',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.js
@@ -13,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-name-no-vendor-prefix',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-feature-parentheses-space-inside/index.js
+++ b/lib/rules/media-feature-parentheses-space-inside/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-feature-range-operator-space-after/index.js
+++ b/lib/rules/media-feature-range-operator-space-after/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-feature-range-operator-space-before/index.js
+++ b/lib/rules/media-feature-range-operator-space-before/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-query-list-comma-newline-after/index.js
+++ b/lib/rules/media-query-list-comma-newline-after/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-query-list-comma-space-after/index.js
+++ b/lib/rules/media-query-list-comma-space-after/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/media-query-list-comma-space-before/index.js
+++ b/lib/rules/media-query-list-comma-space-before/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/no-empty-first-line/index.js
+++ b/lib/rules/no-empty-first-line/index.js
@@ -13,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/no-empty-first-line',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/no-eol-whitespace/index.js
+++ b/lib/rules/no-eol-whitespace/index.js
@@ -18,6 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/no-eol-whitespace',
+	fixable: true,
 };
 
 const whitespacesToReject = new Set([' ', '\t']);

--- a/lib/rules/no-extra-semicolons/index.js
+++ b/lib/rules/no-extra-semicolons/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/no-extra-semicolons',
+	fixable: true,
 };
 
 /**

--- a/lib/rules/no-missing-end-of-source-newline/index.js
+++ b/lib/rules/no-missing-end-of-source-newline/index.js
@@ -12,6 +12,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/number-leading-zero/index.js
+++ b/lib/rules/number-leading-zero/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/number-leading-zero',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/number-no-trailing-zeros/index.js
+++ b/lib/rules/number-no-trailing-zeros/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/property-case/index.js
+++ b/lib/rules/property-case/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/property-case',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/property-no-vendor-prefix/index.js
+++ b/lib/rules/property-no-vendor-prefix/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/rule-empty-line-before/index.js
+++ b/lib/rules/rule-empty-line-before/index.js
@@ -23,6 +23,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/rule-empty-line-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-attribute-brackets-space-inside/index.js
+++ b/lib/rules/selector-attribute-brackets-space-inside/index.js
@@ -18,6 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-attribute-operator-space-after/index.js
+++ b/lib/rules/selector-attribute-operator-space-after/index.js
@@ -14,6 +14,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-attribute-operator-space-before/index.js
+++ b/lib/rules/selector-attribute-operator-space-before/index.js
@@ -14,6 +14,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-attribute-quotes',
+	fixable: true,
 };
 
 const acceptedQuoteMark = '"';

--- a/lib/rules/selector-combinator-space-after/index.js
+++ b/lib/rules/selector-combinator-space-after/index.js
@@ -14,6 +14,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-combinator-space-before/index.js
+++ b/lib/rules/selector-combinator-space-before/index.js
@@ -14,6 +14,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-combinator-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-descendant-combinator-no-non-space/index.js
+++ b/lib/rules/selector-descendant-combinator-no-non-space/index.js
@@ -14,6 +14,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-list-comma-newline-after/index.js
+++ b/lib/rules/selector-list-comma-newline-after/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-list-comma-newline-before/index.js
+++ b/lib/rules/selector-list-comma-newline-before/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-list-comma-space-after/index.js
+++ b/lib/rules/selector-list-comma-space-after/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-list-comma-space-before/index.js
+++ b/lib/rules/selector-list-comma-space-before/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-max-empty-lines/index.js
+++ b/lib/rules/selector-max-empty-lines/index.js
@@ -13,6 +13,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-max-empty-lines',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-no-vendor-prefix/index.js
+++ b/lib/rules/selector-no-vendor-prefix/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-no-vendor-prefix',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-not-notation/index.js
+++ b/lib/rules/selector-not-notation/index.js
@@ -20,7 +20,10 @@ const ruleName = 'selector-not-notation';
 const messages = ruleMessages(ruleName, {
 	expected: (type) => `Expected ${type} :not() pseudo-class notation`,
 });
-const meta = { url: 'https://stylelint.io/user-guide/rules/list/selector-not-notation' };
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/list/selector-not-notation',
+	fixable: true,
+};
 
 /** @typedef {import('postcss-selector-parser').Node} Node */
 /** @typedef {import('postcss-selector-parser').Selector} Selector */

--- a/lib/rules/selector-pseudo-class-case/index.js
+++ b/lib/rules/selector-pseudo-class-case/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
+++ b/lib/rules/selector-pseudo-class-parentheses-space-inside/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-pseudo-element-case/index.js
+++ b/lib/rules/selector-pseudo-element-case/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -19,6 +19,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-type-case',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -17,6 +17,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values',
+	fixable: true,
 };
 
 const propertiesWithShorthandNotation = new Set([

--- a/lib/rules/string-quotes/index.js
+++ b/lib/rules/string-quotes/index.js
@@ -18,6 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/string-quotes',
+	fixable: true,
 };
 
 const singleQuote = `'`;

--- a/lib/rules/unit-case/index.js
+++ b/lib/rules/unit-case/index.js
@@ -16,6 +16,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/unit-case',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -22,6 +22,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/value-keyword-case',
+	fixable: true,
 };
 
 // Operators are interpreted as "words" by the value parser, so we want to make sure to ignore them.

--- a/lib/rules/value-list-comma-newline-after/index.js
+++ b/lib/rules/value-list-comma-newline-after/index.js
@@ -18,6 +18,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/value-list-comma-space-after/index.js
+++ b/lib/rules/value-list-comma-space-after/index.js
@@ -19,6 +19,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/value-list-comma-space-after',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/value-list-comma-space-before/index.js
+++ b/lib/rules/value-list-comma-space-before/index.js
@@ -19,6 +19,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/value-list-comma-space-before',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/value-list-max-empty-lines/index.js
+++ b/lib/rules/value-list-max-empty-lines/index.js
@@ -15,6 +15,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines',
+	fixable: true,
 };
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/value-no-vendor-prefix/index.js
+++ b/lib/rules/value-no-vendor-prefix/index.js
@@ -21,6 +21,7 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix',
+	fixable: true,
 };
 
 const valuePrefixes = ['-webkit-', '-moz-', '-ms-', '-o-'];

--- a/system-tests/001/__snapshots__/fs.test.js.snap
+++ b/system-tests/001/__snapshots__/fs.test.js.snap
@@ -26,69 +26,87 @@ Object {
   ],
   "ruleMetadata": Object {
     "at-rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
     },
     "at-rule-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
     },
     "at-rule-name-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
     },
     "at-rule-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
     },
     "at-rule-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
     },
     "block-closing-brace-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
     },
     "block-closing-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
     },
     "block-closing-brace-newline-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
     },
     "block-closing-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
     },
     "block-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
     },
     "block-opening-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
     },
     "block-opening-brace-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
     },
     "block-opening-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
     },
     "color-hex-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
     },
     "color-hex-length": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
     },
     "color-no-invalid-hex": Object {
       "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
     },
     "comment-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
     },
     "comment-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
     },
     "comment-whitespace-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
     },
     "custom-property-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
     },
     "declaration-bang-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
     },
     "declaration-bang-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
     },
     "declaration-block-no-duplicate-properties": Object {
@@ -98,30 +116,38 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
     },
     "declaration-block-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
     },
     "declaration-block-semicolon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
     },
     "declaration-block-semicolon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
     },
     "declaration-block-single-line-max-declarations": Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
     },
     "declaration-block-trailing-semicolon": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
     },
     "declaration-colon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
     },
     "declaration-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
     },
     "declaration-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
     },
     "declaration-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
     },
     "font-family-no-duplicate-names": Object {
@@ -131,75 +157,96 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
     },
     "function-calc-no-unspaced-operator": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
     },
     "function-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
     },
     "function-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
     },
     "function-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
     },
     "function-linear-gradient-no-nonstandard-direction": Object {
       "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
     },
     "function-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
     },
     "function-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
     },
     "function-parentheses-newline-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
     },
     "function-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
     },
     "function-whitespace-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
     },
     "indentation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/indentation",
     },
     "keyframe-declaration-no-important": Object {
       "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
     },
     "length-zero-no-unit": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
     },
     "max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
     },
     "media-feature-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
     },
     "media-feature-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
     },
     "media-feature-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
     },
     "media-feature-name-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
     },
     "media-feature-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
     },
     "media-feature-range-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
     },
     "media-feature-range-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
     },
     "media-query-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
     },
     "media-query-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
     },
     "media-query-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
     },
     "no-duplicate-at-import-rules": Object {
@@ -212,78 +259,99 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
     },
     "no-eol-whitespace": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
     },
     "no-extra-semicolons": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
     },
     "no-invalid-double-slash-comments": Object {
       "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
     },
     "no-missing-end-of-source-newline": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
     },
     "number-leading-zero": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
     },
     "number-no-trailing-zeros": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
     },
     "property-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/property-case",
     },
     "property-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
     },
     "rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
     },
     "selector-attribute-brackets-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
     },
     "selector-attribute-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
     },
     "selector-attribute-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
     },
     "selector-combinator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
     },
     "selector-combinator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
     },
     "selector-descendant-combinator-no-non-space": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
     },
     "selector-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
     },
     "selector-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
     },
     "selector-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
     },
     "selector-pseudo-class-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
     },
     "selector-pseudo-class-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
     },
     "selector-pseudo-class-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
     },
     "selector-pseudo-element-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
     },
     "selector-pseudo-element-colon-notation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
     },
     "selector-pseudo-element-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
     },
     "selector-type-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
     },
     "selector-type-no-unknown": Object {
@@ -293,24 +361,30 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
     },
     "unit-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/unit-case",
     },
     "unit-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
     },
     "value-keyword-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
     },
     "value-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
     },
     "value-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
     },
     "value-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
     },
     "value-list-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
     },
   },

--- a/system-tests/001/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/001/__snapshots__/no-fs.test.js.snap
@@ -26,69 +26,87 @@ Object {
   ],
   "ruleMetadata": Object {
     "at-rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
     },
     "at-rule-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
     },
     "at-rule-name-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
     },
     "at-rule-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
     },
     "at-rule-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
     },
     "block-closing-brace-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
     },
     "block-closing-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
     },
     "block-closing-brace-newline-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
     },
     "block-closing-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
     },
     "block-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
     },
     "block-opening-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
     },
     "block-opening-brace-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
     },
     "block-opening-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
     },
     "color-hex-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
     },
     "color-hex-length": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
     },
     "color-no-invalid-hex": Object {
       "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
     },
     "comment-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
     },
     "comment-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
     },
     "comment-whitespace-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
     },
     "custom-property-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
     },
     "declaration-bang-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
     },
     "declaration-bang-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
     },
     "declaration-block-no-duplicate-properties": Object {
@@ -98,30 +116,38 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
     },
     "declaration-block-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
     },
     "declaration-block-semicolon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
     },
     "declaration-block-semicolon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
     },
     "declaration-block-single-line-max-declarations": Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
     },
     "declaration-block-trailing-semicolon": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
     },
     "declaration-colon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
     },
     "declaration-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
     },
     "declaration-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
     },
     "declaration-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
     },
     "font-family-no-duplicate-names": Object {
@@ -131,75 +157,96 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
     },
     "function-calc-no-unspaced-operator": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
     },
     "function-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
     },
     "function-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
     },
     "function-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
     },
     "function-linear-gradient-no-nonstandard-direction": Object {
       "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
     },
     "function-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
     },
     "function-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
     },
     "function-parentheses-newline-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
     },
     "function-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
     },
     "function-whitespace-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
     },
     "indentation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/indentation",
     },
     "keyframe-declaration-no-important": Object {
       "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
     },
     "length-zero-no-unit": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
     },
     "max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
     },
     "media-feature-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
     },
     "media-feature-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
     },
     "media-feature-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
     },
     "media-feature-name-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
     },
     "media-feature-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
     },
     "media-feature-range-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
     },
     "media-feature-range-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
     },
     "media-query-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
     },
     "media-query-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
     },
     "media-query-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
     },
     "no-duplicate-at-import-rules": Object {
@@ -212,78 +259,99 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
     },
     "no-eol-whitespace": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
     },
     "no-extra-semicolons": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
     },
     "no-invalid-double-slash-comments": Object {
       "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
     },
     "no-missing-end-of-source-newline": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
     },
     "number-leading-zero": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
     },
     "number-no-trailing-zeros": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
     },
     "property-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/property-case",
     },
     "property-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
     },
     "rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
     },
     "selector-attribute-brackets-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
     },
     "selector-attribute-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
     },
     "selector-attribute-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
     },
     "selector-combinator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
     },
     "selector-combinator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
     },
     "selector-descendant-combinator-no-non-space": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
     },
     "selector-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
     },
     "selector-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
     },
     "selector-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
     },
     "selector-pseudo-class-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
     },
     "selector-pseudo-class-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
     },
     "selector-pseudo-class-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
     },
     "selector-pseudo-element-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
     },
     "selector-pseudo-element-colon-notation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
     },
     "selector-pseudo-element-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
     },
     "selector-type-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
     },
     "selector-type-no-unknown": Object {
@@ -293,24 +361,30 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
     },
     "unit-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/unit-case",
     },
     "unit-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
     },
     "value-keyword-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
     },
     "value-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
     },
     "value-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
     },
     "value-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
     },
     "value-list-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
     },
   },

--- a/system-tests/002/__snapshots__/fs.test.js.snap
+++ b/system-tests/002/__snapshots__/fs.test.js.snap
@@ -82,9 +82,11 @@ Object {
   ],
   "ruleMetadata": Object {
     "at-rule-name-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
     },
     "at-rule-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix",
     },
     "at-rule-semicolon-space-before": Object {
@@ -100,6 +102,7 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-no-important",
     },
     "font-family-name-quotes": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/font-family-name-quotes",
     },
     "font-weight-notation": Object {
@@ -112,30 +115,38 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/function-url-quotes",
     },
     "max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
     },
     "media-feature-name-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-vendor-prefix",
     },
     "number-leading-zero": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
     },
     "property-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix",
     },
     "selector-attribute-quotes": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-quotes",
     },
     "selector-class-pattern": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-class-pattern",
     },
     "selector-list-comma-newline-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before",
     },
     "selector-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-after",
     },
     "selector-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
     },
     "selector-max-attribute": Object {
@@ -163,27 +174,33 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type",
     },
     "selector-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-no-vendor-prefix",
     },
     "shorthand-property-no-redundant-values": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values",
     },
     "string-quotes": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/string-quotes",
     },
     "unicode-bom": Object {
       "url": "https://stylelint.io/user-guide/rules/list/unicode-bom",
     },
     "value-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
     },
     "value-list-comma-newline-before": Object {
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-before",
     },
     "value-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
     },
     "value-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix",
     },
   },

--- a/system-tests/002/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/002/__snapshots__/no-fs.test.js.snap
@@ -82,9 +82,11 @@ Object {
   ],
   "ruleMetadata": Object {
     "at-rule-name-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
     },
     "at-rule-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix",
     },
     "at-rule-semicolon-space-before": Object {
@@ -100,6 +102,7 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-no-important",
     },
     "font-family-name-quotes": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/font-family-name-quotes",
     },
     "font-weight-notation": Object {
@@ -112,30 +115,38 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/function-url-quotes",
     },
     "max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
     },
     "media-feature-name-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-vendor-prefix",
     },
     "number-leading-zero": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
     },
     "property-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix",
     },
     "selector-attribute-quotes": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-quotes",
     },
     "selector-class-pattern": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-class-pattern",
     },
     "selector-list-comma-newline-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-before",
     },
     "selector-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-after",
     },
     "selector-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
     },
     "selector-max-attribute": Object {
@@ -163,27 +174,33 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type",
     },
     "selector-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-no-vendor-prefix",
     },
     "shorthand-property-no-redundant-values": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values",
     },
     "string-quotes": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/string-quotes",
     },
     "unicode-bom": Object {
       "url": "https://stylelint.io/user-guide/rules/list/unicode-bom",
     },
     "value-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
     },
     "value-list-comma-newline-before": Object {
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-before",
     },
     "value-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
     },
     "value-no-vendor-prefix": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix",
     },
   },

--- a/system-tests/003/__snapshots__/fs.test.js.snap
+++ b/system-tests/003/__snapshots__/fs.test.js.snap
@@ -46,69 +46,87 @@ Object {
   ],
   "ruleMetadata": Object {
     "at-rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
     },
     "at-rule-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
     },
     "at-rule-name-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
     },
     "at-rule-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
     },
     "at-rule-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
     },
     "block-closing-brace-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
     },
     "block-closing-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
     },
     "block-closing-brace-newline-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
     },
     "block-closing-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
     },
     "block-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
     },
     "block-opening-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
     },
     "block-opening-brace-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
     },
     "block-opening-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
     },
     "color-hex-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
     },
     "color-hex-length": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
     },
     "color-no-invalid-hex": Object {
       "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
     },
     "comment-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
     },
     "comment-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
     },
     "comment-whitespace-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
     },
     "custom-property-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
     },
     "declaration-bang-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
     },
     "declaration-bang-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
     },
     "declaration-block-no-duplicate-properties": Object {
@@ -118,30 +136,38 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
     },
     "declaration-block-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
     },
     "declaration-block-semicolon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
     },
     "declaration-block-semicolon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
     },
     "declaration-block-single-line-max-declarations": Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
     },
     "declaration-block-trailing-semicolon": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
     },
     "declaration-colon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
     },
     "declaration-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
     },
     "declaration-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
     },
     "declaration-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
     },
     "font-family-no-duplicate-names": Object {
@@ -151,75 +177,96 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
     },
     "function-calc-no-unspaced-operator": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
     },
     "function-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
     },
     "function-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
     },
     "function-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
     },
     "function-linear-gradient-no-nonstandard-direction": Object {
       "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
     },
     "function-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
     },
     "function-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
     },
     "function-parentheses-newline-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
     },
     "function-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
     },
     "function-whitespace-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
     },
     "indentation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/indentation",
     },
     "keyframe-declaration-no-important": Object {
       "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
     },
     "length-zero-no-unit": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
     },
     "max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
     },
     "media-feature-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
     },
     "media-feature-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
     },
     "media-feature-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
     },
     "media-feature-name-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
     },
     "media-feature-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
     },
     "media-feature-range-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
     },
     "media-feature-range-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
     },
     "media-query-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
     },
     "media-query-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
     },
     "media-query-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
     },
     "no-descending-specificity": Object {
@@ -235,78 +282,99 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
     },
     "no-eol-whitespace": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
     },
     "no-extra-semicolons": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
     },
     "no-invalid-double-slash-comments": Object {
       "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
     },
     "no-missing-end-of-source-newline": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
     },
     "number-leading-zero": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
     },
     "number-no-trailing-zeros": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
     },
     "property-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/property-case",
     },
     "property-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
     },
     "rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
     },
     "selector-attribute-brackets-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
     },
     "selector-attribute-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
     },
     "selector-attribute-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
     },
     "selector-combinator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
     },
     "selector-combinator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
     },
     "selector-descendant-combinator-no-non-space": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
     },
     "selector-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
     },
     "selector-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
     },
     "selector-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
     },
     "selector-pseudo-class-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
     },
     "selector-pseudo-class-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
     },
     "selector-pseudo-class-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
     },
     "selector-pseudo-element-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
     },
     "selector-pseudo-element-colon-notation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
     },
     "selector-pseudo-element-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
     },
     "selector-type-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
     },
     "selector-type-no-unknown": Object {
@@ -316,24 +384,30 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
     },
     "unit-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/unit-case",
     },
     "unit-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
     },
     "value-keyword-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
     },
     "value-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
     },
     "value-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
     },
     "value-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
     },
     "value-list-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
     },
   },

--- a/system-tests/003/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/003/__snapshots__/no-fs.test.js.snap
@@ -238,69 +238,87 @@ footer a:visited {
   ],
   "ruleMetadata": Object {
     "at-rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before",
     },
     "at-rule-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-case",
     },
     "at-rule-name-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-name-space-after",
     },
     "at-rule-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-no-unknown",
     },
     "at-rule-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/at-rule-semicolon-newline-after",
     },
     "block-closing-brace-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-empty-line-before",
     },
     "block-closing-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after",
     },
     "block-closing-brace-newline-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-before",
     },
     "block-closing-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-closing-brace-space-before",
     },
     "block-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/block-no-empty",
     },
     "block-opening-brace-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-newline-after",
     },
     "block-opening-brace-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-after",
     },
     "block-opening-brace-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/block-opening-brace-space-before",
     },
     "color-hex-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-case",
     },
     "color-hex-length": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/color-hex-length",
     },
     "color-no-invalid-hex": Object {
       "url": "https://stylelint.io/user-guide/rules/list/color-no-invalid-hex",
     },
     "comment-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-empty-line-before",
     },
     "comment-no-empty": Object {
       "url": "https://stylelint.io/user-guide/rules/list/comment-no-empty",
     },
     "comment-whitespace-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/comment-whitespace-inside",
     },
     "custom-property-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/custom-property-empty-line-before",
     },
     "declaration-bang-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-after",
     },
     "declaration-bang-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-bang-space-before",
     },
     "declaration-block-no-duplicate-properties": Object {
@@ -310,30 +328,38 @@ footer a:visited {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides",
     },
     "declaration-block-semicolon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-newline-after",
     },
     "declaration-block-semicolon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-after",
     },
     "declaration-block-semicolon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-semicolon-space-before",
     },
     "declaration-block-single-line-max-declarations": Object {
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations",
     },
     "declaration-block-trailing-semicolon": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-block-trailing-semicolon",
     },
     "declaration-colon-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-newline-after",
     },
     "declaration-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-after",
     },
     "declaration-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-colon-space-before",
     },
     "declaration-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/declaration-empty-line-before",
     },
     "font-family-no-duplicate-names": Object {
@@ -343,75 +369,96 @@ footer a:visited {
       "url": "https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword",
     },
     "function-calc-no-unspaced-operator": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator",
     },
     "function-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-newline-after",
     },
     "function-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-after",
     },
     "function-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-comma-space-before",
     },
     "function-linear-gradient-no-nonstandard-direction": Object {
       "url": "https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction",
     },
     "function-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-max-empty-lines",
     },
     "function-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-name-case",
     },
     "function-parentheses-newline-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-newline-inside",
     },
     "function-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-parentheses-space-inside",
     },
     "function-whitespace-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/function-whitespace-after",
     },
     "indentation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/indentation",
     },
     "keyframe-declaration-no-important": Object {
       "url": "https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important",
     },
     "length-zero-no-unit": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/length-zero-no-unit",
     },
     "max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/max-empty-lines",
     },
     "media-feature-colon-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-after",
     },
     "media-feature-colon-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-colon-space-before",
     },
     "media-feature-name-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-case",
     },
     "media-feature-name-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown",
     },
     "media-feature-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-parentheses-space-inside",
     },
     "media-feature-range-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-after",
     },
     "media-feature-range-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-feature-range-operator-space-before",
     },
     "media-query-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-newline-after",
     },
     "media-query-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-after",
     },
     "media-query-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/media-query-list-comma-space-before",
     },
     "no-descending-specificity": Object {
@@ -427,78 +474,99 @@ footer a:visited {
       "url": "https://stylelint.io/user-guide/rules/list/no-empty-source",
     },
     "no-eol-whitespace": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-eol-whitespace",
     },
     "no-extra-semicolons": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-extra-semicolons",
     },
     "no-invalid-double-slash-comments": Object {
       "url": "https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments",
     },
     "no-missing-end-of-source-newline": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/no-missing-end-of-source-newline",
     },
     "number-leading-zero": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-leading-zero",
     },
     "number-no-trailing-zeros": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/number-no-trailing-zeros",
     },
     "property-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/property-case",
     },
     "property-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/property-no-unknown",
     },
     "rule-empty-line-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/rule-empty-line-before",
     },
     "selector-attribute-brackets-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-brackets-space-inside",
     },
     "selector-attribute-operator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-after",
     },
     "selector-attribute-operator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-attribute-operator-space-before",
     },
     "selector-combinator-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-after",
     },
     "selector-combinator-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-combinator-space-before",
     },
     "selector-descendant-combinator-no-non-space": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-descendant-combinator-no-non-space",
     },
     "selector-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-newline-after",
     },
     "selector-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-list-comma-space-before",
     },
     "selector-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-max-empty-lines",
     },
     "selector-pseudo-class-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-case",
     },
     "selector-pseudo-class-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown",
     },
     "selector-pseudo-class-parentheses-space-inside": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-class-parentheses-space-inside",
     },
     "selector-pseudo-element-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-case",
     },
     "selector-pseudo-element-colon-notation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation",
     },
     "selector-pseudo-element-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown",
     },
     "selector-type-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/selector-type-case",
     },
     "selector-type-no-unknown": Object {
@@ -508,24 +576,30 @@ footer a:visited {
       "url": "https://stylelint.io/user-guide/rules/list/string-no-newline",
     },
     "unit-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/unit-case",
     },
     "unit-no-unknown": Object {
       "url": "https://stylelint.io/user-guide/rules/list/unit-no-unknown",
     },
     "value-keyword-case": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-keyword-case",
     },
     "value-list-comma-newline-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-newline-after",
     },
     "value-list-comma-space-after": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-after",
     },
     "value-list-comma-space-before": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-comma-space-before",
     },
     "value-list-max-empty-lines": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/value-list-max-empty-lines",
     },
   },

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -178,6 +178,7 @@ declare module 'stylelint' {
 		export type RuleMeta = {
 			url: string;
 			deprecated?: boolean;
+			fixable?: boolean;
 		};
 
 		export type Rule<P = any, S = any> = RuleBase<P, S> & {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6099

> Is there anything in the PR that needs further explanation?

This commit adds a new property `meta.fixable` to each rule.
Also, this fixes inaccurate docs about autofix.

---

I used the following script for [`jscodeshift`](https://github.com/facebook/jscodeshift) to perform the task easily.
(though I needed to fix a few files manually)

```js
/**
 * @type {import('jscodeshift').Transform}
 */
module.exports = function transform(fileInfo, api) {
	const j = api.jscodeshift;
	const root = j(fileInfo.source);

	root.findVariableDeclarators('meta').forEach((decl) => {
		if (root.find(j.Identifier, { name: 'fix' }).length > 0) {
			decl.node.init.properties.push(j.property('init', j.identifier('fixable'), j.literal(true)));
		}
	});

	return root.toSource();
};
```

```console
$ npm i -D jscodeshift @types/jscodeshift
...

$ npx jscodeshift lib/rules/*/index.js
...
```
