### PR TITLE
Enable merge queue

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - '**'
+  merge_group:
 
 env:
   FORCE_COLOR: 2


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Pull request merge queue is now public beta. We try it out.

See also:
- https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

Note: I've already enabled a merge queue for the `main` branch.
