### PR TITLE
Fix selector-id-pattern performance

### DIFF
--- a/.changeset/silly-eagles-grow.md
+++ b/.changeset/silly-eagles-grow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-id-pattern` performance

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -32,6 +32,8 @@ const rule = (primary) => {
 		const normalizedPattern = isString(primary) ? new RegExp(primary) : primary;
 
 		root.walkRules((ruleNode) => {
+			if (!ruleNode?.selector.includes('#')) return;
+
 			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}

--- a/lib/rules/selector-id-pattern/index.js
+++ b/lib/rules/selector-id-pattern/index.js
@@ -31,9 +31,7 @@ const rule = (primary) => {
 
 		const normalizedPattern = isString(primary) ? new RegExp(primary) : primary;
 
-		root.walkRules((ruleNode) => {
-			if (!ruleNode?.selector.includes('#')) return;
-
+		root.walkRules(/#/, (ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) {
 				return;
 			}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

Mean: 240.67508675000005 ms
Deviation: 20.382065001610304 ms

To

Mean: 85.73348046666666 ms
Deviation: 8.678100769643914 ms

Avoiding unnecessary selector parsing is a win. We seldom see id selectors in the wild.
