### PR TITLE
Add `no-unknown-custom-properties` rule

### DIFF
--- a/.changeset/tasty-carrots-camp.md
+++ b/.changeset/tasty-carrots-camp.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `no-unknown-custom-properties` rule

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -89,6 +89,7 @@ Disallow unknown things with these `no-unknown` rules.
 - [`function-no-unknown`](../../lib/rules/function-no-unknown/README.md): Disallow unknown functions (Ⓡ & Ⓢ).
 - [`media-feature-name-no-unknown`](../../lib/rules/media-feature-name-no-unknown/README.md): Disallow unknown media feature names (Ⓡ & Ⓢ).
 - [`no-unknown-animations`](../../lib/rules/no-unknown-animations/README.md): Disallow unknown animations.
+- [`no-unknown-custom-properties`](../../lib/rules/no-unknown-custom-properties/README.md): Disallow unknown custom properties.
 - [`property-no-unknown`](../../lib/rules/property-no-unknown/README.md): Disallow unknown properties (Ⓡ & Ⓢ).
 - [`selector-pseudo-class-no-unknown`](../../lib/rules/selector-pseudo-class-no-unknown/README.md): Disallow unknown pseudo-class selectors (Ⓡ & Ⓢ).
 - [`selector-pseudo-element-no-unknown`](../../lib/rules/selector-pseudo-element-no-unknown/README.md): Disallow unknown pseudo-element selectors (Ⓡ & Ⓢ).

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -241,6 +241,7 @@ const rules = {
 		require('./no-missing-end-of-source-newline'),
 	)(),
 	'no-unknown-animations': importLazy(() => require('./no-unknown-animations'))(),
+	'no-unknown-custom-properties': importLazy(() => require('./no-unknown-custom-properties'))(),
 	'number-leading-zero': importLazy(() => require('./number-leading-zero'))(),
 	'number-max-precision': importLazy(() => require('./number-max-precision'))(),
 	'number-no-trailing-zeros': importLazy(() => require('./number-no-trailing-zeros'))(),

--- a/lib/rules/no-unknown-custom-properties/README.md
+++ b/lib/rules/no-unknown-custom-properties/README.md
@@ -1,0 +1,57 @@
+# no-unknown-custom-properties
+
+Disallow unknown custom properties.
+
+<!-- prettier-ignore -->
+```css
+a { color: var(--foo); }
+/**            ↑
+ *             This custom property */
+
+a { color: var(--foo, var(--bar)); }
+/**                       ↑
+ *                        And this one */
+```
+
+This rule considers custom properties defined within the same source to be known.
+
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
+## Options
+
+### `true`
+
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
+```css
+a { color: var(--foo); }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: var(--foo, var(--bar)); }
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a { --foo: #f00; color: var(--foo); }
+```
+
+<!-- prettier-ignore -->
+```css
+a { color: var(--foo, #f00); }
+```
+
+<!-- prettier-ignore -->
+```css
+a { --foo: #f00; color: var(--bar, var(--foo)); }
+```
+
+<!-- prettier-ignore -->
+``` css
+@property --foo { syntax: "<color>"; inherits: false; initial-value: #f00; }
+a { color: var(--foo); }
+```

--- a/lib/rules/no-unknown-custom-properties/__tests__/index.js
+++ b/lib/rules/no-unknown-custom-properties/__tests__/index.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { stripIndent } = require('common-tags');
+
+const { messages, ruleName } = require('..');
+
+testRule({
+	ruleName,
+	config: [true],
+
+	accept: [
+		{
+			code: 'a { --foo: #f00; color: var(--foo); }',
+			description: 'declared custom property',
+		},
+		{
+			code: 'a { --foo: #f00; border: solid var(--foo); }',
+			description: 'declared custom property in multi-value property',
+		},
+		{
+			code: 'a { color: var(--foo, #f00); }',
+			description: 'undeclared custom property with fallback',
+		},
+		{
+			code: 'a { --foo: #f00; color: var(--bar, var(--foo)); }',
+			description: 'undeclared custom property with declared custom property fallback',
+		},
+		{
+			code: stripIndent`
+				@property --foo { syntax: "<color>"; inherits: false; initial-value: #f00; }
+				a { color: var(--foo); }
+			`,
+			description: 'declared custom property via at-property',
+		},
+		{
+			code: 'a { color: var(); }',
+			description: 'empty function',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { color: var(--foo); }',
+			description: 'undeclared custom property',
+			message: messages.rejected('--foo'),
+			line: 1,
+			column: 16,
+			endLine: 1,
+			endColumn: 21,
+		},
+		{
+			code: 'a { border: solid var(--foo); }',
+			description: 'undeclared custom property in multi-value property',
+			message: messages.rejected('--foo'),
+			line: 1,
+			column: 23,
+			endLine: 1,
+			endColumn: 28,
+		},
+		{
+			code: 'a { color: var(--foo, var(--bar)); }',
+			description: 'undeclared custom property with undeclared custom property fallback',
+			message: messages.rejected('--bar'),
+			line: 1,
+			column: 27,
+			endLine: 1,
+			endColumn: 32,
+		},
+	],
+});

--- a/lib/rules/no-unknown-custom-properties/index.js
+++ b/lib/rules/no-unknown-custom-properties/index.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const valueParser = require('postcss-value-parser');
+const declarationValueIndex = require('../../utils/declarationValueIndex');
+const report = require('../../utils/report');
+const ruleMessages = require('../../utils/ruleMessages');
+const { isValueFunction } = require('../../utils/typeGuards');
+const validateOptions = require('../../utils/validateOptions');
+
+const ruleName = 'no-unknown-custom-properties';
+
+const messages = ruleMessages(ruleName, {
+	rejected: (propName) => `Unexpected unknown custom property "${propName}"`,
+});
+
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/no-unknown-custom-properties',
+};
+
+/** @type {import('stylelint').Rule} */
+const rule = (primary) => {
+	return (root, result) => {
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
+
+		if (!validOptions) return;
+
+		/** @type {Set<string>} */
+		const declaredCustomProps = new Set();
+
+		root.walkAtRules(/^property$/i, ({ params }) => {
+			declaredCustomProps.add(params);
+		});
+
+		root.walkDecls(/^--/, ({ prop }) => {
+			declaredCustomProps.add(prop);
+		});
+
+		root.walkDecls((decl) => {
+			const { value } = decl;
+
+			const parsedValue = valueParser(value);
+
+			parsedValue.walk((node) => {
+				if (!isValueFunction(node) || node.value !== 'var') return;
+
+				const [firstNode, secondNode] = node.nodes;
+
+				if (!firstNode || declaredCustomProps.has(firstNode.value)) return;
+
+				// Second node (div) indicates fallback exists in all cases
+				if (secondNode && secondNode.type === 'div') return;
+
+				const startIndex = declarationValueIndex(decl);
+
+				report({
+					result,
+					ruleName,
+					message: messages.rejected,
+					messageArgs: [firstNode.value],
+					node: decl,
+					index: startIndex + firstNode.sourceIndex,
+					endIndex: startIndex + firstNode.sourceEndIndex,
+				});
+			});
+		});
+	};
+};
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+rule.meta = meta;
+module.exports = rule;


### PR DESCRIPTION
#### Summary

Adds new rule, `no-unknown-custom-properties`, which disallows unknown custom properties. Initial implementation is to consider custom properties defined within the same source.

Relates to #6361. Could close the issue if a new one is created to track a potential `importFrom` option, or a `resolver` option once #4088 is addressed.