### PR TITLE
Avoid at-mark use in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1090,7 +1090,7 @@ Changes:
   - `rule-empty-line-before`
 - Added: `selector-max-class` rule.
 - Added: `ignore: ["custom-elements"]` option to `selector-type-no-unknown` ([#2366](https://github.com/stylelint/stylelint/pull/2366)).
-- Fixed: "Cannot find module 'pify'" regression in node@4 with npm@2 ([#2614](https://github.com/stylelint/stylelint/pull/2614)).
+- Fixed: "Cannot find module 'pify'" regression in `node@4` with `npm@2` ([#2614](https://github.com/stylelint/stylelint/pull/2614)).
 - Fixed: no error is thrown when linting a string with `cache` enabled ([#2494](https://github.com/stylelint/stylelint/pull/2494)).
 - Fixed: Less `:extend` is now ignored ([#2571](https://github.com/stylelint/stylelint/pull/2571)).
 - Fixed: `function-parentheses-space-inside` now ignores functions without parameters ([#2587](https://github.com/stylelint/stylelint/pull/2587)).

--- a/docs/developer-guide/syntaxes.md
+++ b/docs/developer-guide/syntaxes.md
@@ -30,4 +30,4 @@ module.exports = {
 };
 ```
 
-We recommended requiring the custom syntax until PostCSS@7 is no longer in circulation.
+We recommended requiring the custom syntax until PostCSS v7 is no longer in circulation.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

This change ensures that an at-mark unexpectedly is not handled as a user mention, especially generating the website pages (stylelint.io).
