### PR TITLE
Fix `alpha-value-notation` performance with improved benchmark script

### DIFF
--- a/.changeset/tricky-gorillas-drive.md
+++ b/.changeset/tricky-gorillas-drive.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `alpha-value-notation` performance with improved benchmark script

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -26,7 +26,7 @@ const meta = {
 const ALPHA_PROPS_REGEXP =
 	/^(?:opacity|shape-image-threshold|fill-opacity|flood-opacity|stop-opacity|stroke-opacity)$/i;
 const ALPHA_FUNCTION_REGEXP = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
-const ALPHA_FUNCTION_NAME_REGXP = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
+const ALPHA_FUNCTION_NAME_REGEXP = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
 const DIGIT_REGEXP = /\d/;
 
 /** @type {import('stylelint').Rule} */

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -23,11 +23,11 @@ const meta = {
 	fixable: true,
 };
 
-const ALPHA_PROPS_REGEXP =
+const ALPHA_PROPS =
 	/^(?:opacity|shape-image-threshold|fill-opacity|flood-opacity|stop-opacity|stroke-opacity)$/i;
-const ALPHA_FUNCTION_REGEXP = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
-const ALPHA_FUNCTION_NAME_REGEXP = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
-const DIGIT_REGEXP = /\d/;
+const ALPHA_FUNCTION = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
+const ALPHA_FUNCTION_NAME = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
+const DIGIT = /\d/;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
@@ -63,15 +63,15 @@ const rule = (primary, secondaryOptions, context) => {
 
 		root.walkDecls((decl) => {
 			const declarationValue = getDeclarationValue(decl);
-			const isAlphaProp = ALPHA_PROPS_REGEXP.test(decl.prop);
+			const isAlphaProp = ALPHA_PROPS.test(decl.prop);
 
 			if (
 				// If the property is not an alpha property
 				(!isAlphaProp &&
 					// And the value is not an alpha function
-					!ALPHA_FUNCTION_REGEXP.test(declarationValue)) ||
+					!ALPHA_FUNCTION.test(declarationValue)) ||
 				// Or the value does not contain digits
-				!DIGIT_REGEXP.test(declarationValue)
+				!DIGIT.test(declarationValue)
 			) {
 				// Abort early
 				return;
@@ -84,9 +84,9 @@ const rule = (primary, secondaryOptions, context) => {
 				/** @type {import('postcss-value-parser').Node | undefined} */
 				let alpha;
 
-				if (isAlphaProp && DIGIT_REGEXP.test(node.value)) {
+				if (isAlphaProp && DIGIT.test(node.value)) {
 					alpha = findAlphaInValue(node);
-				} else if (node.type === 'function' && ALPHA_FUNCTION_NAME_REGEXP.test(node.value)) {
+				} else if (node.type === 'function' && ALPHA_FUNCTION_NAME.test(node.value)) {
 					alpha = findAlphaInFunction(node);
 				}
 

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -23,27 +23,11 @@ const meta = {
 	fixable: true,
 };
 
-const ALPHA_PROPS = new Set([
-	'opacity',
-	'shape-image-threshold',
-	// SVG properties
-	'fill-opacity',
-	'flood-opacity',
-	'stop-opacity',
-	'stroke-opacity',
-]);
-const ALPHA_FUNCS = new Set([
-	'color',
-	'hsl',
-	'hsla',
-	'hwb',
-	'lab',
-	'lch',
-	'oklab',
-	'oklch',
-	'rgb',
-	'rgba',
-]);
+const ALPHA_PROPS_REGEXP =
+	/^(?:opacity|shape-image-threshold|fill-opacity|flood-opacity|stop-opacity|stroke-opacity)$/i;
+const ALPHA_FUNCTION_REGEXP = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
+const ALPHA_FUNCTION_NAME_REGXP = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
+const DIGIT_REGEXP = /\d/;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions, context) => {
@@ -78,20 +62,31 @@ const rule = (primary, secondaryOptions, context) => {
 		});
 
 		root.walkDecls((decl) => {
+			const declarationValue = getDeclarationValue(decl);
+			const isAlphaProp = ALPHA_PROPS_REGEXP.test(decl.prop);
+
+			if (
+				// If the property is not an alpha property
+				(!isAlphaProp &&
+					// And the value is not an alpha function
+					!ALPHA_FUNCTION_REGEXP.test(declarationValue)) ||
+				// Or the value does not contain digits
+				!DIGIT_REGEXP.test(declarationValue)
+			) {
+				// Abort early
+				return;
+			}
+
 			let needsFix = false;
-			const parsedValue = valueParser(getDeclarationValue(decl));
+			const parsedValue = valueParser(declarationValue);
 
 			parsedValue.walk((node) => {
 				/** @type {import('postcss-value-parser').Node | undefined} */
 				let alpha;
 
-				if (ALPHA_PROPS.has(decl.prop.toLowerCase())) {
+				if (isAlphaProp && DIGIT_REGEXP.test(node.value)) {
 					alpha = findAlphaInValue(node);
-				} else {
-					if (node.type !== 'function') return;
-
-					if (!ALPHA_FUNCS.has(node.value.toLowerCase())) return;
-
+				} else if (node.type === 'function' && ALPHA_FUNCTION_NAME_REGXP.test(node.value)) {
 					alpha = findAlphaInFunction(node);
 				}
 

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -86,7 +86,7 @@ const rule = (primary, secondaryOptions, context) => {
 
 				if (isAlphaProp && DIGIT_REGEXP.test(node.value)) {
 					alpha = findAlphaInValue(node);
-				} else if (node.type === 'function' && ALPHA_FUNCTION_NAME_REGXP.test(node.value)) {
+				} else if (node.type === 'function' && ALPHA_FUNCTION_NAME_REGEXP.test(node.value)) {
 					alpha = findAlphaInFunction(node);
 				}
 

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -30,6 +30,7 @@ let parsedOptions = ruleOptions;
 /* eslint-disable eqeqeq */
 if (
 	ruleOptions[0] === '[' ||
+	ruleOptions[0] === '{' ||
 	parsedOptions === 'true' ||
 	parsedOptions === 'false' ||
 	Number(parsedOptions) == parsedOptions

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -53,7 +53,7 @@ fetch(CSS_URL)
 	.then((response) => {
 		let css = '';
 
-		for (let i = 0; i < 10; i++) {
+		for (let i = 0; i < 20; i++) {
 			css += `${response}\n\n`;
 		}
 

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -25,6 +25,13 @@ if (!ruleOptions) {
 
 const CSS_URL = 'https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.css';
 
+// PostCSS and modern hardware is too fast to benchmark with a small source.
+// Duplicating the source CSS N times gives a larger mean while reducing the deviation.
+//
+// 20 was chosen because it gives a mean in the 50-200ms range
+// with a deviation that is ±10% of the mean.
+const DUPLICATE_SOURCE_N_TIMES = 20;
+
 let parsedOptions = ruleOptions;
 
 /* eslint-disable eqeqeq */
@@ -54,7 +61,7 @@ fetch(CSS_URL)
 	.then((response) => {
 		let css = '';
 
-		for (let i = 0; i < 20; i++) {
+		for (let i = 0; i < DUPLICATE_SOURCE_N_TIMES; i++) {
 			css += `${response}\n\n`;
 		}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6853

> Is there anything in the PR that needs further explanation?

I was curious about performance and if there were any benchmark tools in place.

I found that the current benchmark script is just checking PostCSS performance, not rule performance in specific. I've refactored this script to separate the initial parsing phase and the plugin processing.

This gives a more relevant result to Stylelint plugins.

I also found that processing Bootstrap only once doesn't give meaningful results.
PostCSS is just too fast, the deviation too high and the actual duration per cycle with or without a code change isn't clear.

I found that duplicating the Bootstrap source 20 times gives a more useful output.


```
> node scripts/benchmark-rule.mjs alpha-value-notation ["number"]

Warnings: 0
Mean: 94.41161338888888 ms
Deviation: 12.21578916466738 ms
```

```
> node scripts/benchmark-rule.mjs alpha-value-notation ["number"]

Warnings: 0
Mean: 72.47793288888887 ms
Deviation: 6.865530836418062 ms
```

I have a M2 macbook air, which is possibly the worst machine to run benchmarks on.
So someone with a decent machine (no power saving cores, cooled cpu) should verify this work.

-------

This change also adds some improvements to the first rule.
I just picked the first rule at random, not because I noticed anything wrong in terms of performance.

- add a fast abort before any parsing
- some minor code improvements

--------

Changes like these do not take away the underlying issue as described in https://github.com/stylelint/stylelint/issues/6853

But I do think it is worthwhile to look into and apply trivial improvements like these.
Even with a different style parser it will be a good practice to add fast aborts before doing a deeper AST walk.