### PR TITLE
Fix `unit-no-unknown` false positives for the second and subsequent `image-set()` with `x` descriptor

### DIFF
--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -228,6 +228,18 @@ testRule({
 			description: 'ignore `x` unit in vendor-prefixed image-set',
 		},
 		{
+			code: "a { background-image: url('first.png'), image-set(url('second.png') 1x), image-set(url('third.png') 1x) }",
+			description: 'ignore `x` unit in the second and subsequent image-set',
+		},
+		{
+			code: "a { background-image: url('first.png'), -webkit-image-set(url('second.png') 1x), -webkit-image-set(url('third.png') 1x) }",
+			description: 'ignore `x` unit in the second and subsequent vendor-prefixed image-set',
+		},
+		{
+			code: "a { background-image: image-set(url('first.png') calc(1x * 1), url('second.png') calc(1x + 0.5x)); }",
+			description: 'ignore `x` unit in image-set with calc',
+		},
+		{
 			code: '@media (resolution: 2x) {}',
 			description: 'ignore `x` unit in @media with `resolution`',
 		},
@@ -443,9 +455,9 @@ testRule({
 			message: messages.rejected('x'),
 			description: '`x` rejected with inappropriate property',
 			line: 1,
-			column: 47,
+			column: 60,
 			endLine: 1,
-			endColumn: 48,
+			endColumn: 61,
 		},
 		{
 			code: "a { background: image-set('img1x.png' 1x, 'img2x.png' 2x) left 20x / 15% 60% repeat-x; }",

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -228,18 +228,6 @@ testRule({
 			description: 'ignore `x` unit in vendor-prefixed image-set',
 		},
 		{
-			code: "a { background-image: url('first.png'), image-set(url('second.png') 1x), image-set(url('third.png') 1x) }",
-			description: 'ignore `x` unit in the second and subsequent image-set',
-		},
-		{
-			code: "a { background-image: url('first.png'), -webkit-image-set(url('second.png') 1x), -webkit-image-set(url('third.png') 1x) }",
-			description: 'ignore `x` unit in the second and subsequent vendor-prefixed image-set',
-		},
-		{
-			code: "a { background-image: image-set(url('first.png') calc(1x * 1), url('second.png') calc(1x + 0.5x)); }",
-			description: 'ignore `x` unit in image-set with calc',
-		},
-		{
 			code: '@media (resolution: 2x) {}',
 			description: 'ignore `x` unit in @media with `resolution`',
 		},
@@ -455,9 +443,9 @@ testRule({
 			message: messages.rejected('x'),
 			description: '`x` rejected with inappropriate property',
 			line: 1,
-			column: 60,
+			column: 47,
 			endLine: 1,
-			endColumn: 61,
+			endColumn: 48,
 		},
 		{
 			code: "a { background: image-set('img1x.png' 1x, 'img2x.png' 2x) left 20x / 15% 60% repeat-x; }",

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -1,21 +1,28 @@
 'use strict';
 
+const { tokenize, TokenType } = require('@csstools/css-tokenizer');
+const {
+	parseCommaSeparatedListOfComponentValues,
+	isFunctionNode,
+	isSimpleBlockNode,
+	isTokenNode,
+} = require('@csstools/css-parser-algorithms');
+const { isMediaFeature, parseFromTokens } = require('@csstools/media-query-list-parser');
+
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const declarationValueIndex = require('../../utils/declarationValueIndex');
-const getDimension = require('../../utils/getDimension');
+const getAtRuleParams = require('../../utils/getAtRuleParams');
+const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
-const { units } = require('../../reference/units');
-const mediaParser = require('postcss-media-query-parser').default;
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const valueParser = require('postcss-value-parser');
 const vendor = require('../../utils/vendor');
-const { isRegExp, isString, assert } = require('../../utils/validateTypes');
-const { isAtRule } = require('../../utils/typeGuards');
-const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
+const { isRegExp, isString } = require('../../utils/validateTypes');
+const { units } = require('../../reference/units');
 
 const ruleName = 'unit-no-unknown';
 
@@ -26,6 +33,9 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/unit-no-unknown',
 };
+
+const HAS_DIMENSION_LIKE_VALUES = /\d[\w-]/;
+const RESOLUTION_MEDIA_FEATURE_NAME = /^(?:min-|max-)?resolution$/i;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
@@ -49,121 +59,142 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		/**
+		 * @param {string} value
+		 */
+		const tokenizeIfValueMightContainUnknownUnits = (value) => {
+			if (!HAS_DIMENSION_LIKE_VALUES.test(value)) return;
+
+			const tokens = tokenize({ css: value });
+			const hasUnknownUnits = tokens.some((token) => {
+				return token[0] === TokenType.Dimension && !units.has(token[4].unit.toLowerCase());
+			});
+
+			if (!hasUnknownUnits) return;
+
+			return tokens;
+		};
+
+		/**
 		 * @template {import('postcss').AtRule | import('postcss').Declaration} T
 		 * @param {T} node
-		 * @param {string} value
 		 * @param {(node: T) => number} getIndex
-		 * @returns {void}
+		 * @param {import('@csstools/css-parser-algorithms').ComponentValue} componentValue
+		 * @param {{ ignored: boolean, allowX: boolean }} state
 		 */
-		function check(node, value, getIndex) {
-			// make sure multiplication operations (*) are divided - not handled
-			// by postcss-value-parser
-			value = value.replace(/\*/g, ',');
-			const parsedValue = valueParser(value);
+		const walker = (node, getIndex, componentValue, state) => {
+			if (isFunctionNode(componentValue)) {
+				const name = componentValue.getName();
 
-			parsedValue.walk((valueNode) => {
-				// Ignore wrong units within `url` function
-				// and within functions listed in the `ignoreFunctions` option
 				if (
-					valueNode.type === 'function' &&
-					(valueNode.value.toLowerCase() === 'url' ||
-						optionsMatches(secondaryOptions, 'ignoreFunctions', valueNode.value))
+					name.toLowerCase() === 'url' ||
+					optionsMatches(secondaryOptions, 'ignoreFunctions', name)
 				) {
-					return false;
-				}
+					state.ignored = true;
 
-				const { number, unit } = getDimension(valueNode);
-
-				if (!number || !unit) {
 					return;
 				}
 
-				if (optionsMatches(secondaryOptions, 'ignoreUnits', unit)) {
+				if (
+					vendor.unprefixed(name.toLowerCase()) === 'image-set' ||
+					optionsMatches(secondaryOptions, 'ignoreFunctions', name)
+				) {
+					state.allowX = true;
+
 					return;
 				}
-
-				if (units.has(unit.toLowerCase()) && unit.toLowerCase() !== 'x') {
-					return;
-				}
-
-				if (unit.toLowerCase() === 'x') {
-					if (
-						isAtRule(node) &&
-						node.name === 'media' &&
-						node.params.toLowerCase().includes('resolution')
-					) {
-						let ignoreUnit = false;
-
-						mediaParser(node.params).walk((mediaNode, _i, mediaNodes) => {
-							const lastMediaNode = mediaNodes[mediaNodes.length - 1];
-
-							if (
-								mediaNode.value.toLowerCase().includes('resolution') &&
-								lastMediaNode &&
-								lastMediaNode.sourceIndex === valueNode.sourceIndex
-							) {
-								ignoreUnit = true;
-
-								return false;
-							}
-						});
-
-						if (ignoreUnit) {
-							return;
-						}
-					}
-
-					if (node.type === 'decl') {
-						if (node.prop.toLowerCase() === 'image-resolution') {
-							return;
-						}
-
-						if (/^(?:-webkit-)?image-set[\s(]/i.test(value)) {
-							const imageSet = parsedValue.nodes.find(
-								(n) => vendor.unprefixed(n.value) === 'image-set',
-							);
-
-							assert(imageSet);
-							assert('nodes' in imageSet);
-							const imageSetLastNode = imageSet.nodes[imageSet.nodes.length - 1];
-
-							assert(imageSetLastNode);
-							const imageSetValueLastIndex = imageSetLastNode.sourceIndex;
-
-							if (imageSetValueLastIndex >= valueNode.sourceIndex) {
-								return;
-							}
-						}
-					}
-				}
-
-				const index = getIndex(node);
-
-				report({
-					index: index + valueNode.sourceIndex + number.length,
-					endIndex: index + valueNode.sourceEndIndex,
-					message: messages.rejected,
-					messageArgs: [unit],
-					node,
-					result,
-					ruleName,
-				});
-			});
-		}
-
-		root.walkAtRules(/^media$/i, (atRule) => {
-			if (!isStandardSyntaxAtRule(atRule)) {
-				return;
 			}
 
-			check(atRule, atRule.params, atRuleParamIndex);
+			if (!isTokenNode(componentValue)) return;
+
+			const [tokenType, , , endIndex, tokenValue] = componentValue.value;
+
+			if (tokenType !== TokenType.Dimension) return;
+
+			if (optionsMatches(secondaryOptions, 'ignoreUnits', tokenValue.unit)) return;
+
+			const unit = tokenValue.unit.toLowerCase();
+
+			if (unit === 'x' && state.allowX) return;
+
+			if (units.has(unit) && unit !== 'x') return;
+
+			const startIndex = getIndex(node) + (endIndex + 1) - unit.length;
+
+			report({
+				message: messages.rejected,
+				messageArgs: [tokenValue.unit],
+				node,
+				index: startIndex,
+				endIndex: startIndex + unit.length,
+				result,
+				ruleName,
+			});
+		};
+
+		root.walkAtRules(/^media$/i, (atRule) => {
+			if (!isStandardSyntaxAtRule(atRule)) return;
+
+			const params = getAtRuleParams(atRule);
+
+			const tokens = tokenizeIfValueMightContainUnknownUnits(params);
+
+			if (!tokens) return;
+
+			parseFromTokens(tokens).forEach((mediaQuery) => {
+				const state = {
+					ignored: false,
+					allowX: false,
+				};
+
+				mediaQuery.walk((entry) => {
+					if (entry.state?.ignored) return;
+
+					if (isMediaFeature(entry.node)) {
+						const name = entry.node.getName();
+
+						if (RESOLUTION_MEDIA_FEATURE_NAME.test(name)) {
+							entry.state.allowX = true;
+						}
+					}
+
+					walker(atRule, atRuleParamIndex, entry.node, entry.state ?? state);
+				}, state);
+			});
 		});
+
 		root.walkDecls((decl) => {
 			if (!isStandardSyntaxDeclaration(decl)) return;
 
-			if (!isStandardSyntaxValue(decl.value)) return;
+			const value = getDeclarationValue(decl);
 
-			check(decl, decl.value, declarationValueIndex);
+			if (!isStandardSyntaxValue(value)) return;
+
+			const tokens = tokenizeIfValueMightContainUnknownUnits(value);
+
+			if (!tokens) return;
+
+			const isImageResolutionProp = decl.prop.toLowerCase() === 'image-resolution';
+
+			parseCommaSeparatedListOfComponentValues(tokens)
+				.flatMap((x) => x)
+				.forEach((componentValue) => {
+					const state = {
+						ignored: false,
+						allowX: isImageResolutionProp,
+					};
+
+					walker(decl, declarationValueIndex, componentValue, state);
+
+					if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) {
+						return;
+					}
+
+					componentValue.walk((entry) => {
+						if (entry.state?.ignored) return;
+
+						walker(decl, declarationValueIndex, entry.node, entry.state ?? state);
+					}, state);
+				});
 		});
 	};
 };

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -78,7 +78,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @template {import('postcss').AtRule | import('postcss').Declaration} T
 		 * @param {T} node
 		 * @param {(node: T) => number} getIndex
-		 * @param {import('@csstools/css-parser-algorithms').ComponentValue} componentValue
+		 * @param {import('@csstools/css-parser-algorithms').FunctionNode | import('@csstools/css-parser-algorithms').TokenNode} componentValue
 		 * @param {{ ignored: boolean, allowX: boolean }} state
 		 */
 		const check = (node, getIndex, componentValue, state) => {
@@ -102,9 +102,9 @@ const rule = (primary, secondaryOptions) => {
 
 					return;
 				}
-			}
 
-			if (!isTokenNode(componentValue)) return;
+				return;
+			}
 
 			const [tokenType, , , endIndex, tokenValue] = componentValue.value;
 
@@ -149,6 +149,13 @@ const rule = (primary, secondaryOptions) => {
 				mediaQuery.walk((entry) => {
 					if (entry.state?.ignored) return;
 
+					if (!entry.state) {
+						entry.state = {
+							ignored: false,
+							allowX: false,
+						};
+					}
+
 					if (isMediaFeature(entry.node)) {
 						const name = entry.node.getName();
 
@@ -157,7 +164,9 @@ const rule = (primary, secondaryOptions) => {
 						}
 					}
 
-					check(atRule, atRuleParamIndex, entry.node, entry.state ?? state);
+					if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
+						check(atRule, atRuleParamIndex, entry.node, entry.state ?? state);
+					}
 				}, state);
 			});
 		});
@@ -183,7 +192,9 @@ const rule = (primary, secondaryOptions) => {
 						allowX: isImageResolutionProp,
 					};
 
-					check(decl, declarationValueIndex, componentValue, state);
+					if (isFunctionNode(componentValue) || isTokenNode(componentValue)) {
+						check(decl, declarationValueIndex, componentValue, state);
+					}
 
 					if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) {
 						return;
@@ -192,7 +203,9 @@ const rule = (primary, secondaryOptions) => {
 					componentValue.walk((entry) => {
 						if (entry.state?.ignored) return;
 
-						check(decl, declarationValueIndex, entry.node, entry.state ?? state);
+						if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
+							check(decl, declarationValueIndex, entry.node, entry.state ?? state);
+						}
 					}, state);
 				});
 		});

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -147,6 +147,7 @@ const rule = (primary, secondaryOptions) => {
 				};
 
 				mediaQuery.walk((entry) => {
+					if (!entry.state) return;
 					if (entry.state?.ignored) return;
 
 					if (isMediaFeature(entry.node)) {

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -148,18 +148,19 @@ const rule = (primary, secondaryOptions) => {
 
 				mediaQuery.walk((entry) => {
 					if (!entry.state) return;
-					if (entry.state?.ignored) return;
+
+					if (entry.state.ignored) return;
 
 					if (isMediaFeature(entry.node)) {
 						const name = entry.node.getName();
 
-						if (entry.state && RESOLUTION_MEDIA_FEATURE_NAME.test(name)) {
+						if (RESOLUTION_MEDIA_FEATURE_NAME.test(name)) {
 							entry.state.allowX = true;
 						}
 					}
 
 					if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
-						check(atRule, atRuleParamIndex, entry.node, entry.state ?? state);
+						check(atRule, atRuleParamIndex, entry.node, entry.state);
 					}
 				}, state);
 			});
@@ -195,10 +196,12 @@ const rule = (primary, secondaryOptions) => {
 					}
 
 					componentValue.walk((entry) => {
-						if (entry.state?.ignored) return;
+						if (!entry.state) return;
+
+						if (entry.state.ignored) return;
 
 						if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
-							check(decl, declarationValueIndex, entry.node, entry.state ?? state);
+							check(decl, declarationValueIndex, entry.node, entry.state);
 						}
 					}, state);
 				});

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -81,7 +81,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {import('@csstools/css-parser-algorithms').ComponentValue} componentValue
 		 * @param {{ ignored: boolean, allowX: boolean }} state
 		 */
