### PR TITLE
Fix `*-case|*-unknown` false positives for CSS-in-JS template literals

### DIFF
--- a/.changeset/five-waves-relax.md
+++ b/.changeset/five-waves-relax.md
@@ -2,8 +2,8 @@
 "stylelint": patch
 ---
 
-Fixed: `annotation-no-unknown` false positives in CSS-in-JS syntax
-Fixed: `function-name-case` false positives in CSS-in-JS syntax
-Fixed: `function-no-unknown` false positives in CSS-in-JS syntax
-Fixed: `unit-no-unknown` false positives in CSS-in-JS syntax
-Fixed: `value-keyword-case` false positives in CSS-in-JS syntax
+Fixed: `annotation-no-unknown` false positives for CSS-in-JS template literals
+Fixed: `function-name-case` false positives for CSS-in-JS template literals
+Fixed: `function-no-unknown` false positives for CSS-in-JS template literals
+Fixed: `unit-no-unknown` false positives for CSS-in-JS template literals
+Fixed: `value-keyword-case` false positives for CSS-in-JS template literals

--- a/.changeset/five-waves-relax.md
+++ b/.changeset/five-waves-relax.md
@@ -1,0 +1,9 @@
+---
+"stylelint": patch
+---
+
+Fixed: `annotation-no-unknown` false positives in CSS-in-JS syntax
+Fixed: `function-name-case` false positives in CSS-in-JS syntax
+Fixed: `function-no-unknown` false positives in CSS-in-JS syntax
+Fixed: `unit-no-unknown` false positives in CSS-in-JS syntax
+Fixed: `value-keyword-case` false positives in CSS-in-JS syntax

--- a/lib/rules/annotation-no-unknown/__tests__/index.js
+++ b/lib/rules/annotation-no-unknown/__tests__/index.js
@@ -56,3 +56,15 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	customSyntax: 'postcss-scss',
+	config: [true],
+
+	accept: [
+		{
+			code: 'a { color: #{$green} !imprtant; }',
+		},
+	],
+});

--- a/lib/rules/annotation-no-unknown/index.js
+++ b/lib/rules/annotation-no-unknown/index.js
@@ -3,6 +3,7 @@
 const valueParser = require('postcss-value-parser');
 
 const getDeclarationValue = require('../../utils/getDeclarationValue');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -45,6 +46,10 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {import('postcss').Declaration} decl
 		 */
 		function checkStatement(decl) {
+			if (!isStandardSyntaxValue(decl.value)) {
+				return;
+			}
+
 			if (decl.important) return;
 
 			if (!decl.value.includes('!')) return;

--- a/lib/rules/annotation-no-unknown/index.js
+++ b/lib/rules/annotation-no-unknown/index.js
@@ -46,9 +46,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {import('postcss').Declaration} decl
 		 */
 		function checkStatement(decl) {
-			if (!isStandardSyntaxValue(decl.value)) {
-				return;
-			}
+			if (!isStandardSyntaxValue(decl.value)) return;
 
 			if (decl.important) return;
 

--- a/lib/rules/function-name-case/__tests__/index.js
+++ b/lib/rules/function-name-case/__tests__/index.js
@@ -583,3 +583,15 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	customSyntax: 'postcss-scss',
+	config: ['upper'],
+	fix: true,
+	accept: [
+		{
+			code: 'a { margin: cAlC(5% - #{$size2}); }',
+		},
+	],
+});

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -11,6 +11,7 @@ const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
 const valueParser = require('postcss-value-parser');
 const { isRegExp, isString } = require('../../utils/validateTypes');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 
 const ruleName = 'function-name-case';
 
