### PR TITLE
docs: add an 's' because there are several patterns

### DIFF
--- a/lib/rules/keyframe-selector-notation/README.md
+++ b/lib/rules/keyframe-selector-notation/README.md
@@ -64,7 +64,7 @@ The following pattern is considered a problem:
 @keyframes foo { from {} 100% {} }
 ```
 
-The following pattern are _not_ considered problems:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Last two block code of [`keyframe-selector-notation`](https://stylelint.io/user-guide/rules/list/keyframe-selector-notation/#percentage-unless-within-keyword-only-block) are red, but there isn't error. I think it's because the _pattern_ is missing an _s_ (and it doesn't respect the pattern to put in green).