### PR TITLE
Bump eslint-config-stylelint from 17.0.0 to 17.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "common-tags": "^1.8.2",
         "deepmerge": "^4.2.2",
         "eslint": "^8.28.0",
-        "eslint-config-stylelint": "^17.0.0",
+        "eslint-config-stylelint": "^17.1.0",
         "husky": "^8.0.2",
         "jest": "^28.1.3",
         "jest-preset-stylelint": "^5.0.4",
@@ -2470,13 +2470,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.1.tgz",
-      "integrity": "sha512-BfRDq5RidVU3RbqApKmS7RFMtkyWMM50qWnDAkKgQiezRtLKsoyRKIvz1Ok5ilRWeD9IuHvaidaLxvGx/2eqTQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.0.tgz",
+      "integrity": "sha512-noDMjr87Arp/PuVrtvN3dXiJstQR1+XlQ4R1EvzG+NMgXi8CuMCXpb8JqNtFHKceVSQ985BZhfRdowJzbv4yKw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.38.1",
-        "@typescript-eslint/visitor-keys": "5.38.1"
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2487,9 +2487,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.1.tgz",
-      "integrity": "sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.0.tgz",
+      "integrity": "sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2500,13 +2500,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.1.tgz",
-      "integrity": "sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.0.tgz",
+      "integrity": "sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.38.1",
-        "@typescript-eslint/visitor-keys": "5.38.1",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2527,17 +2527,19 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.1.tgz",
-      "integrity": "sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.0.tgz",
+      "integrity": "sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.38.1",
-        "@typescript-eslint/types": "5.38.1",
-        "@typescript-eslint/typescript-estree": "5.38.1",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/typescript-estree": "5.45.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2549,6 +2551,12 @@
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -2573,12 +2581,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.1.tgz",
-      "integrity": "sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.0.tgz",
+      "integrity": "sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.38.1",
+        "@typescript-eslint/types": "5.45.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -4222,15 +4230,15 @@
       }
     },
     "node_modules/eslint-config-stylelint": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-17.0.0.tgz",
-      "integrity": "sha512-9HrWIUYw24m/Tom0X65e+ovPSnopXEY1lJYdcLrRbozr9Qu2qWr9+TN6dGppMuNitjm8/hMDfy+0rUP6oSyKFQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-17.1.0.tgz",
+      "integrity": "sha512-W4wVdtIUdgjNpIAdWtFtsxuxCu7uSe+2WuTerH923UW800+B0FbO+9uk0ZFFvu9+MYdLyQ+RYU8GLjl9ZnCm8g==",
       "dev": true,
       "dependencies": {
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-jest": "^27.0.4",
+        "eslint-plugin-jest": "^27.1.6",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-regexp": "^1.9.0"
+        "eslint-plugin-regexp": "^1.11.0"
       }
     },
     "node_modules/eslint-plugin-es": {
@@ -4277,9 +4285,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.0.4.tgz",
-      "integrity": "sha512-BuvY78pHMpMJ6Cio7sKg6jrqEcnRYPUc4Nlihku4vKx3FjlmMINSX4vcYokZIe+8TKcyr1aI5Kq7vYwgJNdQSA==",
+      "version": "27.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.6.tgz",
+      "integrity": "sha512-XA7RFLSrlQF9IGtAmhddkUkBuICCTuryfOTfCSWcZHiHb69OilIH05oozH2XA6CEOtztnOd0vgXyvxZodkxGjg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -4354,9 +4362,9 @@
       }
     },
     "node_modules/eslint-plugin-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.9.0.tgz",
