### PR TITLE
Fix `selector-pseudo-element-no-unknown` false positives for `view-transition` pseudo-elements

### DIFF
--- a/.changeset/lazy-geese-begin.md
+++ b/.changeset/lazy-geese-begin.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Add support for view-transition pseudo-elements
+Fixed: `selector-pseudo-element-no-unknown` false positives for `view-transition` pseudo-elements

--- a/.changeset/lazy-geese-begin.md
+++ b/.changeset/lazy-geese-begin.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Add support for view-transition pseudo-elements

--- a/lib/reference/selectors.js
+++ b/lib/reference/selectors.js
@@ -177,6 +177,11 @@ const pseudoElements = uniteSets(
 		'slotted',
 		'spelling-error',
 		'target-text',
+		'view-transition',
+		'view-transition-group',
+		'view-transition-image-pair',
+		'view-transition-old',
+		'view-transition-new',
 	],
 );
 

--- a/lib/reference/selectors.js
+++ b/lib/reference/selectors.js
@@ -181,7 +181,7 @@ const pseudoElements = uniteSets(
 		'view-transition-group',
 		'view-transition-image-pair',
 		'view-transition-new',
-		'view-transition-new',
+		'view-transition-old',
 	],
 );
 

--- a/lib/reference/selectors.js
+++ b/lib/reference/selectors.js
@@ -180,7 +180,7 @@ const pseudoElements = uniteSets(
 		'view-transition',
 		'view-transition-group',
 		'view-transition-image-pair',
-		'view-transition-old',
+		'view-transition-new',
 		'view-transition-new',
 	],
 );


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Resolves https://github.com/stylelint/stylelint/issues/7069

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory. I've added some details in the linked issue.