### PR TITLE
Refactor to remove `get-stdin` dependency

### DIFF
--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -12,7 +12,7 @@ const replaceBackslashes = require('../testUtils/replaceBackslashes');
 const fixturesPath = (...elems) => replaceBackslashes(path.join(__dirname, 'fixtures', ...elems));
 const { buildCLI } = cli;
 
-jest.mock('get-stdin');
+jest.mock('../utils/getStdin', () => () => Promise.resolve(''));
 
 describe('buildCLI', () => {
 	it('flags - default', () => {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,17 +1,18 @@
 'use strict';
 
-const checkInvalidCLIOptions = require('./utils/checkInvalidCLIOptions');
-const EOL = require('os').EOL;
-const getFormatterOptionsText = require('./utils/getFormatterOptionsText');
-const getModulePath = require('./utils/getModulePath');
-const getStdin = require('get-stdin');
+const { EOL } = require('os');
 const meow = require('meow');
 const path = require('path');
+const { red, dim } = require('picocolors');
+
+const checkInvalidCLIOptions = require('./utils/checkInvalidCLIOptions');
+const getFormatterOptionsText = require('./utils/getFormatterOptionsText');
+const getModulePath = require('./utils/getModulePath');
+const getStdin = require('./utils/getStdin');
 const printConfig = require('./printConfig');
 const resolveFrom = require('resolve-from');
 const standalone = require('./standalone');
 const writeOutputFile = require('./writeOutputFile');
-const { red, dim } = require('picocolors');
 
 const EXIT_CODE_ERROR = 2;
 

--- a/lib/utils/__tests__/getStdin.test.js
+++ b/lib/utils/__tests__/getStdin.test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { Readable } = require('stream');
+
+const getStdin = require('../getStdin');
+
+test('get stdin as string', async () => {
+	const stdin = Readable.from(Buffer.from('abc'));
+
+	expect(await getStdin(stdin)).toBe('abc');
+});

--- a/lib/utils/getStdin.js
+++ b/lib/utils/getStdin.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * @returns {Promise<string>}
  */

--- a/lib/utils/getStdin.js
+++ b/lib/utils/getStdin.js
@@ -1,0 +1,12 @@
+/**
+ * @returns {Promise<string>}
+ */
+module.exports = async function getStdin() {
+	const chunks = [];
+
+	for await (const chunk of process.stdin) {
+		chunks.push(chunk);
+	}
+
+	return Buffer.concat(chunks).toString();
+};

--- a/lib/utils/getStdin.js
+++ b/lib/utils/getStdin.js
@@ -1,12 +1,13 @@
 'use strict';
 
 /**
+ * @param {NodeJS.ReadStream} [stdin]
  * @returns {Promise<string>}
  */
-module.exports = async function getStdin() {
+module.exports = async function getStdin(stdin = process.stdin) {
 	const chunks = [];
 
-	for await (const chunk of process.stdin) {
+	for await (const chunk of stdin) {
 		chunks.push(chunk);
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "fast-glob": "^3.2.11",
         "fastest-levenshtein": "^1.0.12",
         "file-entry-cache": "^6.0.1",
-        "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -3927,17 +3926,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-stdin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -15994,11 +15982,6 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
-    },
-    "get-stdin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="
     },
     "get-stream": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "fast-glob": "^3.2.11",
     "fastest-levenshtein": "^1.0.12",
     "file-entry-cache": "^6.0.1",
-    "get-stdin": "^8.0.0",
     "global-modules": "^2.0.0",
     "globby": "^11.1.0",
     "globjoin": "^0.1.4",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The `get-stdin` package is a tiny library, so we can replace it with its utility and reduce an extra dependency.
Also, since the package is used only by `cli.js`, replacing it is easy.

See https://github.com/sindresorhus/get-stdin
