### PR TITLE
Fix `color-function-notation` false positives for namespaced imports

### DIFF
--- a/.changeset/popular-ducks-marry.md
+++ b/.changeset/popular-ducks-marry.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `color-function notation` false positives for namespaced imports
+Fixed: `color-function-notation` false positives for namespaced imports

--- a/.changeset/popular-ducks-marry.md
+++ b/.changeset/popular-ducks-marry.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `color-function notation` false positives for namespaced imports

--- a/lib/rules/color-function-notation/__tests__/index.js
+++ b/lib/rules/color-function-notation/__tests__/index.js
@@ -429,6 +429,14 @@ testRule({
 		{
 			code: 'a { color: rgba($a, $b, $c, $d) }',
 		},
+		{
+			code: 'a { color: rgb(color.$var, 0.1) }',
+			description: 'namespaced import',
+		},
+		{
+			code: 'a { color: rgba(color.$var, 0.1) }',
+			description: 'namespaced import',
+		},
 	],
 
 	reject: [
@@ -470,6 +478,10 @@ testRule({
 		},
 		{
 			code: 'a { color: rgb($a $b $c / $d) }',
+		},
+		{
+			code: 'a { color: rgb(color.$a color.$b color.$c / color.$d) }',
+			description: 'namespaced import',
 		},
 	],
 

--- a/lib/utils/__tests__/isStandardSyntaxColorFunction.test.js
+++ b/lib/utils/__tests__/isStandardSyntaxColorFunction.test.js
@@ -44,27 +44,31 @@ describe('isStandardSyntaxColorFunction', () => {
 	});
 
 	it('scss color function conversion', () => {
-		expect(isStandardSyntaxColorFunction(func('a { color: rbga(#aaa, 0.5) }'))).toBe(false);
+		expect(isStandardSyntaxColorFunction(func('a { color: rgba(#aaa, 0.5) }'))).toBe(false);
 	});
 
 	it('scss color function conversion with comment', () => {
-		expect(isStandardSyntaxColorFunction(func('a { color: rbga(/* comment */ #aaa, 0.5) }'))).toBe(
+		expect(isStandardSyntaxColorFunction(func('a { color: rgba(/* comment */ #aaa, 0.5) }'))).toBe(
 			false,
 		);
 	});
 
 	it('scss variable', () => {
-		expect(isStandardSyntaxColorFunction(func('a { color: rbga($var, 0.5) }'))).toBe(false);
+		expect(isStandardSyntaxColorFunction(func('a { color: rgba($var, 0.5) }'))).toBe(false);
 	});
 
 	it('scss variable in last param', () => {
-		expect(isStandardSyntaxColorFunction(func('a { color: rbg(0 0 0 / $var) }'))).toBe(false);
+		expect(isStandardSyntaxColorFunction(func('a { color: rgb(0 0 0 / $var) }'))).toBe(false);
 	});
 
 	it('scss nested function', () => {
 		expect(
 			isStandardSyntaxColorFunction(func('a { color: rgba(color.mix(#000, #fff, 35%), 0.6); }')),
 		).toBe(false);
+	});
+
+	it('namespaced scss variable', () => {
+		expect(isStandardSyntaxColorFunction(func('a { color: rgba(color.$var, 0.5) }'))).toBe(false);
 	});
 });
 

--- a/lib/utils/isStandardSyntaxColorFunction.js
+++ b/lib/utils/isStandardSyntaxColorFunction.js
@@ -15,7 +15,10 @@ module.exports = function isStandardSyntaxColorFunction(node) {
 	for (const fnNode of node.nodes) {
 		if (fnNode.type === 'function') return isStandardSyntaxColorFunction(fnNode);
 
-		if (fnNode.type === 'word' && (fnNode.value.startsWith('#') || fnNode.value.startsWith('$')))
+		if (
+			fnNode.type === 'word' &&
+			(fnNode.value.startsWith('#') || fnNode.value.startsWith('$') || fnNode.value.includes('.$'))
+		)
 			return false;
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6610.

> Is there anything in the PR that needs further explanation?

Ref for searching for `.$`: [SCSS highlights those characters as errors for invalid namespace imports](https://sass-lang.com/documentation/variables#built-in-variables).

I noticed that `rgba` was misspelt in some of the test cases for `isStandardSyntaxColorFunction.test.js`, so I've changed those too.
