### PR TITLE
Refactor to use `sourceIndices` utility from `@csstools/css-parser-algorithms`

### DIFF
--- a/lib/rules/media-feature-name-unit-allowed-list/index.js
+++ b/lib/rules/media-feature-name-unit-allowed-list/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const report = require('../../utils/report');
-const ruleMessages = require('../../utils/ruleMessages');
-const validateOptions = require('../../utils/validateOptions');
 const { TokenType } = require('@csstools/css-tokenizer');
 const { isTokenNode } = require('@csstools/css-parser-algorithms');
 const {
@@ -10,6 +7,10 @@ const {
 	isMediaFeatureRange,
 	isMediaQueryInvalid,
 } = require('@csstools/media-query-list-parser');
+
+const report = require('../../utils/report');
+const ruleMessages = require('../../utils/ruleMessages');
+const validateOptions = require('../../utils/validateOptions');
 const validateObjectWithArrayProps = require('../../utils/validateObjectWithArrayProps');
 const { isString } = require('../../utils/validateTypes');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp');

--- a/lib/rules/media-feature-name-value-allowed-list/index.js
+++ b/lib/rules/media-feature-name-value-allowed-list/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { sourceIndices } = require('@csstools/css-parser-algorithms');
 const {
 	isMediaQueryInvalid,
 	isMediaFeature,
@@ -80,7 +81,7 @@ const rule = (primary) => {
 					}
 
 					const atRuleIndex = atRuleParamIndex(atRule);
-					const [startIndex, endIndex] = startAndEndIndex(componentValues);
+					const [startIndex, endIndex] = sourceIndices(componentValues);
 
 					report({
 						index: atRuleIndex + startIndex,
@@ -96,40 +97,6 @@ const rule = (primary) => {
 		});
 	};
 };
-
-/**
- * A recursive function that returns the start and end boundaries of a node.
- *
- * @template {import('@csstools/css-tokenizer').CSSToken} T
- * @param {Array<{ tokens(): Array<T> }> | { tokens(): Array<T> }} node
- * @returns {[number, number]}
- */
-function startAndEndIndex(node) {
-	if (Array.isArray(node)) {
-		const nodeStart = node[0];
-
-		if (!nodeStart) return [0, 0];
-
-		const nodeEnd = node[node.length - 1] || nodeStart;
-
-		const [startA] = startAndEndIndex(nodeStart);
-		const [, endB] = startAndEndIndex(nodeEnd);
-
-		return [startA, endB];
-	}
-
-	const tokens = node.tokens();
-
-	const firstToken = tokens[0];
-	const lastToken = tokens[tokens.length - 1];
-
-	if (!firstToken || !lastToken) return [0, 0];
-
-	const start = firstToken[2];
-	const end = lastToken[3];
-
-	return [start, end];
-}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-name-value-no-unknown/index.js
+++ b/lib/rules/media-feature-name-value-no-unknown/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { TokenType, NumberType } = require('@csstools/css-tokenizer');
-const { isTokenNode, isFunctionNode } = require('@csstools/css-parser-algorithms');
+const { isTokenNode, isFunctionNode, sourceIndices } = require('@csstools/css-parser-algorithms');
 const {
 	isMediaFeature,
 	isMediaFeatureValue,
@@ -161,7 +161,7 @@ const rule = (primary) => {
 			}
 
 			// An unexpected function or a media feature that doesn't support types that can be the result of a function.
-			reporter(state, functionNode.toString(), ...startAndEndIndex(functionNode));
+			reporter(state, functionNode.toString(), ...sourceIndices(functionNode));
 		}
 
 		/**
@@ -187,7 +187,7 @@ const rule = (primary) => {
 			reporter(
 				state,
 				componentValues.map((x) => x.toString()).join(''),
-				...startAndEndIndex(componentValues),
+				...sourceIndices(componentValues),
 			);
 		}
 
@@ -270,40 +270,6 @@ const rule = (primary) => {
 		});
 	};
 };
-
-/**
- * A recursive function that returns the start and end boundaries of a node.
- *
- * @template {import('@csstools/css-tokenizer').CSSToken} T
- * @param {Array<{ tokens(): Array<T> }> | { tokens(): Array<T> }} node
- * @returns {[number, number]}
- */
-function startAndEndIndex(node) {
-	if (Array.isArray(node)) {
-		const nodeStart = node[0];
-
-		if (!nodeStart) return [0, 0];
-
-		const nodeEnd = node[node.length - 1] || nodeStart;
-
-		const [startA] = startAndEndIndex(nodeStart);
-		const [, endB] = startAndEndIndex(nodeEnd);
-
-		return [startA, endB];
-	}
-
-	const tokens = node.tokens();
-
-	const firstToken = tokens[0];
-	const lastToken = tokens[tokens.length - 1];
-
-	if (!firstToken || !lastToken) return [0, 0];
-
-	const start = firstToken[2];
-	const end = lastToken[3];
-
-	return [start, end];
-}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/media-feature-range-notation/index.js
+++ b/lib/rules/media-feature-range-notation/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { TokenType } = require('@csstools/css-tokenizer');
+const { TokenNode, sourceIndices } = require('@csstools/css-parser-algorithms');
 const {
 	MediaFeatureName,
 	MediaFeatureRangeNameValue,
@@ -8,8 +10,6 @@ const {
 	isMediaFeatureRange,
 	isMediaQueryInvalid,
 } = require('@csstools/media-query-list-parser');
-const { TokenNode } = require('@csstools/css-parser-algorithms');
-const { TokenType } = require('@csstools/css-tokenizer');
 
 const atRuleParamIndex = require('../../utils/atRuleParamIndex');
 const parseMediaQuery = require('../../utils/parseMediaQuery');
@@ -94,17 +94,7 @@ const rule = (primary, _secondaryOptions, context) => {
 						return;
 					}
 
-					const tokens = node.tokens();
-					const firstToken = tokens[0];
-					const lastToken = tokens[tokens.length - 1];
-
-					let startIndex = 0;
-					let endIndex = atRule.params.length;
-
-					if (firstToken && lastToken) {
-						startIndex = firstToken[2];
-						endIndex = lastToken[3];
-					}
+					const [startIndex, endIndex] = sourceIndices(node);
 
 					const atRuleIndex = atRuleParamIndex(atRule);
 

--- a/lib/rules/media-query-no-invalid/index.js
+++ b/lib/rules/media-query-no-invalid/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { sourceIndices } = require('@csstools/css-parser-algorithms');
 const {
 	isMediaQueryInvalid,
 	isGeneralEnclosed,
@@ -116,7 +117,7 @@ const rule = (primary) => {
 			const atRuleParamIndexValue = atRuleParamIndex(atRule);
 
 			invalidNodes.forEach((invalidNode) => {
-				const [start, end] = startAndEndIndex(invalidNode);
+				const [start, end] = sourceIndices(invalidNode);
 
 				report({
 					message: messages.rejected,
@@ -131,26 +132,6 @@ const rule = (primary) => {
 		});
 	};
 };
-
-/**
- * A function that returns the start and end boundaries of a node.
- *
- * @param {{ tokens(): Array<import('@csstools/css-tokenizer').CSSToken> }} node
- * @returns {[number, number]}
- */
-function startAndEndIndex(node) {
-	const tokens = node.tokens();
-
-	const firstToken = tokens[0];
-	const lastToken = tokens[tokens.length - 1];
-
-	if (!firstToken || !lastToken) return [0, 0];
-
-	const start = firstToken[2];
-	const end = lastToken[3];
-
-	return [start, end];
-}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "15.9.0",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^2.2.0",
+        "@csstools/css-parser-algorithms": "^2.3.0",
         "@csstools/css-tokenizer": "^2.1.1",
-        "@csstools/media-query-list-parser": "^2.1.1",
-        "@csstools/selector-specificity": "^2.2.0",
+        "@csstools/media-query-list-parser": "^2.1.2",
+        "@csstools/selector-specificity": "^3.0.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
         "cosmiconfig": "^8.2.0",
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
-      "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.0.tgz",
+      "integrity": "sha512-dTKSIHHWc0zPvcS5cqGP+/TPFUJB0ekJ9dGKvMAFoNuBFhDPBt9OMGNZiIA5vTiNdGHHBeScYPXIGBMnVOahsA==",
       "funding": [
         {
           "type": "github",
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.1.tgz",
-      "integrity": "sha512-pUjtFbaKbiFNjJo8pprrIaXLvQvWIlwPiFnRI4sEnc4F0NIGTOsw8kaJSR3CmZAKEvV8QYckovgAnWQC0bgLLQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.2.tgz",
+      "integrity": "sha512-M8cFGGwl866o6++vIY7j1AKuq9v57cf+dGepScwCcbut9ypJNr4Cj+LLTWligYUZ0uyhEoJDKt5lvyBfh2L3ZQ==",
       "funding": [
         {
           "type": "github",
@@ -1509,23 +1509,29 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^2.2.0",
+        "@csstools/css-parser-algorithms": "^2.3.0",
         "@csstools/css-tokenizer": "^2.1.1"
       }
     },
     "node_modules/@csstools/selector-specificity": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
+      "integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
       "peerDependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "postcss-selector-parser": "^6.0.13"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -17014,9 +17020,9 @@
       }
     },
     "@csstools/css-parser-algorithms": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
-      "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.0.tgz",
+      "integrity": "sha512-dTKSIHHWc0zPvcS5cqGP+/TPFUJB0ekJ9dGKvMAFoNuBFhDPBt9OMGNZiIA5vTiNdGHHBeScYPXIGBMnVOahsA==",
       "requires": {}
     },
     "@csstools/css-tokenizer": {
@@ -17025,15 +17031,15 @@
       "integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA=="
     },
     "@csstools/media-query-list-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.1.tgz",
-      "integrity": "sha512-pUjtFbaKbiFNjJo8pprrIaXLvQvWIlwPiFnRI4sEnc4F0NIGTOsw8kaJSR3CmZAKEvV8QYckovgAnWQC0bgLLQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.2.tgz",
+      "integrity": "sha512-M8cFGGwl866o6++vIY7j1AKuq9v57cf+dGepScwCcbut9ypJNr4Cj+LLTWligYUZ0uyhEoJDKt5lvyBfh2L3ZQ==",
       "requires": {}
     },
     "@csstools/selector-specificity": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
+      "integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
       "requires": {}
     },
     "@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -130,10 +130,10 @@
     ]
   },
   "dependencies": {
-    "@csstools/css-parser-algorithms": "^2.2.0",
+    "@csstools/css-parser-algorithms": "^2.3.0",
     "@csstools/css-tokenizer": "^2.1.1",
-    "@csstools/media-query-list-parser": "^2.1.1",
-    "@csstools/selector-specificity": "^2.2.0",
+    "@csstools/media-query-list-parser": "^2.1.2",
+    "@csstools/selector-specificity": "^3.0.0",
     "balanced-match": "^2.0.0",
     "colord": "^2.9.3",
     "cosmiconfig": "^8.2.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, this is more cleanup after migrating to parsers from `@csstools`.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
