### PR TITLE
 Add missing semicolon in version 15 migration guide

### DIFF
--- a/docs/migration-guide/to-15.md
+++ b/docs/migration-guide/to-15.md
@@ -30,7 +30,7 @@ You can [extend](../user-guide/configure.md#extends) the [standard config](https
 ```diff json
 {
 + "extends": ["stylelint-config-standard"],
-  "rules" { .. }
+  "rules": { .. }
 }
 ```
 
@@ -39,7 +39,7 @@ Additionally, you may no longer need to extend [Prettier's Stylelint config](htt
 ```diff json
 {
 - "extends": ["stylelint-config-prettier"],
-  "rules" { .. }
+  "rules": { .. }
 }
 ```
 
@@ -68,7 +68,7 @@ To turn it on in your configuration object:
 ```diff json
 {
   "extends": ["stylelint-config-standard"],
-  "rules" {
+  "rules": {
 +   "declaration-property-value-no-unknown": true
     ..
    }
@@ -88,7 +88,7 @@ If you currently use the [`stylelint-csstree-validator`](https://www.npmjs.com/p
 
 ```diff json
 {
-  "rules" {
+  "rules": {
     "csstree/validator": [true, {
 +      "ignoreProperties": ["/.+/"]
     }]
@@ -118,7 +118,7 @@ For example, if you use [styled-components](https://styled-components.com):
 {
 - "processors": ["stylelint-processor-styled-components"],
 + "customSyntax": "postcss-styled-syntax",
-  "rules" { .. }
+  "rules": { .. }
 }
 ```
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

There is colon missing after "rules" property in this document. Adding colon to make configurations a valid JSON.
