### PR TITLE
Avoid heap out of memory with CI coverage job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,9 @@ jobs:
 
       - name: Test with coverage
         run: npm run test-coverage
+        env:
+          # https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes
+          NODE_OPTIONS: '--max-old-space-size=4096'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change aims to avoid the following error that sometimes happens with the CI test coverage job.

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

See https://github.com/stylelint/stylelint/actions/runs/5670173698/job/15364468310#step:6:263

I refered to this solution on <https://github.com/actions/runner-images/issues/70#issuecomment-1191708172>.
