### PR TITLE
Fix `selector-class-pattern` end positions

### DIFF
--- a/lib/rules/selector-class-pattern/__tests__/index.js
+++ b/lib/rules/selector-class-pattern/__tests__/index.js
@@ -54,15 +54,19 @@ testRule({
 	reject: [
 		{
 			code: 'a .foo {}',
-			message: messages.expected('foo', /^[A-Z]+$/),
+			message: messages.expected('.foo', /^[A-Z]+$/),
 			line: 1,
 			column: 3,
+			endLine: 1,
+			endColumn: 7,
 		},
 		{
 			code: '.ABABA > .bar {}',
-			message: messages.expected('bar', /^[A-Z]+$/),
+			message: messages.expected('.bar', /^[A-Z]+$/),
 			line: 1,
 			column: 10,
+			endLine: 1,
+			endColumn: 14,
 		},
 	],
 });
@@ -76,15 +80,19 @@ testRule({
 	reject: [
 		{
 			code: 'a .foo {}',
-			message: messages.expected('foo', '^[A-Z]+$'),
+			message: messages.expected('.foo', '^[A-Z]+$'),
 			line: 1,
 			column: 3,
+			endLine: 1,
+			endColumn: 7,
 		},
 		{
 			code: '.ABABA > .bar {}',
-			message: messages.expected('bar', '^[A-Z]+$'),
+			message: messages.expected('.bar', '^[A-Z]+$'),
 			line: 1,
 			column: 10,
+			endLine: 1,
+			endColumn: 14,
 		},
 	],
 });
@@ -141,9 +149,11 @@ testRule({
 	reject: [
 		{
 			code: '.A { &__B { }}',
-			message: messages.expected('A__B', /^[A-Z]+$/),
+			message: messages.expected('.A__B', /^[A-Z]+$/),
 			line: 1,
 			column: 6,
+			endLine: 1,
+			endColumn: 11,
 		},
 	],
 });
@@ -157,9 +167,11 @@ testRule({
 	reject: [
 		{
 			code: '.A { &__B { }}',
-			message: messages.expected('A__B', '^[A-Z]+$'),
+			message: messages.expected('.A__B', '^[A-Z]+$'),
 			line: 1,
 			column: 6,
+			endLine: 1,
+			endColumn: 11,
 		},
 	],
 });
@@ -171,15 +183,15 @@ testRule({
 	reject: [
 		{
 			code: '.A { .B {} }',
-			message: messages.expected('A', /^B+$/),
+			message: messages.expected('.A', /^B+$/),
 		},
 		{
 			code: '.A { & .B {} }',
-			message: messages.expected('A', /^B+$/),
+			message: messages.expected('.A', /^B+$/),
 		},
 		{
 			code: '.A { &>.B {} }',
-			message: messages.expected('A', /^B+$/),
+			message: messages.expected('.A', /^B+$/),
 		},
 	],
 });

--- a/lib/rules/selector-class-pattern/index.js
+++ b/lib/rules/selector-class-pattern/index.js
@@ -13,15 +13,15 @@ const { isBoolean, isRegExp, isString } = require('../../utils/validateTypes');
 const ruleName = 'selector-class-pattern';
 
 const messages = ruleMessages(ruleName, {
-	expected: (selectorValue, pattern) =>
-		`Expected class selector ".${selectorValue}" to match pattern "${pattern}"`,
+	expected: (selector, pattern) =>
+		`Expected class selector "${selector}" to match pattern "${pattern}"`,
 });
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-class-pattern',
 };
 
-/** @type {import('stylelint').Rule} */
+/** @type {import('stylelint').Rule<string | RegExp, { resolveNestedSelector: boolean }>} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -44,15 +44,14 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		/** @type {boolean} */
-		const shouldResolveNestedSelectors =
-			secondaryOptions && secondaryOptions.resolveNestedSelectors;
-		/** @type {RegExp} */
+		const shouldResolveNestedSelectors = Boolean(
+			secondaryOptions && secondaryOptions.resolveNestedSelectors,
+		);
+
 		const normalizedPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkRules((ruleNode) => {
-			const selector = ruleNode.selector;
-			const selectors = ruleNode.selectors;
+			const { selector, selectors } = ruleNode;
 
 			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
@@ -77,24 +76,34 @@ const rule = (primary, secondaryOptions) => {
 		});
 
 		/**
-		 * @param {import('postcss-selector-parser').Root} fullSelector
+		 * @param {import('postcss-selector-parser').Root} selectorNode
 		 * @param {import('postcss').Rule} ruleNode
 		 */
-		function checkSelector(fullSelector, ruleNode) {
-			fullSelector.walkClasses((classNode) => {
-				const value = classNode.value;
-				const sourceIndex = classNode.sourceIndex;
+		function checkSelector(selectorNode, ruleNode) {
+			selectorNode.walkClasses((classNode) => {
+				const { value, sourceIndex: index } = classNode;
 
 				if (normalizedPattern.test(value)) {
 					return;
 				}
 
+				const selector = String(classNode);
+
+				// TODO: `selector` may be resolved. So, getting its raw value may be pretty hard.
+				//       It means `endIndex` may be inaccurate (though non-standard selectors).
+				//
+				//       For example, given ".abc { &_x {} }".
+				//       Then, an expected raw `selector` is "&_x",
+				//       but, an actual `selector` is ".abc_x".
+				const endIndex = index + selector.length;
+
 				report({
 					result,
 					ruleName,
-					message: messages.expected(value, primary),
+					message: messages.expected(selector, primary),
 					node: ruleNode,
-					index: sourceIndex,
+					index,
+					endIndex,
 				});
 			});
 		}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5694

> Is there anything in the PR that needs further explanation?

This changes the implementation of `messages.expect` a bit:

```diff
- messages.expected('foo', /^[A-Z]+$/)
- Expected class selector ".${selector}" to match pattern "${pattern}"

+ messages.expected('.foo', /^[A-Z]+$/)
+ Expected class selector "${selector}" to match pattern "${pattern}"
```

Because I think it's clear to pass a full selector explicitly. The output message remains the same in both cases.


