### PR TITLE
Fix typo for `--ignore-scripts` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "release": "np --no-release-draft",
     "pretest": "npm run lint",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "test-coverage": "npm run test --ignore-script -- --coverage",
+    "test-coverage": "npm test --ignore-scripts -- --coverage",
     "version": "changeset version",
     "postversion": "git restore package.json",
-    "watch": "npm run test --ignore-script -- --watch",
+    "watch": "npm test --ignore-scripts -- --watch",
     "changelog-to-github-release": "remark --quiet --use ./scripts/remark-changelog-to-github-release.mjs CHANGELOG.md"
   },
   "lint-staged": {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/pull/6964#discussion_r1240432958

> Is there anything in the PR that needs further explanation?

See https://docs.npmjs.com/cli/v9/commands/npm-test#ignore-scripts
