### PR TITLE
Fix `function-url-quotes` autofix for multiple `url()`

### DIFF
--- a/.changeset/chatty-boxes-grab.md
+++ b/.changeset/chatty-boxes-grab.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-url-quotes` autofix for multiple `url()`

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -296,6 +296,26 @@ testRule({
 			endLine: 1,
 			endColumn: 68,
 		},
+		{
+			code: 'a { background-image: url(foo.css), url(bar.css); }',
+			fixed: 'a { background-image: url("foo.css"), url("bar.css"); }',
+			warnings: [
+				{
+					message: messages.expected('url'),
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 34,
+				},
+				{
+					message: messages.expected('url'),
+					line: 1,
+					column: 41,
+					endLine: 1,
+					endColumn: 48,
+				},
+			],
+		},
 	],
 });
 
@@ -652,6 +672,26 @@ testRule({
 			column: 21,
 			endLine: 1,
 			endColumn: 46,
+		},
+		{
+			code: 'a { background-image: url("foo.css"), url(\'bar.css\'); }',
+			fixed: 'a { background-image: url(foo.css), url(bar.css); }',
+			warnings: [
+				{
+					message: messages.rejected('url'),
+					line: 1,
+					column: 27,
+					endLine: 1,
+					endColumn: 36,
+				},
+				{
+					message: messages.rejected('url'),
+					line: 1,
+					column: 43,
+					endLine: 1,
+					endColumn: 52,
+				},
+			],
 		},
 	],
 });

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -3,6 +3,8 @@
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const functionArgumentsSearch = require('../../utils/functionArgumentsSearch');
+const getAtRuleParams = require('../../utils/getAtRuleParams');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxUrl = require('../../utils/isStandardSyntaxUrl');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
@@ -44,6 +46,9 @@ const rule = (primary, secondaryOptions, context) => {
 			return;
 		}
 
+		const exceptEmpty = optionsMatches(secondaryOptions, 'except', 'empty');
+		const emptyArgumentPatterns = new Set(['', "''", '""']);
+
 		root.walkAtRules(checkAtRuleParams);
 		root.walkDecls(checkDeclParams);
 
@@ -51,89 +56,68 @@ const rule = (primary, secondaryOptions, context) => {
 		 * @param {import('postcss').Declaration} decl
 		 */
 		function checkDeclParams(decl) {
-			functionArgumentsSearch(decl.toString(), /^url$/i, (args, index) => {
-				checkArgs(args, decl, index, 'url');
+			const value = getDeclarationValue(decl);
+			const startIndex = declarationValueIndex(decl);
+			const parsed = functionArgumentsSearch(value, /^url$/i, (args, index, funcNode) => {
+				checkArgs(decl, args, startIndex + index, funcNode);
 			});
+
+			if (context.fix) {
+				decl.value = parsed.toString();
+			}
 		}
 
 		/**
 		 * @param {import('postcss').AtRule} atRule
 		 */
 		function checkAtRuleParams(atRule) {
-			functionArgumentsSearch(atRule.params, /^url$/i, (args, index) => {
-				checkArgs(args, atRule, index + atRuleParamIndex(atRule), 'url');
-			});
-			functionArgumentsSearch(atRule.params, /^url-prefix$/i, (args, index) => {
-				checkArgs(args, atRule, index + atRuleParamIndex(atRule), 'url-prefix');
-			});
-			functionArgumentsSearch(atRule.params, /^domain$/i, (args, index) => {
-				checkArgs(args, atRule, index + atRuleParamIndex(atRule), 'domain');
-			});
+			const params = getAtRuleParams(atRule);
+			const startIndex = atRuleParamIndex(atRule);
+			const parsed = functionArgumentsSearch(
+				params,
+				/^(url|url-prefix|domain)$/i,
+				(args, index, funcNode) => {
+					checkArgs(atRule, args, startIndex + index, funcNode);
+				},
+			);
+
+			if (context.fix) {
+				atRule.params = parsed.toString();
+			}
 		}
 
 		/**
-		 * @param {import('postcss').AtRule} node
-		 * @param {string} args
-		 * @param {number} index
+		 * @param {import('postcss-value-parser').FunctionNode} funcNode
 		 */
-		function addQuotesForAtRule(node, args, index) {
-			const fixedName = `"${args}"`;
-			const openIndex = index - atRuleParamIndex(node);
-			const closeIndex = openIndex + args.length;
-
-			node.params =
-				node.params.substring(0, openIndex) + fixedName + node.params.substring(closeIndex);
+		function addQuotes(funcNode) {
+			for (const argNode of funcNode.nodes) {
+				if (argNode.type === 'word') {
+					argNode.value = `"${argNode.value}"`;
+				}
+			}
 		}
 
 		/**
-		 * @param {import('postcss').Declaration} node
-		 * @param {string} args
-		 * @param {number} index
+		 * @param {import('postcss-value-parser').FunctionNode} funcNode
 		 */
-		function addQuotesForDecl(node, args, index) {
-			const fixedName = `"${args}"`;
-			const openIndex = index - declarationValueIndex(node);
-			const closeIndex = openIndex + args.length;
-
-			node.value =
-				node.value.substring(0, openIndex) + fixedName + node.value.substring(closeIndex);
+		function removeQuotes(funcNode) {
+			for (const argNode of funcNode.nodes) {
+				if (argNode.type === 'string') {
+					// NOTE: We can ignore this error because the test passes.
+					// @ts-expect-error -- TS2322: Type '"word"' is not assignable to type '"string"'.
+					argNode.type = 'word';
+				}
+			}
 		}
 
 		/**
-		 * @param {import('postcss').AtRule} node
-		 * @param {string} args
-		 * @param {number} index
-		 */
-
-		function removeQuotesForAtRule(node, args, index) {
-			const fixedName = args.slice(1, args.length - 1);
-			const openIndex = index - atRuleParamIndex(node);
-			const closeIndex = openIndex + args.length;
-
-			node.params = node.params.slice(0, openIndex) + fixedName + node.params.slice(closeIndex);
-		}
-
-		/**
-		 * @param {import('postcss').Declaration} node
-		 * @param {string} args
-		 * @param {number} index
-		 */
-
-		function removeQuotesForDecl(node, args, index) {
-			const fixedName = args.slice(1, args.length - 1);
-			const openIndex = index - declarationValueIndex(node);
-			const closeIndex = openIndex + args.length;
-
-			node.value = node.value.slice(0, openIndex) + fixedName + node.value.slice(closeIndex);
-		}
-
-		/**
-		 * @param {string} args
 		 * @param {import('postcss').Declaration | import('postcss').AtRule} node
+		 * @param {string} args
 		 * @param {number} index
-		 * @param {string} functionName
+		 * @param {import('postcss-value-parser').FunctionNode} funcNode
 		 */
-		function checkArgs(args, node, index, functionName) {
+		function checkArgs(node, args, index, funcNode) {
+			const functionName = funcNode.value.toLowerCase();
 			let shouldHasQuotes = primary === 'always';
 
 			const leftTrimmedArgs = args.trimStart();
@@ -146,10 +130,7 @@ const rule = (primary, secondaryOptions, context) => {
 			const complaintEndIndex = index + args.length;
 			const hasQuotes = leftTrimmedArgs.startsWith("'") || leftTrimmedArgs.startsWith('"');
 
-			const trimmedArg = args.trim();
-			const isEmptyArgument = ['', "''", '""'].includes(trimmedArg);
-
-			if (optionsMatches(secondaryOptions, 'except', 'empty') && isEmptyArgument) {
+			if (exceptEmpty && emptyArgumentPatterns.has(args.trim())) {
 				shouldHasQuotes = !shouldHasQuotes;
 			}
 
@@ -159,11 +140,7 @@ const rule = (primary, secondaryOptions, context) => {
 				}
 
 				if (context.fix) {
-					if (node.type === 'atrule') {
-						addQuotesForAtRule(node, trimmedArg, complaintIndex);
-					} else {
-						addQuotesForDecl(node, trimmedArg, complaintIndex);
-					}
+					addQuotes(funcNode);
 
 					return;
 				}
@@ -175,11 +152,7 @@ const rule = (primary, secondaryOptions, context) => {
 				}
 
 				if (context.fix) {
-					if (node.type === 'atrule') {
-						removeQuotesForAtRule(node, trimmedArg, complaintIndex);
-					} else {
-						removeQuotesForDecl(node, trimmedArg, complaintIndex);
-					}
+					removeQuotes(funcNode);
 
 					return;
 				}

--- a/lib/utils/__tests__/functionArgumentsSearch.test.js
+++ b/lib/utils/__tests__/functionArgumentsSearch.test.js
@@ -3,12 +3,19 @@
 const functionArgumentsSearch = require('../functionArgumentsSearch');
 
 it('passes function arguments to callback', () => {
-	expect.assertions(2);
+	expect.assertions(4);
 
-	functionArgumentsSearch('calc(1 + 3)', 'calc', (expression, expressionIndex) => {
-		expect(expression).toBe('1 + 3');
-		expect(expressionIndex).toBe(5);
-	});
+	const parsed = functionArgumentsSearch(
+		'calc(1 + 3)',
+		'calc',
+		(expression, expressionIndex, funcNode) => {
+			expect(expression).toBe('1 + 3');
+			expect(expressionIndex).toBe(5);
+			expect(funcNode).toMatchObject({ type: 'function' });
+		},
+	);
+
+	expect(parsed.nodes).toHaveLength(1);
 });
 
 it('passes function arguments to callback when a case with multiple expressions', () => {
@@ -38,7 +45,7 @@ it('works with nested functions', () => {
 });
 
 it('works with nested functions inside `color()`', () => {
-	expect.assertions(2);
+	expect.hasAssertions();
 
 	functionArgumentsSearch(
 		'color(red s(- 10%) s( - 10%))',

--- a/lib/utils/functionArgumentsSearch.js
+++ b/lib/utils/functionArgumentsSearch.js
@@ -17,11 +17,11 @@ const { assert, isString, isRegExp } = require('./validateTypes');
  *
  * @param {string} source
  * @param {string | RegExp} functionName
- * @param {(expression: string, expressionIndex: number) => void} callback
- * @returns {void}
+ * @param {(expression: string, expressionIndex: number, funcNode: valueParser.FunctionNode) => void} callback
+ * @returns {valueParser.ParsedValue}
  */
 module.exports = function functionArgumentsSearch(source, functionName, callback) {
-	valueParser(source).walk((node) => {
+	return valueParser(source).walk((node) => {
 		if (node.type !== 'function') return;
 
 		const { value } = node;
@@ -38,6 +38,6 @@ module.exports = function functionArgumentsSearch(source, functionName, callback
 		const parenLength = 1; // == '('
 		const expressionIndex = node.sourceIndex + value.length + parenLength;
 
-		callback(expression, expressionIndex);
+		callback(expression, expressionIndex, node);
 	});
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6710

> Is there anything in the PR that needs further explanation?

This pull request rewrites the rule implementation to use the [`postcss-value-parser`](https://github.com/TrySound/postcss-value-parser) AST node rather than string-based indexes.