-      "integrity": "sha512-Che49IZ07w9KcKvrMiqfwBYv44VBunA4NqUo+UTLluYbCos9Du3+pnhkPTLTAx6ZoZ1Rmz7u7o2iC6g6qCuvxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.11.0.tgz",
+      "integrity": "sha512-xSFARZrg0LMIp6g7XXUByS52w0fBp3lucoDi347BbeN9XqkGNFdsN+nDzNZIJbJJ1tWB08h3Pd8RfA5p7Kezhg==",
       "dev": true,
       "dependencies": {
         "comment-parser": "^1.1.2",
@@ -16195,29 +16203,29 @@
       "dev": true
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.38.1.tgz",
-      "integrity": "sha512-BfRDq5RidVU3RbqApKmS7RFMtkyWMM50qWnDAkKgQiezRtLKsoyRKIvz1Ok5ilRWeD9IuHvaidaLxvGx/2eqTQ==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.45.0.tgz",
+      "integrity": "sha512-noDMjr87Arp/PuVrtvN3dXiJstQR1+XlQ4R1EvzG+NMgXi8CuMCXpb8JqNtFHKceVSQ985BZhfRdowJzbv4yKw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.38.1",
-        "@typescript-eslint/visitor-keys": "5.38.1"
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.38.1.tgz",
-      "integrity": "sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.45.0.tgz",
+      "integrity": "sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.38.1.tgz",
-      "integrity": "sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.0.tgz",
+      "integrity": "sha512-maRhLGSzqUpFcZgXxg1qc/+H0bT36lHK4APhp0AEUVrpSwXiRAomm/JGjSG+kNUio5kAa3uekCYu/47cnGn5EQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.38.1",
-        "@typescript-eslint/visitor-keys": "5.38.1",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/visitor-keys": "5.45.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -16226,19 +16234,27 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.38.1.tgz",
-      "integrity": "sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.45.0.tgz",
+      "integrity": "sha512-OUg2JvsVI1oIee/SwiejTot2OxwU8a7UfTFMOdlhD2y+Hl6memUSL4s98bpUTo8EpVEr0lmwlU7JSu/p2QpSvA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.38.1",
-        "@typescript-eslint/types": "5.38.1",
-        "@typescript-eslint/typescript-estree": "5.38.1",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.45.0",
+        "@typescript-eslint/types": "5.45.0",
+        "@typescript-eslint/typescript-estree": "5.45.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "dependencies": {
+        "@types/semver": {
+          "version": "7.3.13",
+          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+          "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+          "dev": true
+        },
         "eslint-scope": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -16258,12 +16274,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.38.1.tgz",
-      "integrity": "sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.0.tgz",
+      "integrity": "sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.38.1",
+        "@typescript-eslint/types": "5.45.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -17507,15 +17523,15 @@
       "requires": {}
     },
     "eslint-config-stylelint": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-17.0.0.tgz",
-      "integrity": "sha512-9HrWIUYw24m/Tom0X65e+ovPSnopXEY1lJYdcLrRbozr9Qu2qWr9+TN6dGppMuNitjm8/hMDfy+0rUP6oSyKFQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-17.1.0.tgz",
+      "integrity": "sha512-W4wVdtIUdgjNpIAdWtFtsxuxCu7uSe+2WuTerH923UW800+B0FbO+9uk0ZFFvu9+MYdLyQ+RYU8GLjl9ZnCm8g==",
       "dev": true,
       "requires": {
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-jest": "^27.0.4",
+        "eslint-plugin-jest": "^27.1.6",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-regexp": "^1.9.0"
+        "eslint-plugin-regexp": "^1.11.0"
       }
     },
     "eslint-plugin-es": {
@@ -17546,9 +17562,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "27.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.0.4.tgz",
-      "integrity": "sha512-BuvY78pHMpMJ6Cio7sKg6jrqEcnRYPUc4Nlihku4vKx3FjlmMINSX4vcYokZIe+8TKcyr1aI5Kq7vYwgJNdQSA==",
+      "version": "27.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.1.6.tgz",
+      "integrity": "sha512-XA7RFLSrlQF9IGtAmhddkUkBuICCTuryfOTfCSWcZHiHb69OilIH05oozH2XA6CEOtztnOd0vgXyvxZodkxGjg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -17592,9 +17608,9 @@
       }
     },
     "eslint-plugin-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.9.0.tgz",
-      "integrity": "sha512-Che49IZ07w9KcKvrMiqfwBYv44VBunA4NqUo+UTLluYbCos9Du3+pnhkPTLTAx6ZoZ1Rmz7u7o2iC6g6qCuvxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-1.11.0.tgz",
+      "integrity": "sha512-xSFARZrg0LMIp6g7XXUByS52w0fBp3lucoDi347BbeN9XqkGNFdsN+nDzNZIJbJJ1tWB08h3Pd8RfA5p7Kezhg==",
       "dev": true,
       "requires": {
         "comment-parser": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,6 @@
   },
   "prettier": "@stylelint/prettier-config",
   "eslintConfig": {
-    "parserOptions": {
-      "ecmaVersion": 2020
-    },
     "extends": [
       "stylelint"
     ],
@@ -175,7 +172,7 @@
     "common-tags": "^1.8.2",
     "deepmerge": "^4.2.2",
     "eslint": "^8.28.0",
-    "eslint-config-stylelint": "^17.0.0",
+    "eslint-config-stylelint": "^17.1.0",
     "husky": "^8.0.2",
     "jest": "^28.1.3",
     "jest-preset-stylelint": "^5.0.4",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Overriding the `parserOptions.ecmaVersion` option is no longer needed.

- https://github.com/stylelint/eslint-config-stylelint/releases/tag/17.1.0
- https://github.com/stylelint/eslint-config-stylelint/compare/17.0.0...17.1.0
