### PR TITLE
Fix shorthand-property-no-redundant-values message to be consistent

### DIFF
--- a/.changeset/yellow-seals-kick.md
+++ b/.changeset/yellow-seals-kick.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `shorthand-property-no-redundant-values` message to be consistent

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -11,8 +11,7 @@ const vendor = require('../../utils/vendor');
 const ruleName = 'shorthand-property-no-redundant-values';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (unexpected, expected) =>
-		`Unexpected longhand value "${unexpected}" instead of "${expected}"`,
+	rejected: (unexpected, expected) => `Expected "${unexpected}" to be "${expected}"`,
 });
 
 const meta = {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6404.
> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