-		const walker = (node, getIndex, componentValue, state) => {
+		const check = (node, getIndex, componentValue, state) => {
 			if (isFunctionNode(componentValue)) {
 				const name = componentValue.getName();
 
@@ -157,7 +157,7 @@ const rule = (primary, secondaryOptions) => {
 						}
 					}
 
-					walker(atRule, atRuleParamIndex, entry.node, entry.state ?? state);
+					check(atRule, atRuleParamIndex, entry.node, entry.state ?? state);
 				}, state);
 			});
 		});
@@ -183,7 +183,7 @@ const rule = (primary, secondaryOptions) => {
 						allowX: isImageResolutionProp,
 					};
 
-					walker(decl, declarationValueIndex, componentValue, state);
+					check(decl, declarationValueIndex, componentValue, state);
 
 					if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) {
 						return;
@@ -192,7 +192,7 @@ const rule = (primary, secondaryOptions) => {
 					componentValue.walk((entry) => {
 						if (entry.state?.ignored) return;
 
-						walker(decl, declarationValueIndex, entry.node, entry.state ?? state);
+						check(decl, declarationValueIndex, entry.node, entry.state ?? state);
 					}, state);
 				});
 		});

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -149,17 +149,10 @@ const rule = (primary, secondaryOptions) => {
 				mediaQuery.walk((entry) => {
 					if (entry.state?.ignored) return;
 
-					if (!entry.state) {
-						entry.state = {
-							ignored: false,
-							allowX: false,
-						};
-					}
-
 					if (isMediaFeature(entry.node)) {
 						const name = entry.node.getName();
 
-						if (RESOLUTION_MEDIA_FEATURE_NAME.test(name)) {
+						if (entry.state && RESOLUTION_MEDIA_FEATURE_NAME.test(name)) {
 							entry.state.allowX = true;
 						}
 					}

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -157,9 +157,7 @@ const rule = (primary, secondaryOptions) => {
 						if (RESOLUTION_MEDIA_FEATURE_NAME.test(name)) {
 							entry.state.allowX = true;
 						}
-					}
-
-					if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
+					} else if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
 						check(atRule, atRuleParamIndex, entry.node, entry.state);
 					}
 				}, state);

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@stylelint/remark-preset": "^4.0.0",
         "@types/balanced-match": "^1.0.2",
         "@types/css-tree": "^2.3.1",
