### PR TITLE
Fix: add timeouts for GitHub Workflows

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -20,6 +20,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/preparing-github-release.yml
+++ b/.github/workflows/preparing-github-release.yml
@@ -12,6 +12,7 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -17,6 +17,7 @@ jobs:
     if: github.repository == 'stylelint/stylelint' # Workaround. See https://github.com/changesets/action/issues/4
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,6 +24,7 @@ jobs:
   test-coverage:
     name: Test on Node.js 18 and ubuntu-latest with coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6880

> Is there anything in the PR that needs further explanation?

CI for Stylelint seems to take ±6 minutes on most runs, sometimes a little bit over 10 minutes.

30 minutes seems like a safe multiple of the current duration.
Sufficient headroom so that no one will ever encounter this timeout during normal operations.

I've lowered this to 20 minutes for jobs that don't do any heavy lifting.
