### PR TITLE
Refactor AST walking with `@csstools` parsers for code consistency

### DIFF
--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -93,8 +93,8 @@ const rule = (primary, secondaryOptions) => {
 				if (isFunctionNode(componentValue) || isSimpleBlockNode(componentValue)) {
 					walker(componentValue);
 
-					componentValue.walk((entry) => {
-						walker(entry.node);
+					componentValue.walk(({ node }) => {
+						walker(node);
 					});
 				}
 			});

--- a/lib/rules/media-feature-name-unit-allowed-list/index.js
+++ b/lib/rules/media-feature-name-unit-allowed-list/index.js
@@ -53,45 +53,49 @@ const rule = (primary) => {
 			mediaQueryList.forEach((mediaQuery) => {
 				if (isMediaQueryInvalid(mediaQuery)) return;
 
-				mediaQuery.walk((entry) => {
-					if (!isMediaFeaturePlain(entry.node) && !isMediaFeatureRange(entry.node)) {
+				const initialState = {
+					mediaFeatureName: '',
+					/** @type {string[] | undefined} */
+					unitList: undefined,
+				};
+
+				mediaQuery.walk(({ node, state }) => {
+					if (!state) return;
+
+					if (isMediaFeaturePlain(node) || isMediaFeatureRange(node)) {
+						state.mediaFeatureName = node.getName();
+						state.unitList = primaryUnitList(state.mediaFeatureName);
+
 						return;
 					}
 
-					const featureName = entry.node.getName();
-					const unitList = primaryUnitList(featureName);
+					if (!isTokenNode(node)) return;
 
-					if (!unitList) {
+					const { mediaFeatureName, unitList } = state;
+
+					if (!mediaFeatureName || !unitList) return;
+
+					const [tokenType, , startIndex, endIndex, parsedValue] = node.value;
+
+					if (tokenType !== TokenType.Dimension) {
 						return;
 					}
 
-					entry.node.walk(({ node: childNode }) => {
-						if (!isTokenNode(childNode)) {
-							return;
-						}
+					if (unitList.includes(parsedValue.unit.toLowerCase())) {
+						return;
+					}
 
-						const [tokenType, , startIndex, endIndex, parsedValue] = childNode.value;
+					const atRuleIndex = atRuleParamIndex(atRule);
 
-						if (tokenType !== TokenType.Dimension) {
-							return;
-						}
-
-						if (unitList.includes(parsedValue.unit.toLowerCase())) {
-							return;
-						}
-
-						const atRuleIndex = atRuleParamIndex(atRule);
-
-						report({
-							message: messages.rejected(parsedValue.unit, featureName),
-							node: atRule,
-							index: atRuleIndex + startIndex,
-							endIndex: atRuleIndex + endIndex + 1,
-							result,
-							ruleName,
-						});
+					report({
+						message: messages.rejected(parsedValue.unit, mediaFeatureName),
+						node: atRule,
+						index: atRuleIndex + startIndex,
+						endIndex: atRuleIndex + endIndex + 1,
+						result,
+						ruleName,
 					});
-				});
+				}, initialState);
 			});
 		});
 	};

--- a/lib/rules/media-feature-name-value-no-unknown/index.js
+++ b/lib/rules/media-feature-name-value-no-unknown/index.js
@@ -234,7 +234,7 @@ const rule = (primary) => {
 			};
 
 			/** @type {State} */
-			const state = {
+			const initialState = {
 				mediaFeatureName: '',
 				mediaFeatureNameRaw: '',
 			};
@@ -242,11 +242,11 @@ const rule = (primary) => {
 			parseMediaQuery(atRule).forEach((mediaQuery) => {
 				if (isMediaQueryInvalid(mediaQuery)) return;
 
-				mediaQuery.walk((entry) => {
-					if (!entry.state) return;
+				mediaQuery.walk(({ node, state }) => {
+					if (!state) return;
 
-					if (isMediaFeature(entry.node)) {
-						const mediaFeatureNameRaw = entry.node.getName();
+					if (isMediaFeature(node)) {
+						const mediaFeatureNameRaw = node.getName();
 						let mediaFeatureName = vendor.unprefixed(mediaFeatureNameRaw.toLowerCase());
 
 						// Unknown media feature names are handled by "media-feature-name-no-unknown".
@@ -254,18 +254,18 @@ const rule = (primary) => {
 
 						mediaFeatureName = mediaFeatureName.replace(HAS_MIN_MAX_PREFIX, '');
 
-						entry.state.mediaFeatureName = mediaFeatureName;
-						entry.state.mediaFeatureNameRaw = mediaFeatureNameRaw;
+						state.mediaFeatureName = mediaFeatureName;
+						state.mediaFeatureNameRaw = mediaFeatureNameRaw;
 
 						return;
 					}
 
-					if (!entry.state.mediaFeatureName || !entry.state.mediaFeatureNameRaw) return;
+					if (!state.mediaFeatureName || !state.mediaFeatureNameRaw) return;
 
-					if (isMediaFeatureValue(entry.node)) {
-						checkMediaFeatureValue(entry.state, entry.node, reporter);
+					if (isMediaFeatureValue(node)) {
+						checkMediaFeatureValue(state, node, reporter);
 					}
-				}, state);
+				}, initialState);
 			});
 		});
 	};

--- a/lib/rules/media-feature-range-notation/index.js
+++ b/lib/rules/media-feature-range-notation/index.js
@@ -48,9 +48,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			mediaQueryList.forEach((mediaQuery) => {
 				if (isMediaQueryInvalid(mediaQuery)) return;
 
-				mediaQuery.walk((entry) => {
-					const node = entry.node;
-
+				mediaQuery.walk(({ node, parent }) => {
 					// Only look at plain and range notation media features
 					if (!isMediaFeatureRange(node) && !isMediaFeaturePlain(node)) return;
 
@@ -66,8 +64,6 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (!rangeTypeMediaFeatureNames.has(unprefixedMediaFeature)) return;
 
 					if (context.fix && primary === 'context' && isMediaFeaturePlain(node)) {
-						const parent = entry.parent;
-
 						if (!isMediaFeature(parent)) return;
 
 						hasFixes = true;

--- a/lib/rules/media-query-no-invalid/index.js
+++ b/lib/rules/media-query-no-invalid/index.js
@@ -49,21 +49,21 @@ const rule = (primary) => {
 					return;
 				}
 
-				mediaQuery.walk((entry) => {
-					// All general enclosured nodes are invalid.
-					if (isGeneralEnclosed(entry.node)) {
-						invalidNodes.push(entry.node);
+				mediaQuery.walk(({ node, parent }) => {
+					// All general enclosed nodes are invalid.
+					if (isGeneralEnclosed(node)) {
+						invalidNodes.push(node);
 
 						return;
 					}
 
 					// Invalid plain media features.
-					if (isMediaFeaturePlain(entry.node)) {
-						const name = entry.node.getName();
+					if (isMediaFeaturePlain(node)) {
+						const name = node.getName();
 
 						if (isCustomMediaQuery(name)) {
 							// In a plain context, custom media queries are invalid.
-							invalidNodes.push(entry.parent);
+							invalidNodes.push(parent);
 
 							return;
 						}
@@ -72,26 +72,26 @@ const rule = (primary) => {
 					}
 
 					// Invalid range media features.
-					if (isMediaFeatureRange(entry.node)) {
-						const name = entry.node.getName().toLowerCase();
+					if (isMediaFeatureRange(node)) {
+						const name = node.getName().toLowerCase();
 
 						if (isCustomMediaQuery(name)) {
 							// In a range context, custom media queries are invalid.
-							invalidNodes.push(entry.parent);
+							invalidNodes.push(parent);
 
 							return;
 						}
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid.
-							invalidNodes.push(entry.parent);
+							invalidNodes.push(parent);
 
 							return;
 						}
 
 						if (!rangeTypeMediaFeatureNames.has(name)) {
 							// In a range context, non-range typed features are invalid.
-							invalidNodes.push(entry.parent);
+							invalidNodes.push(parent);
 
 							return;
 						}
@@ -100,12 +100,12 @@ const rule = (primary) => {
 					}
 
 					// Invalid boolean media features.
-					if (isMediaFeatureBoolean(entry.node)) {
-						const name = entry.node.getName().toLowerCase();
+					if (isMediaFeatureBoolean(node)) {
+						const name = node.getName().toLowerCase();
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid
-							invalidNodes.push(entry.parent);
+							invalidNodes.push(parent);
 						}
 					}
 				});

--- a/lib/rules/number-max-precision/index.js
+++ b/lib/rules/number-max-precision/index.js
@@ -89,21 +89,21 @@ const rule = (primary, secondaryOptions) => {
 			}
 
 			parseListOfComponentValues(tokenize({ css: value })).forEach((componentValue) => {
-				const state = {
+				const initialState = {
 					ignored: false,
 					precision: primary,
 				};
 
-				walker(node, getIndex, componentValue, state);
+				walker(node, getIndex, componentValue, initialState);
 
 				if (isFunctionNode(componentValue) || isSimpleBlockNode(componentValue)) {
-					componentValue.walk((entry) => {
-						if (!entry.state) return;
+					componentValue.walk(({ node: mediaNode, state }) => {
+						if (!state) return;
 
-						if (entry.state.ignored) return;
+						if (state.ignored) return;
 
-						walker(node, getIndex, entry.node, entry.state);
-					}, state);
+						walker(node, getIndex, mediaNode, state);
+					}, initialState);
 				}
 			});
 		}

--- a/lib/rules/unit-disallowed-list/index.js
+++ b/lib/rules/unit-disallowed-list/index.js
@@ -121,31 +121,32 @@ const rule = (primary, secondaryOptions) => {
 
 			parseFromTokens(tokenizeWithoutPercentageTokens(params)).forEach((mediaQuery) => {
 				/** @type {{ mediaFeatureName: string | undefined }} */
-				const state = {
+				const initialState = {
 					mediaFeatureName: undefined,
 				};
 
-				mediaQuery.walk((entry) => {
-					if (!entry.state) return;
+				mediaQuery.walk(({ node, state }) => {
+					if (!state) return;
 
-					if (isMediaFeature(entry.node)) {
-						entry.state.mediaFeatureName = entry.node.getName().toLowerCase();
+					if (isMediaFeature(node)) {
+						state.mediaFeatureName = node.getName().toLowerCase();
 					}
 
-					if (!entry.state.mediaFeatureName) return;
+					if (!state.mediaFeatureName) return;
 
-					if (!isTokenNode(entry.node)) return;
+					if (!isTokenNode(node)) return;
 
 					check(
 						atRule,
 						atRuleParamIndex,
-						entry.node,
-						entry.state.mediaFeatureName,
+						node,
+						state.mediaFeatureName,
 						secondaryOptions?.ignoreMediaFeatureNames,
 					);
-				}, state);
+				}, initialState);
 			});
 		});
+
 		root.walkDecls((decl) => {
 			if (isUnicodeRangeDescriptor(decl)) return;
 
@@ -168,31 +169,25 @@ const rule = (primary, secondaryOptions) => {
 
 				if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) return;
 
-				const state = {
+				const initialState = {
 					ignored: componentValueIsIgnored(componentValue),
 				};
 
-				componentValue.walk((entry) => {
-					if (!entry.state) return;
+				componentValue.walk(({ node, state }) => {
+					if (!state) return;
 
-					if (entry.state.ignored) return;
+					if (state.ignored) return;
 
-					if (isTokenNode(entry.node)) {
-						check(
-							decl,
-							declarationValueIndex,
-							entry.node,
-							decl.prop,
-							secondaryOptions?.ignoreProperties,
-						);
+					if (isTokenNode(node)) {
+						check(decl, declarationValueIndex, node, decl.prop, secondaryOptions?.ignoreProperties);
 
 						return;
 					}
 
-					if (componentValueIsIgnored(entry.node)) {
-						entry.state.ignored = true;
+					if (componentValueIsIgnored(node)) {
+						state.ignored = true;
 					}
-				}, state);
+				}, initialState);
 			});
 		});
 	};

--- a/lib/rules/unit-no-unknown/index.js
+++ b/lib/rules/unit-no-unknown/index.js
@@ -147,26 +147,26 @@ const rule = (primary, secondaryOptions) => {
 			if (!tokens) return;
 
 			parseFromTokens(tokens).forEach((mediaQuery) => {
-				const state = {
+				const initialState = {
 					ignored: false,
 					allowX: false,
 				};
 
-				mediaQuery.walk((entry) => {
-					if (!entry.state) return;
+				mediaQuery.walk(({ node, state }) => {
+					if (!state) return;
 
-					if (entry.state.ignored) return;
+					if (state.ignored) return;
 
-					if (isMediaFeature(entry.node)) {
-						const name = entry.node.getName();
+					if (isMediaFeature(node)) {
+						const name = node.getName();
 
 						if (RESOLUTION_MEDIA_FEATURE_NAME.test(name)) {
-							entry.state.allowX = true;
+							state.allowX = true;
 						}
-					} else if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
-						check(atRule, atRuleParamIndex, entry.node, entry.state);
+					} else if (isFunctionNode(node) || isTokenNode(node)) {
+						check(atRule, atRuleParamIndex, node, state);
 					}
-				}, state);
+				}, initialState);
 			});
 		});
 
@@ -186,28 +186,28 @@ const rule = (primary, secondaryOptions) => {
 			const isImageResolutionProp = decl.prop.toLowerCase() === 'image-resolution';
 
 			parseListOfComponentValues(tokens).forEach((componentValue) => {
-				const state = {
+				const initialState = {
 					ignored: false,
 					allowX: isImageResolutionProp,
 				};
 
 				if (isFunctionNode(componentValue) || isTokenNode(componentValue)) {
-					check(decl, declarationValueIndex, componentValue, state);
+					check(decl, declarationValueIndex, componentValue, initialState);
 				}
 
 				if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) {
 					return;
 				}
 
-				componentValue.walk((entry) => {
-					if (!entry.state) return;
+				componentValue.walk(({ node, state }) => {
+					if (!state) return;
 
-					if (entry.state.ignored) return;
+					if (state.ignored) return;
 
-					if (isFunctionNode(entry.node) || isTokenNode(entry.node)) {
-						check(decl, declarationValueIndex, entry.node, entry.state);
+					if (isFunctionNode(node) || isTokenNode(node)) {
+						check(decl, declarationValueIndex, node, state);
 					}
-				}, state);
+				}, initialState);
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/issues/6848

> Is there anything in the PR that needs further explanation?

- consistent naming of `state`, `inititalState`
- consistently destructure `entry` into `{ node, state, ... }` 
- refactor `media-feature-name-unit-allowed-list` to use the `state` mechanic instead of dual walking

_this might not be the final refactor_
