### PR TITLE
Add support for multiple `--ignore-path` flags

### DIFF
--- a/.changeset/real-items-wait.md
+++ b/.changeset/real-items-wait.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: support for multiple `--ignore-path` flags

--- a/docs/user-guide/usage/cli.md
+++ b/docs/user-guide/usage/cli.md
@@ -58,7 +58,7 @@ Ignore `stylelint-disable` (e.g. `/* stylelint-disable block-no-empty */`) comme
 
 ### `--ignore-path, -i`
 
-A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, Stylelint looks for `.stylelintignore` in `process.cwd()`. [More info](options.md#ignorePath).
+Path to a file containing patterns that describe files to ignore. The path can be absolute or relative to `process.cwd()`. You can repeat the option to provide multiple paths. By default, Stylelint looks for `.stylelintignore` in `process.cwd()`. [More info](options.md#ignorePath).
 
 ### `--ignore-pattern, --ip`
 

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -133,7 +133,7 @@ Disable the default ignores. Stylelint will not automatically ignore the content
 
 CLI flags: `--ignore-path, -i`
 
-A path to a file containing patterns describing files to ignore. The path can be absolute or relative to `process.cwd()`. By default, Stylelint looks for `.stylelintignore` in `process.cwd()`.
+Path to a file containing patterns that describe files to ignore. The path can be absolute or relative to `process.cwd()`. You can repeat the option to provide multiple paths. By default, Stylelint looks for `.stylelintignore` in `process.cwd()`.
 
 ## `ignoreDisables`
 

--- a/lib/__tests__/__snapshots__/cli.test.js.snap
+++ b/lib/__tests__/__snapshots__/cli.test.js.snap
@@ -40,8 +40,9 @@ exports[`CLI --help 1`] = `
     --ignore-path, -i
 
       Path to a file containing patterns that describe files to ignore. The
-      path can be absolute or relative to process.cwd(). By default, stylelint
-      looks for .stylelintignore in process.cwd().
+      path can be absolute or relative to process.cwd(). You can repeat the
+      option to provide multiple paths. By default, Stylelint looks for
+      .stylelintignore in process.cwd().
 
     --ignore-pattern, --ip
 

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -25,6 +25,7 @@ describe('buildCLI', () => {
 			formatter: 'string',
 			help: false,
 			ignoreDisables: false,
+			ignorePath: [],
 			ignorePattern: [],
 			printConfig: false,
 			quiet: false,
@@ -95,8 +96,8 @@ describe('buildCLI', () => {
 	});
 
 	it('flags.ignorePath', () => {
-		expect(buildCLI(['--ignore-path=/path/to/file']).flags.ignorePath).toBe('/path/to/file');
-		expect(buildCLI(['-i', '/path/to/file']).flags.ignorePath).toBe('/path/to/file');
+		expect(buildCLI(['--ignore-path=/path/to/file']).flags.ignorePath).toEqual(['/path/to/file']);
+		expect(buildCLI(['-i', '/path/to/file']).flags.ignorePath).toEqual(['/path/to/file']);
 	});
 
 	it('flags.ignorePattern', () => {

--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -98,6 +98,13 @@ describe('buildCLI', () => {
 	it('flags.ignorePath', () => {
 		expect(buildCLI(['--ignore-path=/path/to/file']).flags.ignorePath).toEqual(['/path/to/file']);
 		expect(buildCLI(['-i', '/path/to/file']).flags.ignorePath).toEqual(['/path/to/file']);
+		expect(
+			buildCLI(['--ignore-path=/path/to/file1', '--ignore-path=/path/to/file2']).flags.ignorePath,
+		).toEqual(['/path/to/file1', '/path/to/file2']);
+		expect(buildCLI(['-i', '/path/to/file1', '-i', '/path/to/file2']).flags.ignorePath).toEqual([
+			'/path/to/file1',
+			'/path/to/file2',
+		]);
 	});
 
 	it('flags.ignorePattern', () => {

--- a/lib/__tests__/fixtures/ignore-2.txt
+++ b/lib/__tests__/fixtures/ignore-2.txt
@@ -1,0 +1,3 @@
+# Ignore file patterns are always relative to process.cwd()
+
+fixtures/empty-block-with-disables.css

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -182,6 +182,27 @@ test('specified `ignorePath` file ignoring one file', async () => {
 	process.chdir(actualCwd);
 });
 
+test('specified multiple `ignorePath` to ignore files', async () => {
+	const files = [fixtures('empty-block.css'), fixtures('empty-block-with-disables.css')];
+	const actualCwd = process.cwd();
+
+	process.chdir(__dirname);
+
+	await expect(
+		standalone({
+			files,
+			config: {
+				rules: {
+					'block-no-empty': true,
+				},
+			},
+			ignorePath: [fixtures('ignore.txt'), fixtures('ignore-2.txt')],
+		}),
+	).rejects.toThrow(AllFilesIgnoredError); // all files ignore
+
+	process.chdir(actualCwd);
+});
+
 test('specified `ignorePath` file ignoring one file using options.cwd', async () => {
 	const files = [fixtures('empty-block.css')];
 	const allFilesIgnoredErrorMessage = new AllFilesIgnoredError(files);

--- a/lib/__tests__/ignore.test.js
+++ b/lib/__tests__/ignore.test.js
@@ -175,7 +175,7 @@ test('specified `ignorePath` file ignoring one file', async () => {
 					'block-no-empty': true,
 				},
 			},
-			ignorePath: fixtures('ignore.txt'),
+			ignorePath: [fixtures('ignore.txt')],
 		}),
 	).rejects.toThrow(AllFilesIgnoredError); // all files ignore
 
@@ -196,7 +196,7 @@ test('specified `ignorePath` file ignoring one file using options.cwd', async ()
 					'block-no-empty': true,
 				},
 			},
-			ignorePath: fixtures('ignore.txt'),
+			ignorePath: [fixtures('ignore.txt')],
 			cwd: __dirname,
 		}),
 	).rejects.toThrow(allFilesIgnoredErrorMessage); // all files ignore
@@ -209,7 +209,7 @@ test('specified `ignorePath` directory, not a file', async () => {
 		standalone({
 			files: [],
 			config: {},
-			ignorePath: '__snapshots__',
+			ignorePath: ['__snapshots__'],
 			cwd: __dirname,
 		}),
 	).rejects.toThrow(/EISDIR/);

--- a/lib/__tests__/invalidScopeDisables.test.js
+++ b/lib/__tests__/invalidScopeDisables.test.js
@@ -157,7 +157,7 @@ it('invalidScopeDisables ignored case', async () => {
 		config,
 		files: [fixture('disabled-ranges-1.css'), fixture('ignored-file.css')],
 		ignoreDisables: true,
-		ignorePath: fixture('.stylelintignore'),
+		ignorePath: [fixture('.stylelintignore')],
 		reportInvalidScopeDisables: true,
 	});
 

--- a/lib/__tests__/needlessDisables.test.js
+++ b/lib/__tests__/needlessDisables.test.js
@@ -223,7 +223,7 @@ it('needlessDisables ignored case', async () => {
 		config,
 		files: [fixture('disabled-ranges-1.css'), fixture('ignored-file.css')],
 		reportNeedlessDisables: true,
-		ignorePath: fixture('.stylelintignore'),
+		ignorePath: [fixture('.stylelintignore')],
 	});
 
 	expect(results).toHaveLength(1);

--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -127,7 +127,7 @@ describe('stylelintignore', () => {
 					'block-no-empty': true,
 				},
 			},
-			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
+			ignorePath: [path.join(__dirname, './stylelintignore-test/.postcssPluginignore')],
 		};
 
 		return expect(
@@ -162,7 +162,7 @@ describe('stylelintignore with options.cwd', () => {
 				},
 			},
 			cwd: __dirname,
-			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
+			ignorePath: [path.join(__dirname, './stylelintignore-test/.postcssPluginignore')],
 		};
 
 		return expect(

--- a/lib/__tests__/postcssPlugin.test.js
+++ b/lib/__tests__/postcssPlugin.test.js
@@ -127,6 +127,21 @@ describe('stylelintignore', () => {
 					'block-no-empty': true,
 				},
 			},
+			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
+		};
+
+		return expect(
+			postcss([postcssPlugin(options)]).process('a {}', { from: 'foo.css' }),
+		).resolves.toHaveProperty('stylelint.ignored', true);
+	});
+
+	it('postcssPlugin with ignorePath array and file is ignored', () => {
+		const options = {
+			config: {
+				rules: {
+					'block-no-empty': true,
+				},
+			},
 			ignorePath: [path.join(__dirname, './stylelintignore-test/.postcssPluginignore')],
 		};
 
@@ -155,6 +170,22 @@ describe('stylelintignore with options.cwd', () => {
 	});
 
 	it('postcssPlugin with ignorePath and file is ignored', () => {
+		const options = {
+			config: {
+				rules: {
+					'block-no-empty': true,
+				},
+			},
+			cwd: __dirname,
+			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
+		};
+
+		return expect(
+			postcss([postcssPlugin(options)]).process('a {}', { from: path.join(__dirname, 'foo.css') }),
+		).resolves.toHaveProperty('stylelint.ignored', true);
+	});
+
+	it('postcssPlugin with ignorePath array and file is ignored', () => {
 		const options = {
 			config: {
 				rules: {

--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.js
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.js
@@ -58,7 +58,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: path.join(__dirname, '.stylelintignore'),
+				ignorePath: [path.join(__dirname, '.stylelintignore')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -78,7 +78,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: path.join(__dirname, '.stylelintignore-empty'),
+				ignorePath: [path.join(__dirname, '.stylelintignore-empty')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -95,7 +95,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: path.join(__dirname, '.stylelintignore2'),
+				ignorePath: [path.join(__dirname, '.stylelintignore2')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -115,7 +115,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: path.join(__dirname, '.stylelintignore2'),
+				ignorePath: [path.join(__dirname, '.stylelintignore2')],
 			});
 
 			expect(data).toEqual({
@@ -175,7 +175,7 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: path.join(__dirname, '.stylelintignore'),
+				ignorePath: [path.join(__dirname, '.stylelintignore')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -196,7 +196,7 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: path.join(__dirname, '.stylelintignore-empty'),
+				ignorePath: [path.join(__dirname, '.stylelintignore-empty')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -214,7 +214,7 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: path.join(__dirname, '.stylelintignore2'),
+				ignorePath: [path.join(__dirname, '.stylelintignore2')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -235,7 +235,7 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: path.join(__dirname, '.stylelintignore2'),
+				ignorePath: [path.join(__dirname, '.stylelintignore2')],
 				cwd: __dirname,
 			});
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,7 +32,7 @@ const EXIT_CODE_ERROR = 2;
  * @property {string} [formatter="string"]
  * @property {string} [help]
  * @property {boolean} [ignoreDisables]
- * @property {string} [ignorePath]
+ * @property {string[]} [ignorePath]
  * @property {string[]} [ignorePattern]
  * @property {string} [noColor]
  * @property {string} [outputFile]
@@ -273,6 +273,7 @@ const meowOptions = {
 		ignorePath: {
 			alias: 'i',
 			type: 'string',
+			isMultiple: true,
 		},
 		ignorePattern: {
 			alias: 'ip',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -125,8 +125,9 @@ const meowOptions = {
       --ignore-path, -i
 
         Path to a file containing patterns that describe files to ignore. The
-        path can be absolute or relative to process.cwd(). By default, stylelint
-        looks for .stylelintignore in process.cwd().
+        path can be absolute or relative to process.cwd(). You can repeat the
+        option to provide multiple paths. By default, Stylelint looks for
+        .stylelintignore in process.cwd().
 
       --ignore-pattern, --ip
 

--- a/lib/utils/getFileIgnorer.js
+++ b/lib/utils/getFileIgnorer.js
@@ -10,14 +10,18 @@ const isPathNotFoundError = require('./isPathNotFoundError');
 const DEFAULT_IGNORE_FILENAME = '.stylelintignore';
 
 /**
- * @param {{ cwd: string, ignorePath?: string[], ignorePattern?: string[] }} options
+ * @param {{ cwd: string, ignorePath?: string | string[], ignorePattern?: string[] }} options
  * @return {import('ignore').Ignore}
  */
 module.exports = function getFileIgnorer(options) {
 	const ignorer = ignore();
-	const ignorePath = options.ignorePath || [];
+	let ignorePath = [];
 
-	if (ignorePath.length <= 0) {
+	if (Array.isArray(options.ignorePath) && options.ignorePath.length > 0) {
+		ignorePath = options.ignorePath;
+	} else if (typeof options.ignorePath === 'string') {
+		ignorePath.push(options.ignorePath);
+	} else {
 		ignorePath.push(DEFAULT_IGNORE_FILENAME);
 	}
 

--- a/lib/utils/getFileIgnorer.js
+++ b/lib/utils/getFileIgnorer.js
@@ -15,17 +15,13 @@ const DEFAULT_IGNORE_FILENAME = '.stylelintignore';
  */
 module.exports = function getFileIgnorer(options) {
 	const ignorer = ignore();
-	let ignorePath = [];
+	const ignorePaths = [options.ignorePath || []].flat();
 
-	if (Array.isArray(options.ignorePath) && options.ignorePath.length > 0) {
-		ignorePath = options.ignorePath;
-	} else if (typeof options.ignorePath === 'string') {
-		ignorePath.push(options.ignorePath);
-	} else {
-		ignorePath.push(DEFAULT_IGNORE_FILENAME);
+	if (ignorePaths.length === 0) {
+		ignorePaths.push(DEFAULT_IGNORE_FILENAME);
 	}
 
-	for (const ignoreFilePath of ignorePath) {
+	for (const ignoreFilePath of ignorePaths) {
 		const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
 			? ignoreFilePath
 			: path.resolve(options.cwd, ignoreFilePath);

--- a/lib/utils/getFileIgnorer.js
+++ b/lib/utils/getFileIgnorer.js
@@ -10,25 +10,34 @@ const isPathNotFoundError = require('./isPathNotFoundError');
 const DEFAULT_IGNORE_FILENAME = '.stylelintignore';
 
 /**
- * @param {{ cwd: string, ignorePath?: string, ignorePattern?: string[] }} options
+ * @param {{ cwd: string, ignorePath?: string[], ignorePattern?: string[] }} options
  * @return {import('ignore').Ignore}
  */
 module.exports = function getFileIgnorer(options) {
-	const ignoreFilePath = options.ignorePath || DEFAULT_IGNORE_FILENAME;
-	const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
-		? ignoreFilePath
-		: path.resolve(options.cwd, ignoreFilePath);
-	let ignoreText = '';
+	const ignorer = ignore();
+	const ignorePath = options.ignorePath || [];
 
-	try {
-		ignoreText = fs.readFileSync(absoluteIgnoreFilePath, 'utf8');
-	} catch (readError) {
-		if (!isPathNotFoundError(readError)) {
-			throw readError;
+	if (ignorePath.length <= 0) {
+		ignorePath.push(DEFAULT_IGNORE_FILENAME);
+	}
+
+	for (const ignoreFilePath of ignorePath) {
+		const absoluteIgnoreFilePath = path.isAbsolute(ignoreFilePath)
+			? ignoreFilePath
+			: path.resolve(options.cwd, ignoreFilePath);
+
+		try {
+			const ignoreText = fs.readFileSync(absoluteIgnoreFilePath, 'utf8');
+
+			ignorer.add(ignoreText);
+		} catch (readError) {
+			if (!isPathNotFoundError(readError)) {
+				throw readError;
+			}
 		}
 	}
 
-	return ignore()
-		.add(ignoreText)
-		.add(options.ignorePattern || []);
+	ignorer.add(options.ignorePattern || []);
+
+	return ignorer;
 };

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -223,7 +223,7 @@ declare module 'stylelint' {
 			 */
 			cwd?: string;
 			ignoreDisables?: boolean;
-			ignorePath?: string;
+			ignorePath?: string[];
 			ignorePattern?: string[];
 			reportDescriptionlessDisables?: boolean;
 			reportNeedlessDisables?: boolean;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -223,7 +223,7 @@ declare module 'stylelint' {
 			 */
 			cwd?: string;
 			ignoreDisables?: boolean;
-			ignorePath?: string[];
+			ignorePath?: string | string[];
 			ignorePattern?: string[];
 			reportDescriptionlessDisables?: boolean;
 			reportNeedlessDisables?: boolean;

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -32,7 +32,7 @@ const options: Partial<LinterOptions> = {
 	reportDescriptionlessDisables: true,
 	reportInvalidScopeDisables: true,
 	reportNeedlessDisables: true,
-	ignorePath: 'foo',
+	ignorePath: ['foo'],
 	customSyntax: 'postcss-scss',
 	syntax: 'scss', // Removed but still accepted in type definition
 	config: {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4680

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
Please let me know if I'm missing a unit test.