### PR TITLE
Change type names to be more consistent

### DIFF
--- a/.changeset/early-penguins-know.md
+++ b/.changeset/early-penguins-know.md
@@ -1,0 +1,5 @@
+---
+"stylelint": major
+---
+
+Changed: type names to be more consistent

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -7,10 +7,10 @@ declare module 'stylelint' {
 		export type Severity = 'warning' | 'error';
 
 		export type ConfigExtends = string | string[];
-		export type PluginType =
+		export type Plugin =
 			| { default?: { ruleName: string; rule: Rule } }
 			| { ruleName: string; rule: Rule };
-		export type ConfigPlugins = string | PluginType | (string | PluginType)[];
+		export type ConfigPlugins = string | Plugin | (string | Plugin)[];
 		export type ConfigProcessor = string | [string, Object];
 		export type ConfigProcessors = string | ConfigProcessor[];
 		export type ConfigIgnoreFiles = string | string[];
@@ -195,8 +195,6 @@ declare module 'stylelint' {
 			primaryOptionArray?: boolean;
 			meta?: RuleMeta;
 		};
-
-		export type Plugin = RuleBase;
 
 		export type GetPostcssOptions = {
 			code?: string;
@@ -449,7 +447,7 @@ declare module 'stylelint' {
 			/**
 			 * Creates a Stylelint plugin.
 			 */
-			createPlugin: (ruleName: string, rule: Rule) => { ruleName: string; rule: Rule };
+			createPlugin: (ruleName: string, rule: Rule) => Plugin;
 			/**
 			 * Internal use only. Do not use or rely on this method. It may
 			 * change at any time.

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -11,8 +11,8 @@ import type {
 	FormatterType,
 	LintResult,
 	LinterResult,
-	Plugin,
 	Rule,
+	RuleBase,
 	RuleMeta,
 	Warning,
 } from 'stylelint';
@@ -89,9 +89,9 @@ const meta: RuleMeta = { url: '...' };
 const problemMessage: string = messages.problem;
 const problemFunc: (...reason: string[]) => string = messages.warning;
 
-const testPlugin: Plugin = (options) => {
+const testRule: RuleBase = (option) => {
 	return (root, result) => {
-		const validOptions = stylelint.utils.validateOptions(result, ruleName, { actual: options });
+		const validOptions = stylelint.utils.validateOptions(result, ruleName, { actual: option });
 		if (!validOptions) {
 			return;
 		}
@@ -117,12 +117,12 @@ const testPlugin: Plugin = (options) => {
 	};
 };
 
-(testPlugin as Rule).ruleName = ruleName;
-(testPlugin as Rule).messages = messages;
-(testPlugin as Rule).primaryOptionArray = true;
-(testPlugin as Rule).meta = meta;
+(testRule as Rule).ruleName = ruleName;
+(testRule as Rule).messages = messages;
+(testRule as Rule).primaryOptionArray = true;
+(testRule as Rule).meta = meta;
 
-stylelint.createPlugin(ruleName, testPlugin as Rule);
+stylelint.createPlugin(ruleName, testRule as Rule);
 
 messages.withNarrowedParam('should work');
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up for #6481

> Is there anything in the PR that needs further explanation?

The `Plugin` type should be used as a return type of the `createPlugin()` function.

Type-checking failures may occur if people use the types changed in this PR, but I believe they accept the failures because of the major update (v15).
