### PR TITLE
Fix `function-url-quotes` false positives for SCSS `with()` construct

### DIFF
--- a/.changeset/nasty-chefs-flow.md
+++ b/.changeset/nasty-chefs-flow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-url-quotes` false positives for SCSS `with()` construct

--- a/lib/rules/function-url-quotes/__tests__/index.js
+++ b/lib/rules/function-url-quotes/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { stripIndent } = require('common-tags');
+
 const naiveCssInJs = require('../../../__tests__/fixtures/postcss-naive-css-in-js');
 
 const { messages, ruleName } = require('..');
@@ -743,12 +745,25 @@ testRule({
 
 	accept: [
 		{
-			code: '$a: (\n  // foo\n)',
+			code: stripIndent`
+				$a: (
+					// foo
+				)`,
 			description: 'SCSS map',
 		},
 		{
-			code: '@function a(\n  // foo\n) {}',
+			code: stripIndent`
+				@function a(
+					// foo
+				) {}`,
 			description: 'SCSS function',
+		},
+		{
+			code: stripIndent`
+				@forward "module" with (
+					// foo
+				)`,
+			description: 'SCSS with',
 		},
 	],
 });

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -71,27 +71,20 @@ const rule = (primary, secondaryOptions, context) => {
 		}
 
 		/**
-		 * @param {import('postcss-value-parser').Node} node
-		 */
-		function containsOnlyComments(node) {
-			return 'nodes' in node && node.nodes.every((child) => child.type === 'comment');
-		}
-
-		/**
 		 * @param {import('postcss').AtRule} atRule
 		 */
 		function checkAtRuleParams(atRule) {
 			const params = getAtRuleParams(atRule);
 			const startIndex = atRuleParamIndex(atRule);
+
+			let hasUrlFunction = false;
+
 			const parsed = functionArgumentsSearch(params, /^url$/i, (args, index, funcNode) => {
+				hasUrlFunction = true;
 				checkArgs(atRule, args, startIndex + index, funcNode);
 			});
 
-			const [funcNode] = parsed.nodes;
-
-			if (funcNode && containsOnlyComments(funcNode)) {
-				return;
-			}
+			if (!hasUrlFunction) return;
 
 			if (context.fix) {
 				atRule.params = parsed.toString();


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/issues/6741#issuecomment-1546878778

> Is there anything in the PR that needs further explanation?

This PR introduces a better logic, so the rule implementation becomes simpler (removing the `containsOnlyComments()` internal function).
