### PR TITLE
Fix `plugins.md` document and `createPlugin` type definition

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -26,33 +26,32 @@ const meta = {
   // deprecated: true,
 };
 
-module.exports = stylelint.createPlugin(
-  ruleName,
-  (primaryOption, secondaryOptionObject) => {
-    return (postcssRoot, postcssResult) => {
-      const validOptions = stylelint.utils.validateOptions(
-        postcssResult,
-        ruleName,
-        {
-          /* .. */
-        }
-      );
-
-      if (!validOptions) {
-        return;
-      }
-
-      // ... some logic ...
-      stylelint.utils.report({
+const ruleFunction = (primaryOption, secondaryOptionObject) => {
+  return (postcssRoot, postcssResult) => {
+    const validOptions = stylelint.utils.validateOptions(
+      postcssResult,
+      ruleName,
+      {
         /* .. */
-      });
-    };
-  }
-);
+      }
+    );
 
-module.exports.ruleName = ruleName;
-module.exports.messages = messages;
-module.exports.meta = meta;
+    if (!validOptions) {
+      return;
+    }
+
+    // ... some logic ...
+    stylelint.utils.report({
+      /* .. */
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);
 ```
 
 Your plugin's rule name must be namespaced, e.g. `your-namespace/your-rule-name`, to ensure it never clashes with the built-in rules. If your plugin provides only a single rule or you can't think of a good namespace, you can use `plugin/my-rule`. _You should document your plugin's rule name (and namespace) because users need to use them in their config._
@@ -89,39 +88,38 @@ const meta = {
   /* .. */
 };
 
-module.exports = stylelint.createPlugin(
-  ruleName,
-  (primaryOption, secondaryOptionObject) => {
-    return (postcssRoot, postcssResult) => {
-      const validOptions = stylelint.utils.validateOptions(
-        postcssResult,
-        ruleName,
-        {
-          /* .. */
-        }
-      );
-
-      if (!validOptions) {
-        return;
+const ruleFunction = (primaryOption, secondaryOptionObject) => {
+  return (postcssRoot, postcssResult) => {
+    const validOptions = stylelint.utils.validateOptions(
+      postcssResult,
+      ruleName,
+      {
+        /* .. */
       }
+    );
 
-      return new Promise((resolve) => {
-        // some async operation
-        setTimeout(() => {
-          // ... some logic ...
-          stylelint.utils.report({
-            /* .. */
-          });
-          resolve();
-        }, 1);
-      });
-    };
-  }
-);
+    if (!validOptions) {
+      return;
+    }
 
-module.exports.ruleName = ruleName;
-module.exports.messages = messages;
-module.exports.meta = meta;
+    return new Promise((resolve) => {
+      // some async operation
+      setTimeout(() => {
+        // ... some logic ...
+        stylelint.utils.report({
+          /* .. */
+        });
+        resolve();
+      }, 1);
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);
 ```
 
 ## Testing
@@ -132,7 +130,9 @@ For example:
 
 ```js
 // index.test.js
-const { messages, ruleName } = require(".");
+const {
+  rule: { ruleName, messages }
+} = require(".");
 
 testRule({
   plugins: ["./index.js"],
@@ -153,7 +153,7 @@ testRule({
     {
       code: ".myClass {}",
       fixed: ".my-class {}",
-      message: messages.expected(),
+      message: messages.expected,
       line: 1,
       column: 1,
       endLine: 1,

--- a/lib/__tests__/fixtures/plugin-warn-about-foo.js
+++ b/lib/__tests__/fixtures/plugin-warn-about-foo.js
@@ -4,11 +4,15 @@ const stylelint = require('../..');
 
 const ruleName = 'plugin/warn-about-foo';
 
-const warnAboutFooMessages = stylelint.utils.ruleMessages('plugin/warn-about-foo', {
+const warnAboutFooMessages = stylelint.utils.ruleMessages(ruleName, {
 	found: 'found .foo',
 });
 
-module.exports = stylelint.createPlugin(ruleName, (expectation) => {
+const meta = {
+	url: 'https://github.com/stylelint/stylelint-foo-plugin/warn-about-foo',
+};
+
+const warnAboutFoo = (expectation) => {
 	return (root, result) => {
 		root.walkRules((rule) => {
 			if (rule.selector === '.foo' && expectation === 'always') {
@@ -21,4 +25,10 @@ module.exports = stylelint.createPlugin(ruleName, (expectation) => {
 			}
 		});
 	};
-});
+};
+
+warnAboutFoo.ruleName = ruleName;
+warnAboutFoo.messages = warnAboutFooMessages;
+warnAboutFoo.meta = meta;
+
+module.exports = stylelint.createPlugin(ruleName, warnAboutFoo);

--- a/lib/__tests__/plugins.test.js
+++ b/lib/__tests__/plugins.test.js
@@ -67,6 +67,19 @@ it('another plugin runs', async () => {
 	expect(result.warnings()[0].text).toBe('Unexpected empty block (block-no-empty)');
 });
 
+it('plugin with rule metadata', async () => {
+	const result = await processorRelative.process(cssWithFoo, { from: undefined });
+
+	expect(result.stylelint).toHaveProperty('ruleMetadata', {
+		'plugin/warn-about-foo': {
+			url: 'https://github.com/stylelint/stylelint-foo-plugin/warn-about-foo',
+		},
+		'block-no-empty': {
+			url: expect.stringMatching(/block-no-empty/),
+		},
+	});
+});
+
 it('plugin with absolute path and no configBasedir', async () => {
 	const result = await processorAbsolute.process(cssWithFoo, { from: undefined });
 

--- a/lib/createPlugin.js
+++ b/lib/createPlugin.js
@@ -1,17 +1,11 @@
 'use strict';
 
-/** @typedef {import('stylelint').Rule} StylelintRule */
-
 /**
- * @param {string} ruleName
- * @param {StylelintRule} rule
- * @returns {{ruleName: string, rule: StylelintRule}}
+ * @type {typeof import('stylelint').createPlugin}
  */
-function createPlugin(ruleName, rule) {
+module.exports = function createPlugin(ruleName, rule) {
 	return {
 		ruleName,
 		rule,
 	};
-}
-
-module.exports = /** @type {typeof import('stylelint').createPlugin} */ (createPlugin);
+};

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -188,7 +188,7 @@ declare module 'stylelint' {
 			meta?: RuleMeta;
 		};
 
-		export type Plugin<P = any, S = any> = RuleBase<P, S>;
+		export type Plugin = RuleBase;
 
 		export type CodeProcessor = (code: string, file: string | undefined) => string;
 
@@ -440,7 +440,7 @@ declare module 'stylelint' {
 			/**
 			 * Creates a Stylelint plugin.
 			 */
-			createPlugin: (ruleName: string, plugin: Plugin) => { ruleName: string; rule: Rule };
+			createPlugin: (ruleName: string, rule: Rule) => { ruleName: string; rule: Rule };
 			/**
 			 * Internal use only. Do not use or rely on this method. It may
 			 * change at any time.

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -12,6 +12,8 @@ import type {
 	LintResult,
 	LinterResult,
 	Plugin,
+	Rule,
+	RuleMeta,
 	Warning,
 } from 'stylelint';
 import stylelint from 'stylelint';
@@ -84,6 +86,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 	warning: (reason) => `This is not allowed because ${reason}`,
 	withNarrowedParam: (mixinName: string) => `Mixin not allowed: ${mixinName}`,
 });
+const meta: RuleMeta = { url: '...' };
 const problemMessage: string = messages.problem;
 const problemFunc: (...reason: string[]) => string = messages.warning;
 
@@ -115,7 +118,12 @@ const testPlugin: Plugin = (options) => {
 	};
 };
 
-stylelint.createPlugin(ruleName, testPlugin);
+(testPlugin as Rule).ruleName = ruleName;
+(testPlugin as Rule).messages = messages;
+(testPlugin as Rule).primaryOptionArray = true;
+(testPlugin as Rule).meta = meta;
+
+stylelint.createPlugin(ruleName, testPlugin as Rule);
 
 messages.withNarrowedParam('should work');
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6245

> Is there anything in the PR that needs further explanation?

This PR mainly fixes the incorrect examples on the [plugin document](https://stylelint.io/developer-guide/plugins). Also, this improves the type definition of the `stylelint.createPlugin()` API, although it may be called *refactorings*.

The incorrect part on the doc is here: ⬇️ 

https://github.com/stylelint/stylelint/blob/e424be5eca77c5532b13147c4a7dad14085a4276/docs/developer-guide/plugins.md?plain=1#L53-L55

Because `stylelint.createPlugin()` returns an object `{ ruleName: string, rule: Function }`,

https://github.com/stylelint/stylelint/blob/4772851c0a1745db03f149ac35a2de6fe375c369/lib/createPlugin.js#L10-L15

the following code using `module.exports` produces an incorrect object `{ ruleName: string, rule: Function, messages: Object, meta: Object }`.

```js
module.exports.ruleName = ruleName;
module.exports.messages = messages;
module.exports.meta = meta;
```

To be correct, the `rule` function should have the `ruleName`, `messages`, and `meta` properties as below. The current example on the doc is confusing.

```js
const ruleFunc = () => { /* .. */ };

ruleFunc.ruleName = ruleName;
ruleFunc.messages = messages;
ruleFunc.meta = meta;
```

For example, the `stylelint-scss` plugin [sets the properties correctly](https://github.com/stylelint-scss/stylelint-scss/blob/v4.3.0/src/rules/at-each-key-value-single-line/index.js#L75-L77).


