### PR TITLE
Fix `declaration-property-value-no-unknown` parse error for `alpha(opacity=n)` to report as violation

### DIFF
--- a/.changeset/clean-snakes-cheat.md
+++ b/.changeset/clean-snakes-cheat.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `declaration-property-value-no-unknown` parseError even when a file starts with `/* stylelint-disable */`
+Fixed: `declaration-property-value-no-unknown` parse error for `alpha(opacity=n)` to report as violation

--- a/.changeset/clean-snakes-cheat.md
+++ b/.changeset/clean-snakes-cheat.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-property-value-no-unknown` parseError even when a file starts with `/* stylelint-disable */`

--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -49,6 +49,9 @@ testRule({
 		{
 			code: 'a { font-size: max(1rem, 3rem); }',
 		},
+		{
+			code: '/* stylelint-disable */ a { filter: alpha(opacity=30); }',
+		},
 	],
 
 	reject: [
@@ -123,6 +126,14 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 17,
+		},
+		{
+			code: 'a { filter: alpha(opacity=30); }',
+			message: messages.rejectedParseError('filter', 'alpha(opacity=30)'),
+			line: 1,
+			column: 13,
+			endLine: 1,
+			endColumn: 30,
 		},
 	],
 });

--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -49,9 +49,6 @@ testRule({
 		{
 			code: 'a { font-size: max(1rem, 3rem); }',
 		},
-		{
-			code: '/* stylelint-disable */ a { filter: alpha(opacity=30); }',
-		},
 	],
 
 	reject: [

--- a/lib/rules/declaration-property-value-no-unknown/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/index.js
@@ -94,10 +94,10 @@ const rule = (primary, secondaryOptions) => {
 				if (containsUnsupportedFunction(cssTreeValueNode)) return;
 			} catch (e) {
 				const index = declarationValueIndex(decl);
-				const endIndex = index + decl.value.length;
+				const endIndex = index + value.length;
 
 				report({
-					message: messages.rejectedParseError(prop, decl.value),
+					message: messages.rejectedParseError(prop, value),
 					node: decl,
 					index,
 					endIndex,

--- a/lib/rules/declaration-property-value-no-unknown/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/index.js
@@ -19,6 +19,8 @@ const ruleName = 'declaration-property-value-no-unknown';
 
 const messages = ruleMessages(ruleName, {
 	rejected: (property, value) => `Unexpected unknown value "${value}" for property "${property}"`,
+	rejectedParseError: (property, value) =>
+		`Cannot parse property value "${value}" for property "${property}"`,
 });
 
 const meta = {
@@ -91,9 +93,16 @@ const rule = (primary, secondaryOptions) => {
 
 				if (containsUnsupportedFunction(cssTreeValueNode)) return;
 			} catch (e) {
-				result.warn(`Cannot parse property value "${value}"`, {
+				const index = declarationValueIndex(decl);
+				const endIndex = index + decl.value.length;
+
+				report({
+					message: messages.rejectedParseError(prop, decl.value),
 					node: decl,
-					stylelintType: 'parseError',
+					index,
+					endIndex,
+					result,
+					ruleName,
 				});
 
 				return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6649

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
