### PR TITLE
fix: consider ruleless declarations as standard

### DIFF
--- a/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxDeclaration.test.js
@@ -166,6 +166,16 @@ describe('isStandardSyntaxDeclaration', () => {
 			true,
 		);
 	});
+
+	it('supports root-level declarations', () => {
+		const doc = new postcss.Document();
+		const root = postcss.parse('color: yellow;');
+
+		root.parent = doc;
+		doc.nodes.push(root);
+
+		expect(isStandardSyntaxDeclaration(root.nodes[0])).toBe(true);
+	});
 });
 
 function decl(css, parser = postcss) {

--- a/lib/utils/isStandardSyntaxDeclaration.js
+++ b/lib/utils/isStandardSyntaxDeclaration.js
@@ -1,14 +1,7 @@
 'use strict';
 
 const isScssVariable = require('./isScssVariable');
-const { isRoot, isRule } = require('./typeGuards');
-
-/**
- * @param {string} [lang]
- */
-function isStandardSyntaxLang(lang) {
-	return lang && (lang === 'css' || lang === 'custom-template' || lang === 'template-literal');
-}
+const { isRule } = require('./typeGuards');
 
 /**
  * Check whether a declaration is standard
@@ -18,18 +11,6 @@ function isStandardSyntaxLang(lang) {
 module.exports = function isStandardSyntaxDeclaration(decl) {
 	const prop = decl.prop;
 	const parent = decl.parent;
-
-	// Declarations belong in a declaration block or standard CSS source
-	if (
-		parent &&
-		isRoot(parent) &&
-		parent.source &&
-		!isStandardSyntaxLang(
-			/** @type {import('postcss').Source & {lang?: string}} */ (parent.source).lang,
-		)
-	) {
-		return false;
-	}
 
 	// SCSS var; covers map and list declarations
 	if (isScssVariable(prop)) {


### PR DESCRIPTION
it seems this is leftover logic from back when we bundled various parts of the css-in-js solutions in the past.

by removing this, newer postcss syntaxes can be correctly used by stylelint (as they often have declarations with no parent rule).

cc @jeddy3 