### PR TITLE
Fix `printf`-like formatting for custom messages

### DIFF
--- a/.changeset/strong-lions-listen.md
+++ b/.changeset/strong-lions-listen.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `printf`-like formatting for custom messages

--- a/lib/utils/__tests__/report.test.js
+++ b/lib/utils/__tests__/report.test.js
@@ -260,7 +260,7 @@ test('with custom message', () => {
 			},
 		},
 		message: 'bar',
-		messageArgs: ['str', true, 10, /regex/],
+		messageArgs: ['str', true, 10, /regex/, 'should_be_ignored'],
 		node: {
 			rangeBy: defaultRangeBy,
 		},

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const util = require('util');
-
 /**
  * Report a problem.
  *
@@ -124,8 +122,19 @@ function buildWarningMessage(message, messageArgs) {
 	const args = messageArgs || [];
 
 	if (typeof message === 'string') {
-		return util.format(message, ...args);
+		return printfLike(message, ...args);
 	}
 
 	return message(...args);
+}
+
+/**
+ * @param {string} format
+ * @param {Array<unknown>} args
+ * @returns {string}
+ */
+function printfLike(format, ...args) {
+	return args.reduce((/** @type {string} */ result, arg) => {
+		return result.replace(/%[ds]/, String(arg));
+	}, format);
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #6312

> Is there anything in the PR that needs further explanation?

The Node.js [`util.format()`](https://nodejs.org/api/util.html#utilformatformat-args) API can concatenate extra arguments to the result string. This behavior is not suitable for custom messages. So, this commit replace `util.format()` with our implementation.

> If there are more arguments passed to the `util.format()` method than the number of specifiers, the extra arguments are concatenated to the returned string, separated by spaces:
>
> ```js
> util.format('%s:%s', 'foo', 'bar', 'baz');
> // Returns: 'foo:bar baz'
> ```
