### PR TITLE
Add support for reporting with custom severity

### DIFF
--- a/.changeset/khaki-flowers-suffer.md
+++ b/.changeset/khaki-flowers-suffer.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: support for reporting with custom severity

--- a/lib/utils/__tests__/report.test.js
+++ b/lib/utils/__tests__/report.test.js
@@ -230,6 +230,78 @@ test("with quiet mode on and rule severity of 'error'", () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(1);
 });
 
+test('with custom rule severity', () => {
+	const v = {
+		ruleName: 'foo',
+		severity: 'warning',
+		result: {
+			warn: jest.fn(),
+			stylelint: {
+				ruleSeverities: {
+					foo: 'error',
+				},
+			},
+		},
+		message: 'bar',
+		node: {
+			rangeBy: defaultRangeBy,
+		},
+	};
+
+	report(v);
+	const spyArgs = v.result.warn.mock.calls[0];
+
+	expect(spyArgs[0]).toBe('bar');
+	expect(spyArgs[1].severity).toBe('warning');
+	expect(spyArgs[1].node).toBe(v.node);
+});
+
+test("with quiet mode on and custom rule severity of 'error'", () => {
+	const v = {
+		ruleName: 'foo',
+		severity: 'error',
+		result: {
+			warn: jest.fn(),
+			stylelint: {
+				quiet: true,
+				ruleSeverities: {
+					foo: 'warning',
+				},
+			},
+		},
+		message: 'bar',
+		node: {
+			rangeBy: defaultRangeBy,
+		},
+	};
+
+	report(v);
+	expect(v.result.warn).toHaveBeenCalledTimes(1);
+});
+
+test("with quiet mode on and custom rule severity of 'warning'", () => {
+	const v = {
+		ruleName: 'foo',
+		severity: 'warning',
+		result: {
+			warn: jest.fn(),
+			stylelint: {
+				quiet: true,
+				ruleSeverities: {
+					foo: 'error',
+				},
+			},
+		},
+		message: 'bar',
+		node: {
+			rangeBy: defaultRangeBy,
+		},
+	};
+
+	report(v);
+	expect(v.result.warn).toHaveBeenCalledTimes(0);
+});
+
 test('with message function', () => {
 	const v = {
 		ruleName: 'foo',

--- a/lib/utils/report.js
+++ b/lib/utils/report.js
@@ -15,7 +15,8 @@
  * @type {typeof import('stylelint').utils.report}
  */
 module.exports = function report(problem) {
-	const { ruleName, result, message, messageArgs, line, node, index, endIndex, word } = problem;
+	const { ruleName, result, message, messageArgs, line, node, index, endIndex, word, severity } =
+		problem;
 
 	result.stylelint = result.stylelint || {
 		ruleSeverities: {},
@@ -23,8 +24,11 @@ module.exports = function report(problem) {
 		ruleMetadata: {},
 	};
 
+	const ruleSeverity =
+		severity || (result.stylelint.ruleSeverities && result.stylelint.ruleSeverities[ruleName]);
+
 	// In quiet mode, mere warnings are ignored
-	if (result.stylelint.quiet && result.stylelint.ruleSeverities[ruleName] !== 'error') {
+	if (result.stylelint.quiet && ruleSeverity !== 'error') {
 		return;
 	}
 
@@ -72,19 +76,17 @@ module.exports = function report(problem) {
 		}
 	}
 
-	const severity = result.stylelint.ruleSeverities && result.stylelint.ruleSeverities[ruleName];
-
-	if (!result.stylelint.stylelintError && severity === 'error') {
+	if (!result.stylelint.stylelintError && ruleSeverity === 'error') {
 		result.stylelint.stylelintError = true;
 	}
 
-	if (!result.stylelint.stylelintWarning && severity === 'warning') {
+	if (!result.stylelint.stylelintWarning && ruleSeverity === 'warning') {
 		result.stylelint.stylelintWarning = true;
 	}
 
 	/** @type {import('stylelint').WarningOptions} */
 	const warningProperties = {
-		severity,
+		severity: ruleSeverity,
 		rule: ruleName,
 	};
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -396,6 +396,10 @@ declare module 'stylelint' {
 			};
 			word?: string;
 			line?: number;
+			/**
+			 * Optional severity override for the problem.
+			 */
+			severity?: Severity;
 		};
 
 		export type LonghandSubPropertiesOfShorthandProperties = ReadonlyMap<


### PR DESCRIPTION
### Short description

This PR introduces the ability to report warnings with custom rule severities:

```js
stylelint.utils.report({ ruleName, severity: 'warning' })
```

### Context

My team is working on a rule that is used for both linting and gathering metrics on warnings and have encountered a need to set custom rule severities per report. In short our rule dynamically categorizes warnings and reports with a modified rule name that we target on an external metrics dashboard e.g.

```js
stylelint.utils.report({ ruleName: `${ruleName}/colors`, ... })
stylelint.utils.report({ ruleName: `${ruleName}/layout`, ... })
// etc.
```

However, because we report dynamically created rule names the warning's `severity` is set to `undefined`.

### In summary

This small restructure and override mechanism gives us more programmatic control when handling warnings and from what I can tell doesn't affect the CLI or VS Code extension.

That said, I'm very interested to hear what folks think!