### PR TITLE
Migrate `lib/formatters/*` to ESM except `formatters/index`

### DIFF
--- a/lib/__tests__/standalone-formatter.test.mjs
+++ b/lib/__tests__/standalone-formatter.test.mjs
@@ -2,7 +2,7 @@ import stripAnsi from 'strip-ansi';
 
 import readJSONFile from '../testUtils/readJSONFile.mjs';
 import standalone from '../standalone.js';
-import stringFormatter from '../formatters/stringFormatter.js';
+import stringFormatter from '../formatters/stringFormatter.mjs';
 
 const configBlockNoEmpty = readJSONFile(
 	new URL('./fixtures/config-block-no-empty.json', import.meta.url),

--- a/lib/__tests__/standalone-syntax.test.mjs
+++ b/lib/__tests__/standalone-syntax.test.mjs
@@ -5,7 +5,7 @@ import { jest } from '@jest/globals';
 
 import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import standalone from '../standalone.js';
-import stringFormatter from '../formatters/stringFormatter.js';
+import stringFormatter from '../formatters/stringFormatter.mjs';
 
 const require = createRequire(import.meta.url);
 

--- a/lib/formatters/__tests__/compactFormatter.test.mjs
+++ b/lib/formatters/__tests__/compactFormatter.test.mjs
@@ -1,4 +1,4 @@
-import compactFormatter from '../compactFormatter.js';
+import compactFormatter from '../compactFormatter.mjs';
 import prepareFormatterOutput from './prepareFormatterOutput.mjs';
 
 describe('compactFormatter', () => {

--- a/lib/formatters/__tests__/githubFormatter.test.mjs
+++ b/lib/formatters/__tests__/githubFormatter.test.mjs
@@ -1,4 +1,4 @@
-import githubFormatter from '../githubFormatter.js';
+import githubFormatter from '../githubFormatter.cjs';
 
 describe('githubFormatter', () => {
 	test('outputs no warnings', () => {

--- a/lib/formatters/__tests__/jsonFormatter.test.mjs
+++ b/lib/formatters/__tests__/jsonFormatter.test.mjs
@@ -1,4 +1,4 @@
-import jsonFormatter from '../jsonFormatter.js';
+import jsonFormatter from '../jsonFormatter.mjs';
 
 describe('jsonFormatter', () => {
 	it('outputs corresponding json', () => {

--- a/lib/formatters/__tests__/stringFormatter.test.mjs
+++ b/lib/formatters/__tests__/stringFormatter.test.mjs
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 
 import prepareFormatterOutput from './prepareFormatterOutput.mjs';
-import stringFormatter from '../stringFormatter.js';
+import stringFormatter from '../stringFormatter.mjs';
 
 describe('stringFormatter', () => {
 	let actualTTY;

--- a/lib/formatters/__tests__/tapFormatter.test.mjs
+++ b/lib/formatters/__tests__/tapFormatter.test.mjs
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 
 import prepareFormatterOutput from './prepareFormatterOutput.mjs';
-import tapFormatter from '../tapFormatter.js';
+import tapFormatter from '../tapFormatter.mjs';
 
 describe('tapFormatter', () => {
 	let actualTTY;

--- a/lib/formatters/__tests__/terminalLink.test.mjs
+++ b/lib/formatters/__tests__/terminalLink.test.mjs
@@ -1,9 +1,5 @@
 import { jest } from '@jest/globals';
 
-// TODO: Remove `require` when migrating to ESM.
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-
 describe('terminallink', () => {
 	const originalEnv = process.env;
 
@@ -15,18 +11,20 @@ describe('terminallink', () => {
 		process.env = originalEnv;
 	});
 
-	it('returns an ANSI escaped link', () => {
+	it('returns an ANSI escaped link', async () => {
 		process.env = { ...originalEnv, FORCE_HYPERLINK: '1' };
-		const terminalLink = require('../terminalLink.js');
+
+		const { default: terminalLink } = await import('../terminalLink.mjs');
 
 		expect(terminalLink('stylelint', 'https://stylelint.io/')).toBe(
 			'\u001B]8;;https://stylelint.io/\u0007stylelint\u001B]8;;\u0007',
 		);
 	});
 
-	it('returns a passed text with an unsupported environment', () => {
+	it('returns a passed text with an unsupported environment', async () => {
 		process.env = { ...originalEnv, FORCE_HYPERLINK: '0' };
-		const terminalLink = require('../terminalLink.js');
+
+		const { default: terminalLink } = await import('../terminalLink.mjs');
 
 		expect(terminalLink('stylelint', 'https://stylelint.io/')).toBe('stylelint');
 	});

--- a/lib/formatters/__tests__/unixFormatter.test.mjs
+++ b/lib/formatters/__tests__/unixFormatter.test.mjs
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 
 import prepareFormatterOutput from './prepareFormatterOutput.mjs';
-import unixFormatter from '../unixFormatter.js';
+import unixFormatter from '../unixFormatter.mjs';
 
 describe('unixFormatter', () => {
 	let actualTTY;

--- a/lib/formatters/__tests__/verboseFormatter.test.mjs
+++ b/lib/formatters/__tests__/verboseFormatter.test.mjs
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 
 import prepareFormatterOutput from './prepareFormatterOutput.mjs';
-import verboseFormatter from '../verboseFormatter.js';
+import verboseFormatter from '../verboseFormatter.mjs';
 
 describe('verboseFormatter', () => {
 	it('outputs no warnings', () => {

--- a/lib/formatters/calcSeverityCounts.cjs
+++ b/lib/formatters/calcSeverityCounts.cjs
@@ -7,7 +7,7 @@
  * @param {Record<Severity, number>} counts
  * @returns {void}
  */
-module.exports = function calcSeverityCounts(severity, counts) {
+function calcSeverityCounts(severity, counts) {
 	switch (severity) {
 		case 'error':
 			counts.error += 1;
@@ -18,4 +18,6 @@ module.exports = function calcSeverityCounts(severity, counts) {
 		default:
 			throw new Error(`Unknown severity: "${severity}"`);
 	}
-};
+}
+
+module.exports = calcSeverityCounts;

--- a/lib/formatters/calcSeverityCounts.mjs
+++ b/lib/formatters/calcSeverityCounts.mjs
@@ -1,0 +1,19 @@
+/**
+ * @typedef {import('stylelint').Severity} Severity
+ *
+ * @param {Severity} severity
+ * @param {Record<Severity, number>} counts
+ * @returns {void}
+ */
+export default function calcSeverityCounts(severity, counts) {
+	switch (severity) {
+		case 'error':
+			counts.error += 1;
+			break;
+		case 'warning':
+			counts.warning += 1;
+			break;
+		default:
+			throw new Error(`Unknown severity: "${severity}"`);
+	}
+}

--- a/lib/formatters/compactFormatter.cjs
+++ b/lib/formatters/compactFormatter.cjs
@@ -1,0 +1,25 @@
+'use strict';
+
+const preprocessWarnings = require('./preprocessWarnings.cjs');
+
+/**
+ * @type {import('stylelint').Formatter}
+ */
+function compactFormatter(results) {
+	return results
+		.flatMap((result) => {
+			const { warnings } = preprocessWarnings(result);
+
+			return warnings.map(
+				(warning) =>
+					`${result.source}: ` +
+					`line ${warning.line}, ` +
+					`col ${warning.column}, ` +
+					`${warning.severity} - ` +
+					`${warning.text}`,
+			);
+		})
+		.join('\n');
+}
+
+module.exports = compactFormatter;

--- a/lib/formatters/compactFormatter.mjs
+++ b/lib/formatters/compactFormatter.mjs
@@ -1,11 +1,9 @@
-'use strict';
-
-const preprocessWarnings = require('./preprocessWarnings');
+import preprocessWarnings from './preprocessWarnings.mjs';
 
 /**
  * @type {import('stylelint').Formatter}
  */
-module.exports = function compactFormatter(results) {
+export default function compactFormatter(results) {
 	return results
 		.flatMap((result) => {
 			const { warnings } = preprocessWarnings(result);
@@ -20,4 +18,4 @@ module.exports = function compactFormatter(results) {
 			);
 		})
 		.join('\n');
-};
+}

--- a/lib/formatters/githubFormatter.cjs
+++ b/lib/formatters/githubFormatter.cjs
@@ -1,13 +1,13 @@
 'use strict';
 
-const preprocessWarnings = require('./preprocessWarnings');
+const preprocessWarnings = require('./preprocessWarnings.cjs');
 
 /**
  * @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
  *
  * @type {import('stylelint').Formatter}
  */
-module.exports = function githubFormatter(results, returnValue) {
+function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';
 	const metadata = returnValue.ruleMetadata;
 
@@ -26,7 +26,7 @@ module.exports = function githubFormatter(results, returnValue) {
 	lines.push('');
 
 	return lines.join('\n');
-};
+}
 
 /**
  * @param {string} msg
@@ -49,3 +49,5 @@ function buildMessage(msg, metadata) {
 
 	return `${msg}${additional}${url}`;
 }
+
+module.exports = githubFormatter;

--- a/lib/formatters/githubFormatter.mjs
+++ b/lib/formatters/githubFormatter.mjs
@@ -1,0 +1,49 @@
+import preprocessWarnings from './preprocessWarnings.mjs';
+
+/**
+ * @see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+ *
+ * @type {import('stylelint').Formatter}
+ */
+export default function githubFormatter(results, returnValue) {
+	const title = 'Stylelint problem';
+	const metadata = returnValue.ruleMetadata;
+
+	const lines = results.flatMap((result) => {
+		const { source, warnings } = preprocessWarnings(result);
+
+		return warnings.map(({ line, column, endLine, endColumn, text, severity, rule }) => {
+			const msg = buildMessage(text, metadata[rule]);
+
+			return endLine === undefined
+				? `::${severity} file=${source},line=${line},col=${column},title=${title}::${msg}`
+				: `::${severity} file=${source},line=${line},col=${column},endLine=${endLine},endColumn=${endColumn},title=${title}::${msg}`;
+		});
+	});
+
+	lines.push('');
+
+	return lines.join('\n');
+}
+
+/**
+ * @param {string} msg
+ * @param {Partial<import('stylelint').RuleMeta> | undefined} metadata
+ * @returns {string}
+ */
+function buildMessage(msg, metadata) {
+	if (!metadata) return msg;
+
+	const url = metadata.url ? ` - ${metadata.url}` : '';
+
+	let additional = [
+		metadata.fixable ? 'maybe fixable' : '',
+		metadata.deprecated ? 'deprecated' : '',
+	]
+		.filter(Boolean)
+		.join(', ');
+
+	additional = additional ? ` [${additional}]` : '';
+
+	return `${msg}${additional}${url}`;
+}

--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -4,13 +4,13 @@ const importLazy = require('import-lazy');
 
 /** @type {import('stylelint')['formatters']} */
 const formatters = {
-	compact: importLazy(() => require('./compactFormatter'))(),
-	github: importLazy(() => require('./githubFormatter'))(),
-	json: importLazy(() => require('./jsonFormatter'))(),
-	string: importLazy(() => require('./stringFormatter'))(),
-	tap: importLazy(() => require('./tapFormatter'))(),
-	unix: importLazy(() => require('./unixFormatter'))(),
-	verbose: importLazy(() => require('./verboseFormatter'))(),
+	compact: importLazy(() => require('./compactFormatter.cjs'))(),
+	github: importLazy(() => require('./githubFormatter.cjs'))(),
+	json: importLazy(() => require('./jsonFormatter.cjs'))(),
+	string: importLazy(() => require('./stringFormatter.cjs'))(),
+	tap: importLazy(() => require('./tapFormatter.cjs'))(),
+	unix: importLazy(() => require('./unixFormatter.cjs'))(),
+	verbose: importLazy(() => require('./verboseFormatter.cjs'))(),
 };
 
 module.exports = formatters;

--- a/lib/formatters/jsonFormatter.cjs
+++ b/lib/formatters/jsonFormatter.cjs
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Omit any properties starting with `_`, which are fake-private
+ *
+ * @type {import('stylelint').Formatter}
+ */
+function jsonFormatter(results) {
+	const cleanedResults = results.map((result) =>
+		Object.entries(result)
+			.filter(([key]) => !key.startsWith('_'))
+			.reduce((/** @type {{ [key: string]: any }} */ obj, [key, value]) => {
+				obj[key] = value;
+
+				return obj;
+			}, {}),
+	);
+
+	return JSON.stringify(cleanedResults);
+}
+
+module.exports = jsonFormatter;

--- a/lib/formatters/jsonFormatter.mjs
+++ b/lib/formatters/jsonFormatter.mjs
@@ -1,11 +1,9 @@
-'use strict';
-
 /**
  * Omit any properties starting with `_`, which are fake-private
  *
  * @type {import('stylelint').Formatter}
  */
-module.exports = function jsonFormatter(results) {
+export default function jsonFormatter(results) {
 	const cleanedResults = results.map((result) =>
 		Object.entries(result)
 			.filter(([key]) => !key.startsWith('_'))
@@ -17,4 +15,4 @@ module.exports = function jsonFormatter(results) {
 	);
 
 	return JSON.stringify(cleanedResults);
-};
+}

--- a/lib/formatters/preprocessWarnings.cjs
+++ b/lib/formatters/preprocessWarnings.cjs
@@ -12,7 +12,7 @@
  * @param {LintResult} result
  * @returns {LintResult}
  */
-module.exports = function preprocessWarnings(result) {
+function preprocessWarnings(result) {
 	for (const error of result.parseErrors || []) {
 		result.warnings.push(parseErrorToWarning(error));
 	}
@@ -24,7 +24,7 @@ module.exports = function preprocessWarnings(result) {
 	result.warnings.sort(byLocationOrder);
 
 	return result;
-};
+}
 
 /**
  * @param {ParseError} error
@@ -72,3 +72,5 @@ function byLocationOrder(a, b) {
 
 	return 0;
 }
+
+module.exports = preprocessWarnings;

--- a/lib/formatters/preprocessWarnings.mjs
+++ b/lib/formatters/preprocessWarnings.mjs
@@ -1,0 +1,72 @@
+/** @typedef {import('stylelint').LintResult} LintResult */
+/** @typedef {LintResult['parseErrors'][0]} ParseError */
+/** @typedef {LintResult['warnings'][0]} Warning */
+/** @typedef {Warning['severity']} Severity */
+
+/**
+ * Preprocess warnings in a given lint result.
+ * Note that this function has a side-effect.
+ *
+ * @param {LintResult} result
+ * @returns {LintResult}
+ */
+export default function preprocessWarnings(result) {
+	for (const error of result.parseErrors || []) {
+		result.warnings.push(parseErrorToWarning(error));
+	}
+
+	for (const warning of result.warnings) {
+		warning.severity = normalizeSeverity(warning);
+	}
+
+	result.warnings.sort(byLocationOrder);
+
+	return result;
+}
+
+/**
+ * @param {ParseError} error
+ * @returns {Warning}
+ */
+function parseErrorToWarning(error) {
+	return {
+		line: error.line,
+		column: error.column,
+		rule: error.stylelintType,
+		severity: 'error',
+		text: `${error.text} (${error.stylelintType})`,
+	};
+}
+
+/**
+ * @param {Warning} warning
+ * @returns {Severity}
+ */
+function normalizeSeverity(warning) {
+	// NOTE: Plugins may add a warning without severity, for example,
+	// by directly using the PostCSS `Result#warn()` API.
+	return warning.severity || 'error';
+}
+
+/**
+ * @param {Warning} a
+ * @param {Warning} b
+ * @returns {number}
+ */
+function byLocationOrder(a, b) {
+	// positionless first
+	if (!a.line && b.line) return -1;
+
+	// positionless first
+	if (a.line && !b.line) return 1;
+
+	if (a.line < b.line) return -1;
+
+	if (a.line > b.line) return 1;
+
+	if (a.column < b.column) return -1;
+
+	if (a.column > b.column) return 1;
+
+	return 0;
+}

--- a/lib/formatters/stringFormatter.cjs
+++ b/lib/formatters/stringFormatter.cjs
@@ -1,15 +1,16 @@
 'use strict';
 
-const path = require('path');
+const node_path = require('node:path');
+const picocolors = require('picocolors');
 const stringWidth = require('string-width');
 const table = require('table');
-const { yellow, dim, underline, blue, red, green } = require('picocolors');
-
-const calcSeverityCounts = require('./calcSeverityCounts');
+const validateTypes = require('../utils/validateTypes.cjs');
+const calcSeverityCounts = require('./calcSeverityCounts.cjs');
 const pluralize = require('../utils/pluralize.cjs');
-const { assertNumber } = require('../utils/validateTypes.cjs');
-const preprocessWarnings = require('./preprocessWarnings');
-const terminalLink = require('./terminalLink');
+const preprocessWarnings = require('./preprocessWarnings.cjs');
+const terminalLink = require('./terminalLink.cjs');
+
+const { yellow, dim, underline, blue, red, green } = picocolors;
 
 const NON_ASCII_PATTERN = /\P{ASCII}/u;
 const MARGIN_WIDTHS = 9;
@@ -95,7 +96,7 @@ function logFrom(fromValue, cwd) {
 		return underline(fromValue);
 	}
 
-	const filePath = path.relative(cwd, fromValue).split(path.sep).join('/');
+	const filePath = node_path.relative(cwd, fromValue).split(node_path.sep).join('/');
 
 	return terminalLink(filePath, `file://${fromValue}`);
 }
@@ -107,7 +108,7 @@ function logFrom(fromValue, cwd) {
 function getMessageWidth(columnWidths) {
 	const width = columnWidths[3];
 
-	assertNumber(width);
+	validateTypes.assertNumber(width);
 
 	if (!process.stdout.isTTY) {
 		return width;
@@ -149,7 +150,7 @@ function formatter(messages, source, cwd) {
 			const normalisedValue = value ? value.toString() : value;
 			const width = columnWidths[key];
 
-			assertNumber(width);
+			validateTypes.assertNumber(width);
 			columnWidths[key] = Math.max(width, stringWidth(normalisedValue));
 		}
 
@@ -230,7 +231,7 @@ function formatter(messages, source, cwd) {
 /**
  * @type {import('stylelint').Formatter}
  */
-module.exports = function stringFormatter(results, returnValue) {
+function stringFormatter(results, returnValue) {
 	let output = invalidOptionsFormatter(results);
 
 	output += deprecationsFormatter(results);
@@ -273,4 +274,6 @@ module.exports = function stringFormatter(results, returnValue) {
 	}
 
 	return output;
-};
+}
+
+module.exports = stringFormatter;

--- a/lib/formatters/stringFormatter.mjs
+++ b/lib/formatters/stringFormatter.mjs
@@ -1,0 +1,277 @@
+import { relative, sep } from 'node:path';
+
+import picocolors from 'picocolors';
+import stringWidth from 'string-width';
+import table from 'table';
+
+import { assertNumber } from '../utils/validateTypes.mjs';
+import calcSeverityCounts from './calcSeverityCounts.mjs';
+import pluralize from '../utils/pluralize.mjs';
+import preprocessWarnings from './preprocessWarnings.mjs';
+import terminalLink from './terminalLink.mjs';
+
+const { yellow, dim, underline, blue, red, green } = picocolors;
+
+const NON_ASCII_PATTERN = /\P{ASCII}/u;
+const MARGIN_WIDTHS = 9;
+
+/**
+ * @param {string} s
+ * @returns {string}
+ */
+function nope(s) {
+	return s;
+}
+
+const levelColors = {
+	info: blue,
+	warning: yellow,
+	error: red,
+	success: nope,
+};
+
+const symbols = {
+	info: blue('ℹ'),
+	warning: yellow('⚠'),
+	error: red('✖'),
+	success: green('✔'),
+};
+
+/**
+ * @param {import('stylelint').LintResult[]} results
+ * @returns {string}
+ */
+function deprecationsFormatter(results) {
+	const allDeprecationWarnings = results.flatMap((result) => result.deprecations || []);
+
+	if (allDeprecationWarnings.length === 0) {
+		return '';
+	}
+
+	const seenText = new Set();
+	const lines = [];
+
+	for (const { text, reference } of allDeprecationWarnings) {
+		if (seenText.has(text)) continue;
+
+		seenText.add(text);
+
+		let line = ` ${dim('-')} ${text}`;
+
+		if (reference) {
+			line += dim(` See: ${underline(reference)}`);
+		}
+
+		lines.push(line);
+	}
+
+	return ['', yellow('Deprecation warnings:'), ...lines, ''].join('\n');
+}
+
+/**
+ * @param {import('stylelint').LintResult[]} results
+ * @return {string}
+ */
+function invalidOptionsFormatter(results) {
+	const allInvalidOptionWarnings = results.flatMap((result) =>
+		(result.invalidOptionWarnings || []).map((warning) => warning.text),
+	);
+	const uniqueInvalidOptionWarnings = [...new Set(allInvalidOptionWarnings)];
+
+	return uniqueInvalidOptionWarnings.reduce((output, warning) => {
+		output += red('Invalid Option: ');
+		output += warning;
+
+		return `${output}\n`;
+	}, '\n');
+}
+
+/**
+ * @param {string} fromValue
+ * @param {string} cwd
+ * @return {string}
+ */
+function logFrom(fromValue, cwd) {
+	if (fromValue.startsWith('<')) {
+		return underline(fromValue);
+	}
+
+	const filePath = relative(cwd, fromValue).split(sep).join('/');
+
+	return terminalLink(filePath, `file://${fromValue}`);
+}
+
+/**
+ * @param {{[k: number]: number}} columnWidths
+ * @return {number}
+ */
+function getMessageWidth(columnWidths) {
+	const width = columnWidths[3];
+
+	assertNumber(width);
+
+	if (!process.stdout.isTTY) {
+		return width;
+	}
+
+	const availableWidth = process.stdout.columns < 80 ? 80 : process.stdout.columns;
+	const fullWidth = Object.values(columnWidths).reduce((a, b) => a + b);
+
+	// If there is no reason to wrap the text, we won't align the last column to the right
+	if (availableWidth > fullWidth + MARGIN_WIDTHS) {
+		return width;
+	}
+
+	return availableWidth - (fullWidth - width + MARGIN_WIDTHS);
+}
+
+/**
+ * @param {import('stylelint').Warning[]} messages
+ * @param {string} source
+ * @param {string} cwd
+ * @return {string}
+ */
+function formatter(messages, source, cwd) {
+	if (messages.length === 0) return '';
+
+	/**
+	 * Create a list of column widths, needed to calculate
+	 * the size of the message column and if needed wrap it.
+	 * @type {{[k: string]: number}}
+	 */
+	const columnWidths = { 0: 1, 1: 1, 2: 1, 3: 1, 4: 1 };
+
+	/**
+	 * @param {[string, string, string, string, string]} columns
+	 * @return {[string, string, string, string, string]}
+	 */
+	function calculateWidths(columns) {
+		for (const [key, value] of Object.entries(columns)) {
+			const normalisedValue = value ? value.toString() : value;
+			const width = columnWidths[key];
+
+			assertNumber(width);
+			columnWidths[key] = Math.max(width, stringWidth(normalisedValue));
+		}
+
+		return columns;
+	}
+
+	let output = '\n';
+
+	if (source) {
+		output += `${logFrom(source, cwd)}\n`;
+	}
+
+	/**
+	 * @param {import('stylelint').Warning} message
+	 * @return {string}
+	 */
+	function formatMessageText(message) {
+		let result = message.text;
+
+		result = result
+			// Remove all control characters (newline, tab and etc)
+			.replace(/[\u0001-\u001A]+/g, ' ') // eslint-disable-line no-control-regex
+			.replace(/\.$/, '');
+
+		const ruleString = ` (${message.rule})`;
+
+		if (result.endsWith(ruleString)) {
+			result = result.slice(0, result.lastIndexOf(ruleString));
+		}
+
+		return result;
+	}
+
+	const cleanedMessages = messages.map((message) => {
+		const { line, column, severity } = message;
+		/**
+		 * @type {[string, string, string, string, string]}
+		 */
+		const row = [
+			line ? line.toString() : '',
+			column ? column.toString() : '',
+			symbols[severity] ? levelColors[severity](symbols[severity]) : severity,
+			formatMessageText(message),
+			dim(message.rule || ''),
+		];
+
+		calculateWidths(row);
+
+		return row;
+	});
+
+	const messageWidth = getMessageWidth(columnWidths);
+	const hasNonAsciiChar = messages.some((msg) => NON_ASCII_PATTERN.test(msg.text));
+
+	output += table
+		.table(cleanedMessages, {
+			border: table.getBorderCharacters('void'),
+			columns: {
+				0: { alignment: 'right', width: columnWidths[0], paddingRight: 0 },
+				1: { alignment: 'left', width: columnWidths[1] },
+				2: { alignment: 'center', width: columnWidths[2] },
+				3: {
+					alignment: 'left',
+					width: messageWidth,
+					wrapWord: messageWidth > 1 && !hasNonAsciiChar,
+				},
+				4: { alignment: 'left', width: columnWidths[4], paddingRight: 0 },
+			},
+			drawHorizontalLine: () => false,
+		})
+		.split('\n')
+		.map((el) => el.replace(/(\d+)\s+(\d+)/, (_m, p1, p2) => dim(`${p1}:${p2}`)).trimEnd())
+		.join('\n');
+
+	return output;
+}
+
+/**
+ * @type {import('stylelint').Formatter}
+ */
+export default function stringFormatter(results, returnValue) {
+	let output = invalidOptionsFormatter(results);
+
+	output += deprecationsFormatter(results);
+
+	const counts = { error: 0, warning: 0 };
+
+	output = results.reduce((accum, result) => {
+		preprocessWarnings(result);
+
+		accum += formatter(
+			result.warnings,
+			result.source || '',
+			(returnValue && returnValue.cwd) || process.cwd(),
+		);
+
+		for (const warning of result.warnings) {
+			calcSeverityCounts(warning.severity, counts);
+		}
+
+		return accum;
+	}, output);
+
+	// Ensure consistent padding
+	output = output.trim();
+
+	if (output !== '') {
+		output = `\n${output}\n\n`;
+
+		const errorCount = counts.error;
+		const warningCount = counts.warning;
+		const total = errorCount + warningCount;
+
+		if (total > 0) {
+			const error = red(`${errorCount} ${pluralize('error', errorCount)}`);
+			const warning = yellow(`${warningCount} ${pluralize('warning', warningCount)}`);
+			const tally = `${total} ${pluralize('problem', total)} (${error}, ${warning})`;
+
+			output += `${tally}\n\n`;
+		}
+	}
+
+	return output;
+}

--- a/lib/formatters/tapFormatter.cjs
+++ b/lib/formatters/tapFormatter.cjs
@@ -1,0 +1,54 @@
+'use strict';
+
+const preprocessWarnings = require('./preprocessWarnings.cjs');
+
+/**
+ * @type {import('stylelint').Formatter}
+ */
+function tapFormatter(results) {
+	const lines = [`TAP version 13\n1..${results.length}`];
+
+	for (const [index, result] of results.entries()) {
+		preprocessWarnings(result);
+
+		lines.push(
+			`${result.errored ? 'not ok' : 'ok'} ${index + 1} - ${result.ignored ? 'ignored ' : ''}${
+				result.source
+			}`,
+		);
+
+		if (result.warnings.length > 0) {
+			lines.push('---', 'messages:');
+
+			for (const warning of result.warnings) {
+				lines.push(
+					` - message: "${warning.text}"`,
+					`   severity: ${warning.severity}`,
+					`   data:`,
+					`     line: ${warning.line}`,
+					`     column: ${warning.column}`,
+				);
+
+				if (typeof warning.endLine === 'number') {
+					lines.push(`     endLine: ${warning.endLine}`);
+				}
+
+				if (typeof warning.endColumn === 'number') {
+					lines.push(`     endColumn: ${warning.endColumn}`);
+				}
+
+				if (typeof warning.rule === 'string') {
+					lines.push(`     ruleId: ${warning.rule}`);
+				}
+			}
+
+			lines.push('---');
+		}
+	}
+
+	lines.push('');
+
+	return lines.join('\n');
+}
+
+module.exports = tapFormatter;

--- a/lib/formatters/tapFormatter.mjs
+++ b/lib/formatters/tapFormatter.mjs
@@ -1,11 +1,9 @@
-'use strict';
-
-const preprocessWarnings = require('./preprocessWarnings');
+import preprocessWarnings from './preprocessWarnings.mjs';
 
 /**
  * @type {import('stylelint').Formatter}
  */
-module.exports = function tapFormatter(results) {
+export default function tapFormatter(results) {
 	const lines = [`TAP version 13\n1..${results.length}`];
 
 	for (const [index, result] of results.entries()) {
@@ -49,4 +47,4 @@ module.exports = function tapFormatter(results) {
 	lines.push('');
 
 	return lines.join('\n');
-};
+}

--- a/lib/formatters/terminalLink.cjs
+++ b/lib/formatters/terminalLink.cjs
@@ -1,0 +1,25 @@
+'use strict';
+
+const supportsHyperlinks = require('supports-hyperlinks');
+
+// ANSI escapes
+const OSC = '\u001B]';
+const BEL = '\u0007';
+const SEP = ';';
+
+/**
+ * @see https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+ *
+ * @param {string} text
+ * @param {string} url
+ * @returns {string}
+ */
+function terminalLink(text, url) {
+	if (supportsHyperlinks.stdout) {
+		return [OSC, '8', SEP, SEP, url, BEL, text, OSC, '8', SEP, SEP, BEL].join('');
+	}
+
+	return text;
+}
+
+module.exports = terminalLink;

--- a/lib/formatters/terminalLink.mjs
+++ b/lib/formatters/terminalLink.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-const supportsHyperlinks = require('supports-hyperlinks');
+import supportsHyperlinks from 'supports-hyperlinks';
 
 // ANSI escapes
 const OSC = '\u001B]';
@@ -14,10 +12,10 @@ const SEP = ';';
  * @param {string} url
  * @returns {string}
  */
-module.exports = function terminalLink(text, url) {
+export default function terminalLink(text, url) {
 	if (supportsHyperlinks.stdout) {
 		return [OSC, '8', SEP, SEP, url, BEL, text, OSC, '8', SEP, SEP, BEL].join('');
 	}
 
 	return text;
-};
+}

--- a/lib/formatters/unixFormatter.cjs
+++ b/lib/formatters/unixFormatter.cjs
@@ -1,13 +1,13 @@
 'use strict';
 
-const calcSeverityCounts = require('./calcSeverityCounts');
+const calcSeverityCounts = require('./calcSeverityCounts.cjs');
 const pluralize = require('../utils/pluralize.cjs');
-const preprocessWarnings = require('./preprocessWarnings');
+const preprocessWarnings = require('./preprocessWarnings.cjs');
 
 /**
  * @type {import('stylelint').Formatter}
  */
-module.exports = function unixFormatter(results) {
+function unixFormatter(results) {
 	const counts = { error: 0, warning: 0 };
 	const lines = results.flatMap((result) => {
 		preprocessWarnings(result);
@@ -31,4 +31,6 @@ module.exports = function unixFormatter(results) {
 	}
 
 	return output;
-};
+}
+
+module.exports = unixFormatter;

--- a/lib/formatters/unixFormatter.mjs
+++ b/lib/formatters/unixFormatter.mjs
@@ -1,0 +1,32 @@
+import calcSeverityCounts from './calcSeverityCounts.mjs';
+import pluralize from '../utils/pluralize.mjs';
+import preprocessWarnings from './preprocessWarnings.mjs';
+
+/**
+ * @type {import('stylelint').Formatter}
+ */
+export default function unixFormatter(results) {
+	const counts = { error: 0, warning: 0 };
+	const lines = results.flatMap((result) => {
+		preprocessWarnings(result);
+
+		return result.warnings.map((warning) => {
+			calcSeverityCounts(warning.severity, counts);
+
+			return (
+				`${result.source}:${warning.line}:${warning.column}: ` +
+				`${warning.text} [${warning.severity}]`
+			);
+		});
+	});
+	const total = lines.length;
+	let output = lines.join('\n');
+
+	if (total > 0) {
+		output += `\n\n${total} ${pluralize('problem', total)}`;
+		output += ` (${counts.error} ${pluralize('error', counts.error)}`;
+		output += `, ${counts.warning} ${pluralize('warning', counts.warning)})\n`;
+	}
+
+	return output;
+}

--- a/lib/formatters/verboseFormatter.cjs
+++ b/lib/formatters/verboseFormatter.cjs
@@ -1,10 +1,11 @@
 'use strict';
 
-const { underline, red, yellow, dim, green } = require('picocolors');
-
+const picocolors = require('picocolors');
 const pluralize = require('../utils/pluralize.cjs');
-const stringFormatter = require('./stringFormatter');
-const terminalLink = require('./terminalLink');
+const stringFormatter = require('./stringFormatter.cjs');
+const terminalLink = require('./terminalLink.cjs');
+
+const { underline, red, yellow, dim, green } = picocolors;
 
 /** @typedef {import('stylelint').Formatter} Formatter */
 /** @typedef {import('stylelint').LintResult} LintResult */
@@ -15,7 +16,7 @@ const terminalLink = require('./terminalLink');
 /**
  * @type {Formatter}
  */
-module.exports = function verboseFormatter(results, returnValue) {
+function verboseFormatter(results, returnValue) {
 	let output = stringFormatter(results, returnValue);
 
 	if (output === '') {
@@ -97,7 +98,7 @@ module.exports = function verboseFormatter(results, returnValue) {
 	}
 
 	return `${output}\n`;
-};
+}
 
 /**
  * @template {string} K
@@ -147,3 +148,5 @@ function ruleLink(rule, metadata) {
 
 	return rule;
 }
+
+module.exports = verboseFormatter;

--- a/lib/formatters/verboseFormatter.mjs
+++ b/lib/formatters/verboseFormatter.mjs
@@ -1,0 +1,148 @@
+import picocolors from 'picocolors';
+const { underline, red, yellow, dim, green } = picocolors;
+
+import pluralize from '../utils/pluralize.mjs';
+import stringFormatter from './stringFormatter.mjs';
+import terminalLink from './terminalLink.mjs';
+
+/** @typedef {import('stylelint').Formatter} Formatter */
+/** @typedef {import('stylelint').LintResult} LintResult */
+/** @typedef {import('stylelint').Warning} Warning */
+/** @typedef {import('stylelint').Severity} Severity */
+/** @typedef {import('stylelint').RuleMeta} RuleMeta */
+
+/**
+ * @type {Formatter}
+ */
+export default function verboseFormatter(results, returnValue) {
+	let output = stringFormatter(results, returnValue);
+
+	if (output === '') {
+		output = '\n';
+	}
+
+	const ignoredCount = results.filter((result) => result.ignored).length;
+	const checkedDisplay = ignoredCount
+		? `${results.length - ignoredCount} of ${results.length}`
+		: results.length;
+
+	output += underline(`${checkedDisplay} ${pluralize('source', results.length)} checked\n`);
+
+	for (const result of results) {
+		let formatting = green;
+
+		if (result.errored) {
+			formatting = red;
+		} else if (result.warnings.length) {
+			formatting = yellow;
+		} else if (result.ignored) {
+			formatting = dim;
+		}
+
+		let sourceText = fileLink(result.source);
+
+		if (result.ignored) {
+			sourceText += ' (ignored)';
+		}
+
+		output += formatting(` ${sourceText}\n`);
+	}
+
+	const warnings = results.flatMap((r) => r.warnings);
+
+	if (warnings.length === 0) {
+		output += '\n0 problems found\n';
+	} else {
+		const warningsBySeverity = groupBy(warnings, (w) => w.severity);
+		let fixableProblemsFound = false;
+
+		/**
+		 * @param {Severity} severity
+		 */
+		const printProblems = (severity) => {
+			const problems = warningsBySeverity[severity];
+
+			if (problems === undefined) return;
+
+			output += '\n';
+			output += underline(`${problems.length} ${pluralize(severity, problems.length)} found\n`);
+
+			const problemsByRule = groupBy(problems, (w) => w.rule);
+			const metadata = returnValue.ruleMetadata;
+
+			for (const [rule, list] of Object.entries(problemsByRule)) {
+				const meta = metadata[rule] || {};
+
+				let additional = [meta.fixable ? 'maybe fixable' : '', meta.deprecated ? 'deprecated' : '']
+					.filter(Boolean)
+					.join(', ');
+
+				additional = additional ? ` (${additional})` : '';
+
+				output += dim(` ${ruleLink(rule, meta)}: ${list.length}${additional}\n`);
+
+				if (!fixableProblemsFound && meta.fixable) {
+					fixableProblemsFound = true;
+				}
+			}
+		};
+
+		printProblems('error');
+		printProblems('warning');
+
+		if (fixableProblemsFound) {
+			output += yellow('\nYou may fix some problems with the "--fix" option.\n');
+		}
+	}
+
+	return `${output}\n`;
+}
+
+/**
+ * @template {string} K
+ * @param {Warning[]} array
+ * @param {(w: Warning) => K} keyFn
+ * @returns {Record<K, Warning[]>}
+ */
+function groupBy(array, keyFn) {
+	/** @type {Record<string, Warning[]>} */
+	const result = {};
+
+	for (const item of array) {
+		const key = keyFn(item);
+		let warnings = result[key];
+
+		if (warnings === undefined) {
+			result[key] = warnings = [];
+		}
+
+		warnings.push(item);
+	}
+
+	return result;
+}
+
+/**
+ * @param {string | undefined} source
+ * @returns {string}
+ */
+function fileLink(source) {
+	if (!source || source.startsWith('<')) {
+		return `${source}`;
+	}
+
+	return terminalLink(source, `file://${source}`);
+}
+
+/**
+ * @param {string} rule
+ * @param {Partial<RuleMeta> | undefined} metadata
+ * @returns {string}
+ */
+function ruleLink(rule, metadata) {
+	if (metadata && metadata.url) {
+		return terminalLink(rule, metadata.url);
+	}
+
+	return rule;
+}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #5291

> Is there anything in the PR that needs further explanation?

`formatters/index` internally uses `lazy-import`. This is a bit hard to resolve, so I will migrate it later (with another PR).

```console
$ git ls-files 'lib/formatters/*.js'
lib/formatters/index.js
```