-        "@types/debug": "^4.1.7",
+        "@types/debug": "^4.1.8",
         "@types/file-entry-cache": "^5.0.2",
         "@types/global-modules": "^2.0.0",
         "@types/globjoin": "^0.1.0",
@@ -2325,9 +2325,9 @@
       "dev": true
     },
     "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
@@ -16056,9 +16056,9 @@
       "dev": true
     },
     "@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
       "dev": true,
       "requires": {
         "@types/ms": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "15.6.2",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^2.1.1",
+        "@csstools/css-parser-algorithms": "^2.2.0",
         "@csstools/css-tokenizer": "^2.1.1",
-        "@csstools/media-query-list-parser": "^2.0.4",
+        "@csstools/media-query-list-parser": "^2.1.0",
         "@csstools/selector-specificity": "^2.2.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
@@ -1419,15 +1419,21 @@
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.1.1.tgz",
-      "integrity": "sha512-viRnRh02AgO4mwIQb2xQNJju0i+Fh9roNgmbR5xEuG7J3TGgxjnE95HnBLgsFJOJOksvcfxOUCgODcft6Y07cA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
+      "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": "^14 || ^16 || >=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "@csstools/css-tokenizer": "^2.1.1"
@@ -1446,15 +1452,21 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.0.4.tgz",
-      "integrity": "sha512-GyYot6jHgcSDZZ+tLSnrzkR7aJhF2ZW6d+CXH66mjy5WpAQhZD4HDke2OQ36SivGRWlZJpAz7TzbW6OKlEpxAA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.0.tgz",
+      "integrity": "sha512-MXkR+TeaS2q9IkpyO6jVCdtA/bfpABJxIrfkLswThFN8EZZgI2RfAHhm6sDNDuYV25d5+b8Lj1fpTccIcSLPsQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": "^14 || ^16 || >=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "@csstools/css-parser-algorithms": "^2.1.1",
@@ -15337,9 +15349,9 @@
       }
     },
     "@csstools/css-parser-algorithms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.1.1.tgz",
