### PR TITLE
Fix unexpected `output` in Node.js API lint result when any rule contains `disableFix: true`

### DIFF
--- a/.changeset/lemon-cheetahs-complain.md
+++ b/.changeset/lemon-cheetahs-complain.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: unexpected `output` in Node.js API lint result when any rule contains `disableFix: true`

--- a/lib/__tests__/standalone-fix.test.js
+++ b/lib/__tests__/standalone-fix.test.js
@@ -246,7 +246,8 @@ it('one rule being disabled', async () => {
 		fix: true,
 	});
 
-	expect(JSON.parse(result.output)[0].errored).toBe(true);
+	expect(result.results[0].errored).toBe(true);
+	expect(result.output).toBe('\n		a {\n			color: red;\n		}');
 });
 
 it('two rules being disabled', async () => {
@@ -276,7 +277,7 @@ it('two rules being disabled', async () => {
 		fix: true,
 	});
 
-	const warnings = JSON.parse(result.output)[0].warnings;
+	const warnings = result.results[0].warnings;
 
 	expect(warnings.some((w) => w.text === 'Expected indentation of 0 spaces (indentation)')).toBe(
 		true,
@@ -284,6 +285,7 @@ it('two rules being disabled', async () => {
 	expect(warnings.some((w) => w.text === 'Expected "COLOR" to be "color" (property-case)')).toBe(
 		true,
 	);
+	expect(result.output).toBe('\n		a {\n			COLOR: red;\n		}');
 });
 
 it('one rule being disabled and another still autofixing', async () => {
@@ -296,24 +298,25 @@ it('one rule being disabled and another still autofixing', async () => {
 		code,
 		config: {
 			rules: {
-				indentation: [
-					2,
+				indentation: [0],
+				'property-case': [
+					'lower',
 					{
 						disableFix: true,
 					},
 				],
-				'property-case': ['lower'],
 			},
 		},
 		fix: true,
 	});
 
-	const warnings = JSON.parse(result.output)[0].warnings;
+	const warnings = result.results[0].warnings;
 
 	expect(warnings.some((w) => w.text === 'Expected indentation of 0 spaces (indentation)')).toBe(
-		true,
-	);
-	expect(warnings.some((w) => w.text === 'Expected "COLOR" to be "color" (property-case)')).toBe(
 		false,
 	);
+	expect(warnings.some((w) => w.text === 'Expected "COLOR" to be "color" (property-case)')).toBe(
+		true,
+	);
+	expect(result.output).toBe('\na {\nCOLOR: red;\n}');
 });

--- a/lib/__tests__/standalone-fix.test.js
+++ b/lib/__tests__/standalone-fix.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { stripIndent } = require('common-tags');
+const { stripIndent, stripIndents } = require('common-tags');
 const fs = require('fs').promises;
 
 const removeFile = require('../testUtils/removeFile');
@@ -247,7 +247,7 @@ it('one rule being disabled', async () => {
 	});
 
 	expect(result.results[0].errored).toBe(true);
-	expect(result.output).toBe('\n		a {\n			color: red;\n		}');
+	expect(result.output).toBe(code);
 });
 
 it('two rules being disabled', async () => {
@@ -285,11 +285,12 @@ it('two rules being disabled', async () => {
 	expect(warnings.some((w) => w.text === 'Expected "COLOR" to be "color" (property-case)')).toBe(
 		true,
 	);
-	expect(result.output).toBe('\n		a {\n			COLOR: red;\n		}');
+	expect(result.output).toBe(code);
 });
 
 it('one rule being disabled and another still autofixing', async () => {
-	const code = `
+	// use stripIndent to remove first linebreak that is also removed in the stripIndents expect
+	const code = stripIndent`
 		a {
 			COLOR: red;
 		}`;
@@ -318,5 +319,5 @@ it('one rule being disabled and another still autofixing', async () => {
 	expect(warnings.some((w) => w.text === 'Expected "COLOR" to be "color" (property-case)')).toBe(
 		true,
 	);
-	expect(result.output).toBe('\na {\nCOLOR: red;\n}');
+	expect(result.output).toBe(stripIndents(code));
 });

--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -91,10 +91,6 @@ function lintPostcssResult(stylelintOptions, postcssResult, config) {
 		// disableFix in secondary option
 		const disableFix = (secondaryOptions && secondaryOptions.disableFix === true) || false;
 
-		if (disableFix) {
-			postcssResult.stylelint.ruleDisableFix = true;
-		}
-
 		postcssResult.stylelint.ruleSeverities[ruleName] =
 			(secondaryOptions && secondaryOptions.severity) || defaultSeverity;
 		postcssResult.stylelint.customMessages[ruleName] = secondaryOptions && secondaryOptions.message;

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -139,12 +139,7 @@ async function standalone({
 		const postcssResult = stylelintResult._postcssResult;
 		const returnValue = prepareReturnValue([stylelintResult], maxWarnings, formatterFunction, cwd);
 
-		if (
-			fix &&
-			postcssResult &&
-			!postcssResult.stylelint.ignored &&
-			!postcssResult.stylelint.ruleDisableFix
-		) {
+		if (fix && postcssResult && !postcssResult.stylelint.ignored) {
 			returnValue.output =
 				!postcssResult.stylelint.disableWritingFix && postcssResult.opts
 					? // If we're fixing, the output should be the fixed code

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -110,7 +110,6 @@ declare module 'stylelint' {
 			stylelintWarning?: boolean;
 			disableWritingFix?: boolean;
 			config?: Config;
-			ruleDisableFix?: boolean;
 		};
 
 		type EmptyResult = {


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #6542
and by that should also fix https://github.com/stylelint/vscode-stylelint/issues/369

> Is there anything in the PR that needs further explanation?

Issue: The API did not return the fixed css in `output` if any rule contained `ruleDisableFix`.

I have removed the `ruleDisableFix` code, because it did not affect the code fixing itself and I assume was wrongly used to change the content format of `output`. I have adjusted some tests to adapt to the changed behavior and extended the test conditions to check that the returned code has the correct fixes applied.

Issue was introduced in https://github.com/stylelint/stylelint/pull/5460
