### PR TITLE
Remove v8-compile-cache

### DIFF
--- a/bin/stylelint.js
+++ b/bin/stylelint.js
@@ -3,6 +3,7 @@
 'use strict';
 
 // to use V8's code cache to speed up instantiation time
-require('v8-compile-cache');
+// (in its current state, this breaks any dynamic imports)
+// require('v8-compile-cache');
 
 require('../lib/cli')(process.argv.slice(2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@csstools/selector-specificity": "^2.2.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^8.1.3",
+        "cosmiconfig": "^8.2.0",
         "css-functions-list": "^3.1.0",
         "css-tree": "^2.3.1",
         "debug": "^4.3.4",
@@ -3768,9 +3768,9 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -17089,9 +17089,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "requires": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@csstools/selector-specificity": "^2.2.0",
     "balanced-match": "^2.0.0",
     "colord": "^2.9.3",
-    "cosmiconfig": "^8.1.3",
+    "cosmiconfig": "^8.2.0",
     "css-functions-list": "^3.1.0",
     "css-tree": "^2.3.1",
     "debug": "^4.3.4",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes #6898 

> Is there anything in the PR that needs further explanation?

This makes dynamic imports work, which cosmiconfig 8.2.0 makes use of.