### PR TITLE
Add regex support for `ignorePseudoElements` option of `selector-pseudo-element-no-unknown`

### DIFF
--- a/.changeset/silver-baboons-dress.md
+++ b/.changeset/silver-baboons-dress.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: regex support for `ignorePseudoElements` option of `selector-pseudo-element-no-unknown`

--- a/lib/rules/selector-pseudo-element-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-element-no-unknown/README.md
@@ -58,27 +58,27 @@ input::-moz-placeholder {}
 
 ## Optional secondary options
 
-### `ignorePseudoElements: ["/regex/", "string"]`
+### `ignorePseudoElements: ["/regex/", /regex/, "non-regex"]`
 
 Given:
 
 ```json
-["/^my-/", "pseudo-element"]
+["/^--my-/", "--pseudo-element"]
 ```
 
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-a::pseudo-element {}
+a::--my-pseudo {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-a::my-pseudo {}
+a::--my-other-pseudo {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-a::my-other-pseudo {}
+a::--pseudo-element {}
 ```

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.js
@@ -189,7 +189,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignorePseudoElements: ['pseudo', '/^my-/'] }],
+	config: [true, { ignorePseudoElements: ['pseudo', '/^my-/', /foo/i] }],
 
 	accept: [
 		{
@@ -203,6 +203,9 @@ testRule({
 		},
 		{
 			code: 'a::my-pseudo { }',
+		},
+		{
+			code: 'a::FOO-pseudo { }',
 		},
 	],
 

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -9,7 +9,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
 const vendor = require('../../utils/vendor');
-const { isString } = require('../../utils/validateTypes');
+const { isString, isRegExp } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-pseudo-element-no-unknown';
 
@@ -31,7 +31,7 @@ const rule = (primary, secondaryOptions) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignorePseudoElements: [isString],
+					ignorePseudoElements: [isString, isRegExp],
 				},
 				optional: true,
 			},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #5523

> Is there anything in the PR that needs further explanation?

Similar reason with #6316.
