### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positive for `:modal`

### DIFF
--- a/.changeset/many-mugs-camp.md
+++ b/.changeset/many-mugs-camp.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Fixed selector-pseudo-class-no-unknown false positive for :modal
+Fixed: `selector-pseudo-class-no-unknown` false positive for `:modal`

--- a/.changeset/many-mugs-camp.md
+++ b/.changeset/many-mugs-camp.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed selector-pseudo-class-no-unknown false positive for :modal

--- a/lib/reference/selectors.js
+++ b/lib/reference/selectors.js
@@ -277,6 +277,7 @@ const pseudoClasses = uniteSets(
 		'last-child',
 		'last-of-type',
 		'link',
+		'modal',
 		'only-child',
 		'only-of-type',
 		'optional',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -29,6 +29,9 @@ testRule({
 			code: 'a::before { }',
 		},
 		{
+			code: 'a:modal { }',
+		},
+		{
 			code: "input:not([type='submit']) { }",
 		},
 		{
@@ -122,6 +125,14 @@ testRule({
 		{
 			code: 'a:unknown { }',
 			message: messages.rejected(':unknown'),
+			line: 1,
+			column: 2,
+			endLine: 1,
+			endColumn: 10,
+		},
+		{
+			code: 'a:modal { }',
+			message: messages.rejected(':modal'),
 			line: 1,
 			column: 2,
 			endLine: 1,

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -29,7 +29,7 @@ testRule({
 			code: 'a::before { }',
 		},
 		{
-			code: 'a:modal { }',
+			code: ':modal { }',
 		},
 		{
 			code: "input:not([type='submit']) { }",
@@ -125,14 +125,6 @@ testRule({
 		{
 			code: 'a:unknown { }',
 			message: messages.rejected(':unknown'),
-			line: 1,
-			column: 2,
-			endLine: 1,
-			endColumn: 10,
-		},
-		{
-			code: 'a:modal { }',
-			message: messages.rejected(':modal'),
 			line: 1,
 			column: 2,
 			endLine: 1,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

Closes #6809.

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
