### PR TITLE
Fix heading level typo in `to-15.md`

### DIFF
--- a/docs/migration-guide/to-15.md
+++ b/docs/migration-guide/to-15.md
@@ -133,7 +133,7 @@ You'll find a complete list of them in [Awesome Stylelint](https://github.com/st
 
 If you create a new custom syntax, please [open a pull request](https://github.com/stylelint/awesome-stylelint/compare) to update [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint#readme) so that others can find it. For example, [Stitches](https://stitches.dev/) and [vanilla-extract](https://vanilla-extract.style/) need syntaxes, which are object-based CSS-in-JS libraries.
 
-## Removed support for Node.js 12
+### Removed support for Node.js 12
 
 Node.js 12 has reached end-of-life. We've removed support for it so that we could update some of our dependencies. You should use the following or higher versions of Node.js:
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

"_Removed support for Node.js 12_" should be under "_Breaking changes_".