### PR TITLE
Improve `npm run benchmark-rule` script and doc

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -287,7 +287,7 @@ Deprecating rules doesn't happen very often. When you do, you must:
 
 ## Improve the performance of a rule
 
-You can run a benchmarks on any given rule with any valid config using:
+You can run a benchmark on any given rule with any valid config using:
 
 ```shell
 npm run benchmark-rule -- ruleName ruleOptions [ruleContext]
@@ -296,21 +296,17 @@ npm run benchmark-rule -- ruleName ruleOptions [ruleContext]
 If the `ruleOptions` argument is anything other than a string or a boolean, it must be valid JSON wrapped in quotation marks.
 
 ```shell
-npm run benchmark-rule -- selector-combinator-space-after never
+npm run benchmark-rule -- value-keyword-case lower
 ```
 
 ```shell
-npm run benchmark-rule -- selector-combinator-space-after always
-```
-
-```shell
-npm run benchmark-rule -- block-opening-brace-space-before "[\"always\", {\"ignoreAtRules\": [\"else\"]}]"
+npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'
 ```
 
 If the `ruleContext` argument is specified, the sames procedure would apply:
 
 ```shell
-npm run benchmark-rule -- block-opening-brace-space-before "[\"always\", {\"ignoreAtRules\": [\"else\"]}]" "{\"fix\": \"true\"}"
+npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'
 ```
 
 The script loads Bootstrap's CSS (from its CDN) and runs it through the configured rule.

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -1,6 +1,6 @@
-'use strict';
-
 /* eslint-disable no-console */
+import { argv, exit } from 'node:process';
+
 import Benchmark from 'benchmark';
 import picocolors from 'picocolors';
 import postcss from 'postcss';
@@ -10,16 +10,31 @@ import rules from '../lib/rules/index.js';
 
 const { bold, yellow } = picocolors;
 
-const [, , ruleName, ruleOptions, ruleContext] = process.argv;
+const [, , ruleName, ruleOptions, ruleContext] = argv;
 
 const ruleFunc = rules[ruleName];
 
-if (!ruleFunc) {
-	throw new Error('You must specify a valid rule name');
+function printHelp() {
+	const script = 'node benchmark-rule.mjs';
+
+	console.log(`Usage: ${script} <ruleName> <ruleOptions> [ruleContext]`);
+	console.log('');
+	console.log('Examples:');
+	console.log('  # With a primary option');
+	console.log(`  ${script} value-keyword-case lower`);
+	console.log('');
+	console.log('  # With secondary options (JSON format)');
+	console.log(`  ${script} value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'`);
+	console.log('');
+	console.log('  # With a context');
+	console.log(
+		`  ${script} value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'`,
+	);
 }
 
-if (!ruleOptions) {
-	throw new Error('You must specify rule options');
+if (!ruleFunc || !ruleOptions) {
+	printHelp();
+	exit(-1);
 }
 
 const CSS_URL = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.css';


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

- Add the help output (usage and examples).
- Replace deprecated rule in the doc.

```console
$ npm run benchmark-rule -s
Usage: node benchmark-rule.mjs <ruleName> <ruleOptions> [ruleContext]

Examples:
  # With a primary option
  node benchmark-rule.mjs value-keyword-case lower

  # With secondary options (JSON format)
  node benchmark-rule.mjs value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'

  # With a context
  node benchmark-rule.mjs value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'
```

Ref: https://github.com/stylelint/stylelint/blob/15.9.0/lib/rules/value-keyword-case/README.md