### PR TITLE
Automate GitHub Release

### DIFF
--- a/.github/workflows/preparing-github-release.yml
+++ b/.github/workflows/preparing-github-release.yml
@@ -1,0 +1,36 @@
+name: Preparing GitHub Release
+
+on:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          cache: npm
+
+      - name: Install latest npm
+        run: npm install --global npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Extract changelog entries
+        run: npm run changelog-to-github-release --silent > /tmp/changes.md
+
+      - name: Create draft release
+        run: gh release create "${GITHUB_REF_NAME}" --draft --notes-file /tmp/changes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/maintainer-guide/releases.md
+++ b/docs/maintainer-guide/releases.md
@@ -13,9 +13,8 @@
    3. Open a terminal window in the `stylelint` repository.
    4. Run `npm run release`.
    5. Select the version from the [`np`](https://github.com/sindresorhus/np) prompt that matches the one in the changelog.
-   6. Copy and paste the latest changelog entries from [changelog](../../CHANGELOG.md) into the GitHub release page when it opens.
-   7. Confirm the publishing of the package to [www.npmjs.com/package/stylelint](https://www.npmjs.com/package/stylelint).
-   8. Confirm the creation of the release at [github.com/stylelint/stylelint/releases](https://github.com/stylelint/stylelint/releases).
+   6. Confirm the publishing of the package to [www.npmjs.com/package/stylelint](https://www.npmjs.com/package/stylelint).
+   7. Confirm the creation of the release at [github.com/stylelint/stylelint/releases](https://github.com/stylelint/stylelint/releases).
 4. If necessary, release `stylelint-config-*`:
    1. Change to the `stylelint-config-*` repository.
    2. Repeat steps 5 to 8 above for that repository.

--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "lint:md": "remark . --quiet --frail",
     "lint:types": "tsc",
     "prepare": "husky install && patch-package",
-    "release": "np",
+    "release": "np --no-release-draft",
     "pretest": "npm run lint",
     "test": "jest --coverage",
     "version": "changeset version",
     "postversion": "git restore package.json",
-    "watch": "jest --watch"
+    "watch": "jest --watch",
+    "changelog-to-github-release": "remark --quiet --use ./scripts/remark-changelog-to-github-release.mjs CHANGELOG.md"
   },
   "lint-staged": {
     "*.{js,mjs}": "eslint --cache --fix",

--- a/scripts/remark-changelog-to-github-release.mjs
+++ b/scripts/remark-changelog-to-github-release.mjs
@@ -1,0 +1,26 @@
+// eslint-disable-next-line node/no-extraneous-import -- We don't want to manage extra dependencies.
+import { visit } from 'unist-util-visit';
+
+/**
+ * This plugin aims to make it easier to prepare a GitHub release.
+ *
+ * @see https://github.com/stylelint/stylelint/issues/6343#issuecomment-1250353973
+ *
+ * @type {import('unified').Plugin}
+ */
+export default function remarkChangelogToGitHubRelease() {
+	return (tree) => {
+		const firstList = tree.children.find((node) => node.type === 'list');
+
+		// Rewrite a link to a PR notation (#123) or a user mention (@username).
+		visit(firstList, { type: 'link' }, (node) => {
+			const text = node.children[0];
+
+			node.type = 'text';
+			node.value = text.value;
+		});
+
+		tree.children.length = 0; // clear
+		tree.children.push(firstList);
+	};
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/issues/6343#issuecomment-1250353973
Ref: #6253

> Is there anything in the PR that needs further explanation?

I believe this PR can omit the following step of releasing:

https://github.com/stylelint/stylelint/blob/eee9deb35190f46c5f964769d521fef5d7d1d7a8/docs/maintainer-guide/releases.md?plain=1#L16

This is not just a copy-and-paste of `CHANGELOG.md`. Instead, it rewrites user links to user mentions (e.g. `@ybiquitous`) so that the "Contributors" section should be displayed on a release page [like this](https://github.com/postcss/postcss/releases/tag/8.4.14).

But, one downside. This PR increase complexity: a remark script and a GitHub action. It may be too much for this automation. I'll close the PR if anyone expresses a concern.
