### PR TITLE
Fix `unit-no-unknown` false positives for font-relative length units

### DIFF
--- a/.changeset/old-moles-sort.md
+++ b/.changeset/old-moles-sort.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `unit-no-unknown` false positives for font-relative length units

--- a/lib/reference/units.js
+++ b/lib/reference/units.js
@@ -3,13 +3,19 @@
 const uniteSets = require('../utils/uniteSets.js');
 
 const lengthUnits = new Set([
-	// Relative length units
+	// Font-relative length units
+	'cap',
+	'ch',
 	'em',
 	'ex',
-	'ch',
-	'rem',
-	'rlh',
+	'ic',
 	'lh',
+	'rcap',
+	'rch',
+	'rem',
+	'rex',
+	'ric',
+	'rlh',
 	// Viewport-percentage lengths
 	'dvh',
 	'dvmax',

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -239,6 +239,9 @@ testRule({
 			code: 'a { image-resolution: 1x; }',
 			description: 'ignore `x` unit in image-resolution',
 		},
+		{
+			code: 'a { width: 8ic; }',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6373

> Is there anything in the PR that needs further explanation?

I've updated the unit list based on the ["CSS Values and Units Module Level 4" spec](https://w3c.github.io/csswg-drafts/css-values-4/#font-relative-lengths).
