### PR TITLE
Show fixable metadata with `verbose` and `github` formatters

### DIFF
--- a/lib/formatters/__tests__/githubFormatter.test.js
+++ b/lib/formatters/__tests__/githubFormatter.test.js
@@ -34,11 +34,11 @@ test('githubFormatter', () => {
 	const returnValue = {
 		ruleMetadata: {
 			foo: { url: 'https://stylelint.io/rules/foo' },
-			bar: {},
+			bar: { fixable: true },
 		},
 	};
 
 	expect(githubFormatter(results, returnValue))
 		.toBe(`::error file=path/to/file.css,line=1,col=2,endLine=1,endColumn=5,title=Stylelint problem::Unexpected "foo" (foo) - https://stylelint.io/rules/foo
-::warning file=a.css,line=10,col=20,title=Stylelint problem::Unexpected "bar" (bar)`);
+::warning file=a.css,line=10,col=20,title=Stylelint problem::Unexpected "bar" (bar) [fixable]`);
 });

--- a/lib/formatters/__tests__/prepareFormatterOutput.js
+++ b/lib/formatters/__tests__/prepareFormatterOutput.js
@@ -9,8 +9,8 @@ symbolConversions.set('✔', '√');
 symbolConversions.set('⚠', '‼');
 symbolConversions.set('✖', '×');
 
-module.exports = function (results, formatter) {
-	const returnValue = {
+module.exports = function (results, formatter, returnValue) {
+	returnValue = returnValue || {
 		ruleMetadata: {},
 	};
 	let output = stripAnsi(formatter(results, returnValue)).trim();

--- a/lib/formatters/__tests__/verboseFormatter.test.js
+++ b/lib/formatters/__tests__/verboseFormatter.test.js
@@ -340,17 +340,15 @@ describe('verboseFormatter', () => {
 				],
 				deprecations: [],
 				invalidOptionWarnings: [],
-				_postcssResult: {
-					stylelint: {
-						ruleMetadata: {
-							'no-foo': { url: 'https://stylelint.io' },
-						},
-					},
-				},
 			},
 		];
+		const returnValue = {
+			ruleMetadata: {
+				'no-foo': { url: 'https://stylelint.io', fixable: true },
+			},
+		};
 
-		const output = prepareFormatterOutput(results, verboseFormatter);
+		const output = prepareFormatterOutput(results, verboseFormatter, returnValue);
 
 		expect(output).toBe(stripIndent`
 			file.css
@@ -362,6 +360,6 @@ describe('verboseFormatter', () => {
 			 file.css
 
 			1 error found
-			 no-foo: 1`);
+			 no-foo: 1 (fixable)`);
 	});
 });

--- a/lib/formatters/githubFormatter.js
+++ b/lib/formatters/githubFormatter.js
@@ -30,7 +30,8 @@ module.exports = function githubFormatter(results, returnValue) {
 function buildMessage(msg, metadata) {
 	if (!metadata) return msg;
 
-	if (!metadata.url) return msg;
+	const url = metadata.url ? ` - ${metadata.url}` : '';
+	const fixable = metadata.fixable ? ' [fixable]' : '';
 
-	return `${msg} - ${metadata.url}`;
+	return `${msg}${fixable}${url}`;
 }

--- a/lib/formatters/verboseFormatter.js
+++ b/lib/formatters/verboseFormatter.js
@@ -71,7 +71,10 @@ module.exports = function verboseFormatter(results, returnValue) {
 			const metadata = returnValue.ruleMetadata;
 
 			for (const [rule, list] of Object.entries(problemsByRule)) {
-				output += dim(` ${ruleLink(rule, metadata[rule])}: ${list.length}\n`);
+				const meta = metadata[rule];
+				const fixable = meta && meta.fixable ? ' (fixable)' : '';
+
+				output += dim(` ${ruleLink(rule, meta)}: ${list.length}${fixable}\n`);
 			}
 		};
 

--- a/scripts/visual-config.json
+++ b/scripts/visual-config.json
@@ -9,6 +9,7 @@
 				"message": "Expected custom property name to be kebab-case",
 				"severity": "warning"
 			}
-		]
+		],
+		"import-notation": "string"
 	}
 }

--- a/scripts/visual.css
+++ b/scripts/visual.css
@@ -1,3 +1,5 @@
+@import url("foo.css");
+
 .foo {
   color:#4f;
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #6099

> Is there anything in the PR that needs further explanation?

In this pull request, I try showing *fixable* metadata with the `verbose` and `github` formatters.
But I’m not sure whether this addition is really useful. I would be happy if any feedback.

Demo on localhost:

```console
$ (cd scripts ; ./visual.sh)
...

4 errors found
 color-no-invalid-hex: 1
 import-notation: 1 (fixable)
 selector-max-class: 1
 unit-disallowed-list: 1

1 warning found
 custom-property-pattern: 1
```

<img width="371" alt="image" src="https://user-images.githubusercontent.com/473530/176211068-c573b8f0-c2b2-4e4d-bd80-019ee6bf3661.png">
