### PR TITLE
Add regex support to `ignoreTypes` option of `selector-type-case`

### DIFF
--- a/.changeset/fast-papayas-dress.md
+++ b/.changeset/fast-papayas-dress.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: regex support for `ignoreTypes` option of `selector-type-case`

--- a/lib/rules/selector-type-case/README.md
+++ b/lib/rules/selector-type-case/README.md
@@ -69,7 +69,7 @@ LI {}
 
 ## Optional secondary options
 
-### `ignoreTypes: ["/regex/", "non-regex"]`
+### `ignoreTypes: ["/regex/", /regex/, "non-regex"]`
 
 Given:
 

--- a/lib/rules/selector-type-case/__tests__/index.js
+++ b/lib/rules/selector-type-case/__tests__/index.js
@@ -305,7 +305,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: ['lower', { ignoreTypes: ['$childClass', '/(p|P)arent.*/'] }],
+	config: ['lower', { ignoreTypes: ['$childClass', '/(p|P)arent.*/', /foo$/i] }],
 
 	accept: [
 		{
@@ -313,6 +313,9 @@ testRule({
 		},
 		{
 			code: '$childClass { color: pink; }',
+		},
+		{
+			code: 'myFoo { color: pink; }',
 		},
 	],
 

--- a/lib/rules/selector-type-case/index.js
+++ b/lib/rules/selector-type-case/index.js
@@ -8,7 +8,7 @@ const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isString } = require('../../utils/validateTypes');
+const { isString, isRegExp } = require('../../utils/validateTypes');
 const { mixedCaseSvgTypeSelectors } = require('../../reference/selectors');
 
 const ruleName = 'selector-type-case';
@@ -35,7 +35,7 @@ const rule = (primary, secondaryOptions, context) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignoreTypes: [isString],
+					ignoreTypes: [isString, isRegExp],
 				},
 				optional: true,
 			},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The `ignoreTypes` option of the `selector-type-case` rule has supported a regex-like string already. Supporting also regex expressions in JS config files should be helpful.
