### PR TITLE
Refactor `declarationValueIndex` util to fix `@ts-expect-error`

### DIFF
--- a/lib/utils/__tests__/validateTypes.test.js
+++ b/lib/utils/__tests__/validateTypes.test.js
@@ -5,6 +5,7 @@ const {
 	isFunction,
 	isNullish,
 	isNumber,
+	isObject,
 	isRegExp,
 	isString,
 	isPlainObject,
@@ -63,6 +64,16 @@ describe('isNumber()', () => {
 
 	it('returns false when a number value is not specified', () => {
 		expect(isNumber(null)).toBe(false);
+	});
+});
+
+describe('isObject()', () => {
+	it('returns true when an object is specified', () => {
+		expect(isObject({})).toBe(true);
+	});
+
+	it('returns false when an object is not specified', () => {
+		expect(isObject(null)).toBe(false);
 	});
 });
 

--- a/lib/utils/declarationValueIndex.js
+++ b/lib/utils/declarationValueIndex.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isObject, isString } = require('./validateTypes');
+
 /**
  * Get the index of a declaration's value
  *
@@ -8,19 +10,16 @@
  */
 module.exports = function declarationValueIndex(decl) {
 	const raws = decl.raws;
+	const prop = raws.prop;
 
 	return [
-		// @ts-expect-error -- TS2571: Object is of type 'unknown'.
-		raws.prop && raws.prop.prefix,
-		// @ts-expect-error -- TS2571: Object is of type 'unknown'.
-		(raws.prop && raws.prop.raw) || decl.prop,
-		// @ts-expect-error -- TS2571: Object is of type 'unknown'.
-		raws.prop && raws.prop.suffix,
+		isObject(prop) && 'prefix' in prop && prop.prefix,
+		(isObject(prop) && 'raw' in prop && prop.raw) || decl.prop,
+		isObject(prop) && 'suffix' in prop && prop.suffix,
 		raws.between || ':',
-		// @ts-expect-error -- TS2339: Property 'prefix' does not exist on type '{ value: string; raw: string; }'.
-		raws.value && raws.value.prefix,
-	].reduce((count, str) => {
-		if (str) {
+		raws.value && 'prefix' in raws.value && raws.value.prefix,
+	].reduce((/** @type {number} */ count, str) => {
+		if (isString(str)) {
 			return count + str.length;
 		}
 

--- a/lib/utils/validateTypes.js
+++ b/lib/utils/validateTypes.js
@@ -40,6 +40,15 @@ function isNumber(value) {
 }
 
 /**
+ * Checks if the value is an object.
+ * @param {unknown} value
+ * @returns {value is object}
+ */
+function isObject(value) {
+	return value !== null && typeof value === 'object';
+}
+
+/**
  * Checks if the value is a regular expression.
  * @param {unknown} value
  * @returns {value is RegExp}
@@ -117,6 +126,7 @@ module.exports = {
 	isFunction,
 	isNullish,
 	isNumber,
+	isObject,
 	isRegExp,
 	isString,
 	isPlainObject,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change also adds a new util `isObject()`.
