### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` autofix for `border-radius` shorthand

### DIFF
--- a/.changeset/violet-otters-rule.md
+++ b/.changeset/violet-otters-rule.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `border-radius` shorthand

--- a/lib/reference/properties.js
+++ b/lib/reference/properties.js
@@ -141,8 +141,8 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 		'border-radius',
 		new Set([
 			// prettier-ignore
-			'border-top-right-radius',
 			'border-top-left-radius',
+			'border-top-right-radius',
 			'border-bottom-right-radius',
 			'border-bottom-left-radius',
 		]),

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.js
@@ -206,6 +206,12 @@ testRule({
 			description: 'autofixer should not mangle css functions with comma separated values',
 			message: messages.expected('transition'),
 		},
+		{
+			code: 'a { border-top-left-radius: 1em; border-top-right-radius: 2em; border-bottom-right-radius: 3em; border-bottom-left-radius: 4em; }',
+			fixed: 'a { border-radius: 1em 2em 3em 4em; }',
+			description: 'explicit border-radius test',
+			message: messages.expected('border-radius'),
+		},
 	],
 });
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/pull/6956#issuecomment-1603347258

> Is there anything in the PR that needs further explanation?

e.g. "No, it's self-explanatory."
