### PR TITLE
Refactor `no-duplicate-at-import-rules` to remove `postcss-media-query-parser`

### DIFF
--- a/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
@@ -79,6 +79,12 @@ testRule({
 			column: 38,
 		},
 		{
+			code: "@import url('a.css') /* a comment */ tv; @import 'a.css' tv /* a comment */;",
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 42,
+		},
+		{
 			code: "@import url('a.css') tv, projection; @import 'a.css' projection, screen, tv;",
 			message: messages.rejected(`a.css`),
 			line: 1,

--- a/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
@@ -31,12 +31,6 @@ testRule({
 		{
 			code: '@IMPORT "a.css"; @ImPoRt "b.css";',
 		},
-		{
-			code: '@import "a.css" supports(display: flex) tv; @import "a.css" layer tv;',
-		},
-		{
-			code: '@import "a.css" supports(display: flex) tv; @import "a.css" supports(display: grid) tv;',
-		},
 	],
 
 	reject: [
@@ -85,12 +79,6 @@ testRule({
 			column: 38,
 		},
 		{
-			code: "@import url('a.css') /* a comment */ tv; @import 'a.css' tv /* a comment */;",
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 42,
-		},
-		{
 			code: "@import url('a.css') tv, projection; @import 'a.css' projection, screen, tv;",
 			message: messages.rejected(`a.css`),
 			line: 1,
@@ -113,70 +101,6 @@ testRule({
 			message: messages.rejected(`a.css`),
 			line: 1,
 			column: 18,
-		},
-		{
-			code: '@import url("a.css") layer; @import url("a.css") layer;',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 29,
-			endLine: 1,
-			endColumn: 55,
-		},
-		{
-			code: '@import url("a.css") layer(base); @import url("a.css") layer(base);',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 35,
-			endLine: 1,
-			endColumn: 67,
-		},
-		{
-			code: '@import url("a.css") layer(base) supports(display: grid); @import url("a.css") layer(base) supports(display: grid);',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 59,
-			endLine: 1,
-			endColumn: 115,
-		},
-		{
-			code: '@import url("a.css") supports(display: grid); @import url("a.css") supports(display: grid);',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 47,
-			endLine: 1,
-			endColumn: 91,
-		},
-		{
-			code: '@import url("a.css") layer tv; @import url("a.css") layer tv;',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 32,
-			endLine: 1,
-			endColumn: 61,
-		},
-		{
-			code: '@import url("a.css") layer(base) tv; @import url("a.css") layer(base) tv;',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 38,
-			endLine: 1,
-			endColumn: 73,
-		},
-		{
-			code: '@import url("a.css") layer(base) supports(display: grid) tv; @import url("a.css") layer(base) supports(display: grid) tv;',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 62,
-			endLine: 1,
-			endColumn: 121,
-		},
-		{
-			code: '@import url("a.css") layer(base) supports(display: grid) screen, tv; @import url("a.css") layer(base) supports(display: grid) tv;',
-			message: messages.rejected(`a.css`),
-			line: 1,
-			column: 70,
-			endLine: 1,
-			endColumn: 129,
 		},
 	],
 });

--- a/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
@@ -31,6 +31,12 @@ testRule({
 		{
 			code: '@IMPORT "a.css"; @ImPoRt "b.css";',
 		},
+		{
+			code: '@import "a.css" supports(display: flex) tv; @import "a.css" layer tv;',
+		},
+		{
+			code: '@import "a.css" supports(display: flex) tv; @import "a.css" supports(display: grid) tv;',
+		},
 	],
 
 	reject: [
@@ -107,6 +113,70 @@ testRule({
 			message: messages.rejected(`a.css`),
 			line: 1,
 			column: 18,
+		},
+		{
+			code: '@import url("a.css") layer; @import url("a.css") layer;',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 29,
+			endLine: 1,
+			endColumn: 55,
+		},
+		{
+			code: '@import url("a.css") layer(base); @import url("a.css") layer(base);',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 35,
+			endLine: 1,
+			endColumn: 67,
+		},
+		{
+			code: '@import url("a.css") layer(base) supports(display: grid); @import url("a.css") layer(base) supports(display: grid);',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 59,
+			endLine: 1,
+			endColumn: 115,
+		},
+		{
+			code: '@import url("a.css") supports(display: grid); @import url("a.css") supports(display: grid);',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 47,
+			endLine: 1,
+			endColumn: 91,
+		},
+		{
+			code: '@import url("a.css") layer tv; @import url("a.css") layer tv;',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 32,
+			endLine: 1,
+			endColumn: 61,
+		},
+		{
+			code: '@import url("a.css") layer(base) tv; @import url("a.css") layer(base) tv;',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 38,
+			endLine: 1,
+			endColumn: 73,
+		},
+		{
+			code: '@import url("a.css") layer(base) supports(display: grid) tv; @import url("a.css") layer(base) supports(display: grid) tv;',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 62,
+			endLine: 1,
+			endColumn: 121,
+		},
+		{
+			code: '@import url("a.css") layer(base) supports(display: grid) screen, tv; @import url("a.css") layer(base) supports(display: grid) tv;',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 70,
+			endLine: 1,
+			endColumn: 129,
 		},
 	],
 });

--- a/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
@@ -91,6 +91,12 @@ testRule({
 			column: 38,
 		},
 		{
+			code: "@import url('a.css') /* a comment */ tv; @import 'a.css' tv /* a comment */;",
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 42,
+		},
+		{
 			code: '@import "a.css" tv, (min-width : 500px);@import url(a.css) (  min-width:500px   ), tv;',
 			message: messages.rejected(`a.css`),
 			line: 1,

--- a/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/__tests__/index.js
@@ -97,6 +97,12 @@ testRule({
 			column: 42,
 		},
 		{
+			code: '@import "a.css" (min-width : 500px);@import url(a.css) (  min-width:500px   );',
+			message: messages.rejected(`a.css`),
+			line: 1,
+			column: 37,
+		},
+		{
 			code: '@import "a.css" tv, (min-width : 500px);@import url(a.css) (  min-width:500px   ), tv;',
 			message: messages.rejected(`a.css`),
 			line: 1,

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -41,7 +41,7 @@ const rule = (primary) => {
 					? firstParam.nodes[0].value
 					: firstParam.value;
 
-			const media = listMediaQueryConditions(restParams);
+			const media = listImportConditions(restParams);
 
 			let importedUris = imports[uri];
 			const isDuplicate = media.length
@@ -71,12 +71,12 @@ const rule = (primary) => {
 };
 
 /**
- * List the media query conditions found in the prelude of an `@import` rule
+ * List the import conditions found in the prelude of an `@import` rule
  *
  * @param {import('postcss-value-parser').Node[]} params
  * @returns {Array<string>}
  */
-function listMediaQueryConditions(params) {
+function listImportConditions(params) {
 	if (!params.length) return [];
 
 	/** @type {Array<import('postcss-value-parser').Node>} */

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -79,9 +79,6 @@ const rule = (primary) => {
 function listImportConditions(params) {
 	if (!params.length) return [];
 
-	/** @type {Array<import('postcss-value-parser').Node>} */
-	let layerOrSupportConditions = [];
-
 	/** @type {Array<Array<import('postcss-value-parser').Node>>} */
 	let media = [];
 	/** @type {Array<import('postcss-value-parser').Node>} */
@@ -91,20 +88,6 @@ function listImportConditions(params) {
 		const param = params[i];
 
 		if (!param) break;
-
-		if (!media.length) {
-			// @import url(...) layer(base) supports(display: flex)
-			if (param.type === 'function' && (param.value === 'supports' || param.value === 'layer')) {
-				layerOrSupportConditions.push(param);
-				continue;
-			}
-
-			// @import url(...) layer
-			if (param.type === 'word' && param.value === 'layer') {
-				layerOrSupportConditions.push(param);
-				continue;
-			}
-		}
 
 		// remove whitespace to get a consistent key
 		if (param.type === 'space') {
@@ -129,15 +112,7 @@ function listImportConditions(params) {
 		media.push(lastMediaQuery);
 	}
 
-	const layerOrSupportConditionsString = layerOrSupportConditions.length
-		? `${layerOrSupportConditions.map((c) => valueParser.stringify(c)).join(' ')} `
-		: '';
-
-	return media
-		.map((m) => {
-			return layerOrSupportConditionsString + valueParser.stringify(m).trim();
-		})
-		.filter((n) => n.length);
+	return media.map((m) => valueParser.stringify(m).trim()).filter((n) => n.length);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -79,6 +79,9 @@ const rule = (primary) => {
 function listMediaQueryConditions(params) {
 	if (!params.length) return [];
 
+	/** @type {Array<import('postcss-value-parser').Node>} */
+	let layerOrSupportConditions = [];
+
 	/** @type {Array<Array<import('postcss-value-parser').Node>>} */
 	let media = [];
 	/** @type {Array<import('postcss-value-parser').Node>} */
@@ -92,11 +95,13 @@ function listMediaQueryConditions(params) {
 		if (!media.length) {
 			// @import url(...) layer(base) supports(display: flex)
 			if (param.type === 'function' && (param.value === 'supports' || param.value === 'layer')) {
+				layerOrSupportConditions.push(param);
 				continue;
 			}
 
 			// @import url(...) layer
 			if (param.type === 'word' && param.value === 'layer') {
+				layerOrSupportConditions.push(param);
 				continue;
 			}
 		}
@@ -124,7 +129,15 @@ function listMediaQueryConditions(params) {
 		media.push(lastMediaQuery);
 	}
 
-	return media.map((m) => valueParser.stringify(m).trim()).filter((n) => n.length);
+	const layerOrSupportConditionsString = layerOrSupportConditions.length
+		? `${layerOrSupportConditions.map((c) => valueParser.stringify(c)).join(' ')} `
+		: '';
+
+	return media
+		.map((m) => {
+			return layerOrSupportConditionsString + valueParser.stringify(m).trim();
+		})
+		.filter((n) => n.length);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -109,7 +109,7 @@ function listImportConditions(params) {
 		media.push(lastMediaQuery);
 	}
 
-	return media.map((m) => valueParser.stringify(m).trim()).filter((n) => n.length);
+	return media.map((m) => valueParser.stringify(m));
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -80,24 +80,19 @@ const rule = (primary) => {
 function listImportConditions(params) {
 	if (!params.length) return [];
 
-	/** @type {Array<Array<Node>>} */
+	/** @type {Array<String>} */
 	let media = [];
 	/** @type {Array<Node>} */
 	let lastMediaQuery = [];
 
 	for (const param of params) {
-		// remove whitespace to get a consistent key
-		if (param.type === 'space') {
-			continue;
-		}
-
-		// remove comments to get a consistent key
-		if (param.type === 'comment') {
+		// remove top level whitespace and comments to get a more consistent key
+		if (param.type === 'space' || param.type === 'comment') {
 			continue;
 		}
 
 		if (param.type === 'div' && param.value === ',') {
-			media.push(lastMediaQuery);
+			media.push(valueParser.stringify(lastMediaQuery));
 			lastMediaQuery = [];
 			continue;
 		}
@@ -106,10 +101,11 @@ function listImportConditions(params) {
 	}
 
 	if (lastMediaQuery.length) {
-		media.push(lastMediaQuery);
+		media.push(valueParser.stringify(lastMediaQuery));
 	}
 
-	return media.map((m) => valueParser.stringify(m));
+	// remove remaining whitespace to get a more consistent key
+	return media.map((m) => m.replace(/\s/g, ''));
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -85,11 +85,7 @@ function listImportConditions(params) {
 	/** @type {Array<Node>} */
 	let lastMediaQuery = [];
 
-	for (let i = 0; i < params.length; i++) {
-		const param = params[i];
-
-		if (!param) break;
-
+	for (const param of params) {
 		// remove whitespace to get a consistent key
 		if (param.type === 'space') {
 			continue;

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const mediaParser = require('postcss-media-query-parser').default;
+const getAtRuleParams = require('../../utils/getAtRuleParams');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -29,7 +29,7 @@ const rule = (primary) => {
 		const imports = {};
 
 		root.walkAtRules(/^import$/i, (atRule) => {
-			const [firstParam, ...restParams] = valueParser(atRule.params).nodes;
+			const [firstParam, ...restParams] = valueParser(getAtRuleParams(atRule)).nodes;
 
 			if (!firstParam) {
 				return;
@@ -41,10 +41,7 @@ const rule = (primary) => {
 					? firstParam.nodes[0].value
 					: firstParam.value;
 
-			// extract media queries if any
-			const media = (mediaParser(valueParser.stringify(restParams)).nodes || [])
-				.map((n) => n.value.replace(/\s/g, ''))
-				.filter((n) => n.length);
+			const media = listMediaQueryConditions(restParams);
 
 			let importedUris = imports[uri];
 			const isDuplicate = media.length
@@ -72,6 +69,63 @@ const rule = (primary) => {
 		});
 	};
 };
+
+/**
+ * List the media query conditions found in the prelude of an `@import` rule
+ *
+ * @param {import('postcss-value-parser').Node[]} params
+ * @returns {Array<string>}
+ */
+function listMediaQueryConditions(params) {
+	if (!params.length) return [];
+
+	/** @type {Array<Array<import('postcss-value-parser').Node>>} */
+	let media = [];
+	/** @type {Array<import('postcss-value-parser').Node>} */
+	let lastMediaQuery = [];
+
+	for (let i = 0; i < params.length; i++) {
+		const param = params[i];
+
+		if (!param) break;
+
+		if (!media.length) {
+			// @import url(...) layer(base) supports(display: flex)
+			if (param.type === 'function' && (param.value === 'supports' || param.value === 'layer')) {
+				continue;
+			}
+
+			// @import url(...) layer
+			if (param.type === 'word' && param.value === 'layer') {
+				continue;
+			}
+		}
+
+		// remove whitespace to get a consistent key
+		if (param.type === 'space') {
+			continue;
+		}
+
+		// remove comments to get a consistent key
+		if (param.type === 'comment') {
+			continue;
+		}
+
+		if (param.type === 'div' && param.value === ',') {
+			media.push(lastMediaQuery);
+			lastMediaQuery = [];
+			continue;
+		}
+
+		lastMediaQuery.push(param);
+	}
+
+	if (lastMediaQuery.length) {
+		media.push(lastMediaQuery);
+	}
+
+	return media.map((m) => valueParser.stringify(m).trim()).filter((n) => n.length);
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/no-duplicate-at-import-rules/index.js
+++ b/lib/rules/no-duplicate-at-import-rules/index.js
@@ -73,15 +73,16 @@ const rule = (primary) => {
 /**
  * List the import conditions found in the prelude of an `@import` rule
  *
- * @param {import('postcss-value-parser').Node[]} params
+ * @param {Node[]} params
+ * @typedef {import('postcss-value-parser').Node} Node
  * @returns {Array<string>}
  */
 function listImportConditions(params) {
 	if (!params.length) return [];
 
-	/** @type {Array<Array<import('postcss-value-parser').Node>>} */
+	/** @type {Array<Array<Node>>} */
 	let media = [];
-	/** @type {Array<import('postcss-value-parser').Node>} */
+	/** @type {Array<Node>} */
 	let lastMediaQuery = [];
 
 	for (let i = 0; i < params.length; i++) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/issues/6848

> Is there anything in the PR that needs further explanation?

I found that this rule doesn't actually require parsing media queries.
It only used the media query parser to split on comma's.

This is something that can be easily done with the `postcss-value-parser` AST nodes.
