### PR TITLE
Fix `alpha-value-notation` false negatives for `oklab()`, `oklch()`, and `color()`

### DIFF
--- a/.changeset/healthy-planets-hide.md
+++ b/.changeset/healthy-planets-hide.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `alpha-value-notation` false negatives for `oklab()`, `oklch()`, and `color()`

--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -53,10 +53,42 @@ testRule({
 			code: 'a { color: lch(56.29% 19.86 10 / var(--alpha)) }',
 		},
 		{
+			code: 'a { color: oklch(56.29% 19.86 10 / var(--alpha)) }',
+		},
+		{
 			code: 'a { color: rgba(0, 0, 0, 0.5/*comment*/) }',
 		},
 		{
 			code: 'a { color: rgb(0 0 0 / /*comment*/0.5) }',
+		},
+		{
+			code: 'a { color: color(display-p3 0 0 0 / 0.5) }',
+		},
+
+		// Relative color syntax
+		{
+			code: 'a { color: rgb(from blue 0 0 0 / 0.5) }',
+		},
+		{
+			code: 'a { color: hsl(from blue 198deg 28% 50% / .50) }',
+		},
+		{
+			code: 'a { color: RGB(from blue 0 0 0 / 0.5) }',
+		},
+		{
+			code: 'a { color: hsl(from blue var(--hsl) / 0.5) }',
+		},
+		{
+			code: 'a { color: lch(from rgb(0 0 0) 56.29% 19.86 10 / var(--alpha)) }',
+		},
+		{
+			code: 'a { color: oklch(from #fff 56.29% 19.86 10 / var(--alpha)) }',
+		},
+		{
+			code: 'a { color: rgb(from blue 0 0 0 / /*comment*/0.5) }',
+		},
+		{
+			code: 'a { color: color(from blue display-p3 0 0 0 / 0.5) }',
 		},
 	],
 
@@ -197,6 +229,35 @@ testRule({
 			endLine: 1,
 			endColumn: 18,
 			description: 'properly deals with floating-point conversions',
+		},
+		{
+			code: 'a { color: rgb(from rgb(127 127 127 / 25%) 0 0 0 / 50%) }',
+			fixed: 'a { color: rgb(from rgb(127 127 127 / 0.25) 0 0 0 / 0.5) }',
+			warnings: [
+				{
+					message: messages.expected('50%', '0.5'),
+					line: 1,
+					column: 52,
+					endLine: 1,
+					endColumn: 55,
+				},
+				{
+					message: messages.expected('25%', '0.25'),
+					line: 1,
+					column: 39,
+					endLine: 1,
+					endColumn: 42,
+				},
+			],
+		},
+		{
+			code: 'a { color: color(display-p3 0 0 0 / 50%) }',
+			fixed: 'a { color: color(display-p3 0 0 0 / 0.5) }',
+			message: messages.expected('50%', '0.5'),
+			line: 1,
+			column: 37,
+			endLine: 1,
+			endColumn: 40,
 		},
 	],
 });

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -32,7 +32,18 @@ const ALPHA_PROPS = new Set([
 	'stop-opacity',
 	'stroke-opacity',
 ]);
-const ALPHA_FUNCS = new Set(['hsl', 'hsla', 'hwb', 'lab', 'lch', 'rgb', 'rgba']);
+const ALPHA_FUNCS = new Set([
+	'color',
+	'hsl',
+	'hsla',
+	'hwb',
+	'lab',
+	'lch',
+	'oklab',
+	'oklch',
+	'rgb',
+	'rgba',
+]);
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {


### PR DESCRIPTION

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6823

> Is there anything in the PR that needs further explanation?

This didn't require any logic changes because this rule just scans ahead for the first `/`.
This works for all color functions and for relative color syntax.

I've added a few more tests to verify that everything is working as expected.
Happy to add more if needed.
