### PR TITLE
Stabilise functional support for `message` option

### DIFF
--- a/lib/rules/block-no-empty/README.md
+++ b/lib/rules/block-no-empty/README.md
@@ -9,6 +9,8 @@ Disallow empty blocks.
  * Blocks like this */
 ```
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/block-no-empty/index.js
+++ b/lib/rules/block-no-empty/index.js
@@ -75,7 +75,8 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			report({
-				message: messages.rejected,
+				message: () => messages.rejected,
+				messageArgs: [],
 				node: statement,
 				start: statement.positionBy({ index }),
 				result,

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -11,6 +11,8 @@ a { color: black }
 
 This rule ignores `$sass` and `@less` variable syntaxes.
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `string`: `"always-where-possible"|"never"`

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -110,7 +110,8 @@ const rule = (primary, secondaryOptions) => {
 					namedColorsKeywords.has(value.toLowerCase())
 				) {
 					complain(
-						messages.rejected(value),
+						messages.rejected,
+						[value],
 						decl,
 						declarationValueIndex(decl) + sourceIndex,
 						value.length,
@@ -150,7 +151,8 @@ const rule = (primary, secondaryOptions) => {
 
 				if (namedColor && namedColor.toLowerCase() !== 'transparent') {
 					complain(
-						messages.expected(namedColor, colorString),
+						messages.expected,
+						[namedColor, colorString],
 						decl,
 						declarationValueIndex(decl) + sourceIndex,
 						rawColorString.length,
@@ -160,16 +162,18 @@ const rule = (primary, secondaryOptions) => {
 		});
 
 		/**
-		 * @param {string} message
+		 * @param {((named: string, original: string) => string) | ((original: string) => string)} message
+		 * @param {[string, string] | [string]} messageArgs
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {number} length
 		 */
-		function complain(message, node, index, length) {
+		function complain(message, messageArgs, node, index, length) {
 			report({
 				result,
 				ruleName,
 				message,
+				messageArgs,
 				node,
 				index,
 				endIndex: index + length,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #6966.

> Is there anything in the PR that needs further explanation?

Draft for now as I ask about some edge cases. My intention with this PR is to make it eventually do everything required to stabilize functional message arguments in code. 

I've chosen to base this against `main` since we could potentially release some of these changes in a minor patch, depending on how long the new major release takes. Rebasing against `v16` should be relatively easy.
