### PR TITLE
Fix `shorthand-property-no-redundant-values` message

### DIFF
--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -115,6 +115,8 @@ testRule({
 			message: messages.rejected('1px 1px', '1px'),
 			line: 1,
 			column: 5,
+			endLine: 1,
+			endColumn: 21,
 		},
 		{
 			code: 'a { margin: 1Px 1pX; }',

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -12,7 +12,7 @@ const ruleName = 'shorthand-property-no-redundant-values';
 
 const messages = ruleMessages(ruleName, {
 	rejected: (unexpected, expected) =>
-		`Unexpected longhand value '${unexpected}' instead of '${expected}'`,
+		`Unexpected longhand value "${unexpected}" instead of "${expected}"`,
 });
 
 const meta = {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5694

> Is there anything in the PR that needs further explanation?

This PR fixes the message to use double quotes for consistency with other rules:

```diff
- Unexpected longhand value '1px 1px' instead of '1px'
+ Unexpected longhand value "1px 1px" instead of "1px"
```

This also adds test cases for end positions (#5694).
