### PR TITLE
Refactor to rewrite `lib/formatters/__tests__/*` to ESM

### DIFF
--- a/lib/formatters/__tests__/compactFormatter.test.mjs
+++ b/lib/formatters/__tests__/compactFormatter.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const compactFormatter = require('../compactFormatter');
-const prepareFormatterOutput = require('./prepareFormatterOutput');
+import compactFormatter from '../compactFormatter.js';
+import prepareFormatterOutput from './prepareFormatterOutput.mjs';
 
 describe('compactFormatter', () => {
 	let actualTTY;

--- a/lib/formatters/__tests__/githubFormatter.test.mjs
+++ b/lib/formatters/__tests__/githubFormatter.test.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const githubFormatter = require('../githubFormatter');
+import githubFormatter from '../githubFormatter.js';
 
 describe('githubFormatter', () => {
 	test('outputs no warnings', () => {

--- a/lib/formatters/__tests__/jsonFormatter.test.mjs
+++ b/lib/formatters/__tests__/jsonFormatter.test.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const jsonFormatter = require('../jsonFormatter');
+import jsonFormatter from '../jsonFormatter.js';
 
 describe('jsonFormatter', () => {
 	it('outputs corresponding json', () => {

--- a/lib/formatters/__tests__/prepareFormatterOutput.mjs
+++ b/lib/formatters/__tests__/prepareFormatterOutput.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const stripAnsi = require('strip-ansi');
+import stripAnsi from 'strip-ansi';
 
 const symbolConversions = new Map();
 
@@ -9,7 +7,7 @@ symbolConversions.set('✔', '√');
 symbolConversions.set('⚠', '‼');
 symbolConversions.set('✖', '×');
 
-module.exports = function prepareFormatterOutput(results, formatter, returnValue) {
+export default function prepareFormatterOutput(results, formatter, returnValue) {
 	returnValue = returnValue || {
 		ruleMetadata: {},
 	};
@@ -20,4 +18,4 @@ module.exports = function prepareFormatterOutput(results, formatter, returnValue
 	}
 
 	return output;
-};
+}

--- a/lib/formatters/__tests__/stringFormatter.test.mjs
+++ b/lib/formatters/__tests__/stringFormatter.test.mjs
@@ -1,9 +1,7 @@
-'use strict';
+import { stripIndent } from 'common-tags';
 
-const { stripIndent } = require('common-tags');
-
-const prepareFormatterOutput = require('./prepareFormatterOutput');
-const stringFormatter = require('../stringFormatter');
+import prepareFormatterOutput from './prepareFormatterOutput.mjs';
+import stringFormatter from '../stringFormatter.js';
 
 describe('stringFormatter', () => {
 	let actualTTY;

--- a/lib/formatters/__tests__/tapFormatter.test.mjs
+++ b/lib/formatters/__tests__/tapFormatter.test.mjs
@@ -1,9 +1,7 @@
-'use strict';
+import { stripIndent } from 'common-tags';
 
-const { stripIndent } = require('common-tags');
-
-const prepareFormatterOutput = require('./prepareFormatterOutput');
-const tapFormatter = require('../tapFormatter');
+import prepareFormatterOutput from './prepareFormatterOutput.mjs';
+import tapFormatter from '../tapFormatter.js';
 
 describe('tapFormatter', () => {
 	let actualTTY;

--- a/lib/formatters/__tests__/terminalLink.test.mjs
+++ b/lib/formatters/__tests__/terminalLink.test.mjs
@@ -1,4 +1,8 @@
-'use strict';
+import { jest } from '@jest/globals';
+
+// TODO: Remove `require` when migrating to ESM.
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
 
 describe('terminallink', () => {
 	const originalEnv = process.env;
@@ -13,7 +17,7 @@ describe('terminallink', () => {
 
 	it('returns an ANSI escaped link', () => {
 		process.env = { ...originalEnv, FORCE_HYPERLINK: '1' };
-		const terminalLink = require('../terminalLink');
+		const terminalLink = require('../terminalLink.js');
 
 		expect(terminalLink('stylelint', 'https://stylelint.io/')).toBe(
 			'\u001B]8;;https://stylelint.io/\u0007stylelint\u001B]8;;\u0007',
@@ -22,7 +26,7 @@ describe('terminallink', () => {
 
 	it('returns a passed text with an unsupported environment', () => {
 		process.env = { ...originalEnv, FORCE_HYPERLINK: '0' };
-		const terminalLink = require('../terminalLink');
+		const terminalLink = require('../terminalLink.js');
 
 		expect(terminalLink('stylelint', 'https://stylelint.io/')).toBe('stylelint');
 	});

--- a/lib/formatters/__tests__/unixFormatter.test.mjs
+++ b/lib/formatters/__tests__/unixFormatter.test.mjs
@@ -1,9 +1,7 @@
-'use strict';
+import { stripIndent } from 'common-tags';
 
-const { stripIndent } = require('common-tags');
-
-const prepareFormatterOutput = require('./prepareFormatterOutput');
-const unixFormatter = require('../unixFormatter');
+import prepareFormatterOutput from './prepareFormatterOutput.mjs';
+import unixFormatter from '../unixFormatter.js';
 
 describe('unixFormatter', () => {
 	let actualTTY;

--- a/lib/formatters/__tests__/verboseFormatter.test.mjs
+++ b/lib/formatters/__tests__/verboseFormatter.test.mjs
@@ -1,9 +1,7 @@
-'use strict';
+import { stripIndent } from 'common-tags';
 
-const { stripIndent } = require('common-tags');
-
-const prepareFormatterOutput = require('./prepareFormatterOutput');
-const verboseFormatter = require('../verboseFormatter');
+import prepareFormatterOutput from './prepareFormatterOutput.mjs';
+import verboseFormatter from '../verboseFormatter.js';
 
 describe('verboseFormatter', () => {
 	it('outputs no warnings', () => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #5291

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
