### PR TITLE
Remove `v8-compile-cache`

### DIFF
--- a/.changeset/early-dodos-invent.md
+++ b/.changeset/early-dodos-invent.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: remove `v8-compile-cache`

--- a/bin/stylelint.js
+++ b/bin/stylelint.js
@@ -2,7 +2,4 @@
 
 'use strict';
 
-// to use V8's code cache to speed up instantiation time
-require('v8-compile-cache');
-
 require('../lib/cli')(process.argv.slice(2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "supports-hyperlinks": "^3.0.0",
         "svg-tags": "^1.0.0",
         "table": "^6.8.1",
-        "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^5.0.1"
       },
       "bin": {
@@ -13733,11 +13732,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -24320,11 +24314,6 @@
           "dev": true
         }
       }
-    },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "supports-hyperlinks": "^3.0.0",
     "svg-tags": "^1.0.0",
     "table": "^6.8.1",
-    "v8-compile-cache": "^2.3.0",
     "write-file-atomic": "^5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6904
Closes #6901

> Is there anything in the PR that needs further explanation?

`v8-compile-cache` no longer has performance benefits on Node.js 20.
Please see the benchmark on <https://github.com/stylelint/stylelint/issues/6904#issuecomment-1579131889>.
