### PR TITLE
Fix false positives for SCSS interpolation in `no-unknown-animations`

### DIFF
--- a/lib/rules/no-unknown-animations/__tests__/index.js
+++ b/lib/rules/no-unknown-animations/__tests__/index.js
@@ -232,3 +232,16 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: [true],
+	customSyntax: 'postcss-scss',
+
+	accept: [
+		{
+			code: '@keyframes foo {} a { animation: foo 2s linear #{0.2 * $i}s both; }',
+			description: 'animation shorthand with SCSS interpolation',
+		},
+	],
+});

--- a/lib/utils/__tests__/findAnimationName.test.js
+++ b/lib/utils/__tests__/findAnimationName.test.js
@@ -100,4 +100,5 @@ it('findAnimationName', () => {
 			value: 'drive',
 		},
 	]);
+	expect(findAnimationName('foo 2s linear #{0.2 * $i}s both')).toEqual([]);
 });

--- a/lib/utils/findAnimationName.js
+++ b/lib/utils/findAnimationName.js
@@ -27,9 +27,11 @@ module.exports = function findAnimationName(value) {
 		return [nodes[0]];
 	}
 
-	let hasNonStandardSyntaxValue = false;
+	let shouldBeIgnored = false;
 
 	valueNodes.walk((valueNode) => {
+		if (shouldBeIgnored) return;
+
 		if (valueNode.type === 'function') {
 			return false;
 		}
@@ -42,7 +44,9 @@ module.exports = function findAnimationName(value) {
 
 		// Ignore non-standard syntax
 		if (!isStandardSyntaxValue(valueLowerCase)) {
-			hasNonStandardSyntaxValue = true;
+			// Cannot find animation name if shorthand has non-standard syntax value (#5532)
+			shouldBeIgnored = true;
+			animationNames.length = 0; // clears animationNames
 
 			return;
 		}
@@ -67,6 +71,5 @@ module.exports = function findAnimationName(value) {
 		animationNames.push(valueNode);
 	});
 
-	// Cannot find animation name if shorthand has non-standard syntax value (#5532)
-	return hasNonStandardSyntaxValue ? [] : animationNames;
+	return animationNames;
 };

--- a/lib/utils/findAnimationName.js
+++ b/lib/utils/findAnimationName.js
@@ -27,6 +27,8 @@ module.exports = function findAnimationName(value) {
 		return [nodes[0]];
 	}
 
+	let hasNonStandardSyntaxValue = false;
+
 	valueNodes.walk((valueNode) => {
 		if (valueNode.type === 'function') {
 			return false;
@@ -40,6 +42,8 @@ module.exports = function findAnimationName(value) {
 
 		// Ignore non-standard syntax
 		if (!isStandardSyntaxValue(valueLowerCase)) {
+			hasNonStandardSyntaxValue = true;
+
 			return;
 		}
 
@@ -63,5 +67,6 @@ module.exports = function findAnimationName(value) {
 		animationNames.push(valueNode);
 	});
 
-	return animationNames;
+	// Cannot find animation name if shorthand has non-standard syntax value (#5532)
+	return hasNonStandardSyntaxValue ? [] : animationNames;
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5532.

> Is there anything in the PR that needs further explanation?

This "early return" feels unnatural - I'm not even actually returning early, since I'm not breaking out of the AST walk. Any suggestions on how to make this cleaner?
