### PR TITLE
Add coverage badge into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/stylelint)](https://www.npmjs.com/package/stylelint)
 [![Build Status](https://github.com/stylelint/stylelint/workflows/Testing/badge.svg)](https://github.com/stylelint/stylelint/actions/workflows/testing.yml?query=branch%3Amain)
+[![codecov](https://codecov.io/gh/stylelint/stylelint/branch/main/graph/badge.svg)](https://codecov.io/gh/stylelint/stylelint)
 [![npm downloads](https://img.shields.io/npm/dm/stylelint)](https://npmcharts.com/compare/stylelint?minimal=true)
 
 A mighty, modern linter that helps you avoid errors and enforce conventions in your styles.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

 Displaying coverage data on the readme of a repository.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

Codecov's badge links:
* https://docs.codecov.com/docs/status-badges
* https://docs.codecov.com/docs/github-3-customizing-codecov
