### PR TITLE
Simplify array-from in rules

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -235,7 +235,7 @@ const rule = (primary, secondaryOptions, context) => {
 					longhandDeclarationNodes.set(prefixedShorthandProperty, longhandDeclarationNode);
 
 					const shorthandProps = longhandSubPropertiesOfShorthandProperties.get(shorthandProperty);
-					const prefixedShorthandData = Array.from(shorthandProps || []).map(
+					const prefixedShorthandData = Array.from(shorthandProps || [],
 						(item) => prefix + item,
 					);
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.js
@@ -235,9 +235,7 @@ const rule = (primary, secondaryOptions, context) => {
 					longhandDeclarationNodes.set(prefixedShorthandProperty, longhandDeclarationNode);
 
 					const shorthandProps = longhandSubPropertiesOfShorthandProperties.get(shorthandProperty);
-					const prefixedShorthandData = Array.from(shorthandProps || [],
-						(item) => prefix + item,
-					);
+					const prefixedShorthandData = Array.from(shorthandProps || [], (item) => prefix + item);
 
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

"None, as it's a documentation fix."

> Is there anything in the PR that needs further explanation?

`Array.from` has optional second argument, so calling `map` after is not required.
