### PR TITLE
Fix `selector-pseudo-element-no-unknown` false positives for `::highlight` pseudo-element

### DIFF
--- a/.changeset/nasty-tomatoes-confess.md
+++ b/.changeset/nasty-tomatoes-confess.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-element-no-unknown` false positives for `::highlight` pseudo-element

--- a/lib/reference/selectors.js
+++ b/lib/reference/selectors.js
@@ -169,6 +169,7 @@ const pseudoElements = uniteSets(
 		'cue',
 		'file-selector-button',
 		'grammar-error',
+		'highlight',
 		'marker',
 		'placeholder',
 		'selection',


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #6366.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
