### PR TITLE
Refactor `declaration-property-value-no-unknown` to reuse parsed CSSTree node

### DIFF
--- a/lib/rules/declaration-property-value-no-unknown/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/index.js
@@ -84,10 +84,12 @@ const rule = (primary, secondaryOptions) => {
 
 			if (isPropIgnored(prop, value)) return;
 
-			try {
-				const valueNode = parse(value, { context: 'value' });
+			let cssTreeValueNode;
 
-				if (containsUnsupportedMathFunction(valueNode)) return;
+			try {
+				cssTreeValueNode = parse(value, { context: 'value' });
+
+				if (containsUnsupportedMathFunction(cssTreeValueNode)) return;
 			} catch (e) {
 				result.warn(`Cannot parse property value "${value}"`, {
 					node: decl,
@@ -97,7 +99,7 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			const { error } = forkedLexer.matchProperty(prop, value);
+			const { error } = forkedLexer.matchProperty(prop, cssTreeValueNode);
 
 			if (!error) return;
 

--- a/patches/@types+css-tree+2.0.1.patch
+++ b/patches/@types+css-tree+2.0.1.patch
@@ -17,7 +17,7 @@ index 2e4ed18..7f096c6 100755
 +};
 +
 +declare class Lexer {
-+    matchProperty(propertyName: string, value: string): MatchResult;
++    matchProperty(propertyName: string, value: CssNode | string): MatchResult;
 +}
 +
 +export function fork(extension: Record<string, Record<string, string>>): { lexer: Lexer };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up for #6511

> Is there anything in the PR that needs further explanation?

According to the [CSSTree doc](https://github.com/csstree/csstree/blob/v2.3.1/README.md#usage), it is likely a typical case to pass a node to `lexer.matchProperty()`.

<details>
<summary>CSSTree Usage</summary>

```js
// parse CSS to AST as a declaration value
const ast = csstree.parse('red 1px solid', { context: 'value' });

// match to syntax of `border` property
const matchResult = csstree.lexer.matchProperty('border', last);
```

</details>

I guess this change may reduce extra parsing, but I'm not sure about the implementation details of CSSTree.