### PR TITLE
Support `.mjs` configuration files

### DIFF
--- a/.changeset/swift-pugs-matter.md
+++ b/.changeset/swift-pugs-matter.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: support for `.mjs` configuration files

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -5,7 +5,7 @@ Stylelint expects a configuration object, and looks for one in a:
 - `stylelint` property in `package.json`
 - `.stylelintrc` file
 - `.stylelintrc.{cjs,js,json,yaml,yml}` file
-- `stylelint.config.{cjs,js}` file exporting a JS object
+- `stylelint.config.{cjs,mjs,js}` file
 
 Starting from the current working directory, Stylelint stops searching when one of these is found. Alternatively, you can use the [`--config` or `configFile` option](options.md#configfile) to short-circuit the search.
 

--- a/lib/__tests__/__snapshots__/cli.test.js.snap
+++ b/lib/__tests__/__snapshots__/cli.test.js.snap
@@ -16,15 +16,15 @@ exports[`CLI --help 1`] = `
 
     --config, -c <path_or_module>
 
-      A path to a specific configuration file (JSON, YAML, or CommonJS), or a
-      module name in "node_modules" that points to one. If no argument is
+      A path to a specific configuration file (JSON, YAML, CommonJS, or ES module),
+      or a module name in "node_modules" that points to one. If no argument is
       provided, Stylelint will search for configuration files in the following
       places, in this order:
 
         - a "stylelint" property in "package.json"
-        - a ".stylelintrc" file (with or without filename extension:
-          ".json", ".yaml", ".yml", ".js", and ".cjs" are available)
-        - a "stylelint.config.js" file exporting a JS object
+        - a ".stylelintrc" file
+        - a ".stylelintrc.{cjs,mjs,js,json,yaml,yml}" file
+        - a "stylelint.config.{cjs,mjs,js}" file
 
       The search will begin in the working directory and move up the directory
       tree until a configuration file is found.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -107,15 +107,15 @@ const meowOptions = {
 
       --config, -c <path_or_module>
 
-        A path to a specific configuration file (JSON, YAML, or CommonJS), or a
-        module name in "node_modules" that points to one. If no argument is
+        A path to a specific configuration file (JSON, YAML, CommonJS, or ES module),
+        or a module name in "node_modules" that points to one. If no argument is
         provided, Stylelint will search for configuration files in the following
         places, in this order:
 
           - a "stylelint" property in "package.json"
-          - a ".stylelintrc" file (with or without filename extension:
-            ".json", ".yaml", ".yml", ".js", and ".cjs" are available)
-          - a "stylelint.config.js" file exporting a JS object
+          - a ".stylelintrc" file
+          - a ".stylelintrc.{cjs,mjs,js,json,yaml,yml}" file
+          - a "stylelint.config.{cjs,mjs,js}" file
 
         The search will begin in the working directory and move up the directory
         tree until a configuration file is found.

--- a/scripts/visual-config.cjs
+++ b/scripts/visual-config.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const config = require('./visual-config.json');
+
+module.exports = config;

--- a/scripts/visual-config.mjs
+++ b/scripts/visual-config.mjs
@@ -1,0 +1,3 @@
+import config from './visual-config.cjs';
+
+export default config;

--- a/scripts/visual.sh
+++ b/scripts/visual.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
+set -u
 
-echo "Normal:"
-node ../bin/stylelint.js visual.css --config=visual-config.json
+echo "########## Compact formatter ##########"
+echo ""
+node ../bin/stylelint.js visual.css --config visual-config.mjs --formatter compact
+echo ""
 
-echo -e "\n\nVerbose:"
-node ../bin/stylelint.js visual.css --config=visual-config.json --formatter verbose
+echo ""
+echo "########## Default formatter ##########"
+node ../bin/stylelint.js visual.css --config visual-config.json
+
+echo "########## Verbose formatter ##########"
+node ../bin/stylelint.js visual.css --config visual-config.cjs --formatter verbose


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6905

> Is there anything in the PR that needs further explanation?

This PR mainly does the following:

- Update the CLI help.
- Update the user guide.

In addition, this PR improves files in the `scripts` folder so that we can easily try the `.mjs` support. Try running the following at the project root.

```console
$ (cd scripts ; ./visual.sh)
```
