### PR TITLE
Fix selector-pseudo-element-no-unknown performance

### DIFF
--- a/.changeset/smooth-tigers-wink.md
+++ b/.changeset/smooth-tigers-wink.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-element-no-unknown` performance

--- a/lib/rules/selector-pseudo-element-no-unknown/index.js
+++ b/lib/rules/selector-pseudo-element-no-unknown/index.js
@@ -42,15 +42,15 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
-
 			const selector = ruleNode.selector;
 
 			// Return early before parse if no pseudos for performance
 
 			if (!selector.includes(':')) {
+				return;
+			}
+
+			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

Aborting as early as possible, i.e. before any `isStandardSyntax*` checks, helps too. I've added that as the third aspect of https://github.com/stylelint/stylelint/issues/6869#issuecomment-1605428748.

Before:
Mean: 159.1181665714286 ms
Deviation: 18.599824916664016 ms

After:
Mean: 138.47696128571428 ms
Deviation: 16.776228134868457 ms


