### PR TITLE
Fix `max-nesting-depth` error for at-rules in Sass syntax

### DIFF
--- a/.changeset/cyan-dingos-own.md
+++ b/.changeset/cyan-dingos-own.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `max-nesting-depth` error for at-rules in Sass syntax

--- a/lib/rules/max-nesting-depth/__tests__/index.js
+++ b/lib/rules/max-nesting-depth/__tests__/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { stripIndent } = require('common-tags');
+
 const { messages, ruleName } = require('..');
 
 testRule({
@@ -278,6 +280,21 @@ testRule({
 		{
 			code: '.foo { .bar { margin: { bottom: 0; } } }',
 			description: 'SCSS nested properties',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [1],
+	customSyntax: 'postcss-sass',
+
+	accept: [
+		{
+			code: stripIndent`
+				@media print
+					color: white
+			`,
 		},
 	],
 });

--- a/lib/rules/max-nesting-depth/index.js
+++ b/lib/rules/max-nesting-depth/index.js
@@ -90,8 +90,8 @@ const rule = (primary, secondaryOptions) => {
 	function nestingDepth(node, level) {
 		const parent = node.parent;
 
-		if (parent == null) {
-			throw new Error('The parent node must exist');
+		if (!parent) {
+			return 0;
 		}
 
 		if (isIgnoreAtRule(parent)) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6160

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
