### PR TITLE
Fix `function-no-unknown` false positives for unspaced operators against nested brackets

### DIFF
--- a/.changeset/mean-trees-serve.md
+++ b/.changeset/mean-trees-serve.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-no-unknown` false positives for unspaced operators against nested brackets

--- a/lib/rules/function-no-unknown/__tests__/index.js
+++ b/lib/rules/function-no-unknown/__tests__/index.js
@@ -25,6 +25,9 @@ testRule({
 		{
 			code: 'a { background: -webkit-gradient(linear, 0 50%, 0 100%, from(white), color-stop(0.5, yellow), to(red)); }',
 		},
+		{
+			code: 'a { height: calc(10px*(5*(10 - 5))); }',
+		},
 	],
 
 	reject: [

--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -1,15 +1,19 @@
 'use strict';
 
 const fs = require('fs');
-const valueParser = require('postcss-value-parser');
 const functionsListPath = require('css-functions-list');
+const { tokenize } = require('@csstools/css-tokenizer');
+const {
+	parseCommaSeparatedListOfComponentValues,
+	isFunctionNode,
+	isSimpleBlockNode,
+} = require('@csstools/css-parser-algorithms');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const isStandardSyntaxFunction = require('../../utils/isStandardSyntaxFunction');
 const isCustomFunction = require('../../utils/isCustomFunction');
 const { isRegExp, isString } = require('../../utils/validateTypes');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
@@ -60,39 +64,42 @@ const rule = (primary, secondaryOptions) => {
 
 			if (!isStandardSyntaxValue(value)) return;
 
-			valueParser(value).walk((node) => {
-				const name = node.value;
+			/**
+			 * @param {import('@csstools/css-parser-algorithms').ComponentValue} [componentValue]
+			 */
+			const walker = (componentValue) => {
+				if (!isFunctionNode(componentValue)) return;
 
-				if (node.type !== 'function') {
-					return;
-				}
+				const name = componentValue.getName();
 
-				if (!isStandardSyntaxFunction(node)) {
-					return;
-				}
+				if (isCustomFunction(name)) return;
 
-				if (isCustomFunction(name)) {
-					return;
-				}
+				if (optionsMatches(secondaryOptions, 'ignoreFunctions', name)) return;
 
-				if (optionsMatches(secondaryOptions, 'ignoreFunctions', name)) {
-					return;
-				}
-
-				if (functionsList.includes(name.toLowerCase())) {
-					return;
-				}
+				if (functionsList.includes(name.toLowerCase())) return;
 
 				report({
 					message: messages.rejected,
 					messageArgs: [name],
 					node: decl,
-					index: declarationValueIndex(decl) + node.sourceIndex,
+					index: declarationValueIndex(decl) + componentValue.name[2],
 					result,
 					ruleName,
 					word: name,
 				});
-			});
+			};
+
+			parseCommaSeparatedListOfComponentValues(tokenize({ css: value }))
+				.flatMap((x) => x)
+				.forEach((componentValue) => {
+					if (isFunctionNode(componentValue) || isSimpleBlockNode(componentValue)) {
+						walker(componentValue);
+
+						componentValue.walk((entry) => {
+							walker(entry.node);
+						});
+					}
+				});
 		});
 	};
 };

--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -65,7 +65,7 @@ const rule = (primary, secondaryOptions) => {
 			if (!isStandardSyntaxValue(value)) return;
 
 			/**
-			 * @param {import('@csstools/css-parser-algorithms').ComponentValue} [componentValue]
+			 * @param {import('@csstools/css-parser-algorithms').ComponentValue} componentValue
 			 */
 			const walker = (componentValue) => {
 				if (!isFunctionNode(componentValue)) return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6582

> Is there anything in the PR that needs further explanation?

This change migrates this rule from `postcss-value-parser` to `@csstools/css-parser-algorithms`.

