### PR TITLE
Introduce Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,17 @@ updates:
     labels:
       - 'pr: dependencies'
     versioning-strategy: increase
+    groups:
+      changesets:
+        patterns: ['@changesets/*']
+      eslint:
+        patterns: ['eslint', 'eslint-*']
+      jest:
+        patterns: ['jest', 'jest-*', '@jest/*']
+      stylelint:
+        patterns: ['@stylelint/*']
+      typescript:
+        patterns: ['typescript', '@types/*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR aims to reduce Dependabot PRs.

The new feature is now public beta. See:
https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

Including only dev dependencies is intentional. Welcome any feedback.

Here's an example in my personal repository: https://github.com/ybiquitous/npm-audit-fix-action/pull/759