### PR TITLE
Fix `fs.rmdir()` warning by `fs.rm()` in test

### DIFF
--- a/lib/__tests__/writeOutputFile.test.js
+++ b/lib/__tests__/writeOutputFile.test.js
@@ -22,6 +22,6 @@ describe('writeOutputFile', () => {
 
 		expect((await fs.readFile(filePath)).toString()).toBe('test content');
 
-		await fs.rmdir(path.dirname(filePath), { recursive: true });
+		await fs.rm(path.dirname(filePath), { recursive: true });
 	});
 });


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #6631

> Is there anything in the PR that needs further explanation?

This change aims to fix the following warning:

```
[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed.
Use fs.rm(path, { recursive: true }) instead
```

Note that `fs.rm()` has been added in Node.js 14.14.0, and our `engines.node` (`^14.13.1 || >=16.0.0`) doesn't satisfy the version.
But I believe this is used only in tests, so no problem.

See also:
- https://nodejs.org/api/fs.html#fsrmpath-options-callback
- https://github.com/stylelint/stylelint/blob/15.0.0/package.json#L199-L201
