### PR TITLE
Remove deprecated `PluginContext` type

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -180,11 +180,6 @@ declare module 'stylelint' {
 			newline?: string | undefined;
 		};
 
-		/**
-		 * @deprecated Use `RuleContext` instead.
-		 */
-		export type PluginContext = RuleContext;
-
 		export type RuleBase<P = any, S = any> = (
 			primaryOption: P,
 			secondaryOptions: Record<string, S>,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #6466

> Is there anything in the PR that needs further explanation?

The `PluginContext` type has been marked as deprecated in PR #6466.

Note that the base branch of this PR is `v15`.
