### PR TITLE
Fix Segmentation fault errors for Cosmiconfig 8.2

### DIFF
--- a/.changeset/blue-lions-guess.md
+++ b/.changeset/blue-lions-guess.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `Segmentation fault` errors
+Fixed: Segmentation fault errors for Cosmiconfig 8.2

--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { cosmiconfig } = require('cosmiconfig');
+const { cosmiconfig, defaultLoadersSync } = require('cosmiconfig');
 
 const augmentConfig = require('./augmentConfig');
 const FileCache = require('./utils/FileCache');
@@ -19,6 +19,10 @@ module.exports = function createStylelint(options = {}) {
 
 		_extendExplorer: cosmiconfig('', {
 			transform: augmentConfig.augmentConfigExtended(cwd),
+			loaders: {
+				'.cjs': defaultLoadersSync['.cjs'],
+				'.js': defaultLoadersSync['.js'],
+			},
 			stopDir: STOP_DIR,
 		}),
 

--- a/lib/createStylelint.js
+++ b/lib/createStylelint.js
@@ -20,8 +20,10 @@ module.exports = function createStylelint(options = {}) {
 		_extendExplorer: cosmiconfig('', {
 			transform: augmentConfig.augmentConfigExtended(cwd),
 			loaders: {
-				'.cjs': defaultLoadersSync['.cjs'],
-				'.js': defaultLoadersSync['.js'],
+				'.cjs': (cjsPath, cjsContent) =>
+					Promise.resolve(defaultLoadersSync['.cjs'](cjsPath, cjsContent)),
+				'.js': (jsPath, cjsContent) =>
+					Promise.resolve(defaultLoadersSync['.js'](jsPath, cjsContent)),
 			},
 			stopDir: STOP_DIR,
 		}),

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -3,7 +3,7 @@
 const configurationError = require('./utils/configurationError');
 const path = require('path');
 const { augmentConfigFull } = require('./augmentConfig');
-const { cosmiconfig } = require('cosmiconfig');
+const { cosmiconfig, defaultLoadersSync } = require('cosmiconfig');
 
 const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
@@ -49,6 +49,10 @@ module.exports = async function getConfigForFile(
 
 	const configExplorer = cosmiconfig('stylelint', {
 		transform: (cosmiconfigResult) => augmentConfigFull(stylelint, filePath, cosmiconfigResult),
+		loaders: {
+			'.cjs': defaultLoadersSync['.cjs'],
+			'.js': defaultLoadersSync['.js'],
+		},
 		stopDir: STOP_DIR,
 	});
 

--- a/lib/getConfigForFile.js
+++ b/lib/getConfigForFile.js
@@ -50,8 +50,9 @@ module.exports = async function getConfigForFile(
 	const configExplorer = cosmiconfig('stylelint', {
 		transform: (cosmiconfigResult) => augmentConfigFull(stylelint, filePath, cosmiconfigResult),
 		loaders: {
-			'.cjs': defaultLoadersSync['.cjs'],
-			'.js': defaultLoadersSync['.js'],
+			'.cjs': (cjsPath, cjsContent) =>
+				Promise.resolve(defaultLoadersSync['.cjs'](cjsPath, cjsContent)),
+			'.js': (jsPath, cjsContent) => Promise.resolve(defaultLoadersSync['.js'](jsPath, cjsContent)),
 		},
 		stopDir: STOP_DIR,
 	});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6898

> Is there anything in the PR that needs further explanation?

The `sync` loaders from `cosmiconfig` for `.js` and `.cjs` still use the old logic/code.
Only the `async` loaders were changed.

Switching back to the `sync` loaders makes the errors go away.
