### PR TITLE
Colorize tally output of `string` formatter

### DIFF
--- a/.changeset/cyan-cats-destroy.md
+++ b/.changeset/cyan-cats-destroy.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: tally output of `string` formatter colorized

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -301,10 +301,9 @@ module.exports = function stringFormatter(results, returnValue) {
 		const total = errorCount + warningCount;
 
 		if (total > 0) {
-			const tally =
-				`${total} ${pluralize('problem', total)}` +
-				` (${errorCount} ${pluralize('error', errorCount)}` +
-				`, ${warningCount} ${pluralize('warning', warningCount)})`;
+			const error = red(`${errorCount} ${pluralize('error', errorCount)}`);
+			const warning = yellow(`${warningCount} ${pluralize('warning', warningCount)}`);
+			const tally = `${total} ${pluralize('problem', total)} (${error}, ${warning})`;
 
 			output += `${tally}\n\n`;
 		}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

|Before|After|
|-|-|
|<img width="363" alt="image" src="https://user-images.githubusercontent.com/473530/199387277-d4bae7f6-eea6-49fe-aca4-7127605b09ce.png">|<img width="364" alt="image" src="https://user-images.githubusercontent.com/473530/199387328-db2eaff5-1da2-4238-9470-9385206674d6.png">|

You can confirm the output above by running the `(cd scripts ; ./visual.sh)` command.
