### PR TITLE
Fix `selector-pseudo-class-no-unknown` false negatives for pseudo-elements with matching names

### DIFF
--- a/.changeset/great-feet-brake.md
+++ b/.changeset/great-feet-brake.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false negatives for pseudo-elements with matching names

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.js
@@ -203,6 +203,22 @@ testRule({
 			endColumn: 7,
 		},
 		{
+			code: ':slotted {}',
+			message: messages.rejected(':slotted'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 9,
+		},
+		{
+			code: ':placeholder {}',
+			message: messages.rejected(':placeholder'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 13,
+		},
+		{
 			code: '@page :blank:unknown { }',
 			message: messages.rejected(':unknown'),
 			line: 1,

--- a/lib/rules/selector-pseudo-class-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.js
@@ -7,6 +7,7 @@ const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule');
 const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector');
 const {
 	atRulePagePseudoClasses,
+	levelOneAndTwoPseudoElements,
 	pseudoClasses,
 	pseudoElements,
 	webkitScrollbarPseudoClasses,
@@ -68,8 +69,13 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
-					// Ignore pseudo-elements
-					if (value.slice(0, 2) === '::') {
+					if (value.startsWith('::')) {
+						return;
+					}
+
+					const name = value.replace(/^:*/, '').toLowerCase();
+
+					if (levelOneAndTwoPseudoElements.has(name)) {
 						return;
 					}
 
@@ -77,8 +83,8 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
+					const hasVendorPrefix = vendor.prefix(name);
 					let index = null;
-					const name = value.slice(1).toLowerCase();
 
 					if (isAtRule(node) && node.name === 'page') {
 						if (atRulePagePseudoClasses.has(name)) {
@@ -86,8 +92,10 @@ const rule = (primary, secondaryOptions) => {
 						}
 
 						index = atRuleParamIndex(node) + pseudoNode.sourceIndex;
+					} else if (pseudoElements.has(name) && !hasVendorPrefix) {
+						index = pseudoNode.sourceIndex;
 					} else {
-						if (vendor.prefix(name) || pseudoClasses.has(name) || pseudoElements.has(name)) {
+						if (hasVendorPrefix || pseudoClasses.has(name)) {
 							return;
 						}
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #6878

> Is there anything in the PR that needs further explanation?

I have added a test for `:placeholder` because `:-moz-placeholder` and `:-ms-input-placeholder` exist.
i.e. it's a good example of something that the rule will pick up from now on