### PR TITLE
Add regex support for `ignorePseudoClasses` option of `selector-pseudo-class-no-unknown`

### DIFF
--- a/.changeset/big-crabs-tap.md
+++ b/.changeset/big-crabs-tap.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: regex support for `ignorePseudoClasses` option of `selector-pseudo-class-no-unknown`

--- a/lib/rules/selector-pseudo-class-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-class-no-unknown/README.md
@@ -58,27 +58,27 @@ input:-moz-placeholder {}
 
 ## Optional secondary options
 
-### `ignorePseudoClasses: ["/regex/", "string"]`
+### `ignorePseudoClasses: ["/regex/", /regex/, "non-regex"]`
 
 Given:
 
 ```json
-["/^my-/", "pseudo-class"]
+["/^--my-/", "--pseudo-class"]
 ```
 
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-a:pseudo-class {}
+a:--my-pseudo {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-a:my-pseudo {}
+a:--my-other-pseudo {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-a:my-other-pseudo {}
+a:--pseudo-class {}
 ```

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -275,7 +275,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignorePseudoClasses: ['unknown', '/^my-/', '/^YOUR-/i'] }],
+	config: [true, { ignorePseudoClasses: ['unknown', '/^my-/', /^YOUR-/i] }],
 
 	accept: [
 		{

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -18,7 +18,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isString } = require('../../utils/validateTypes');
+const { isString, isRegExp } = require('../../utils/validateTypes');
 const { isAtRule } = require('../../utils/typeGuards');
 
 const ruleName = 'selector-pseudo-class-no-unknown';
@@ -41,7 +41,7 @@ const rule = (primary, secondaryOptions) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignorePseudoClasses: [isString],
+					ignorePseudoClasses: [isString, isRegExp],
 				},
 				optional: true,
 			},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5523

> Is there anything in the PR that needs further explanation?

While working on #5523, I notice the `selector-pseudo-class-no-unknown` rule doesn't support a real regex.
