### PR TITLE
Add `allowEmptyInput`, `cache`, `fix` options to configuration object

### DIFF
--- a/.changeset/seven-coats-perform.md
+++ b/.changeset/seven-coats-perform.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `allowEmptyInput`, `cache`, `fix` options to configuration object

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -473,6 +473,8 @@ For example:
 }
 ```
 
+Note: this config option should not be overridden on a per-file basis.
+
 [More info](options.md#cache).
 
 ## `fix`

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -459,6 +459,8 @@ For example:
 }
 ```
 
+Note: this config option should not be overridden on a per-file basis.
+
 [More info](options.md#allowemptyinput).
 
 ## `cache`
@@ -488,5 +490,7 @@ For example:
   "fix": true
 }
 ```
+
+Note: this config option should not be overridden on a per-file basis.
 
 [More info](options.md#fix).

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -446,3 +446,45 @@ If the globs are absolute paths, they are used as is. If they are relative, they
 - or `process.cwd()`.
 
 _Note that this is not an efficient method for ignoring lots of files._ If you want to ignore a lot of files efficiently, use [`.stylelintignore`](ignore-code.md) or adjust your files globs.
+
+## `allowEmptyInput`
+
+Stylelint does not throw an error when the glob pattern matches no files.
+
+For example:
+
+```json
+{
+  "allowEmptyInput": true
+}
+```
+
+[More info](options.md#allowemptyinput).
+
+## `cache`
+
+Store the results of processed files so that Stylelint only operates on the changed ones.
+
+For example:
+
+```json
+{
+  "cache": true
+}
+```
+
+[More info](options.md#cache).
+
+## `fix`
+
+Automatically fix, where possible, problems reported by rules.
+
+For example:
+
+```json
+{
+  "fix": true
+}
+```
+
+[More info](options.md#fix).

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -34,6 +34,18 @@ function getConfig(additional = {}) {
 	};
 }
 
+// equivalent function, but cache is enabled as a config option
+function getConfigWithCache(additional = {}) {
+	return {
+		files: replaceBackslashes(path.join(fixturesPath, 'cache', '*.css')),
+		config: {
+			cache: true,
+			rules: { 'block-no-empty': true, 'color-no-invalid-hex': true },
+		},
+		...additional,
+	};
+}
+
 describe('standalone cache', () => {
 	const cwd = path.join(__dirname, 'tmp', 'standalone-cache');
 
@@ -220,6 +232,44 @@ describe('standalone cache uses cacheLocation', () => {
 
 		expect(typeof cache.getKey(validFile)).toBe('object');
 		expect(cache.getKey(validFile)).toBeTruthy();
+	});
+});
+
+describe('standalone cache (enabled in config)', () => {
+	const cwd = path.join(__dirname, 'tmp', 'standalone-cache');
+
+	safeChdir(cwd);
+
+	const expectedCacheFilePath = path.join(cwd, '.stylelintcache');
+
+	beforeEach(async () => {
+		// Initial run to warm up the cache
+		await standalone(getConfigWithCache());
+	});
+
+	afterEach(async () => {
+		// Clean up after each test case
+		await removeFile(expectedCacheFilePath);
+		await removeFile(newFileDest);
+	});
+
+	it('only changed files are linted', async () => {
+		// Add "changed" file
+		await fs.copyFile(validFile, newFileDest);
+
+		// Next run should lint only changed files
+		const { results } = await standalone(getConfigWithCache());
+
+		// Ensure only changed files are linted
+		expect(results.some((file) => isChanged(file, validFile))).toBe(false);
+		expect(results.some((file) => isChanged(file, newFileDest))).toBe(true);
+
+		const { cache } = fCache.createFromFile(expectedCacheFilePath);
+
+		expect(typeof cache.getKey(validFile)).toBe('object');
+		expect(cache.getKey(validFile)).toBeTruthy();
+		expect(typeof cache.getKey(newFileDest)).toBe('object');
+		expect(cache.getKey(newFileDest)).toBeTruthy();
 	});
 });
 

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -252,7 +252,7 @@ describe('standalone cache (enabled in config)', () => {
 		await removeFile(newFileDest);
 	});
 
-	it('uses cache when no CLI argument is provided', async () => {
+	it('uses cache by default (option is not provided)', async () => {
 		// Add "changed" file
 		await fs.copyFile(validFile, newFileDest);
 
@@ -271,7 +271,7 @@ describe('standalone cache (enabled in config)', () => {
 		expect(cache.getKey(newFileDest)).toBeTruthy();
 	});
 
-	it('uses cache when --cache is provided', async () => {
+	it('uses cache when option explicitly enables cache', async () => {
 		// Add "changed" file
 		await fs.copyFile(validFile, newFileDest);
 
@@ -290,7 +290,7 @@ describe('standalone cache (enabled in config)', () => {
 		expect(cache.getKey(newFileDest)).toBeTruthy();
 	});
 
-	it('does not use cache when --no-cache is explicitly provided', async () => {
+	it('does not use cache when option explicitly disables cache', async () => {
 		// Add "changed" file
 		await fs.copyFile(validFile, newFileDest);
 

--- a/lib/__tests__/standalone-cache.test.js
+++ b/lib/__tests__/standalone-cache.test.js
@@ -34,18 +34,6 @@ function getConfig(additional = {}) {
 	};
 }
 
-// equivalent function, but cache is enabled as a config option
-function getConfigWithCache(additional = {}) {
-	return {
-		files: replaceBackslashes(path.join(fixturesPath, 'cache', '*.css')),
-		config: {
-			cache: true,
-			rules: { 'block-no-empty': true, 'color-no-invalid-hex': true },
-		},
-		...additional,
-	};
-}
-
 describe('standalone cache', () => {
 	const cwd = path.join(__dirname, 'tmp', 'standalone-cache');
 
@@ -242,6 +230,17 @@ describe('standalone cache (enabled in config)', () => {
 
 	const expectedCacheFilePath = path.join(cwd, '.stylelintcache');
 
+	function getConfigWithCache(additional = {}) {
+		return {
+			files: replaceBackslashes(path.join(fixturesPath, 'cache', '*.css')),
+			config: {
+				cache: true,
+				rules: { 'block-no-empty': true, 'color-no-invalid-hex': true },
+			},
+			...additional,
+		};
+	}
+
 	beforeEach(async () => {
 		// Initial run to warm up the cache
 		await standalone(getConfigWithCache());
@@ -253,7 +252,7 @@ describe('standalone cache (enabled in config)', () => {
 		await removeFile(newFileDest);
 	});
 
-	it('only changed files are linted', async () => {
+	it('uses cache when no CLI argument is provided', async () => {
 		// Add "changed" file
 		await fs.copyFile(validFile, newFileDest);
 
@@ -270,6 +269,42 @@ describe('standalone cache (enabled in config)', () => {
 		expect(cache.getKey(validFile)).toBeTruthy();
 		expect(typeof cache.getKey(newFileDest)).toBe('object');
 		expect(cache.getKey(newFileDest)).toBeTruthy();
+	});
+
+	it('uses cache when --cache is provided', async () => {
+		// Add "changed" file
+		await fs.copyFile(validFile, newFileDest);
+
+		// Next run should lint only changed files
+		const { results } = await standalone(getConfigWithCache({ cache: true }));
+
+		// Ensure only changed files are linted
+		expect(results.some((file) => isChanged(file, validFile))).toBe(false);
+		expect(results.some((file) => isChanged(file, newFileDest))).toBe(true);
+
+		const { cache } = fCache.createFromFile(expectedCacheFilePath);
+
+		expect(typeof cache.getKey(validFile)).toBe('object');
+		expect(cache.getKey(validFile)).toBeTruthy();
+		expect(typeof cache.getKey(newFileDest)).toBe('object');
+		expect(cache.getKey(newFileDest)).toBeTruthy();
+	});
+
+	it('does not use cache when --no-cache is explicitly provided', async () => {
+		// Add "changed" file
+		await fs.copyFile(validFile, newFileDest);
+
+		// Next run should lint all files (regardless of changed)
+		const { results } = await standalone(getConfigWithCache({ cache: false }));
+
+		// Ensure all files are linted
+		expect(results.some((file) => isChanged(file, validFile))).toBe(true);
+		expect(results.some((file) => isChanged(file, newFileDest))).toBe(true);
+
+		const { cache } = fCache.createFromFile(expectedCacheFilePath);
+
+		expect(cache.getKey(validFile)).toBeUndefined();
+		expect(cache.getKey(newFileDest)).toBeUndefined();
 	});
 });
 

--- a/lib/__tests__/standalone-fix.test.js
+++ b/lib/__tests__/standalone-fix.test.js
@@ -26,6 +26,19 @@ it('outputs fixed code when input is code string', async () => {
 	expect(result.output).toBe('a { color: red; }');
 });
 
+it('fixes when enabled in config', async () => {
+	const config = {
+		fix: true,
+		rules: {
+			'color-hex-length': 'short',
+		},
+	};
+
+	const { output } = await standalone({ code: 'a { color: #ffffff; }', config });
+
+	expect(output).toBe('a { color: #fff; }');
+});
+
 it('apply indentation autofix at last', async () => {
 	const result = await standalone({
 		code: 'a {\nbox-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);\n}',

--- a/lib/__tests__/standalone.test.js
+++ b/lib/__tests__/standalone.test.js
@@ -167,6 +167,17 @@ it('standalone with nonexistent-file and allowEmptyInput enabled quietly exits',
 	expect(output).toBe('[]');
 });
 
+it('standalone with nonexistent-file and allowEmptyInput enabled (in config) quitely exits', async () => {
+	const { results, errored, output } = await standalone({
+		files: `${fixturesPath}/nonexistent-file.css`,
+		config: { ...configBlockNoEmpty, allowEmptyInput: true },
+	});
+
+	expect(results).toHaveLength(0);
+	expect(errored).toBe(false);
+	expect(output).toBe('[]');
+});
+
 describe('standalone passing code with syntax error', () => {
 	let results;
 

--- a/lib/augmentConfig.js
+++ b/lib/augmentConfig.js
@@ -424,6 +424,10 @@ function addOptions(stylelint, config) {
 		augmentedConfig.customSyntax = stylelint._options.customSyntax;
 	}
 
+	if (stylelint._options.fix) {
+		augmentedConfig.fix = stylelint._options.fix;
+	}
+
 	return augmentedConfig;
 }
 

--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -112,7 +112,7 @@ module.exports = function lintPostcssResult(stylelintOptions, postcssResult, con
 						configurationComment: config.configurationComment || DEFAULT_CONFIGURATION_COMMENT,
 						fix:
 							!disableFix &&
-							stylelintOptions.fix &&
+							config.fix &&
 							// Next two conditionals are temporary measures until #2643 is resolved
 							isFileFixCompatible &&
 							!postcssResult.stylelint.disabledRanges[ruleName],

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -30,7 +30,7 @@ const writeFileAtomic = require('write-file-atomic');
  */
 async function standalone({
 	allowEmptyInput = false,
-	cache: useCache = false,
+	cache = false,
 	cacheLocation,
 	cacheStrategy,
 	code,
@@ -134,7 +134,7 @@ async function standalone({
 		const postcssResult = stylelintResult._postcssResult;
 		const returnValue = prepareReturnValue([stylelintResult], maxWarnings, formatterFunction, cwd);
 
-		if (fix && postcssResult && !postcssResult.stylelint.ignored) {
+		if ((fix || config?.fix) && postcssResult && !postcssResult.stylelint.ignored) {
 			returnValue.output =
 				!postcssResult.stylelint.disableWritingFix && postcssResult.opts
 					? // If we're fixing, the output should be the fixed code
@@ -163,6 +163,8 @@ async function standalone({
 	if (!disableDefaultIgnores) {
 		fileList = fileList.concat(ALWAYS_IGNORED_GLOBS.map((glob) => `!${glob}`));
 	}
+
+	const useCache = cache || config?.cache;
 
 	if (!useCache) {
 		stylelint._fileCache.destroy();
@@ -246,7 +248,7 @@ async function standalone({
 		});
 
 		stylelintResults = await Promise.all(getStylelintResults);
-	} else if (allowEmptyInput) {
+	} else if (allowEmptyInput || config?.allowEmptyInput) {
 		stylelintResults = await Promise.all([]);
 	} else if (filePathsLengthBeforeIgnore) {
 		// All input files ignored

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -134,7 +134,9 @@ async function standalone({
 		const postcssResult = stylelintResult._postcssResult;
 		const returnValue = prepareReturnValue([stylelintResult], maxWarnings, formatterFunction, cwd);
 
-		if ((fix || config?.fix) && postcssResult && !postcssResult.stylelint.ignored) {
+		const autofix = fix ?? config?.fix ?? false;
+
+		if (autofix && postcssResult && !postcssResult.stylelint.ignored) {
 			returnValue.output =
 				!postcssResult.stylelint.disableWritingFix && postcssResult.opts
 					? // If we're fixing, the output should be the fixed code
@@ -165,7 +167,7 @@ async function standalone({
 	}
 
 	// do not cache if config is explicitly overrided by option
-	const useCache = cache || (config?.cache && cache !== false);
+	const useCache = cache ?? config?.cache ?? false;
 
 	if (!useCache) {
 		stylelint._fileCache.destroy();
@@ -249,7 +251,7 @@ async function standalone({
 		});
 
 		stylelintResults = await Promise.all(getStylelintResults);
-	} else if (allowEmptyInput || config?.allowEmptyInput) {
+	} else if (allowEmptyInput ?? config?.allowEmptyInput) {
 		stylelintResults = await Promise.all([]);
 	} else if (filePathsLengthBeforeIgnore) {
 		// All input files ignored

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -30,7 +30,7 @@ const writeFileAtomic = require('write-file-atomic');
  */
 async function standalone({
 	allowEmptyInput = false,
-	cache = false,
+	cache,
 	cacheLocation,
 	cacheStrategy,
 	code,
@@ -164,7 +164,8 @@ async function standalone({
 		fileList = fileList.concat(ALWAYS_IGNORED_GLOBS.map((glob) => `!${glob}`));
 	}
 
-	const useCache = cache || config?.cache;
+	// do not cache if config is explicitly overrided by option
+	const useCache = cache || (config?.cache && cache !== false);
 
 	if (!useCache) {
 		stylelint._fileCache.destroy();

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -29,7 +29,7 @@ const writeFileAtomic = require('write-file-atomic');
  * @type {import('stylelint')['lint']}
  */
 async function standalone({
-	allowEmptyInput = false,
+	allowEmptyInput,
 	cache,
 	cacheLocation,
 	cacheStrategy,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -106,6 +106,9 @@ declare namespace stylelint {
 		configurationComment?: string;
 		overrides?: ConfigOverride[];
 		customSyntax?: CustomSyntax;
+		allowEmptyInput?: boolean;
+		cache?: boolean;
+		fix?: boolean;
 	};
 
 	/** @internal */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of (but does not close) #5142. This PR handles all the `boolean` flags (which should be relatively simple).

> Is there anything in the PR that needs further explanation?

Sorry about the CodeQL alerts - it was an approach that I tried (and chose to abandon) that I forgot to remove 😅 

As well as my note below on `cache`, two quick questions:

1. For the configuration docs, what orders should the options go in? I may have missed a pattern - I was confused since it's not in the same order as the flags.
2. Any tests I should add?

---

Note that I didn't `augmentConfig` for `allowEmptyInput` and `cache`, since we never access them through the `config` object outside of `standalone.js`; including them drops code coverage. That being said, maybe there's a cleaner way to use these options "downstream", and be consistent in augmenting the config?