### PR TITLE
Improve Pull Request title for preparing release

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -37,11 +37,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get changeset status
+        id: get-changeset-status
+        run: |
+          npx changeset status --output .changeset/status.json
+          new_version=$(jq -r '.releases[0].newVersion' < .changeset/status.json)
+          rm -v .changeset/status.json
+          echo "new-version=${new_version}" >> "$GITHUB_OUTPUT"
+
       - name: Create release pull request
         uses: changesets/action@v1
         with:
-          commit: Prepare release
-          title: Prepare release
+          commit: Prepare ${{ steps.get-changeset-status.outputs.new-version }}
+          title: Prepare ${{ steps.get-changeset-status.outputs.new-version }}
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
           # We're also restoring `package.json` because we're using `np` for publishing
           version: npm run version


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #7089

> Is there anything in the PR that needs further explanation?

This change aims to make a Pull Request title for preparing release clearer.
For example, changing from `Prepare release` to `Prepare 15.10.3`.

For example, we can locally confirm the script:

```console
$ npx changeset status --output .changeset/status.json

$ new_version=$(jq -r '.releases[0].newVersion' < .changeset/status.json)

$ echo "new-version=${new_version}"
new-version=15.10.3
```
