### PR TITLE
Fix false negatives for SVG properties in alpha-value-notation

### DIFF
--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -80,6 +80,15 @@ testRule({
 			endColumn: 31,
 		},
 		{
+			code: 'feDropShadow { flood-opacity: 50% }',
+			fixed: 'feDropShadow { flood-opacity: 0.5 }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 31,
+			endLine: 1,
+			endColumn: 34,
+		},
+		{
 			code: 'a { color: rgba(0, 0, 0, 50%) }',
 			fixed: 'a { color: rgba(0, 0, 0, 0.5) }',
 			message: messages.expected('50%', '0.5'),

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -23,7 +23,15 @@ const meta = {
 	fixable: true,
 };
 
-const ALPHA_PROPS = new Set(['opacity', 'shape-image-threshold']);
+const ALPHA_PROPS = new Set([
+	'opacity',
+	'shape-image-threshold',
+	// SVG properties
+	'fill-opacity',
+	'flood-opacity',
+	'stop-opacity',
+	'stroke-opacity',
+]);
 const ALPHA_FUNCS = new Set(['hsl', 'hsla', 'hwb', 'lab', 'lch', 'rgb', 'rgba']);
 
 /** @type {import('stylelint').Rule} */


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

see stylelint/stylelint-config-standard#257

> Is there anything in the PR that needs further explanation?

- a PR has been opened on stylelint-config-standard: stylelint/stylelint-config-standard#258
- ensure that stylelint and stylelint-config-standard are synced
