### PR TITLE
Fix `function-no-unknown` false positives for `scroll`, `-webkit-gradient`, `color-stop`, `from`, and `to`

### DIFF
--- a/.changeset/itchy-seas-care.md
+++ b/.changeset/itchy-seas-care.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-no-unknown` false positives for `scroll`, `-webkit-gradient`, `color-stop`, `from`, and `to`

--- a/lib/rules/function-no-unknown/__tests__/index.js
+++ b/lib/rules/function-no-unknown/__tests__/index.js
@@ -19,6 +19,12 @@ testRule({
 		{
 			code: 'a { transform: scale(0.5) translate(-100%, -100%); }',
 		},
+		{
+			code: 'a { animation-timeline: scroll(); }',
+		},
+		{
+			code: 'a { background: -webkit-gradient(linear, 0 50%, 0 100%, from(white), color-stop(0.5, yellow), to(red)); }',
+		},
 	],
 
 	reject: [

--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -43,7 +43,16 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		const functionsList = JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
+		const functionsList = [
+			...JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8')),
+			// #5960
+			'-webkit-gradient',
+			'color-stop',
+			'from',
+			'to',
+			// #6537
+			'scroll',
+		];
 
 		root.walkDecls((decl) => {
 			const { value } = decl;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #6537

> Is there anything in the PR that needs further explanation?

see https://github.com/stylelint/stylelint/issues/6537#issuecomment-1363471880