### PR TITLE
Bump eslint from 8.26.0 to 8.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "benchmark": "^2.1.4",
         "common-tags": "^1.8.2",
         "deepmerge": "^4.2.2",
-        "eslint": "^8.26.0",
+        "eslint": "^8.27.0",
         "eslint-config-stylelint": "^17.0.0",
         "husky": "^8.0.1",
         "jest": "^28.1.3",
@@ -4154,9 +4154,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-      "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
@@ -17414,9 +17414,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-      "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
+      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "benchmark": "^2.1.4",
     "common-tags": "^1.8.2",
     "deepmerge": "^4.2.2",
-    "eslint": "^8.26.0",
+    "eslint": "^8.27.0",
     "eslint-config-stylelint": "^17.0.0",
     "husky": "^8.0.1",
     "jest": "^28.1.3",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Close #6456

> Is there anything in the PR that needs further explanation?

This PR's base branch is `main` instead of `v15`. Also, this commit is created by:

```shell
git cherry-pick 90e09c28cd6ead99b4236629b0740060d1c61092
```
