### PR TITLE
Add test case to check `rule.meta.url` more precisely

### DIFF
--- a/lib/rules/__tests__/index.test.js
+++ b/lib/rules/__tests__/index.test.js
@@ -17,9 +17,9 @@ beforeAll(async () => {
 });
 
 describe('all rules', () => {
-	test.each(ruleEntries)('"%s" should have metadata', (_name, rule) => {
+	test.each(ruleEntries)('"%s" should have metadata', (name, rule) => {
 		expect(rule.meta).toBeTruthy();
-		expect(rule.meta.url).toMatch(/^https:\/\/stylelint\.io\/.+/);
+		expect(rule.meta.url).toBe(`https://stylelint.io/user-guide/rules/${name}`);
 		expect([true, undefined]).toContain(rule.meta.fixable);
 	});
 
@@ -69,7 +69,7 @@ describe('custom message option', () => {
 	);
 });
 
-describe('recommended and standard configs', () => {
+describe('standard config', () => {
 	const cwd = path.join(__dirname, 'tmp');
 
 	fs.rmSync(cwd, { recursive: true, force: true });


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

For example, if a URL were incorrect, the test case would fail:

```
  ● all rules › "alpha-value-notation" should have metadata

    expect(received).toBe(expected) // Object.is equality

    Expected: "https://stylelint.io/user-guide/rules/alpha-value-notation"
    Received: "https://stylelint.io/user-guide/rules/alpha-value-notation_"
```
