### PR TITLE
Install `@jest/globals` explicitly

### DIFF
--- a/lib/testUtils/safeChdir.js
+++ b/lib/testUtils/safeChdir.js
@@ -1,6 +1,6 @@
 const { mkdir } = require('node:fs/promises');
 const { fileURLToPath } = require('node:url');
-const { beforeEach, afterEach } = require('@jest/globals'); // eslint-disable-line node/no-extraneous-require
+const { beforeEach, afterEach } = require('@jest/globals');
 
 /**
  * A safe `process.chdir()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.26.1",
         "@changesets/get-github-info": "^0.5.2",
+        "@jest/globals": "^29.5.0",
         "@stylelint/prettier-config": "^2.0.0",
         "@stylelint/remark-preset": "^4.0.0",
         "@types/balanced-match": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.1",
     "@changesets/get-github-info": "^0.5.2",
+    "@jest/globals": "^29.5.0",
     "@stylelint/prettier-config": "^2.0.0",
     "@stylelint/remark-preset": "^4.0.0",
     "@types/balanced-match": "^1.0.2",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #5291

> Is there anything in the PR that needs further explanation?

`@jest/globals` is already installed by `jest`, but we need to import `@jest/globals` in ESM.
In this case, a comment like `// eslint-disable-line node/no-extraneous-require` is noisy.

```console
$ npm ls '@jest/globals'
stylelint@15.8.0 /Users/masafumi.koba/git/stylelint/stylelint
├── @jest/globals@29.5.0
└─┬ jest@29.5.0
  └─┬ @jest/core@29.5.0
    └─┬ jest-runtime@29.5.0
      └── @jest/globals@29.5.0 deduped
```
