### PR TITLE
Revert CHANGELOG.md and remove `.changeset/*.md` except for README.md

### DIFF
--- a/.changeset/calm-tables-hide.md
+++ b/.changeset/calm-tables-hide.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `selector-pseudo-class-allowed-list` end positions and message ([#6262](https://github.com/stylelint/stylelint/pull/6262))

--- a/.changeset/chatty-eagles-act.md
+++ b/.changeset/chatty-eagles-act.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `selector-no-vendor-prefix` end positions ([#6261](https://github.com/stylelint/stylelint/pull/6261))

--- a/.changeset/cold-peas-push.md
+++ b/.changeset/cold-peas-push.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `shorthand-property-no-redundant-values` message ([#6272](https://github.com/stylelint/stylelint/pull/6272))

--- a/.changeset/cool-baboons-cross.md
+++ b/.changeset/cool-baboons-cross.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `selector-pseudo-element-disallowed-list` end positions and message ([#6270](https://github.com/stylelint/stylelint/pull/6270))

--- a/.changeset/empty-humans-bake.md
+++ b/.changeset/empty-humans-bake.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `selector-pseudo-element-allowed-list` end positions and message ([#6270](https://github.com/stylelint/stylelint/pull/6270))

--- a/.changeset/modern-mayflies-scream.md
+++ b/.changeset/modern-mayflies-scream.md
@@ -1,5 +1,0 @@
----
-"stylelint": minor
----
-
-Added: `ignoreAfterCombinators: []` to `selector-max-universal` ([#6275](https://github.com/stylelint/stylelint/pull/6275))

--- a/.changeset/modern-plants-nail.md
+++ b/.changeset/modern-plants-nail.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `time-min-milliseconds` end positions ([#6273](https://github.com/stylelint/stylelint/pull/6273))

--- a/.changeset/plenty-timers-learn.md
+++ b/.changeset/plenty-timers-learn.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `keyframes-name-pattern` false positives for interpolation ([#6265](https://github.com/stylelint/stylelint/pull/6265))

--- a/.changeset/serious-teachers-juggle.md
+++ b/.changeset/serious-teachers-juggle.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `selector-nested-pattern` end positions ([#6259](https://github.com/stylelint/stylelint/pull/6259))

--- a/.changeset/shy-clouds-joke.md
+++ b/.changeset/shy-clouds-joke.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `selector-no-qualifying-type` message, positions, and false positives ([#6260](https://github.com/stylelint/stylelint/pull/6260))

--- a/.changeset/sour-socks-type.md
+++ b/.changeset/sour-socks-type.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `createPlugin` type definition ([#6264](https://github.com/stylelint/stylelint/pull/6264))

--- a/.changeset/wise-kiwis-repeat.md
+++ b/.changeset/wise-kiwis-repeat.md
@@ -1,5 +1,0 @@
----
-"stylelint": patch
----
-
-Fixed: `selector-pseudo-class-disallowed-list` end positions and message ([#6263](https://github.com/stylelint/stylelint/pull/6263))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Head
+
+- Added: `ignoreAfterCombinators: []` to `selector-max-universal` ([#6275](https://github.com/stylelint/stylelint/pull/6275)).
+- Fixed: `createPlugin` type definition ([#6264](https://github.com/stylelint/stylelint/pull/6264)).
+- Fixed: `keyframes-name-pattern` false positives for interpolation ([#6265](https://github.com/stylelint/stylelint/pull/6265)).
+- Fixed: `selector-nested-pattern` end positions ([#6259](https://github.com/stylelint/stylelint/pull/6259)).
+- Fixed: `selector-no-qualifying-type` message, positions, and false positives ([#6260](https://github.com/stylelint/stylelint/pull/6260)).
+- Fixed: `selector-no-vendor-prefix` end positions ([#6261](https://github.com/stylelint/stylelint/pull/6261)).
+- Fixed: `selector-pseudo-class-allowed-list` end positions and message ([#6262](https://github.com/stylelint/stylelint/pull/6262)).
+- Fixed: `selector-pseudo-class-disallowed-list` end positions and message ([#6263](https://github.com/stylelint/stylelint/pull/6263)).
+- Fixed: `selector-pseudo-element-allowed-list` end positions and message ([#6270](https://github.com/stylelint/stylelint/pull/6270)).
+- Fixed: `selector-pseudo-element-disallowed-list` end positions and message ([#6270](https://github.com/stylelint/stylelint/pull/6270)).
+- Fixed: `shorthand-property-no-redundant-values` message ([#6272](https://github.com/stylelint/stylelint/pull/6272)).
+- Fixed: `time-min-milliseconds` end positions ([#6273](https://github.com/stylelint/stylelint/pull/6273)).
+
 ## 14.10.0
 
 - Added: rule metadata to public `LinterResult` API ([#6166](https://github.com/stylelint/stylelint/pull/6166)).


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/pull/6282#issuecomment-1221456083

> Is there anything in the PR that needs further explanation?

This PR reverts `CHANGELOG.md` on aff9a8efe5923113e899d40b3bed0685d508697d for the existing release workflow. We'll try the new workflow in the next iteration.
