### PR TITLE
Fix `custom-property-no-missing-var-function` performance

### DIFF
--- a/.changeset/heavy-pandas-cheer.md
+++ b/.changeset/heavy-pandas-cheer.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `custom-property-no-missing-var-function` performance

--- a/lib/rules/custom-property-no-missing-var-function/index.js
+++ b/lib/rules/custom-property-no-missing-var-function/index.js
@@ -17,9 +17,6 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
 
-const DASHED_IDENT_START = /^--/;
-const DOUBLE_DASH = /--/;
-
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -34,14 +31,14 @@ const rule = (primary) => {
 			knownCustomProperties.add(atRule.params);
 		});
 
-		root.walkDecls(DASHED_IDENT_START, ({ prop }) => {
+		root.walkDecls(/^--/, ({ prop }) => {
 			knownCustomProperties.add(prop);
 		});
 
 		root.walkDecls((decl) => {
 			const { value } = decl;
 
-			if (!DOUBLE_DASH.test(value)) return;
+			if (!value.includes('--')) return;
 
 			const parsedValue = valueParser(value);
 

--- a/lib/rules/custom-property-no-missing-var-function/index.js
+++ b/lib/rules/custom-property-no-missing-var-function/index.js
@@ -3,7 +3,6 @@
 const valueParser = require('postcss-value-parser');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
-const isCustomProperty = require('../../utils/isCustomProperty');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -17,6 +16,9 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
+
+const DOUBLE_DASH = /--/;
+const DASHED_IDENT_START = /^--/;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
@@ -32,12 +34,15 @@ const rule = (primary) => {
 			knownCustomProperties.add(atRule.params);
 		});
 
-		root.walkDecls(({ prop }) => {
-			if (isCustomProperty(prop)) knownCustomProperties.add(prop);
+		root.walkDecls(DASHED_IDENT_START, ({ prop }) => {
+			knownCustomProperties.add(prop);
 		});
 
 		root.walkDecls((decl) => {
 			const { value } = decl;
+
+			if (!DOUBLE_DASH.test(value)) return;
+
 			const parsedValue = valueParser(value);
 
 			parsedValue.walk((node) => {

--- a/lib/rules/custom-property-no-missing-var-function/index.js
+++ b/lib/rules/custom-property-no-missing-var-function/index.js
@@ -17,8 +17,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
 
-const DOUBLE_DASH = /--/;
 const DASHED_IDENT_START = /^--/;
+const DOUBLE_DASH = /--/;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

----

before :

```
Warnings: 0
Mean: 106.64779905882351 ms
Deviation: 14.50380702371365 ms
```

after :

```
Warnings: 0
Mean: 98.50316917647058 ms
Deviation: 11.405372458359288 ms
```
