### PR TITLE
Fix TS compilation error due to needless `file-entry-cache` import

### DIFF
--- a/.changeset/fix-unused-type-import.md
+++ b/.changeset/fix-unused-type-import.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: remove unused type import in `index.d.ts` to avoid TS compilation error for plugin authors

--- a/.changeset/fix-unused-type-import.md
+++ b/.changeset/fix-unused-type-import.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: remove unused type import in `index.d.ts` to avoid TS compilation error for plugin authors
+Fixed: TS compilation error due to needless `file-entry-cache` import

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -2,7 +2,6 @@ declare module 'stylelint' {
 	import type * as PostCSS from 'postcss';
 	import type { GlobbyOptions } from 'globby';
 	import type { cosmiconfig } from 'cosmiconfig';
-	import type * as fileEntryCache from 'file-entry-cache';
 
 	namespace stylelint {
 		export type Severity = 'warning' | 'error';


### PR DESCRIPTION
Fixes https://github.com/stylelint/stylelint/issues/6392

This type import was added in https://github.com/stylelint/stylelint/pull/6356, but during code review that PR was refactored to obviate the `file-entry-cache` types in the public API. The import was never removed. Keeping the import here results in [compilation errors](https://app.circleci.com/pipelines/github/palantir/blueprint/3156/workflows/9eda97ec-3a2f-4aa6-aa6c-89d5b65b8491/jobs/61694) for downstream consumers.

cc @jeddy3 @kimulaco