### PR TITLE
Added null-ls option for Neovim users

### DIFF
--- a/docs/user-guide/integrations/editor.md
+++ b/docs/user-guide/integrations/editor.md
@@ -7,6 +7,7 @@ Editor integrations built and maintained by the community:
 - [Ale](https://github.com/dense-analysis/ale) - Vim plugin that supports Stylelint.
 - [Flycheck](https://github.com/flycheck/flycheck) - Emacs extension that supports Stylelint. Alternatively, if you use CLI option `--formatter=unix`, Emacs' _Compilation mode_ will automatically hyperlink the lint messages.
 - [linter-stylelint](https://github.com/AtomLinter/linter-stylelint) - Atom plugin for Stylelint.
+- [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#stylelint-1) - Neovim plugin that has built-in support for Stylelint
 - [SublimeLinter-stylelint](https://github.com/SublimeLinter/SublimeLinter-stylelint) - Sublime Text plugin for Stylelint.
 - [SublimeLinter-contrib-stylelint_d](https://github.com/jo-sm/SublimeLinter-contrib-stylelint_d) - Sublime Text plugin for Stylelint that run's on daemon.
 - [JetBrains IDEs](https://www.jetbrains.com/products/#lang=js) – WebStorm, IntelliJ IDEA, PhpStorm, PyCharm, RubyMine, and other JetBrains IDEs have [built-in support](https://www.jetbrains.com/help/webstorm/using-stylelint-code-quality-tool.html) for Stylelint.


### PR DESCRIPTION
Wasn't obvious for Neovim users that the easiest option is using null-ls as this has built-in support for Stylelint. Added that to the list. 👍

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation

No, it's self-explanatory.
