### PR TITLE
Add `ignore: ["inside-block"]` and `splitList` to selector-disallowed-list

### DIFF
--- a/.changeset/unlucky-dolphins-fetch.md
+++ b/.changeset/unlucky-dolphins-fetch.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `ignore: ["inside-block"]` and `splitList` to `selector-disallowed-list`

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -69,7 +69,7 @@ a[href] {}
 
 ## Optional secondary options
 
-### `iterateThroughSelectorList: true | false` (default: `false`)
+### `iterateThroughList: true | false` (default: `false`)
 
 Iterate through each individual selector in a selector list.
 

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -93,6 +93,7 @@ The following pattern is _not_ considered a problem:
 <!-- prettier-ignore -->
 ```css
 .bar .foo {}
+```
 
 ### `ignore: ["inside-block"]`
 

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -71,53 +71,44 @@ a[href] {}
 
 ### `iterateThroughSelectorList: true | false` (default: `false`)
 
-This option will apply your configuration to each individual selector in a selector list where each selector is seperated by a comma separated value. ','
+Iterate through each individual selector in a selector list.
 
-For example, with 'true'.
+For example, with `true`.
 
-Given the string:
+Given:
 
 ```json
-.foo
+[".foo"]
 ```
 
-The following patterns are considered problems:
+The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
 ```css
-.bar, .foo { }
+.bar, .foo {}
 ```
 
-The following patterns are _not_ considered problems:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css
-.bar .foo { }
+.bar .foo {}
 
 ###  `ignore: ["inside-block"]`
 
-Excludes any selectors that are inside a block. Use this if you only want to target selectors at the root level.
+Ignore selectors that are inside a block. 
 
-Given the string:
+Given:
 
 ```json
-.foo
+[".foo"]
 ```
 
-The following patterns are considered problems:
-
-<!-- prettier-ignore -->
-```css
-.foo { }
-```
-
-The following patterns are _not_ considered problems:
+The following pattern is _not_ considered a problem:
 
 <!-- prettier-ignore -->
 ```css
 .bar {
-    .foo {
-
-    }
+  .foo {}
 }
 ```

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -69,7 +69,7 @@ a[href] {}
 
 ## Optional secondary options
 
-### `iterateThroughList: true | false` (default: `false`)
+### `splitList: true | false` (default: `false`)
 
 Iterate through each individual selector in a selector list.
 
@@ -94,7 +94,7 @@ The following pattern is _not_ considered a problem:
 ```css
 .bar .foo {}
 
-###  `ignore: ["inside-block"]`
+### `ignore: ["inside-block"]`
 
 Ignore selectors that are inside a block. 
 

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -97,7 +97,7 @@ The following pattern is _not_ considered a problem:
 
 ### `ignore: ["inside-block"]`
 
-Ignore selectors that are inside a block. 
+Ignore selectors that are inside a block.
 
 Given:
 

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -71,7 +71,7 @@ a[href] {}
 
 ### `splitList: true | false` (default: `false`)
 
-Iterate through each individual selector in a selector list.
+Split selector lists into individual selectors.
 
 For example, with `true`.
 

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -66,3 +66,58 @@ a
 ```css
 a[href] {}
 ```
+
+## Optional secondary options
+
+### `iterateThroughSelectorList: true | false` (default: `false`)
+
+This option will apply your configuration to each individual selector in a selector list where each selector is seperated by a comma separated value. ','
+
+For example, with 'true'.
+
+Given the string:
+
+```json
+.foo
+```
+
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
+```css
+.bar, .foo { }
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+.bar .foo { }
+
+###  `ignore: ["inside-block"]`
+
+Excludes any selectors that are inside a block. Use this if you only want to target selectors at the root level.
+
+Given the string:
+
+```json
+.foo
+```
+
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
+```css
+.foo { }
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+.bar {
+    .foo {
+
+    }
+}
+```

