### PR TITLE
Fixes `at-rule-no-unknown` false positives for `@scroll-timeline`

### DIFF
--- a/.changeset/nice-ligers-type.md
+++ b/.changeset/nice-ligers-type.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixes `at-rule-no-unknown` false positives for `@scroll-timeline`

--- a/.changeset/nice-ligers-type.md
+++ b/.changeset/nice-ligers-type.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixes `at-rule-no-unknown` false positives for `@scroll-timeline`
+Fixed: `at-rule-no-unknown` false positives for `@scroll-timeline`

--- a/lib/reference/atKeywords.js
+++ b/lib/reference/atKeywords.js
@@ -44,6 +44,7 @@ const atKeywords = uniteSets(pageMarginAtKeywords, [
 	'ornaments',
 	'page',
 	'property',
+	'scroll-timeline',
 	'styleset',
 	'stylistic',
 	'supports',

--- a/lib/rules/at-rule-no-unknown/__tests__/index.js
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.js
@@ -92,7 +92,7 @@ testRule({
 			code: '@layer framework { h1 { background: white; } }',
 		},
 		{
-			code: '@scroll-timeline spin-slash { }',
+			code: '@scroll-timeline foo {}',
 		},
 	],
 

--- a/lib/rules/at-rule-no-unknown/__tests__/index.js
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.js
@@ -91,6 +91,9 @@ testRule({
 		{
 			code: '@layer framework { h1 { background: white; } }',
 		},
+		{
+			code: '@scroll-timeline spin-slash { }',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6548.

> Is there anything in the PR that needs further explanation?

Pretty self-explanatory - added failing test case, then used @Mouvedia's proposed solution.
