### PR TITLE
Add autofix to `font-weight-notation`

### DIFF
--- a/.changeset/cool-zebras-sparkle.md
+++ b/.changeset/cool-zebras-sparkle.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `font-weight-notation` autofix

--- a/docs/user-guide/rules/list.md
+++ b/docs/user-guide/rules/list.md
@@ -123,7 +123,7 @@ Within each cateogory, the rules are grouped by the [_thing_](http://apps.workfl
 
 ### Font weight
 
-- [`font-weight-notation`](../../../lib/rules/font-weight-notation/README.md): Require numeric or named (where possible) `font-weight` values. Also, when named values are expected, require only valid names.
+- [`font-weight-notation`](../../../lib/rules/font-weight-notation/README.md): Require numeric or named (where possible) `font-weight` values. Also, when named values are expected, require only valid names (Autofixable).
 
 ### Function
 

--- a/lib/reference/keywords.js
+++ b/lib/reference/keywords.js
@@ -311,6 +311,7 @@ module.exports = {
 	fontFamilyKeywords,
 	fontShorthandKeywords,
 	fontSizeKeywords,
+	fontWeightAbsoluteKeywords,
 	fontWeightKeywords,
 	fontWeightRelativeKeywords,
 	gridAreaKeywords,

--- a/lib/reference/keywords.js
+++ b/lib/reference/keywords.js
@@ -28,7 +28,12 @@ const fontFamilyKeywords = uniteSets(basicKeywords, [
 
 const fontWeightRelativeKeywords = new Set(['bolder', 'lighter']);
 
-const fontWeightAbsoluteKeywords = new Set(['bold']);
+const fontWeightAbsoluteKeywords = new Set(['normal', 'bold']);
+
+const fontWeightNonNumericKeywords = uniteSets(
+	fontWeightRelativeKeywords,
+	fontWeightAbsoluteKeywords,
+);
 
 const fontWeightNumericKeywords = new Set([
 	'100',
@@ -44,8 +49,7 @@ const fontWeightNumericKeywords = new Set([
 
 const fontWeightKeywords = uniteSets(
 	basicKeywords,
-	fontWeightRelativeKeywords,
-	fontWeightAbsoluteKeywords,
+	fontWeightNonNumericKeywords,
 	fontWeightNumericKeywords,
 );
 
@@ -313,6 +317,7 @@ module.exports = {
 	fontSizeKeywords,
 	fontWeightAbsoluteKeywords,
 	fontWeightKeywords,
+	fontWeightNonNumericKeywords,
 	fontWeightRelativeKeywords,
 	gridAreaKeywords,
 	gridColumnKeywords,

--- a/lib/rules/font-weight-notation/README.md
+++ b/lib/rules/font-weight-notation/README.md
@@ -21,6 +21,8 @@ Valid font-weight names are `normal`, `bold`, `bolder`, and `lighter`.
 
 This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntaxes.
 
+The [`fix` option](../../../docs/user-guide/usage/options.md#fix) can automatically fix all of the problems reported by this rule.
+
 ## Options
 
 `string`: `"numeric"|"named-where-possible"`

--- a/lib/rules/font-weight-notation/__tests__/index.js
+++ b/lib/rules/font-weight-notation/__tests__/index.js
@@ -5,6 +5,7 @@ const { messages, ruleName } = require('..');
 testRule({
 	ruleName,
 	config: ['numeric'],
+	fix: true,
 
 	accept: [
 		{
@@ -84,6 +85,10 @@ testRule({
 			description: 'ignore initial value',
 		},
 		{
+			code: 'a { font-weight: /* bold */ 400; }',
+			description: 'ignore comment',
+		},
+		{
 			code: '@font-face { font-weight: 400; }',
 		},
 		{
@@ -115,6 +120,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { font-weight: normal; }',
+			fixed: 'a { font-weight: 400; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 18,
@@ -123,6 +129,7 @@ testRule({
 		},
 		{
 			code: 'a { fOnT-wEiGhT: normal; }',
+			fixed: 'a { fOnT-wEiGhT: 400; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 18,
@@ -131,6 +138,7 @@ testRule({
 		},
 		{
 			code: 'a { FONT-WEIGHT: normal; }',
+			fixed: 'a { FONT-WEIGHT: 400; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 18,
@@ -139,6 +147,7 @@ testRule({
 		},
 		{
 			code: 'a { font-weight: nOrMaL; }',
+			fixed: 'a { font-weight: 400; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 18,
@@ -147,6 +156,7 @@ testRule({
 		},
 		{
 			code: 'a { font-weight: NORMAL; }',
+			fixed: 'a { font-weight: 400; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 18,
@@ -154,7 +164,17 @@ testRule({
 			endColumn: 24,
 		},
 		{
+			code: 'a { font-weight: /* bold */ normal; }',
+			fixed: 'a { font-weight: /* bold */ 400; }',
+			message: messages.expected('numeric'),
+			line: 1,
+			column: 29,
+			endLine: 1,
+			endColumn: 35,
+		},
+		{
 			code: 'a { font: italic small-caps bolder 16px/3 cursive; }',
+			unfixable: true,
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 29,
@@ -163,6 +183,7 @@ testRule({
 		},
 		{
 			code: 'a { font: normal 16px/3 cursive; }',
+			fixed: 'a { font: 400 16px/3 cursive; }',
 			description: 'one normal and no numbered weight',
 			message: messages.expected('numeric'),
 			line: 1,
@@ -172,6 +193,7 @@ testRule({
 		},
 		{
 			code: 'a { font: normal normal 16px/3 cursive; }',
+			fixed: 'a { font: 400 normal 16px/3 cursive; }',
 			description: 'two normals and no numbered weight',
 			message: messages.expected('numeric'),
 			line: 1,
@@ -181,6 +203,7 @@ testRule({
 		},
 		{
 			code: 'a { font: normal normal normal 16px/3 cursive; }',
+			fixed: 'a { font: 400 normal normal 16px/3 cursive; }',
 			description: 'three normals and no numbered weight',
 			message: messages.expected('numeric'),
 			line: 1,
@@ -190,14 +213,27 @@ testRule({
 		},
 		{
 			code: '@font-face { font-weight: normal bold; }',
-			message: messages.expected('numeric'),
-			line: 1,
-			column: 27,
-			endLine: 1,
-			endColumn: 33,
+			fixed: '@font-face { font-weight: 400 700; }',
+			warnings: [
+				{
+					message: messages.expected('numeric'),
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 33,
+				},
+				{
+					message: messages.expected('numeric'),
+					line: 1,
+					column: 34,
+					endLine: 1,
+					endColumn: 38,
+				},
+			],
 		},
 		{
 			code: '@font-face { font-weight: 400 bold; }',
+			fixed: '@font-face { font-weight: 400 700; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 31,
@@ -206,6 +242,7 @@ testRule({
 		},
 		{
 			code: '@font-face { font-weight: normal 700; }',
+			fixed: '@font-face { font-weight: 400 700; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 27,
@@ -214,6 +251,7 @@ testRule({
 		},
 		{
 			code: '@font-face { font-weight: /* 400 */ normal 700; }',
+			fixed: '@font-face { font-weight: /* 400 */ 400 700; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 37,
@@ -222,6 +260,7 @@ testRule({
 		},
 		{
 			code: '@font-face { font-weight: normal /* 400 */700; }',
+			fixed: '@font-face { font-weight: 400 /* 400 */700; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 27,
@@ -230,6 +269,7 @@ testRule({
 		},
 		{
 			code: '@font-face { font-weight: normal/* 400 */ 700; }',
+			fixed: '@font-face { font-weight: 400/* 400 */ 700; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 27,
@@ -242,6 +282,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['numeric', { ignore: ['relative'] }],
+	fix: true,
 
 	accept: [
 		{
@@ -267,6 +308,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { font-weight: normal; }',
+			fixed: 'a { font-weight: 400; }',
 			message: messages.expected('numeric'),
 			line: 1,
 			column: 18,
@@ -279,6 +321,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['named-where-possible'],
+	fix: true,
 
 	accept: [
 		{
@@ -357,6 +400,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { font-weight: 400; }',
+			fixed: 'a { font-weight: normal; }',
 			message: messages.expected('named'),
 			line: 1,
 			column: 18,
@@ -365,6 +409,7 @@ testRule({
 		},
 		{
 			code: 'a { font-weight: boldd; }',
+			unfixable: true,
 			description: 'invalid font-weight value',
 			message: messages.invalidNamed('boldd'),
 			line: 1,
@@ -374,6 +419,7 @@ testRule({
 		},
 		{
 			code: 'a { font: italic small-caps 700 16px/3 cursive; }',
+			fixed: 'a { font: italic small-caps bold 16px/3 cursive; }',
 			message: messages.expected('named'),
 			line: 1,
 			column: 29,
@@ -382,6 +428,7 @@ testRule({
 		},
 		{
 			code: 'a { font: normal 400 normal 16px serif; }',
+			fixed: 'a { font: normal normal normal 16px serif; }',
 			description: 'two normals and a numbered weight',
 			message: messages.expected('named'),
 			line: 1,
@@ -391,6 +438,7 @@ testRule({
 		},
 		{
 			code: 'a { font: 400 normal 16px serif; }',
+			fixed: 'a { font: normal normal 16px serif; }',
 			description: 'one normal and a numbered weight',
 			message: messages.expected('named'),
 			line: 1,
@@ -400,6 +448,7 @@ testRule({
 		},
 		{
 			code: 'a { font: 400 16px serif; }',
+			fixed: 'a { font: normal 16px serif; }',
 			description: 'no normals and a numbered weight',
 			message: messages.expected('named'),
 			line: 1,

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -9,14 +9,13 @@ const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const isVariable = require('../../utils/isVariable');
 const {
 	fontWeightKeywords,
-	fontWeightAbsoluteKeywords,
+	fontWeightNonNumericKeywords,
 	fontWeightRelativeKeywords,
 } = require('../../reference/keywords');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
-const uniteSets = require('../../utils/uniteSets.js');
 const validateOptions = require('../../utils/validateOptions');
 
 const ruleName = 'font-weight-notation';
@@ -32,11 +31,6 @@ const meta = {
 };
 
 const NORMAL_KEYWORD = 'normal';
-const VALID_FONT_WEIGHT_KEYWORDS = uniteSets(
-	[NORMAL_KEYWORD],
-	fontWeightAbsoluteKeywords,
-	fontWeightRelativeKeywords,
-);
 
 const KEYWORD_TO_NUMERIC = new Map([
 	['normal', '400'],
@@ -129,7 +123,7 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			if (primary === 'numeric') {
-				if (!isNumbery(lowerWeightValue) && VALID_FONT_WEIGHT_KEYWORDS.has(lowerWeightValue)) {
+				if (!isNumbery(lowerWeightValue) && fontWeightNonNumericKeywords.has(lowerWeightValue)) {
 					if (context.fix) {
 						const numericValue = KEYWORD_TO_NUMERIC.get(lowerWeightValue);
 

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -3,15 +3,21 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isNumbery = require('../../utils/isNumbery');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const isVariable = require('../../utils/isVariable');
-const { fontWeightKeywords, fontWeightRelativeKeywords } = require('../../reference/keywords');
+const {
+	fontWeightKeywords,
+	fontWeightAbsoluteKeywords,
+	fontWeightRelativeKeywords,
+} = require('../../reference/keywords');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
+const setDeclarationValue = require('../../utils/setDeclarationValue');
+const uniteSets = require('../../utils/uniteSets.js');
 const validateOptions = require('../../utils/validateOptions');
-const { isAtRule } = require('../../utils/typeGuards');
 
 const ruleName = 'font-weight-notation';
 
@@ -22,15 +28,27 @@ const messages = ruleMessages(ruleName, {
 
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/list/font-weight-notation',
+	fixable: true,
 };
 
-const INHERIT_KEYWORD = 'inherit';
-const INITIAL_KEYWORD = 'initial';
 const NORMAL_KEYWORD = 'normal';
-const WEIGHTS_WITH_KEYWORD_EQUIVALENTS = new Set(['400', '700']);
+const VALID_FONT_WEIGHT_KEYWORDS = uniteSets(
+	[NORMAL_KEYWORD],
+	fontWeightAbsoluteKeywords,
+	fontWeightRelativeKeywords,
+);
 
-/** @type {import('stylelint').Rule} */
-const rule = (primary, secondaryOptions) => {
+const KEYWORD_TO_NUMERIC = new Map([
+	['normal', '400'],
+	['bold', '700'],
+]);
+const NUMERIC_TO_KEYWORD = new Map([
+	['400', 'normal'],
+	['700', 'bold'],
+]);
+
+/** @type {import('stylelint').Rule<'numeric' | 'named-where-possible'>} */
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -52,49 +70,50 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		root.walkDecls(/^font(-weight)?$/i, (decl) => {
-			const prop = decl.prop.toLowerCase();
+		const ignoreRelative = optionsMatches(secondaryOptions, 'ignore', 'relative');
 
-			if (prop === 'font-weight') {
-				checkWeight(decl, decl.value);
-			} else if (prop === 'font') {
-				checkFont(decl);
+		root.walkDecls(/^font(-weight)?$/i, (decl) => {
+			const isFontShorthandProp = decl.prop.toLowerCase() === 'font';
+
+			const parsedValue = valueParser(getDeclarationValue(decl));
+			const valueNodes = parsedValue.nodes;
+
+			const hasNumericFontWeight = valueNodes.some((node, index, nodes) => {
+				return isNumbery(node.value) && !isDivNode(nodes[index - 1]);
+			});
+
+			for (const [index, valueNode] of valueNodes.entries()) {
+				if (!isPossibleFontWeightNode(valueNode, index, valueNodes)) continue;
+
+				const { value } = valueNode;
+
+				if (isFontShorthandProp) {
+					if (value.toLowerCase() === NORMAL_KEYWORD && hasNumericFontWeight) {
+						continue; // Not `normal` for font-weight
+					}
+
+					if (checkWeight(decl, valueNode)) {
+						break; // Stop traverse if font-weight is processed
+					}
+				}
+
+				checkWeight(decl, valueNode);
+			}
+
+			if (context.fix) {
+				// Autofix after the loop ends can prevent value nodes from changing their positions during the loop.
+				setDeclarationValue(decl, parsedValue.toString());
 			}
 		});
 
 		/**
 		 * @param {import('postcss').Declaration} decl
+		 * @param {import('postcss-value-parser').Node} weightValueNode
+		 * @returns {true | undefined}
 		 */
-		function checkFont(decl) {
-			const valueNodes = findFontWeights(decl.value);
+		function checkWeight(decl, weightValueNode) {
+			const weightValue = weightValueNode.value;
 
-			// We do not need to more carefully distinguish font-weight
-			// numbers from unitless line-heights because line-heights in
-			// `font` values need to be part of a font-size/line-height pair
-			const hasNumericFontWeight = valueNodes.some(({ value }) => isNumbery(value));
-
-			for (const valueNode of valueNodes) {
-				const value = valueNode.value;
-				const lowerValue = value.toLowerCase();
-
-				if (
-					(lowerValue === NORMAL_KEYWORD && !hasNumericFontWeight) ||
-					isNumbery(value) ||
-					(lowerValue !== NORMAL_KEYWORD && fontWeightKeywords.has(lowerValue))
-				) {
-					checkWeight(decl, value, valueNode);
-
-					return;
-				}
-			}
-		}
-
-		/**
-		 * @param {import('postcss').Declaration} decl
-		 * @param {string} weightValue
-		 * @param {import('postcss-value-parser').Node} [weightValueNode]
-		 */
-		function checkWeight(decl, weightValue, weightValueNode) {
 			if (!isStandardSyntaxValue(weightValue)) {
 				return;
 			}
@@ -103,64 +122,65 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			if (includesOnlyFunction(weightValue)) {
-				return;
-			}
-
 			const lowerWeightValue = weightValue.toLowerCase();
 
-			if (lowerWeightValue === INHERIT_KEYWORD || lowerWeightValue === INITIAL_KEYWORD) {
-				return;
-			}
-
-			if (
-				optionsMatches(secondaryOptions, 'ignore', 'relative') &&
-				fontWeightRelativeKeywords.has(lowerWeightValue)
-			) {
+			if (ignoreRelative && fontWeightRelativeKeywords.has(lowerWeightValue)) {
 				return;
 			}
 
 			if (primary === 'numeric') {
-				const parent = decl.parent;
+				if (!isNumbery(lowerWeightValue) && VALID_FONT_WEIGHT_KEYWORDS.has(lowerWeightValue)) {
+					if (context.fix) {
+						const numericValue = KEYWORD_TO_NUMERIC.get(lowerWeightValue);
 
-				if (parent && isAtRule(parent) && parent.name.toLowerCase() === 'font-face') {
-					// @font-face allows multiple values.
-					for (const valueNode of findFontWeights(weightValue)) {
-						if (!isNumbery(valueNode.value)) {
-							return complain(messages.expected('numeric'), valueNode.value, valueNode);
+						if (numericValue) {
+							weightValueNode.value = numericValue;
+
+							return true;
 						}
 					}
 
-					return;
-				}
+					complain(messages.expected('numeric'), weightValueNode);
 
-				if (!isNumbery(weightValue)) {
-					return complain(messages.expected('numeric'), weightValue, weightValueNode);
+					return true;
 				}
 			}
 
 			if (primary === 'named-where-possible') {
-				if (isNumbery(weightValue)) {
-					if (WEIGHTS_WITH_KEYWORD_EQUIVALENTS.has(weightValue)) {
-						complain(messages.expected('named'), weightValue, weightValueNode);
+				if (isNumbery(lowerWeightValue) && NUMERIC_TO_KEYWORD.has(lowerWeightValue)) {
+					if (context.fix) {
+						const keyword = NUMERIC_TO_KEYWORD.get(lowerWeightValue);
+
+						if (keyword) {
+							weightValueNode.value = keyword;
+						}
+
+						return true;
 					}
 
-					return;
+					complain(messages.expected('named'), weightValueNode);
+
+					return true;
 				}
 
-				if (!fontWeightKeywords.has(lowerWeightValue) && lowerWeightValue !== NORMAL_KEYWORD) {
-					return complain(messages.invalidNamed(weightValue), weightValue, weightValueNode);
+				if (
+					decl.prop.toLowerCase() === 'font-weight' &&
+					!fontWeightKeywords.has(lowerWeightValue) &&
+					lowerWeightValue !== NORMAL_KEYWORD
+				) {
+					complain(messages.invalidNamed(weightValue), weightValueNode);
+
+					return true;
 				}
 			}
 
 			/**
 			 * @param {string} message
-			 * @param {string} value
-			 * @param {import('postcss-value-parser').Node | undefined} valueNode
+			 * @param {import('postcss-value-parser').Node} valueNode
 			 */
-			function complain(message, value, valueNode) {
-				const index = declarationValueIndex(decl) + (valueNode ? valueNode.sourceIndex : 0);
-				const endIndex = index + value.length;
+			function complain(message, valueNode) {
+				const index = declarationValueIndex(decl) + valueNode.sourceIndex;
+				const endIndex = index + valueNode.value.length;
 
 				report({
 					ruleName,
@@ -176,33 +196,28 @@ const rule = (primary, secondaryOptions) => {
 };
 
 /**
- * @param {string} value
- * @returns {import('postcss-value-parser').Node[]}
+ * @param {import('postcss-value-parser').Node | undefined} node
+ * @returns {boolean}
  */
-function findFontWeights(value) {
-	return valueParser(value).nodes.filter((node, index, nodes) => {
-		if (node.type !== 'word') return false;
-
-		// Exclude `<font-size>/<line-height>` format like `16px/3`.
-		const prevNode = nodes[index - 1];
-		const nextNode = nodes[index + 1];
-
-		if (prevNode && prevNode.type === 'div') return false;
-
-		if (nextNode && nextNode.type === 'div') return false;
-
-		return true;
-	});
+function isDivNode(node) {
+	return node !== undefined && node.type === 'div';
 }
 
 /**
- * @param {string} value
+ * @param {import('postcss-value-parser').Node} node
+ * @param {number} index
+ * @param {import('postcss-value-parser').Node[]} nodes
  * @returns {boolean}
  */
-function includesOnlyFunction(value) {
-	return valueParser(value).nodes.every(({ type }) => {
-		return type === 'function' || type === 'comment' || type === 'space';
-	});
+function isPossibleFontWeightNode(node, index, nodes) {
+	if (node.type !== 'word') return false;
+
+	// Exclude `<font-size>/<line-height>` format like `16px/3`.
+	if (isDivNode(nodes[index - 1])) return false;
+
+	if (isDivNode(nodes[index + 1])) return false;
+
+	return true;
 }
 
 rule.ruleName = ruleName;

--- a/lib/utils/__tests__/isNumbery.test.js
+++ b/lib/utils/__tests__/isNumbery.test.js
@@ -2,12 +2,19 @@
 
 const isNumbery = require('../isNumbery');
 
-it('isNumbery', () => {
-	expect(isNumbery('1')).toBeTruthy();
-	expect(isNumbery('21 ')).toBeTruthy();
-	expect(isNumbery(' 212')).toBeTruthy();
-	expect(isNumbery('232 ')).toBeTruthy();
-	expect(isNumbery('')).toBeFalsy();
-	expect(isNumbery(' ')).toBeFalsy();
-	expect(isNumbery('a')).toBeFalsy();
+test('isNumbery', () => {
+	expect(isNumbery('1')).toBe(true);
+	expect(isNumbery('21 ')).toBe(true);
+	expect(isNumbery(' 212')).toBe(true);
+	expect(isNumbery('232 ')).toBe(true);
+	expect(isNumbery('')).toBe(false);
+	expect(isNumbery(' ')).toBe(false);
+	expect(isNumbery('a')).toBe(false);
+	expect(isNumbery(0)).toBe(true);
+	expect(isNumbery(1)).toBe(true);
+	expect(isNumbery(-1)).toBe(true);
+	expect(isNumbery(0.1)).toBe(true);
+	expect(isNumbery(-0.1)).toBe(true);
+	expect(isNumbery(NaN)).toBe(false);
+	expect(isNumbery('NaN')).toBe(false);
 });

--- a/lib/utils/isNumbery.js
+++ b/lib/utils/isNumbery.js
@@ -6,8 +6,6 @@
  *
  * @param {string | number} value
  */
-module.exports = function (value) {
-	/* eslint-disable eqeqeq */
-	return value.toString().trim().length !== 0 && Number(value) == value;
-	/* eslint-enable eqeqeq */
+module.exports = function isNumbery(value) {
+	return value.toString().trim().length !== 0 && Number(value) == value; // eslint-disable-line eqeqeq
 };

--- a/system-tests/002/__snapshots__/fs.test.js.snap
+++ b/system-tests/002/__snapshots__/fs.test.js.snap
@@ -106,6 +106,7 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/font-family-name-quotes",
     },
     "font-weight-notation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/font-weight-notation",
     },
     "function-url-no-scheme-relative": Object {

--- a/system-tests/002/__snapshots__/no-fs.test.js.snap
+++ b/system-tests/002/__snapshots__/no-fs.test.js.snap
@@ -106,6 +106,7 @@ Object {
       "url": "https://stylelint.io/user-guide/rules/list/font-family-name-quotes",
     },
     "font-weight-notation": Object {
+      "fixable": true,
       "url": "https://stylelint.io/user-guide/rules/list/font-weight-notation",
     },
     "function-url-no-scheme-relative": Object {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #3158

> Is there anything in the PR that needs further explanation?

I've refactored the rule implementation much to support autofix:

- check each value node by the `postcss-value-parser` module
- unify some logic between the `font` and `font-weight` properties (though a few conditional branches remain)
- remove specific logic for the `@font-face` at-rule

Here is the code outline after the refactoring:

```js
root.walkDecls(/^font(-weight)?$/i, (decl) => {
  const parsedValue = valueParser(getDeclarationValue(decl));

  for (const [index, valueNode] of valueNodes.entries()) {
    // checking each value node...
  }
});
```