### PR TITLE
Refactor `safeChdir()` test util to fix `@ts-expect-error`

### DIFF
--- a/lib/testUtils/safeChdir.js
+++ b/lib/testUtils/safeChdir.js
@@ -1,4 +1,5 @@
-const { mkdir } = require('fs').promises;
+const { mkdir } = require('node:fs/promises');
+const { beforeEach, afterEach } = require('@jest/globals'); // eslint-disable-line node/no-extraneous-require
 
 /**
  * A safe `process.chdir()`.
@@ -10,14 +11,12 @@ module.exports = function safeChdir(dir) {
 	/** @type {string | undefined} */
 	let actualCwd;
 
-	// @ts-expect-error - Jest global
 	beforeEach(async () => {
 		actualCwd = process.cwd();
 		await mkdir(dir, { recursive: true });
 		process.chdir(dir);
 	});
 
-	// @ts-expect-error - Jest global
 	afterEach(() => {
 		if (actualCwd) process.chdir(actualCwd);
 	});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The `@jest/globals` package is included in Jest by default:

```console
$ npm ls '@jest/globals'
stylelint@15.2.0 /Users/masafumi.koba/git/stylelint/stylelint
└─┬ jest@29.4.3
  └─┬ @jest/core@29.4.3
    └─┬ jest-runtime@29.4.3
      └── @jest/globals@29.4.3
```

Also, because the refactored util is used for only tests, we can use the modern module syntax `node:fs/promises` for Node.js. See also: <https://nodejs.org/api/fs.html>
