### PR TITLE
Fix `value-keyword-case` false positives for Level 4 system colours

### DIFF
--- a/.changeset/purple-meals-visit.md
+++ b/.changeset/purple-meals-visit.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `value-keyword-case` false positives for Level 4 system colours

--- a/lib/reference/keywords.js
+++ b/lib/reference/keywords.js
@@ -273,8 +273,8 @@ const camelCaseKeywords = new Set([
 
 const keyframeSelectorKeywords = new Set(['from', 'to']);
 
-// https://www.w3.org/TR/CSS22/ui.html#system-colors
 const systemColorsKeywords = new Set([
+	// https://www.w3.org/TR/CSS22/ui.html#system-colors
 	'activeborder',
 	'activecaption',
 	'appworkspace',
@@ -303,6 +303,26 @@ const systemColorsKeywords = new Set([
 	'window',
 	'windowframe',
 	'windowtext',
+	// https://www.w3.org/TR/css-color-4/#css-system-colors
+	'accentcolor',
+	'accentcolortext',
+	'activetext',
+	'buttonborder',
+	'buttonface',
+	'buttontext',
+	'canvas',
+	'canvastext',
+	'field',
+	'fieldtext',
+	'graytext',
+	'highlight',
+	'highlighttext',
+	'linktext',
+	'mark',
+	'marktext',
+	'selecteditem',
+	'selecteditemtext',
+	'visitedtext',
 ]);
 
 module.exports = {

--- a/lib/rules/value-keyword-case/__tests__/index.js
+++ b/lib/rules/value-keyword-case/__tests__/index.js
@@ -311,6 +311,10 @@ testRule({
 			description: 'another system color',
 		},
 		{
+			code: 'a { color: CanvasText; }',
+			description: 'newer system color',
+		},
+		{
 			code: 'a { grid-column-start: span camelCaseArea; }',
 			description: 'ignore area case',
 		},
@@ -1288,6 +1292,10 @@ testRule({
 		{
 			code: 'a { color: ThreeDShadow; }',
 			description: 'another system color',
+		},
+		{
+			code: 'a { color: CanvasText; }',
+			description: 'newer system color',
 		},
 		{
 			code: 'a { GRID-COLUMN-START: SPAN camelCaseArea; }',


### PR DESCRIPTION
This adds the [CSS Color Module Level 4 system colours](https://www.w3.org/TR/css-color-4/#css-system-colors) to the list of keywords that are not changed.