### PR TITLE
Fix `function-url-quotes` autofix for comments in SCSS function

### DIFF
--- a/.changeset/tricky-kangaroos-whisper.md
+++ b/.changeset/tricky-kangaroos-whisper.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-url-quotes` autofix for comments in SCSS function

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -754,6 +754,11 @@ testRule({
 	accept: [
 		{
 			code: '$a: (\n  // foo\n)',
+			description: 'SCSS map',
+		},
+		{
+			code: '@function a(\n  // foo\n) {}',
+			description: 'SCSS function',
 		},
 	],
 });

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -71,6 +71,13 @@ const rule = (primary, secondaryOptions, context) => {
 		}
 
 		/**
+		 * @param {import('postcss-value-parser').Node} node
+		 */
+		function containsOnlyComments(node) {
+			return 'nodes' in node && node.nodes.every((child) => child.type === 'comment');
+		}
+
+		/**
 		 * @param {import('postcss').AtRule} atRule
 		 */
 		function checkAtRuleParams(atRule) {
@@ -79,6 +86,12 @@ const rule = (primary, secondaryOptions, context) => {
 			const parsed = functionArgumentsSearch(params, /^url$/i, (args, index, funcNode) => {
 				checkArgs(atRule, args, startIndex + index, funcNode);
 			});
+
+			const [funcNode] = parsed.nodes;
+
+			if (funcNode && containsOnlyComments(funcNode)) {
+				return;
+			}
 
 			if (context.fix) {
 				atRule.params = parsed.toString();


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6799

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
