### PR TITLE
Use `invalidConfig` property of `jest-preset-stylelint` new feature

### DIFF
--- a/lib/rules/alpha-value-notation/__tests__/index.mjs
+++ b/lib/rules/alpha-value-notation/__tests__/index.mjs
@@ -6,6 +6,7 @@ const { messages, ruleName } = rule;
 testRule({
 	ruleName,
 	config: ['number'],
+	invalidConfig: ['foo'],
 	fix: true,
 
 	accept: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "eslint-plugin-jest": "^27.2.3",
         "husky": "^8.0.3",
         "jest": "^29.6.2",
-        "jest-preset-stylelint": "^6.1.1",
+        "jest-preset-stylelint": "github:stylelint/jest-preset-stylelint#invalidConfig",
         "jest-watch-typeahead": "^2.2.2",
         "lint-staged": "^13.2.3",
         "np": "^8.0.4",
@@ -8937,9 +8937,9 @@
     },
     "node_modules/jest-preset-stylelint": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/jest-preset-stylelint/-/jest-preset-stylelint-6.1.1.tgz",
-      "integrity": "sha512-rrZODELzLku1HIm0HrtopXAckvqXglh+7T1J5EqczHQSH3XdtkGTqIj9GJfMv7utKMeMmTvuLz26WJFuCVoHig==",
+      "resolved": "git+ssh://git@github.com/stylelint/jest-preset-stylelint.git#264ebf1298abaf2789b34737f75c47d5aead270b",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || >=16.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "eslint-plugin-jest": "^27.2.3",
     "husky": "^8.0.3",
     "jest": "^29.6.2",
-    "jest-preset-stylelint": "^6.1.1",
+    "jest-preset-stylelint": "github:stylelint/jest-preset-stylelint#invalidConfig",
     "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^13.2.3",
     "np": "^8.0.4",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/jest-preset-stylelint/pull/68

> Is there anything in the PR that needs further explanation?

Note that this PR uses the unpublished version of `jest-preset-stylelint`.
