### PR TITLE
Add regex support to `ignoreSelectors` option of `selector-no-vendor-prefix`

### DIFF
--- a/.changeset/rotten-onions-occur.md
+++ b/.changeset/rotten-onions-occur.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: regex support for `ignoreSelectors` option of `selector-no-vendor-prefix`

--- a/lib/rules/selector-no-vendor-prefix/README.md
+++ b/lib/rules/selector-no-vendor-prefix/README.md
@@ -43,7 +43,7 @@ input::placeholder {}
 
 ## Optional secondary options
 
-### `ignoreSelectors: ["/regex/", "non-regex"]`
+### `ignoreSelectors: ["/regex/", /regex/, "non-regex"]`
 
 Ignore vendor prefixes for selectors.
 

--- a/lib/rules/selector-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/selector-no-vendor-prefix/__tests__/index.js
@@ -113,7 +113,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreSelectors: ['::-webkit-input-placeholder', '/-moz-.*/'] }],
+	config: [true, { ignoreSelectors: ['::-webkit-input-placeholder', '/-moz-.*/', /-screen$/] }],
 	fix: true,
 
 	accept: [
@@ -122,6 +122,9 @@ testRule({
 		},
 		{
 			code: 'input::-moz-placeholder { color: pink; }',
+		},
+		{
+			code: ':-webkit-full-screen a {}',
 		},
 	],
 

--- a/lib/rules/selector-no-vendor-prefix/index.js
+++ b/lib/rules/selector-no-vendor-prefix/index.js
@@ -7,7 +7,7 @@ const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isString } = require('../../utils/validateTypes');
+const { isString, isRegExp } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-no-vendor-prefix';
 
@@ -30,7 +30,7 @@ const rule = (primary, secondaryOptions, context) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignoreSelectors: [isString],
+					ignoreSelectors: [isString, isRegExp],
 				},
 				optional: true,
 			},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Similar to #6326

> Is there anything in the PR that needs further explanation?

See the description on #6326.
