### PR TITLE
Fix `isStandardSyntaxFunction` false positives for interpolation and backticks in CSS-in-JS

### DIFF
--- a/.changeset/quiet-adults-leave.md
+++ b/.changeset/quiet-adults-leave.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-no-unknown` false positives for interpolation and backticks in CSS-in-JS

--- a/lib/rules/function-no-unknown/__tests__/index.js
+++ b/lib/rules/function-no-unknown/__tests__/index.js
@@ -71,6 +71,22 @@ testRule({
 });
 
 testRule({
+	skip: true,
+	ruleName,
+	config: true,
+	customSyntax: 'postcss-styled-syntax',
+
+	accept: [
+		{
+			code: 'const buttonFontSize = css`font-size: ${({ size }) => (size === "small") ? "0.8em" : "1em"};`;',
+		},
+		{
+			code: 'const buttonFontSize = css`border-radius: ${`calc(${token.radiusBase} + 2px)`};`;',
+		},
+	],
+});
+
+testRule({
 	ruleName,
 	config: [true, { ignoreFunctions: ['theme', '/^foo-/', /^bar$/i] }],
 

--- a/lib/rules/function-no-unknown/__tests__/index.js
+++ b/lib/rules/function-no-unknown/__tests__/index.js
@@ -71,22 +71,6 @@ testRule({
 });
 
 testRule({
-	skip: true,
-	ruleName,
-	config: true,
-	customSyntax: 'postcss-styled-syntax',
-
-	accept: [
-		{
-			code: 'const buttonFontSize = css`font-size: ${({ size }) => (size === "small") ? "0.8em" : "1em"};`;',
-		},
-		{
-			code: 'const buttonFontSize = css`border-radius: ${`calc(${token.radiusBase} + 2px)`};`;',
-		},
-	],
-});
-
-testRule({
 	ruleName,
 	config: [true, { ignoreFunctions: ['theme', '/^foo-/', /^bar$/i] }],
 

--- a/lib/utils/__tests__/isStandardSyntaxFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxFunction.test.js
@@ -26,6 +26,30 @@ describe('isStandardSyntaxFunction', () => {
 			false,
 		);
 	});
+
+	it('CSS-in-JS interpolation', () => {
+		const functions = [];
+
+		valueParser('${({ size }) => (size === "small") ? "0.8em" : "1em"}').walk((valueNode) => {
+			if (valueNode.type === 'function') {
+				functions.push(valueNode);
+			}
+		});
+
+		expect(isStandardSyntaxFunction(functions[0])).toBe(false);
+	});
+
+	it('CSS-in-JS syntax', () => {
+		const functions = [];
+
+		valueParser('`calc(${token.radiusBase} + 2px)`').walk((valueNode) => {
+			if (valueNode.type === 'function') {
+				functions.push(valueNode);
+			}
+		});
+
+		expect(isStandardSyntaxFunction(functions[0])).toBe(false);
+	});
 });
 
 function func(css) {

--- a/lib/utils/__tests__/isStandardSyntaxFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxFunction.test.js
@@ -1,66 +1,51 @@
 'use strict';
 
 const isStandardSyntaxFunction = require('../isStandardSyntaxFunction');
-const postcss = require('postcss');
 const valueParser = require('postcss-value-parser');
 
 describe('isStandardSyntaxFunction', () => {
 	it('calc', () => {
-		expect(isStandardSyntaxFunction(func('a { prop: calc(a + b) }'))).toBe(true);
+		expect(isStandardSyntaxFunction(getFunction('calc(a + b)'))).toBe(true);
 	});
 
 	it('url', () => {
-		expect(isStandardSyntaxFunction(func("a { prop: url('x.css') }"))).toBe(true);
+		expect(isStandardSyntaxFunction(getFunction("url('x.css')"))).toBe(true);
 	});
 
 	it('scss list', () => {
-		expect(isStandardSyntaxFunction(func('a { $list: (list) }'))).toBe(false);
+		// as in $list: (list)
+		expect(isStandardSyntaxFunction(getFunction('(list)'))).toBe(false);
 	});
 
 	it('scss map', () => {
-		expect(isStandardSyntaxFunction(func('a { $map: (key: value) }'))).toBe(false);
+		// as in $map: (key: value)
+		expect(isStandardSyntaxFunction(getFunction('(key: value)'))).toBe(false);
 	});
 
-	it('scss function in custom prop', () => {
-		expect(isStandardSyntaxFunction(func('a { --primary-color: #{darken(#fff, 0.2)} }'))).toBe(
-			false,
-		);
+	it('scss function in scss interpolation', () => {
+		expect(isStandardSyntaxFunction(getFunction('#{darken(#fff, 0.2)}'))).toBe(false);
 	});
 
 	it('CSS-in-JS interpolation', () => {
-		const functions = [];
-
-		valueParser('${({ size }) => (size === "small") ? "0.8em" : "1em"}').walk((valueNode) => {
-			if (valueNode.type === 'function') {
-				functions.push(valueNode);
-			}
-		});
-
-		expect(isStandardSyntaxFunction(functions[0])).toBe(false);
+		expect(
+			isStandardSyntaxFunction(
+				getFunction('${({ size }) => (size === "small") ? "0.8em" : "1em"}'),
+			),
+		).toBe(false);
 	});
 
 	it('CSS-in-JS syntax', () => {
-		const functions = [];
-
-		valueParser('`calc(${token.radiusBase} + 2px)`').walk((valueNode) => {
-			if (valueNode.type === 'function') {
-				functions.push(valueNode);
-			}
-		});
-
-		expect(isStandardSyntaxFunction(functions[0])).toBe(false);
+		expect(isStandardSyntaxFunction(getFunction('`calc(${token.radiusBase} + 2px)`'))).toBe(false);
 	});
 });
 
-function func(css) {
+function getFunction(declValue) {
 	const functions = [];
 
-	postcss.parse(css).walkDecls((decl) => {
-		valueParser(decl.value).walk((valueNode) => {
-			if (valueNode.type === 'function') {
-				functions.push(valueNode);
-			}
-		});
+	valueParser(declValue).walk((valueNode) => {
+		if (valueNode.type === 'function') {
+			functions.push(valueNode);
+		}
 	});
 
 	return functions[0];

--- a/lib/utils/isStandardSyntaxFunction.js
+++ b/lib/utils/isStandardSyntaxFunction.js
@@ -16,5 +16,15 @@ module.exports = function isStandardSyntaxFunction(node) {
 		return false;
 	}
 
+	// CSS-in-JS interpolation
+	if (node.value.startsWith('${')) {
+		return false;
+	}
+
+	// CSS-in-JS syntax
+	if (node.value.startsWith('`')) {
+		return false;
+	}
+
 	return true;
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #6564

> Is there anything in the PR that needs further explanation?

Tests for the rule are skipped, because there is no CSS-in-JS syntax added to the repo yet. ~~Waiting for https://github.com/stylelint/stylelint/pull/6556.~~
