### PR TITLE
Fix `selector-attribute-quotes` false positives for "never"

### DIFF
--- a/.changeset/chilly-ties-trade.md
+++ b/.changeset/chilly-ties-trade.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: false positives for "never" in `selector-attribute-quotes`

--- a/.changeset/chilly-ties-trade.md
+++ b/.changeset/chilly-ties-trade.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: false positives for "never" in `selector-attribute-quotes`
+Fixed: `selector-attribute-quotes` false positives for "never"

--- a/lib/rules/selector-attribute-quotes/__tests__/index.js
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.js
@@ -182,6 +182,14 @@ testRule({
 			code: "[href=\\'test\\'] { }",
 			description: 'escaped single-quotes are not considered as framing quotes',
 		},
+		{
+			code: `[href="te'st"] { }`,
+			description: 'removing quotes would produce invalid CSS', // see: https://github.com/stylelint/stylelint/issues/4300
+		},
+		{
+			code: `[href='te"st'] { }`,
+			description: 'removing quotes would produce invalid CSS', // see: https://github.com/stylelint/stylelint/issues/4300
+		},
 	],
 
 	reject: [
@@ -265,24 +273,6 @@ testRule({
 			column: 13,
 			endLine: 1,
 			endColumn: 20,
-		},
-		{
-			code: `[href="te'st"] { }`,
-			fixed: "[href=te\\'st] { }",
-			message: messages.rejected("te'st"),
-			line: 1,
-			column: 7,
-			endLine: 1,
-			endColumn: 14,
-		},
-		{
-			code: `[href='te"st'] { }`,
-			fixed: '[href=te\\"st] { }',
-			message: messages.rejected('te"st'),
-			line: 1,
-			column: 7,
-			endLine: 1,
-			endColumn: 14,
 		},
 		{
 			code: "[href='te\\'s\\'t'] { }",

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -66,8 +66,13 @@ const rule = (primary, _secondaryOptions, context) => {
 
 					if (quoted && primary === 'never') {
 						// some selectors require quotes to be valid;
+						// we pass in the raw string value, which contains the escape characters
+						// necessary to check if escaped characters are valid
 						// see: https://github.com/stylelint/stylelint/issues/4300
-						if (!isValidIdentifier(value)) {
+						if (
+							!attributeNode.raws.value ||
+							!isValidIdentifier(attributeNode.raws.value.slice(1, -1))
+						) {
 							return;
 						}
 

--- a/lib/rules/selector-attribute-quotes/index.js
+++ b/lib/rules/selector-attribute-quotes/index.js
@@ -2,6 +2,7 @@
 
 const getRuleSelector = require('../../utils/getRuleSelector');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
+const isValidIdentifier = require('../../utils/isValidIdentifier');
 const parseSelector = require('../../utils/parseSelector');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -64,6 +65,12 @@ const rule = (primary, _secondaryOptions, context) => {
 					}
 
 					if (quoted && primary === 'never') {
+						// some selectors require quotes to be valid;
+						// see: https://github.com/stylelint/stylelint/issues/4300
+						if (!isValidIdentifier(value)) {
+							return;
+						}
+
 						if (context.fix) {
 							selectorFixed = true;
 							attributeNode.quoteMark = null;

--- a/lib/utils/__tests__/isValidIdentifier.test.js
+++ b/lib/utils/__tests__/isValidIdentifier.test.js
@@ -7,12 +7,11 @@ it('isValidIdentifier', () => {
 	expect(isValidIdentifier('foo1')).toBeTruthy();
 	expect(isValidIdentifier('1')).toBeFalsy();
 	expect(isValidIdentifier('-1')).toBeFalsy();
-	expect(isValidIdentifier('--foo')).toBeFalsy();
+	expect(isValidIdentifier('--foo')).toBeTruthy();
 	expect(isValidIdentifier('has a space')).toBeFalsy();
 	expect(isValidIdentifier(null)).toBeFalsy();
 	expect(isValidIdentifier('')).toBeFalsy();
 	expect(isValidIdentifier(' ')).toBeFalsy();
-	expect(isValidIdentifier(' --foo')).toBeFalsy();
 	expect(isValidIdentifier('foö')).toBeFalsy();
 	expect(isValidIdentifier('\\26 B')).toBeTruthy(); // ISO 10646 character
 	expect(isValidIdentifier('\\000026B')).toBeTruthy(); // ISO 10646 character

--- a/lib/utils/__tests__/isValidIdentifier.test.js
+++ b/lib/utils/__tests__/isValidIdentifier.test.js
@@ -13,5 +13,13 @@ it('isValidIdentifier', () => {
 	expect(isValidIdentifier('')).toBeFalsy();
 	expect(isValidIdentifier(' ')).toBeFalsy();
 	expect(isValidIdentifier(' --foo')).toBeFalsy();
-	expect(isValidIdentifier(' --foö')).toBeFalsy();
+	expect(isValidIdentifier('foö')).toBeFalsy();
+	expect(isValidIdentifier('\\26 B')).toBeTruthy(); // ISO 10646 character
+	expect(isValidIdentifier('\\000026B')).toBeTruthy(); // ISO 10646 character
+	expect(isValidIdentifier("te'st")).toBeFalsy(); // unescaped quotation mark
+	expect(isValidIdentifier('te"st')).toBeFalsy(); // unescaped quotation mark
+	expect(isValidIdentifier("te\\'st")).toBeTruthy(); // escaped (in CSS) quotation mark
+	expect(isValidIdentifier('te\\"st')).toBeTruthy(); // escaped (in CSS) quotation mark
+	expect(isValidIdentifier("te\\'s\\'t")).toBeTruthy(); // escaped (in CSS) quotation mark
+	expect(isValidIdentifier('te\\"s\\"t')).toBeTruthy(); // escaped (in CSS) quotation mark
 });

--- a/lib/utils/__tests__/isValidIdentifier.test.js
+++ b/lib/utils/__tests__/isValidIdentifier.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const isValidIdentifier = require('../isValidIdentifier');
+
+it('isValidIdentifier', () => {
+	expect(isValidIdentifier('foo')).toBeTruthy();
+	expect(isValidIdentifier('foo1')).toBeTruthy();
+	expect(isValidIdentifier('1')).toBeFalsy();
+	expect(isValidIdentifier('-1')).toBeFalsy();
+	expect(isValidIdentifier('--foo')).toBeFalsy();
+	expect(isValidIdentifier('has a space')).toBeFalsy();
+	expect(isValidIdentifier(null)).toBeFalsy();
+	expect(isValidIdentifier('')).toBeFalsy();
+	expect(isValidIdentifier(' ')).toBeFalsy();
+	expect(isValidIdentifier(' --foo')).toBeFalsy();
+	expect(isValidIdentifier(' --foö')).toBeFalsy();
+});

--- a/lib/utils/isValidIdentifier.js
+++ b/lib/utils/isValidIdentifier.js
@@ -1,11 +1,11 @@
 'use strict';
 
 /**
- * returns whether a string is a valid CSS identifier
+ * Returns whether a string is a valid CSS identifier
  * (i.e. only alphanumeric characters, `-`, and `_`;
  * does not have a leading digit, leading dash followed by digit, or two leading dashes)
  * furthermore, any escaped or ISO 10646 characters are allowed.
- * see: https://www.w3.org/TR/CSS2/syndata.html#value-def-identifier
+ * @see https://www.w3.org/TR/CSS2/syndata.html#value-def-identifier
  * @param {string} ident
  * @returns {boolean}
  */
@@ -23,17 +23,15 @@ module.exports = function isValidIdentifier(ident) {
 		.replace(/\\./g, '');
 
 	// characters that are not alphanumeric, hyphen or underscore
-	if (trimmedIdent.match(/[^\w-]/)) {
+	if (/[^\w-]/.test(trimmedIdent)) {
 		return false;
 	}
 
-	// ident has a leading digit
-	if (hasDigitAt(0)) {
+	if (/\d/.test(trimmedIdent.charAt(0))) {
 		return false;
 	}
 
-	// ident has a leading dash followed by a digit
-	if (trimmedIdent.charAt(0) === '-' && hasDigitAt(1)) {
+	if (trimmedIdent.charAt(0) === '-' && /\d/.test(trimmedIdent.charAt(1))) {
 		return false;
 	}
 

--- a/lib/utils/isValidIdentifier.js
+++ b/lib/utils/isValidIdentifier.js
@@ -19,8 +19,8 @@ module.exports = function isValidIdentifier(ident) {
 	// trims, removes ISO 10646 characters, and singly-escaped characters
 	const trimmedIdent = ident
 		.trim()
-		.replaceAll(/\\[0-9a-f]{1,6}(\\r\\n|[ \t\r\n\f])?/gi, '')
-		.replaceAll(/\\./g, '');
+		.replace(/\\[0-9a-f]{1,6}(\\r\\n|[ \t\r\n\f])?/gi, '')
+		.replace(/\\./g, '');
 
 	// characters that are not alphanumeric, hyphen or underscore
 	if (trimmedIdent.match(/[^\w-]/)) {

--- a/lib/utils/isValidIdentifier.js
+++ b/lib/utils/isValidIdentifier.js
@@ -32,8 +32,8 @@ module.exports = function isValidIdentifier(ident) {
 		return false;
 	}
 
-	// ident has a leading dash followed by a digit or a dash
-	if (trimmedIdent.charAt(0) === '-' && (hasDigitAt(1) || trimmedIdent.charAt(1) === '-')) {
+	// ident has a leading dash followed by a digit
+	if (trimmedIdent.charAt(0) === '-' && hasDigitAt(1)) {
 		return false;
 	}
 

--- a/lib/utils/isValidIdentifier.js
+++ b/lib/utils/isValidIdentifier.js
@@ -4,6 +4,7 @@
  * returns whether a string is a valid CSS identifier
  * (i.e. only alphanumeric characters, `-`, and `_`;
  * does not have a leading digit, leading dash followed by digit, or two leading dashes)
+ * furthermore, any escaped or ISO 10646 characters are allowed.
  * see: https://www.w3.org/TR/CSS2/syndata.html#value-def-identifier
  * @param {string} ident
  * @returns {boolean}
@@ -15,19 +16,23 @@ module.exports = function isValidIdentifier(ident) {
 
 	const hasDigitAt = (/** @type {number} */ i) => !isNaN(parseInt(ident.charAt(i)));
 
-	const trimmedIdent = ident.trim();
+	// trims, removes ISO 10646 characters, and singly-escaped characters
+	const trimmedIdent = ident
+		.trim()
+		.replaceAll(/\\[0-9a-f]{1,6}(\\r\\n|[ \t\r\n\f])?/gi, '')
+		.replaceAll(/\\./g, '');
 
 	// characters that are not alphanumeric, hyphen or underscore
 	if (trimmedIdent.match(/[^\w-]/)) {
 		return false;
 	}
 
-	// string has a leading digit
+	// const has a leading digit
 	if (hasDigitAt(0)) {
 		return false;
 	}
 
-	// string has a leading dash followed by a digit or a dash
+	// const has a leading dash followed by a digit or a dash
 	if (trimmedIdent.charAt(0) === '-' && (hasDigitAt(1) || trimmedIdent.charAt(1) === '-')) {
 		return false;
 	}

--- a/lib/utils/isValidIdentifier.js
+++ b/lib/utils/isValidIdentifier.js
@@ -14,15 +14,12 @@ module.exports = function isValidIdentifier(ident) {
 		return false;
 	}
 
-	const hasDigitAt = (/** @type {number} */ i) => !isNaN(parseInt(ident.charAt(i)));
-
 	// trims, removes ISO 10646 characters, and singly-escaped characters
 	const trimmedIdent = ident
 		.trim()
 		.replace(/\\[0-9a-f]{1,6}(\\r\\n|[ \t\r\n\f])?/gi, '')
 		.replace(/\\./g, '');
 
-	// characters that are not alphanumeric, hyphen or underscore
 	if (/[^\w-]/.test(trimmedIdent)) {
 		return false;
 	}

--- a/lib/utils/isValidIdentifier.js
+++ b/lib/utils/isValidIdentifier.js
@@ -27,12 +27,12 @@ module.exports = function isValidIdentifier(ident) {
 		return false;
 	}
 
-	// const has a leading digit
+	// ident has a leading digit
 	if (hasDigitAt(0)) {
 		return false;
 	}
 
-	// const has a leading dash followed by a digit or a dash
+	// ident has a leading dash followed by a digit or a dash
 	if (trimmedIdent.charAt(0) === '-' && (hasDigitAt(1) || trimmedIdent.charAt(1) === '-')) {
 		return false;
 	}

--- a/lib/utils/isValidIdentifier.js
+++ b/lib/utils/isValidIdentifier.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/**
+ * returns whether a string is a valid CSS identifier
+ * (i.e. only alphanumeric characters, `-`, and `_`;
+ * does not have a leading digit, leading dash followed by digit, or two leading dashes)
+ * see: https://www.w3.org/TR/CSS2/syndata.html#value-def-identifier
+ * @param {string} ident
+ * @returns {boolean}
+ */
+module.exports = function isValidIdentifier(ident) {
+	if (!ident || ident.trim() === '') {
+		return false;
+	}
+
+	const hasDigitAt = (/** @type {number} */ i) => !isNaN(parseInt(ident.charAt(i)));
+
+	const trimmedIdent = ident.trim();
+
+	// characters that are not alphanumeric, hyphen or underscore
+	if (trimmedIdent.match(/[^\w-]/)) {
+		return false;
+	}
+
+	// string has a leading digit
+	if (hasDigitAt(0)) {
+		return false;
+	}
+
+	// string has a leading dash followed by a digit or a dash
+	if (trimmedIdent.charAt(0) === '-' && (hasDigitAt(1) || trimmedIdent.charAt(1) === '-')) {
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4300.

> Is there anything in the PR that needs further explanation?

First - should I add some documentation to explain this new behaviour? Or do we think the current setup is enough.

There's a bit of discussion in #4300. To reiterate @Mouvedia's point: 

> so to me
> ```
> [href='te\'s\'t'] { }
> [href="te\"s\"t"] { }
> ```
> 
> can be processed and become
> ```
> [href=te\'s\'t] { }
> [href=te\"s\"t] { }
> ```
> 
> but
> ```
> [href="te'st"] { }
> [href='te"st'] { }
> ```
> 
> should remain untouched.

As such, I've adjusted the relevant test cases. The latter two are moved from being rejected to accepted; let me know if that was the desired change (or if instead we should still report, but not fix).

### Regex alternative

I realized that the CSS grammar actually has [a FLEX tokenizer](https://www.w3.org/TR/CSS21/grammar.html#scanner), so I tried to directly copy the rule as a Regex:

```js
// directly taken from spec: https://www.w3.org/TR/CSS21/grammar.html#scanner
const h = "[0-9a-f]";
const nonascii = "[\\240-\\377]";
const unicode = "\\\\{h}{1,6}(\\r\\n|[ \\t\\r\\n\\f])?".replace("{h}", h);
const escape = "({unicode}|\\\\[^\\r\\n\\f0-9a-fA-F])".replace("{unicode}", unicode);
const nmstart = "([_a-zA-Z]|{nonascii}|{escape})".replace("{nonascii}", nonascii).replace("{escape}", escape);
const nmchar = "([_a-zA-Z0-9-]|{nonascii}|{escape})".replace("{nonascii}", nonascii).replace("{escape}", escape);
const identifier = "-?{nmstart}{nmchar}*".replace("{nmstart}", nmstart).replace("{nmchar}", nmchar);
	
return Boolean(ident.match(identifier));
```

Unfortunately, this doesn't work! It misses some "basic" cases, including strings with spaces in them. If anybody has any ideas on what I've done wrong, that would be great - I feel like using the CSS spec when possible seems like a good idea.
