### PR TITLE
Migrate simpler `lib/*` files to ESM

### DIFF
--- a/lib/__tests__/disableRanges.test.mjs
+++ b/lib/__tests__/disableRanges.test.mjs
@@ -1,4 +1,4 @@
-import assignDisabledRanges from '../assignDisabledRanges.js';
+import assignDisabledRanges from '../assignDisabledRanges.mjs';
 import merge from 'deepmerge';
 import postcss from 'postcss';
 import postcssLess from 'postcss-less';

--- a/lib/__tests__/normalizeRuleSettings.test.mjs
+++ b/lib/__tests__/normalizeRuleSettings.test.mjs
@@ -1,5 +1,5 @@
-import createPlugin from '../createPlugin.js';
-import normalizeRuleSettings from '../normalizeRuleSettings.js';
+import createPlugin from '../createPlugin.mjs';
+import normalizeRuleSettings from '../normalizeRuleSettings.mjs';
 import rules from '../rules/index.js';
 
 const mockRule = createPlugin('mock-rule', () => () => {});

--- a/lib/assignDisabledRanges.cjs
+++ b/lib/assignDisabledRanges.cjs
@@ -1,0 +1,411 @@
+'use strict';
+
+const configurationComment = require('./utils/configurationComment.cjs');
+const validateTypes = require('./utils/validateTypes.cjs');
+const isStandardSyntaxComment = require('./utils/isStandardSyntaxComment.cjs');
+
+const ALL_RULES = 'all';
+
+/** @typedef {import('postcss').Comment} PostcssComment */
+/** @typedef {import('postcss').Root} PostcssRoot */
+/** @typedef {import('postcss').Document} PostcssDocument */
+/** @typedef {import('stylelint').PostcssResult} PostcssResult */
+/** @typedef {import('stylelint').DisabledRangeObject} DisabledRangeObject */
+/** @typedef {import('stylelint').DisabledRange} DisabledRange */
+
+/**
+ * @param {PostcssComment} comment
+ * @param {number} start
+ * @param {boolean} strictStart
+ * @param {string|undefined} description
+ * @param {number} [end]
+ * @param {boolean} [strictEnd]
+ * @returns {DisabledRange}
+ */
+function createDisableRange(comment, start, strictStart, description, end, strictEnd) {
+	return {
+		comment,
+		start,
+		end: end || undefined,
+		strictStart,
+		strictEnd: typeof strictEnd === 'boolean' ? strictEnd : undefined,
+		description,
+	};
+}
+
+/**
+ * Run it like a PostCSS plugin
+ * @param {PostcssRoot | PostcssDocument} root
+ * @param {PostcssResult} result
+ * @returns {PostcssResult}
+ */
+function assignDisabledRanges(root, result) {
+	result.stylelint = result.stylelint || {
+		disabledRanges: {},
+		ruleSeverities: {},
+		customMessages: {},
+		ruleMetadata: {},
+	};
+
+	/**
+	 * Most of the functions below work via side effects mutating this object
+	 * @type {DisabledRangeObject & { all: DisabledRange[] }}
+	 */
+	const disabledRanges = {
+		[ALL_RULES]: [],
+	};
+
+	result.stylelint.disabledRanges = disabledRanges;
+
+	// Work around postcss/postcss-scss#109 by merging adjacent `//` comments
+	// into a single node before passing to `checkComment`.
+
+	/** @type {PostcssComment?} */
+	let inlineEnd;
+
+	const configurationComment$1 = result.stylelint.config?.configurationComment;
+
+	root.walkComments((comment) => {
+		if (inlineEnd) {
+			// Ignore comments already processed by grouping with a previous one.
+			if (inlineEnd === comment) inlineEnd = null;
+
+			return;
+		}
+
+		const nextComment = comment.next();
+
+		// If any of these conditions are not met, do not merge comments.
+		if (
+			!(
+				!isStandardSyntaxComment(comment) &&
+				configurationComment.isConfigurationComment(comment, configurationComment$1) &&
+				nextComment &&
+				nextComment.type === 'comment' &&
+				(comment.text.includes('--') || nextComment.text.startsWith('--'))
+			)
+		) {
+			checkComment(comment);
+
+			return;
+		}
+
+		let lastLine = (comment.source && comment.source.end && comment.source.end.line) || 0;
+		const fullComment = comment.clone();
+
+		let current = nextComment;
+
+		while (
+			!isStandardSyntaxComment(current) &&
+			!configurationComment.isConfigurationComment(current, configurationComment$1)
+		) {
+			const currentLine = (current.source && current.source.end && current.source.end.line) || 0;
+
+			if (lastLine + 1 !== currentLine) break;
+
+			fullComment.text += `\n${current.text}`;
+
+			if (fullComment.source && current.source) {
+				fullComment.source.end = current.source.end;
+			}
+
+			inlineEnd = current;
+			const next = current.next();
+
+			if (!next || next.type !== 'comment') break;
+
+			current = next;
+			lastLine = currentLine;
+		}
+
+		checkComment(fullComment);
+	});
+
+	return result;
+
+	/**
+	 * @param {PostcssComment} comment
+	 */
+	function processDisableLineCommand(comment) {
+		if (comment.source && comment.source.start) {
+			const line = comment.source.start.line;
+			const description = getDescription(comment.text);
+
+			for (const ruleName of getCommandRules(configurationComment.DISABLE_LINE_COMMAND, comment.text)) {
+				disableLine(comment, line, ruleName, description);
+			}
+		}
+	}
+
+	/**
+	 * @param {PostcssComment} comment
+	 */
+	function processDisableNextLineCommand(comment) {
+		if (comment.source && comment.source.end) {
+			const line = comment.source.end.line;
+			const description = getDescription(comment.text);
+
+			for (const ruleName of getCommandRules(configurationComment.DISABLE_NEXT_LINE_COMMAND, comment.text)) {
+				disableLine(comment, line + 1, ruleName, description);
+			}
+		}
+	}
+
+	/**
+	 * @param {PostcssComment} comment
+	 * @param {number} line
+	 * @param {string} ruleName
+	 * @param {string|undefined} description
+	 */
+	function disableLine(comment, line, ruleName, description) {
+		if (ruleIsDisabled(ALL_RULES)) {
+			throw comment.error('All rules have already been disabled', {
+				plugin: 'stylelint',
+			});
+		}
+
+		if (ruleName === ALL_RULES) {
+			for (const disabledRuleName of Object.keys(disabledRanges)) {
+				if (ruleIsDisabled(disabledRuleName)) continue;
+
+				const strict = disabledRuleName === ALL_RULES;
+
+				startDisabledRange(comment, line, disabledRuleName, strict, description);
+				endDisabledRange(line, disabledRuleName, strict);
+			}
+		} else {
+			if (ruleIsDisabled(ruleName)) {
+				throw comment.error(`"${ruleName}" has already been disabled`, {
+					plugin: 'stylelint',
+				});
+			}
+
+			startDisabledRange(comment, line, ruleName, true, description);
+			endDisabledRange(line, ruleName, true);
+		}
+	}
+
+	/**
+	 * @param {PostcssComment} comment
+	 */
+	function processDisableCommand(comment) {
+		const description = getDescription(comment.text);
+
+		for (const ruleToDisable of getCommandRules(configurationComment.DISABLE_COMMAND, comment.text)) {
+			const isAllRules = ruleToDisable === ALL_RULES;
+
+			if (ruleIsDisabled(ruleToDisable)) {
+				throw comment.error(
+					isAllRules
+						? 'All rules have already been disabled'
+						: `"${ruleToDisable}" has already been disabled`,
+					{
+						plugin: 'stylelint',
+					},
+				);
+			}
+
+			if (comment.source && comment.source.start) {
+				const line = comment.source.start.line;
+
+				if (isAllRules) {
+					for (const ruleName of Object.keys(disabledRanges)) {
+						startDisabledRange(comment, line, ruleName, ruleName === ALL_RULES, description);
+					}
+				} else {
+					startDisabledRange(comment, line, ruleToDisable, true, description);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param {PostcssComment} comment
+	 */
+	function processEnableCommand(comment) {
+		for (const ruleToEnable of getCommandRules(configurationComment.ENABLE_COMMAND, comment.text)) {
+			// need fallback if endLine will be undefined
+			const endLine = comment.source && comment.source.end && comment.source.end.line;
+
+			validateTypes.assertNumber(endLine);
+
+			if (ruleToEnable === ALL_RULES) {
+				if (
+					Object.values(disabledRanges).every((ranges) => {
+						if (ranges.length === 0) return true;
+
+						const lastRange = ranges[ranges.length - 1];
+
+						return lastRange && typeof lastRange.end === 'number';
+					})
+				) {
+					throw comment.error('No rules have been disabled', {
+						plugin: 'stylelint',
+					});
+				}
+
+				for (const [ruleName, ranges] of Object.entries(disabledRanges)) {
+					const lastRange = ranges[ranges.length - 1];
+
+					if (!lastRange || !lastRange.end) {
+						endDisabledRange(endLine, ruleName, ruleName === ALL_RULES);
+					}
+				}
+
+				continue;
+			}
+
+			if (ruleIsDisabled(ALL_RULES) && disabledRanges[ruleToEnable] === undefined) {
+				// Get a starting point from the where all rules were disabled
+				disabledRanges[ruleToEnable] = disabledRanges[ALL_RULES].map(
+					({ start, end, description }) =>
+						createDisableRange(comment, start, false, description, end, false),
+				);
+
+				endDisabledRange(endLine, ruleToEnable, true);
+
+				continue;
+			}
+
+			if (ruleIsDisabled(ruleToEnable)) {
+				endDisabledRange(endLine, ruleToEnable, true);
+
+				continue;
+			}
+
+			throw comment.error(`"${ruleToEnable}" has not been disabled`, {
+				plugin: 'stylelint',
+			});
+		}
+	}
+
+	/**
+	 * @param {PostcssComment} comment
+	 */
+	function checkComment(comment) {
+		// Ignore comments that are not relevant commands
+
+		if (!configurationComment.isConfigurationComment(comment, configurationComment$1)) {
+			return;
+		}
+
+		switch (configurationComment.extractConfigurationComment(comment, configurationComment$1)) {
+			case configurationComment.DISABLE_LINE_COMMAND:
+				processDisableLineCommand(comment);
+				break;
+			case configurationComment.DISABLE_NEXT_LINE_COMMAND:
+				processDisableNextLineCommand(comment);
+				break;
+			case configurationComment.DISABLE_COMMAND:
+				processDisableCommand(comment);
+				break;
+			case configurationComment.ENABLE_COMMAND:
+				processEnableCommand(comment);
+				break;
+		}
+	}
+
+	/**
+	 * @param {string} command
+	 * @param {string} fullText
+	 * @returns {string[]}
+	 */
+	function getCommandRules(command, fullText) {
+		// Allow for description (f.e. /* stylelint-disable a, b -- Description */).
+		const fullCommand = configurationComment.getConfigurationComment(command, configurationComment$1);
+		const rulesText = fullText.slice(fullCommand.length).split(/\s-{2,}\s/u)[0];
+
+		validateTypes.assertString(rulesText);
+		const rules = rulesText
+			.trim()
+			.split(',')
+			.filter(Boolean)
+			.map((r) => r.trim());
+
+		if (rules.length === 0) {
+			return [ALL_RULES];
+		}
+
+		return rules;
+	}
+
+	/**
+	 * @param {string} fullText
+	 * @returns {string|undefined}
+	 */
+	function getDescription(fullText) {
+		const descriptionStart = fullText.indexOf('--');
+
+		if (descriptionStart === -1) return;
+
+		return fullText.slice(descriptionStart + 2).trim();
+	}
+
+	/**
+	 * @param {PostcssComment} comment
+	 * @param {number} line
+	 * @param {string} ruleName
+	 * @param {boolean} strict
+	 * @param {string|undefined} description
+	 */
+	function startDisabledRange(comment, line, ruleName, strict, description) {
+		const rangeObj = createDisableRange(comment, line, strict, description);
+
+		ensureRuleRanges(ruleName);
+
+		const range = disabledRanges[ruleName];
+
+		validateTypes.assert(range);
+		range.push(rangeObj);
+	}
+
+	/**
+	 * @param {number} line
+	 * @param {string} ruleName
+	 * @param {boolean} strict
+	 */
+	function endDisabledRange(line, ruleName, strict) {
+		const ranges = disabledRanges[ruleName];
+		const lastRangeForRule = ranges ? ranges[ranges.length - 1] : null;
+
+		if (!lastRangeForRule) {
+			return;
+		}
+
+		// Add an `end` prop to the last range of that rule
+		lastRangeForRule.end = line;
+		lastRangeForRule.strictEnd = strict;
+	}
+
+	/**
+	 * @param {string} ruleName
+	 */
+	function ensureRuleRanges(ruleName) {
+		if (!disabledRanges[ruleName]) {
+			disabledRanges[ruleName] = disabledRanges[ALL_RULES].map(
+				({ comment, start, end, description }) =>
+					createDisableRange(comment, start, false, description, end, false),
+			);
+		}
+	}
+
+	/**
+	 * @param {string} ruleName
+	 * @returns {boolean}
+	 */
+	function ruleIsDisabled(ruleName) {
+		const ranges = disabledRanges[ruleName];
+
+		if (!ranges) return false;
+
+		const lastRange = ranges[ranges.length - 1];
+
+		if (!lastRange) return false;
+
+		if (!lastRange.end) return true;
+
+		return false;
+	}
+}
+
+module.exports = assignDisabledRanges;

--- a/lib/assignDisabledRanges.mjs
+++ b/lib/assignDisabledRanges.mjs
@@ -1,7 +1,4 @@
-'use strict';
-
-const isStandardSyntaxComment = require('./utils/isStandardSyntaxComment.cjs');
-const {
+import {
 	DISABLE_COMMAND,
 	DISABLE_LINE_COMMAND,
 	DISABLE_NEXT_LINE_COMMAND,
@@ -9,8 +6,9 @@ const {
 	extractConfigurationComment,
 	getConfigurationComment,
 	isConfigurationComment,
-} = require('./utils/configurationComment.cjs');
-const { assert, assertNumber, assertString } = require('./utils/validateTypes.cjs');
+} from './utils/configurationComment.mjs';
+import { assert, assertNumber, assertString } from './utils/validateTypes.mjs';
+import isStandardSyntaxComment from './utils/isStandardSyntaxComment.mjs';
 
 const ALL_RULES = 'all';
 
@@ -47,7 +45,7 @@ function createDisableRange(comment, start, strictStart, description, end, stric
  * @param {PostcssResult} result
  * @returns {PostcssResult}
  */
-module.exports = function assignDisabledRanges(root, result) {
+export default function assignDisabledRanges(root, result) {
 	result.stylelint = result.stylelint || {
 		disabledRanges: {},
 		ruleSeverities: {},
@@ -414,4 +412,4 @@ module.exports = function assignDisabledRanges(root, result) {
 
 		return false;
 	}
-};
+}

--- a/lib/createPartialStylelintResult.cjs
+++ b/lib/createPartialStylelintResult.cjs
@@ -8,7 +8,7 @@
  * @param {import('stylelint').CssSyntaxError} [cssSyntaxError]
  * @return {StylelintResult}
  */
-module.exports = function createPartialStylelintResult(postcssResult, cssSyntaxError) {
+function createPartialStylelintResult(postcssResult, cssSyntaxError) {
 	/** @type {StylelintResult} */
 	let stylelintResult;
 	/** @type {string | undefined} */
@@ -106,4 +106,6 @@ module.exports = function createPartialStylelintResult(postcssResult, cssSyntaxE
 	}
 
 	return stylelintResult;
-};
+}
+
+module.exports = createPartialStylelintResult;

--- a/lib/createPartialStylelintResult.mjs
+++ b/lib/createPartialStylelintResult.mjs
@@ -1,0 +1,107 @@
+/** @typedef {import('stylelint').PostcssResult} PostcssResult */
+/** @typedef {import('stylelint').LintResult} StylelintResult */
+
+/**
+ * @param {PostcssResult} [postcssResult]
+ * @param {import('stylelint').CssSyntaxError} [cssSyntaxError]
+ * @return {StylelintResult}
+ */
+export default function createPartialStylelintResult(postcssResult, cssSyntaxError) {
+	/** @type {StylelintResult} */
+	let stylelintResult;
+	/** @type {string | undefined} */
+	let source;
+
+	if (postcssResult && postcssResult.root) {
+		if (postcssResult.root.source) {
+			source = postcssResult.root.source.input.file;
+
+			if (!source && 'id' in postcssResult.root.source.input) {
+				source = postcssResult.root.source.input.id;
+			}
+		}
+
+		const deprecationMessages = postcssResult.messages.filter(
+			(message) => message.stylelintType === 'deprecation',
+		);
+		const deprecations = deprecationMessages.map((deprecationMessage) => {
+			return {
+				text: deprecationMessage.text,
+				reference: deprecationMessage.stylelintReference,
+			};
+		});
+
+		const invalidOptionMessages = postcssResult.messages.filter(
+			(message) => message.stylelintType === 'invalidOption',
+		);
+		const invalidOptionWarnings = invalidOptionMessages.map((invalidOptionMessage) => {
+			return {
+				text: invalidOptionMessage.text,
+			};
+		});
+
+		const parseErrors = postcssResult.messages.filter(
+			(message) => message.stylelintType === 'parseError',
+		);
+
+		// Remove deprecation warnings, invalid options, and parse errors from the messages
+		postcssResult.messages = postcssResult.messages.filter(
+			(message) =>
+				message.stylelintType !== 'deprecation' &&
+				message.stylelintType !== 'invalidOption' &&
+				message.stylelintType !== 'parseError',
+		);
+
+		// This defines the stylelint result object that formatters receive
+		stylelintResult = {
+			source,
+			deprecations,
+			invalidOptionWarnings,
+			// @ts-expect-error -- TS2322: Type 'Message[]' is not assignable to type '(Warning & { stylelintType: string; })[]'.
+			parseErrors,
+			errored: postcssResult.stylelint.stylelintError,
+			warnings: postcssResult.messages.map((message) => {
+				return {
+					line: message.line,
+					column: message.column,
+					endLine: message.endLine,
+					endColumn: message.endColumn,
+					rule: message.rule,
+					severity: message.severity,
+					text: message.text,
+				};
+			}),
+			ignored: postcssResult.stylelint.ignored,
+			_postcssResult: postcssResult,
+		};
+	} else if (cssSyntaxError) {
+		if (cssSyntaxError.name !== 'CssSyntaxError') {
+			throw cssSyntaxError;
+		}
+
+		stylelintResult = {
+			source: cssSyntaxError.file || '<input css 1>',
+			deprecations: [],
+			invalidOptionWarnings: [],
+			parseErrors: [],
+			errored: true,
+			warnings: [
+				{
+					line: cssSyntaxError.line,
+					column: cssSyntaxError.column,
+					endLine: cssSyntaxError.endLine,
+					endColumn: cssSyntaxError.endColumn,
+					rule: cssSyntaxError.name,
+					severity: 'error',
+					text: `${cssSyntaxError.reason} (${cssSyntaxError.name})`,
+				},
+			],
+		};
+	} else {
+		throw new Error(
+			'createPartialStylelintResult must be called with either postcssResult or CssSyntaxError',
+		);
+	}
+
+	return stylelintResult;
+}

--- a/lib/createPlugin.cjs
+++ b/lib/createPlugin.cjs
@@ -3,9 +3,11 @@
 /**
  * @type {import('stylelint')['createPlugin']}
  */
-module.exports = function createPlugin(ruleName, rule) {
+function createPlugin(ruleName, rule) {
 	return {
 		ruleName,
 		rule,
 	};
-};
+}
+
+module.exports = createPlugin;

--- a/lib/createPlugin.mjs
+++ b/lib/createPlugin.mjs
@@ -1,0 +1,9 @@
+/**
+ * @type {import('stylelint')['createPlugin']}
+ */
+export default function createPlugin(ruleName, rule) {
+	return {
+		ruleName,
+		rule,
+	};
+}

--- a/lib/descriptionlessDisables.cjs
+++ b/lib/descriptionlessDisables.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+const optionsMatches = require('./utils/optionsMatches.cjs');
+const validateDisableSettings = require('./validateDisableSettings.cjs');
+
+/** @typedef {import('postcss').Comment} PostcssComment */
+/** @typedef {import('stylelint').DisableReportRange} DisableReportRange */
+/** @typedef {import('stylelint').DisableOptionsReport} StylelintDisableOptionsReport */
+
+/**
+ * @param {import('stylelint').LintResult[]} results
+ */
+function descriptionlessDisables(results) {
+	for (const result of results) {
+		const settings = validateDisableSettings(
+			result._postcssResult,
+			'reportDescriptionlessDisables',
+		);
+
+		if (!settings) continue;
+
+		const [enabled, options, stylelintResult] = settings;
+
+		/** @type {Set<PostcssComment>} */
+		const alreadyReported = new Set();
+
+		for (const [rule, ruleRanges] of Object.entries(stylelintResult.disabledRanges)) {
+			for (const range of ruleRanges) {
+				if (range.description) continue;
+
+				if (alreadyReported.has(range.comment)) continue;
+
+				if (enabled === optionsMatches(options, 'except', rule)) {
+					// An 'all' rule will get copied for each individual rule. If the
+					// configuration is `[false, {except: ['specific-rule']}]`, we
+					// don't want to report the copies that match except, so we record
+					// the comment as already reported.
+					if (!enabled && rule === 'all') alreadyReported.add(range.comment);
+
+					continue;
+				}
+
+				alreadyReported.add(range.comment);
+
+				// If the comment doesn't have a location, we can't report a useful error.
+				// In practice we expect all comments to have locations, though.
+				if (!range.comment.source || !range.comment.source.start) continue;
+
+				result.warnings.push({
+					text: `Disable for "${rule}" is missing a description`,
+					rule: '--report-descriptionless-disables',
+					line: range.comment.source.start.line,
+					column: range.comment.source.start.column,
+					endLine: range.comment.source.end && range.comment.source.end.line,
+					endColumn: range.comment.source.end && range.comment.source.end.column,
+					severity: options.severity,
+				});
+			}
+		}
+	}
+}
+
+module.exports = descriptionlessDisables;

--- a/lib/descriptionlessDisables.mjs
+++ b/lib/descriptionlessDisables.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const optionsMatches = require('./utils/optionsMatches.cjs');
-const validateDisableSettings = require('./validateDisableSettings');
+import optionsMatches from './utils/optionsMatches.mjs';
+import validateDisableSettings from './validateDisableSettings.mjs';
 
 /** @typedef {import('postcss').Comment} PostcssComment */
 /** @typedef {import('stylelint').DisableReportRange} DisableReportRange */
@@ -10,7 +8,7 @@ const validateDisableSettings = require('./validateDisableSettings');
 /**
  * @param {import('stylelint').LintResult[]} results
  */
-module.exports = function descriptionlessDisables(results) {
+export default function descriptionlessDisables(results) {
 	for (const result of results) {
 		const settings = validateDisableSettings(
 			result._postcssResult,
@@ -58,4 +56,4 @@ module.exports = function descriptionlessDisables(results) {
 			}
 		}
 	}
-};
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const checkAgainstRule = require('./utils/checkAgainstRule');
-const createPlugin = require('./createPlugin');
+const createPlugin = require('./createPlugin.cjs');
 const createStylelint = require('./createStylelint');
 const formatters = require('./formatters');
 const postcssPlugin = require('./postcssPlugin');

--- a/lib/invalidScopeDisables.cjs
+++ b/lib/invalidScopeDisables.cjs
@@ -1,0 +1,49 @@
+'use strict';
+
+const optionsMatches = require('./utils/optionsMatches.cjs');
+const validateDisableSettings = require('./validateDisableSettings.cjs');
+
+/**
+ * @param {import('stylelint').LintResult[]} results
+ */
+function invalidScopeDisables(results) {
+	for (const result of results) {
+		const settings = validateDisableSettings(result._postcssResult, 'reportInvalidScopeDisables');
+
+		if (!settings) continue;
+
+		const [enabled, options, stylelintResult] = settings;
+
+		const configRules = (stylelintResult.config || {}).rules || {};
+
+		const usedRules = new Set(Object.keys(configRules));
+
+		usedRules.add('all');
+
+		for (const [rule, ruleRanges] of Object.entries(stylelintResult.disabledRanges)) {
+			if (usedRules.has(rule)) continue;
+
+			if (enabled === optionsMatches(options, 'except', rule)) continue;
+
+			for (const range of ruleRanges) {
+				if (!range.strictStart && !range.strictEnd) continue;
+
+				// If the comment doesn't have a location, we can't report a useful error.
+				// In practice we expect all comments to have locations, though.
+				if (!range.comment.source || !range.comment.source.start) continue;
+
+				result.warnings.push({
+					text: `Rule "${rule}" isn't enabled`,
+					rule: '--report-invalid-scope-disables',
+					line: range.comment.source.start.line,
+					column: range.comment.source.start.column,
+					endLine: range.comment.source.end && range.comment.source.end.line,
+					endColumn: range.comment.source.end && range.comment.source.end.column,
+					severity: options.severity,
+				});
+			}
+		}
+	}
+}
+
+module.exports = invalidScopeDisables;

--- a/lib/invalidScopeDisables.mjs
+++ b/lib/invalidScopeDisables.mjs
@@ -1,12 +1,10 @@
-'use strict';
-
-const optionsMatches = require('./utils/optionsMatches.cjs');
-const validateDisableSettings = require('./validateDisableSettings');
+import optionsMatches from './utils/optionsMatches.mjs';
+import validateDisableSettings from './validateDisableSettings.mjs';
 
 /**
  * @param {import('stylelint').LintResult[]} results
  */
-module.exports = function invalidScopeDisables(results) {
+export default function invalidScopeDisables(results) {
 	for (const result of results) {
 		const settings = validateDisableSettings(result._postcssResult, 'reportInvalidScopeDisables');
 
@@ -44,4 +42,4 @@ module.exports = function invalidScopeDisables(results) {
 			}
 		}
 	}
-};
+}

--- a/lib/lintPostcssResult.js
+++ b/lib/lintPostcssResult.js
@@ -2,7 +2,7 @@
 
 const { EOL } = require('os');
 
-const assignDisabledRanges = require('./assignDisabledRanges');
+const assignDisabledRanges = require('./assignDisabledRanges.cjs');
 const reportUnknownRuleNames = require('./reportUnknownRuleNames');
 const rules = require('./rules');
 const getStylelintRule = require('./utils/getStylelintRule');

--- a/lib/needlessDisables.cjs
+++ b/lib/needlessDisables.cjs
@@ -2,7 +2,7 @@
 
 const optionsMatches = require('./utils/optionsMatches.cjs');
 const putIfAbsent = require('./utils/putIfAbsent.cjs');
-const validateDisableSettings = require('./validateDisableSettings');
+const validateDisableSettings = require('./validateDisableSettings.cjs');
 
 /** @typedef {import('postcss').Comment} PostcssComment */
 /** @typedef {import('stylelint').DisabledRange} DisabledRange */
@@ -11,7 +11,7 @@ const validateDisableSettings = require('./validateDisableSettings');
 /**
  * @param {import('stylelint').LintResult[]} results
  */
-module.exports = function needlessDisables(results) {
+function needlessDisables(results) {
 	for (const result of results) {
 		const settings = validateDisableSettings(result._postcssResult, 'reportNeedlessDisables');
 
@@ -83,7 +83,7 @@ module.exports = function needlessDisables(results) {
 			}
 		}
 	}
-};
+}
 
 /**
  * @param {import('stylelint').DisabledWarning} warning
@@ -99,3 +99,5 @@ function isWarningInRange(warning, range) {
 		((range.end !== undefined && range.end >= line) || range.end === undefined)
 	);
 }
+
+module.exports = needlessDisables;

--- a/lib/needlessDisables.mjs
+++ b/lib/needlessDisables.mjs
@@ -1,0 +1,99 @@
+import optionsMatches from './utils/optionsMatches.mjs';
+import putIfAbsent from './utils/putIfAbsent.mjs';
+import validateDisableSettings from './validateDisableSettings.mjs';
+
+/** @typedef {import('postcss').Comment} PostcssComment */
+/** @typedef {import('stylelint').DisabledRange} DisabledRange */
+/** @typedef {import('stylelint').DisableReportRange} DisableReportRange */
+
+/**
+ * @param {import('stylelint').LintResult[]} results
+ */
+export default function needlessDisables(results) {
+	for (const result of results) {
+		const settings = validateDisableSettings(result._postcssResult, 'reportNeedlessDisables');
+
+		if (!settings) continue;
+
+		const [enabled, options, stylelintResult] = settings;
+
+		const rangeData = stylelintResult.disabledRanges;
+
+		if (!rangeData) continue;
+
+		const disabledWarnings = stylelintResult.disabledWarnings || [];
+
+		// A map from `stylelint-disable` comments to the set of rules that
+		// are usefully disabled by each comment. We track this
+		// comment-by-comment rather than range-by-range because ranges that
+		// disable *all* rules are duplicated for each rule they apply to in
+		// practice.
+		/** @type {Map<PostcssComment, Set<string>>}} */
+		const usefulDisables = new Map();
+
+		for (const warning of disabledWarnings) {
+			const rule = warning.rule;
+			const ruleRanges = rangeData[rule];
+
+			if (ruleRanges) {
+				for (const range of ruleRanges) {
+					if (isWarningInRange(warning, range)) {
+						putIfAbsent(usefulDisables, range.comment, () => new Set()).add(rule);
+					}
+				}
+			}
+
+			for (const range of rangeData.all || []) {
+				if (isWarningInRange(warning, range)) {
+					putIfAbsent(usefulDisables, range.comment, () => new Set()).add(rule);
+				}
+			}
+		}
+
+		const allRangeComments = new Set((rangeData.all || []).map((range) => range.comment));
+
+		for (const [rule, ranges] of Object.entries(rangeData)) {
+			for (const range of ranges) {
+				if (rule !== 'all' && allRangeComments.has(range.comment)) continue;
+
+				if (enabled === optionsMatches(options, 'except', rule)) continue;
+
+				const useful = usefulDisables.get(range.comment) || new Set();
+
+				// Only emit a warning if this range's comment isn't useful for this rule.
+				// For the special rule "all", only emit a warning if it's not useful for
+				// *any* rules, because it covers all of them.
+				if (rule === 'all' ? useful.size !== 0 : useful.has(rule)) continue;
+
+				// If the comment doesn't have a location, we can't report a useful error.
+				// In practice we expect all comments to have locations, though.
+				if (!range.comment.source || !range.comment.source.start) continue;
+
+				result.warnings.push({
+					text: `Needless disable for "${rule}"`,
+					rule: '--report-needless-disables',
+					line: range.comment.source.start.line,
+					column: range.comment.source.start.column,
+					endLine: range.comment.source.end && range.comment.source.end.line,
+					endColumn: range.comment.source.end && range.comment.source.end.column,
+					severity: options.severity,
+				});
+			}
+		}
+	}
+}
+
+/**
+ * @param {import('stylelint').DisabledWarning} warning
+ * @param {DisabledRange} range
+ * @return {boolean}
+ */
+function isWarningInRange(warning, range) {
+	const line = warning.line;
+
+	// Need to check if range.end exist, because line number type cannot be compared to undefined
+	return (
+		range.start <= line &&
+		((range.end !== undefined && range.end >= line) || range.end === undefined)
+	);
+}

--- a/lib/normalizeAllRuleSettings.js
+++ b/lib/normalizeAllRuleSettings.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const normalizeRuleSettings = require('./normalizeRuleSettings');
+const normalizeRuleSettings = require('./normalizeRuleSettings.cjs');
 const getStylelintRule = require('./utils/getStylelintRule');
 
 /** @typedef {import('stylelint').Config} StylelintConfig */

--- a/lib/normalizeRuleSettings.cjs
+++ b/lib/normalizeRuleSettings.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { isPlainObject } = require('./utils/validateTypes.cjs');
+const validateTypes = require('./utils/validateTypes.cjs');
 
 // Rule settings can take a number of forms, e.g.
 // a. "rule-name": null
@@ -21,7 +21,7 @@ const { isPlainObject } = require('./utils/validateTypes.cjs');
  * @param {import('stylelint').Rule<T, O>} [rule]
  * @return {[T] | [T, O] | null}
  */
-module.exports = function normalizeRuleSettings(rawSettings, rule) {
+function normalizeRuleSettings(rawSettings, rule) {
 	if (rawSettings === null || rawSettings === undefined) {
 		return null;
 	}
@@ -48,11 +48,13 @@ module.exports = function normalizeRuleSettings(rawSettings, rule) {
 		return rawSettings;
 	}
 
-	if (rawSettings.length === 2 && !isPlainObject(primary) && isPlainObject(secondary)) {
+	if (rawSettings.length === 2 && !validateTypes.isPlainObject(primary) && validateTypes.isPlainObject(secondary)) {
 		return rawSettings;
 	}
 
 	// `T` must be an array type, but TSC thinks it's probably invalid to
 	// cast `[T]` to `T` so we cast through `any` first.
 	return [/** @type {T} */ (/** @type {any} */ (rawSettings))];
-};
+}
+
+module.exports = normalizeRuleSettings;

--- a/lib/normalizeRuleSettings.mjs
+++ b/lib/normalizeRuleSettings.mjs
@@ -1,0 +1,56 @@
+import { isPlainObject } from './utils/validateTypes.mjs';
+
+// Rule settings can take a number of forms, e.g.
+// a. "rule-name": null
+// b. "rule-name": [null, ...]
+// c. "rule-name": primaryOption
+// d. "rule-name": [primaryOption]
+// e. "rule-name": [primaryOption, secondaryOption]
+// Where primaryOption can be anything: primitive, Object, or Array.
+
+/**
+ * This function normalizes all the possibilities into the
+ * standard form: [primaryOption, secondaryOption]
+ * Except in the cases with null, a & b, in which case
+ * null is returned
+ * @template T
+ * @template {Object} O
+ * @param {import('stylelint').ConfigRuleSettings<T, O>} rawSettings
+ * @param {import('stylelint').Rule<T, O>} [rule]
+ * @return {[T] | [T, O] | null}
+ */
+export default function normalizeRuleSettings(rawSettings, rule) {
+	if (rawSettings === null || rawSettings === undefined) {
+		return null;
+	}
+
+	if (!Array.isArray(rawSettings)) {
+		return [rawSettings];
+	}
+	// Everything below is an array ...
+
+	const [primary, secondary] = rawSettings;
+
+	if (rawSettings.length > 0 && (primary === null || primary === undefined)) {
+		return null;
+	}
+
+	if (rule && !rule.primaryOptionArray) {
+		return rawSettings;
+	}
+	// Everything below is a rule that CAN have an array for a primary option ...
+	// (they might also have something else, e.g. rule-properties-order can
+	// have the string "alphabetical")
+
+	if (rawSettings.length === 1 && Array.isArray(primary)) {
+		return rawSettings;
+	}
+
+	if (rawSettings.length === 2 && !isPlainObject(primary) && isPlainObject(secondary)) {
+		return rawSettings;
+	}
+
+	// `T` must be an array type, but TSC thinks it's probably invalid to
+	// cast `[T]` to `T` so we cast through `any` first.
+	return [/** @type {T} */ (/** @type {any} */ (rawSettings))];
+}

--- a/lib/prepareReturnValue.cjs
+++ b/lib/prepareReturnValue.cjs
@@ -1,9 +1,9 @@
 'use strict';
 
-const descriptionlessDisables = require('./descriptionlessDisables');
-const invalidScopeDisables = require('./invalidScopeDisables');
-const needlessDisables = require('./needlessDisables');
-const reportDisables = require('./reportDisables');
+const descriptionlessDisables = require('./descriptionlessDisables.cjs');
+const invalidScopeDisables = require('./invalidScopeDisables.cjs');
+const needlessDisables = require('./needlessDisables.cjs');
+const reportDisables = require('./reportDisables.cjs');
 
 /** @typedef {import('stylelint').Formatter} Formatter */
 /** @typedef {import('stylelint').LintResult} StylelintResult */
@@ -18,7 +18,7 @@ const reportDisables = require('./reportDisables');
  *
  * @returns {LinterResult}
  */
-module.exports = function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
+function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
 	reportDisables(stylelintResults);
 	needlessDisables(stylelintResults);
 	invalidScopeDisables(stylelintResults);
@@ -59,7 +59,7 @@ module.exports = function prepareReturnValue(stylelintResults, maxWarnings, form
 	returnValue.results = stylelintResults;
 
 	return returnValue;
-};
+}
 
 /**
  * @param {StylelintResult[]} lintResults
@@ -73,3 +73,5 @@ function getRuleMetadata(lintResults) {
 
 	return lintResult._postcssResult.stylelint.ruleMetadata;
 }
+
+module.exports = prepareReturnValue;

--- a/lib/prepareReturnValue.mjs
+++ b/lib/prepareReturnValue.mjs
@@ -1,0 +1,73 @@
+import descriptionlessDisables from './descriptionlessDisables.mjs';
+import invalidScopeDisables from './invalidScopeDisables.mjs';
+import needlessDisables from './needlessDisables.mjs';
+import reportDisables from './reportDisables.mjs';
+
+/** @typedef {import('stylelint').Formatter} Formatter */
+/** @typedef {import('stylelint').LintResult} StylelintResult */
+/** @typedef {import('stylelint').LinterOptions["maxWarnings"]} maxWarnings */
+/** @typedef {import('stylelint').LinterResult} LinterResult */
+
+/**
+ * @param {StylelintResult[]} stylelintResults
+ * @param {maxWarnings} maxWarnings
+ * @param {Formatter} formatter
+ * @param {string} cwd
+ *
+ * @returns {LinterResult}
+ */
+export default function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
+	reportDisables(stylelintResults);
+	needlessDisables(stylelintResults);
+	invalidScopeDisables(stylelintResults);
+	descriptionlessDisables(stylelintResults);
+
+	let errored = false;
+
+	for (const result of stylelintResults) {
+		if (
+			result.errored ||
+			result.parseErrors.length > 0 ||
+			result.warnings.some((warning) => warning.severity === 'error')
+		) {
+			errored = true;
+			result.errored = true;
+		}
+	}
+
+	/** @type {LinterResult} */
+	const returnValue = {
+		cwd,
+		errored,
+		results: [],
+		output: '',
+		reportedDisables: [],
+		ruleMetadata: getRuleMetadata(stylelintResults),
+	};
+
+	if (maxWarnings !== undefined) {
+		const foundWarnings = stylelintResults.reduce((count, file) => count + file.warnings.length, 0);
+
+		if (foundWarnings > maxWarnings) {
+			returnValue.maxWarningsExceeded = { maxWarnings, foundWarnings };
+		}
+	}
+
+	returnValue.output = formatter(stylelintResults, returnValue);
+	returnValue.results = stylelintResults;
+
+	return returnValue;
+}
+
+/**
+ * @param {StylelintResult[]} lintResults
+ */
+function getRuleMetadata(lintResults) {
+	const [lintResult] = lintResults;
+
+	if (lintResult === undefined) return {};
+
+	if (lintResult._postcssResult === undefined) return {};
+
+	return lintResult._postcssResult.stylelint.ruleMetadata;
+}

--- a/lib/reportDisables.cjs
+++ b/lib/reportDisables.cjs
@@ -10,7 +10,7 @@
  *
  * @param {StylelintResult[]} results
  */
-module.exports = function reportDisables(results) {
+function reportDisables(results) {
 	for (const result of results) {
 		// File with `CssSyntaxError` don't have `_postcssResult`s.
 		if (!result._postcssResult) {
@@ -51,7 +51,7 @@ module.exports = function reportDisables(results) {
 			}
 		}
 	}
-};
+}
 
 /**
  * @param {StylelintConfigRuleSettings} options
@@ -62,3 +62,5 @@ function reportDisablesForRule(options) {
 
 	return Boolean(options[1].reportDisables);
 }
+
+module.exports = reportDisables;

--- a/lib/reportDisables.mjs
+++ b/lib/reportDisables.mjs
@@ -1,0 +1,62 @@
+/** @typedef {import('stylelint').DisableReportRange} DisabledRange */
+/** @typedef {import('stylelint').LintResult} StylelintResult */
+/** @typedef {import('stylelint').ConfigRuleSettings<any, Object>} StylelintConfigRuleSettings */
+
+/**
+ * Returns a report describing which `results` (if any) contain disabled ranges
+ * for rules that disallow disables via `reportDisables: true`.
+ *
+ * @param {StylelintResult[]} results
+ */
+export default function reportDisables(results) {
+	for (const result of results) {
+		// File with `CssSyntaxError` don't have `_postcssResult`s.
+		if (!result._postcssResult) {
+			continue;
+		}
+
+		const rangeData = result._postcssResult.stylelint.disabledRanges;
+
+		if (!rangeData) continue;
+
+		const config = result._postcssResult.stylelint.config;
+
+		if (!config || !config.rules) continue;
+
+		// If no rules actually disallow disables, don't bother looking for ranges
+		// that correspond to disabled rules.
+		if (!Object.values(config.rules).some((rule) => reportDisablesForRule(rule))) {
+			continue;
+		}
+
+		for (const [rule, ranges] of Object.entries(rangeData)) {
+			for (const range of ranges) {
+				if (!reportDisablesForRule(config.rules[rule] || [])) continue;
+
+				// If the comment doesn't have a location, we can't report a useful error.
+				// In practice we expect all comments to have locations, though.
+				if (!range.comment.source || !range.comment.source.start) continue;
+
+				result.warnings.push({
+					text: `Rule "${rule}" may not be disabled`,
+					rule: 'reportDisables',
+					line: range.comment.source.start.line,
+					column: range.comment.source.start.column,
+					endLine: range.comment.source.end && range.comment.source.end.line,
+					endColumn: range.comment.source.end && range.comment.source.end.column,
+					severity: 'error',
+				});
+			}
+		}
+	}
+}
+
+/**
+ * @param {StylelintConfigRuleSettings} options
+ * @return {boolean}
+ */
+function reportDisablesForRule(options) {
+	if (!options || !options[1]) return false;
+
+	return Boolean(options[1].reportDisables);
+}

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -8,7 +8,7 @@ const normalizePath = require('normalize-path');
 const path = require('path');
 
 const createStylelint = require('./createStylelint');
-const createPartialStylelintResult = require('./createPartialStylelintResult');
+const createPartialStylelintResult = require('./createPartialStylelintResult.cjs');
 const filterFilePaths = require('./utils/filterFilePaths.cjs');
 const formatters = require('./formatters');
 const getConfigForFile = require('./getConfigForFile');
@@ -18,7 +18,7 @@ const lintSource = require('./lintSource');
 const NoFilesFoundError = require('./utils/noFilesFoundError.cjs');
 const AllFilesIgnoredError = require('./utils/allFilesIgnoredError.cjs');
 const { assert } = require('./utils/validateTypes.cjs');
-const prepareReturnValue = require('./prepareReturnValue');
+const prepareReturnValue = require('./prepareReturnValue.cjs');
 
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 const writeFileAtomic = require('write-file-atomic');

--- a/lib/utils/checkAgainstRule.js
+++ b/lib/utils/checkAgainstRule.js
@@ -2,7 +2,7 @@
 
 const Result = require('postcss/lib/result').default;
 
-const normalizeRuleSettings = require('../normalizeRuleSettings');
+const normalizeRuleSettings = require('../normalizeRuleSettings.cjs');
 const { isPlainObject } = require('./validateTypes.cjs');
 const getStylelintRule = require('./getStylelintRule');
 

--- a/lib/validateDisableSettings.cjs
+++ b/lib/validateDisableSettings.cjs
@@ -1,0 +1,81 @@
+'use strict';
+
+const validateTypes = require('./utils/validateTypes.cjs');
+const validateOptions = require('./utils/validateOptions.cjs');
+
+/**
+ * @typedef {import('stylelint').PostcssResult} PostcssResult
+ * @typedef {import('stylelint').DisableOptions} DisableOptions
+ * @typedef {import('stylelint').DisablePropertyName} DisablePropertyName
+ * @typedef {import('stylelint').StylelintPostcssResult} StylelintPostcssResult
+ */
+
+/**
+ * Validates that the stylelint config for `result` has a valid disable field
+ * named `field`, and returns the result in normalized form as well as a
+ * `StylelintPostcssResult` for convenience.
+ *
+ * Returns `null` if no disables should be reported, and automatically reports
+ * an invalid configuration. If this returns non-`null`, it guarantees that
+ * `result._postcssResult` is defined as well.
+ *
+ * @param {PostcssResult | undefined} result
+ * @param {DisablePropertyName} field
+ * @return {[boolean, Required<DisableOptions>, StylelintPostcssResult] | null}
+ */
+function validateDisableSettings(result, field) {
+	// Files with `CssSyntaxError`s don't have `_postcssResult`s.
+	if (!result) return null;
+
+	const stylelintResult = result.stylelint;
+
+	// Files with linting errors may not have configs associated with them.
+	if (!stylelintResult.config) return null;
+
+	const rawSettings = stylelintResult.config[field];
+
+	/** @type {boolean} */
+	let enabled;
+	/** @type {DisableOptions} */
+	let options;
+
+	if (Array.isArray(rawSettings)) {
+		enabled = rawSettings[0];
+		options = rawSettings[1] || {};
+	} else {
+		enabled = rawSettings || false;
+		options = {};
+	}
+
+	const validOptions = validateOptions(
+		result,
+		field,
+		{
+			actual: enabled,
+			possible: [true, false],
+		},
+		{
+			actual: options,
+			possible: {
+				except: [validateTypes.isString, validateTypes.isRegExp],
+			},
+		},
+	);
+
+	if (!validOptions) return null;
+
+	// If the check is disabled with no exceptions, there's no reason to run
+	// it at all.
+	if (!enabled && !options.except) return null;
+
+	return [
+		enabled,
+		{
+			except: options.except || [],
+			severity: options.severity || stylelintResult.config.defaultSeverity || 'error',
+		},
+		stylelintResult,
+	];
+}
+
+module.exports = validateDisableSettings;

--- a/lib/validateDisableSettings.mjs
+++ b/lib/validateDisableSettings.mjs
@@ -1,7 +1,5 @@
-'use strict';
-
-const validateOptions = require('./utils/validateOptions.cjs');
-const { isRegExp, isString } = require('./utils/validateTypes.cjs');
+import { isRegExp, isString } from './utils/validateTypes.mjs';
+import validateOptions from './utils/validateOptions.mjs';
 
 /**
  * @typedef {import('stylelint').PostcssResult} PostcssResult
@@ -23,7 +21,7 @@ const { isRegExp, isString } = require('./utils/validateTypes.cjs');
  * @param {DisablePropertyName} field
  * @return {[boolean, Required<DisableOptions>, StylelintPostcssResult] | null}
  */
-module.exports = function validateDisableSettings(result, field) {
+export default function validateDisableSettings(result, field) {
 	// Files with `CssSyntaxError`s don't have `_postcssResult`s.
 	if (!result) return null;
 
@@ -76,4 +74,4 @@ module.exports = function validateDisableSettings(result, field) {
 		},
 		stylelintResult,
 	];
-};
+}

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -5,7 +5,7 @@ import Benchmark from 'benchmark';
 import picocolors from 'picocolors';
 import postcss from 'postcss';
 
-import normalizeRuleSettings from '../lib/normalizeRuleSettings.js';
+import normalizeRuleSettings from '../lib/normalizeRuleSettings.mjs';
 import rules from '../lib/rules/index.js';
 
 const { bold, yellow } = picocolors;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #5291

> Is there anything in the PR that needs further explanation?

This change rewrites relatively simpler `lib/*.js` files to ESM.
