### PR TITLE
Document stylistic plugin in migration guide

### DIFF
--- a/docs/migration-guide/to-15.md
+++ b/docs/migration-guide/to-15.md
@@ -47,17 +47,10 @@ We've removed the [deprecated rules](../user-guide/rules.md#deprecated) from the
 
 There are lots of other rules we don't turn on in the [standard config](https://www.npmjs.com/package/stylelint-config-standard) and you can learn more about using them to customize Stylelint to your exact needs in our [new guide](../user-guide/customize.md).
 
-Alternatively, you can [migrate the deprecated rules you need to a plugin](../developer-guide/plugins.md) if you want to continue using Stylelint to enforce stylistic consistency.
+Alternatively, you can continue to enforce stylistic consistency with Stylelint by using one of the community plugins that have migrated the deprecated rules:
 
-To migrate a rule to a plugin, you can:
-
-1. Copy the rule, test, util and README file you need
-2. Correct import paths
-3. Prefix the:
-   - relevant functions with [`stylelint.utils`](../developer-guide/plugins.md#stylelintutils)
-   - rule name, e.g. `stylistic/indentation`
-
-Please let us know once you've published the plugin to NPM so that we can add a link to it in this migration guide.
+- [stylelint-stylistic](https://www.npmjs.com/package/stylelint-stylistic)
+- [stylelint-codeguide](https://www.npmjs.com/package/stylelint-codeguide)
 
 ### Added `declaration-property-value-no-unknown` rule
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6753

> Is there anything in the PR that needs further explanation?

Let's list both for now so that they are at least discoverable by users. If the plugin authors consolidate efforts and one package is deprecated, we can update the migration guide again.
