### PR TITLE
Add message arguments to `declaration-property-unit-allowed-list`

### DIFF
--- a/.changeset/perfect-suits-unite.md
+++ b/.changeset/perfect-suits-unite.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added message arguments to `declaration-property-unit-allowed-list`
+Added: message arguments to `declaration-property-unit-allowed-list`

--- a/.changeset/perfect-suits-unite.md
+++ b/.changeset/perfect-suits-unite.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added message arguments to `declaration-property-unit-allowed-list`

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -9,6 +9,8 @@ a { width: 100px; }
  * These properties and these units */
 ```
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `object`: `{ "unprefixed-property-name": ["array", "of", "units"]|"unit" }`

--- a/lib/rules/declaration-property-unit-allowed-list/index.js
+++ b/lib/rules/declaration-property-unit-allowed-list/index.js
@@ -93,7 +93,8 @@ const rule = (primary, secondaryOptions) => {
 				const endIndex = index + node.value.length;
 
 				report({
-					message: messages.rejected(prop, unit),
+					message: messages.rejected,
+					messageArgs: [prop, unit],
 					node: decl,
 					index,
 					endIndex,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6454.

> Is there anything in the PR that needs further explanation?

Seems like it *should* be a simple addition, but perhaps I'm missing something?

Huge thanks to @ybiquitous for doing a great job implementing this feature!
