### PR TITLE
Switch Jest `coverageProvider` from `babel` (default) to `v8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
       "!lib/**/{__tests__,testUtils}/**/*.{js,mjs}"
     ],
     "coverageDirectory": "./.coverage/",
+    "coverageProvider": "v8",
     "coverageReporters": [
       "lcov",
       "text-summary"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #4562

> Is there anything in the PR that needs further explanation?

This change should prevent potential out-of-memory errors. See <https://github.com/stylelint/stylelint/pull/7024#issuecomment-1616548676>.

Ref:
- https://jestjs.io/docs/29.0/configuration#coverageprovider-string
- https://jestjs.io/blog/2020/01/21/jest-25#v8-code-coverage
