### PR TITLE
Fix `property-no-vendor-prefix` example in doc

### DIFF
--- a/lib/rules/property-no-vendor-prefix/README.md
+++ b/lib/rules/property-no-vendor-prefix/README.md
@@ -38,8 +38,7 @@ a { transform: scale(1); }
 
 <!-- prettier-ignore -->
 ```css
-a {
-columns: 2; }
+a { columns: 2; }
 ```
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
