### PR TITLE
Fix inaccurate `customSyntax` inference

### DIFF
--- a/.changeset/clever-humans-hunt.md
+++ b/.changeset/clever-humans-hunt.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: inaccurate `customSyntax` inference

--- a/lib/__tests__/overrides.test.js
+++ b/lib/__tests__/overrides.test.js
@@ -204,6 +204,7 @@ describe('single input file. all overrides are matching', () => {
 
 	// https://github.com/stylelint/stylelint/issues/5656
 	it('priority to apply overrides (scss): scss extends', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 		const linted = await standalone({
 			files: [path.join(fixturesPath, 'style.scss')],
 			config: {
@@ -220,10 +221,14 @@ describe('single input file. all overrides are matching', () => {
 
 		expect(linted.results).toHaveLength(1);
 		expect(linted.results[0].warnings).toHaveLength(0);
+
+		expect(warn).toHaveBeenCalledWith(expect.stringMatching(/use the "customSyntax" option/));
+		warn.mockRestore();
 	});
 
 	// https://github.com/stylelint/stylelint/issues/5656
 	it('priority to apply overrides (scss): apply rules', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 		const linted = await standalone({
 			files: [path.join(fixturesPath, 'style.scss')],
 			config: {
@@ -243,6 +248,9 @@ describe('single input file. all overrides are matching', () => {
 		expect(linted.results).toHaveLength(1);
 		expect(linted.results[0].warnings).toHaveLength(1);
 		expect(linted.results[0].warnings[0].rule).toBe('at-rule-no-unknown');
+
+		expect(warn).toHaveBeenCalledWith(expect.stringMatching(/use the "customSyntax" option/));
+		warn.mockRestore();
 	});
 });
 

--- a/lib/getPostcssResult.js
+++ b/lib/getPostcssResult.js
@@ -117,24 +117,6 @@ function getCustomSyntax(customSyntax, basedir) {
 	throw new Error('Custom syntax must be a string or a Syntax object');
 }
 
-/** @type {{ [key: string]: string }} */
-const previouslyInferredExtensions = {
-	html: 'postcss-html',
-	js: '@stylelint/postcss-css-in-js',
-	jsx: '@stylelint/postcss-css-in-js',
-	less: 'postcss-less',
-	md: 'postcss-markdown',
-	sass: 'postcss-sass',
-	sss: 'sugarss',
-	scss: 'postcss-scss',
-	svelte: 'postcss-html',
-	ts: '@stylelint/postcss-css-in-js',
-	tsx: '@stylelint/postcss-css-in-js',
-	vue: 'postcss-html',
-	xml: 'postcss-html',
-	xst: 'postcss-html',
-};
-
 /**
  * @param {StylelintInternalApi} stylelint
  * @param {string|undefined} filePath
@@ -144,9 +126,9 @@ function cssSyntax(stylelint, filePath) {
 	const fileExtension = filePath ? path.extname(filePath).slice(1).toLowerCase() : '';
 	const extensions = ['css', 'pcss', 'postcss'];
 
-	if (previouslyInferredExtensions[fileExtension]) {
+	if (fileExtension && !extensions.includes(fileExtension)) {
 		console.warn(
-			`${filePath}: When linting something other than CSS, you should install an appropriate syntax, e.g. "${previouslyInferredExtensions[fileExtension]}", and use the "customSyntax" option`,
+			`${filePath}: you should use the "customSyntax" option when linting something other than CSS`,
 		);
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6631

> Is there anything in the PR that needs further explanation?

Also, this change mocks `console.warn()` to clean test output.
