### PR TITLE
Fix inconsistent `errored` properties in `stylelint.lint()` return value

### DIFF
--- a/.changeset/hot-planets-rest.md
+++ b/.changeset/hot-planets-rest.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: inconsistent `errored` properties in `stylelint.lint()` return value

--- a/lib/__tests__/descriptionlessDisables.test.mjs
+++ b/lib/__tests__/descriptionlessDisables.test.mjs
@@ -27,19 +27,14 @@ it('descriptionlessDisables', async () => {
 		/* stylelint-disable-next-line block-no-empty */
 		a {}`;
 
-	const linted = await standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportDescriptionlessDisables: true,
 	});
-	const results = linted.results;
 
 	expect(results).toHaveLength(1);
-	const warnings = results[0].warnings.filter(
-		(warning) => warning.rule === '--report-descriptionless-disables',
-	);
-
-	expect(warnings).toEqual([
+	expect(descriptionlessWarnings(results[0])).toEqual([
 		{
 			line: 12,
 			column: 1,
@@ -97,18 +92,13 @@ it('descriptionlessDisables from config', async () => {
 		/* stylelint-disable-next-line block-no-empty */
 		a {}`;
 
-	const linted = await standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 	});
-	const results = linted.results;
 
 	expect(results).toHaveLength(1);
