### PR TITLE
Add `ignore: ["with-var-inside"]` to `color-function-notation`

### DIFF
--- a/.changeset/popular-jeans-tap.md
+++ b/.changeset/popular-jeans-tap.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `ignore: ["with-var-inside"]` to `color-function-notation`

--- a/lib/rules/color-function-notation/README.md
+++ b/lib/rules/color-function-notation/README.md
@@ -116,3 +116,37 @@ a { color: hsla(270, 60%, 50%, 15%) }
 ```css
 a { color: hsl(.75turn, 60%, 70%) }
 ```
+
+## Optional secondary options
+
+### `ignore: ["with-var-inside"]`
+
+Ignore color functions containing variables.
+
+Given
+
+```json
+["modern", { "ignore": ["with-var-inside"] }]
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+a {
+  color: rgba(var(--foo), 0.5);
+}
+```
+
+Given
+
+```json
+["legacy", { "ignore": ["with-var-inside"] }]
+```
+
+The following patterns are _not_ considered problems:
+
+```css
+a {
+  color: rgba(var(--foo) / 0.5);
+}
+```

--- a/lib/rules/color-function-notation/README.md
+++ b/lib/rules/color-function-notation/README.md
@@ -123,7 +123,7 @@ a { color: hsl(.75turn, 60%, 70%) }
 
 Ignore color functions containing variables.
 
-Given
+Given:
 
 ```json
 ["modern", { "ignore": ["with-var-inside"] }]
@@ -137,7 +137,7 @@ a {
 }
 ```
 
-Given
+Given:
 
 ```json
 ["legacy", { "ignore": ["with-var-inside"] }]

--- a/lib/rules/color-function-notation/__tests__/index.js
+++ b/lib/rules/color-function-notation/__tests__/index.js
@@ -463,6 +463,36 @@ testRule({
 
 testRule({
 	ruleName,
+	config: ['modern', { ignore: 'with-var-inside' }],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { color: rgba(var(--bar), 0.5); }',
+		},
+		{
+			code: 'a { color: rgba(VaR(--bar), 0.5); }',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['legacy', { ignore: 'with-var-inside' }],
+	fix: true,
+
+	accept: [
+		{
+			code: 'a { color: rgb(var(--foo) / 0.5); }',
+		},
+		{
+			code: 'a { color: rgb(VaR(--foo) / 0.5); }',
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	customSyntax: 'postcss-scss',
 	config: ['legacy'],
 

--- a/lib/rules/color-function-notation/index.js
+++ b/lib/rules/color-function-notation/index.js
@@ -60,10 +60,7 @@ const rule = (primary, secondaryOptions, context) => {
 
 				const { value, sourceIndex, sourceEndIndex, nodes } = node;
 
-				if (
-					ignoreWithVarInside &&
-					nodes.some((child) => child.type === 'function' && child.value.toLowerCase() === 'var')
-				) {
+				if (ignoreWithVarInside && containsVariable(nodes)) {
 					return;
 				}
 
@@ -131,6 +128,13 @@ const rule = (primary, secondaryOptions, context) => {
  */
 function atLeastOneSpace(whitespace) {
 	return whitespace !== '' ? whitespace : ' ';
+}
+
+/**
+ * @param {import('postcss-value-parser').Node[]} nodes
+ */
+function containsVariable(nodes) {
+	return nodes.some(({ type, value }) => type === 'function' && value.toLowerCase() === 'var');
 }
 
 /**

--- a/lib/rules/color-function-notation/index.js
+++ b/lib/rules/color-function-notation/index.js
@@ -62,10 +62,10 @@ const rule = (primary, secondaryOptions, context) => {
 
 				if (
 					ignoreWithVarInside &&
-					nodes.filter((child) => child.type === 'function' && child.value.toLowerCase() === 'var')
-						.length > 0
-				)
+					nodes.some((child) => child.type === 'function' && child.value.toLowerCase() === 'var')
+				) {
 					return;
+				}
 
 				if (!LEGACY_NOTATION_FUNCS.has(value.toLowerCase())) return;
 

--- a/lib/rules/color-function-notation/index.js
+++ b/lib/rules/color-function-notation/index.js
@@ -10,6 +10,7 @@ const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const { isValueFunction } = require('../../utils/typeGuards');
 const validateOptions = require('../../utils/validateOptions');
+const optionsMatches = require('../../utils/optionsMatches');
 
 const ruleName = 'color-function-notation';
 
@@ -26,14 +27,27 @@ const LEGACY_FUNCS = new Set(['rgba', 'hsla']);
 const LEGACY_NOTATION_FUNCS = new Set(['rgb', 'rgba', 'hsl', 'hsla']);
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary, secondaryOptions, context) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: ['modern', 'legacy'],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: ['modern', 'legacy'],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignore: ['with-var-inside'],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) return;
+
+		const ignoreWithVarInside = optionsMatches(secondaryOptions, 'ignore', 'with-var-inside');
 
 		root.walkDecls((decl) => {
 			let needsFix = false;
@@ -45,6 +59,13 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (!isStandardSyntaxColorFunction(node)) return;
 
 				const { value, sourceIndex, sourceEndIndex, nodes } = node;
+
+				if (
+					ignoreWithVarInside &&
+					nodes.filter((child) => child.type === 'function' && child.value.toLowerCase() === 'var')
+						.length > 0
+				)
+					return;
 
 				if (!LEGACY_NOTATION_FUNCS.has(value.toLowerCase())) return;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6620.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
