### PR TITLE
Fix typo in annotation-no-unknown document

### DIFF
--- a/lib/rules/annotation-no-unknown/README.md
+++ b/lib/rules/annotation-no-unknown/README.md
@@ -24,7 +24,7 @@ a {
 }
 ```
 
-The following pattern is _not_ considered problem:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/annotation-no-unknown/README.md
+++ b/lib/rules/annotation-no-unknown/README.md
@@ -29,7 +29,7 @@ The following pattern is _not_ considered a problem:
 <!-- prettier-ignore -->
 ```css
 a {
- color: green !important;
+  color: green !important;
 }
 ```
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

I think this typo is causing a problem in stylelint.io page of the `annotation-no-unknown` rule.
The color of box-shadow in the code block  is red (invalid-pattern color) even though the pattern is not considered a problem.

https://stylelint.io/user-guide/rules/list/annotation-no-unknown/
