### PR TITLE
 Fix `function-no-unknown` false positives for SCSS functions with namespace

### DIFF
--- a/.changeset/brave-balloons-rescue.md
+++ b/.changeset/brave-balloons-rescue.md
@@ -2,5 +2,4 @@
 "stylelint": patch
 ---
 
- Fixed: `function-no-unknown` false positives for SCSS functions with namespace
- 
+Fixed: `function-no-unknown` false positives for SCSS functions with namespace

--- a/.changeset/brave-balloons-rescue.md
+++ b/.changeset/brave-balloons-rescue.md
@@ -1,0 +1,6 @@
+---
+"stylelint": patch
+---
+
+ Fixed: `function-no-unknown` false positives for SCSS functions with namespace
+ 

--- a/lib/rules/function-no-unknown/__tests__/index.js
+++ b/lib/rules/function-no-unknown/__tests__/index.js
@@ -28,6 +28,10 @@ testRule({
 		{
 			code: 'a { height: calc(10px*(5*(10 - 5))); }',
 		},
+		{
+			code: 'a { transform: color.adjust(1px); transform: rgb(color.adjust(1px)); }',
+			description: 'ignore scss namespaced functions',
+		},
 	],
 
 	reject: [

--- a/lib/utils/isStandardSyntaxValue.js
+++ b/lib/utils/isStandardSyntaxValue.js
@@ -26,6 +26,11 @@ module.exports = function isStandardSyntaxValue(value) {
 		return false;
 	}
 
+	// SCSS namespace (example namespace.function-name())
+	if (/^.+\.[-\w]+\(/.test(value)) {
+		return false;
+	}
+
 	// Less variable
 	if (normalizedValue.startsWith('@')) {
 		return false;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6920

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
