### PR TITLE
Document `media-feature-name-no-vendor-prefix` as standard rule

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -144,7 +144,7 @@ Allow, disallow or require things with these `allowed-list`, `disallowed-list`, 
 
 - [`media-feature-name-allowed-list`](../../lib/rules/media-feature-name-allowed-list/README.md): Specify a list of allowed media feature names.
 - [`media-feature-name-disallowed-list`](../../lib/rules/media-feature-name-disallowed-list/README.md): Specify a list of disallowed media feature names.
-- [`media-feature-name-no-vendor-prefix`](../../lib/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names (Autofixable).
+- [`media-feature-name-no-vendor-prefix`](../../lib/rules/media-feature-name-no-vendor-prefix/README.md): Disallow vendor prefixes for media feature names (Autofixable) (Ⓢ).
 - [`media-feature-name-unit-allowed-list`](../../lib/rules/media-feature-name-unit-allowed-list/README.md): Specify a list of allowed name and unit pairs within media features.
 - [`media-feature-name-value-allowed-list`](../../lib/rules/media-feature-name-value-allowed-list/README.md): Specify a list of allowed media feature name and value pairs.
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, as it’s a documentation fix.

> Is there anything in the PR that needs further explanation?

The [rule is enabled by stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard/blob/30.0.1/index.js#L81).