### PR TITLE
Fix `declaration-block-single-line-max-declarations`, and `shorthand-property-no-redundant-values` doc

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -203,7 +203,7 @@ Specify lowercase or uppercase for words.
 
 Apply limits with these `max` and `min` rules.
 
-- [`declaration-block-single-line-max-declarations`](../../lib/rules/declaration-block-single-line-max-declarations/README.md): Limit the number of declarations within a single-line declaration block.
+- [`declaration-block-single-line-max-declarations`](../../lib/rules/declaration-block-single-line-max-declarations/README.md): Limit the number of declarations within a single-line declaration block (Ⓢ).
 - [`declaration-property-max-values`](../../lib/rules/declaration-property-max-values/README.md): Limit the number of values for a list of properties within declarations.
 - [`max-nesting-depth`](../../lib/rules/max-nesting-depth/README.md): Limit the depth of nesting.
 - [`number-max-precision`](../../lib/rules/number-max-precision/README.md): Limit the number of decimal places allowed in numbers (Ⓢ).
@@ -258,7 +258,7 @@ Require or disallow quotes with these `quotes` rules.
 Disallow redundancy with these `no-redundant` rules.
 
 - [`declaration-block-no-redundant-longhand-properties`](../../lib/rules/declaration-block-no-redundant-longhand-properties/README.md): Disallow redundant longhand properties within declaration-block (Autofixable) (Ⓢ).
-- [`shorthand-property-no-redundant-values`](../../lib/rules/shorthand-property-no-redundant-values/README.md): Disallow redundant values within shorthand properties (Autofixable).
+- [`shorthand-property-no-redundant-values`](../../lib/rules/shorthand-property-no-redundant-values/README.md): Disallow redundant values within shorthand properties (Autofixable) (Ⓢ).
 
 ### Whitespace inside
 


### PR DESCRIPTION
I'm reviewing my stylelint config, and found two doc mistakes:

- `declaration-block-single-line-max-declarations` has been included in the `standard` last month ([link](https://github.com/stylelint/stylelint-config-standard/blob/5aa5dd57ac814edd98c656da35f2ccc99a64d433/index.js#L56))
- `shorthand-property-no-redundant-values` has been included in the `standard` 2 years ago ([link](https://github.com/stylelint/stylelint-config-standard/blob/5aa5dd57ac814edd98c656da35f2ccc99a64d433/index.js#L110))
