### PR TITLE
Refactor `lib/cli.mjs`

### DIFF
--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -3,6 +3,7 @@
 import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import process from 'node:process';
 
 import { jest } from '@jest/globals';
 import stripAnsi from 'strip-ansi';

--- a/lib/cli.mjs
+++ b/lib/cli.mjs
@@ -1,5 +1,6 @@
+import { isAbsolute, join, resolve } from 'node:path';
 import { EOL } from 'node:os';
-import path from 'node:path';
+import process from 'node:process';
 
 import picocolors from 'picocolors';
 const { dim, red } = picocolors;
@@ -7,8 +8,8 @@ const { dim, red } = picocolors;
 import meow from 'meow';
 import resolveFrom from 'resolve-from';
 
+import { isBoolean, isNumber, isObject, isPlainObject, isString } from './utils/validateTypes.mjs';
 import checkInvalidCLIOptions from './utils/checkInvalidCLIOptions.mjs';
-import { isPlainObject } from './utils/validateTypes.mjs';
 import printConfig from './printConfig.js';
 import resolveCustomFormatter from './resolveCustomFormatter.js';
 import standalone from './standalone.js';
@@ -27,81 +28,7 @@ import { createRequire } from 'module';
 // @ts-expect-error
 const require = createRequire(import.meta.url);
 
