### PR TITLE
Fix `rule-selector-property-disallowed-list` secondary options

### DIFF
--- a/.changeset/purple-avocados-help.md
+++ b/.changeset/purple-avocados-help.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `rule-selector-property-disallowed-list` secondary options

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -5,7 +5,7 @@ Specify a list of disallowed properties for selectors within rules.
 <!-- prettier-ignore -->
 ```css
     a { color: red; }
-/** ↑          ↑
+/** ↑   ↑
  * Selector and property name */
 ```
 

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.js
@@ -92,3 +92,16 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: [{ a: 'color' }, { message: 'foo' }],
+
+	reject: [
+		{
+			code: 'a { color: red; }',
+			message: 'foo',
+			description: 'custom message',
+		},
+	],
+});

--- a/lib/rules/rule-selector-property-disallowed-list/index.js
+++ b/lib/rules/rule-selector-property-disallowed-list/index.js
@@ -69,8 +69,6 @@ const rule = (primary) => {
 	};
 };
 
-rule.primaryOptionArray = true;
-
 rule.ruleName = ruleName;
 rule.messages = messages;
 rule.meta = meta;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6688.

> Is there anything in the PR that needs further explanation?

I'm a bit confused why this wasn't caught by the test suite when the rule was first made/messages were added; presumably, I should write a regression test here. Any suggestions?