-	const warnings = results[0].warnings.filter(
-		(warning) => warning.rule === '--report-descriptionless-disables',
-	);
-
-	expect(warnings).toEqual([
+	expect(descriptionlessWarnings(results[0])).toEqual([
 		{
 			line: 12,
 			column: 1,
@@ -165,19 +155,14 @@ it('descriptionlessDisables true except', async () => {
 		/* stylelint-disable-next-line block-no-empty */
 		a {}`;
 
-	const linted = await standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportDescriptionlessDisables: [true, { except: ['invalid-hex-case'] }],
 	});
-	const results = linted.results;
 
 	expect(results).toHaveLength(1);
-	const warnings = results[0].warnings.filter(
-		(warning) => warning.rule === '--report-descriptionless-disables',
-	);
-
-	expect(warnings).toEqual([
+	expect(descriptionlessWarnings(results[0])).toEqual([
 		{
 			line: 12,
 			column: 1,
@@ -225,19 +210,14 @@ it('descriptionlessDisables false except', async () => {
 		/* stylelint-disable-next-line block-no-empty */
 		a {}`;
 
-	const linted = await standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportDescriptionlessDisables: [false, { except: ['invalid-hex-case'] }],
 	});
-	const results = linted.results;
 
 	expect(results).toHaveLength(1);
-	const warnings = results[0].warnings.filter(
-		(warning) => warning.rule === '--report-descriptionless-disables',
-	);
-
-	expect(warnings).toEqual([
+	expect(descriptionlessWarnings(results[0])).toEqual([
 		{
 			line: 16,
 			column: 7,
@@ -276,19 +256,14 @@ it('descriptionlessDisables severity', async () => {
 		/* stylelint-disable-next-line block-no-empty */
 		a {}`;
 
-	const linted = await standalone({
+	const { results } = await standalone({
 		config,
 		code: css,
 		reportDescriptionlessDisables: [true, { severity: 'warning' }],
 	});
-	const results = linted.results;
 
 	expect(results).toHaveLength(1);
-	const warnings = results[0].warnings.filter(
-		(warning) => warning.rule === '--report-descriptionless-disables',
-	);
-
-	expect(warnings).toEqual([
+	expect(descriptionlessWarnings(results[0])).toEqual([
 		{
 			line: 12,
 			column: 1,
@@ -318,3 +293,43 @@ it('descriptionlessDisables severity', async () => {
 		},
 	]);
 });
+
+it('descriptionlessDisables only', async () => {
+	const config = {
+		rules: {},
+	};
+	const css = '/* stylelint-disable */';
+
+	const { results } = await standalone({
+		config,
+		code: css,
+		reportDescriptionlessDisables: true,
+	});
+
+	expect(results).toHaveLength(1);
+	expect(results[0].errored).toBe(true);
+	expect(results[0].warnings).toHaveLength(1);
+	expect(descriptionlessWarnings(results[0])).toHaveLength(1);
+});
+
+it('descriptionlessDisables only with warning severity', async () => {
+	const config = {
+		rules: {},
+	};
+	const css = '/* stylelint-disable */';
+
+	const { results } = await standalone({
+		config,
+		code: css,
+		reportDescriptionlessDisables: [true, { severity: 'warning' }],
+	});
+
+	expect(results).toHaveLength(1);
+	expect(results[0].errored).toBe(false);
+	expect(results[0].warnings).toHaveLength(1);
+	expect(descriptionlessWarnings(results[0])).toHaveLength(1);
+});
+
+function descriptionlessWarnings(result) {
+	return result.warnings.filter(({ rule }) => rule === '--report-descriptionless-disables');
+}

--- a/lib/__tests__/needlessDisables.test.mjs
+++ b/lib/__tests__/needlessDisables.test.mjs
@@ -58,6 +58,7 @@ it('needlessDisables simple case', async () => {
 			severity: 'error',
 		},
 	]);
+	expect(results[0].errored).toBe(true);
 });
 
 it('needlessDisables with config', async () => {
@@ -404,6 +405,7 @@ it('needlessDisables severity', async () => {
 			severity: 'warning',
 		},
 	]);
+	expect(results[0].errored).toBe(false);
 });
 
 it('needlessDisables with configurationComment', async () => {

--- a/lib/__tests__/reportDisables.test.mjs
+++ b/lib/__tests__/reportDisables.test.mjs
@@ -39,6 +39,7 @@ describe('reportDisables', () => {
 				severity: 'error',
 			},
 		]);
+		expect(results[0].errored).toBe(true);
 	});
 
 	it('reports an ignored disabled comment', async () => {

--- a/lib/prepareReturnValue.js
+++ b/lib/prepareReturnValue.js
@@ -24,12 +24,18 @@ module.exports = function prepareReturnValue(stylelintResults, maxWarnings, form
 	invalidScopeDisables(stylelintResults);
 	descriptionlessDisables(stylelintResults);
 
-	const errored = stylelintResults.some(
-		(result) =>
+	let errored = false;
+
+	for (const result of stylelintResults) {
+		if (
 			result.errored ||
 			result.parseErrors.length > 0 ||
-			result.warnings.some((warning) => warning.severity === 'error'),
-	);
+			result.warnings.some((warning) => warning.severity === 'error')
+		) {
+			errored = true;
+			result.errored = true;
+		}
+	}
 
 	/** @type {LinterResult} */
 	const returnValue = {

--- a/system-tests/004/__snapshots__/fs.test.mjs.snap
+++ b/system-tests/004/__snapshots__/fs.test.mjs.snap
@@ -7,7 +7,7 @@ exports[`fs - errored state for reportNeedlessDisables 1`] = `
   "output": [
     {
       "deprecations": [],
-      "errored": false,
+      "errored": true,
       "invalidOptionWarnings": [],
       "parseErrors": [],
       "warnings": [
@@ -27,7 +27,7 @@ exports[`fs - errored state for reportNeedlessDisables 1`] = `
   "results": [
     {
       "deprecations": [],
-      "errored": false,
+      "errored": true,
       "ignored": undefined,
       "invalidOptionWarnings": [],
       "parseErrors": [],

--- a/system-tests/004/__snapshots__/no-fs.test.mjs.snap
+++ b/system-tests/004/__snapshots__/no-fs.test.mjs.snap
@@ -7,7 +7,7 @@ exports[`no-fs - errored state for reportNeedlessDisables 1`] = `
   "output": [
     {
       "deprecations": [],
-      "errored": false,
+      "errored": true,
       "invalidOptionWarnings": [],
       "parseErrors": [],
       "warnings": [
@@ -27,7 +27,7 @@ exports[`no-fs - errored state for reportNeedlessDisables 1`] = `
   "results": [
     {
       "deprecations": [],
-      "errored": false,
+      "errored": true,
       "ignored": undefined,
       "invalidOptionWarnings": [],
       "parseErrors": [],


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6982

> Is there anything in the PR that needs further explanation?

This pull request fixes the `errored` property calculation in `prepareReturnValue()`.

---

Internal details:

`standalone()` just returns a return value from `prepareReturnValue()`. This value includes a correct `errored` property.

https://github.com/stylelint/stylelint/blob/9ddba420d9f146331a55d0f62d3154331ce4291c/lib/standalone.js#L268-L272

https://github.com/stylelint/stylelint/blob/9ddba420d9f146331a55d0f62d3154331ce4291c/lib/prepareReturnValue.js#L40-L48

Before this pull request's change, `returnValue.errored` could differ from `returnValue.results[*].errored`.

https://github.com/stylelint/stylelint/blob/9ddba420d9f146331a55d0f62d3154331ce4291c/lib/prepareReturnValue.js#L59