### PR TITLE
Add `npm run test-only` script for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "pretest": "npm run lint",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test-coverage": "npm test --ignore-scripts -- --coverage",
+    "test-only": "npm test --ignore-scripts",
     "version": "changeset version",
     "postversion": "git restore package.json",
     "watch": "npm test --ignore-scripts -- --watch",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: https://github.com/stylelint/stylelint/pull/6964#discussion_r1240545427

> Is there anything in the PR that needs further explanation?

Difference between `npm test` and `npm run test-only`:

- `npm test` - run linting before testing
- `npm run test-only` - without linting (useful for local development)

Example:

```console
$ npm run test-only -- cli
...
 PASS  lib/__tests__/cli.test.mjs
 PASS  lib/utils/__tests__/checkInvalidCLIOptions.test.js
...
```
