### PR TITLE
Fix `function-linear-gradient-no-nonstandard-direction` false positives for `<color-interpolation-method>`

### DIFF
--- a/.changeset/strong-cycles-raise.md
+++ b/.changeset/strong-cycles-raise.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-linear-gradient-no-nonstandard-direction` false positives for `<color-interpolation-method>`

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/__tests__/index.js
@@ -56,6 +56,12 @@ testRule({
 			code: '.foo { background: linear-gradient(black, white); }',
 		},
 		{
+			code: '.foo { background: linear-gradient(in srgb to top, #fff, #000); }',
+		},
+		{
+			code: '.foo { background: linear-gradient(to top in srgb, #fff, #000); }',
+		},
+		{
 			code: '.foo { background: linear-gradient(rgba(255, 255, 255, 0.5) 0%, #000); }',
 		},
 		{
@@ -190,6 +196,16 @@ testRule({
 		},
 		{
 			code: '.foo { background: linear-gradient(1.577, #fff, #000; )}',
+			message: messages.rejected,
+			line: 1,
+			column: 36,
+			endLine: 1,
+			endColumn: 41,
+		},
+		{
+			code: '.foo { background: linear-gradient(topin, #fff, #000); }',
+			description:
+				'An incorrect direction that contains the word "in", only "in" as a word on its own is ignored by this rule.',
 			message: messages.rejected,
 			line: 1,
 			column: 36,

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/index.js
@@ -29,6 +29,7 @@ const DIRECTION_WITHOUT_TO = new RegExp(`^(${DIRECTION.source})(?: (${DIRECTION.
 
 const DIGIT = /[\d.]/;
 const ANGLE = /^[\d.]+(?:deg|grad|rad|turn)$/;
+const IN_KEYWORD = /\bin\b/i;
 
 /**
  * @param {string} source
@@ -81,6 +82,11 @@ const rule = (primary) => {
 
 						// If the first arg is not standard, return early
 						if (!isStandardSyntaxValue(firstArg)) {
+							return;
+						}
+
+						// Ignore gradients with modern syntax that have color space interpolation arguments
+						if (IN_KEYWORD.test(firstArg)) {
 							return;
 						}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6951

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
