### PR TITLE
Fix `patch-package` warning

### DIFF
--- a/patches/@changesets+apply-release-plan+6.1.4.patch
+++ b/patches/@changesets+apply-release-plan+6.1.4.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
-index c2e8d2f..3e40b6e 100644
+index a537ba7..27062a3 100644
 --- a/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
 +++ b/node_modules/@changesets/apply-release-plan/dist/apply-release-plan.cjs.dev.js
-@@ -199,7 +199,7 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
+@@ -203,7 +203,7 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
    onlyUpdatePeerDependentsWhenOutOfRange
  }) {
    if (release.type === "none") return null;
@@ -11,7 +11,7 @@ index c2e8d2f..3e40b6e 100644
      major: [],
      minor: [],
      patch: []
-@@ -240,6 +240,15 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
+@@ -244,6 +244,15 @@ async function getChangelogEntry(release, releases, changesets, changelogFuncs,
    });
    let relevantChangesets = changesets.filter(cs => relevantChangesetIds.has(cs.id));
    changelogLines.patch.push(changelogFuncs.getDependencyReleaseLine(relevantChangesets, dependentReleases, changelogOpts));


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change fixes the following warning when running `npm install`:

```
Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    @changesets/apply-release-plan@6.1.3

  applied to

    @changesets/apply-release-plan@6.1.4

  At path

    node_modules/@changesets/apply-release-plan

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package @changesets/apply-release-plan

  to update the version in the patch file name and make this warning go away.

---
patch-package finished with 1 warning(s).
```
