### PR TITLE
Fix `media-feature-name-no-vendor-prefix` positions for `*-device-pixel-ratio`

### DIFF
--- a/.changeset/tough-shrimps-walk.md
+++ b/.changeset/tough-shrimps-walk.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `media-feature-name-no-vendor-prefix` positions for `*-device-pixel-ratio`

--- a/lib/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/__tests__/index.js
@@ -42,11 +42,32 @@ testRule({
 			column: 9,
 		},
 		{
+			code: '@media (min--moz-device-pixel-ratio: 1) {}',
+			fixed: '@media (min-device-pixel-ratio: 1) {}',
+			message: messages.rejected,
+			line: 1,
+			column: 9,
+		},
+		{
+			code: '@media ( max--moz-device-pixel-ratio: 1) {}',
+			fixed: '@media ( max-device-pixel-ratio: 1) {}',
+			message: messages.rejected,
+			line: 1,
+			column: 10,
+		},
+		{
+			code: '@media (/* a comment */MIN--moz-device-pixel-ratio: 1) {}',
+			fixed: '@media (/* a comment */MIN-device-pixel-ratio: 1) {}',
+			message: messages.rejected,
+			line: 1,
+			column: 24,
+		},
+		{
 			code: '@media\n\t(min--moz-device-pixel-ratio: 1) {}',
 			fixed: '@media\n\t(min-device-pixel-ratio: 1) {}',
 			message: messages.rejected,
 			line: 2,
-			column: 6,
+			column: 3,
 		},
 		{
 			code: '@media   (-o-max-device-pixel-ratio: 1/1) {}',

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.js
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.js
@@ -32,7 +32,7 @@ const rule = (primary, _secondaryOptions, context) => {
 				return;
 			}
 
-			const matches = atRule.toString().match(/-[a-z-]+device-pixel-ratio/gi);
+			const matches = atRule.toString().match(/(?:min-|max-)?-[a-z-]+device-pixel-ratio/gi);
 
 			if (!matches) {
 				return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6975

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
