### PR TITLE
Fix `alpha-value-notation` false positives for `color()`

### DIFF
--- a/.changeset/neat-owls-knock.md
+++ b/.changeset/neat-owls-knock.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `alpha-value-notation` false positives for `color()`

--- a/lib/rules/alpha-value-notation/__tests__/index.js
+++ b/lib/rules/alpha-value-notation/__tests__/index.js
@@ -64,6 +64,9 @@ testRule({
 		{
 			code: 'a { color: color(display-p3 0 0 0 / 0.5) }',
 		},
+		{
+			code: 'a { color: color(display-p3 0 0 0) }',
+		},
 
 		// Relative color syntax
 		{
@@ -285,6 +288,12 @@ testRule({
 		},
 		{
 			code: 'a { color: lch(56.29% 19.86 10 / var(--alpha)) }',
+		},
+		{
+			code: 'a { color: color(display-p3 0 0 0) }',
+		},
+		{
+			code: 'a { color: color(display-p3 0 0 0 / 50%) }',
 		},
 	],
 

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -181,7 +181,6 @@ function findAlphaInValue(node) {
  */
 function findAlphaInFunction(node) {
 	const legacySyntax = node.nodes.some(({ type, value }) => type === 'div' && value === ',');
-	const slashNodeIndex = node.nodes.findIndex(({ type, value }) => type === 'div' && value === '/');
 
 	if (legacySyntax) {
 		const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
@@ -190,6 +189,8 @@ function findAlphaInFunction(node) {
 
 		return undefined;
 	}
+
+	const slashNodeIndex = node.nodes.findIndex(({ type, value }) => type === 'div' && value === '/');
 
 	if (slashNodeIndex !== -1) {
 		const nodesAfterSlash = node.nodes.slice(slashNodeIndex + 1, node.nodes.length);

--- a/lib/rules/alpha-value-notation/index.js
+++ b/lib/rules/alpha-value-notation/index.js
@@ -180,11 +180,16 @@ function findAlphaInValue(node) {
  * @returns {import('postcss-value-parser').Node | undefined}
  */
 function findAlphaInFunction(node) {
-	const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
-
-	if (args.length === 4) return args[3];
-
+	const legacySyntax = node.nodes.some(({ type, value }) => type === 'div' && value === ',');
 	const slashNodeIndex = node.nodes.findIndex(({ type, value }) => type === 'div' && value === '/');
+
+	if (legacySyntax) {
+		const args = node.nodes.filter(({ type }) => type === 'word' || type === 'function');
+
+		if (args.length === 4) return args[3];
+
+		return undefined;
+	}
 
 	if (slashNodeIndex !== -1) {
 		const nodesAfterSlash = node.nodes.slice(slashNodeIndex + 1, node.nodes.length);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6884

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
