### PR TITLE
Fix `keyframe-selector-notation` false positives for named timeline range

### DIFF
--- a/.changeset/spotty-baboons-train.md
+++ b/.changeset/spotty-baboons-train.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `keyframe-selector-notation` false positives for named timeline ranges

--- a/lib/rules/keyframe-selector-notation/__tests__/index.js
+++ b/lib/rules/keyframe-selector-notation/__tests__/index.js
@@ -29,6 +29,10 @@ testRule({
 			code: '@keyframes foo { from, to {} }',
 			description: 'selector lists',
 		},
+		{
+			code: '@keyframes foo { enter 0% {} enter 100% {} }',
+			description: 'timeline-range-name',
+		},
 	],
 
 	reject: [
@@ -166,6 +170,10 @@ testRule({
 			code: '@keyframes foo { 0%, 100% {} }',
 			description: 'selector lists',
 		},
+		{
+			code: '@keyframes foo { enter 0% {} enter 100% {} }',
+			description: 'timeline-range-name',
+		},
 	],
 
 	reject: [
@@ -300,6 +308,10 @@ testRule({
 		},
 		{
 			code: '@keyframes foo { from,to {} }',
+		},
+		{
+			code: '@keyframes foo { enter 0% {} enter 100% {} }',
+			description: 'timeline-range-name',
 		},
 	],
 

--- a/lib/rules/keyframe-selector-notation/__tests__/index.js
+++ b/lib/rules/keyframe-selector-notation/__tests__/index.js
@@ -30,8 +30,24 @@ testRule({
 			description: 'selector lists',
 		},
 		{
+			code: '@keyframes foo { cover 0% {} cover 100% {} }',
+			description: 'timeline-range-name cover',
+		},
+		{
+			code: '@keyframes foo { contain 0% {} contain 100% {} }',
+			description: 'timeline-range-name contain',
+		},
+		{
+			code: '@keyframes foo { entry 0% {} entry 100% {} }',
+			description: 'timeline-range-name entry',
+		},
+		{
 			code: '@keyframes foo { enter 0% {} enter 100% {} }',
-			description: 'timeline-range-name',
+			description: 'timeline-range-name enter',
+		},
+		{
+			code: '@keyframes foo { exit 0% {} exit 100% {} }',
+			description: 'timeline-range-name exit',
 		},
 	],
 
@@ -171,8 +187,24 @@ testRule({
 			description: 'selector lists',
 		},
 		{
+			code: '@keyframes foo { cover 0% {} cover 100% {} }',
+			description: 'timeline-range-name cover',
+		},
+		{
+			code: '@keyframes foo { contain 0% {} contain 100% {} }',
+			description: 'timeline-range-name contain',
+		},
+		{
+			code: '@keyframes foo { entry 0% {} entry 100% {} }',
+			description: 'timeline-range-name entry',
+		},
+		{
 			code: '@keyframes foo { enter 0% {} enter 100% {} }',
-			description: 'timeline-range-name',
+			description: 'timeline-range-name enter',
+		},
+		{
+			code: '@keyframes foo { exit 0% {} exit 100% {} }',
+			description: 'timeline-range-name exit',
 		},
 	],
 
@@ -310,8 +342,24 @@ testRule({
 			code: '@keyframes foo { from,to {} }',
 		},
 		{
+			code: '@keyframes foo { cover 0% {} cover 100% {} }',
+			description: 'timeline-range-name cover',
+		},
+		{
+			code: '@keyframes foo { contain 0% {} contain 100% {} }',
+			description: 'timeline-range-name contain',
+		},
+		{
+			code: '@keyframes foo { entry 0% {} entry 100% {} }',
+			description: 'timeline-range-name entry',
+		},
+		{
 			code: '@keyframes foo { enter 0% {} enter 100% {} }',
-			description: 'timeline-range-name',
+			description: 'timeline-range-name enter',
+		},
+		{
+			code: '@keyframes foo { exit 0% {} exit 100% {} }',
+			description: 'timeline-range-name exit',
 		},
 	],
 

--- a/lib/rules/keyframe-selector-notation/__tests__/index.js
+++ b/lib/rules/keyframe-selector-notation/__tests__/index.js
@@ -2,6 +2,29 @@
 
 const { messages, ruleName } = require('..');
 
+const ACCEPT_TIMELINE_RANGE_NAME_TEST_CASES = [
+	{
+		code: '@keyframes foo { cover 0% {} cover 100% {} }',
+		description: 'timeline-range-name cover',
+	},
+	{
+		code: '@keyframes foo { contain 0% {} contain 100% {} }',
+		description: 'timeline-range-name contain',
+	},
+	{
+		code: '@keyframes foo { entry 0% {} entry 100% {} }',
+		description: 'timeline-range-name entry',
+	},
+	{
+		code: '@keyframes foo { enter 0% {} enter 100% {} }',
+		description: 'timeline-range-name enter',
+	},
+	{
+		code: '@keyframes foo { exit 0% {} exit 100% {} }',
+		description: 'timeline-range-name exit',
+	},
+];
+
 testRule({
 	ruleName,
 	config: ['keyword'],
@@ -29,26 +52,7 @@ testRule({
 			code: '@keyframes foo { from, to {} }',
 			description: 'selector lists',
 		},
-		{
-			code: '@keyframes foo { cover 0% {} cover 100% {} }',
-			description: 'timeline-range-name cover',
-		},
-		{
-			code: '@keyframes foo { contain 0% {} contain 100% {} }',
-			description: 'timeline-range-name contain',
-		},
-		{
-			code: '@keyframes foo { entry 0% {} entry 100% {} }',
-			description: 'timeline-range-name entry',
-		},
-		{
-			code: '@keyframes foo { enter 0% {} enter 100% {} }',
-			description: 'timeline-range-name enter',
-		},
-		{
-			code: '@keyframes foo { exit 0% {} exit 100% {} }',
-			description: 'timeline-range-name exit',
-		},
+		...ACCEPT_TIMELINE_RANGE_NAME_TEST_CASES,
 	],
 
 	reject: [
@@ -186,26 +190,7 @@ testRule({
 			code: '@keyframes foo { 0%, 100% {} }',
 			description: 'selector lists',
 		},
-		{
-			code: '@keyframes foo { cover 0% {} cover 100% {} }',
-			description: 'timeline-range-name cover',
-		},
-		{
-			code: '@keyframes foo { contain 0% {} contain 100% {} }',
-			description: 'timeline-range-name contain',
-		},
-		{
-			code: '@keyframes foo { entry 0% {} entry 100% {} }',
-			description: 'timeline-range-name entry',
-		},
-		{
-			code: '@keyframes foo { enter 0% {} enter 100% {} }',
-			description: 'timeline-range-name enter',
-		},
-		{
-			code: '@keyframes foo { exit 0% {} exit 100% {} }',
-			description: 'timeline-range-name exit',
-		},
+		...ACCEPT_TIMELINE_RANGE_NAME_TEST_CASES,
 	],
 
 	reject: [
@@ -341,26 +326,7 @@ testRule({
 		{
 			code: '@keyframes foo { from,to {} }',
 		},
-		{
-			code: '@keyframes foo { cover 0% {} cover 100% {} }',
-			description: 'timeline-range-name cover',
-		},
-		{
-			code: '@keyframes foo { contain 0% {} contain 100% {} }',
-			description: 'timeline-range-name contain',
-		},
-		{
-			code: '@keyframes foo { entry 0% {} entry 100% {} }',
-			description: 'timeline-range-name entry',
-		},
-		{
-			code: '@keyframes foo { enter 0% {} enter 100% {} }',
-			description: 'timeline-range-name enter',
-		},
-		{
-			code: '@keyframes foo { exit 0% {} exit 100% {} }',
-			description: 'timeline-range-name exit',
-		},
+		...ACCEPT_TIMELINE_RANGE_NAME_TEST_CASES,
 	],
 
 	reject: [

--- a/lib/rules/keyframe-selector-notation/index.js
+++ b/lib/rules/keyframe-selector-notation/index.js
@@ -160,8 +160,9 @@ function getSelectorsInBlock(atRule) {
 function isNamedTimelineRange(selectors) {
 	for (const selectorNode of Array.from(selectors.nodes)) {
 		const firstTagNode = selectorNode.nodes.filter((node) => node.type === 'tag')[0];
+		const firstTagValue = firstTagNode && firstTagNode.value ? firstTagNode.value : '';
 
-		if (firstTagNode?.value && NAMED_TIMELINE_RABGE_SELECTORS.has(firstTagNode.value)) {
+		if (firstTagValue && NAMED_TIMELINE_RABGE_SELECTORS.has(firstTagValue)) {
 			return true;
 		}
 	}

--- a/lib/rules/keyframe-selector-notation/index.js
+++ b/lib/rules/keyframe-selector-notation/index.js
@@ -19,6 +19,7 @@ const meta = {
 
 const PERCENTAGE_SELECTORS = new Set(['0%', '100%']);
 const KEYWORD_SELECTORS = new Set(['from', 'to']);
+const NAMED_TIMELINE_RABGE_SELECTORS = new Set(['cover', 'contain', 'entry', 'enter', 'exit']);
 const PERCENTAGE_TO_KEYWORD = new Map([
 	['0%', 'from'],
 	['100%', 'to'],
@@ -73,7 +74,7 @@ const rule = (primary, _, context) => {
 
 			atRuleKeyframes.walkRules((keyframeRule) => {
 				transformSelector(result, keyframeRule, (selectors) => {
-					if (hasMultipleTags(selectors)) {
+					if (isNamedTimelineRange(selectors)) {
 						return;
 					}
 
@@ -156,13 +157,11 @@ function getSelectorsInBlock(atRule) {
  * @param {import('postcss-selector-parser').Root} selectors
  * @returns boolean
  */
-function hasMultipleTags(selectors) {
+function isNamedTimelineRange(selectors) {
 	for (const selectorNode of Array.from(selectors.nodes)) {
-		const tagNodes = selectorNode.nodes.filter((node) => {
-			return node.type === 'tag';
-		});
+		const firstTagNode = selectorNode.nodes.filter((node) => node.type === 'tag')[0];
 
-		if (tagNodes.length >= 2) {
+		if (firstTagNode?.value && NAMED_TIMELINE_RABGE_SELECTORS.has(firstTagNode.value)) {
 			return true;
 		}
 	}

--- a/lib/rules/keyframe-selector-notation/index.js
+++ b/lib/rules/keyframe-selector-notation/index.js
@@ -19,7 +19,7 @@ const meta = {
 
 const PERCENTAGE_SELECTORS = new Set(['0%', '100%']);
 const KEYWORD_SELECTORS = new Set(['from', 'to']);
-const NAMED_TIMELINE_RABGE_SELECTORS = new Set(['cover', 'contain', 'entry', 'enter', 'exit']);
+const NAMED_TIMELINE_RANGE_SELECTORS = new Set(['cover', 'contain', 'entry', 'enter', 'exit']);
 const PERCENTAGE_TO_KEYWORD = new Map([
 	['0%', 'from'],
 	['100%', 'to'],
@@ -74,11 +74,15 @@ const rule = (primary, _, context) => {
 
 			atRuleKeyframes.walkRules((keyframeRule) => {
 				transformSelector(result, keyframeRule, (selectors) => {
-					if (isNamedTimelineRange(selectors)) {
-						return;
-					}
+					let first = true;
 
 					selectors.walkTags((selectorTag) => {
+						if (first && NAMED_TIMELINE_RANGE_SELECTORS.has(selectorTag.value)) {
+							return false;
+						}
+
+						first = false;
+
 						checkSelector(
 							selectorTag.value,
 							optionFuncs[primary],
@@ -151,23 +155,6 @@ function getSelectorsInBlock(atRule) {
 	});
 
 	return selectors;
-}
-
-/**
- * @param {import('postcss-selector-parser').Root} selectors
- * @returns boolean
- */
-function isNamedTimelineRange(selectors) {
-	for (const selectorNode of Array.from(selectors.nodes)) {
-		const firstTagNode = selectorNode.nodes.filter((node) => node.type === 'tag')[0];
-		const firstTagValue = firstTagNode && firstTagNode.value ? firstTagNode.value : '';
-
-		if (firstTagValue && NAMED_TIMELINE_RABGE_SELECTORS.has(firstTagValue)) {
-			return true;
-		}
-	}
-
-	return false;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/keyframe-selector-notation/index.js
+++ b/lib/rules/keyframe-selector-notation/index.js
@@ -73,6 +73,10 @@ const rule = (primary, _, context) => {
 
 			atRuleKeyframes.walkRules((keyframeRule) => {
 				transformSelector(result, keyframeRule, (selectors) => {
+					if (hasMultipleTags(selectors)) {
+						return;
+					}
+
 					selectors.walkTags((selectorTag) => {
 						checkSelector(
 							selectorTag.value,
@@ -146,6 +150,24 @@ function getSelectorsInBlock(atRule) {
 	});
 
 	return selectors;
+}
+
+/**
+ * @param {import('postcss-selector-parser').Root} selectors
+ * @returns boolean
+ */
+function hasMultipleTags(selectors) {
+	for (const selectorNode of Array.from(selectors.nodes)) {
+		const tagNodes = selectorNode.nodes.filter((node) => {
+			return node.type === 'tag';
+		});
+
+		if (tagNodes.length >= 2) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 rule.ruleName = ruleName;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #6538

> Is there anything in the PR that needs further explanation?

Fix to stop linting if the selector of the keyframe has multiple tags.
Please let me know if there is a better approach.