### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` false positives for `inherit` keyword

### DIFF
--- a/.changeset/fair-oranges-love.md
+++ b/.changeset/fair-oranges-love.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fix `declaration-block-no-redundant-longhand-properties` false positives for `inherit` keyword

--- a/.changeset/fair-oranges-love.md
+++ b/.changeset/fair-oranges-love.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fix `declaration-block-no-redundant-longhand-properties` false positives for `inherit` keyword
+Fixed: `declaration-block-no-redundant-longhand-properties` false positives for `inherit` keyword

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -22,7 +22,7 @@ a {
 }
 ```
 
-This rule will only complain if you've used the longhand equivalent of _all_ the properties that the shorthand will set.
+This rule will only complain if you've used the longhand equivalent of _all_ the properties that the shorthand will set and if their values are not `inherit`.
 
 This rule complains when the following shorthand properties can be used:
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -145,6 +145,18 @@ a {
 }
 ```
 
+You should use a longhand property to have only the specific value inherited. So, the following patterns are also not considered problems:
+
+<!-- prettier-ignore -->
+```css
+a {
+  margin-top: 1px;
+  margin-right: 2px;
+  margin-bottom: 3px;
+  margin-left: inherit;
+}
+```
+
 ## Optional secondary options
 
 ### `ignoreShorthands: ["/regex/", /regex/, "string"]`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -145,18 +145,6 @@ a {
 }
 ```
 
-You should use a longhand property to have only the specific value inherited. So, the following patterns are also not considered problems:
-
-<!-- prettier-ignore -->
-```css
-a {
-  margin-top: 1px;
-  margin-right: 2px;
-  margin-bottom: 3px;
-  margin-left: inherit;
-}
-```
-
 ## Optional secondary options
 
 ### `ignoreShorthands: ["/regex/", /regex/, "string"]`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -14,6 +14,9 @@ testRule({
 			code: 'a { margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }',
 		},
 		{
+			code: 'a { margin-left: inherit; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }',
+		},
+		{
 			code: 'a { padding-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }',
 		},
 		{

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -20,6 +20,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties',
 };
 
+const longhandMustValues = ['inherit'];
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -61,6 +63,10 @@ const rule = (primary, secondaryOptions) => {
 			const longhandDeclarations = new Map();
 
 			eachDecl((decl) => {
+				if (longhandMustValues.includes(decl.value)) {
+					return;
+				}
+
 				const prop = decl.prop.toLowerCase();
 				const unprefixedProp = vendor.unprefixed(prop);
 				const prefix = vendor.prefix(prop);

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -20,7 +20,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties',
 };
 
-const longhandMustValues = ['inherit'];
+const IGNORED_VALUES = new Set(['inherit']);
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
@@ -63,7 +63,7 @@ const rule = (primary, secondaryOptions) => {
 			const longhandDeclarations = new Map();
 
 			eachDecl((decl) => {
-				if (longhandMustValues.includes(decl.value)) {
+				if (IGNORED_VALUES.has(decl.value)) {
 					return;
 				}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6394

> Is there anything in the PR that needs further explanation?

I think this CSS spec is often overlooked. So, I added a description and example to the docs. https://github.com/stylelint/stylelint/commit/94a21c3dd197144ac92c4803641b86c4fb6402c0
