### PR TITLE
Fix `function-calc-no-unspaced-operator` performance

### DIFF
--- a/.changeset/wet-countries-think.md
+++ b/.changeset/wet-countries-think.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-calc-no-unspaced-operator` performance

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -48,6 +48,8 @@ const rule = (primary, _secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
+			if (!OPERATOR_REGEX.test(getDeclarationValue(decl))) return;
+
 			let needsFix = false;
 			const valueIndex = declarationValueIndex(decl);
 			const parsedValue = valueParser(getDeclarationValue(decl));

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -48,11 +48,13 @@ const rule = (primary, _secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
-			if (!OPERATOR_REGEX.test(getDeclarationValue(decl))) return;
+			const value = getDeclarationValue(decl);
+
+			if (!OPERATOR_REGEX.test(value)) return;
 
 			let needsFix = false;
 			const valueIndex = declarationValueIndex(decl);
-			const parsedValue = valueParser(getDeclarationValue(decl));
+			const parsedValue = valueParser(value);
 
 			/**
 			 * @param {import('postcss-value-parser').Node} operatorNode


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

----

before :

```
Warnings: 0
Mean: 90.56110877777778 ms
Deviation: 11.54085198893875 ms
```

after : 

```
Warnings: 0
Mean: 83.60294444444445 ms
Deviation: 10.305877029720664 ms
```