### PR TITLE
Restore `Node#rangeBy` method if not present

### DIFF
--- a/lib/utils/__tests__/report.test.js
+++ b/lib/utils/__tests__/report.test.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const report = require('../report');
+const postcss = require('postcss');
 
-it('without disabledRanges', () => {
+test('without disabledRanges', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -21,7 +22,7 @@ it('without disabledRanges', () => {
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
-it('with irrelevant general disabledRange', () => {
+test('with irrelevant general disabledRange', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -45,7 +46,7 @@ it('with irrelevant general disabledRange', () => {
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
-it('with relevant general disabledRange', () => {
+test('with relevant general disabledRange', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -66,7 +67,7 @@ it('with relevant general disabledRange', () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
-it('with irrelevant rule-specific disabledRange', () => {
+test('with irrelevant rule-specific disabledRange', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -91,7 +92,7 @@ it('with irrelevant rule-specific disabledRange', () => {
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
-it('with relevant rule-specific disabledRange', () => {
+test('with relevant rule-specific disabledRange', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -113,7 +114,7 @@ it('with relevant rule-specific disabledRange', () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
-it('with relevant general disabledRange, among others', () => {
+test('with relevant general disabledRange, among others', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -137,7 +138,7 @@ it('with relevant general disabledRange, among others', () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
-it('with relevant rule-specific disabledRange, among others', () => {
+test('with relevant rule-specific disabledRange, among others', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -162,7 +163,7 @@ it('with relevant rule-specific disabledRange, among others', () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
-it('with relevant rule-specific disabledRange with range report', () => {
+test('with relevant rule-specific disabledRange with range report', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -184,7 +185,7 @@ it('with relevant rule-specific disabledRange with range report', () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
-it("with quiet mode on and rule severity of 'warning'", () => {
+test("with quiet mode on and rule severity of 'warning'", () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -206,7 +207,7 @@ it("with quiet mode on and rule severity of 'warning'", () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
-it("with quiet mode on and rule severity of 'error'", () => {
+test("with quiet mode on and rule severity of 'error'", () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -222,6 +223,24 @@ it("with quiet mode on and rule severity of 'error'", () => {
 		node: {
 			rangeBy: () => ({ start: { line: 6, column: 1 }, end: { line: 6, column: 2 } }),
 		},
+	};
+
+	report(v);
+	expect(v.result.warn).toHaveBeenCalledTimes(1);
+});
+
+test('restoration of the `rangeBy` method if not present', () => {
+	const node = postcss.parse('a {}').first;
+
+	node.rangeBy = undefined;
+
+	const v = {
+		ruleName: 'foo',
+		result: {
+			warn: jest.fn(),
+		},
+		message: 'bar',
+		node,
 	};
 
 	report(v);

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -110,6 +110,8 @@ module.exports = function report(problem) {
 	result.warn(warningMessage, warningProperties);
 };
 
+let warningShown = false;
+
 /**
  * @param {import('postcss').Node | undefined} node
  * @param {number | undefined} index
@@ -124,9 +126,13 @@ function getStartLine(node, index, endIndex) {
 	//       that doesn't have the method.
 	//       See https://github.com/stylelint/stylelint/issues/5766
 	if (typeof node.rangeBy !== 'function') {
-		console.warn(
-			'It appears different PostCSS versions are used in your dependency tree. Please consider updating PostCSS to use one version.',
-		);
+		if (!warningShown) {
+			console.warn(
+				'It appears different PostCSS versions are used in your dependency tree. Please consider updating PostCSS to use one version. See https://github.com/stylelint/stylelint/issues/5766 for details.',
+			);
+			warningShown = true;
+		}
+
 		node.rangeBy = postcss.Node.prototype.rangeBy.bind(node);
 	}
 

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -123,7 +123,10 @@ function getStartLine(node, index, endIndex) {
 	//       while the `node` may be produced by PostCSS 8.3.x or lower
 	//       that doesn't have the method.
 	//       See https://github.com/stylelint/stylelint/issues/5766
-	if (node.rangeBy === undefined) {
+	if (typeof node.rangeBy !== 'function') {
+		console.warn(
+			'It appears different PostCSS versions are used in your dependency tree. Please consider updating PostCSS to use one version.',
+		);
 		node.rangeBy = postcss.Node.prototype.rangeBy.bind(node);
 	}
 

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const postcss = require('postcss');
+
 /**
  * Report a problem.
  *
@@ -28,11 +30,9 @@ module.exports = function report(problem) {
 		return;
 	}
 
-	const { start } = (node && node.rangeBy({ index, endIndex })) || {};
-
 	// If a line is not passed, use the node.rangeBy method to get the
 	// line number that the complaint pertains to
-	const startLine = line || (start && start.line);
+	const startLine = line || getStartLine(node, index, endIndex);
 
 	if (!startLine) {
 		throw new Error('You must pass either a node or a line number');
@@ -109,3 +109,23 @@ module.exports = function report(problem) {
 
 	result.warn(warningMessage, warningProperties);
 };
+
+/**
+ * @param {import('postcss').Node | undefined} node
+ * @param {number | undefined} index
+ * @param {number | undefined} endIndex
+ * @returns {number | undefined}
+ */
+function getStartLine(node, index, endIndex) {
+	if (node === undefined) return undefined;
+
+	// HACK: The `rangeBy` method has been added since PostCSS 8.4.0,
+	//       while the `node` may be produced by PostCSS 8.3.x or lower
+	//       that doesn't have the method.
+	//       See https://github.com/stylelint/stylelint/issues/5766
+	if (node.rangeBy === undefined) {
+		node.rangeBy = postcss.Node.prototype.rangeBy.bind(node);
+	}
+
+	return node.rangeBy({ index, endIndex }).start.line;
+}

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -117,7 +117,7 @@ module.exports = function report(problem) {
  * @returns {number | undefined}
  */
 function getStartLine(node, index, endIndex) {
-	if (node === undefined) return undefined;
+	if (!node) return;
 
 	// HACK: The `rangeBy` method has been added since PostCSS 8.4.0,
 	//       while the `node` may be produced by PostCSS 8.3.x or lower

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -133,7 +133,7 @@ function getStartLine(node, index, endIndex) {
 			warningShown = true;
 		}
 
-		node.rangeBy = postcss.Node.prototype.rangeBy.bind(node);
+		node.rangeBy = postcss.Node.prototype.rangeBy;
 	}
 
 	return node.rangeBy({ index, endIndex }).start.line;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5766

> Is there anything in the PR that needs further explanation?

This PR adds a hack to a situation where there are different PostCSS versions in a dependency tree like a reproduction described on <https://github.com/stylelint/stylelint/issues/5766#issuecomment-1200483928>.

[PostCSS 8.4.0](https://github.com/postcss/postcss/releases/tag/8.4.0) has added the [`Node#rangeBy`](https://postcss.org/api/#node-rangeby) method, while PostCSS 8.3.x or lower doesn't have the method. In the situation above, a parser like `postcss-less` may create a `Node` by an old PostCSS version like 8.3.6. Because the parser's peer dependency version on PostCSS may not match the PostCSS version that Stylelint requires.

* [`postcss-less@6.0.0` requires `postcss@^8.3.5`](https://github.com/shellscape/postcss-less/blob/v6.0.0/package.json#L49-L51) as a peer dependency
* [`stylelint@14.9.1` requires `postcss@^8.4.14`](https://github.com/stylelint/stylelint/blob/14.9.1/package.json#L136) as a normal dependency

Note: If anyone is concerned about adding such a hack, please let me know.