### PR TITLE
Fix `declaration-block-no-duplicate-properties` autofix for 3 or more duplicates

### DIFF
--- a/.changeset/lucky-forks-fold.md
+++ b/.changeset/lucky-forks-fold.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-duplicate-properties` autofix for 3 or more duplicates

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.js
@@ -102,6 +102,48 @@ testRule({
 			endColumn: 23,
 		},
 		{
+			code: 'a { color: pink; color: pink; color: pink }',
+			fixed: 'a { color: pink }',
+			description: 'multiple duplicates - same',
+			warnings: [
+				{
+					message: messages.rejected('color'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 23,
+				},
+				{
+					message: messages.rejected('color'),
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 36,
+				},
+			],
+		},
+		{
+			code: 'a { color: pink; color: pink; color: orange }',
+			fixed: 'a { color: orange }',
+			description: 'multiple duplicates - diff',
+			warnings: [
+				{
+					message: messages.rejected('color'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 23,
+				},
+				{
+					message: messages.rejected('color'),
+					line: 1,
+					column: 31,
+					endLine: 1,
+					endColumn: 36,
+				},
+			],
+		},
+		{
 			code: 'a { color: pink; background: orange; color: orange }',
 			fixed: 'a { background: orange; color: orange }',
 			message: messages.rejected('color'),

--- a/lib/rules/declaration-block-no-duplicate-properties/index.js
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.js
@@ -217,6 +217,9 @@ const rule = (primary, secondaryOptions, context) => {
 						return decl.remove();
 					}
 
+					// replace previous "active" decl with current one
+					decls[indexDuplicate] = decl;
+
 					return duplicateDecl.remove();
 				};
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6784.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
