### PR TITLE
Change Dependabot target branch to v16 (retry)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
         patterns: ['@stylelint/*']
       typescript:
         patterns: ['typescript', '@types/*']
+    target-branch: v16 # TODO: We must remove this setting when deleting this branch.
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Retry for #7151

> Is there anything in the PR that needs further explanation?

We had to push changes in `dependabot.yml` into the `main` branch rather than the `v16` branch.
