### PR TITLE
Update `tsconfig.json` for ES2021

### DIFF
--- a/lib/rules/no-descending-specificity/index.js
+++ b/lib/rules/no-descending-specificity/index.js
@@ -153,7 +153,7 @@ function lastCompoundSelectorWithoutPseudoClasses(selectorNode) {
 		return (
 			node.type !== 'pseudo' ||
 			node.value.startsWith('::') ||
-			pseudoElements.has(node.value.replace(/:/g, ''))
+			pseudoElements.has(node.value.replaceAll(':', ''))
 		);
 	});
 

--- a/lib/rules/selector-pseudo-element-colon-notation/index.js
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.js
@@ -52,7 +52,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			const fixedSelector = parseSelector(selector, result, ruleNode, (selectors) => {
 				selectors.walkPseudos((pseudo) => {
-					const pseudoElement = pseudo.value.replace(/:/g, '');
+					const pseudoElement = pseudo.value.replaceAll(':', '');
 
 					if (!levelOneAndTwoPseudoElements.has(pseudoElement.toLowerCase())) {
 						return;

--- a/lib/rules/unit-allowed-list/index.js
+++ b/lib/rules/unit-allowed-list/index.js
@@ -57,7 +57,7 @@ const rule = (primary, secondaryOptions) => {
 		function check(node, value, getIndex) {
 			// make sure multiplication operations (*) are divided - not handled
 			// by postcss-value-parser
-			value = value.replace(/\*/g, ',');
+			value = value.replaceAll('*', ',');
 			valueParser(value).walk((valueNode) => {
 				if (valueNode.type === 'function') {
 					const valueLowerCase = valueNode.value.toLowerCase();

--- a/lib/testUtils/replaceBackslashes.mjs
+++ b/lib/testUtils/replaceBackslashes.mjs
@@ -5,5 +5,5 @@ import { fileURLToPath } from 'node:url';
  * @returns {string}
  */
 export default function replaceBackslashes(path) {
-	return (typeof path === 'string' ? path : fileURLToPath(path)).replace(/\\/g, '/');
+	return (typeof path === 'string' ? path : fileURLToPath(path)).replaceAll('\\', '/');
 }

--- a/lib/utils/__tests__/checkInvalidCLIOptions.test.mjs
+++ b/lib/utils/__tests__/checkInvalidCLIOptions.test.mjs
@@ -35,7 +35,7 @@ Invalid option ${r('"--conig"')}. Did you mean ${c('"--config"')}?
 Invalid option ${r('"--mx-war"')}. Did you mean ${c('"--max-war"')}?
 Invalid option ${r('"--ma"')}. Did you mean ${c('"--mw"')}?
 Invalid option ${r('"-o"')}.
-`.replace(/\n/g, EOL),
+`.replaceAll('\n', EOL),
 		);
 	});
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
-		"target": "ES2020",
+		"target": "ES2021",
 		"module": "commonjs",
-		"lib": ["ES2020"],
+		"lib": ["ES2021"],
 		"checkJs": true,
 		"noEmit": true,
 		"strict": true,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Node.js 16 is 100% compatible with ES2021.
See https://node.green/#ES2021

<details>
<summary>Screenshot</summary>

<img width="82" alt="image" src="https://github.com/stylelint/stylelint/assets/473530/154eec44-2426-4dfd-95f0-b721e7640d91">

</details>

In addition, this change uses [`String.prototype.replaceAll()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll) as possible for readability. This method has been available since ES2021.

---

Context: Stylelint 16.0.0 will support Node.js 16 or later. See #7020.