### PR TITLE
Stop creating release PR in forked repos

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -14,7 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    if: github.repository == 'stylelint/stylelint'
+    if: github.repository == 'stylelint/stylelint' # Workaround. See https://github.com/changesets/action/issues/4
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -14,6 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
+    if: github.repository == 'stylelint/stylelint'
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #6253

> Is there anything in the PR that needs further explanation?

I notice [`changesets/action`](https://github.com/changesets) creates a release PR also in a forked repository, e.g., <https://github.com/kawaguchi1102/stylelint/pull/1>.

This PR adds a workaround to avoid the problem. See also https://github.com/changesets/action/issues/4#issuecomment-647322349