### PR TITLE
Use npm v8 instead of v9 on CI testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,7 +39,8 @@ jobs:
           cache: npm
 
       - name: Install latest npm
-        run: npm install --global npm@latest
+        # TODO: npm@9 is the latest, but it doesn't work on Node.js v12 and v14 with windows.
+        run: npm install --global npm@8
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

I believe this PR should fix the CI failures with PR #6463.

> Is there anything in the PR that needs further explanation?

See the announcement about npm v9:
https://github.blog/changelog/2022-11-09-npm-cli-v9-is-now-generally-available/

See the failed job:
https://github.com/stylelint/stylelint/actions/runs/3433111899

