### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` autofix for `grid-column` and `grid-row`

### DIFF
--- a/.changeset/wet-houses-warn.md
+++ b/.changeset/wet-houses-warn.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `grid-column` and `grid-row`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -206,6 +206,18 @@ testRule({
 			description: 'autofixer should not mangle css functions with comma separated values',
 			message: messages.expected('transition'),
 		},
+		{
+			code: 'a { grid-column-start: 1; grid-column-end: 2; }',
+			fixed: 'a { grid-column: 1 / 2; }',
+			description: 'explicit grid-column test',
+			message: messages.expected('grid-column'),
+		},
+		{
+			code: 'a { grid-row-start: 1; grid-row-end: 2; }',
+			fixed: 'a { grid-row: 1 / 2; }',
+			description: 'explicit grid-row test',
+			message: messages.expected('grid-row'),
+		},
 	],
 });
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -29,6 +29,28 @@ const meta = {
 /** @type {Map<string, (decls: Map<string, Declaration>) => (string | undefined)>} */
 const customResolvers = new Map([
 	[
+		'grid-column',
+		(decls) => {
+			const start = decls.get('grid-column-start')?.value.trim();
+			const end = decls.get('grid-column-end')?.value.trim();
+
+			if (!start || !end) return;
+
+			return `${start} / ${end}`;
+		},
+	],
+	[
+		'grid-row',
+		(decls) => {
+			const start = decls.get('grid-row-start')?.value.trim();
+			const end = decls.get('grid-row-end')?.value.trim();
+
+			if (!start || !end) return;
+
+			return `${start} / ${end}`;
+		},
+	],
+	[
 		'grid-template',
 		(decls) => {
 			const areas = decls.get('grid-template-areas')?.value.trim();


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6918.

> Is there anything in the PR that needs further explanation?

Also fixed the one for `grid-row`, since it's the same syntax.
