### PR TITLE
Fix `hue-degree-notation` false negatives for `oklch`

### DIFF
--- a/.changeset/ten-mirrors-clean.md
+++ b/.changeset/ten-mirrors-clean.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `hue-degree-notation` false negatives for `oklch`

--- a/lib/rules/hue-degree-notation/__tests__/index.js
+++ b/lib/rules/hue-degree-notation/__tests__/index.js
@@ -24,6 +24,9 @@ testRule({
 			description: 'malformed lch',
 		},
 		{
+			code: 'a { color: oklch(56.29% 19.86 10deg) }',
+		},
+		{
 			code: 'a { color: hsl(170deg 60% 50% / 15%) }',
 		},
 		{
@@ -97,6 +100,15 @@ testRule({
 			column: 29,
 			endLine: 1,
 			endColumn: 31,
+		},
+		{
+			code: 'a { color: oklch(56.29% 19.86 10) }',
+			fixed: 'a { color: oklch(56.29% 19.86 10deg) }',
+			message: messages.expected('10', '10deg'),
+			line: 1,
+			column: 31,
+			endLine: 1,
+			endColumn: 33,
 		},
 		{
 			code: 'a { color: hsl(/*comment*/120 60% 70%) }',
@@ -199,6 +211,15 @@ testRule({
 			column: 29,
 			endLine: 1,
 			endColumn: 34,
+		},
+		{
+			code: 'a { color: oklch(56.29% 19.86 10deg) }',
+			fixed: 'a { color: oklch(56.29% 19.86 10) }',
+			message: messages.expected('10deg', '10'),
+			line: 1,
+			column: 31,
+			endLine: 1,
+			endColumn: 36,
 		},
 		{
 			code: stripIndent`

--- a/lib/rules/hue-degree-notation/index.js
+++ b/lib/rules/hue-degree-notation/index.js
@@ -22,7 +22,7 @@ const meta = {
 };
 
 const HUE_FIRST_ARG_FUNCS = ['hsl', 'hsla', 'hwb'];
-const HUE_THIRD_ARG_FUNCS = ['lch'];
+const HUE_THIRD_ARG_FUNCS = ['lch', 'oklch'];
 const HUE_FUNCS = new Set([...HUE_FIRST_ARG_FUNCS, ...HUE_THIRD_ARG_FUNCS]);
 
 /** @type {import('stylelint').Rule} */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7014

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
