### PR TITLE
Fix spelling mistakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1005,7 +1005,7 @@ Changes:
 - Added: `stylelint.utils.checkAgainstRule` for checking CSS against a standard Stylelint rule _within your own rule_ ([#2173](https://github.com/stylelint/stylelint/pull/2173)).
 - Added: `allow-empty-input` flag to CLI ([#2117](https://github.com/stylelint/stylelint/pull/2117)).
 - Added: `except: ["after-rule"]` option to `rule-nested-empty-line-before` ([#2188](https://github.com/stylelint/stylelint/pull/2188)).
-- Fixed: regression causing `--stdin-filename` in CLI and `codeFilename` in Node.js API to error if a non-existent filename is provided ([#2128](https://github.com/stylelint/stylelint/pull/2128)).
+- Fixed: regression causing `--stdin-filename` in CLI and `codeFilename` in Node.js API to error if a nonexistent filename is provided ([#2128](https://github.com/stylelint/stylelint/pull/2128)).
 - Fixed: a boolean CLI flag (e.g. `--quiet`) placed before an input glob no longer causes the input to be ignored ([#2186](https://github.com/stylelint/stylelint/pull/2186)).
 - Fixed: the `node_modules` and `bower_components` directories are correctly ignored by default when Stylelint is used as a PostCSS plugin ([#2171](https://github.com/stylelint/stylelint/pull/2171)).
 - Fixed: bug where some Node.js errors in special cases did not cause the CLI to exit with a non-zero code ([#2140](https://github.com/stylelint/stylelint/pull/2140))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1140,7 +1140,7 @@ Changes:
 
 ## 7.0.0
 
-- Removed: `--extract` and `extractSyleTagsFromHtml` options. Instead, [build](/docs/developer-guide/processors.md) and [use](/docs/user-guide/configure.md#processors) processors.
+- Removed: `--extract` and `extractStyleTagsFromHtml` options. Instead, [build](/docs/developer-guide/processors.md) and [use](/docs/user-guide/configure.md#processors) processors.
 - Removed: support for plugin rule names that aren't namespaced, i.e. only `your-namespace/your-rule-name` rule names are supported. (If your plugin provides only a single rule or you can't think of a good namespace, you can simply use `plugin/my-rule`.)
 - Removed: `--verbose` CLI flag. Use `--formatter verbose` instead.
 - Removed: NodeJS `0.12.x` support. `4.2.1 LTS` or greater is now required.

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -78,7 +78,7 @@ Disallow missing things with these `no-missing` rules.
 
 Disallow non-standard things with these `no-nonstandard` rules.
 
-- [`function-linear-gradient-no-nonstandard-direction`](../../lib/rules/function-linear-gradient-no-nonstandard-direction/README.md): Disallow non-standard direction values for linerar gradient functions.
+- [`function-linear-gradient-no-nonstandard-direction`](../../lib/rules/function-linear-gradient-no-nonstandard-direction/README.md): Disallow non-standard direction values for linear gradient functions.
 
 ### Overrides
 

--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -98,7 +98,7 @@ Store the results of processed files so that Stylelint only operates on the chan
 
 Enabling this option can dramatically improve Stylelint's speed because only changed files are linted.
 
-_If you run Stylelint with `cache` and then run Stylelint without `cache`, Stylelint deletes the `.stylelintcache` because we have to assume that that second command invalidated `.stylelintcache`._
+_If you run Stylelint with `cache` and then run Stylelint without `cache`, Stylelint deletes the `.stylelintcache` because we have to assume that the second command invalidated `.stylelintcache`._
 
 ## `cacheLocation`
 

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -143,8 +143,8 @@ it('standalone without input css and file(s) should throw error', async () => {
 	await expect(() => standalone({ config: configBlockNoEmpty })).rejects.toThrow(expectedError);
 });
 
-it('standalone with non-existent-file throws an error', async () => {
-	const files = `${fixturesPath}/non-existent-file.css`;
+it('standalone with nonexistent-file throws an error', async () => {
+	const files = `${fixturesPath}/nonexistent-file.css`;
 	const expectedError = new NoFilesFoundError(files);
 
 	await expect(
@@ -155,9 +155,9 @@ it('standalone with non-existent-file throws an error', async () => {
 	).rejects.toThrow(expectedError);
 });
 
-it('standalone with non-existent-file and allowEmptyInput enabled quietly exits', async () => {
+it('standalone with nonexistent-file and allowEmptyInput enabled quietly exits', async () => {
 	const { results, errored, output } = await standalone({
-		files: `${fixturesPath}/non-existent-file.css`,
+		files: `${fixturesPath}/nonexistent-file.css`,
 		config: configBlockNoEmpty,
 		allowEmptyInput: true,
 	});

--- a/lib/formatters/__tests__/jsonFormatter.test.js
+++ b/lib/formatters/__tests__/jsonFormatter.test.js
@@ -24,7 +24,7 @@ describe('jsonFormatter', () => {
 		const results = [
 			{
 				...resultClean,
-				_privateVaribale: [],
+				_privateVariable: [],
 			},
 		];
 

--- a/lib/resolveConfig.js
+++ b/lib/resolveConfig.js
@@ -4,7 +4,7 @@ const createStylelint = require('./createStylelint');
 const path = require('path');
 
 /**
- * Resolves the effective configuation for a given file. Resolves to `undefined`
+ * Resolves the effective configuration for a given file. Resolves to `undefined`
  * if no config is found.
  * @param {string} filePath - The path to the file to get the config for.
  * @param {Pick<

--- a/lib/rules/at-rule-no-unknown/__tests__/index.js
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.js
@@ -203,7 +203,7 @@ testRule({
         @my-variable: #f7f8f9;
         span { background-color: @my-variable; }
       `,
-			description: 'ingore Less variable',
+			description: 'ignore Less variable',
 		},
 	],
 });

--- a/lib/rules/color-hex-case/__tests__/index.js
+++ b/lib/rules/color-hex-case/__tests__/index.js
@@ -15,7 +15,7 @@ const sharedTests = {
 			description: 'ignore sass-like interpolation',
 		},
 		{
-			code: 'a { stroke: url(#gradiantA) }',
+			code: 'a { stroke: url(#gradientA) }',
 			description: 'SVG reference interaction',
 		},
 	],

--- a/lib/rules/comment-empty-line-before/__tests__/index.js
+++ b/lib/rules/comment-empty-line-before/__tests__/index.js
@@ -273,7 +273,7 @@ testRule({
 		},
 		{
 			code: '// first line\n// second line\na { color: pink; }',
-			description: 'subsequent single-line comments ingnored',
+			description: 'subsequent single-line comments ignored',
 		},
 	],
 });
@@ -305,7 +305,7 @@ testRule({
 		},
 		{
 			code: '// first line\n// second line\na { color: pink; }',
-			description: 'subsequent single-line comments ingnored',
+			description: 'subsequent single-line comments ignored',
 		},
 	],
 });

--- a/lib/rules/declaration-block-single-line-max-declarations/__tests__/index.js
+++ b/lib/rules/declaration-block-single-line-max-declarations/__tests__/index.js
@@ -48,7 +48,7 @@ testRule({
 		},
 		{
 			code: 'a,\nb\n{ color: pink; top: 3px; }',
-			description: 'rule-line rule with single-line delclaration block with 2 declarations',
+			description: 'rule-line rule with single-line declaration block with 2 declarations',
 			message: messages.expected(1),
 			line: 3,
 			column: 1,

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
@@ -1,6 +1,6 @@
 # function-linear-gradient-no-nonstandard-direction
 
-Disallow non-standard direction values for linerar gradient functions.
+Disallow non-standard direction values for linear gradient functions.
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -95,7 +95,7 @@ const rule = (primary, secondaryOptions) => {
 		};
 
 		/**
-		 * Calculate the the specificity of the most specific direct child.
+		 * Calculate the specificity of the most specific direct child.
 		 *
 		 * @param {import('postcss-selector-parser').Container<unknown>} node
 		 * @returns {Specificity}

--- a/lib/rules/selector-max-specificity/index.js
+++ b/lib/rules/selector-max-specificity/index.js
@@ -37,7 +37,7 @@ const meta = {
 const zeroSpecificity = () => ({ a: 0, b: 0, c: 0 });
 
 /**
- * Calculate the sum of given specificiies.
+ * Calculate the sum of given specificities.
  *
  * @param {Specificity[]} specificities
  * @returns {Specificity}

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -109,7 +109,7 @@ testRule({
 		{
 			code: 'a:defined { }',
 			description:
-				'represents any element that has been defined; includes any standard element built in to the browser, and custom elements that have been successfully defined (i.e. with the CustomElementRegistry.define() method).',
+				'represents any element that has been defined; includes any standard element built into the browser, and custom elements that have been successfully defined (i.e. with the CustomElementRegistry.define() method).',
 		},
 		{
 			code: '*:is(*) { }',

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -225,7 +225,7 @@ testRule({
 		},
 		{
 			code: "a { background-image: -webkit-image-set('img-1x.jpg' 1x, 'img-2x.jpg' 2x) }",
-			description: 'ignore `x` unit in vendor-prefixd image-set',
+			description: 'ignore `x` unit in vendor-prefixed image-set',
 		},
 		{
 			code: '@media (resolution: 2x) {}',

--- a/lib/utils/__tests__/findAnimationName.test.js
+++ b/lib/utils/__tests__/findAnimationName.test.js
@@ -19,7 +19,7 @@ it('findAnimationName', () => {
 			value: 'INHERIT',
 		},
 	]);
-	expect(findAnimationName('3s @varialbe')).toEqual([]);
+	expect(findAnimationName('3s @variable')).toEqual([]);
 	expect(findAnimationName('3s #{$variable}')).toEqual([]);
 	expect(findAnimationName('none')).toEqual([]);
 	expect(findAnimationName('slidein')).toEqual([

--- a/lib/utils/__tests__/functionArgumentsSearch.test.js
+++ b/lib/utils/__tests__/functionArgumentsSearch.test.js
@@ -11,7 +11,7 @@ it('passes function arguments to callback', () => {
 	});
 });
 
-it('passes function arguments to callback when a case with mutiple expressions', () => {
+it('passes function arguments to callback when a case with multiple expressions', () => {
 	expect.assertions(2);
 
 	functionArgumentsSearch('4px 5px calc(1px + 3px)', 'calc', (expression, expressionIndex) => {

--- a/lib/utils/isOnlyWhitespace.js
+++ b/lib/utils/isOnlyWhitespace.js
@@ -3,7 +3,7 @@
 const isWhitespace = require('./isWhitespace');
 
 /**
- * Returns a Boolean indicating whether the the input string is only whitespace.
+ * Returns a Boolean indicating whether the input string is only whitespace.
  *
  * @param {string} input
  * @returns {boolean}

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -462,7 +462,7 @@ declare module 'stylelint' {
 			 */
 			createLinter: (options: LinterOptions) => InternalApi;
 			/**
-			 * Resolves the effective configuation for a given file. Resolves to
+			 * Resolves the effective configuration for a given file. Resolves to
 			 * `undefined` if no config is found.
 			 * @param filePath - The path to the file to get the config for.
 			 * @param options - The options to use when creating the Stylelint instance.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6400

> Is there anything in the PR that needs further explanation?

This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/IoT-For-Beginners/commit/152f85d8f8ced0c5b63649a5e9fb622ee2d36705#commitcomment-86437888

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/stylelint/commit/bd2b632047e1b0d9e707e8ed7af4f2b7d50c642a
 
Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

