### PR TITLE
Fix `function-url-quotes` autofix for double-slash comments in SCSS maps

### DIFF
--- a/.changeset/olive-dolphins-reply.md
+++ b/.changeset/olive-dolphins-reply.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-url-quotes` autofix for double-slash comments in SCSS maps

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -744,3 +744,16 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: ['always'],
+	customSyntax: 'postcss-scss',
+	fix: true,
+
+	accept: [
+		{
+			code: '$a: (\n  // foo\n)',
+		},
+	],
+});

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -6,6 +6,7 @@ const functionArgumentsSearch = require('../../utils/functionArgumentsSearch');
 const getAtRuleParams = require('../../utils/getAtRuleParams');
 const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxUrl = require('../../utils/isStandardSyntaxUrl');
+const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -56,6 +57,8 @@ const rule = (primary, secondaryOptions, context) => {
 		 * @param {import('postcss').Declaration} decl
 		 */
 		function checkDeclParams(decl) {
+			if (!isStandardSyntaxDeclaration(decl)) return;
+
 			const value = getDeclarationValue(decl);
 			const startIndex = declarationValueIndex(decl);
 			const parsed = functionArgumentsSearch(value, /^url$/i, (args, index, funcNode) => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6741 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
