### PR TITLE
Improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
@@ -16,6 +16,19 @@ body:
     id: reproduce-bug
     attributes:
       label: 'What steps are needed to reproduce the bug?'
+      description: 'Provide the smallest reproducible CSS example or steps.'
+      placeholder: |
+        ```css
+        a {
+          colo: red;
+        }
+        ```
+
+        Or
+
+        1. Step 1
+        2. Step 2
+        3. ...
     validations:
       required: true
   - type: textarea
@@ -27,26 +40,42 @@ body:
         ```json
         {
           "rules": {
-            "number-leading-zero": "always"
+            "declaration-block-no-duplicate-properties": true
           }
         }
         ```
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: stylelint-run
     attributes:
       label: 'How did you run Stylelint?'
-      description: 'For example, CLI, Node,js API or PostCSS plugin.'
+      description: 'For example, CLI, Node.js API, PostCSS plugin, or [Stylelint demo](https://stylelint.io/demo/).'
       placeholder: |
-        CLI with `stylelint "**/*.css" --config myconfig.json`
+        ```shell
+        stylelint "**/*.css" --config myconfig.json
+        ```
+
+        Or
+
+        https://stylelint.io/demo/#...
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: stylelint-version
     attributes:
-      label: 'Which version of Stylelint are you using?'
-      placeholder: '`14.0.0`'
+      label: 'Which version of Stylelint or dependencies are you using?'
+      placeholder: |
+        15.6.0
+
+        Or
+
+        ```json
+        {
+          "stylelint": "15.6.0",
+          "stylelint-config-standard": "33.0.0"
+        }
+        ```
     validations:
       required: true
   - type: textarea
@@ -67,11 +96,11 @@ body:
 
         ```
         test.css
-        2:4    Expected a leading zero (number-leading-zero)
+         4:9   ✖  Unexpected unknown property "colo" (property-no-unknown)
         ```
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: non-standard-syntax
     attributes:
       label: 'Does the bug relate to non-standard syntax?'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This pull request improves the bug report template so that we can easily reproduce a reported issue.

Changes summary:
- Add description and placeholder to `reproduce-bug` section
- Avoid deprecated rule `number-leading-zero`
- Add a demo link for easy reproduction
- Add an example of dependencies
- Use `textarea` instead of `input` so that people can easily input

I've prepared a test repository to try this PR's change easily:
https://github.com/ybiquitous/stylelint-pull-6817/issues/new?template=REPORT_A_BUG.yml
