### PR TITLE
Refactor to add utility for media feature names and migrate `media-feature-name-case`

### DIFF
--- a/lib/rules/media-feature-name-case/__tests__/index.js
+++ b/lib/rules/media-feature-name-case/__tests__/index.js
@@ -165,7 +165,7 @@ testRule({
 		},
 		{
 			code: '@media not all and (\\MONOCHROME) {}',
-			fixed: '@media not all and (monochrome) { }',
+			fixed: '@media not all and (monochrome) {}',
 			message: messages.expected('MONOCHROME', 'monochrome'),
 			line: 1,
 			column: 21,
@@ -173,15 +173,15 @@ testRule({
 			endColumn: 32,
 		},
 		{
-			code: '@media not all and (\\@MONOCHROME) { }',
-			fixed: '@media not all and (\\40 monochrome) { }',
+			code: '@media not all and (\\@MONOCHROME) {}',
+			fixed: '@media not all and (\\40 monochrome) {}',
 			message: messages.expected('@MONOCHROME', '@monochrome'),
 			line: 1,
 			column: 21,
 		},
 		{
-			code: '@media not all and (\\40MONOCHROME) { }',
-			fixed: '@media not all and (\\40 monochrome) { }',
+			code: '@media not all and (\\40MONOCHROME) {}',
+			fixed: '@media not all and (\\40 monochrome) {}',
 			message: messages.expected('@MONOCHROME', '@monochrome'),
 			line: 1,
 			column: 21,

--- a/lib/rules/media-feature-name-case/__tests__/index.js
+++ b/lib/rules/media-feature-name-case/__tests__/index.js
@@ -68,6 +68,8 @@ testRule({
 			message: messages.expected('MONOCHROME', 'monochrome'),
 			line: 1,
 			column: 21,
+			endLine: 1,
+			endColumn: 31,
 		},
 		{
 			code: '@media not all and (mOnOcHrOmE) { }',
@@ -75,6 +77,8 @@ testRule({
 			message: messages.expected('mOnOcHrOmE', 'monochrome'),
 			line: 1,
 			column: 21,
+			endLine: 1,
+			endColumn: 31,
 		},
 		{
 			code: '@media (MIN-WIDTH: 700px) { }',
@@ -82,6 +86,8 @@ testRule({
 			message: messages.expected('MIN-WIDTH', 'min-width'),
 			line: 1,
 			column: 9,
+			endLine: 1,
+			endColumn: 18,
 		},
 		{
 			code: '@media (mIn-WiDtH: 700px) { }',
@@ -89,6 +95,8 @@ testRule({
 			message: messages.expected('mIn-WiDtH', 'min-width'),
 			line: 1,
 			column: 9,
+			endLine: 1,
+			endColumn: 18,
 		},
 		{
 			code: '@media (MIN-WIDTH: 700px) and (orientation: landscape) { }',
@@ -96,6 +104,8 @@ testRule({
 			message: messages.expected('MIN-WIDTH', 'min-width'),
 			line: 1,
 			column: 9,
+			endLine: 1,
+			endColumn: 18,
 		},
 		{
 			code: '@media (min-width: 700px) and (ORIENTATION: landscape) { }',
@@ -103,6 +113,8 @@ testRule({
 			message: messages.expected('ORIENTATION', 'orientation'),
 			line: 1,
 			column: 32,
+			endLine: 1,
+			endColumn: 43,
 		},
 		{
 			code: '@media (min-width: 700px) /* comments */ and (ORIENTATION: landscape) {}',
@@ -110,6 +122,8 @@ testRule({
 			message: messages.expected('ORIENTATION', 'orientation'),
 			line: 1,
 			column: 47,
+			endLine: 1,
+			endColumn: 58,
 		},
 		{
 			code: '@media /* comments */ (MIN-WIDTH: 700px) and (orientation: landscape) {}',
@@ -117,6 +131,8 @@ testRule({
 			message: messages.expected('MIN-WIDTH', 'min-width'),
 			line: 1,
 			column: 24,
+			endLine: 1,
+			endColumn: 33,
 		},
 		{
 			code: '@media (-WEBKIT-MIN-DEVICE-PIXEL-RATION: 2) { }',
@@ -127,6 +143,8 @@ testRule({
 			),
 			line: 1,
 			column: 9,
+			endLine: 1,
+			endColumn: 40,
 		},
 		{
 			code: '@media (height: 50em) and (orientation: landscape) and (WIDTH: 25em) {}',
@@ -134,6 +152,8 @@ testRule({
 			message: messages.expected('WIDTH', 'width'),
 			line: 1,
 			column: 57,
+			endLine: 1,
+			endColumn: 62,
 		},
 		{
 			code: '@media (WIDTH > 50em) {}',
@@ -141,6 +161,8 @@ testRule({
 			message: messages.expected('WIDTH', 'width'),
 			line: 1,
 			column: 9,
+			endLine: 1,
+			endColumn: 14,
 		},
 		{
 			code: '@media (10em < WIDTH <= 50em) {}',
@@ -148,6 +170,8 @@ testRule({
 			message: messages.expected('WIDTH', 'width'),
 			line: 1,
 			column: 16,
+			endLine: 1,
+			endColumn: 21,
 		},
 		{
 			code: '@media (width > 10em) and (WIDTH < 50em) {}',
@@ -155,6 +179,8 @@ testRule({
 			message: messages.expected('WIDTH', 'width'),
 			line: 1,
 			column: 28,
+			endLine: 1,
+			endColumn: 33,
 		},
 		{
 			code: '@media (10em < WIDTH) {}',
@@ -162,6 +188,8 @@ testRule({
 			message: messages.expected('WIDTH', 'width'),
 			line: 1,
 			column: 16,
+			endLine: 1,
+			endColumn: 21,
 		},
 		{
 			code: '@media not all and (\\MONOCHROME) {}',
@@ -178,6 +206,8 @@ testRule({
 			message: messages.expected('@MONOCHROME', '@monochrome'),
 			line: 1,
 			column: 21,
+			endLine: 1,
+			endColumn: 33,
 		},
 		{
 			code: '@media not all and (\\40MONOCHROME) {}',
@@ -185,6 +215,8 @@ testRule({
 			message: messages.expected('@MONOCHROME', '@monochrome'),
 			line: 1,
 			column: 21,
+			endLine: 1,
+			endColumn: 34,
 		},
 	],
 });

--- a/lib/rules/media-feature-name-case/__tests__/index.js
+++ b/lib/rules/media-feature-name-case/__tests__/index.js
@@ -164,11 +164,13 @@ testRule({
 			column: 16,
 		},
 		{
-			code: '@media not all and (\\MONOCHROME) { }',
+			code: '@media not all and (\\MONOCHROME) {}',
 			fixed: '@media not all and (monochrome) { }',
 			message: messages.expected('MONOCHROME', 'monochrome'),
 			line: 1,
 			column: 21,
+			endLine: 1,
+			endColumn: 32,
 		},
 		{
 			code: '@media not all and (\\@MONOCHROME) { }',

--- a/lib/rules/media-feature-name-case/__tests__/index.js
+++ b/lib/rules/media-feature-name-case/__tests__/index.js
@@ -490,6 +490,13 @@ testRule({
 			line: 1,
 			column: 41,
 		},
+		{
+			code: '@media @@smartphones /* comments */ and (orientation: landscape) { }',
+			fixed: '@media @@smartphones /* comments */ and (ORIENTATION: landscape) { }',
+			message: messages.expected('orientation', 'ORIENTATION'),
+			line: 1,
+			column: 42,
+		},
 	],
 });
 

--- a/lib/rules/media-feature-name-case/__tests__/index.js
+++ b/lib/rules/media-feature-name-case/__tests__/index.js
@@ -551,6 +551,8 @@ testRule({
 			message: messages.expected('orientation', 'ORIENTATION'),
 			line: 1,
 			column: 42,
+			endLine: 1,
+			endColumn: 53,
 		},
 	],
 });

--- a/lib/rules/media-feature-name-case/__tests__/index.js
+++ b/lib/rules/media-feature-name-case/__tests__/index.js
@@ -163,6 +163,27 @@ testRule({
 			line: 1,
 			column: 16,
 		},
+		{
+			code: '@media not all and (\\MONOCHROME) { }',
+			fixed: '@media not all and (monochrome) { }',
+			message: messages.expected('MONOCHROME', 'monochrome'),
+			line: 1,
+			column: 21,
+		},
+		{
+			code: '@media not all and (\\@MONOCHROME) { }',
+			fixed: '@media not all and (\\40 monochrome) { }',
+			message: messages.expected('@MONOCHROME', '@monochrome'),
+			line: 1,
+			column: 21,
+		},
+		{
+			code: '@media not all and (\\40MONOCHROME) { }',
+			fixed: '@media not all and (\\40 monochrome) { }',
+			message: messages.expected('@MONOCHROME', '@monochrome'),
+			line: 1,
+			column: 21,
+		},
 	],
 });
 

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
+const findMediaFeatureNamesSearch = require('../../utils/findMediaFeatureNamesSearch');
 const isCustomMediaQuery = require('../../utils/isCustomMediaQuery');
-const isRangeContextMediaFeature = require('../../utils/isRangeContextMediaFeature');
 const isStandardSyntaxMediaFeatureName = require('../../utils/isStandardSyntaxMediaFeatureName');
-const mediaParser = require('postcss-media-query-parser').default;
-const rangeContextNodeParser = require('../rangeContextNodeParser');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -36,65 +34,54 @@ const rule = (primary, _secondaryOptions, context) => {
 
 		root.walkAtRules(/^media$/i, (atRule) => {
 			let hasComments = atRule.raws.params && atRule.raws.params.raw;
-			const mediaRule = hasComments ? hasComments : atRule.params;
+			let params = hasComments || atRule.params;
 
-			mediaParser(mediaRule).walk(/^media-feature$/i, (mediaFeatureNode) => {
-				const parent = mediaFeatureNode.parent;
-				const mediaFeatureRangeContext = isRangeContextMediaFeature(parent.value);
+			let hasFixes = false;
 
-				let value;
-				let sourceIndex;
+			params = findMediaFeatureNamesSearch(params, (mediaFeatureNameToken) => {
+				const [, , startIndex, endIndex, { value: featureName }] = mediaFeatureNameToken;
 
-				if (mediaFeatureRangeContext) {
-					const parsedRangeContext = rangeContextNodeParser(mediaFeatureNode);
-
-					value = parsedRangeContext.name.value;
-					sourceIndex = parsedRangeContext.name.sourceIndex;
-				} else {
-					value = mediaFeatureNode.value;
-					sourceIndex = mediaFeatureNode.sourceIndex;
-				}
-
-				if (!isStandardSyntaxMediaFeatureName(value) || isCustomMediaQuery(value)) {
+				if (!isStandardSyntaxMediaFeatureName(featureName) || isCustomMediaQuery(featureName)) {
 					return;
 				}
 
-				const expectedFeatureName = primary === 'lower' ? value.toLowerCase() : value.toUpperCase();
+				const expectedFeatureName =
+					primary === 'lower' ? featureName.toLowerCase() : featureName.toUpperCase();
 
-				if (value === expectedFeatureName) {
+				if (featureName === expectedFeatureName) {
 					return;
 				}
 
 				if (context.fix) {
-					if (hasComments) {
-						hasComments =
-							hasComments.slice(0, sourceIndex) +
-							expectedFeatureName +
-							hasComments.slice(sourceIndex + expectedFeatureName.length);
-
-						if (atRule.raws.params == null) {
-							throw new Error('The `AtRuleRaws` node must have a `params` property');
-						}
-
-						atRule.raws.params.raw = hasComments;
-					} else {
-						atRule.params =
-							atRule.params.slice(0, sourceIndex) +
-							expectedFeatureName +
-							atRule.params.slice(sourceIndex + expectedFeatureName.length);
-					}
+					mediaFeatureNameToken[1] = expectedFeatureName;
+					hasFixes = true;
 
 					return;
 				}
 
+				const atRuleIndex = atRuleParamIndex(atRule);
+
 				report({
-					index: atRuleParamIndex(atRule) + sourceIndex,
-					message: messages.expected(value, expectedFeatureName),
+					message: messages.expected(featureName, expectedFeatureName),
 					node: atRule,
+					index: atRuleIndex + startIndex,
+					endIndex: atRuleIndex + endIndex + 1,
 					ruleName,
 					result,
 				});
-			});
+			}).stringify();
+
+			if (hasFixes) {
+				if (hasComments) {
+					if (atRule.raws.params == null) {
+						throw new Error('The `AtRuleRaws` node must have a `params` property');
+					}
+
+					atRule.raws.params.raw = params;
+				} else {
+					atRule.params = params;
+				}
+			}
 		});
 	};
 };

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { mutateIdent } = require('@csstools/css-tokenizer');
+
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const findMediaFeatureNamesSearch = require('../../utils/findMediaFeatureNamesSearch');
 const isCustomMediaQuery = require('../../utils/isCustomMediaQuery');
@@ -53,7 +55,7 @@ const rule = (primary, _secondaryOptions, context) => {
 				}
 
 				if (context.fix) {
-					mediaFeatureNameToken[1] = expectedFeatureName;
+					mutateIdent(mediaFeatureNameToken, expectedFeatureName);
 					hasFixes = true;
 
 					return;

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -36,11 +36,11 @@ const rule = (primary, _secondaryOptions, context) => {
 
 		root.walkAtRules(/^media$/i, (atRule) => {
 			let hasComments = atRule.raws.params && atRule.raws.params.raw;
-			let params = hasComments || atRule.params;
+			let mediaRule = hasComments ? hasComments : atRule.params;
 
 			let hasFixes = false;
 
-			params = findMediaFeatureNames(params, (mediaFeatureNameToken) => {
+			mediaRule = findMediaFeatureNames(mediaRule, (mediaFeatureNameToken) => {
 				const [, , startIndex, endIndex, { value: featureName }] = mediaFeatureNameToken;
 
 				if (!isStandardSyntaxMediaFeatureName(featureName) || isCustomMediaQuery(featureName)) {
@@ -79,9 +79,9 @@ const rule = (primary, _secondaryOptions, context) => {
 						throw new Error('The `AtRuleRaws` node must have a `params` property');
 					}
 
-					atRule.raws.params.raw = params;
+					atRule.raws.params.raw = mediaRule;
 				} else {
-					atRule.params = params;
+					atRule.params = mediaRule;
 				}
 			}
 		});

--- a/lib/rules/media-feature-name-case/index.js
+++ b/lib/rules/media-feature-name-case/index.js
@@ -3,7 +3,7 @@
 const { mutateIdent } = require('@csstools/css-tokenizer');
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
-const findMediaFeatureNamesSearch = require('../../utils/findMediaFeatureNamesSearch');
+const findMediaFeatureNames = require('../../utils/findMediaFeatureNames');
 const isCustomMediaQuery = require('../../utils/isCustomMediaQuery');
 const isStandardSyntaxMediaFeatureName = require('../../utils/isStandardSyntaxMediaFeatureName');
 const report = require('../../utils/report');
@@ -40,7 +40,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			let hasFixes = false;
 
-			params = findMediaFeatureNamesSearch(params, (mediaFeatureNameToken) => {
+			params = findMediaFeatureNames(params, (mediaFeatureNameToken) => {
 				const [, , startIndex, endIndex, { value: featureName }] = mediaFeatureNameToken;
 
 				if (!isStandardSyntaxMediaFeatureName(featureName) || isCustomMediaQuery(featureName)) {

--- a/lib/utils/findMediaFeatureNames.js
+++ b/lib/utils/findMediaFeatureNames.js
@@ -69,13 +69,13 @@ module.exports = function findMediaFeatureNames(mediaQueryParams, callback) {
 			}
 
 			if (isGeneralEnclosed(node)) {
-				topLevelTokenNodes(node).forEach((token, i, tokens) => {
+				topLevelTokenNodes(node).forEach((token, i, topLevelTokens) => {
 					if (token[0] !== TokenType.Ident) {
 						return;
 					}
 
-					const nextToken = tokens[i + 1];
-					const prevToken = tokens[i - 1];
+					const nextToken = topLevelTokens[i + 1];
+					const prevToken = topLevelTokens[i - 1];
 
 					if (
 						// Media Feature

--- a/lib/utils/findMediaFeatureNames.js
+++ b/lib/utils/findMediaFeatureNames.js
@@ -96,6 +96,9 @@ module.exports = function findMediaFeatureNames(mediaQueryParams, callback) {
 		});
 	});
 
+	// Serializing takes time/resources and not all callers will use this.
+	// By returning an object with a stringify method, we can avoid doing
+	// this work when it's not needed.
 	return {
 		stringify() {
 			return stringify(...tokens);

--- a/lib/utils/findMediaFeatureNamesSearch.js
+++ b/lib/utils/findMediaFeatureNamesSearch.js
@@ -33,7 +33,7 @@ const rangeFeatureOperator = /[<>=]/;
  *
  * @returns {MediaQuerySerializer}
  */
-module.exports = function findMediaFeatureNamesSearch(mediaQueryParams, callback) {
+module.exports = function findMediaFeatureNames(mediaQueryParams, callback) {
 	const tokens = tokenize({ css: mediaQueryParams });
 	const list = parseCommaSeparatedListOfComponentValues(tokens);
 
@@ -69,19 +69,13 @@ module.exports = function findMediaFeatureNamesSearch(mediaQueryParams, callback
 			}
 
 			if (isGeneralEnclosed(node)) {
-				const relevantTokens = topLevelTokenNodes(node);
-
-				if (!relevantTokens) {
-					return;
-				}
-
-				relevantTokens.forEach((token, i) => {
+				topLevelTokenNodes(node).forEach((token, i, tokens) => {
 					if (token[0] !== TokenType.Ident) {
 						return;
 					}
 
-					const nextToken = relevantTokens[i + 1];
-					const prevToken = relevantTokens[i - 1];
+					const nextToken = tokens[i + 1];
+					const prevToken = tokens[i - 1];
 
 					if (
 						// Media Feature
@@ -114,7 +108,7 @@ function topLevelTokenNodes(node) {
 	const components = node.value.value;
 
 	if (isToken(components) || components.length === 0 || isToken(components[0])) {
-		return false;
+		return [];
 	}
 
 	/** @type {Array<import('@csstools/css-tokenizer').CSSToken>} */

--- a/lib/utils/findMediaFeatureNamesSearch.js
+++ b/lib/utils/findMediaFeatureNamesSearch.js
@@ -2,9 +2,9 @@
 
 const { TokenType, isToken, stringify, tokenize } = require('@csstools/css-tokenizer');
 const {
-	TokenNode,
 	isTokenNode,
 	parseCommaSeparatedListOfComponentValues,
+	isSimpleBlockNode,
 } = require('@csstools/css-parser-algorithms');
 const {
 	isGeneralEnclosed,
@@ -18,8 +18,6 @@ const {
 /** @typedef {{ stringify: () => string }} MediaQuerySerializer */
 
 const rangeFeatureOperator = /[<>=]/;
-const nonStandardSyntaxMarkers = /[#@${]/;
-const startsWithNonStandardSyntaxMarker = /^[#@${]/;
 
 /**
  * Search a CSS string for Media Feature names.
@@ -36,32 +34,41 @@ const startsWithNonStandardSyntaxMarker = /^[#@${]/;
  * @returns {MediaQuerySerializer}
  */
 module.exports = function findMediaFeatureNamesSearch(mediaQueryParams, callback) {
-	const [tokens, hasNonStandardSyntax] = normalizeTokenStreamForMediaQueryListParser(
-		tokenize({ css: mediaQueryParams }),
-		mediaQueryParams,
-	);
+	const tokens = tokenize({ css: mediaQueryParams });
+	const list = parseCommaSeparatedListOfComponentValues(tokens);
 
-	const mediaQueryList = parseFromTokens(tokens, {
-		preserveInvalidMediaQueries: true,
+	const mediaQueryConditions = list.flatMap((listItem) => {
+		return listItem.flatMap((componentValue) => {
+			if (
+				!isSimpleBlockNode(componentValue) ||
+				componentValue.startToken[0] !== TokenType.OpenParen
+			) {
+				return [];
+			}
+
+			const blockTokens = componentValue.tokens();
+
+			const mediaQueryList = parseFromTokens(blockTokens, {
+				preserveInvalidMediaQueries: true,
+			});
+
+			return mediaQueryList.filter((mediaQuery) => {
+				return !isMediaQueryInvalid(mediaQuery);
+			});
+		});
 	});
 
-	mediaQueryList.forEach((mediaQuery) => {
-		if (isMediaQueryInvalid(mediaQuery)) return;
-
+	mediaQueryConditions.forEach((mediaQuery) => {
 		mediaQuery.walk(({ node }) => {
 			if (isMediaFeature(node)) {
 				const token = node.getNameToken();
 
 				if (token[0] !== TokenType.Ident) return;
 
-				const raw = token[1];
-
-				if (startsWithNonStandardSyntaxMarker.test(raw)) return;
-
 				callback(token);
 			}
 
-			if (hasNonStandardSyntax && isGeneralEnclosed(node)) {
+			if (isGeneralEnclosed(node)) {
 				const relevantTokens = topLevelTokenNodes(node);
 
 				if (!relevantTokens) {
@@ -97,113 +104,10 @@ module.exports = function findMediaFeatureNamesSearch(mediaQueryParams, callback
 
 	return {
 		stringify() {
-			return mediaQueryList.map((mediaQuery) => mediaQuery.toString()).join(',');
+			return stringify(...tokens);
 		},
 	};
 };
-
-/**
- * Normalize the token stream for the media query list parser.
- *
- * The CSSToken construct is quite flexible and can be used to "lie" to the parser.
- * - take all non-standard components and sequences of components that are used as variables or as interpolation.
- * - replace these with a single Ident token that has the same raw value as the original token sequence.
- *
- * The result is something that parses as standard CSS, but serializes to the original input.
- *
- * @param {Array<import('@csstools/css-tokenizer').CSSToken>} tokens
- * @param {string} mediaQueryParams
- * @returns {[Array<import('@csstools/css-tokenizer').CSSToken>, boolean]}
- */
-function normalizeTokenStreamForMediaQueryListParser(tokens, mediaQueryParams) {
-	let hasNonStandardSyntax = false;
-
-	if (nonStandardSyntaxMarkers.test(mediaQueryParams)) {
-		for (let i = 0; i < tokens.length; i++) {
-			const token = tokens[i];
-
-			if (!token) break;
-
-			const [tokenType, raw] = token;
-
-			if (
-				tokenType === TokenType.AtKeyword ||
-				tokenType === TokenType.OpenCurly ||
-				(tokenType === TokenType.Delim && nonStandardSyntaxMarkers.test(raw))
-			) {
-				hasNonStandardSyntax = true;
-				break;
-			}
-		}
-	}
-
-	if (hasNonStandardSyntax) {
-		const list = parseCommaSeparatedListOfComponentValues(tokens);
-
-		list.forEach((listItem) => {
-			listItem.forEach((componentValue, index) => {
-				if (isTokenNode(componentValue)) {
-					// @media @tablet {}
-					if (componentValue.value[0] === TokenType.AtKeyword) {
-						componentValue.value = [
-							TokenType.Ident,
-							componentValue.value[1],
-							componentValue.value[2],
-							componentValue.value[3],
-							{ value: componentValue.value[4].value },
-						];
-
-						return;
-					}
-
-					// @media #{foo} {}
-					// @media $foo {}
-					// @media ${foo} {}
-					// @media @@foo {}
-					// @media @{foo} {}
-					if (
-						componentValue.value[0] === TokenType.Delim &&
-						(componentValue.value[4].value === '$' ||
-							componentValue.value[4].value === '#' ||
-							componentValue.value[4].value === '@')
-					) {
-						const nextComponentValue = listItem[index + 1];
-
-						if (!nextComponentValue) return;
-
-						const nextComponentValueTokens = nextComponentValue.tokens();
-						const lastComponentValueToken =
-							nextComponentValueTokens[nextComponentValueTokens.length - 1];
-
-						if (!lastComponentValueToken) return;
-
-						let raw = stringify(componentValue.value, ...nextComponentValueTokens);
-
-						listItem.splice(
-							index,
-							2,
-							new TokenNode([
-								TokenType.Ident,
-								raw,
-								componentValue.value[2],
-								lastComponentValueToken[3],
-								{
-									value: raw,
-								},
-							]),
-						);
-					}
-				}
-			});
-		});
-
-		tokens = list.flatMap((listItem) =>
-			listItem.flatMap((componentValue) => componentValue.tokens()),
-		);
-	}
-
-	return [tokens, hasNonStandardSyntax];
-}
 
 /** @param {import('@csstools/media-query-list-parser').GeneralEnclosed} node */
 function topLevelTokenNodes(node) {

--- a/lib/utils/findMediaFeatureNamesSearch.js
+++ b/lib/utils/findMediaFeatureNamesSearch.js
@@ -1,0 +1,243 @@
+'use strict';
+
+const { TokenType, isToken, stringify, tokenize } = require('@csstools/css-tokenizer');
+const {
+	TokenNode,
+	isTokenNode,
+	parseCommaSeparatedListOfComponentValues,
+} = require('@csstools/css-parser-algorithms');
+const {
+	isGeneralEnclosed,
+	isMediaFeature,
+	isMediaQueryInvalid,
+	parseFromTokens,
+} = require('@csstools/media-query-list-parser');
+
+/** @typedef {Array<import('@csstools/media-query-list-parser').MediaQuery>} MediaQueryList */
+/** @typedef {import('@csstools/css-tokenizer').TokenIdent} TokenIdent */
+/** @typedef {{ stringify: () => string }} MediaQuerySerializer */
+
+const rangeFeatureOperator = /[<>=]/;
+const nonStandardSyntaxMarkers = /[#@${]/;
+const startsWithNonStandardSyntaxMarker = /^[#@${]/;
+
+/**
+ * Search a CSS string for Media Feature names.
+ * For every found name, invoke the callback, passing the token
+ * as an argument.
+ *
+ * Found tokens are mutable and modifications made to them will be reflected in the output.
+ *
+ * This function supports some non-standard syntaxes like SCSS variables and interpolation.
+ *
+ * @param {string} mediaQueryParams
+ * @param {(mediaFeatureName: TokenIdent) => void} callback
+ *
+ * @returns {MediaQuerySerializer}
+ */
+module.exports = function findMediaFeatureNamesSearch(mediaQueryParams, callback) {
+	const [tokens, hasNonStandardSyntax] = normalizeTokenStreamForMediaQueryListParser(
+		tokenize({ css: mediaQueryParams }),
+		mediaQueryParams,
+	);
+
+	const mediaQueryList = parseFromTokens(tokens, {
+		preserveInvalidMediaQueries: true,
+	});
+
+	mediaQueryList.forEach((mediaQuery) => {
+		if (isMediaQueryInvalid(mediaQuery)) return;
+
+		mediaQuery.walk(({ node }) => {
+			if (isMediaFeature(node)) {
+				const token = node.getNameToken();
+
+				if (token[0] !== TokenType.Ident) return;
+
+				const raw = token[1];
+
+				if (startsWithNonStandardSyntaxMarker.test(raw)) return;
+
+				callback(token);
+			}
+
+			if (hasNonStandardSyntax && isGeneralEnclosed(node)) {
+				const relevantTokens = topLevelTokenNodes(node);
+
+				if (!relevantTokens) {
+					return;
+				}
+
+				relevantTokens.forEach((token, i) => {
+					if (token[0] !== TokenType.Ident) {
+						return;
+					}
+
+					const nextToken = relevantTokens[i + 1];
+					const prevToken = relevantTokens[i - 1];
+
+					if (
+						// Media Feature
+						(!prevToken && nextToken && nextToken[0] === TokenType.Colon) ||
+						// Range Feature
+						(nextToken &&
+							nextToken[0] === TokenType.Delim &&
+							rangeFeatureOperator.test(nextToken[4].value)) ||
+						// Range Feature
+						(prevToken &&
+							prevToken[0] === TokenType.Delim &&
+							rangeFeatureOperator.test(prevToken[4].value))
+					) {
+						callback(token);
+					}
+				});
+			}
+		});
+	});
+
+	return {
+		stringify() {
+			return mediaQueryList.map((mediaQuery) => mediaQuery.toString()).join(',');
+		},
+	};
+};
+
+/**
+ * Normalize the token stream for the media query list parser.
+ *
+ * The CSSToken construct is quite flexible and can be used to "lie" to the parser.
+ * - take all non-standard components and sequences of components that are used as variables or as interpolation.
+ * - replace these with a single Ident token that has the same raw value as the original token sequence.
+ *
+ * The result is something that parses as standard CSS, but serializes to the original input.
+ *
+ * @param {Array<import('@csstools/css-tokenizer').CSSToken>} tokens
+ * @param {string} mediaQueryParams
+ * @returns {[Array<import('@csstools/css-tokenizer').CSSToken>, boolean]}
+ */
+function normalizeTokenStreamForMediaQueryListParser(tokens, mediaQueryParams) {
+	let hasNonStandardSyntax = false;
+
+	if (nonStandardSyntaxMarkers.test(mediaQueryParams)) {
+		for (let i = 0; i < tokens.length; i++) {
+			const token = tokens[i];
+
+			if (!token) break;
+
+			const [tokenType, raw] = token;
+
+			if (
+				tokenType === TokenType.AtKeyword ||
+				tokenType === TokenType.OpenCurly ||
+				(tokenType === TokenType.Delim && nonStandardSyntaxMarkers.test(raw))
+			) {
+				hasNonStandardSyntax = true;
+				break;
+			}
+		}
+	}
+
+	if (hasNonStandardSyntax) {
+		const list = parseCommaSeparatedListOfComponentValues(tokens);
+
+		list.forEach((listItem) => {
+			listItem.forEach((componentValue, index) => {
+				if (isTokenNode(componentValue)) {
+					// @media @tablet {}
+					if (componentValue.value[0] === TokenType.AtKeyword) {
+						componentValue.value = [
+							TokenType.Ident,
+							componentValue.value[1],
+							componentValue.value[2],
+							componentValue.value[3],
+							{ value: componentValue.value[4].value },
+						];
+
+						return;
+					}
+
+					// @media #{foo} {}
+					// @media $foo {}
+					// @media ${foo} {}
+					// @media @@foo {}
+					// @media @{foo} {}
+					if (
+						componentValue.value[0] === TokenType.Delim &&
+						(componentValue.value[4].value === '$' ||
+							componentValue.value[4].value === '#' ||
+							componentValue.value[4].value === '@')
+					) {
+						const nextComponentValue = listItem[index + 1];
+
+						if (!nextComponentValue) return;
+
+						const nextComponentValueTokens = nextComponentValue.tokens();
+						const lastComponentValueToken =
+							nextComponentValueTokens[nextComponentValueTokens.length - 1];
+
+						if (!lastComponentValueToken) return;
+
+						let raw = stringify(componentValue.value, ...nextComponentValueTokens);
+
+						listItem.splice(
+							index,
+							2,
+							new TokenNode([
+								TokenType.Ident,
+								raw,
+								componentValue.value[2],
+								lastComponentValueToken[3],
+								{
+									value: raw,
+								},
+							]),
+						);
+					}
+				}
+			});
+		});
+
+		tokens = list.flatMap((listItem) =>
+			listItem.flatMap((componentValue) => componentValue.tokens()),
+		);
+	}
+
+	return [tokens, hasNonStandardSyntax];
+}
+
+/** @param {import('@csstools/media-query-list-parser').GeneralEnclosed} node */
+function topLevelTokenNodes(node) {
+	const components = node.value.value;
+
+	if (isToken(components) || components.length === 0 || isToken(components[0])) {
+		return false;
+	}
+
+	/** @type {Array<import('@csstools/css-tokenizer').CSSToken>} */
+	const relevantTokens = [];
+
+	// To consume the next token if it is a scss variable
+	let lastWasDollarSign = false;
+
+	components.forEach((component) => {
+		// Only preserve top level tokens (idents, delims, ...)
+		// Discard all blocks, functions, ...
+		if (component && isTokenNode(component)) {
+			if (component.value[0] === TokenType.Delim && component.value[4].value === '$') {
+				lastWasDollarSign = true;
+
+				return;
+			}
+
+			if (lastWasDollarSign) {
+				lastWasDollarSign = false;
+
+				return;
+			}
+
+			relevantTokens.push(component.value);
+		}
+	});
+
+	return relevantTokens;
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6848

> Is there anything in the PR that needs further explanation?

I started with `media-feature-name-case` because it is the only rule for media feature names that also has an autofix option. Any utility that works for that rule will also work for rules without an autofix option.

Almost all of the complexity in this new utility is the result of trying to have some support for non-standard syntax.

There are two issues with non-standard syntax :

1. `@media @foo and (min-width: 320px) {}`

Top level non-standard syntax doesn't have any fallbacks in the media query parser. It's just an invalid list item.

To resolve this I moved to a "two stage" parser.

- first pass tokenizes and parses into component values.
- second pass takes simple blocks that start and end with parenthesis and parses these as media queries

`@media @foo and (min-width: 320px) and @bar {}` -> only `(min-width: 320px)` is fully parsed.

2. `@media (something = @foo)` vs. `@media (@foo = something)`

With range syntax there isn't a fixed order, so we can't make the same assumptions as for non-range syntax.

_`@media (something: @foo)` -> `something` is the feature name because it comes before `:` (colon)_

So the current strategy is to search for ident tokens and to check if these are found in a location that isn't invalid (doesn't mean valid) for media feature names.

This is exactly the same as what we already have for `media-feature-name-no-unknown`.
I didn't touch that rule yet because I only wanted to alter one rule at a time.

------

What is a good commit message for a refactor like this?

What is a good function name for the utility I created?
- it has a callback
- but it also returns something that can be used for autofix options
- did I try to do too much in this utility?