### PR TITLE
Fix `selector-anb-no-unmatchable` performance

### DIFF
--- a/.changeset/olive-candles-fry.md
+++ b/.changeset/olive-candles-fry.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-anb-no-unmatchable` performance

--- a/lib/rules/selector-anb-no-unmatchable/index.js
+++ b/lib/rules/selector-anb-no-unmatchable/index.js
@@ -46,13 +46,11 @@ const rule = (primary) => {
 		}
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
+			if (!hasANPlusBNotationPseudoClasses(ruleNode.selector)) return;
+
+			if (!isStandardSyntaxRule(ruleNode)) return;
 
 			ruleNode.selectors.forEach((selector) => {
-				if (!hasANPlusBNotationPseudoClasses(selector)) return;
-
 				let cssTreeSelector;
 
 				try {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/issues/6869

> Is there anything in the PR that needs further explanation?

This improves on https://github.com/stylelint/stylelint/pull/6925

Before :

```
Warnings: 0
Mean: 146.26963685714287 ms
Deviation: 14.709092200789456 ms
```

After :

```
Warnings: 0
Mean: 108.34356249999999 ms
Deviation: 16.841513983168 ms
```
