### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` with basic keywords

### DIFF
--- a/.changeset/lovely-ligers-sip.md
+++ b/.changeset/lovely-ligers-sip.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` with basic keywords

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -22,7 +22,7 @@ a {
 }
 ```
 
-This rule will only complain if you've used the longhand equivalent of _all_ the properties that the shorthand will set and if their values are not [CSS-wide keywords](https://www.w3.org/TR/css-values/#common-keywords) : `initial`, `inherit`, `revert`, `revert-layer`, `unset`.
+This rule will only complain if you've used the longhand equivalent of _all_ the properties that the shorthand will set and if their values are not [CSS-wide keywords](https://www.w3.org/TR/css-values/#common-keywords) like `initial`, `inherit` etc.
 
 This rule complains when the following shorthand properties can be used:
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -22,7 +22,7 @@ a {
 }
 ```
 
-This rule will only complain if you've used the longhand equivalent of _all_ the properties that the shorthand will set and if their values are not `inherit`.
+This rule will only complain if you've used the longhand equivalent of _all_ the properties that the shorthand will set and if their values are not [CSS-wide keywords](https://www.w3.org/TR/css-values/#common-keywords) : `initial`, `inherit`, `revert`, `revert-layer`, `unset`.
 
 This rule complains when the following shorthand properties can be used:
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -46,6 +46,14 @@ testRule({
 		{
 			code: 'a { top: 0; right: 0; bottom: 0; }',
 		},
+		{
+			code: 'a { top: 0; right: 0; bottom: initial; left: 0; }',
+			description: 'contains basic keyword (initial)',
+		},
+		{
+			code: 'a { margin-top: 0; margin-right: 0; margin-bottom: unset; margin-left: 0; }',
+			description: 'contains basic keyword (unset)',
+		},
 	],
 
 	reject: [

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const arrayEqual = require('../../utils/arrayEqual');
+const { basicKeywords } = require('../../reference/keywords');
 const eachDeclarationBlock = require('../../utils/eachDeclarationBlock');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
@@ -20,8 +21,6 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties',
 	fixable: true,
 };
-
-const IGNORED_VALUES = new Set(['inherit']);
 
 /** @typedef {import('postcss').Declaration} Declaration */
 
@@ -68,7 +67,8 @@ const rule = (primary, secondaryOptions, context) => {
 			const longhandDeclarationNodes = new Map();
 
 			eachDecl((decl) => {
-				if (IGNORED_VALUES.has(decl.value)) {
+				// basic keywords are not allowed in shorthand properties
+				if (basicKeywords.has(decl.value)) {
 					return;
 				}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6738.

> Is there anything in the PR that needs further explanation?

The scope of this PR is broader than autofixing, since we also shouldn't flag instances which use a basic keyword. Let me know if additional test cases / documentation are desired!

Note that we already had this feature for `inherit`; this PR just expands it to use `basicKeywords`.

If we'd like, we could also create a more "aggressive" approach that converts

```css
margin-top: inset;
margin-bottom: inset;
margin-right: inset;
margin-left: inset;
```

to

```css
margin: inset;
```

which is valid (to my understanding). The rule doesn't currently behave this way with `inherit`; but, happy to add this if we think it's helpful!

---

Spec ref for [shorthand properties not supporting CSS-wide keywords](https://w3c.github.io/csswg-drafts/css-cascade-4/#shorthand-property):

> If a [shorthand](https://w3c.github.io/csswg-drafts/css-cascade-4/#shorthand-property) is specified as one of the [CSS-wide keywords](https://www.w3.org/TR/css-values/#common-keywords) [[css-values-3]](https://w3c.github.io/csswg-drafts/css-cascade-4/#biblio-css-values-3), it sets all of its [sub-properties](https://w3c.github.io/csswg-drafts/css-cascade-4/#longhand) to that keyword, including any that are [reset-only sub-properties](https://w3c.github.io/csswg-drafts/css-cascade-4/#reset-only-sub-property). (Note that these keywords cannot be combined with other values in a single [declaration](https://w3c.github.io/csswg-drafts/css-syntax-3/#declaration), not even in a shorthand.)


