### PR TITLE
Stop CI testing on Dependabot branches pushed

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'dependabot/**'
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Dependabot branches always come with pull requests, so I believe duplicate CI jobs on `push` and `pull_request` are useless. For example, see below:

<img width="834" alt="image" src="https://user-images.githubusercontent.com/473530/200571739-fe23b44b-b77d-4da8-9527-9b1a4edeb9f9.png">

