### PR TITLE
Fix `*-no-redundant-*` false negatives for `inset` shorthand

### DIFF
--- a/.changeset/mighty-games-kick.md
+++ b/.changeset/mighty-games-kick.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` and `shorthand-property-no-redundant-values` false negatives for `inset` shorthand

--- a/.changeset/mighty-games-kick.md
+++ b/.changeset/mighty-games-kick.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `declaration-block-no-redundant-longhand-properties` and `shorthand-property-no-redundant-values` false negatives for `inset` shorthand
+Fixed: `*-no-redundant-*` false negatives for `inset` shorthand

--- a/lib/reference/properties.js
+++ b/lib/reference/properties.js
@@ -370,6 +370,16 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 			'transition-delay',
 		]),
 	],
+	[
+		'inset',
+		new Set([
+			// prettier-ignore
+			'top',
+			'right',
+			'bottom',
+			'left',
+		]),
+	],
 ]);
 
 const longhandTimeProperties = new Set([

--- a/lib/reference/properties.js
+++ b/lib/reference/properties.js
@@ -290,6 +290,16 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 		]),
 	],
 	[
+		'inset',
+		new Set([
+			// prettier-ignore
+			'top',
+			'right',
+			'bottom',
+			'left',
+		]),
+	],
+	[
 		'list-style',
 		new Set([
 			// prettier-ignore
@@ -368,16 +378,6 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 			'transition-duration',
 			'transition-timing-function',
 			'transition-delay',
-		]),
-	],
-	[
-		'inset',
-		new Set([
-			// prettier-ignore
-			'top',
-			'right',
-			'bottom',
-			'left',
 		]),
 	],
 ]);

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -28,6 +28,7 @@ This rule complains when the following shorthand properties can be used:
 
 - `margin`
 - `padding`
+- `inset`
 - `background`
 - `font`
 - `border`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -31,6 +31,21 @@ testRule({
 			code: 'a { -webkit-transition-delay: 0.5s; transition-duration: 2s; transition-property: top; transition-timing-function: ease; }',
 			description: 'one of properties is prefixed',
 		},
+		{
+			code: 'div { inset: 0; }',
+		},
+		{
+			code: 'div { inset: 1px 2px; }',
+		},
+		{
+			code: 'div { inset: 1px 2px 3px; }',
+		},
+		{
+			code: 'div { inset: 1px 2px 3px 4px; }',
+		},
+		{
+			code: 'div { top: 0; right: 0; bottom: 0; }',
+		},
 	],
 
 	reject: [
@@ -110,6 +125,16 @@ testRule({
 			code: 'a { border-top-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-right-width: 1px; }',
 			fixed: 'a { border-width: 1px 1px 1px 1px; }',
 			message: messages.expected('border-width'),
+		},
+		{
+			code: 'div { top: 1px; right: 2px; bottom: 3px; left: 4px; }',
+			fixed: 'div { inset: 1px 2px 3px 4px; }',
+			message: messages.expected('inset'),
+		},
+		{
+			code: 'div { top: 0; right: 0; bottom: 0; left: 0; }',
+			fixed: 'div { inset: 0 0 0 0; }',
+			message: messages.expected('inset'),
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -32,19 +32,19 @@ testRule({
 			description: 'one of properties is prefixed',
 		},
 		{
-			code: 'div { inset: 0; }',
+			code: 'a { inset: 0; }',
 		},
 		{
-			code: 'div { inset: 1px 2px; }',
+			code: 'a { inset: 1px 2px; }',
 		},
 		{
-			code: 'div { inset: 1px 2px 3px; }',
+			code: 'a { inset: 1px 2px 3px; }',
 		},
 		{
-			code: 'div { inset: 1px 2px 3px 4px; }',
+			code: 'a { inset: 1px 2px 3px 4px; }',
 		},
 		{
-			code: 'div { top: 0; right: 0; bottom: 0; }',
+			code: 'a { top: 0; right: 0; bottom: 0; }',
 		},
 	],
 
@@ -127,13 +127,13 @@ testRule({
 			message: messages.expected('border-width'),
 		},
 		{
-			code: 'div { top: 1px; right: 2px; bottom: 3px; left: 4px; }',
-			fixed: 'div { inset: 1px 2px 3px 4px; }',
+			code: 'a { top: 1px; right: 2px; bottom: 3px; left: 4px; }',
+			fixed: 'a { inset: 1px 2px 3px 4px; }',
 			message: messages.expected('inset'),
 		},
 		{
-			code: 'div { top: 0; right: 0; bottom: 0; left: 0; }',
-			fixed: 'div { inset: 0 0 0 0; }',
+			code: 'a { top: 0; right: 0; bottom: 0; left: 0; }',
+			fixed: 'a { inset: 0 0 0 0; }',
 			message: messages.expected('inset'),
 		},
 	],

--- a/lib/rules/shorthand-property-no-redundant-values/README.md
+++ b/lib/rules/shorthand-property-no-redundant-values/README.md
@@ -22,6 +22,7 @@ This rule checks the following shorthand properties:
 - `border-style`
 - `border-width`
 - `grid-gap`
+- `inset`
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 

--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -59,16 +59,16 @@ testRule({
 			code: 'a { margin: calc(2px + 1px) calc(1px + 1px); }',
 		},
 		{
-			code: 'div { inset: 0; }',
+			code: 'a { inset: 0; }',
 		},
 		{
-			code: 'div { inset: 1px 2px; }',
+			code: 'a { inset: 1px 2px; }',
 		},
 		{
-			code: 'div { inset: 1px 2px 3px; }',
+			code: 'a { inset: 1px 2px 3px; }',
 		},
 		{
-			code: 'div { inset: 1px 2px 3px 4px; }',
+			code: 'a { inset: 1px 2px 3px 4px; }',
 		},
 		{
 			code: 'a { margin: 1px 1px 1px 1px 1px; }',
@@ -369,18 +369,18 @@ testRule({
 			column: 5,
 		},
 		{
-			code: 'div { inset: 0 0 0 0; }',
-			fixed: 'div { inset: 0; }',
+			code: 'a { inset: 0 0 0 0; }',
+			fixed: 'a { inset: 0; }',
 			message: messages.rejected('0 0 0 0', '0'),
 			line: 1,
-			column: 7,
+			column: 5,
 		},
 		{
-			code: 'div { inset: 1px 0 1px 0; }',
-			fixed: 'div { inset: 1px 0; }',
+			code: 'a { inset: 1px 0 1px 0; }',
+			fixed: 'a { inset: 1px 0; }',
 			message: messages.rejected('1px 0 1px 0', '1px 0'),
 			line: 1,
-			column: 7,
+			column: 5,
 		},
 	],
 });

--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.js
@@ -59,6 +59,18 @@ testRule({
 			code: 'a { margin: calc(2px + 1px) calc(1px + 1px); }',
 		},
 		{
+			code: 'div { inset: 0; }',
+		},
+		{
+			code: 'div { inset: 1px 2px; }',
+		},
+		{
+			code: 'div { inset: 1px 2px 3px; }',
+		},
+		{
+			code: 'div { inset: 1px 2px 3px 4px; }',
+		},
+		{
 			code: 'a { margin: 1px 1px 1px 1px 1px; }',
 			description: 'ignore wrong value',
 		},
@@ -355,6 +367,20 @@ testRule({
 			message: messages.rejected('-1em 0 2em 0', '-1em 0 2em'),
 			line: 1,
 			column: 5,
+		},
+		{
+			code: 'div { inset: 0 0 0 0; }',
+			fixed: 'div { inset: 0; }',
+			message: messages.rejected('0 0 0 0', '0'),
+			line: 1,
+			column: 7,
+		},
+		{
+			code: 'div { inset: 1px 0 1px 0; }',
+			fixed: 'div { inset: 1px 0; }',
+			message: messages.rejected('1px 0 1px 0', '1px 0'),
+			line: 1,
+			column: 7,
 		},
 	],
 });

--- a/lib/rules/shorthand-property-no-redundant-values/index.js
+++ b/lib/rules/shorthand-property-no-redundant-values/index.js
@@ -27,6 +27,7 @@ const propertiesWithShorthandNotation = new Set([
 	'border-style',
 	'border-width',
 	'grid-gap',
+	'inset',
 ]);
 
 const ignoredCharacters = ['+', '*', '/', '(', ')', '$', '@', '--', 'var('];

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -468,7 +468,8 @@ declare module 'stylelint' {
 		| 'padding'
 		| 'text-decoration'
 		| 'text-emphasis'
-		| 'transition';
+		| 'transition'
+		| 'inset';
 
 	/** @internal */
 	export type LonghandSubPropertiesOfShorthandProperties = ReadonlyMap<

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -461,6 +461,7 @@ declare module 'stylelint' {
 		| 'grid-gap'
 		| 'grid-row'
 		| 'grid-template'
+		| 'inset'
 		| 'list-style'
 		| 'margin'
 		| 'mask'
@@ -468,8 +469,7 @@ declare module 'stylelint' {
 		| 'padding'
 		| 'text-decoration'
 		| 'text-emphasis'
-		| 'transition'
-		| 'inset';
+		| 'transition';
 
 	/** @internal */
 	export type LonghandSubPropertiesOfShorthandProperties = ReadonlyMap<


### PR DESCRIPTION
Closes #6613

This PR updates these 2 rules to support the `inset` property

- `declaration-block-no-redundant-longhand-properties`
- `shorthand-property-no-redundant-values`