### PR TITLE
Refactor utils tests to migrate to ESM

### DIFF
--- a/lib/utils/__tests__/addEmptyLineAfter.test.mjs
+++ b/lib/utils/__tests__/addEmptyLineAfter.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const addEmptyLineAfter = require('../addEmptyLineAfter');
-const postcss = require('postcss');
+import addEmptyLineAfter from '../addEmptyLineAfter.js';
+import postcss from 'postcss';
 
 describe('addEmptyLineBefore', () => {
 	it('adds single newline to the newline at the beginning', () => {

--- a/lib/utils/__tests__/addEmptyLineBefore.test.mjs
+++ b/lib/utils/__tests__/addEmptyLineBefore.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const addEmptyLineBefore = require('../addEmptyLineBefore');
-const postcss = require('postcss');
+import addEmptyLineBefore from '../addEmptyLineBefore.js';
+import postcss from 'postcss';
 
 describe('addEmptyLineBefore', () => {
 	it('adds single newline to the newline at the beginning', () => {

--- a/lib/utils/__tests__/arrayEqual.test.mjs
+++ b/lib/utils/__tests__/arrayEqual.test.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const arrayEqual = require('../arrayEqual');
+import arrayEqual from '../arrayEqual.js';
 
 describe('arrayEqual', () => {
 	it('handles arrays', () => {

--- a/lib/utils/__tests__/atRuleParamIndex.test.mjs
+++ b/lib/utils/__tests__/atRuleParamIndex.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const atRuleParamIndex = require('../atRuleParamIndex');
-const postcss = require('postcss');
+import atRuleParamIndex from '../atRuleParamIndex.js';
+import postcss from 'postcss';
 
 describe('atRuleParamIndex', () => {
 	it('has a single space before the param', () => {

--- a/lib/utils/__tests__/beforeBlockString.test.mjs
+++ b/lib/utils/__tests__/beforeBlockString.test.mjs
@@ -1,8 +1,6 @@
-'use strict';
-
-const beforeBlockString = require('../beforeBlockString');
-const postcss = require('postcss');
-const sugarss = require('sugarss');
+import beforeBlockString from '../beforeBlockString.js';
+import postcss from 'postcss';
+import sugarss from 'sugarss';
 
 describe('beforeBlockString', () => {
 	let css;

--- a/lib/utils/__tests__/blockString.test.mjs
+++ b/lib/utils/__tests__/blockString.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const blockString = require('../blockString');
-const postcss = require('postcss');
+import blockString from '../blockString.js';
+import postcss from 'postcss';
 
 it('blockString rules', () => {
 	expect(postcssCheck('a { color: pink; }')).toBe('{ color: pink; }');

--- a/lib/utils/__tests__/blurInterpolation.test.mjs
+++ b/lib/utils/__tests__/blurInterpolation.test.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const blurInterpolation = require('../blurInterpolation');
+import blurInterpolation from '../blurInterpolation.js';
 
 describe('blurInterpolation', () => {
 	let css;

--- a/lib/utils/__tests__/checkInvalidCLIOptions.test.mjs
+++ b/lib/utils/__tests__/checkInvalidCLIOptions.test.mjs
@@ -1,8 +1,9 @@
-'use strict';
+import checkInvalidCLIOptions from '../checkInvalidCLIOptions.js';
 
-const checkInvalidCLIOptions = require('../checkInvalidCLIOptions');
-const EOL = require('os').EOL;
-const { red: r, cyan: c } = require('picocolors');
+import { EOL } from 'node:os';
+import picocolors from 'picocolors';
+
+const { red: r, cyan: c } = picocolors;
 
 describe('checkInvalidCLIOptions', () => {
 	const allowedOptions = {

--- a/lib/utils/__tests__/configurationComment.test.mjs
+++ b/lib/utils/__tests__/configurationComment.test.mjs
@@ -1,8 +1,6 @@
-'use strict';
+import postcss from 'postcss';
 
-const postcss = require('postcss');
-
-const { extractConfigurationComment, isConfigurationComment } = require('../configurationComment');
+import { extractConfigurationComment, isConfigurationComment } from '../configurationComment.js';
 
 test('extractConfigurationComment', () => {
 	expect(extractConfigurationComment(comment('stylelint-disable'))).toBe('-disable');

--- a/lib/utils/__tests__/containsString.test.mjs
+++ b/lib/utils/__tests__/containsString.test.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const containsString = require('../containsString');
+import containsString from '../containsString.js';
 
 it('containsString comparing with string comparison values', () => {
 	expect(containsString('bar', 'bar')).toEqual({

--- a/lib/utils/__tests__/declarationValueIndex.test.mjs
+++ b/lib/utils/__tests__/declarationValueIndex.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const declarationValueIndex = require('../declarationValueIndex');
-const postcss = require('postcss');
+import declarationValueIndex from '../declarationValueIndex.js';
+import postcss from 'postcss';
 
 describe('declarationValueIndex', () => {
 	it('has a space before the value', () => {

--- a/lib/utils/__tests__/filterFilePaths.test.mjs
+++ b/lib/utils/__tests__/filterFilePaths.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const filterFilePaths = require('../filterFilePaths');
-const ignore = require('ignore');
+import filterFilePaths from '../filterFilePaths.js';
+import ignore from 'ignore';
 
 describe('filterFilePaths', () => {
 	it('empty ignorefile', () => {

--- a/lib/utils/__tests__/findAnimationName.test.mjs
+++ b/lib/utils/__tests__/findAnimationName.test.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const findAnimationName = require('../findAnimationName');
+import findAnimationName from '../findAnimationName.js';
 
 it('findAnimationName', () => {
 	expect(findAnimationName('inherit')).toEqual([

--- a/lib/utils/__tests__/findAtRuleContext.test.mjs
+++ b/lib/utils/__tests__/findAtRuleContext.test.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const findAtRuleContext = require('../findAtRuleContext');
-const postcss = require('postcss');
+import findAtRuleContext from '../findAtRuleContext.js';
+import postcss from 'postcss';
 
 it('findAtRuleContext', () => {
 	const css = `

--- a/lib/utils/__tests__/findFontFamily.test.mjs
+++ b/lib/utils/__tests__/findFontFamily.test.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const findFontFamily = require('../findFontFamily');
+import findFontFamily from '../findFontFamily.js';
 
 it('findFontFamily', () => {
 	expect(findFontFamily('inherit')).toEqual([


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref: #5291

> Is there anything in the PR that needs further explanation?

This change rewrites some `lib/utils/__tests__/*.js` files to ESM.
