### PR TITLE
Fix `selector-id-pattern` end positions

### DIFF
--- a/lib/rules/selector-id-pattern/__tests__/index.js
+++ b/lib/rules/selector-id-pattern/__tests__/index.js
@@ -50,15 +50,19 @@ testRule({
 	reject: [
 		{
 			code: 'a #foo {}',
-			message: messages.expected('foo', /^[A-Z]+$/),
+			message: messages.expected('#foo', /^[A-Z]+$/),
 			line: 1,
 			column: 3,
+			endLine: 1,
+			endColumn: 7,
 		},
 		{
 			code: '#ABABA > #bar {}',
-			message: messages.expected('bar', /^[A-Z]+$/),
+			message: messages.expected('#bar', /^[A-Z]+$/),
 			line: 1,
 			column: 10,
+			endLine: 1,
+			endColumn: 14,
 		},
 	],
 });
@@ -72,13 +76,13 @@ testRule({
 	reject: [
 		{
 			code: 'a #foo {}',
-			message: messages.expected('foo', '^[A-Z]+$'),
+			message: messages.expected('#foo', '^[A-Z]+$'),
 			line: 1,
 			column: 3,
 		},
 		{
 			code: '#ABABA > #bar {}',
-			message: messages.expected('bar', '^[A-Z]+$'),
+			message: messages.expected('#bar', '^[A-Z]+$'),
 			line: 1,
 			column: 10,
 		},
@@ -111,7 +115,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { #bar {} }',
-			message: messages.expected('bar', /^[A-Z]+$/),
+			message: messages.expected('#bar', /^[A-Z]+$/),
 			line: 1,
 			column: 5,
 		},

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -10,15 +10,15 @@ const { isRegExp, isString } = require('../../utils/validateTypes');
 const ruleName = 'selector-id-pattern';
 
 const messages = ruleMessages(ruleName, {
-	expected: (selectorValue, pattern) =>
-		`Expected ID selector "#${selectorValue}" to match pattern "${pattern}"`,
+	expected: (selector, pattern) =>
+		`Expected ID selector "${selector}" to match pattern "${pattern}"`,
 });
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-id-pattern',
 };
 
-/** @type {import('stylelint').Rule} */
+/** @type {import('stylelint').Rule<string | RegExp>} */
 const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
@@ -30,7 +30,6 @@ const rule = (primary) => {
 			return;
 		}
 
-		/** @type {RegExp} */
 		const normalizedPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkRules((ruleNode) => {
@@ -38,27 +37,20 @@ const rule = (primary) => {
 				return;
 			}
 
-			const selector = ruleNode.selector;
-
-			parseSelector(selector, result, ruleNode, (fullSelector) => {
-				fullSelector.walk((selectorNode) => {
-					if (selectorNode.type !== 'id') {
+			parseSelector(ruleNode.selector, result, ruleNode, (fullSelector) => {
+				fullSelector.walkIds((selectorNode) => {
+					if (normalizedPattern.test(selectorNode.value)) {
 						return;
 					}
 
-					const value = selectorNode.value;
-					const sourceIndex = selectorNode.sourceIndex;
-
-					if (normalizedPattern.test(value)) {
-						return;
-					}
+					const selector = String(selectorNode);
 
 					report({
 						result,
 						ruleName,
-						message: messages.expected(value, primary),
+						message: messages.expected(selector, primary),
 						node: ruleNode,
-						index: sourceIndex,
+						word: selector,
 					});
 				});
 			});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5694

> Is there anything in the PR that needs further explanation?

This change also performs a refactoring to pass a full selector to the `messages.expected()` function, instead of just a selector value. This refactoring is to make the function's caller code clearer:

```diff
- messages.expected('foo', /^[A-Z]+$/)
+ messages.expected('#foo', /^[A-Z]+$/)
```
