### PR TITLE
Avoid `import-lazy` in `formatters`

### DIFF
--- a/.changeset/fifty-rice-knock.md
+++ b/.changeset/fifty-rice-knock.md
@@ -1,0 +1,5 @@
+---
+"stylelint": major
+---
+
+Changed: Node.js API so that the `stylelint.formatters` object has a `Promise` function

--- a/.changeset/fifty-rice-knock.md
+++ b/.changeset/fifty-rice-knock.md
@@ -2,4 +2,4 @@
 "stylelint": major
 ---
 
-Changed: Node.js API so that the `stylelint.formatters` object has a `Promise` function
+Changed: Node.js API so that the `stylelint.formatters` object has `Promise` functions

--- a/.changeset/red-bottles-invite.md
+++ b/.changeset/red-bottles-invite.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: support for a `Promise` formatter function

--- a/docs/migration-guide/to-16.md
+++ b/docs/migration-guide/to-16.md
@@ -25,7 +25,7 @@ You should use the following or higher versions of Node.js:
 
 ## Changed Node.js API returned resolved object
 
-We changed the resolved object of the Promise returned by `stylelint.lint()` so that:
+We've changed the resolved object of the Promise returned by `stylelint.lint()` so that:
 
 - the [`output`](../user-guide/node-api.md#output) property now only contains formatted problems
 - a new [`code`](../user-guide/node-api.md#code-1) property contains the autofixed code
@@ -44,6 +44,15 @@ async function lint() {
 ```
 
 If you use `stylelint.lint()` to lint files, the `code` property will always be `undefined`.
+
+## Changed Node.js API returned `formatters` object
+
+We've changed the `stylelint.formatters` object in the Node.js API so that every formatter is a `Promise` function.
+
+```diff js
+-stylelint.formatters.json(results);
++stylelint.formatters.json.then(formatter => formatter(results));
+```
 
 ## Changed CLI to print problems to stderr
 

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -90,7 +90,7 @@ Options are:
 - `unix` - generates messages like a C compiler, so that tools like Emacs' _Compilation mode_ can hyperlink them
 - `verbose` - extends `string` to include a list of checked files and a tally for each rule
 
-The `formatter` Node.js API option can also accept a function, whereas the `--custom-formatter` CLI flag accepts a path (either a filesystem path or a dependency) to a JS file exporting one. The function in both cases must fit the signature described in the [Developer Guide](../developer-guide/formatters.md).
+The `formatter` Node.js API option can also accept a function or a `Promise` function, whereas the `--custom-formatter` CLI flag accepts a path (either a filesystem path or a dependency) to a JS file exporting one. The function in both cases must fit the signature described in the [Developer Guide](../developer-guide/formatters.md).
 
 ## `cache`
 

--- a/lib/__tests__/formatters.test.mjs
+++ b/lib/__tests__/formatters.test.mjs
@@ -1,5 +1,5 @@
 import stylelint from '../index.mjs';
 
-it('formatters are exposed on stylelint object', () => {
-	expect(typeof stylelint.formatters.json).toBe('function');
+it('formatters are exposed on stylelint object', async () => {
+	expect(typeof (await stylelint.formatters.json)).toBe('function');
 });

--- a/lib/__tests__/standalone-formatter.test.mjs
+++ b/lib/__tests__/standalone-formatter.test.mjs
@@ -49,3 +49,15 @@ it('standalone with invalid formatter option', async () => {
 		'You must use a valid formatter option: "compact", "github", "json", "string", "tap", "unix", "verbose" or a function',
 	);
 });
+
+it('standalone with input css and custom promised formatter', async () => {
+	const { output } = await standalone({
+		code: 'a {}',
+		config: configBlockNoEmpty,
+		formatter: Promise.resolve((results) => {
+			return results[0].warnings.map((w) => w.rule).join();
+		}),
+	});
+
+	expect(output).toContain('block-no-empty');
+});

--- a/lib/formatters/index.cjs
+++ b/lib/formatters/index.cjs
@@ -1,21 +1,30 @@
 'use strict';
 
-const node_module = require('node:module');
-const importLazy = require('import-lazy');
+const _interopNamespaceDefaultOnly = e => Object.freeze({ __proto__: null, default: e });
 
-var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
-const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/formatters/index.cjs', document.baseURI).href)));
-
-/** @type {import('stylelint')['formatters']} */
+/** @type {import('stylelint').Formatters} */
 const formatters = {
-	compact: importLazy(() => require$1('./compactFormatter.cjs'))(),
-	github: importLazy(() => require$1('./githubFormatter.cjs'))(),
-	json: importLazy(() => require$1('./jsonFormatter.cjs'))(),
-	string: importLazy(() => require$1('./stringFormatter.cjs'))(),
-	tap: importLazy(() => require$1('./tapFormatter.cjs'))(),
-	unix: importLazy(() => require$1('./unixFormatter.cjs'))(),
-	verbose: importLazy(() => require$1('./verboseFormatter.cjs'))(),
+	get compact() {
+		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./compactFormatter.cjs'))).then((m) => m.default);
+	},
+	get github() {
+		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./githubFormatter.cjs'))).then((m) => m.default);
+	},
+	get json() {
+		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./jsonFormatter.cjs'))).then((m) => m.default);
+	},
+	get string() {
+		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./stringFormatter.cjs'))).then((m) => m.default);
+	},
+	get tap() {
+		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./tapFormatter.cjs'))).then((m) => m.default);
+	},
+	get unix() {
+		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./unixFormatter.cjs'))).then((m) => m.default);
+	},
+	get verbose() {
+		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./verboseFormatter.cjs'))).then((m) => m.default);
+	},
 };
 
 module.exports = formatters;

--- a/lib/formatters/index.mjs
+++ b/lib/formatters/index.mjs
@@ -1,18 +1,26 @@
-import { createRequire } from 'node:module';
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
-const require = createRequire(import.meta.url);
-
-import importLazy from 'import-lazy';
-
-/** @type {import('stylelint')['formatters']} */
+/** @type {import('stylelint').Formatters} */
 const formatters = {
-	compact: importLazy(() => require('./compactFormatter.cjs'))(),
-	github: importLazy(() => require('./githubFormatter.cjs'))(),
-	json: importLazy(() => require('./jsonFormatter.cjs'))(),
-	string: importLazy(() => require('./stringFormatter.cjs'))(),
-	tap: importLazy(() => require('./tapFormatter.cjs'))(),
-	unix: importLazy(() => require('./unixFormatter.cjs'))(),
-	verbose: importLazy(() => require('./verboseFormatter.cjs'))(),
+	get compact() {
+		return import('./compactFormatter.mjs').then((m) => m.default);
+	},
+	get github() {
+		return import('./githubFormatter.mjs').then((m) => m.default);
+	},
+	get json() {
+		return import('./jsonFormatter.mjs').then((m) => m.default);
+	},
+	get string() {
+		return import('./stringFormatter.mjs').then((m) => m.default);
+	},
+	get tap() {
+		return import('./tapFormatter.mjs').then((m) => m.default);
+	},
+	get unix() {
+		return import('./unixFormatter.mjs').then((m) => m.default);
+	},
+	get verbose() {
+		return import('./verboseFormatter.mjs').then((m) => m.default);
+	},
 };
 
 export default formatters;

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -10,7 +10,6 @@ const normalizePath = require('normalize-path');
 const writeFileAtomic = require('write-file-atomic');
 const allFilesIgnoredError = require('./utils/allFilesIgnoredError.cjs');
 const noFilesFoundError = require('./utils/noFilesFoundError.cjs');
-const validateTypes = require('./utils/validateTypes.cjs');
 const createPartialStylelintResult = require('./createPartialStylelintResult.cjs');
 const createStylelint = require('./createStylelint.cjs');
 const filterFilePaths = require('./utils/filterFilePaths.cjs');
@@ -84,7 +83,7 @@ async function standalone({
 	let formatterFunction;
 
 	try {
-		formatterFunction = getFormatterFunction(formatter);
+		formatterFunction = await getFormatterFunction(formatter);
 	} catch (error) {
 		return Promise.reject(error);
 	}
@@ -274,7 +273,7 @@ async function standalone({
 
 /**
  * @param {FormatterType | Formatter | undefined} selected
- * @returns {Formatter}
+ * @returns {Promise<Formatter>}
  */
 function getFormatterFunction(selected) {
 	if (typeof selected === 'string') {
@@ -290,10 +289,8 @@ function getFormatterFunction(selected) {
 	}
 
 	if (typeof selected === 'function') {
-		return selected;
+		return Promise.resolve(selected);
 	}
-
-	validateTypes.assert(index.json);
 
 	return index.json;
 }

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -12,7 +12,6 @@ import writeFileAtomic from 'write-file-atomic';
 
 import AllFilesIgnoredError from './utils/allFilesIgnoredError.mjs';
 import NoFilesFoundError from './utils/noFilesFoundError.mjs';
-import { assert } from './utils/validateTypes.mjs';
 import createPartialStylelintResult from './createPartialStylelintResult.mjs';
 import createStylelint from './createStylelint.mjs';
 import filterFilePaths from './utils/filterFilePaths.mjs';
@@ -84,7 +83,7 @@ export default async function standalone({
 	let formatterFunction;
 
 	try {
-		formatterFunction = getFormatterFunction(formatter);
+		formatterFunction = await getFormatterFunction(formatter);
 	} catch (error) {
 		return Promise.reject(error);
 	}
@@ -274,7 +273,7 @@ export default async function standalone({
 
 /**
  * @param {FormatterType | Formatter | undefined} selected
- * @returns {Formatter}
+ * @returns {Promise<Formatter>}
  */
 function getFormatterFunction(selected) {
 	if (typeof selected === 'string') {
@@ -290,10 +289,8 @@ function getFormatterFunction(selected) {
 	}
 
 	if (typeof selected === 'function') {
-		return selected;
+		return Promise.resolve(selected);
 	}
-
-	assert(formatters.json);
 
 	return formatters.json;
 }

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -168,7 +168,18 @@ declare namespace stylelint {
 	type Formatter = (results: LintResult[], returnValue: LinterResult) => string;
 
 	/** @internal */
-	type FormatterType = 'compact' | 'github' | 'json' | 'string' | 'tap' | 'unix' | 'verbose';
+	type Formatters = {
+		readonly compact: Promise<Formatter>;
+		readonly github: Promise<Formatter>;
+		readonly json: Promise<Formatter>;
+		readonly string: Promise<Formatter>;
+		readonly tap: Promise<Formatter>;
+		readonly unix: Promise<Formatter>;
+		readonly verbose: Promise<Formatter>;
+	};
+
+	/** @internal */
+	type FormatterType = keyof Formatters;
 
 	/** @internal */
 	type CustomSyntax = string | PostCSS.Syntax;
@@ -593,7 +604,7 @@ type PublicApi = PostCSS.PluginCreator<stylelint.PostcssPluginOptions> & {
 	/**
 	 * Result report formatters by name.
 	 */
-	formatters: { [k: string]: stylelint.Formatter };
+	formatters: stylelint.Formatters;
 
 	/**
 	 * Creates a Stylelint plugin.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #5291

> Is there anything in the PR that needs further explanation?

This commit avoids using the `import-lazy` package in the `formatters` module.
As a result, `formatters` can be a pure ESM module, which means `require` is no longer needed.

In addition, this change accepts a `Promise` function as a custom formatter.

Note that `import-lazy` is still used:

```console
$ git grep -w 'import-lazy' lib/
lib/rules/index.cjs:4:  const importLazy = require('import-lazy');
lib/rules/index.mjs:5:  import importLazy from 'import-lazy';
```