### PR TITLE
Update `@changesets/apply-release-plan` patch to fix warning

### DIFF
--- a/patches/@changesets+apply-release-plan+6.1.3.patch
+++ b/patches/@changesets+apply-release-plan+6.1.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
-index 0c4d28e..aac0d8d 100644
+index c2e8d2f..3e40b6e 100644
 --- a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
 +++ b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
 @@ -199,7 +199,7 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This commit fixes the following warning by `patch-package` when running `npm ci`:

```
Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    @changesets/apply-release-plan@6.1.2

  applied to

    @changesets/apply-release-plan@6.1.3

  At path

    node_modules/@changesets/apply-release-plan

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package @changesets/apply-release-plan

  to update the version in the patch file name and make this warning go away.
```

See also the changelog:
https://github.com/changesets/changesets/blob/%40changesets/apply-release-plan%406.1.3/packages/apply-release-plan/CHANGELOG.md
