### PR TITLE
Document `quietDeprecationWarnings` in migration guide

### DIFF
--- a/docs/migration-guide/to-15.md
+++ b/docs/migration-guide/to-15.md
@@ -52,6 +52,8 @@ Alternatively, you can continue to enforce stylistic consistency with Stylelint 
 - [stylelint-stylistic](https://www.npmjs.com/package/stylelint-stylistic)
 - [stylelint-codeguide](https://www.npmjs.com/package/stylelint-codeguide)
 
+You can use the [`quietDeprecationWarnings`](../user-guide/options.md#quietdeprecationwarnings) option to silence the deprecationg warnings.
+
 ### Added `declaration-property-value-no-unknown` rule
 
 We added the [`declaration-property-value-no-unknown`](../../lib/rules/declaration-property-value-no-unknown/README.md) rule. It will flag property-value pairs that are unknown in the CSS specifications, for example:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/pull/6979#discussion_r1243272645, it's a documentation fix.

> Is there anything in the PR that needs further explanation?

It's placed where it shouldn't conflict with the `v16` branch changes.
