### PR TITLE
Fix CLI to print unfixed errors when --fix is used with --stdin

### DIFF
--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -4,7 +4,7 @@ import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-import { jest } from '@jest/globals';
+import { expect, jest } from '@jest/globals';
 import stripAnsi from 'strip-ansi';
 
 import readJSONFile from '../testUtils/readJSONFile.mjs';
@@ -257,8 +257,9 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(2);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		expect(process.stdout.write).toHaveBeenCalledWith(
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringMatching(/Needless disable for "color-named".*Unexpected empty block/s),
 		);
 	});
@@ -272,8 +273,9 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(2);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		expect(process.stdout.write).toHaveBeenCalledWith(
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringContaining('Rule "block-no-empty" may not be disabled'),
 		);
 	});
@@ -288,8 +290,9 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(2);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		expect(process.stdout.write).toHaveBeenCalledWith(
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringContaining('Disable for "block-no-empty" is missing a description'),
 		);
 	});
@@ -299,8 +302,9 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(2);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		expect(process.stdout.write).toHaveBeenNthCalledWith(
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenNthCalledWith(
 			1,
 			expect.stringContaining('Unexpected empty source'),
 		);
@@ -315,13 +319,14 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(1);
 
+		expect(process.stdout.write).not.toHaveBeenCalled();
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringContaining('Cannot find module'),
 		);
 	});
 
