### PR TITLE
Fix CLI to avoid waiting for stdin without any input and avoid different outputs

### DIFF
--- a/.changeset/orange-dancers-compete.md
+++ b/.changeset/orange-dancers-compete.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: CLI to avoid waiting for stdin without any input (regression since 14.10.0)
+Fixed: CLI regression to avoid waiting for stdin without any input

--- a/.changeset/orange-dancers-compete.md
+++ b/.changeset/orange-dancers-compete.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": minor
+"stylelint": patch
 ---
 
-Changed: CLI to avoid waiting for stdin without any input
+Fixed: CLI to avoid waiting for stdin without any input (regression since 14.10.0)

--- a/.changeset/orange-dancers-compete.md
+++ b/.changeset/orange-dancers-compete.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Changed: CLI to avoid waiting for stdin without any input

--- a/.changeset/twelve-ladybugs-mate.md
+++ b/.changeset/twelve-ladybugs-mate.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: CLI to avoid different outputs on empty files and empty stdin

--- a/docs/migration-guide/to-16.md
+++ b/docs/migration-guide/to-16.md
@@ -13,20 +13,6 @@ Node.js 14 has reached end-of-life. We've removed support for it so that we coul
 - 16.13.0
 - 18.0.0
 
-## Changed CLI to avoid waiting for stdin without any input
-
-If you run the CLI without any input files or input from stdin, the CLI immediately exits with some message (help, error, etc.). Before 16.0.0, the CLI waited for input from stdin.
-
-```sh
-# Before 16.0.0
-stylelint
-# waiting for stdin...
-
-# After 16.0.0
-stylelint
-# show help and then exit
-```
-
 ## Changed CLI to print problems to stderr instead of stdout
 
 If you use the CLI to fix a source string by using the [`--fix`](../user-guide/cli.md#--fix) and [`--stdin`](../user-guide/cli.md#--stdin) options, the CLI will print the fixed code to stdout and any problems to stderr.

--- a/docs/migration-guide/to-16.md
+++ b/docs/migration-guide/to-16.md
@@ -13,6 +13,20 @@ Node.js 14 has reached end-of-life. We've removed support for it so that we coul
 - 16.13.0
 - 18.0.0
 
+## Changed CLI to avoid waiting for stdin without any input
+
+If you run the CLI without any input files or input from stdin, the CLI immediately exits with some message (help, error, etc.). Before 16.0.0, the CLI waited for input from stdin.
+
+```sh
+# Before 16.0.0
+stylelint
+# waiting for stdin...
+
+# After 16.0.0
+stylelint
+# show help and then exit
+```
+
 ## Changed CLI to print problems to stderr instead of stdout
 
 If you use the CLI to fix a source string by using the [`--fix`](../user-guide/cli.md#--fix) and [`--stdin`](../user-guide/cli.md#--stdin) options, the CLI will print the fixed code to stdout and any problems to stderr.

--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -183,24 +183,22 @@ describe('buildCLI', () => {
 });
 
 describe('CLI', () => {
-	beforeAll(() => {
+	beforeEach(() => {
 		jest.spyOn(process, 'exit').mockImplementation(() => {});
 		jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
 		jest.spyOn(process.stderr, 'write').mockImplementation(() => {});
-		jest.spyOn(process, 'stdin', 'get').mockImplementation(() => Readable.from([Buffer.from('')]));
 		jest.spyOn(console, 'log').mockImplementation(() => {});
 		jest.spyOn(console, 'error').mockImplementation(() => {});
 	});
 
 	afterEach(() => {
+		jest.restoreAllMocks();
 		process.exitCode = undefined;
 	});
 
-	afterAll(() => {
-		jest.restoreAllMocks();
-	});
+	it('no arguments', async () => {
+		jest.spyOn(process, 'stdin', 'get').mockImplementationOnce(() => ({ isTTY: true }));
 
-	it('basic', async () => {
 		await cli([]);
 
 		expect(process.exit).toHaveBeenCalledWith(0);
@@ -223,7 +221,7 @@ describe('CLI', () => {
 	it('--version', async () => {
 		await cli(['--version']);
 
-		expect(process.exitCode).toBeUndefined();
+		expect(process.exit).toHaveBeenCalledWith(0);
 
 		expect(console.log).toHaveBeenCalledTimes(1);
 		expect(console.log).toHaveBeenCalledWith(expect.stringContaining(pkg.version));
@@ -303,17 +301,44 @@ describe('CLI', () => {
 		);
 	});
 
-	it('--stdin', async () => {
+	it('--stdin with any input from stdin', async () => {
+		jest.spyOn(process, 'stdin', 'get').mockImplementationOnce(() => Readable.from([]));
+
 		await cli(['--stdin', '--config', fixturesPath('config-no-empty-source.json')]);
 
 		expect(process.exitCode).toBe(2);
 
 		expect(process.stdout.write).not.toHaveBeenCalled();
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
-		expect(process.stderr.write).toHaveBeenNthCalledWith(
-			1,
+		expect(process.stderr.write).toHaveBeenCalledWith(
 			expect.stringContaining('Unexpected empty source'),
 		);
+	});
+
+	it('--stdin with no input from stdin', async () => {
+		jest.spyOn(process, 'stdin', 'get').mockImplementationOnce(() => ({ isTTY: true }));
+
+		await cli(['--stdin']);
+
+		expect(process.exitCode).toBe(1);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(
+			expect.stringContaining('You must pass stylelint a `files` glob or a `code` string'),
+		);
+	});
+
+	it('empty input from stdin without --stdin', async () => {
+		jest.spyOn(process, 'stdin', 'get').mockImplementation(() => Readable.from([]));
+
+		await cli(['--config', fixturesPath('config-no-empty-source.json')]);
+
+		expect(process.exitCode).toBe(2);
+
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).toHaveBeenCalledTimes(1);
+		expect(process.stderr.write).toHaveBeenCalledWith(expect.stringMatching('no-empty-source'));
 	});
 
 	it('exits with non zero on unfound module in config', async () => {
@@ -365,8 +390,8 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBeUndefined();
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(0);
-		expect(process.stderr.write).toHaveBeenCalledTimes(0);
+		expect(process.stdout.write).not.toHaveBeenCalled();
+		expect(process.stderr.write).not.toHaveBeenCalled();
 	});
 
 	it('--quiet-deprecation-warnings', async () => {
@@ -379,7 +404,7 @@ describe('CLI', () => {
 
 		expect(process.exitCode).toBe(2);
 
-		expect(process.stdout.write).toHaveBeenCalledTimes(0);
+		expect(process.stdout.write).not.toHaveBeenCalled();
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(process.stderr.write.mock.calls[0][0]).toEqual(
 			expect.not.stringContaining('The "color-hex-case" rule is deprecated.'),
@@ -418,7 +443,6 @@ describe('CLI', () => {
 		expect(process.exitCode).toBe(2);
 
 		expect(process.stdout.write).not.toHaveBeenCalled();
-		expect(process.stdout.write).toHaveBeenCalledTimes(0);
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
 		expect(stripAnsi(process.stderr.write.mock.calls[0][0])).toContain(
 			'Invalid option "--globby-options". The value "wrong" is not valid JSON object.',

--- a/lib/cli.mjs
+++ b/lib/cli.mjs
@@ -497,7 +497,7 @@ export default async function main(argv) {
 		return;
 	}
 
-	if (!options.files && !options.code && !stdin) {
+	if (!options.files && !isString(options.code) && !stdin) {
 		showHelp();
 
 		return;
@@ -580,12 +580,18 @@ function parseGlobbyOptions(value) {
 }
 
 /**
- * @returns {Promise<string>}
+ * @returns {Promise<string | undefined>}
  */
 async function getStdin() {
+	const { stdin } = process;
+
+	if (stdin.isTTY) {
+		return undefined;
+	}
+
 	const chunks = [];
 
-	for await (const chunk of process.stdin) {
+	for await (const chunk of stdin) {
 		chunks.push(chunk);
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #3401

> Is there anything in the PR that needs further explanation?

This commit changes the following:

1. To avoid waiting for stdin without any input. For example, just running the `stylelint` command
   immediately exits, instead of waiting. I believe this behavior is more user-friendly.
2. To avoid different outputs on empty files and empty stdin. This is achieved by allowing an empty
   string input (`''`) from stdin. See the example below:
   ```sh
   # code is undefined
   bin/stylelint.mjs

   # code is ''
   echo -n '' | bin/stylelint.mjs
   ```

See also [`process.stdin.isTTY`](https://nodejs.org/api/tty.html#readstreamistty).
