### PR TITLE
Fix custom-property-pattern performance

### DIFF
--- a/.changeset/hot-doors-jump.md
+++ b/.changeset/hot-doors-jump.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `custom-property-pattern` performance

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -20,6 +20,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-pattern',
 };
 
+const VAR_FUNC_REGEX = /var\(/i;
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -49,7 +51,7 @@ const rule = (primary) => {
 		root.walkDecls((decl) => {
 			const { prop, value } = decl;
 
-			if (/var\(/i.test(value)) {
+			if (VAR_FUNC_REGEX.test(value)) {
 				const parsedValue = valueParser(value);
 
 				parsedValue.walk((node) => {

--- a/lib/rules/custom-property-pattern/index.js
+++ b/lib/rules/custom-property-pattern/index.js
@@ -40,8 +40,8 @@ const rule = (primary) => {
 		 */
 		function check(property) {
 			return (
-				!isStandardSyntaxProperty(property) ||
 				!isCustomProperty(property) ||
+				!isStandardSyntaxProperty(property) ||
 				regexpPattern.test(property.slice(2))
 			);
 		}
@@ -49,21 +49,23 @@ const rule = (primary) => {
 		root.walkDecls((decl) => {
 			const { prop, value } = decl;
 
-			const parsedValue = valueParser(value);
+			if (/var\(/i.test(value)) {
+				const parsedValue = valueParser(value);
 
-			parsedValue.walk((node) => {
-				if (!isValueFunction(node)) return;
+				parsedValue.walk((node) => {
+					if (!isValueFunction(node)) return;
 
-				if (node.value.toLowerCase() !== 'var') return;
+					if (node.value.toLowerCase() !== 'var') return;
 
-				const { nodes } = node;
+					const { nodes } = node;
 
-				const firstNode = nodes[0];
+					const firstNode = nodes[0];
 
-				if (!firstNode || check(firstNode.value)) return;
+					if (!firstNode || check(firstNode.value)) return;
 
-				complain(declarationValueIndex(decl) + firstNode.sourceIndex, firstNode.value, decl);
-			});
+					complain(declarationValueIndex(decl) + firstNode.sourceIndex, firstNode.value, decl);
+				});
+			}
 
 			if (check(prop)) return;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

Before: 
Mean: 148.86722335714288 ms
Deviation: 14.868270718260428 ms

After:
Mean: 120.50095842857144 ms
Deviation: 18.926086943302593 ms