-      "integrity": "sha512-viRnRh02AgO4mwIQb2xQNJju0i+Fh9roNgmbR5xEuG7J3TGgxjnE95HnBLgsFJOJOksvcfxOUCgODcft6Y07cA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
+      "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
       "requires": {}
     },
     "@csstools/css-tokenizer": {
@@ -15348,9 +15360,9 @@
       "integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA=="
     },
     "@csstools/media-query-list-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.0.4.tgz",
-      "integrity": "sha512-GyYot6jHgcSDZZ+tLSnrzkR7aJhF2ZW6d+CXH66mjy5WpAQhZD4HDke2OQ36SivGRWlZJpAz7TzbW6OKlEpxAA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.0.tgz",
+      "integrity": "sha512-MXkR+TeaS2q9IkpyO6jVCdtA/bfpABJxIrfkLswThFN8EZZgI2RfAHhm6sDNDuYV25d5+b8Lj1fpTccIcSLPsQ==",
       "requires": {}
     },
     "@csstools/selector-specificity": {

--- a/package.json
+++ b/package.json
@@ -112,9 +112,9 @@
     ]
   },
   "dependencies": {
-    "@csstools/css-parser-algorithms": "^2.1.1",
+    "@csstools/css-parser-algorithms": "^2.2.0",
     "@csstools/css-tokenizer": "^2.1.1",
-    "@csstools/media-query-list-parser": "^2.0.4",
+    "@csstools/media-query-list-parser": "^2.1.0",
     "@csstools/selector-specificity": "^2.2.0",
     "balanced-match": "^2.0.0",
     "colord": "^2.9.3",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "@stylelint/remark-preset": "^4.0.0",
     "@types/balanced-match": "^1.0.2",
     "@types/css-tree": "^2.3.1",
-    "@types/debug": "^4.1.7",
+    "@types/debug": "^4.1.8",
     "@types/file-entry-cache": "^5.0.2",
     "@types/global-modules": "^2.0.0",
     "@types/globjoin": "^0.1.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6848
Supersedes : https://github.com/stylelint/stylelint/pull/6726

> Is there anything in the PR that needs further explanation?

- ~~this will fail because it uses unreleased features of the media query parser~~
- also happens to resolve #6726


before :

```
npm run benchmark-rule unit-no-unknown true
Warnings: 0
Mean: 143.3089323125 ms
Deviation: 10.593647978441565 ms
```

after : 

```
npm run benchmark-rule unit-no-unknown true
Warnings: 0
Mean: 109.86287500000002 ms
Deviation: 9.320724134887374 ms
```