### PR TITLE
Add raw regex support to `ignoreProperties` for `declaration-block-no-duplicate-properties`

### DIFF
--- a/.changeset/twelve-pandas-hide.md
+++ b/.changeset/twelve-pandas-hide.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: raw regex support to `ignoreProperties` for `declaration-block-no-duplicate-properties`

--- a/lib/rules/declaration-block-no-duplicate-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-properties/README.md
@@ -149,7 +149,7 @@ p {
 }
 ```
 
-### `ignoreProperties: ["/regex/", "non-regex"]`
+### `ignoreProperties: ["/regex/", /regex/, "non-regex"]`
 
 Ignore duplicates of specific properties.
 

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -378,7 +378,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreProperties: ['/background-/'] }],
+	config: [true, { ignoreProperties: ['/background-/', /width/] }],
 	fix: true,
 
 	accept: [
@@ -387,6 +387,9 @@ testRule({
 		},
 		{
 			code: 'p { background-color: pink; color: orange; background-color: orange }',
+		},
+		{
+			code: 'p { width: auto; width: 100%; }',
 		},
 	],
 

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -378,7 +378,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreProperties: ['/background-/', /width/] }],
+	config: [true, { ignoreProperties: ['/background-/', /padding-/] }],
 	fix: true,
 
 	accept: [
@@ -389,7 +389,7 @@ testRule({
 			code: 'p { background-color: pink; color: orange; background-color: orange }',
 		},
 		{
-			code: 'p { width: auto; width: 100%; }',
+			code: 'p { padding-left: auto; padding-left: 1rem; }',
 		},
 	],
 

--- a/lib/rules/declaration-block-no-duplicate-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.js
@@ -7,7 +7,7 @@ const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isString } = require('../../utils/validateTypes');
+const { isRegExp, isString } = require('../../utils/validateTypes');
 const vendor = require('../../utils/vendor');
 
 const ruleName = 'declaration-block-no-duplicate-properties';
@@ -36,7 +36,7 @@ const rule = (primary, secondaryOptions, context) => {
 						'consecutive-duplicates-with-different-values',
 						'consecutive-duplicates-with-same-prefixless-values',
 					],
-					ignoreProperties: [isString],
+					ignoreProperties: [isString, isRegExp],
 				},
 				optional: true,
 			},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The `ignoreProperties` option of other rules also supports raw regex.
