### PR TITLE
Fix `--print-config` description in CLI help

### DIFF
--- a/.changeset/sixty-masks-sip.md
+++ b/.changeset/sixty-masks-sip.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `--print-config` description in CLI help

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -94,7 +94,7 @@ Path of file to write a report. Stylelint outputs the report to the specified `f
 
 ### `--print-config`
 
-Print the configuration for the given input path.
+Print the configuration for the given input path. Globs are unsupported.
 
 ### `--quiet, -q`
 
@@ -204,6 +204,14 @@ Ensure output on successful runs:
 
 ```shell
 stylelint -f verbose "foo/**/*.css"
+```
+
+### Example J - print a config
+
+Print a configuration used for the given input file:
+
+```shell
+stylelint test.css --print-config
 ```
 
 ## Exit codes

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -94,7 +94,7 @@ Path of file to write a report. Stylelint outputs the report to the specified `f
 
 ### `--print-config`
 
-Print the configuration for the given path. Stylelint outputs the configuration used for the file passed.
+Print the configuration for the given input path.
 
 ### `--quiet, -q`
 

--- a/lib/__tests__/__snapshots__/cli.test.js.snap
+++ b/lib/__tests__/__snapshots__/cli.test.js.snap
@@ -35,9 +35,9 @@ exports[`CLI --help 1`] = `
       "plugins", and "customSyntax" are *relative to*. Only necessary if these
       values are relative paths.
 
-    --print-config <path>
+    --print-config
 
-      Print the configuration for the given path.
+      Print the configuration for the given input file path. Globs are unsupported.
 
     --ignore-path, -i <path>
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -126,9 +126,9 @@ const meowOptions = {
         "plugins", and "customSyntax" are *relative to*. Only necessary if these
         values are relative paths.
 
-      --print-config <path>
+      --print-config
 
-        Print the configuration for the given path.
+        Print the configuration for the given input file path. Globs are unsupported.
 
       --ignore-path, -i <path>
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The `--print-config` option never requires an argument. For example:

```console
$ bin/stylelint.js --print-config -c scripts/visual-config.json scripts/visual.css
{
  "rules": {
...
```

On the other hand, the following example is mistaken:

```console
$ bin/stylelint.js --print-config scripts/visual-config.json
Error: No configuration provided for /Users/masafumi.koba/git/stylelint/stylelint/scripts/visual-config.json
...
```
