### PR TITLE
Fix lint settings to honor `.mjs` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jest": "jest",
     "lint": "npm-run-all --parallel --continue-on-error lint:*",
     "lint:formatting": "prettier . --check --cache",
-    "lint:js": "eslint . --cache --max-warnings=0",
+    "lint:js": "eslint . --cache --max-warnings=0 --ext .js,.mjs",
     "lint:md": "remark . --quiet --frail",
     "lint:types": "tsc",
     "prepare": "husky install && patch-package",
@@ -52,8 +52,8 @@
     "watch": "jest --watch"
   },
   "lint-staged": {
-    "*.js": "eslint --cache --fix",
-    "*.{js,json,md,ts,yml}": "prettier --write"
+    "*.{js,mjs}": "eslint --cache --fix",
+    "*.{js,json,md,mjs,ts,yml}": "prettier --write"
   },
   "prettier": "@stylelint/prettier-config",
   "eslintConfig": {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

There is a file with `.mjs` extension: [`scripts/benchmark-rule.mjs`](https://github.com/stylelint/stylelint/blob/2d3a3fb37a76e2a34f0732a2239d1d350ceffb7a/scripts/benchmark-rule.mjs)
