### PR TITLE
Fix `string` formatter for unexpected truncation on non-ASCII characters

### DIFF
--- a/.changeset/late-otters-behave.md
+++ b/.changeset/late-otters-behave.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `string` formatter for unexpected truncation on non-ASCII characters

--- a/lib/formatters/__tests__/stringFormatter.test.js
+++ b/lib/formatters/__tests__/stringFormatter.test.js
@@ -57,6 +57,31 @@ path/to/file.css
 1 problem (1 error, 0 warnings)`);
 	});
 
+	it('outputs warnings contains non-ASCII characters', () => {
+		const results = [
+			{
+				source: 'path/to/file.css',
+				warnings: [
+					{
+						line: 1,
+						column: 1,
+						rule: 'bar',
+						severity: 'error',
+						text: '简体中文こんにちは안녕하세요',
+					},
+				],
+			},
+		];
+
+		const output = prepareFormatterOutput(results, stringFormatter);
+
+		expect(output).toBe(stripIndent`
+path/to/file.css
+ 1:1  ×  简体中文こんにちは안녕하세요  bar
+
+1 problem (1 error, 0 warnings)`);
+	});
+
 	it('removes rule name from warning text', () => {
 		const results = [
 			{
@@ -135,6 +160,42 @@ path/to/file.css
 path/to/file.css
  1:1  ×  Unexpected very very very very very very very  bar-very-very-very-very-very-long
          very very very very very very long foo
+
+1 problem (1 error, 0 warnings)`);
+	});
+
+	it('outputs warnings with more than 80 non-ASCII characters and `process.stdout.columns` equal 90 characters', () => {
+		// For Windows tests
+		process.stdout.isTTY = true;
+		process.stdout.columns = 90;
+
+		const results = [
+			{
+				source: 'path/to/file.css',
+				warnings: [
+					{
+						line: 1,
+						column: 1,
+						rule: 'bar-very-very-very-very-very-long',
+						severity: 'error',
+						text:
+							'简体中文こんにちは안녕하세요简体中文こんにちは안녕하세요简体中文こんにちは안녕하세요简体中文こんにちは안녕하세요简体中文' +
+							'こんにちは안녕하세요简体中文こんにちは안녕하세요简体中文こんにちは안녕하세요简体中文こんにちは안녕하세요简体中文こんにちは안녕하세요',
+					},
+				],
+			},
+		];
+
+		const output = prepareFormatterOutput(results, stringFormatter);
+
+		expect(output).toBe(stripIndent`
+path/to/file.css
+ 1:1  ×  简体中文こんにちは안녕하세요简体中文こんにち   bar-very-very-very-very-very-long
+         は안녕하세요简体中文こんにちは안녕하세요简体
+         中文こんにちは안녕하세요简体中文こんにちは안
+         녕하세요简体中文こんにちは안녕하세요简体中文
+         こんにちは안녕하세요简体中文こんにちは안녕하
+         세요简体中文こんにちは안녕하세요
 
 1 problem (1 error, 0 warnings)`);
 	});

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -11,10 +11,8 @@ const { assertNumber } = require('../utils/validateTypes');
 const preprocessWarnings = require('./preprocessWarnings');
 const terminalLink = require('./terminalLink');
 
+const NON_ASCII_PATTERN = /\P{ASCII}/u;
 const MARGIN_WIDTHS = 9;
-// https://stackoverflow.com/questions/3203190/regex-any-ascii-character
-// eslint-disable-next-line no-control-regex
-const NON_ASCII_OR_WS_PATTERN = /[^\x00-\x7F]/;
 
 /**
  * @param {string} s
@@ -203,7 +201,8 @@ function formatter(messages, source, cwd) {
 		return row;
 	});
 
-	const hasNonAsciiChar = messages.some((msg) => NON_ASCII_OR_WS_PATTERN.test(msg.text));
+	const messageWidth = getMessageWidth(columnWidths);
+	const hasNonAsciiChar = messages.some((msg) => NON_ASCII_PATTERN.test(msg.text));
 
 	output += table
 		.table(cleanedMessages, {
@@ -214,8 +213,8 @@ function formatter(messages, source, cwd) {
 				2: { alignment: 'center', width: columnWidths[2] },
 				3: {
 					alignment: 'left',
-					width: getMessageWidth(columnWidths),
-					wrapWord: getMessageWidth(columnWidths) > 1 && !hasNonAsciiChar,
+					width: messageWidth,
+					wrapWord: messageWidth > 1 && !hasNonAsciiChar,
 				},
 				4: { alignment: 'left', width: columnWidths[4], paddingRight: 0 },
 			},

--- a/lib/formatters/stringFormatter.js
+++ b/lib/formatters/stringFormatter.js
@@ -12,6 +12,9 @@ const preprocessWarnings = require('./preprocessWarnings');
 const terminalLink = require('./terminalLink');
 
 const MARGIN_WIDTHS = 9;
+// https://stackoverflow.com/questions/3203190/regex-any-ascii-character
+// eslint-disable-next-line no-control-regex
+const NON_ASCII_OR_WS_PATTERN = /[^\x00-\x7F]/;
 
 /**
  * @param {string} s
@@ -200,6 +203,8 @@ function formatter(messages, source, cwd) {
 		return row;
 	});
 
+	const hasNonAsciiChar = messages.some((msg) => NON_ASCII_OR_WS_PATTERN.test(msg.text));
+
 	output += table
 		.table(cleanedMessages, {
 			border: table.getBorderCharacters('void'),
@@ -210,7 +215,7 @@ function formatter(messages, source, cwd) {
 				3: {
 					alignment: 'left',
 					width: getMessageWidth(columnWidths),
-					wrapWord: getMessageWidth(columnWidths) > 1,
+					wrapWord: getMessageWidth(columnWidths) > 1 && !hasNonAsciiChar,
 				},
 				4: { alignment: 'left', width: columnWidths[4], paddingRight: 0 },
 			},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See issus: [stringFormatter.js truncate non-ASCII characters unexpectedly](https://github.com/stylelint/stylelint/issues/6860)

Closes #6860

> Is there anything in the PR that needs further explanation?

The reason that why don't I just contribute code to repository `table`, is: make it to support full ability about non-ASCII seems like a lot of work. before it, we can solve the problem in this way first。
