### PR TITLE
Refactor `declaration-property-value-no-unknown` to fix `@ts-expect-error`

### DIFF
--- a/lib/rules/declaration-property-value-no-unknown/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/index.js
@@ -13,6 +13,7 @@ const isCustomProperty = require('../../utils/isCustomProperty');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
+const { isAtRule } = require('../../utils/typeGuards');
 const { isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'declaration-property-value-no-unknown';
@@ -70,7 +71,7 @@ const rule = (primary, secondaryOptions) => {
 		}).lexer;
 
 		root.walkDecls((decl) => {
-			const { prop, value } = decl;
+			const { prop, value, parent } = decl;
 
 			// NOTE: CSSTree's `fork()` doesn't support `-moz-initial`, but it may be possible in the future.
 			// See https://github.com/stylelint/stylelint/pull/6511#issuecomment-1412921062
@@ -110,9 +111,8 @@ const rule = (primary, secondaryOptions) => {
 			}
 
 			const { error } =
-				decl?.parent?.type === 'atrule'
-					? // @ts-expect-error -- CSSTree types are not complete
-					  forkedLexer.matchAtruleDescriptor(decl.parent.name, prop, cssTreeValueNode)
+				parent && isAtRule(parent)
+					? forkedLexer.matchAtruleDescriptor(parent.name, prop, cssTreeValueNode)
 					: forkedLexer.matchProperty(prop, cssTreeValueNode);
 
 			if (!error) return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #6683 (see also DefinitelyTyped/DefinitelyTyped#64410)

> Is there anything in the PR that needs further explanation?

By updating `@types/css-tree`, we no longer need to use `@ts-expect-error` to suppress TypeScript errors about `css-tree`.

In addition, this pull request refactors the code to use the `isAtRule` type guard. If not using the type guard, `parent` is not inferred as `AtRule` and so another error occurs.
