### PR TITLE
Fix false positives for interpolation and shorthand in `font-family-name-quotes`

### DIFF
--- a/.changeset/famous-cobras-clean.md
+++ b/.changeset/famous-cobras-clean.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `font-family-name-quotes` false positives for interpolation and shorthand

--- a/lib/rules/font-family-name-quotes/__tests__/index.js
+++ b/lib/rules/font-family-name-quotes/__tests__/index.js
@@ -25,6 +25,13 @@ const variablePositiveTests = [
 	},
 ];
 
+const scssPositiveTests = [
+	{
+		code: 'a { font: #{customFunc($some-length)} "Times", "Arial"; }',
+		description: 'ignores Sass function with interpolation',
+	},
+];
+
 testRule({
 	ruleName,
 	config: ['always-unless-keyword'],
@@ -205,6 +212,14 @@ testRule({
 
 testRule({
 	ruleName,
+	customSyntax: 'postcss-scss',
+	config: ['always-unless-keyword'],
+
+	accept: [...scssPositiveTests],
+});
+
+testRule({
+	ruleName,
 	config: ['always-where-recommended'],
 
 	accept: [
@@ -380,6 +395,14 @@ testRule({
 
 testRule({
 	ruleName,
+	customSyntax: 'postcss-scss',
+	config: ['always-where-recommended'],
+
+	accept: [...scssPositiveTests],
+});
+
+testRule({
+	ruleName,
 	config: ['always-where-required'],
 
 	accept: [
@@ -501,6 +524,14 @@ testRule({
 			endColumn: 53,
 		},
 	],
+});
+
+testRule({
+	ruleName,
+	customSyntax: 'postcss-scss',
+	config: ['always-where-required'],
+
+	accept: [...scssPositiveTests],
 });
 
 testRule({

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -141,6 +141,10 @@ const rule = (primary, _secondary, context) => {
 		}
 
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
+			if (!isStandardSyntaxValue(decl.value)) {
+				return;
+			}
+
 			let fontFamilyNodes = makeMutableFontFamilies(findFontFamily(decl.value), decl);
 
 			if (fontFamilyNodes.length === 0) {
@@ -160,10 +164,6 @@ const rule = (primary, _secondary, context) => {
 			const { name: family, rawName: rawFamily, hasQuotes } = fontFamilyNode;
 
 			if (!isStandardSyntaxValue(rawFamily)) {
-				return;
-			}
-
-			if (!isStandardSyntaxValue(decl.value)) {
 				return;
 			}
 

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -163,6 +163,10 @@ const rule = (primary, _secondary, context) => {
 				return;
 			}
 
+			if (!isStandardSyntaxValue(decl.value)) {
+				return;
+			}
+
 			if (isVariable(rawFamily)) {
 				return;
 			}

--- a/lib/rules/font-family-name-quotes/index.js
+++ b/lib/rules/font-family-name-quotes/index.js
@@ -163,10 +163,6 @@ const rule = (primary, _secondary, context) => {
 		function checkFamilyName(fontFamilyNode, decl) {
 			const { name: family, rawName: rawFamily, hasQuotes } = fontFamilyNode;
 
-			if (!isStandardSyntaxValue(rawFamily)) {
-				return;
-			}
-
 			if (isVariable(rawFamily)) {
 				return;
 			}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4154

> Is there anything in the PR that needs further explanation?

I updated to change the timing of executing `isStandardSyntaxValue` to ignore problematic cases.

However, if `customSyntax` is not set to `'postcss-scss'`, `CssSyntaxError` is raised.
I think this error is correct because this bug is SCSS syntax.