### PR TITLE
Fix `block-no-empty` false positives with non-whitespace characters

### DIFF
--- a/.changeset/long-trainers-impress.md
+++ b/.changeset/long-trainers-impress.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `block-no-empty` false positives with non-whitespace characters

--- a/lib/rules/block-no-empty/__tests__/index.js
+++ b/lib/rules/block-no-empty/__tests__/index.js
@@ -29,10 +29,19 @@ testRule({
 			code: 'a {\n/*\nfoo\nbar\n*/\n}',
 		},
 		{
+			code: 'a { ; }',
+		},
+		{
 			code: '@media print { a { color: pink; } }',
 		},
 		{
 			code: '@media print { a { /* foo */ } }',
+		},
+		{
+			code: '@media print { a { ; } }',
+		},
+		{
+			code: '@media print { ; }',
 		},
 		{
 			code: '@import url(x.css)',

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -63,6 +63,10 @@ const rule = (primary, secondaryOptions, context) => {
 				return;
 			}
 
+			if (hasNonWhitespace(statement)) {
+				return;
+			}
+
 			let index = beforeBlockString(statement, { noRawBefore: true }).length;
 
 			// For empty blocks when using SugarSS parser
@@ -93,6 +97,16 @@ const rule = (primary, secondaryOptions, context) => {
 
 				return true;
 			});
+		}
+
+		/**
+		 * @param {Statement} statement
+		 * @returns {boolean}
+		 */
+		function hasNonWhitespace(statement) {
+			const { after } = statement.raws;
+
+			return typeof after === 'string' && /\S/.test(after);
 		}
 	};
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6779

> Is there anything in the PR that needs further explanation?

This pull request fixes such false positives for not only the standard CSS but also CSS-in-JS like this:

Standard CSS:

```css
a {
  ;
}
```

CSS-in-JS:

```jsx
const Button = styled.button`
  &:hover {
    ${buttonHover}
  }
`;
```
