### PR TITLE
Fix typo in `docs/migration-guide/to-15.md`

### DIFF
--- a/docs/migration-guide/to-15.md
+++ b/docs/migration-guide/to-15.md
@@ -55,7 +55,7 @@ You should use the following or higher versions of Node.js:
 
 ### Removed support for processors
 
-You should use a [custom syntax](../developer-guide/syntaxes.md)](../developer-guide/syntaxes.md) instead.
+You should use a [custom syntax](../developer-guide/syntaxes.md) instead.
 
 ### Changed `overrides.extends` behavior
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