-/**
- * @typedef {{
- *   allowEmptyInput: boolean;
- *   cache: boolean;
- *   cacheLocation?: string;
- *   cacheStrategy?: string;
- *   color: boolean;
- *   config?: string;
- *   configBasedir?: string;
- *   customFormatter?: string;
- *   customSyntax?: string;
- *   disableDefaultIgnores: boolean;
- *   fix: boolean;
- *   formatter: string;
- *   globbyOptions?: string;
- *   help: boolean;
- *   ignoreDisables: boolean;
- *   ignorePath: string[];
- *   ignorePattern: string[];
- *   maxWarnings?: number;
- *   outputFile?: string;
- *   printConfig: boolean;
- *   quiet: boolean;
- *   quietDeprecationWarnings: boolean;
- *   reportDescriptionlessDisables: boolean;
- *   reportInvalidScopeDisables: boolean;
- *   reportNeedlessDisables: boolean;
- *   stdin: boolean;
- *   stdinFilename?: string;
- *   version: boolean;
- * }} CLIFlags
- */
-
-/**
- * @typedef {{
- *   input: string[];
- *   showHelp: (code: number) => void;
- *   showVersion: () => void;
- *   flags: CLIFlags;
- * }} CLIOptions
- */
-
-/**
- * @typedef {{
- *   allowEmptyInput?: boolean;
- *   cache?: boolean;
- *   cacheLocation?: string;
- *   cacheStrategy?: string;
- *   code?: string;
- *   codeFilename?: string;
- *   configFile?: string;
- *   configBasedir?: string;
- *   customSyntax?: string;
- *   disableDefaultIgnores?: boolean;
- *   files?: string[];
- *   fix?: boolean;
- *   formatter: any;
- *   globbyOptions?: Record<string, unknown>;
- *   ignoreDisables?: boolean;
- *   ignorePath?: string[];
- *   ignorePattern?: string[];
- *   maxWarnings?: number;
- *   outputFile?: string;
- *   quiet?: boolean;
- *   quietDeprecationWarnings?: boolean;
- *   reportDescriptionlessDisables?: boolean;
- *   reportInvalidScopeDisables?: boolean;
- *   reportNeedlessDisables?: boolean;
- * }} OptionBaseType
- */
-
-const meowOptions = {
-	autoHelp: false,
-	autoVersion: false,
-	help: `
+const helpText = `
     Usage: stylelint [input] [options]
 
     Input: Files(s), glob(s), or nothing to use stdin.
@@ -272,174 +199,219 @@ const meowOptions = {
       --help, -h
 
         Show the help.
-	`,
-	flags: {
-		allowEmptyInput: {
-			alias: 'aei',
-			type: 'boolean',
-		},
-		cache: {
-			type: 'boolean',
-		},
-		cacheLocation: {
-			type: 'string',
-		},
-		cacheStrategy: {
-			type: 'string',
-		},
-		color: {
-			type: 'boolean',
-		},
-		config: {
-			alias: 'c',
-			type: 'string',
-		},
-		configBasedir: {
-			type: 'string',
-		},
-		customFormatter: {
-			type: 'string',
-		},
-		customSyntax: {
-			type: 'string',
-		},
-		disableDefaultIgnores: {
-			alias: 'di',
-			type: 'boolean',
-		},
-		fix: {
-			type: 'boolean',
-		},
-		formatter: {
-			alias: 'f',
-			type: 'string',
-			default: DEFAULT_FORMATTER,
-		},
-		globbyOptions: {
-			alias: 'go',
-			type: 'string',
-		},
-		help: {
-			alias: 'h',
-			type: 'boolean',
-		},
-		ignoreDisables: {
-			alias: 'id',
-			type: 'boolean',
-		},
-		ignorePath: {
-			alias: 'i',
-			type: 'string',
-			isMultiple: true,
-		},
-		ignorePattern: {
-			alias: 'ip',
-			type: 'string',
-			isMultiple: true,
-		},
-		maxWarnings: {
-			alias: 'mw',
-			type: 'number',
-		},
-		outputFile: {
-			alias: 'o',
-			type: 'string',
-		},
-		printConfig: {
-			type: 'boolean',
-		},
-		quiet: {
-			alias: 'q',
-			type: 'boolean',
-		},
-		quietDeprecationWarnings: {
-			type: 'boolean',
-		},
-		reportDescriptionlessDisables: {
-			alias: 'rdd',
-			type: 'boolean',
-		},
-		reportInvalidScopeDisables: {
-			alias: 'risd',
-			type: 'boolean',
-		},
-		reportNeedlessDisables: {
-			alias: 'rd',
-			type: 'boolean',
-		},
-		stdin: {
-			type: 'boolean',
-		},
-		stdinFilename: {
-			type: 'string',
-		},
-		version: {
-			alias: 'v',
-			type: 'boolean',
-		},
+`;
+
+const flags = {
+	allowEmptyInput: {
+		alias: 'aei',
+		type: 'boolean',
+	},
+	cache: {
+		type: 'boolean',
+	},
+	cacheLocation: {
+		type: 'string',
+	},
+	cacheStrategy: {
+		type: 'string',
+	},
+	color: {
+		type: 'boolean',
+	},
+	config: {
+		alias: 'c',
+		type: 'string',
+	},
+	configBasedir: {
+		type: 'string',
+	},
+	customFormatter: {
+		type: 'string',
+	},
+	customSyntax: {
+		type: 'string',
+	},
+	disableDefaultIgnores: {
+		alias: 'di',
+		type: 'boolean',
+	},
+	fix: {
+		type: 'boolean',
+	},
+	formatter: {
+		alias: 'f',
+		type: 'string',
+		default: DEFAULT_FORMATTER,
+	},
+	globbyOptions: {
+		alias: 'go',
+		type: 'string',
+	},
+	help: {
+		alias: 'h',
+		type: 'boolean',
+	},
+	ignoreDisables: {
+		alias: 'id',
+		type: 'boolean',
+	},
+	ignorePath: {
+		alias: 'i',
+		type: 'string',
+		isMultiple: true,
+	},
+	ignorePattern: {
+		alias: 'ip',
+		type: 'string',
+		isMultiple: true,
+	},
+	maxWarnings: {
+		alias: 'mw',
+		type: 'number',
+	},
+	outputFile: {
+		alias: 'o',
+		type: 'string',
+	},
+	printConfig: {
+		type: 'boolean',
+	},
+	quiet: {
+		alias: 'q',
+		type: 'boolean',
+	},
+	quietDeprecationWarnings: {
+		type: 'boolean',
+	},
+	reportDescriptionlessDisables: {
+		alias: 'rdd',
+		type: 'boolean',
+	},
+	reportInvalidScopeDisables: {
+		alias: 'risd',
+		type: 'boolean',
+	},
+	reportNeedlessDisables: {
+		alias: 'rd',
+		type: 'boolean',
+	},
+	stdin: {
+		type: 'boolean',
+	},
+	stdinFilename: {
+		type: 'string',
+	},
+	version: {
+		alias: 'v',
+		type: 'boolean',
 	},
 };
 
 /**
  * @param {string[]} argv
- * @returns {Promise<any>}
+ * @returns {Promise<void>}
  */
 export default async function main(argv) {
 	const cli = buildCLI(argv);
 
-	const invalidOptionsMessage = checkInvalidCLIOptions(meowOptions.flags, cli.flags);
+	const invalidOptionsMessage = checkInvalidCLIOptions(flags, cli.flags);
 
 	if (invalidOptionsMessage) {
 		process.stderr.write(invalidOptionsMessage);
-		process.exit(EXIT_CODE_ERROR); // eslint-disable-line n/no-process-exit
+		process.exitCode = EXIT_CODE_ERROR;
+
+		return;
 	}
 
-	let formatter = cli.flags.formatter;
+	const {
+		// Sort alphabetically
+		allowEmptyInput,
+		cache,
+		cacheLocation,
+		cacheStrategy,
+		config: configFile,
+		configBasedir,
+		customFormatter,
+		customSyntax,
+		disableDefaultIgnores,
+		formatter: formatterInput,
+		fix,
+		globbyOptions,
+		help,
+		ignoreDisables,
+		ignorePath,
+		ignorePattern,
+		maxWarnings,
+		outputFile,
+		printConfig: printConfigFlag,
+		quiet,
+		quietDeprecationWarnings,
+		reportDescriptionlessDisables,
+		reportInvalidScopeDisables,
+		reportNeedlessDisables,
+		stdin,
+		stdinFilename,
+		version,
+	} = cli.flags;
 
-	if (cli.flags.customFormatter) {
-		const customFormatter = resolveCustomFormatter(cli.flags.customFormatter);
+	const showHelp = () => cli.showHelp(EXIT_CODE_SUCCESS);
 
-		formatter = require(customFormatter);
+	if (help) {
+		showHelp();
+
+		return;
 	}
 
-	/** @type {OptionBaseType} */
-	const optionsBase = {
+	if (version) {
+		cli.showVersion();
+
+		return;
+	}
+
+	let formatter = undefined;
+
+	if (isString(customFormatter)) {
+		formatter = require(resolveCustomFormatter(customFormatter));
+	} else if (isString(formatterInput)) {
+		formatter = formatterInput;
+	}
+
+	/** @type {import('stylelint').LinterOptions} */
+	const options = {
 		formatter,
 	};
 
-	if (cli.flags.quiet) {
-		optionsBase.quiet = cli.flags.quiet;
+	if (isBoolean(quiet)) {
+		options.quiet = quiet;
 	}
 
-	if (cli.flags.quietDeprecationWarnings) {
-		optionsBase.quietDeprecationWarnings = cli.flags.quietDeprecationWarnings;
+	if (isBoolean(quietDeprecationWarnings)) {
+		options.quietDeprecationWarnings = quietDeprecationWarnings;
 	}
 
-	if (cli.flags.customSyntax) {
-		optionsBase.customSyntax = cli.flags.customSyntax;
+	if (isString(customSyntax)) {
+		options.customSyntax = customSyntax;
 	}
 
-	if (cli.flags.config) {
+	const cwd = process.cwd();
+
+	if (isString(configFile)) {
 		// Should check these possibilities:
 		//   a. name of a node_module
 		//   b. absolute path
 		//   c. relative path relative to `process.cwd()`.
 		// If none of the above work, we'll try a relative path starting
 		// in `process.cwd()`.
-		optionsBase.configFile =
-			resolveFrom.silent(process.cwd(), cli.flags.config) ||
-			path.join(process.cwd(), cli.flags.config);
+		options.configFile = resolveFrom.silent(cwd, configFile) || join(cwd, configFile);
 	}
 
-	if (cli.flags.configBasedir) {
-		optionsBase.configBasedir = path.isAbsolute(cli.flags.configBasedir)
-			? cli.flags.configBasedir
-			: path.resolve(process.cwd(), cli.flags.configBasedir);
+	if (isString(configBasedir)) {
+		options.configBasedir = isAbsolute(configBasedir) ? configBasedir : resolve(cwd, configBasedir);
 	}
 
-	if (cli.flags.globbyOptions) {
+	if (isString(globbyOptions)) {
 		try {
-			optionsBase.globbyOptions = await parseGlobbyOptions(cli.flags.globbyOptions);
+			options.globbyOptions = await parseGlobbyOptions(globbyOptions);
 		} catch (error) {
 			if (typeof error === 'string') {
 				process.stderr.write(`${error}${EOL}`);
@@ -452,114 +424,87 @@ export default async function main(argv) {
 		}
 	}
 
-	if (cli.flags.stdinFilename) {
-		optionsBase.codeFilename = cli.flags.stdinFilename;
+	if (isString(stdinFilename)) {
+		options.codeFilename = stdinFilename;
 	}
 
-	if (cli.flags.ignorePath) {
-		optionsBase.ignorePath = cli.flags.ignorePath;
+	if (Array.isArray(ignorePath)) {
+		options.ignorePath = ignorePath;
 	}
 
-	if (cli.flags.ignorePattern) {
-		optionsBase.ignorePattern = cli.flags.ignorePattern;
+	if (Array.isArray(ignorePattern)) {
+		options.ignorePattern = ignorePattern;
 	}
 
-	if (cli.flags.ignoreDisables) {
-		optionsBase.ignoreDisables = cli.flags.ignoreDisables;
+	if (isBoolean(ignoreDisables)) {
+		options.ignoreDisables = ignoreDisables;
 	}
 
-	if (cli.flags.disableDefaultIgnores) {
-		optionsBase.disableDefaultIgnores = cli.flags.disableDefaultIgnores;
+	if (isBoolean(disableDefaultIgnores)) {
+		options.disableDefaultIgnores = disableDefaultIgnores;
 	}
 
-	if (cli.flags.cache) {
-		optionsBase.cache = true;
+	if (isBoolean(cache)) {
+		options.cache = cache;
 	}
 
-	if (cli.flags.cacheLocation) {
-		optionsBase.cacheLocation = cli.flags.cacheLocation;
+	if (isString(cacheLocation)) {
+		options.cacheLocation = cacheLocation;
 	}
 
-	if (cli.flags.cacheStrategy) {
-		optionsBase.cacheStrategy = cli.flags.cacheStrategy;
+	if (isString(cacheStrategy)) {
+		options.cacheStrategy = cacheStrategy;
 	}
 
-	if (cli.flags.fix) {
-		optionsBase.fix = cli.flags.fix;
+	if (isBoolean(fix)) {
+		options.fix = fix;
 	}
 
-	if (cli.flags.outputFile) {
-		optionsBase.outputFile = cli.flags.outputFile;
+	if (isBoolean(reportNeedlessDisables)) {
+		options.reportNeedlessDisables = reportNeedlessDisables;
 	}
 
-	const reportNeedlessDisables = cli.flags.reportNeedlessDisables;
-	const reportInvalidScopeDisables = cli.flags.reportInvalidScopeDisables;
-	const reportDescriptionlessDisables = cli.flags.reportDescriptionlessDisables;
-
-	if (reportNeedlessDisables) {
-		optionsBase.reportNeedlessDisables = reportNeedlessDisables;
+	if (isBoolean(reportInvalidScopeDisables)) {
+		options.reportInvalidScopeDisables = reportInvalidScopeDisables;
 	}
 
-	if (reportInvalidScopeDisables) {
-		optionsBase.reportInvalidScopeDisables = reportInvalidScopeDisables;
+	if (isBoolean(reportDescriptionlessDisables)) {
+		options.reportDescriptionlessDisables = reportDescriptionlessDisables;
 	}
 
-	if (reportDescriptionlessDisables) {
-		optionsBase.reportDescriptionlessDisables = reportDescriptionlessDisables;
+	if (isNumber(maxWarnings)) {
+		options.maxWarnings = maxWarnings;
 	}
 
-	const maxWarnings = cli.flags.maxWarnings;
-
-	if (maxWarnings !== undefined) {
-		optionsBase.maxWarnings = maxWarnings;
-	}
-
-	if (cli.flags.help) {
-		cli.showHelp(EXIT_CODE_SUCCESS);
-
-		return;
-	}
-
-	if (cli.flags.version) {
-		cli.showVersion();
-
-		return;
-	}
-
-	if (cli.flags.allowEmptyInput) {
-		optionsBase.allowEmptyInput = cli.flags.allowEmptyInput;
+	if (isBoolean(allowEmptyInput)) {
+		options.allowEmptyInput = allowEmptyInput;
 	}
 
 	// Add input/code into options
-	/** @type {OptionBaseType} */
-	const options = cli.input.length
-		? {
-				...optionsBase,
-				files: cli.input,
-		  }
-		: await getStdin().then((stdin) => ({
-				...optionsBase,
-				code: stdin,
-		  }));
+	if (cli.input.length > 0) {
+		options.files = cli.input;
+	} else {
+		options.code = await getStdin();
+	}
 
-	if (cli.flags.printConfig) {
-		return printConfig(options)
+	if (printConfigFlag) {
+		await printConfig(options)
 			.then((config) => {
 				process.stdout.write(JSON.stringify(config, null, '  '));
 			})
 			.catch(handleError);
+
+		return;
 	}
 
-	if (!options.files && !options.code && !cli.flags.stdin) {
-		cli.showHelp(EXIT_CODE_SUCCESS);
+	if (!options.files && !options.code && !stdin) {
+		showHelp();
 
 		return;
 	}
 
 	return standalone(options)
-		.then((linted) => {
-			const { output, code } = linted;
-
+		.then(({ output, code, errored, maxWarningsExceeded }) => {
 			if (!output && !code) {
 				return;
 			}
@@ -572,14 +517,14 @@ export default async function main(argv) {
 				process.stderr.write(output);
 			}
 
-			if (options.outputFile) {
-				writeOutputFile(output, options.outputFile).catch(handleError);
+			if (isString(outputFile)) {
+				writeOutputFile(output, outputFile).catch(handleError);
 			}
 
-			if (linted.errored) {
+			if (errored) {
 				process.exitCode = EXIT_CODE_ERROR;
-			} else if (maxWarnings !== undefined && linted.maxWarningsExceeded) {
-				const foundWarnings = linted.maxWarningsExceeded.foundWarnings;
+			} else if (isNumber(maxWarnings) && maxWarningsExceeded) {
+				const foundWarnings = maxWarningsExceeded.foundWarnings;
 
 				process.stderr.write(
 					`${EOL}${red(`Max warnings exceeded: `)}${foundWarnings} found. ${dim(
@@ -593,12 +538,19 @@ export default async function main(argv) {
 }
 
 /**
- * @param {{ stack: any, code: any }} err
+ * @param {unknown} err
  * @returns {void}
  */
 function handleError(err) {
-	process.stderr.write(err.stack + EOL);
-	const exitCode = typeof err.code === 'number' ? err.code : EXIT_CODE_FATAL;
+	if (!isObject(err)) {
+		throw err;
+	}
+
+	if ('stack' in err && isString(err.stack)) {
+		process.stderr.write(err.stack + EOL);
+	}
+
+	const exitCode = 'code' in err && isNumber(err.code) ? err.code : EXIT_CODE_FATAL;
 
 	process.exitCode = exitCode;
 }
@@ -642,9 +594,21 @@ async function getStdin() {
 
 /**
  * @param {string[]} argv
- * @returns {CLIOptions}
  */
 export function buildCLI(argv) {
-	// @ts-expect-error -- TS2322: Type 'Result<AnyFlags>' is not assignable to type 'CLIOptions'.
-	return meow({ ...meowOptions, argv, importMeta: import.meta });
+	return meow(helpText, {
+		autoHelp: false,
+		autoVersion: false,
+		argv,
+
+		// NOTE: `meow()` infers flag types when passing a flag object with inline.
+		// However, `checkInvalidCLIOptions()` also needs this flag object.
+		// So, unfortunately, the return value type inference by `meow()` is unavailable here.
+		//
+		// @ts-expect-error -- TS2322: Type '{ allowEmptyInput: {...} }' is not assignable to type 'AnyFlags'.
+		flags,
+
+		// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+		importMeta: import.meta,
+	});
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

- Remove no longer needed JSDoc types.
- Use type-guard functions for type-safety.
- Make the code more readable with new local variables.

If anyone knows a way to use type inference by `meow()` in this `cli.mjs` module, please let me know.
