### PR TITLE
Add `splitList: boolean` to `selector-nested-pattern`

### DIFF
--- a/.changeset/chilled-lizards-film.md
+++ b/.changeset/chilled-lizards-film.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `splitList: boolean` to `selector-nested-pattern`

--- a/lib/rules/selector-nested-pattern/README.md
+++ b/lib/rules/selector-nested-pattern/README.md
@@ -77,3 +77,37 @@ a {
   &:focus {}
 }
 ```
+
+## Optional secondary options
+
+### `splitList: true | false` (default: `false`)
+
+Split selector lists into individual selectors.
+
+For example, with `true`.
+
+Given the string:
+
+```json
+"^&:(?:hover|focus)$"
+```
+
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
+```css
+a {
+  .bar:hover,
+  &:focus {}
+}
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a {
+  &:hover,
+  &:focus {}
+}
+```

--- a/lib/rules/selector-nested-pattern/__tests__/index.js
+++ b/lib/rules/selector-nested-pattern/__tests__/index.js
@@ -152,12 +152,45 @@ testRule({
 			endColumn: 18,
 		},
 		{
-			code: '.foo { &:hover, &focus {} }',
-			message: messages.expected('&:hover, &focus', '^&:(?:hover|focus)$'),
+			code: '.foo { &:hover, &:focus {} }',
+			message: messages.expected('&:hover, &:focus', '^&:(?:hover|focus)$'),
 			line: 1,
 			column: 8,
 			endLine: 1,
-			endColumn: 23,
+			endColumn: 24,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['^&:(?:hover|focus)$', { splitList: true }],
+
+	accept: [
+		{
+			code: '.foo { &:hover {} }',
+		},
+		{
+			code: '.foo { &:hover, &:focus {} }',
+		},
+	],
+
+	reject: [
+		{
+			code: '.foo { .bar:hover {} }',
+			message: messages.expected('.bar:hover', '^&:(?:hover|focus)$'),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 18,
+		},
+		{
+			code: '.foo { .bar:hover, &:focus {} }',
+			message: messages.expected('.bar:hover', '^&:(?:hover|focus)$'),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 18,
 		},
 	],
 });

--- a/lib/rules/selector-nested-pattern/index.js
+++ b/lib/rules/selector-nested-pattern/index.js
@@ -4,7 +4,7 @@ const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const { isRegExp, isString } = require('../../utils/validateTypes');
+const { isBoolean, isRegExp, isString } = require('../../utils/validateTypes');
 
 const ruleName = 'selector-nested-pattern';
 
@@ -17,18 +17,30 @@ const meta = {
 };
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary) => {
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [isRegExp, isString],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: [isRegExp, isString],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					splitList: [isBoolean],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) {
 			return;
 		}
 
 		const normalizedPattern = isString(primary) ? new RegExp(primary) : primary;
+		const splitList = secondaryOptions && secondaryOptions.splitList;
 
 		root.walkRules((ruleNode) => {
 			if (ruleNode.parent && ruleNode.parent.type !== 'rule') {
@@ -39,20 +51,35 @@ const rule = (primary) => {
 				return;
 			}
 
-			const selector = ruleNode.selector;
+			if (splitList) {
+				ruleNode.selectors.forEach((selector) => {
+					if (!normalizedPattern.test(selector)) {
+						report({
+							result,
+							ruleName,
+							message: messages.expected,
+							messageArgs: [selector, primary],
+							node: ruleNode,
+							word: selector,
+						});
+					}
+				});
+			} else {
+				const selector = ruleNode.selector;
 
-			if (normalizedPattern.test(selector)) {
-				return;
+				if (normalizedPattern.test(selector)) {
+					return;
+				}
+
+				report({
+					result,
+					ruleName,
+					message: messages.expected,
+					messageArgs: [selector, primary],
+					node: ruleNode,
+					word: selector,
+				});
 			}
-
-			report({
-				result,
-				ruleName,
-				message: messages.expected,
-				messageArgs: [selector, primary],
-				node: ruleNode,
-				word: selector,
-			});
 		});
 	};
 };

--- a/lib/rules/selector-nested-pattern/index.js
+++ b/lib/rules/selector-nested-pattern/index.js
@@ -51,24 +51,11 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			if (splitList) {
-				ruleNode.selectors.forEach((selector) => {
-					if (!normalizedPattern.test(selector)) {
-						report({
-							result,
-							ruleName,
-							message: messages.expected,
-							messageArgs: [selector, primary],
-							node: ruleNode,
-							word: selector,
-						});
-					}
-				});
-			} else {
-				const selector = ruleNode.selector;
+			const selectors = splitList ? ruleNode.selectors : [ruleNode.selector];
 
+			for (const selector of selectors) {
 				if (normalizedPattern.test(selector)) {
-					return;
+					continue;
 				}
 
 				report({


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #2430 

> Is there anything in the PR that needs further explanation?

As @jeddy3 said, we could consider a better name for the option.

https://github.com/stylelint/stylelint/issues/2430#issuecomment-1160156212
> (Prehaps there's a better name?. Prior art is [the disallowInList option](https://stylelint.io/user-guide/rules/list/no-duplicate-selectors/#disallowinlist-true--false-default-false). [Spec ref for "list"](https://www.w3.org/TR/selectors-4/#grouping).)

I guess `splitList` is not bad because `selector-disallowed-list` rule has [similar option](https://stylelint.io/user-guide/rules/selector-disallowed-list/#splitlist-true--false-default-false).