-	it('outputs a valid JSON even if max warnings exceeded', async () => {
+	it('outputs a valid JSON to stderr even if max warnings exceeded', async () => {
 		await cli([
 			'--formatter=json',
 			'--max-warnings=0',
@@ -332,14 +337,14 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(2);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		const output = JSON.parse(process.stdout.write.mock.calls[0][0]);
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(2);
+		const output = JSON.parse(process.stderr.write.mock.calls[0][0]);
 
 		expect(output).toBeInstanceOf(Array);
 		expect(output[0]).toHaveProperty('source', expect.stringContaining('empty-block.css'));
 
-		expect(process.stderr.write).toHaveBeenCalledTimes(1);
-		expect(stripAnsi(process.stderr.write.mock.calls[0][0])).toContain(
+		expect(stripAnsi(process.stderr.write.mock.calls[1][0])).toContain(
 			'Max warnings exceeded: 1 found. 0 allowed',
 		);
 	});
@@ -355,6 +360,7 @@ describe('CLI', () => {
 		expect(process.exitCode).toBe(2);
 
 		expect(process.stdout.write).toHaveBeenCalledTimes(0);
+		expect(process.stderr.write).toHaveBeenCalledTimes(0);
 	});
 
 	it('--quiet-deprecation-warnings', async () => {
@@ -367,9 +373,9 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(2);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-
-		expect(process.stdout.write.mock.calls[0][0]).toEqual(
+		expect(process.stdout.write).toHaveBeenCalledTimes(0);
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write.mock.calls[0][0]).toEqual(
 			expect.not.stringContaining('The "color-hex-case" rule is deprecated.'),
 		);
 	});
@@ -382,10 +388,9 @@ describe('CLI', () => {
 			fixturesPath('empty-block.css'),
 		]);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		const output = process.stdout.write.mock.calls[0][0];
-
-		expect(output).toBe('Custom formatter reports 1 warning(s).');
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith('Custom formatter reports 1 warning(s).');
 	});
 
 	it('--custom-formatter with node module', async () => {
@@ -396,16 +401,17 @@ describe('CLI', () => {
 			fixturesPath('empty-block.css'),
 		]);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		const output = process.stdout.write.mock.calls[0][0];
-
-		expect(output).toBe('Custom formatter reports 1 warning(s).');
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith('Custom formatter reports 1 warning(s).');
 	});
 
 	it('output a message when wrong --globby-options provided', async () => {
 		await cli(['--globby-options=wrong']);
 
 		expect(process.exitCode).toBe(2);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
 		expect(process.stdout.write).toHaveBeenCalledTimes(0);
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(stripAnsi(process.stderr.write.mock.calls[0][0])).toContain(
@@ -421,8 +427,11 @@ describe('CLI', () => {
 			fixturesPath('globby-options'),
 		]);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		expect(process.stdout.write).toHaveBeenCalledWith(expect.stringMatching(/block-no-empty/));
+		expect(process.exitCode).toBe(2);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(expect.stringMatching(/block-no-empty/));
 	});
 
 	it('--custom-syntax', async () => {
@@ -433,8 +442,11 @@ describe('CLI', () => {
 			fixturesPath('invalid-hex.scss'),
 		]);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		expect(process.stdout.write).toHaveBeenCalledWith(
+		expect(process.exitCode).toBe(2);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringMatching(/color-no-invalid-hex/),
 		);
 	});
@@ -449,8 +461,11 @@ describe('CLI', () => {
 			fixturesPath('invalid-hex.scss'),
 		]);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(1);
-		expect(process.stdout.write).toHaveBeenCalledWith(
+		expect(process.exitCode).toBe(2);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringMatching(/color-no-invalid-hex/),
 		);
 	});

--- a/lib/__tests__/getCleanOutput.mjs
+++ b/lib/__tests__/getCleanOutput.mjs
@@ -1,0 +1,23 @@
+import stripAnsi from 'strip-ansi';
+
+const symbolConversions = new Map();
+
+symbolConversions.set('ℹ', 'i');
+symbolConversions.set('✔', '√');
+symbolConversions.set('⚠', '‼');
+symbolConversions.set('✖', '×');
+
+/**
+ * @param {string} output
+ *
+ * @returns {string}
+ */
+export default function getCleanOutput(output) {
+	let cleanOutput = stripAnsi(output).trim();
+
+	for (const [nix, win] of symbolConversions.entries()) {
+		cleanOutput = cleanOutput.replace(new RegExp(nix, 'g'), win);
+	}
+
+	return cleanOutput;
+}

--- a/lib/__tests__/standalone-fix.test.mjs
+++ b/lib/__tests__/standalone-fix.test.mjs
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import { stripIndent, stripIndents } from 'common-tags';
+import { expect } from '@jest/globals';
 
+import getCleanOutput from './getCleanOutput.mjs';
 import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import safeChdir from '../testUtils/safeChdir.mjs';
 import standalone from '../standalone.js';
@@ -21,9 +23,14 @@ it('outputs fixed code when input is code string', async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
-	expect(result.output).toBe('a { color: red; }');
+	expect(result.code).toBe('a { color: red; }');
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+	  Deprecation warnings:
+	   - The \"indentation\" rule is deprecated.
+	`);
 });
 
 it('fixes when enabled in config', async () => {
@@ -34,9 +41,14 @@ it('fixes when enabled in config', async () => {
 		},
 	};
 
-	const { output } = await standalone({ code: 'a { color: #ffffff; }', config });
+	const result = await standalone({
+		code: 'a { color: #ffffff; }',
+		config,
+		formatter: 'string',
+	});
 
-	expect(output).toBe('a { color: #fff; }');
+	expect(result.code).toBe('a { color: #fff; }');
+	expect(getCleanOutput(result.output)).toBe('');
 });
 
 it('apply indentation autofix at last', async () => {
@@ -49,11 +61,17 @@ it('apply indentation autofix at last', async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
-	expect(result.output).toBe(
+	expect(result.code).toBe(
 		'a {\n  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1),\n    0 0 0 1px rgba(0, 0, 0, 0.2),\n    inset 0 1px 2px 0 rgba(0, 0, 0, 0.1);\n}',
 	);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The "value-list-comma-newline-after" rule is deprecated.
+		 - The "indentation" rule is deprecated.
+	`);
 });
 
 it("doesn't fix with stylelint-disable commands", async () => {
@@ -71,9 +89,14 @@ it("doesn't fix with stylelint-disable commands", async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
-	expect(result.output).toBe(code);
+	expect(result.code).toBe(code);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The "indentation" rule is deprecated.
+	`);
 });
 
 it("doesn't fix with scoped stylelint-disable commands", async () => {
@@ -91,9 +114,14 @@ it("doesn't fix with scoped stylelint-disable commands", async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
-	expect(result.output).toBe(code);
+	expect(result.code).toBe(code);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The "indentation" rule is deprecated.
+	`);
 });
 
 it("doesn't fix with multiple scoped stylelint-disable commands", async () => {
@@ -112,9 +140,14 @@ it("doesn't fix with multiple scoped stylelint-disable commands", async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
-	expect(result.output).toBe(code);
+	expect(result.code).toBe(code);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The "indentation" rule is deprecated.
+	`);
 });
 
 it("the color-hex-length rule doesn't fix with scoped stylelint-disable commands", async () => {
@@ -131,13 +164,18 @@ it("the color-hex-length rule doesn't fix with scoped stylelint-disable commands
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
-	expect(result.output).toBe(stripIndent`
+	expect(result.code).toBe(stripIndent`
 		/* stylelint-disable color-hex-length */
 		a {
 		  color: #ffffff;
 		}`);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The "indentation" rule is deprecated.
+	`);
 });
 
 it("the indentation rule doesn't fix with scoped stylelint-disable commands", async () => {
@@ -154,13 +192,18 @@ it("the indentation rule doesn't fix with scoped stylelint-disable commands", as
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
-	expect(result.output).toBe(stripIndent`
+	expect(result.code).toBe(stripIndent`
 		/* stylelint-disable indentation */
 		a {
 			color: #fff;
 		}`);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The "indentation" rule is deprecated.
+	`);
 });
 
 describe('writing fixes to files', () => {
@@ -178,8 +221,8 @@ describe('writing fixes to files', () => {
 		await rm(tempFile, { force: true });
 	});
 
-	it('overwrites the original file', async () => {
-		const output = await standalone({
+	it('overwrites the original file and returns unfixable errors', async () => {
+		const result = await standalone({
 			files: [tempFile],
 			config: {
 				rules: {
@@ -189,17 +232,28 @@ describe('writing fixes to files', () => {
 				},
 			},
 			fix: true,
+			formatter: 'string',
 		});
 
-		const result = output.results[0]._postcssResult;
-
+		const postcssResult = result.results[0]._postcssResult;
 		const fileContent = await readFile(tempFile, 'utf8');
 
-		expect(fileContent).toBe(result.root.toString(result.opts.syntax));
+		expect(fileContent).toBe(postcssResult.root.toString(postcssResult.opts.syntax));
+
+		expect(result.code).toBeUndefined();
+		expect(getCleanOutput(result.output)).toBe(stripIndent`
+			Deprecation warnings:
+			 - The "at-rule-name-case" rule is deprecated.
+			
+			stylesheet.css
+			 7:1  ×  Unexpected empty comment  comment-no-empty
+			
+			1 problem (1 error, 0 warnings)
+		`);
 	});
 
 	it("doesn't write to ignored file", async () => {
-		await standalone({
+		const result = await standalone({
 			files: [tempFile],
 			config: {
 				ignoreFiles: tempFile,
@@ -210,12 +264,16 @@ describe('writing fixes to files', () => {
 				},
 			},
 			fix: true,
+			formatter: 'string',
 		});
 
 		const newFile = await readFile(tempFile, 'utf8');
 		const oldFile = await readFile(fixturesPath('fix.css'), 'utf8');
 
 		expect(newFile).toBe(oldFile);
+
+		expect(result.code).toBeUndefined();
+		expect(getCleanOutput(result.output)).toBe('');
 	});
 
 	// eslint-disable-next-line jest/no-disabled-tests
@@ -246,6 +304,7 @@ it('one rule being disabled', async () => {
 
 	const result = await standalone({
 		code,
+		codeFilename: 'test.css',
 		config: {
 			rules: {
 				indentation: [
@@ -257,10 +316,22 @@ it('one rule being disabled', async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
 	expect(result.results[0].errored).toBe(true);
-	expect(result.output).toBe(code);
+	expect(result.code).toBe(code);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The \"indentation\" rule is deprecated.
+		
+		test.css
+		 2:3  ×  Expected indentation of 0 spaces  indentation
+		 3:4  ×  Expected indentation of 2 spaces  indentation
+		 4:3  ×  Expected indentation of 0 spaces  indentation
+		
+		3 problems (3 errors, 0 warnings)
+	`);
 });
 
 it('two rules being disabled', async () => {
@@ -271,6 +342,7 @@ it('two rules being disabled', async () => {
 
 	const result = await standalone({
 		code,
+		codeFilename: 'test.css',
 		config: {
 			rules: {
 				indentation: [
@@ -288,6 +360,7 @@ it('two rules being disabled', async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
 	const warnings = result.results[0].warnings;
@@ -298,7 +371,20 @@ it('two rules being disabled', async () => {
 	expect(warnings.some((w) => w.text === 'Expected "COLOR" to be "color" (property-case)')).toBe(
 		true,
 	);
-	expect(result.output).toBe(code);
+	expect(result.code).toBe(code);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The "property-case" rule is deprecated.
+		 - The "indentation" rule is deprecated.
+		
+		test.css
+		 2:3  ×  Expected indentation of 0 spaces  indentation
+		 3:4  ×  Expected "COLOR" to be "color"    property-case
+		 3:4  ×  Expected indentation of 2 spaces  indentation
+		 4:3  ×  Expected indentation of 0 spaces  indentation
+		
+		4 problems (4 errors, 0 warnings)
+	`);
 });
 
 it('one rule being disabled and another still autofixing', async () => {
@@ -310,6 +396,7 @@ it('one rule being disabled and another still autofixing', async () => {
 
 	const result = await standalone({
 		code,
+		codeFilename: 'test.css',
 		config: {
 			rules: {
 				indentation: [0],
@@ -322,6 +409,7 @@ it('one rule being disabled and another still autofixing', async () => {
 			},
 		},
 		fix: true,
+		formatter: 'string',
 	});
 
 	const warnings = result.results[0].warnings;
@@ -332,5 +420,52 @@ it('one rule being disabled and another still autofixing', async () => {
 	expect(warnings.some((w) => w.text === 'Expected "COLOR" to be "color" (property-case)')).toBe(
 		true,
 	);
-	expect(result.output).toBe(stripIndents(code));
+	expect(result.code).toBe(stripIndents(code));
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		Deprecation warnings:
+		 - The \"property-case\" rule is deprecated.
+		 - The \"indentation\" rule is deprecated.
+		
+		test.css
+		 2:2  ×  Expected \"COLOR\" to be \"color\"  property-case
+		
+		1 problem (1 error, 0 warnings)
+	`);
+});
+
+it('returns partially fixed code and unfixed errors when not all errors are fixable', async () => {
+	const code = stripIndent`
+		a {
+		  color: #ffffff;
+		}
+		
+		div {}
+	`;
+
+	const result = await standalone({
+		code,
+		codeFilename: 'test.css',
+		config: {
+			rules: {
+				'block-no-empty': true,
+				'color-hex-length': 'short',
+			},
+		},
+		fix: true,
+		formatter: 'string',
+	});
+
+	expect(result.code).toBe(stripIndent`
+		a {
+		  color: #fff;
+		}
+
+		div {}
+	`);
+	expect(getCleanOutput(result.output)).toBe(stripIndent`
+		test.css
+		 5:5  ×  Unexpected empty block  block-no-empty
+		
+		1 problem (1 error, 0 warnings)
+	`);
 });

--- a/lib/cli.mjs
+++ b/lib/cli.mjs
@@ -555,11 +555,15 @@ export default async function main(argv) {
 
 	return standalone(options)
 		.then((linted) => {
-			if (!linted.output) {
+			if (!linted.output && !linted.code) {
 				return;
 			}
 
-			process.stdout.write(linted.output);
+			if (linted.code) {
+				process.stdout.write(linted.code);
+			}
+
+			process.stderr.write(linted.output);
 
 			if (options.outputFile) {
 				writeOutputFile(linted.output, options.outputFile).catch(handleError);

--- a/lib/rules/linebreaks/__tests__/integration.test.js
+++ b/lib/rules/linebreaks/__tests__/integration.test.js
@@ -4,7 +4,7 @@ const stylelint = require('../../../..');
 
 describe('integration tests for linebrakes', () => {
 	it('should not be an error (issues/3635).', async () => {
-		const { output } = await stylelint.lint({
+		const { code } = await stylelint.lint({
 			code: 'a{color:red;}',
 			config: {
 				rules: {
@@ -15,6 +15,6 @@ describe('integration tests for linebrakes', () => {
 			fix: true,
 		});
 
-		expect(output).toBe('a{color:red;\n}');
+		expect(code).toBe('a{color:red;\n}');
 	});
 });

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -138,7 +138,7 @@ async function standalone({
 		const autofix = fix ?? config?.fix ?? false;
 
 		if (autofix && postcssResult && !postcssResult.stylelint.ignored) {
-			returnValue.output =
+			returnValue.code =
 				!postcssResult.stylelint.disableWritingFix && postcssResult.opts
 					? // If we're fixing, the output should be the fixed code
 					  postcssResult.root.toString(postcssResult.opts.syntax)

--- a/system-tests/003/__snapshots__/no-fs.test.mjs.snap
+++ b/system-tests/003/__snapshots__/no-fs.test.mjs.snap
@@ -2,9 +2,7 @@
 
 exports[`no-fs - zen garden CSS with standard config 1`] = `
 {
-  "cwd": "",
-  "errored": true,
-  "output": "/* css Zen Garden default style v1.02 */
+  "code": "/* css Zen Garden default style v1.02 */
 
 /* css released under Creative Commons License - http://creativecommons.org/licenses/by-nc-sa/1.0/  */
 
@@ -215,6 +213,211 @@ footer a:visited {
   height: 110px;
 }
 ",
+  "cwd": "",
+  "errored": true,
+  "output": [
+    {
+      "deprecations": [
+        {
+          "text": "The "at-rule-name-case" rule is deprecated.",
+        },
+        {
+          "text": "The "at-rule-name-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "at-rule-semicolon-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "block-closing-brace-empty-line-before" rule is deprecated.",
+        },
+        {
+          "text": "The "block-closing-brace-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "block-closing-brace-newline-before" rule is deprecated.",
+        },
+        {
+          "text": "The "block-closing-brace-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "block-opening-brace-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "block-opening-brace-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "block-opening-brace-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "color-hex-case" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-bang-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-bang-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-block-semicolon-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-block-semicolon-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-block-semicolon-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-block-trailing-semicolon" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-colon-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-colon-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "declaration-colon-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "function-comma-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "function-comma-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "function-comma-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "function-max-empty-lines" rule is deprecated.",
+        },
+        {
+          "text": "The "function-parentheses-newline-inside" rule is deprecated.",
+        },
+        {
+          "text": "The "function-parentheses-space-inside" rule is deprecated.",
+        },
+        {
+          "text": "The "function-whitespace-after" rule is deprecated.",
+        },
+        {
+          "text": "The "max-empty-lines" rule is deprecated.",
+        },
+        {
+          "text": "The "media-feature-colon-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "media-feature-colon-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "media-feature-name-case" rule is deprecated.",
+        },
+        {
+          "text": "The "media-feature-parentheses-space-inside" rule is deprecated.",
+        },
+        {
+          "text": "The "media-feature-range-operator-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "media-feature-range-operator-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "media-query-list-comma-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "media-query-list-comma-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "media-query-list-comma-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "no-eol-whitespace" rule is deprecated.",
+        },
+        {
+          "text": "The "no-extra-semicolons" rule is deprecated.",
+        },
+        {
+          "text": "The "no-missing-end-of-source-newline" rule is deprecated.",
+        },
+        {
+          "text": "The "number-leading-zero" rule is deprecated.",
+        },
+        {
+          "text": "The "number-no-trailing-zeros" rule is deprecated.",
+        },
+        {
+          "text": "The "property-case" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-attribute-brackets-space-inside" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-attribute-operator-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-attribute-operator-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-combinator-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-combinator-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-descendant-combinator-no-non-space" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-list-comma-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-list-comma-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-max-empty-lines" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-pseudo-class-case" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-pseudo-class-parentheses-space-inside" rule is deprecated.",
+        },
+        {
+          "text": "The "selector-pseudo-element-case" rule is deprecated.",
+        },
+        {
+          "text": "The "unit-case" rule is deprecated.",
+        },
+        {
+          "text": "The "value-list-comma-newline-after" rule is deprecated.",
+        },
+        {
+          "text": "The "value-list-comma-space-after" rule is deprecated.",
+        },
+        {
+          "text": "The "value-list-comma-space-before" rule is deprecated.",
+        },
+        {
+          "text": "The "value-list-max-empty-lines" rule is deprecated.",
+        },
+        {
+          "text": "The "indentation" rule is deprecated.",
+        },
+      ],
+      "errored": true,
+      "invalidOptionWarnings": [],
+      "parseErrors": [],
+      "warnings": [
+        {
+          "column": 25,
+          "endColumn": 32,
+          "endLine": 102,
+          "line": 102,
+          "rule": "font-family-no-missing-generic-family-keyword",
+          "severity": "error",
+          "text": "Unexpected missing generic font family (font-family-no-missing-generic-family-keyword)",
+        },
+      ],
+    },
+  ],
   "reportedDisables": [],
   "results": [
     {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -375,7 +375,8 @@ declare namespace stylelint {
 		cwd: string;
 		results: LintResult[];
 		errored: boolean;
-		output: any;
+		output: string;
+		code?: string;
 		maxWarningsExceeded?: {
 			maxWarnings: number;
 			foundWarnings: number;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6604 

> Is there anything in the PR that needs further explanation?

- This PR makes stylelint output fixed code to stdout when `--fix` is used with `--stdin`.
- Currently stylelint outputs linting errors, deprecation warnings, descriptionless disables, etc to stdout. This PR changes it to stderr.
