### PR TITLE
Remove erroneous example from `unit-no-unknown` doc

### DIFF
--- a/lib/rules/unit-no-unknown/README.md
+++ b/lib/rules/unit-no-unknown/README.md
@@ -77,13 +77,6 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-width: 10custom;
-a {
-}
-```
-
-<!-- prettier-ignore -->
-```css
 a {
   width: 10--foo--baz;
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
