### PR TITLE
Fix `declaration-property-value-no-unknown` false negatives for nested declarations

### DIFF
--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
@@ -10,6 +10,9 @@ testRule({
 			code: 'a { top: 0; }',
 		},
 		{
+			code: 'a { @media screen { top: 0; } }',
+		},
+		{
 			code: 'a { margin: auto 10em; }',
 		},
 		{
@@ -65,6 +68,14 @@ testRule({
 			column: 10,
 			endLine: 1,
 			endColumn: 17,
+		},
+		{
+			code: 'a { @media screen { top: unknown; } }',
+			message: messages.rejected('top', 'unknown'),
+			line: 1,
+			column: 26,
+			endLine: 1,
+			endColumn: 33,
 		},
 		{
 			code: 'a { top: red; }',

--- a/lib/rules/declaration-property-value-no-unknown/index.js
+++ b/lib/rules/declaration-property-value-no-unknown/index.js
@@ -28,6 +28,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown',
 };
 
+const CONDITIONAL_RULES_ALLOWED_IN_NESTING = /^(?:media|supports|layer|scope|container)$/i;
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -111,7 +113,7 @@ const rule = (primary, secondaryOptions) => {
 			}
 
 			const { error } =
-				parent && isAtRule(parent)
+				parent && isAtRule(parent) && !CONDITIONAL_RULES_ALLOWED_IN_NESTING.test(parent.name)
 					? forkedLexer.matchAtruleDescriptor(parent.name, prop, cssTreeValueNode)
 					: forkedLexer.matchProperty(prop, cssTreeValueNode);
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7062

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
