### PR TITLE
Fix false negatives for multiple match in `declaration-property-value-disallowed-list`

### DIFF
--- a/lib/rules/declaration-property-value-disallowed-list/__tests__/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/__tests__/index.js
@@ -194,3 +194,25 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: {
+		'/.*/': ['rebeccapurple'],
+		'background-color': ['none'],
+	},
+
+	reject: [
+		{
+			code: 'a { color: rebeccapurple; background-color: none; }',
+			warnings: [
+				{
+					message: messages.rejected('color', 'rebeccapurple'),
+				},
+				{
+					message: messages.rejected('background-color', 'none'),
+				},
+			],
+		},
+	],
+});

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -32,20 +32,19 @@ const rule = (primary) => {
 			return;
 		}
 
+		const propKeys = Object.keys(primary);
+
 		root.walkDecls((decl) => {
-			const prop = decl.prop;
-			const value = decl.value;
+			const { prop, value } = decl;
 
 			const unprefixedProp = vendor.unprefixed(prop);
-			const propKey = Object.keys(primary).find((propIdentifier) =>
-				matchesStringOrRegExp(unprefixedProp, propIdentifier),
-			);
+			const propPatterns = propKeys.filter((key) => matchesStringOrRegExp(unprefixedProp, key));
 
-			if (!propKey) {
+			if (propPatterns.length === 0) {
 				return;
 			}
 
-			if (!optionsMatches(primary, propKey, value)) {
+			if (propPatterns.every((pattern) => !optionsMatches(primary, pattern, value))) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Partially fixing #6187

> Is there anything in the PR that needs further explanation?

This change uses `.filter()` instead of `.find()` for `Object.keys(primary)`.
