### PR TITLE
Add `percentage-unless-within-keyword-only-block` primary option to `keyframe-selector-notation`

### DIFF
--- a/lib/rules/keyframe-selector-notation/README.md
+++ b/lib/rules/keyframe-selector-notation/README.md
@@ -15,7 +15,7 @@ The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatica
 
 ## Options
 
-`string`: `"keyword"|"percentage"`
+`string`: `"keyword"|"percentage"|"percentage-unless-within-keyword-only-block"`
 
 ### `"keyword"`
 
@@ -51,4 +51,27 @@ The following pattern is _not_ considered a problem:
 <!-- prettier-ignore -->
 ```css
 @keyframes foo { 0% {} 100% {} }
+```
+
+### `"percentage-unless-within-keyword-only-block"`
+
+Keyframe selectors _must_ use the percentage notation unless within a keyword-only block.
+
+The following pattern is considered a problem:
+
+<!-- prettier-ignore -->
+```css
+@keyframes foo { from {} 100% {} }
+```
+
+The following pattern are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+@keyframes foo { 0% {} 100% {} }
+```
+
+<!-- prettier-ignore -->
+```css
+@keyframes foo { from {} to {} }
 ```

--- a/lib/rules/keyframe-selector-notation/__tests__/index.js
+++ b/lib/rules/keyframe-selector-notation/__tests__/index.js
@@ -279,3 +279,62 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: ['percentage-unless-within-keyword-only-block'],
+	fix: true,
+
+	accept: [
+		{
+			code: '@keyframes foo { 0% {} 100% {} }',
+		},
+		{
+			code: '@keyframes foo { 0% {} 20%,80% {} 100% {} }',
+		},
+		{
+			code: '@keyframes foo { 0%,100% {} }',
+		},
+		{
+			code: '@keyframes foo { from {} to {} }',
+		},
+		{
+			code: '@keyframes foo { from,to {} }',
+		},
+	],
+
+	reject: [
+		{
+			code: '@keyframes foo { from {} 100% {} }',
+			fixed: '@keyframes foo { 0% {} 100% {} }',
+			message: messages.expected('from', '0%'),
+		},
+		{
+			code: '@keyframes foo { 0% {} to {} }',
+			fixed: '@keyframes foo { 0% {} 100% {} }',
+			message: messages.expected('to', '100%'),
+		},
+		{
+			code: '@keyframes foo { from {} 20%,80% {} to {} }',
+			fixed: '@keyframes foo { 0% {} 20%,80% {} 100% {} }',
+			warnings: [
+				{
+					message: messages.expected('from', '0%'),
+				},
+				{
+					message: messages.expected('to', '100%'),
+				},
+			],
+		},
+		{
+			code: '@keyframes foo { from,100% {} }',
+			fixed: '@keyframes foo { 0%,100% {} }',
+			message: messages.expected('from', '0%'),
+		},
+		{
+			code: '@keyframes foo { 0%,to {} }',
+			fixed: '@keyframes foo { 0%,100% {} }',
+			message: messages.expected('to', '100%'),
+		},
+	],
+});

--- a/lib/rules/keyframe-selector-notation/index.js
+++ b/lib/rules/keyframe-selector-notation/index.js
@@ -2,8 +2,8 @@
 
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
-const validateOptions = require('../../utils/validateOptions');
 const transformSelector = require('../../utils/transformSelector');
+const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'keyframe-selector-notation';
 
@@ -19,21 +19,23 @@ const meta = {
 const PERCENTAGE_SELECTORS = new Set(['0%', '100%']);
 const KEYWORD_SELECTORS = new Set(['from', 'to']);
 
-/** @type {import('stylelint').Rule<'keyword' | 'percentage'>} */
+/** @type {import('stylelint').Rule<'keyword' | 'percentage' | 'percentage-unless-within-keyword-only-block'>} */
 const rule = (primary, _, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
-			possible: ['keyword', 'percentage'],
+			possible: ['keyword', 'percentage', 'percentage-unless-within-keyword-only-block'],
 		});
 
 		if (!validOptions) return;
 
 		/**
-		 * @type {Record<primary, {
-		 *   expFunc: (selector: string) => boolean,
+		 * @typedef {{
+		 *   expFunc: (selector: string, selectorsInBlock: string[]) => boolean,
 		 *   fixFunc: (selector: string) => string,
-		 * }>}
+		 * }} OptionFuncs
+		 *
+		 * @type {Record<primary, OptionFuncs>}
 		 */
 		const optionFuncs = Object.freeze({
 			keyword: {
@@ -48,14 +50,30 @@ const rule = (primary, _, context) => {
 					return selector === 'from' ? '0%' : '100%';
 				},
 			},
+			'percentage-unless-within-keyword-only-block': {
+				expFunc: (selector, selectorsInBlock) => {
+					if (selectorsInBlock.every((s) => KEYWORD_SELECTORS.has(s))) return true;
+
+					return PERCENTAGE_SELECTORS.has(selector);
+				},
+				fixFunc: (selector) => {
+					return selector === 'from' ? '0%' : '100%';
+				},
+			},
 		});
 
 		root.walkAtRules(/^(-(moz|webkit)-)?keyframes$/i, (atRuleKeyframes) => {
+			const selectorsInBlock =
+				primary === 'percentage-unless-within-keyword-only-block'
+					? getSelectorsInBlock(atRuleKeyframes)
+					: [];
+
 			atRuleKeyframes.walkRules((keyframeRule) => {
 				transformSelector(result, keyframeRule, (selectors) => {
 					selectors.walkTags((selectorTag) => {
 						checkSelector(
 							selectorTag.value,
+							optionFuncs[primary],
 							(fixedSelector) => (selectorTag.value = fixedSelector),
 						);
 					});
@@ -63,9 +81,10 @@ const rule = (primary, _, context) => {
 
 				/**
 				 * @param {string} selector
-				 * @param {(fixedSelector: string) => string} fixer
+				 * @param {OptionFuncs} funcs
+				 * @param {(fixedSelector: string) => void} fixer
 				 */
-				function checkSelector(selector, fixer) {
+				function checkSelector(selector, { expFunc, fixFunc }, fixer) {
 					const normalizedSelector = selector.toLowerCase();
 
 					if (
@@ -75,9 +94,9 @@ const rule = (primary, _, context) => {
 						return;
 					}
 
-					if (optionFuncs[primary].expFunc(selector)) return;
+					if (expFunc(selector, selectorsInBlock)) return;
 
-					const fixedSelector = optionFuncs[primary].fixFunc(selector);
+					const fixedSelector = fixFunc(selector);
 
 					if (context.fix) {
 						fixer(fixedSelector);
@@ -97,6 +116,21 @@ const rule = (primary, _, context) => {
 		});
 	};
 };
+
+/**
+ * @param {import('postcss').AtRule} atRule
+ * @returns {string[]}
+ */
+function getSelectorsInBlock(atRule) {
+	/** @type {string[]} */
+	const selectors = [];
+
+	atRule.walkRules((r) => {
+		selectors.push(...r.selectors);
+	});
+
+	return selectors;
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/keyframe-selector-notation/index.js
+++ b/lib/rules/keyframe-selector-notation/index.js
@@ -4,6 +4,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const transformSelector = require('../../utils/transformSelector');
 const validateOptions = require('../../utils/validateOptions');
+const { assertString } = require('../../utils/validateTypes');
 
 const ruleName = 'keyframe-selector-notation';
 
@@ -18,6 +19,14 @@ const meta = {
 
 const PERCENTAGE_SELECTORS = new Set(['0%', '100%']);
 const KEYWORD_SELECTORS = new Set(['from', 'to']);
+const PERCENTAGE_TO_KEYWORD = new Map([
+	['0%', 'from'],
+	['100%', 'to'],
+]);
+const KEYWORD_TO_PERCENTAGE = new Map([
+	['from', '0%'],
+	['to', '100%'],
+]);
 
 /** @type {import('stylelint').Rule<'keyword' | 'percentage' | 'percentage-unless-within-keyword-only-block'>} */
 const rule = (primary, _, context) => {
@@ -40,15 +49,11 @@ const rule = (primary, _, context) => {
 		const optionFuncs = Object.freeze({
 			keyword: {
 				expFunc: (selector) => KEYWORD_SELECTORS.has(selector),
-				fixFunc: (selector) => {
-					return selector === '0%' ? 'from' : 'to';
-				},
+				fixFunc: (selector) => getFromMap(PERCENTAGE_TO_KEYWORD, selector),
 			},
 			percentage: {
 				expFunc: (selector) => PERCENTAGE_SELECTORS.has(selector),
-				fixFunc: (selector) => {
-					return selector === 'from' ? '0%' : '100%';
-				},
+				fixFunc: (selector) => getFromMap(KEYWORD_TO_PERCENTAGE, selector),
 			},
 			'percentage-unless-within-keyword-only-block': {
 				expFunc: (selector, selectorsInBlock) => {
@@ -56,9 +61,7 @@ const rule = (primary, _, context) => {
 
 					return PERCENTAGE_SELECTORS.has(selector);
 				},
-				fixFunc: (selector) => {
-					return selector === 'from' ? '0%' : '100%';
-				},
+				fixFunc: (selector) => getFromMap(KEYWORD_TO_PERCENTAGE, selector),
 			},
 		});
 
@@ -116,6 +119,19 @@ const rule = (primary, _, context) => {
 		});
 	};
 };
+
+/**
+ * @param {Map<string, string>} map
+ * @param {string} key
+ * @returns {string}
+ */
+function getFromMap(map, key) {
+	const value = map.get(key);
+
+	assertString(value);
+
+	return value;
+}
 
 /**
  * @param {import('postcss').AtRule} atRule


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6191

> Is there anything in the PR that needs further explanation?

It's necessary to call `.walkRules()` twice to get all selectors in a `@keyframes` block. In most cases, I don't believe there will not pay a performance penalty.