### PR TITLE
Fix `unit-no-unknown` false positives for the second and subsequent `image-set()` with `x` descriptor

### DIFF
--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -228,6 +228,14 @@ testRule({
 			description: 'ignore `x` unit in vendor-prefixed image-set',
 		},
 		{
+			code: "a { background-image: url('first.png'), image-set(url('second.png') 1x), image-set(url('third.png') 1x) }",
+			description: 'ignore `x` unit in the second and subsequent image-set',
+		},
+		{
+			code: "a { background-image: url('first.png'), -webkit-image-set(url('second.png') 1x), -webkit-image-set(url('third.png') 1x) }",
+			description: 'ignore `x` unit in the second and subsequent vendor-prefixed image-set',
+		},
+		{
 			code: '@media (resolution: 2x) {}',
 			description: 'ignore `x` unit in @media with `resolution`',
 		},

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -118,20 +118,22 @@ const rule = (primary, secondaryOptions) => {
 							return;
 						}
 
-						if (/^(?:-webkit-)?image-set[\s(]/i.test(value)) {
-							const imageSet = parsedValue.nodes.find(
-								(n) => vendor.unprefixed(n.value) === 'image-set',
-							);
+						const imageSets = parsedValue.nodes.filter(
+							(n) => vendor.unprefixed(n.value) === 'image-set',
+						);
 
-							assert(imageSet);
-							assert('nodes' in imageSet);
-							const imageSetLastNode = imageSet.nodes[imageSet.nodes.length - 1];
+						if (imageSets.length !== 0) {
+							for (const imageSet of imageSets) {
+								assert(imageSet);
+								assert('nodes' in imageSet);
+								const imageSetLastNode = imageSet.nodes[imageSet.nodes.length - 1];
 
-							assert(imageSetLastNode);
-							const imageSetValueLastIndex = imageSetLastNode.sourceIndex;
+								assert(imageSetLastNode);
+								const imageSetValueLastIndex = imageSetLastNode.sourceIndex;
 
-							if (imageSetValueLastIndex >= valueNode.sourceIndex) {
-								return;
+								if (imageSetValueLastIndex >= valueNode.sourceIndex) {
+									return;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #6721

> Is there anything in the PR that needs further explanation?

I'll do some refactoring later on, as @ybiquitous [suggested](https://github.com/stylelint/stylelint/issues/6721#issuecomment-1477831540) (it may require a few weeks).