### PR TITLE
[Docs] Fix table formatting in deprecated rules user guide

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -478,7 +478,7 @@ These rules are deprecated — we won't fix bugs nor add options, and we will re
 
 <!-- prettier-ignore-start -->
 | | | |
-| -: |
+| :-- | :-: | :-: |
 | [`declaration-block-semicolon-newline-after`](../../lib/rules/declaration-block-semicolon-newline-after/README.md)<br/>Require a newline or disallow whitespace after the semicolons of declaration blocks. | | 🔧 |
 | [`declaration-block-semicolon-newline-before`](../../lib/rules/declaration-block-semicolon-newline-before/README.md)<br/>Require a newline or disallow whitespace before the semicolons of declaration blocks. | | |
 | [`declaration-block-semicolon-space-after`](../../lib/rules/declaration-block-semicolon-space-after/README.md)<br/>Require a single space or disallow whitespace after the semicolons of declaration blocks. | | 🔧 |


### PR DESCRIPTION
Currently migrating a project to v15 and noticed a [misformatted section](https://stylelint.io/user-guide/rules/#declaration-block) in the deprecated rules guide (btw, thank you for such a clear and thorough migration guide).

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
