### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` autofix for `border-width` shorthand

### DIFF
--- a/.changeset/sixty-lies-repair.md
+++ b/.changeset/sixty-lies-repair.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `border-width` shorthand

--- a/lib/reference/properties.js
+++ b/lib/reference/properties.js
@@ -180,9 +180,9 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 		new Set([
 			// prettier-ignore
 			'border-top-width',
+			'border-right-width',
 			'border-bottom-width',
 			'border-left-width',
-			'border-right-width',
 		]),
 	],
 	[

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -206,6 +206,12 @@ testRule({
 			description: 'autofixer should not mangle css functions with comma separated values',
 			message: messages.expected('transition'),
 		},
+		{
+			code: 'a { border-top-width: 0px; border-right-width: 1px; border-bottom-width: 2px; border-left-width: 3px; }',
+			fixed: 'a { border-width: 0px 1px 2px 3px; }',
+			description: 'explicit border-width test',
+			message: messages.expected('border-width'),
+		},
 	],
 });
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6947.

> Is there anything in the PR that needs further explanation?

Sorry that I missed this! Happy to quickly cut a new release if we'd like.
