### PR TITLE
Fix `length-zero-no-unit` false positives on new math functions

### DIFF
--- a/.changeset/calm-rivers-wink.md
+++ b/.changeset/calm-rivers-wink.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `length-zero-no-unit` false positive on new math functions
+Fixed: `length-zero-no-unit` false positives on new math functions

--- a/lib/reference/functions.js
+++ b/lib/reference/functions.js
@@ -32,6 +32,7 @@ const mathFunctions = new Set([
 	'pow',
 	'rem',
 	'round',
+	'sign',
 	'sin',
 	'sqrt',
 	'tan',

--- a/lib/reference/functions.js
+++ b/lib/reference/functions.js
@@ -14,7 +14,28 @@ const camelCaseFunctions = new Set([
 	'skewY',
 ]);
 
-const mathFunctions = new Set(['calc', 'clamp', 'max', 'min']);
+const mathFunctions = new Set([
+	'abs',
+	'acos',
+	'asin',
+	'atan',
+	'atan2',
+	'calc',
+	'clamp',
+	'cos',
+	'exp',
+	'hypot',
+	'log',
+	'max',
+	'min',
+	'mod',
+	'pow',
+	'rem',
+	'round',
+	'sin',
+	'sqrt',
+	'tan',
+]);
 
 module.exports = {
 	camelCaseFunctions,

--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -29,7 +29,7 @@ testRule({
 			description: 'ignore calc. several `calc`s',
 		},
 		{
-			code: 'a { padding: abs(0px) acos(0px) asin(0px) atan(0px) atan2(0px) calc(0px) clamp(0px) cos(0px) exp(0px) hypot(0px) log(0px) max(0px) min(0px) mod(0px) pow(0px) rem(0px) round(0px) sin(0px) sqrt(0px) tan(0px) }',
+			code: 'a { padding: abs(0px) acos(0px) asin(0px) atan(0px) atan2(0px) calc(0px) clamp(0px) cos(0px) exp(0px) hypot(0px) log(0px) max(0px) min(0px) mod(0px) pow(0px) rem(0px) round(0px) sign(0px) sin(0px) sqrt(0px) tan(0px) }',
 			description: 'ignore new math functions.',
 		},
 		{

--- a/lib/rules/length-zero-no-unit/__tests__/index.js
+++ b/lib/rules/length-zero-no-unit/__tests__/index.js
@@ -29,6 +29,10 @@ testRule({
 			description: 'ignore calc. several `calc`s',
 		},
 		{
+			code: 'a { padding: abs(0px) acos(0px) asin(0px) atan(0px) atan2(0px) calc(0px) clamp(0px) cos(0px) exp(0px) hypot(0px) log(0px) max(0px) min(0px) mod(0px) pow(0px) rem(0px) round(0px) sin(0px) sqrt(0px) tan(0px) }',
+			description: 'ignore new math functions.',
+		},
+		{
 			code: 'padding: calc(var(--foo, 0px) + 10px) 0',
 			description: 'ignore calc, and inner functions',
 		},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6870

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