@@ -53,6 +54,10 @@ const rule = (primary, secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
+			if (!isStandardSyntaxValue(decl.value)) {
+				return;
+			}
+
 			let needFix = false;
 			const parsed = valueParser(getDeclarationValue(decl));
 

--- a/lib/rules/function-name-case/index.js
+++ b/lib/rules/function-name-case/index.js
@@ -54,9 +54,7 @@ const rule = (primary, secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
-			if (!isStandardSyntaxValue(decl.value)) {
-				return;
-			}
+			if (!isStandardSyntaxValue(decl.value)) return;
 
 			let needFix = false;
 			const parsed = valueParser(getDeclarationValue(decl));

--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -58,9 +58,7 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls((decl) => {
 			const { value } = decl;
 
-			if (!isStandardSyntaxValue(value)) {
-				return;
-			}
+			if (!isStandardSyntaxValue(value)) return;
 
 			valueParser(value).walk((node) => {
 				const name = node.value;

--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -12,6 +12,7 @@ const validateOptions = require('../../utils/validateOptions');
 const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const isCustomFunction = require('../../utils/isCustomFunction');
 const { isRegExp, isString } = require('../../utils/validateTypes');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 
 const ruleName = 'function-no-unknown';
 
@@ -56,6 +57,10 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkDecls((decl) => {
 			const { value } = decl;
+
+			if (!isStandardSyntaxValue(value)) {
+				return;
+			}
 
 			valueParser(value).walk((node) => {
 				const name = node.value;

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -490,8 +490,12 @@ testRule({
 			description: 'ignore interpolation',
 		},
 		{
-			code: 'a { margin: calc(100% - #{$margin * 2}); }',
-			description: 'work with interpolation',
+			code: 'a { margin: calc(100% - #{$margin * 2pix}); }',
+			description: 'ignore interpolations',
+		},
+		{
+			code: 'a { margin: $margin + 10pix; }',
+			description: 'ignore values with variables',
 		},
 	],
 
@@ -503,22 +507,6 @@ testRule({
 			column: 15,
 			endLine: 1,
 			endColumn: 18,
-		},
-		{
-			code: 'a { margin: $margin + 10pix; }',
-			message: messages.rejected('pix'),
-			line: 1,
-			column: 25,
-			endLine: 1,
-			endColumn: 28,
-		},
-		{
-			code: 'a { margin: calc(100% - #{$margin * 2pix}); }',
-			message: messages.rejected('pix'),
-			line: 1,
-			column: 38,
-			endLine: 1,
-			endColumn: 42,
 		},
 	],
 });

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -160,7 +160,7 @@ const rule = (primary, secondaryOptions) => {
 		});
 		root.walkDecls((decl) => {
 			if (!isStandardSyntaxDeclaration(decl)) return;
-			
+
 			if (!isStandardSyntaxValue(decl.value)) return;
 
 			check(decl, decl.value, declarationValueIndex);

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -15,6 +15,7 @@ const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
 const { isRegExp, isString, assert } = require('../../utils/validateTypes');
 const { isAtRule } = require('../../utils/typeGuards');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 
 const ruleName = 'unit-no-unknown';
 
@@ -158,7 +159,7 @@ const rule = (primary, secondaryOptions) => {
 			check(atRule, atRule.params, atRuleParamIndex);
 		});
 		root.walkDecls((decl) => {
-			if (!isStandardSyntaxDeclaration(decl)) {
+			if (!isStandardSyntaxDeclaration(decl) || !isStandardSyntaxValue(decl.value)) {
 				return;
 			}
 

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -159,9 +159,9 @@ const rule = (primary, secondaryOptions) => {
 			check(atRule, atRule.params, atRuleParamIndex);
 		});
 		root.walkDecls((decl) => {
-			if (!isStandardSyntaxDeclaration(decl) || !isStandardSyntaxValue(decl.value)) {
-				return;
-			}
+			if (!isStandardSyntaxDeclaration(decl)) return;
+			
+			if (!isStandardSyntaxValue(decl.value)) return;
 
 			check(decl, decl.value, declarationValueIndex);
 		});

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -79,9 +79,7 @@ const rule = (primary, secondaryOptions, context) => {
 			const propLowerCase = decl.prop.toLowerCase();
 			const value = decl.value;
 
-			if (!isStandardSyntaxValue(value)) {
-				return;
-			}
+			if (!isStandardSyntaxValue(value)) return;
 
 			const parsed = valueParser(getDeclarationValue(decl));
 

--- a/lib/rules/value-keyword-case/index.js
+++ b/lib/rules/value-keyword-case/index.js
@@ -79,6 +79,10 @@ const rule = (primary, secondaryOptions, context) => {
 			const propLowerCase = decl.prop.toLowerCase();
 			const value = decl.value;
 
+			if (!isStandardSyntaxValue(value)) {
+				return;
+			}
+
 			const parsed = valueParser(getDeclarationValue(decl));
 
 			let needFix = false;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #6659.

> Is there anything in the PR that needs further explanation?

All rules has same issues: trying to lint non-standard value. Based on test one rule (`unit-no-unknown`) has a “regression”. Since the fix ignores declaration with non-standard values. It means that previous linted declaration with dollar-variables are now ignored as well. Given focus of Stylelint on standard CSS only, and policy to ignore non-standard syntax, I consider this “regression” acceptable as it doesn't break builds or report new violation.
