### PR TITLE
Fix `unit-no-unknown` false positives for `unicode-range` descriptors

### DIFF
--- a/.changeset/shiny-toys-chew.md
+++ b/.changeset/shiny-toys-chew.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `unit-no-unknown` false positives for `unicode-range` descriptors

--- a/lib/rules/unit-no-unknown/__tests__/index.js
+++ b/lib/rules/unit-no-unknown/__tests__/index.js
@@ -254,6 +254,9 @@ testRule({
 		{
 			code: 'a { width: 8ic; }',
 		},
+		{
+			code: '@font-face { unicode-range: U+0100-024F; }',
+		},
 	],
 
 	reject: [
@@ -483,6 +486,24 @@ testRule({
 			description: '`pix` rejected with inappropriate property',
 			line: 1,
 			column: 46,
+		},
+		{
+			code: '@font-face { color: U+0100-024F; }',
+			message: messages.rejected('F'),
+			description: 'Unicode range value in something other than `unicode-range`',
+			line: 1,
+			column: 31,
+			endLine: 1,
+			endColumn: 32,
+		},
+		{
+			code: 'a { unicode-range: U+0100-024F; }',
+			message: messages.rejected('F'),
+			description: 'Unicode range value in something other than `@font-face`',
+			line: 1,
+			column: 30,
+			endLine: 1,
+			endColumn: 31,
 		},
 	],
 });

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -16,6 +16,7 @@ const getDeclarationValue = require('../../utils/getDeclarationValue');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue');
+const isUnicodeRangeDescriptor = require('../../utils/isUnicodeRangeDescriptor');
 const optionsMatches = require('../../utils/optionsMatches');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
@@ -166,6 +167,8 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkDecls((decl) => {
 			if (!isStandardSyntaxDeclaration(decl)) return;
+
+			if (isUnicodeRangeDescriptor(decl)) return;
 
 			const value = getDeclarationValue(decl);
 

--- a/lib/utils/isUnicodeRangeDescriptor.js
+++ b/lib/utils/isUnicodeRangeDescriptor.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { isAtRule } = require('./typeGuards');
+
+const IS_UNICODE_RANGE = /^unicode-range$/i;
+const IS_AT_FONT_FACE = /^font-face$/i;
+
+/**
+ * Check whether a declaration is the `unicode-range` descriptor of an `@font-face` rule.
+ *
+ * @param {import('postcss').Declaration} decl
+ * @returns {boolean}
+ */
+module.exports = function isUnicodeRangeDescriptor(decl) {
+	if (!IS_UNICODE_RANGE.test(decl.prop)) {
+		return false;
+	}
+
+	const parent = decl.parent;
+
+	if (!parent || !isAtRule(parent)) {
+		return false;
+	}
+
+	return IS_AT_FONT_FACE.test(parent.name);
+};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6891

> Is there anything in the PR that needs further explanation?

I forgot about [`<urange>` productions](https://www.w3.org/TR/css-syntax-3/#urange) when migrating rules to `@csstools/css-tokenizer`.

Parsing `<urange>` requires special handling and should only be done when inside a context that expects such values.

I've added a helper (`isUnicodeRangeDescriptor`) to make it easier for rules to skip `@font-face { unicode-range: U+0100-024F; }`

