### PR TITLE
Fix `declaration-property-value-no-unknown` false positives for `env()`

### DIFF
--- a/.changeset/serious-moose-applaud.md
+++ b/.changeset/serious-moose-applaud.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fix `declaration-property-value-no-unknown` false positives for `env()`
+Fixed `declaration-property-value-no-unknown` false positives for `env()`

--- a/.changeset/serious-moose-applaud.md
+++ b/.changeset/serious-moose-applaud.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed `declaration-property-value-no-unknown` false positives for `env()`
+Fixed: `declaration-property-value-no-unknown` false positives for `env()`

--- a/.changeset/serious-moose-applaud.md
+++ b/.changeset/serious-moose-applaud.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fix `declaration-property-value-no-unknown` false positives for `env()`

--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -20,6 +20,9 @@ testRule({
 			code: 'a { top: var(--foo); }',
 		},
 		{
+			code: 'a { top: env(titlebar-area-height); }',
+		},
+		{
 			code: 'a { foo: 1px; }',
 		},
 		{

--- a/lib/rules/declaration-property-value-no-unknown/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/index.js
@@ -130,6 +130,7 @@ const rule = (primary, secondaryOptions) => {
  * some math functions like `clamp()` via `fork()`. In the future, it may be unnecessary.
  *
  * @see https://github.com/stylelint/stylelint/pull/6511#issuecomment-1412921062
+ * @see https://github.com/stylelint/stylelint/issues/6635#issuecomment-1425787649
  *
  * @param {import('css-tree').CssNode} cssTreeNode
  * @returns {boolean}
@@ -138,7 +139,7 @@ function containsUnsupportedMathFunction(cssTreeNode) {
 	return Boolean(
 		find(
 			cssTreeNode,
-			(node) => node.type === 'Function' && ['clamp', 'min', 'max'].includes(node.name),
+			(node) => node.type === 'Function' && ['clamp', 'min', 'max', 'env'].includes(node.name),
 		),
 	);
 }

--- a/lib/rules/declaration-property-value-no-unknown/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/index.js
@@ -89,7 +89,7 @@ const rule = (primary, secondaryOptions) => {
 			try {
 				cssTreeValueNode = parse(value, { context: 'value' });
 
-				if (containsUnsupportedMathFunction(cssTreeValueNode)) return;
+				if (containsUnsupportedFunction(cssTreeValueNode)) return;
 			} catch (e) {
 				result.warn(`Cannot parse property value "${value}"`, {
 					node: decl,
@@ -135,7 +135,7 @@ const rule = (primary, secondaryOptions) => {
  * @param {import('css-tree').CssNode} cssTreeNode
  * @returns {boolean}
  */
-function containsUnsupportedMathFunction(cssTreeNode) {
+function containsUnsupportedFunction(cssTreeNode) {
 	return Boolean(
 		find(
 			cssTreeNode,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6635

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
