### PR TITLE
Fix broken `scripts/visual.sh`

### DIFF
--- a/scripts/visual.sh
+++ b/scripts/visual.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 set -u
 
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+
+cd "${SCRIPT_DIR}" || exit
+
+stylelint() {
+	"${SCRIPT_DIR}/../bin/stylelint.mjs" "$@"
+}
+
 echo "########## Compact formatter ##########"
 echo ""
-node ../bin/stylelint.js visual.css --config visual-config.mjs --formatter compact
+stylelint visual.css --config visual-config.mjs --formatter compact
 echo ""
 
 echo ""
 echo "########## Default formatter ##########"
-node ../bin/stylelint.js visual.css --config visual-config.json
+stylelint visual.css --config visual-config.json
 
 echo "########## Verbose formatter ##########"
-node ../bin/stylelint.js visual.css --config visual-config.cjs --formatter verbose
+stylelint visual.css --config visual-config.cjs --formatter verbose


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #7043 (where renaming happened)

> Is there anything in the PR that needs further explanation?

This change fixes the following error. The correct path is `bin/stylelint.mjs`, not `bin/stylelint.js`.

```console
$ ./scripts/visual.sh
...
node:internal/modules/cjs/loader:1051
  throw err;
  ^

Error: Cannot find module '/Users/masafumi.koba/git/stylelint/bin/stylelint.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Module._load (node:internal/modules/cjs/loader:901:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
...
```
