### PR TITLE
Refactor `checkAgainstRule()` util to make code readable

### DIFF
--- a/lib/utils/checkAgainstRule.js
+++ b/lib/utils/checkAgainstRule.js
@@ -1,14 +1,15 @@
 'use strict';
 
+const Result = require('postcss/lib/result').default;
+
 const normalizeRuleSettings = require('../normalizeRuleSettings');
-const Result = require('postcss/lib/result');
 const { isPlainObject } = require('./validateTypes');
 const getStylelintRule = require('./getStylelintRule');
 
 /**
  * @type {import('stylelint').Utils['checkAgainstRule']}
  */
-function checkAgainstRule(options, callback) {
+module.exports = function checkAgainstRule(options, callback) {
 	if (!isPlainObject(options)) throw new Error('Expected an options object');
 
 	if (!callback) throw new Error('Expected a callback function');
@@ -31,12 +32,26 @@ function checkAgainstRule(options, callback) {
 		return;
 	}
 
-	// @ts-expect-error - this error should not occur with PostCSS 8
-	const tmpPostcssResult = new Result();
+	const tmpPostcssResult = new Result(
+		// NOTE: The first argument is unused, so passing `undefined` raises no problems.
+		//       But this PostCSS's behavior may change in the future.
+		// @ts-expect-error -- TS2345: Argument of type 'undefined' is not assignable to parameter of type 'Processor'.
+		undefined,
+		undefined,
+		undefined,
+	);
 
-	rule(settings[0], /** @type {Object} */ (settings[1]), context)(root, tmpPostcssResult);
+	const [primary, secondary] = settings;
+	const ruleFunc = rule(primary, secondary || {}, context);
+
+	ruleFunc(
+		root,
+
+		// NOTE: This temporary PostCSS result doesn't have a property for Stylelint use.
+		//       Problems may occur if some rules use the property.
+		// @ts-expect-error -- TS2345: Argument of type 'Result' is not assignable to parameter of type 'PostcssResult'.
+		tmpPostcssResult,
+	);
 
 	for (const warning of tmpPostcssResult.warnings()) callback(warning);
-}
-
-module.exports = checkAgainstRule;
+};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

- Name more readable variables.
- Leave comments for `@ts-expect-error` reasons.