--- a/lib/rules/selector-disallowed-list/__tests__/index.js
+++ b/lib/rules/selector-disallowed-list/__tests__/index.js
@@ -68,7 +68,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [/^\.(foo)[,\s]?(?!\w).*$/, { ignore: ['inside-block'], iterateThroughList: true }],
+	config: [/^\.(foo)[,\s]?(?!\w).*$/, { ignore: ['inside-block'], splitList: true }],
 	accept: [
 		{
 			code: 'a.foo {}',

--- a/lib/rules/selector-disallowed-list/__tests__/index.js
+++ b/lib/rules/selector-disallowed-list/__tests__/index.js
@@ -68,6 +68,66 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [
+		/^\.(foo)[,\s]?(?!\w).*$/,
+		{ ignore: ['inside-block'], iterateThroughSelectorList: true },
+	],
+	accept: [
+		{
+			code: 'a.foo{}',
+		},
+		{
+			code: 'a\n>\n.foo {}',
+		},
+		{
+			code: '.bar > a > .foo {}',
+		},
+		{
+			code: '.bar { .foo {} }',
+		},
+		{
+			code: '.fooo {}',
+		},
+	],
+
+	reject: [
+		{
+			code: '.foo {}',
+			message: messages.rejected('.foo'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 5,
+		},
+		{
+			code: '.foo > .bar {}',
+			message: messages.rejected('.foo > .bar'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 12,
+		},
+		{
+			code: '.foo, .bar {}',
+			message: messages.rejected('.foo'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 5,
+		},
+		{
+			code: '.bar, .foo {}',
+			message: messages.rejected('.foo'),
+			line: 1,
+			column: 7,
+			endColumn: 11,
+			endLine: 1,
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: /\.foo[^>]*>.*\.bar/,
 
 	accept: [

--- a/lib/rules/selector-disallowed-list/__tests__/index.js
+++ b/lib/rules/selector-disallowed-list/__tests__/index.js
@@ -74,7 +74,7 @@ testRule({
 	],
 	accept: [
 		{
-			code: 'a.foo{}',
+			code: 'a.foo {}',
 		},
 		{
 			code: 'a\n>\n.foo {}',

--- a/lib/rules/selector-disallowed-list/__tests__/index.js
+++ b/lib/rules/selector-disallowed-list/__tests__/index.js
@@ -68,10 +68,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [
-		/^\.(foo)[,\s]?(?!\w).*$/,
-		{ ignore: ['inside-block'], iterateThroughSelectorList: true },
-	],
+	config: [/^\.(foo)[,\s]?(?!\w).*$/, { ignore: ['inside-block'], iterateThroughList: true }],
 	accept: [
 		{
 			code: 'a.foo {}',

--- a/lib/rules/selector-disallowed-list/index.js
+++ b/lib/rules/selector-disallowed-list/index.js
@@ -3,9 +3,10 @@
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');
 const report = require('../../utils/report');
+const optionsMatches = require('../../utils/optionsMatches');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isRegExp, isString } = require('../../utils/validateTypes');
+const { isRegExp, isString, isBoolean } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-disallowed-list';
 
@@ -17,13 +18,25 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-disallowed-list',
 };
 
-/** @type {import('stylelint').Rule<string | RegExp | Array<string | RegExp>>} */
-const rule = (primary) => {
+/** @type {import('stylelint').Rule<string | RegExp | Array<string | RegExp>, { iterateThroughSelectorList: boolean, ignore: string[] }>} */
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [isString, isRegExp],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: [isString, isRegExp],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignore: ['inside-block'],
+					iterateThroughSelectorList: [isBoolean],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
 			return;
@@ -34,21 +47,45 @@ const rule = (primary) => {
 				return;
 			}
 
-			const { selector, raws } = ruleNode;
+			if (optionsMatches(secondaryOptions, 'ignore', 'inside-block')) {
+				const { parent } = ruleNode;
+				const isInsideBlock = parent && parent.type !== 'root';
 
-			if (!matchesStringOrRegExp(selector, primary)) {
-				return;
+				if (isInsideBlock) {
+					return;
+				}
 			}
 
-			const word = (raws.selector && raws.selector.raw) || selector;
+			const iterateThroughSelectorList =
+				secondaryOptions && secondaryOptions.iterateThroughSelectorList;
 
-			report({
-				result,
-				ruleName,
-				message: messages.rejected(selector),
-				node: ruleNode,
-				word,
-			});
+			if (iterateThroughSelectorList) {
+				ruleNode.selectors.forEach((selector) => {
+					if (matchesStringOrRegExp(selector, primary)) {
+						report({
+							result,
+							ruleName,
+							message: messages.rejected(selector),
+							node: ruleNode,
+							word: selector,
+						});
+					}
+				});
+			} else {
+				const { selector, raws } = ruleNode;
+
+				if (matchesStringOrRegExp(selector, primary)) {
+					const word = (raws.selector && raws.selector.raw) || selector;
+
+					report({
+						result,
+						ruleName,
+						message: messages.rejected(selector),
+						node: ruleNode,
+						word,
+					});
+				}
+			}
 		});
 	};
 };

--- a/lib/rules/selector-disallowed-list/index.js
+++ b/lib/rules/selector-disallowed-list/index.js
@@ -18,7 +18,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-disallowed-list',
 };
 
-/** @type {import('stylelint').Rule<string | RegExp | Array<string | RegExp>, { iterateThroughSelectorList: boolean, ignore: string[] }>} */
+/** @type {import('stylelint').Rule<string | RegExp | Array<string | RegExp>, { iterateThroughList: boolean, ignore: string[] }>} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -32,7 +32,7 @@ const rule = (primary, secondaryOptions) => {
 				actual: secondaryOptions,
 				possible: {
 					ignore: ['inside-block'],
-					iterateThroughSelectorList: [isBoolean],
+					iterateThroughList: [isBoolean],
 				},
 				optional: true,
 			},
@@ -56,10 +56,9 @@ const rule = (primary, secondaryOptions) => {
 				}
 			}
 
-			const iterateThroughSelectorList =
-				secondaryOptions && secondaryOptions.iterateThroughSelectorList;
+			const iterateThroughList = secondaryOptions && secondaryOptions.iterateThroughList;
 
-			if (iterateThroughSelectorList) {
+			if (iterateThroughList) {
 				ruleNode.selectors.forEach((selector) => {
 					if (matchesStringOrRegExp(selector, primary)) {
 						report({

--- a/lib/rules/selector-disallowed-list/index.js
+++ b/lib/rules/selector-disallowed-list/index.js
@@ -18,7 +18,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/selector-disallowed-list',
 };
 
-/** @type {import('stylelint').Rule<string | RegExp | Array<string | RegExp>, { iterateThroughList: boolean, ignore: string[] }>} */
+/** @type {import('stylelint').Rule<string | RegExp | Array<string | RegExp>, { splitList: boolean, ignore: string[] }>} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -32,7 +32,7 @@ const rule = (primary, secondaryOptions) => {
 				actual: secondaryOptions,
 				possible: {
 					ignore: ['inside-block'],
-					iterateThroughList: [isBoolean],
+					splitList: [isBoolean],
 				},
 				optional: true,
 			},
@@ -42,12 +42,15 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
+		const ignoreInsideBlock = optionsMatches(secondaryOptions, 'ignore', 'inside-block');
+		const splitList = secondaryOptions && secondaryOptions.splitList;
+
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 
-			if (optionsMatches(secondaryOptions, 'ignore', 'inside-block')) {
+			if (ignoreInsideBlock) {
 				const { parent } = ruleNode;
 				const isInsideBlock = parent && parent.type !== 'root';
 
@@ -56,9 +59,7 @@ const rule = (primary, secondaryOptions) => {
 				}
 			}
 
-			const iterateThroughList = secondaryOptions && secondaryOptions.iterateThroughList;
-
-			if (iterateThroughList) {
+			if (splitList) {
 				ruleNode.selectors.forEach((selector) => {
 					if (matchesStringOrRegExp(selector, primary)) {
 						report({


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6294 

> Is there anything in the PR that needs further explanation?

A bit of a shuffle, but I added an additional ```iterateThroughSelectorList``` flag which iterates through ruleNode.selectors rather than just the single ruleNode.selector or raw.selector.raw. The RegExp can get a bit unwieldy.

I consider the following ```.foo, .bar {}``` to be 2 separate selectors, so a dev may prefer to parse each of these individually ( ```.foo``` and ```.bar```) than to have to parse a string like ```.foo,\n.bar```
