### PR TITLE
Document using stylelint inside npm-scripts

### DIFF
--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -27,6 +27,8 @@ npm install --save-dev stylelint stylelint-config-standard
 npx stylelint "**/*.css"
 ```
 
+_You should include quotation marks around file globs._
+
 If you use a pretty printer alongside Stylelint, you should turn off any conflicting rules. For example, you can use [Prettier's shared config](https://www.npmjs.com/package/stylelint-config-prettier) to do that:
 
 ```shell
@@ -66,6 +68,8 @@ npm install --save-dev stylelint stylelint-config-standard-scss
 ```shell
 npx stylelint "**/*.scss"
 ```
+
+_You should include quotation marks around file globs._
 
 This config includes the [postcss-scss syntax](https://www.npmjs.com/package/postcss-scss), configures the [built-in rules](../user-guide/rules.md) for SCSS, and includes the [stylelint-scss plugin](https://www.npmjs.com/package/stylelint-scss) (a collection of rules specific to SCSS).
 

--- a/docs/user-guide/usage/cli.md
+++ b/docs/user-guide/usage/cli.md
@@ -6,6 +6,18 @@ You can use Stylelint on the command line. For example:
 npx stylelint "**/*.css"
 ```
 
+_You should include quotation marks around file globs._
+
+If you are using [npm scripts](https://docs.npmjs.com/cli/v8/using-npm/scripts), you'll need to escape the quotes:
+
+```json
+{
+  "scripts": {
+    "lint": "stylelint \"**/*.css\""
+  }
+}
+```
+
 Use `npx stylelint --help` to print the CLI documentation.
 
 ## Options
@@ -112,7 +124,7 @@ Show the currently installed version of Stylelint.
 
 The CLI expects input as either a [file glob](https://github.com/sindresorhus/globby) or `process.stdin`. It outputs formatted results into `process.stdout`.
 
-_Be sure to include quotation marks around file globs._
+_You should include quotation marks around file globs._
 
 ### Example A - recursive
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6395

> Is there anything in the PR that needs further explanation?

As an aside, GitHub copilot wrote the example after I typed "if you are using npm scripts...". Was kinda cool to see 😆 
