### PR TITLE
Increase experimental `messageArgs` support

### DIFF
--- a/.changeset/several-cucumbers-wonder.md
+++ b/.changeset/several-cucumbers-wonder.md
@@ -1,5 +1,5 @@
-Added: `declaration-property-value-disallowed-list` `messageArgs` support
-Added: `declaration-property-unit-disallowed-list` `messageArgs` support
-Added: `function-disallowed-list` `messageArgs` support
-Added: `at-rule-disallowed-list` `messageArgs` support
-Added: `property-disallowed-list` `messageArgs` support
+---
+"stylelint": minor
+---
+
+Added: custom message formatting for `at-rule-disallowed-list`, `declaration-property-unit-disallowed-list`, `declaration-property-value-disallowed-list`, `function-disallowed-list`, and `property-disallowed-list`

--- a/.changeset/several-cucumbers-wonder.md
+++ b/.changeset/several-cucumbers-wonder.md
@@ -1,0 +1,5 @@
+Added: `declaration-property-value-disallowed-list` `messageArgs` support
+Added: `declaration-property-unit-disallowed-list` `messageArgs` support
+Added: `function-disallowed-list` `messageArgs` support
+Added: `at-rule-disallowed-list` `messageArgs` support
+Added: `property-disallowed-list` `messageArgs` support

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -9,7 +9,7 @@ Specify a list of disallowed at-rules.
  * At-rules like this */
 ```
 
-## Options
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.## Options
 
 `array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`
 

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -9,7 +9,9 @@ Specify a list of disallowed at-rules.
  * At-rules like this */
 ```
 
-The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.## Options
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
+## Options
 
 `array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`
 

--- a/lib/rules/at-rule-disallowed-list/index.js
+++ b/lib/rules/at-rule-disallowed-list/index.js
@@ -43,7 +43,8 @@ const rule = (primary) => {
 			}
 
 			report({
-				message: messages.rejected(name),
+				message: messages.rejected,
+				messageArgs: [name],
 				node: atRule,
 				result,
 				ruleName,

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { width: 100px; }
  * These properties and these units */
 ```
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `object`: `{ "unprefixed-property-name": ["array", "of", "units"]|"unit" }`

--- a/lib/rules/declaration-property-unit-disallowed-list/index.js
+++ b/lib/rules/declaration-property-unit-disallowed-list/index.js
@@ -75,7 +75,8 @@ const rule = (primary) => {
 				const endIndex = index + node.value.length;
 
 				report({
-					message: messages.rejected(prop, unit),
+					message: messages.rejected,
+					messageArgs: [prop, unit],
 					node: decl,
 					index,
 					endIndex,

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { text-transform: uppercase; }
  * These properties and these values */
 ```
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `object`: `{ "unprefixed-property-name": ["array", "of", "values", "/regex/", /regex/]|"value"|"/regex/"|/regex/ }`

--- a/lib/rules/declaration-property-value-disallowed-list/index.js
+++ b/lib/rules/declaration-property-value-disallowed-list/index.js
@@ -52,7 +52,8 @@ const rule = (primary) => {
 			const endIndex = index + decl.value.length;
 
 			report({
-				message: messages.rejected(prop, value),
+				message: messages.rejected,
+				messageArgs: [prop, value],
 				node: decl,
 				index,
 				endIndex,

--- a/lib/rules/function-disallowed-list/README.md
+++ b/lib/rules/function-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { transform: scale(1); }
  * This function */
 ```
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `array|string|regex`: `["array", "of", "unprefixed", /functions/, "regex"]|"function"|"/regex/"|/regex/`

--- a/lib/rules/function-disallowed-list/index.js
+++ b/lib/rules/function-disallowed-list/index.js
@@ -50,7 +50,8 @@ const rule = (primary) => {
 				const endIndex = index + node.value.length;
 
 				report({
-					message: messages.rejected(node.value),
+					message: messages.rejected,
+					messageArgs: [node.value],
 					node: decl,
 					index,
 					endIndex,

--- a/lib/rules/property-disallowed-list/README.md
+++ b/lib/rules/property-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { text-rendering: optimizeLegibility; }
  * This property */
 ```
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `array|string|regex`: `["array", "of", /properties/, "regex"]|"property"|"/regex/"|/regex/`

--- a/lib/rules/property-disallowed-list/index.js
+++ b/lib/rules/property-disallowed-list/index.js
@@ -48,7 +48,8 @@ const rule = (primary) => {
 			}
 
 			report({
-				message: messages.rejected(prop),
+				message: messages.rejected,
+				messageArgs: [prop],
 				word: prop,
 				node: decl,
 				result,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6453,
Closes https://github.com/stylelint/stylelint/issues/6454,
Closes https://github.com/stylelint/stylelint/issues/6455,
Closes https://github.com/stylelint/stylelint/issues/6461, and
Closes https://github.com/stylelint/stylelint/issues/6462

> Is there anything in the PR that needs further explanation?

No, it's modeled after the `color-no-hex` changes in #6312 
