### PR TITLE
Change more suitable examples in `unit-no-unknown` doc

### DIFF
--- a/lib/rules/unit-no-unknown/README.md
+++ b/lib/rules/unit-no-unknown/README.md
@@ -94,7 +94,7 @@ a {
 Given:
 
 ```json
-["image-set", "/^my-/", "/^YOUR-/i"]
+["foo", "/^my-/", "/^YOUR-/i"]
 ```
 
 The following patterns are _not_ considered problems:
@@ -102,32 +102,20 @@ The following patterns are _not_ considered problems:
 <!-- prettier-ignore -->
 ```css
 a {
-  background-image: image-set(
-    '/images/some-image-1x.jpg' 1x,
-    '/images/some-image-2x.jpg' 2x,
-    '/images/some-image-3x.jpg' 3x
-  );
+  width: foo(1x);
 }
 ```
 
 <!-- prettier-ignore -->
 ```css
 a {
-  background-image: my-image-set(
-    '/images/some-image-1x.jpg' 1x,
-    '/images/some-image-2x.jpg' 2x,
-    '/images/some-image-3x.jpg' 3x
-  );
+  width: my-func(1x);
 }
 ```
 
 <!-- prettier-ignore -->
 ```css
 a {
-  background-image: YoUr-image-set(
-    '/images/some-image-1x.jpg' 1x,
-    '/images/some-image-2x.jpg' 2x,
-    '/images/some-image-3x.jpg' 3x
-  );
+  width: YoUr-func(1x);
 }
 ```

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -597,50 +597,17 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreFunctions: ['image-set', '/^my-/', '/^YOUR-/i'] }],
+	config: [true, { ignoreFunctions: ['foo', '/^my-/', '/^YOUR-/i'] }],
 
 	accept: [
 		{
-			code: "a { background-image: image-set('/images/some-image-1x.jpg' 1x,'/images/some-image-2x.jpg' 2x,'/images/some-image-3x.jpg' 3x,); }",
+			code: 'a { width: foo(1x); }',
 		},
 		{
-			code: "a { background-image: my-image-set('/images/some-image-1x.jpg' 1x,'/images/some-image-2x.jpg' 2x,'/images/some-image-3x.jpg' 3x,); }",
+			code: 'a { width: my-func(1x); }',
 		},
 		{
-			code: "a { background-image: YoUr-image-set('/images/some-image-1x.jpg' 1x,'/images/some-image-2x.jpg' 2x,'/images/some-image-3x.jpg' 3x,); }",
-		},
-	],
-
-	reject: [
-		{
-			code: 'a { margin: calc(10pixels + 1pixels); }',
-			warnings: [
-				{
-					message: messages.rejected('pixels'),
-					line: 1,
-					column: 20,
-					endLine: 1,
-					endColumn: 26,
-				},
-				{
-					message: messages.rejected('pixels'),
-					line: 1,
-					column: 30,
-					endLine: 1,
-					endColumn: 36,
-				},
-			],
-		},
-	],
-});
-
-testRule({
-	ruleName,
-	config: [true, { ignoreFunctions: [/^my-/] }],
-
-	accept: [
-		{
-			code: "a { background-image: my-image-set('/images/some-image-1x.jpg' 1x,'/images/some-image-2x.jpg' 2x,'/images/some-image-3x.jpg' 3x,); }",
+			code: 'a { width: YoUr-func(1x); }',
 		},
 	],
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #6721 (I found this PR's problem during the issue discussion)

> Is there anything in the PR that needs further explanation?

The `unit-no-unknown` rule handles the `image-set()` function and the `x` unit.
So, specifying `image-set` to the `ignoreFunctions` option doesn't make sense.

Additionally, this change removes duplicate cases in the test for `unit-no-unknown`.

See also the [demo](https://stylelint.io/demo/#N4Igxg9gJgpiBcICGACYAdAdilAjJYA1gOYBOEArplALQCWAtksTPCo8zDQM4wAuACiw4cAcgD0HFt3HcIDLlK4BGAB4A6AFYAHYqJRqANMJESlMuQvpMWNAEwadelA+PZTkmzAvzFXmgDMjrr6QSYAlADcWAC+IIYgAGZ0ADYwAHJICgggMKpZ2mnqYNzc8eAQmMnEORju6CCkFGncDWx1IigNVHR8NJgQNFSEAwDumG0ofE0wJjGx5ZBVdMQAYhCkTHw5mnKY5bDaZYgdXSDcfACeaSl0mHyTDSlIfN4P8SYNF9cwt-c0S2qPD4SGoSFIUEeIGerwuDQWMSAA).
