### PR TITLE
Refactor value parsing to use a simpler algorithm

### DIFF
--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 const functionsListPath = require('css-functions-list');
 const { tokenize } = require('@csstools/css-tokenizer');
 const {
-	parseCommaSeparatedListOfComponentValues,
 	isFunctionNode,
 	isSimpleBlockNode,
+	parseListOfComponentValues,
 } = require('@csstools/css-parser-algorithms');
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
@@ -89,17 +89,15 @@ const rule = (primary, secondaryOptions) => {
 				});
 			};
 
-			parseCommaSeparatedListOfComponentValues(tokenize({ css: value }))
-				.flatMap((x) => x)
-				.forEach((componentValue) => {
-					if (isFunctionNode(componentValue) || isSimpleBlockNode(componentValue)) {
-						walker(componentValue);
+			parseListOfComponentValues(tokenize({ css: value })).forEach((componentValue) => {
+				if (isFunctionNode(componentValue) || isSimpleBlockNode(componentValue)) {
+					walker(componentValue);
 
-						componentValue.walk((entry) => {
-							walker(entry.node);
-						});
-					}
-				});
+					componentValue.walk((entry) => {
+						walker(entry.node);
+					});
+				}
+			});
 		});
 	};
 };

--- a/lib/rules/unit-disallowed-list/index.js
+++ b/lib/rules/unit-disallowed-list/index.js
@@ -2,10 +2,10 @@
 
 const { TokenType, tokenize, NumberType } = require('@csstools/css-tokenizer');
 const {
-	isTokenNode,
 	isFunctionNode,
-	parseCommaSeparatedListOfComponentValues,
 	isSimpleBlockNode,
+	isTokenNode,
+	parseListOfComponentValues,
 } = require('@csstools/css-parser-algorithms');
 const { parseFromTokens, isMediaFeature } = require('@csstools/media-query-list-parser');
 
@@ -153,14 +153,35 @@ const rule = (primary, secondaryOptions) => {
 
 			if (!hasDimension(value)) return;
 
-			parseCommaSeparatedListOfComponentValues(tokenize({ css: value }))
-				.flatMap((x) => x)
-				.forEach((componentValue) => {
-					if (isTokenNode(componentValue)) {
+			parseListOfComponentValues(tokenize({ css: value })).forEach((componentValue) => {
+				if (isTokenNode(componentValue)) {
+					check(
+						decl,
+						declarationValueIndex,
+						componentValue,
+						decl.prop,
+						secondaryOptions?.ignoreProperties,
+					);
+
+					return;
+				}
+
+				if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) return;
+
+				const state = {
+					ignored: componentValueIsIgnored(componentValue),
+				};
+
+				componentValue.walk((entry) => {
+					if (!entry.state) return;
+
+					if (entry.state.ignored) return;
+
+					if (isTokenNode(entry.node)) {
 						check(
 							decl,
 							declarationValueIndex,
-							componentValue,
+							entry.node,
 							decl.prop,
 							secondaryOptions?.ignoreProperties,
 						);
@@ -168,34 +189,11 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
-					if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) return;
-
-					const state = {
-						ignored: componentValueIsIgnored(componentValue),
-					};
-
-					componentValue.walk((entry) => {
-						if (!entry.state) return;
-
-						if (entry.state.ignored) return;
-
-						if (isTokenNode(entry.node)) {
-							check(
-								decl,
-								declarationValueIndex,
-								entry.node,
-								decl.prop,
-								secondaryOptions?.ignoreProperties,
-							);
-
-							return;
-						}
-
-						if (componentValueIsIgnored(entry.node)) {
-							entry.state.ignored = true;
-						}
-					}, state);
-				});
+					if (componentValueIsIgnored(entry.node)) {
+						entry.state.ignored = true;
+					}
+				}, state);
+			});
 		});
 	};
 };

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -2,10 +2,10 @@
 
 const { tokenize, TokenType } = require('@csstools/css-tokenizer');
 const {
-	parseCommaSeparatedListOfComponentValues,
 	isFunctionNode,
 	isSimpleBlockNode,
 	isTokenNode,
+	parseListOfComponentValues,
 } = require('@csstools/css-parser-algorithms');
 const { isMediaFeature, parseFromTokens } = require('@csstools/media-query-list-parser');
 
@@ -185,32 +185,30 @@ const rule = (primary, secondaryOptions) => {
 
 			const isImageResolutionProp = decl.prop.toLowerCase() === 'image-resolution';
 
-			parseCommaSeparatedListOfComponentValues(tokens)
-				.flatMap((x) => x)
-				.forEach((componentValue) => {
-					const state = {
-						ignored: false,
-						allowX: isImageResolutionProp,
-					};
+			parseListOfComponentValues(tokens).forEach((componentValue) => {
+				const state = {
+					ignored: false,
+					allowX: isImageResolutionProp,
+				};
 
-					if (isFunctionNode(componentValue) || isTokenNode(componentValue)) {
-						check(decl, declarationValueIndex, componentValue, state);
+				if (isFunctionNode(componentValue) || isTokenNode(componentValue)) {
+					check(decl, declarationValueIndex, componentValue, state);
+				}
+
+				if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) {
+					return;
+				}
+
+				componentValue.walk((entry) => {
+					if (!entry.state) return;
+
+					if (entry.state.ignored) return;
+
+					if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
+						check(decl, declarationValueIndex, entry.node, entry.state);
 					}
-
-					if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) {
-						return;
-					}
-
-					componentValue.walk((entry) => {
-						if (!entry.state) return;
-
-						if (entry.state.ignored) return;
-
-						if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
-							check(decl, declarationValueIndex, entry.node, entry.state);
-						}
-					}, state);
-				});
+				}, state);
+			});
 		});
 	};
 };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, it's a minor code quality fix that I noticed while working on a different issue.

> Is there anything in the PR that needs further explanation?

This isn't a user facing change, so I am omitting a changelog entry.

----

`parseCommaSeparatedListOfComponentValues` :
- list of lists of component values
- split by comma
- doesn't include the comma as a component value
- useful for : 
   - media query lists
   - selectors
   - function params (`rgb(0, 0, 0)`)


`parseListOfComponentValues` :
- list of component values
- no splits
- does include the comma as a `TokenNode`
- useful for anything

This distinction is important when writing specialized parsers (like the media query parser) but it isn't relevant when validating component values.

Using `parseListOfComponentValues` results in simpler, cleaner code.

--------

The diffs appear large because the indent changed.

Actual diff :

```diff
- parseCommaSeparatedListOfComponentValues(tokenize({ css: value }))
- 	.flatMap((x) => x)
+ parseListOfComponentValues(tokenize({ css: value }))
	.forEach((componentValue) => {
``` 

