### PR TITLE
Fix hue-degree-notation performance

### DIFF
--- a/.changeset/empty-starfishes-leave.md
+++ b/.changeset/empty-starfishes-leave.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `hue-degree-notation` performance

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -25,7 +25,7 @@ const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];
 const HUE_THIRD_ARG_FUNCS = ['lch'];
 const HUE_FUNCS = new Set([...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS]);
 const HAS_HUE_COLOR_FUNC = new RegExp(
-	`\\b(?:${[...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS].join('|')})\\(`,
+	`\\b(?:${[...HUE_FUNCS].join('|')})\\(`,
 	'i',
 );
 

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -24,6 +24,10 @@ const meta = {
 const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];
 const HUE_THIRD_ARG_FUNCS = ['lch'];
 const HUE_FUNCS = new Set([...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS]);
+const HAS_HUE_COLOR_FUNC = new RegExp(
+	`\\b(?:${[...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS].join('|')})\\(`,
+	'i',
+);
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
@@ -36,6 +40,8 @@ const rule = (primary, _secondaryOptions, context) => {
 		if (!validOptions) return;
 
 		root.walkDecls((decl) => {
+			if (!HAS_HUE_COLOR_FUNC.test(decl.value)) return;
+
 			let needsFix = false;
 			const parsedValue = valueParser(getDeclarationValue(decl));
 

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -24,10 +24,7 @@ const meta = {
 const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];
 const HUE_THIRD_ARG_FUNCS = ['lch'];
 const HUE_FUNCS = new Set([...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS]);
-const HAS_HUE_COLOR_FUNC = new RegExp(
-	`\\b(?:${[...HUE_FUNCS].join('|')})\\(`,
-	'i',
-);
+const HAS_HUE_COLOR_FUNC = new RegExp(`\\b(?:${[...HUE_FUNCS].join('|')})\\(`, 'i');
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

Mean: 120.86200307142857 ms
Deviation: 19.25088932105957 ms

To

Mean: 85.13097773333334 ms
Deviation: 8.810119272059223 ms
