### PR TITLE
Fix TypeScript error to export `Plugin` and `RuleContext`

### DIFF
--- a/.changeset/odd-chefs-battle.md
+++ b/.changeset/odd-chefs-battle.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: TypeScript error to export `Plugin` and `RuleContext`

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -8,10 +8,14 @@ declare module 'stylelint' {
 	 */
 	export type Severity = 'warning' | 'error';
 
-	type ConfigExtends = string | string[];
+	/**
+	 * A Stylelint plugin.
+	 */
 	export type Plugin =
 		| { default?: { ruleName: string; rule: Rule } }
 		| { ruleName: string; rule: Rule };
+
+	type ConfigExtends = string | string[];
 	type ConfigPlugins = string | Plugin | (string | Plugin)[];
 	type ConfigIgnoreFiles = string | string[];
 
@@ -182,6 +186,9 @@ declare module 'stylelint' {
 		optional?: boolean;
 	};
 
+	/**
+	 * A rule context.
+	 */
 	export type RuleContext = {
 		fix?: boolean | undefined;
 		newline?: string | undefined;
@@ -621,8 +628,6 @@ declare module 'stylelint' {
 			longhandSubPropertiesOfShorthandProperties: LonghandSubPropertiesOfShorthandProperties;
 		};
 	};
-
-	export type Stylelint = Omit<PublicApi, '_createLinter'>;
 
 	const stylelint: PublicApi;
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -9,7 +9,7 @@ declare module 'stylelint' {
 	export type Severity = 'warning' | 'error';
 
 	type ConfigExtends = string | string[];
-	type Plugin = { default?: { ruleName: string; rule: Rule } } | { ruleName: string; rule: Rule };
+	export type Plugin = { default?: { ruleName: string; rule: Rule } } | { ruleName: string; rule: Rule };
 	type ConfigPlugins = string | Plugin | (string | Plugin)[];
 	type ConfigIgnoreFiles = string | string[];
 
@@ -180,7 +180,7 @@ declare module 'stylelint' {
 		optional?: boolean;
 	};
 
-	type RuleContext = {
+	export type RuleContext = {
 		fix?: boolean | undefined;
 		newline?: string | undefined;
 	};
@@ -620,7 +620,9 @@ declare module 'stylelint' {
 		};
 	};
 
-	const stylelint: PublicApi;
+	export type Stylelint = Omit<PublicApi, '_createLinter'>;
+
+	const stylelint: Stylelint;
 
 	export default stylelint;
 }

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -9,7 +9,9 @@ declare module 'stylelint' {
 	export type Severity = 'warning' | 'error';
 
 	type ConfigExtends = string | string[];
-	export type Plugin = { default?: { ruleName: string; rule: Rule } } | { ruleName: string; rule: Rule };
+	export type Plugin =
+		| { default?: { ruleName: string; rule: Rule } }
+		| { ruleName: string; rule: Rule };
 	type ConfigPlugins = string | Plugin | (string | Plugin)[];
 	type ConfigIgnoreFiles = string | string[];
 
@@ -622,7 +624,7 @@ declare module 'stylelint' {
 
 	export type Stylelint = Omit<PublicApi, '_createLinter'>;
 
-	const stylelint: Stylelint;
+	const stylelint: PublicApi;
 
 	export default stylelint;
 }


### PR DESCRIPTION
Export types for plugin authoring.

Related to https://github.com/stylelint/stylelint/issues/6662