### PR TITLE
Fix `selector-anb-no-unmatchable` performance

### DIFF
--- a/.changeset/modern-numbers-impress.md
+++ b/.changeset/modern-numbers-impress.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-anb-no-unmatchable` performance

--- a/lib/rules/selector-anb-no-unmatchable/index.js
+++ b/lib/rules/selector-anb-no-unmatchable/index.js
@@ -10,6 +10,7 @@ const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const hasANPlusBNotationPseudoClasses = require('../../utils/hasANPlusBNotationPseudoClasses');
 
 const ruleName = 'selector-anb-no-unmatchable';
 
@@ -50,6 +51,8 @@ const rule = (primary) => {
 			}
 
 			ruleNode.selectors.forEach((selector) => {
+				if (!hasANPlusBNotationPseudoClasses(selector)) return;
+
 				let cssTreeSelector;
 
 				try {

--- a/lib/utils/hasANPlusBNotationPseudoClasses.js
+++ b/lib/utils/hasANPlusBNotationPseudoClasses.js
@@ -5,13 +5,11 @@ const {
 	aNPlusBOfSNotationPseudoClasses,
 } = require('../reference/selectors');
 
-const HAS_A_N_PLUS_B_NOTATION_PSEUDO_CLASSES = new RegExp(
-	`\\b:(?:${[
-		...aNPlusBNotationPseudoClasses.values(),
-		...aNPlusBOfSNotationPseudoClasses.values(),
-	].join('|')})\\(`,
-	'i',
-);
+const classes = [
+	...aNPlusBNotationPseudoClasses.values(),
+	...aNPlusBOfSNotationPseudoClasses.values(),
+].join('|');
+const HAS_A_N_PLUS_B_NOTATION_PSEUDO_CLASSES = new RegExp(`\\b:(?:${classes})\\(`, 'i');
 
 /**
  * Check if a selector contains any pseudo class function that might contain an An+B notation

--- a/lib/utils/hasANPlusBNotationPseudoClasses.js
+++ b/lib/utils/hasANPlusBNotationPseudoClasses.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const {
+	aNPlusBNotationPseudoClasses,
+	aNPlusBOfSNotationPseudoClasses,
+} = require('../reference/selectors');
+
+const HAS_A_N_PLUS_B_NOTATION_PSEUDO_CLASSES = new RegExp(
+	`\\b:(?:${[
+		...aNPlusBNotationPseudoClasses.values(),
+		...aNPlusBOfSNotationPseudoClasses.values(),
+	].join('|')})\\(`,
+	'i',
+);
+
+/**
+ * Check if a selector contains any pseudo class function that might contain an An+B notation
+ *
+ * @param {string} selector
+ * @returns {boolean}
+ */
+module.exports = function hasANPlusBNotationPseudoClasses(selector) {
+	return HAS_A_N_PLUS_B_NOTATION_PSEUDO_CLASSES.test(selector);
+};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

-----

before : 

```
Warnings: 0
Mean: 171.01108333333332 ms
Deviation: 11.09835497913841 ms
```

after :

```
Warnings: 0
Mean: 115.6843908125 ms
Deviation: 7.734276833118593 ms
```