### PR TITLE
Refine the bug template to encourage minimal examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
@@ -100,5 +100,6 @@ body:
     id: proposal-bugfix
     attributes:
       label: 'Do you have a proposal to fix the bug?'
+      description: 'Propose your idea to help us.'
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
@@ -100,6 +100,6 @@ body:
     id: proposal-bugfix
     attributes:
       label: 'Do you have a proposal to fix the bug?'
-      description: 'Propose your idea to help us.'
+      description: 'Help us by proposing your ideas.'
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
@@ -16,7 +16,7 @@ body:
     id: reproduce-bug
     attributes:
       label: 'What minimal example or steps are needed to reproduce the bug?'
-      description: 'Provide the smallest reproducible example or steps possible.'
+      description: 'Provide the smallest possible reproducible example or steps.'
       placeholder: |
         ```css
         a {
@@ -35,7 +35,7 @@ body:
     id: stylelint-configuration
     attributes:
       label: 'What minimal configuration is needed to reproduce the bug?'
-      description: 'Provide the smallest reproducible configuration possible.'
+      description: 'Provide the smallest possible reproducible configuration.'
       placeholder: |
         ```json
         {

--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
@@ -7,16 +7,16 @@ body:
       value: |
         Thank you for taking the time to report a bug!
 
-        Please [search our issues](https://github.com/search?q=repo%3Astylelint%2Fstylelint&type=issues) to check that the bug hasn't already been reported.
+        Please [search our issues](https://github.com/search?q=repo%3Astylelint%2Fstylelint+&type=issues) to check that the bug hasn't already been reported.
 
         You can help us fix the bug more quickly by:
-        1. Figuring out what needs doing and proposing it in the issue.
+        1. Figuring out what needs doing and proposing a fix.
         2. After the bug is confirmed, [contributing](https://github.com/stylelint/stylelint/blob/main/CONTRIBUTING.md) a pull request.
   - type: textarea
     id: reproduce-bug
     attributes:
-      label: 'What steps are needed to reproduce the bug?'
-      description: 'Provide the smallest reproducible CSS example or steps.'
+      label: 'What minimal example or steps are needed to reproduce the bug?'
+      description: 'Provide the smallest reproducible example or steps possible.'
       placeholder: |
         ```css
         a {
@@ -34,8 +34,8 @@ body:
   - type: textarea
     id: stylelint-configuration
     attributes:
-      label: 'What Stylelint configuration is needed to reproduce the bug?'
-      description: 'Provide the smallest reproducible example.'
+      label: 'What minimal configuration is needed to reproduce the bug?'
+      description: 'Provide the smallest reproducible configuration possible.'
       placeholder: |
         ```json
         {
@@ -50,26 +50,23 @@ body:
     id: stylelint-run
     attributes:
       label: 'How did you run Stylelint?'
-      description: 'For example, CLI, Node.js API, PostCSS plugin, or [Stylelint demo](https://stylelint.io/demo/).'
+      description: 'If applicable, provide a [Stylelint demo](https://stylelint.io/demo/).'
       placeholder: |
-        ```shell
-        stylelint "**/*.css" --config myconfig.json
-        ```
+        [Demo](https://stylelint.io/demo/#...)
 
         Or
 
-        https://stylelint.io/demo/#...
+        ```shell
+        stylelint "**/*.css" --config myconfig.json
+        ```
     validations:
       required: true
   - type: textarea
     id: stylelint-version
     attributes:
-      label: 'Which version of Stylelint or dependencies are you using?'
+      label: 'Which Stylelint-related dependencies are you using?'
+      description: 'Provide versions from your `package.json`.'
       placeholder: |
-        15.6.0
-
-        Or
-
         ```json
         {
           "stylelint": "15.6.0",
@@ -90,7 +87,6 @@ body:
     id: actual-behavior
     attributes:
       label: 'What actually happened?'
-      description: 'For example, what warnings or errors did you get?'
       placeholder: |
         The following problems were reported:
 
@@ -101,18 +97,8 @@ body:
     validations:
       required: true
   - type: textarea
-    id: non-standard-syntax
-    attributes:
-      label: 'Does the bug relate to non-standard syntax?'
-      description: 'For example, a construct from SCSS, Less or CSS-in-JS.'
-      placeholder: |
-        Yes, it's related to SCSS nested properties.
-    validations:
-      required: false
-  - type: textarea
     id: proposal-bugfix
     attributes:
-      label: 'Proposal to fix the bug'
-      description: 'If you know what needs doing, please propose it below.'
+      label: 'Do you have a proposal to fix the bug?'
     validations:
       required: false


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

A few recent bug reports have included large examples or configurations. This pull request tweaks the template's wording and makes things more consistent to encourage more minimal examples.

