### PR TITLE
Group Dependabot updates by `@csstools/*` parser packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       - 'pr: dependencies'
     versioning-strategy: increase
     groups:
+      csstools-parser:
+        patterns: ['@csstools/*']
+        exclude-patterns: ['@csstools/selector-specificity'] # unrelated to other parser packages
       changesets:
         patterns: ['@changesets/*']
       eslint:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref:
- #7105 
- #7106
- #7107

> Is there anything in the PR that needs further explanation?

This change aims to assemble Dependabot Pull Requests about `@csstools/*` parser packages.

@romainmenke Any thoughts?