### PR TITLE
Fix selector-max-id rule docs so it's parsed properly

### DIFF
--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -94,7 +94,7 @@ The following patterns are considered problems:
 a:matches(#foo) {}
 ```
 
-While the following patters are _not_ considered problems:
+The following patters are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
