### PR TITLE
Fix `function-calc-no-unspaced-operator` TypeError on empty `calc()`

### DIFF
--- a/.changeset/silver-owls-develop.md
+++ b/.changeset/silver-owls-develop.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-calc-no-unspaced-operator` TypeError on empty `calc()`

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.js
@@ -225,6 +225,9 @@ testRule({
 		{
 			code: 'a { top: calc(10px/var(--foo)); }',
 		},
+		{
+			code: 'a { padding: calc(); }',
+		},
 	],
 
 	reject: [

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -314,9 +314,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 				const { nodes } = node;
 
-				if (!nodes.length) {
-					return;
-				}
+				if (!nodes.length) return;
 
 				let foundOperatorNode = false;
 

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -313,6 +313,11 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (node.type !== 'function' || node.value.toLowerCase() !== 'calc') return;
 
 				const { nodes } = node;
+
+				if (!nodes.length) {
+					return;
+				}
+
 				let foundOperatorNode = false;
 
 				for (const [nodeIndex, currNode] of nodes.entries()) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6633

> Is there anything in the PR that needs further explanation?

`calc()` is not valid, or useful but it also isn't an error that is related to this rule specifically.

This rule should not throw when processing `calc()`
