### PR TITLE
Fix typos in `maintainer-guide/issues.md`

### DIFF
--- a/docs/maintainer-guide/issues.md
+++ b/docs/maintainer-guide/issues.md
@@ -8,13 +8,13 @@ Use [labels](https://github.com/stylelint/stylelint/labels).
 
 When you first triage an issue, you should:
 
-- add one of the `status: needs *` labels, e.g. `status: need discussion`
+- add one of the `status: needs *` labels, e.g. `status: needs discussion`
 - don't add any other label
 
 After triage, you should add:
 
 - _one_ of the non-need `status: *` labels, e.g. `status: ready to implement`
-- _zero or one_ of the `type: *` labels, e.g. `status: new rule`
+- _zero or one_ of the `type: *` labels, e.g. `type: new rule`
 - _zero, one or more_ of the `syntax: *` labels, e.g. `syntax: scss`
 - optionally, the `good first issue`, `help wanted`, `priority: high` and `upstream` labels
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory. See also https://github.com/stylelint/stylelint/labels
