### PR TITLE
Fix `selector-anb-no-unmatchable` doc to include in recommended and standard configs

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -77,7 +77,7 @@ Disallow overrides with these `no-overrides` rules.
 
 Disallow unmatchable things with these `no-unmatchable` rules.
 
-- [`selector-anb-no-unmatchable`](../../lib/rules/selector-anb-no-unmatchable/README.md): Disallow unmatchable An+B selectors.
+- [`selector-anb-no-unmatchable`](../../lib/rules/selector-anb-no-unmatchable/README.md): Disallow unmatchable An+B selectors (Ⓡ & Ⓢ).
 
 ### Unknown
 


### PR DESCRIPTION
The `selector-anb-no-unmatchable` rule is actually has been included in the recommended and standard.

https://github.com/stylelint/stylelint-config-recommended/blob/b35e61355d4a9853532a9f977219453456d6b1bc/index.js#L36