### PR TITLE
Fix `configBasedir` being evaluated case-sensitively on Windows

### DIFF
--- a/.changeset/long-toys-boil.md
+++ b/.changeset/long-toys-boil.md
@@ -1,0 +1,5 @@
+---
+'stylelint': patch
+---
+
+Fixes not working "extends", "plugins" and "customSyntax" in case of small drive letter and backward slashes in configBasedir path.

--- a/.changeset/long-toys-boil.md
+++ b/.changeset/long-toys-boil.md
@@ -1,5 +1,0 @@
----
-'stylelint': patch
----
-
-Fixes not working "extends", "plugins" and "customSyntax" in case of small drive letter and backward slashes in configBasedir path.

--- a/.changeset/tidy-balloons-melt.md
+++ b/.changeset/tidy-balloons-melt.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Convert configBasedir e.g. c:\foo\bar to C:/foo/bar

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -85,14 +85,10 @@ async function standalone({
 		return Promise.reject(error);
 	}
 
-	// convert e.g. c:\foo\bar to C:/foo/bar to avoid not working "extends", "plugins" and "customSyntax"
+	// convert e.g. c:/foo/bar to C:/foo/bar to avoid not working "extends", "plugins" and "customSyntax"
 	if (configBasedir) {
 		if (configBasedir[0] && configBasedir[1] === ':') {
 			configBasedir = configBasedir[0].toUpperCase() + configBasedir.substr(1);
-		}
-
-		if (configBasedir.includes('\\')) {
-			configBasedir = configBasedir.replace(/\\/g, '/');
 		}
 	}
 

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -85,6 +85,16 @@ async function standalone({
 		return Promise.reject(error);
 	}
 
+	// convert e.g. c:\foo\bar to C:/foo/bar to avoid not working "extends", "plugins" and "customSyntax"
+	if (configBasedir) {
+		if (configBasedir[1] == ':') {
+			configBasedir = configBasedir[0].toUpperCase() + configBasedir.substr(1);
+		}
+		if (configBasedir.includes('\\')) {
+			configBasedir = configBasedir.replace(/\\/g, '/');
+		}
+	}
+
 	const stylelint = createStylelint({
 		cacheLocation,
 		cacheStrategy,

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -87,9 +87,10 @@ async function standalone({
 
 	// convert e.g. c:\foo\bar to C:/foo/bar to avoid not working "extends", "plugins" and "customSyntax"
 	if (configBasedir) {
-		if (configBasedir[1] == ':') {
+		if (configBasedir[0] && configBasedir[1] === ':') {
 			configBasedir = configBasedir[0].toUpperCase() + configBasedir.substr(1);
 		}
+
 		if (configBasedir.includes('\\')) {
 			configBasedir = configBasedir.replace(/\\/g, '/');
 		}

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -86,10 +86,8 @@ async function standalone({
 	}
 
 	// convert e.g. c:/foo/bar to C:/foo/bar to avoid not working "extends", "plugins" and "customSyntax"
-	if (configBasedir) {
-		if (configBasedir[0] && configBasedir[1] === ':') {
-			configBasedir = configBasedir[0].toUpperCase() + configBasedir.substr(1);
-		}
+	if (configBasedir && configBasedir[0] && configBasedir[1] === ':') {
+		configBasedir = configBasedir[0].toUpperCase() + configBasedir.substr(1);
 	}
 
 	const stylelint = createStylelint({


### PR DESCRIPTION
Fixes not working "extends", "plugins" and "customSyntax" in case of small drive letter and backward slashes in configBasedir path. After this fix warn `When linting something other than CSS, you should install an appropriate syntax, e.g. "postcss-html", and use the "customSyntax" option.` is not shown and plugins works.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Such as https://github.com/stylelint/stylelint/issues/5594 but for configBasedir

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
