### PR TITLE
Add an ability to pass a function for severity secondary option

### DIFF
--- a/.changeset/functional-severity.md
+++ b/.changeset/functional-severity.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `severity` secondary option now accepts a function allowing to adjust the severity based on the rule's `messageArgs`.
+Added: `severity` secondary option's function support

--- a/.changeset/functional-severity.md
+++ b/.changeset/functional-severity.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `severity` secondary option now accepts a function allowing to adjust the severity based on the rule's `messageArgs`.

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -179,7 +179,7 @@ For example:
 
 Reporters may use these severity levels to display problems or exit the process differently.
 
-Experimental feature: some rules support message arguments. For these rules, it is possible to use a function for `severity`, which would accept these arguments, allowing you to adjust the severity based on these arguments.
+Experimental feature: some rules support [message arguments](#message). For these rules, it is possible to use a function for `severity`, which would accept these arguments, allowing you to adjust the severity based on these arguments.
 
 This function must return `"error"`, `"warning"`, or `null`. When it would return `null`, the `defaultSeverity` would be used.
 
@@ -202,16 +202,16 @@ For example, given:
 
 The following pattern is reported as an error:
 
+<!-- prettier-ignore -->
 ```css
-a > .foo {
-}
+a > .foo {}
 ```
 
 But the following pattern would be reported as a warning:
 
+<!-- prettier-ignore -->
 ```css
-a[data-auto="1"] {
-}
+a[data-auto="1"] {}
 ```
 
 ## `extends`

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -179,6 +179,41 @@ For example:
 
 Reporters may use these severity levels to display problems or exit the process differently.
 
+Experimental feature: some rules support message arguments. For these rules, it is possible to use a function for `severity`, which would accept these arguments, allowing you to adjust the severity based on these arguments.
+
+This function must return `"error"`, `"warning"`, or `null`. When it would return `null`, the `defaultSeverity` would be used.
+
+For example, given:
+
+```js
+{
+	rules: {
+		'selector-disallowed-list': [
+			['a > .foo', '/\\[data-.+]/'],
+			{
+				severity: (selector) => {
+					return selector.includes('a > .foo') ? 'error' : 'warning';
+				},
+			},
+		],
+	},
+}
+```
+
+The following pattern is reported as an error:
+
+```css
+a > .foo {
+}
+```
+
+But the following pattern would be reported as a warning:
+
+```css
+a[data-auto="1"] {
+}
+```
+
 ## `extends`
 
 You can extend an existing configuration (whether your own or a third-party one). Configurations can bundle plugins, custom syntaxes, options, and configure rules. They can also extend other configurations.

--- a/lib/__tests__/defaultSeverity.test.mjs
+++ b/lib/__tests__/defaultSeverity.test.mjs
@@ -18,3 +18,48 @@ it('`defaultSeverity` option set to warning', async () => {
 		}),
 	]);
 });
+
+it('`defaultSeverity` option set to warning, and a functional severity returns `null`', async () => {
+	const config = {
+		defaultSeverity: 'warning',
+		rules: {
+			'block-no-empty': [
+				true,
+				{
+					severity: () => null,
+				},
+			],
+		},
+	};
+
+	const result = await postcss([postcssPlugin(config)]).process('a {}', { from: undefined });
+
+	expect(result.warnings()).toMatchObject([
+		expect.objectContaining({
+			text: expect.stringContaining('block-no-empty'),
+			severity: 'warning',
+		}),
+	]);
+});
+
+it('`defaultSeverity` option is absent, and a functional severity returns `null`', async () => {
+	const config = {
+		rules: {
+			'block-no-empty': [
+				true,
+				{
+					severity: () => null,
+				},
+			],
+		},
+	};
+
+	const result = await postcss([postcssPlugin(config)]).process('a {}', { from: undefined });
+
+	expect(result.warnings()).toMatchObject([
+		expect.objectContaining({
+			text: expect.stringContaining('block-no-empty'),
+			severity: 'error',
+		}),
+	]);
+});

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -302,6 +302,58 @@ test("with quiet mode on and custom rule severity of 'warning'", () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(0);
 });
 
+test("with quiet mode on and with functional rule severity of 'error'", () => {
+	const customSeverity = jest.fn(() => 'error');
+	const v = {
+		ruleName: 'foo',
+		result: {
+			warn: jest.fn(),
+			stylelint: {
+				quiet: true,
+				ruleSeverities: {
+					foo: customSeverity,
+				},
+			},
+		},
+		message: 'bar',
+		messageArgs: ['baz'],
+		node: {
+			rangeBy: defaultRangeBy,
+		},
+	};
+
+	report(v);
+	expect(customSeverity).toHaveBeenCalledTimes(1);
+	expect(customSeverity.mock.calls[0][0]).toBe('baz');
+	expect(v.result.warn).toHaveBeenCalledTimes(1);
+});
+
+test("with quiet mode on and with functional rule severity of 'warning'", () => {
+	const customSeverity = jest.fn(() => 'warning');
+	const v = {
+		ruleName: 'foo',
+		result: {
+			warn: jest.fn(),
+			stylelint: {
+				quiet: true,
+				ruleSeverities: {
+					foo: customSeverity,
+				},
+			},
+		},
+		message: 'bar',
+		messageArgs: ['baz'],
+		node: {
+			rangeBy: defaultRangeBy,
+		},
+	};
+
+	report(v);
+	expect(customSeverity).toHaveBeenCalledTimes(1);
+	expect(customSeverity.mock.calls[0][0]).toBe('baz');
+	expect(v.result.warn).toHaveBeenCalledTimes(0);
+});
+
 test('with message function', () => {
 	const v = {
 		ruleName: 'foo',

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -24,8 +24,14 @@ function report(problem) {
 		ruleMetadata: {},
 	};
 
+	const ruleSeverityOption = severity || result.stylelint.ruleSeverities?.[ruleName];
+
+	const defaultSeverity = result.stylelint.config?.defaultSeverity || 'error';
+
 	const ruleSeverity =
-		severity || (result.stylelint.ruleSeverities && result.stylelint.ruleSeverities[ruleName]);
+		typeof ruleSeverityOption === 'function'
+			? ruleSeverityOption(...(messageArgs || [])) || defaultSeverity
+			: ruleSeverityOption;
 
 	// In quiet mode, mere warnings are ignored
 	if (result.stylelint.quiet && ruleSeverity !== 'error') {

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -22,8 +22,14 @@ export default function report(problem) {
 		ruleMetadata: {},
 	};
 
+	const ruleSeverityOption = severity || result.stylelint.ruleSeverities?.[ruleName];
+
+	const defaultSeverity = result.stylelint.config?.defaultSeverity || 'error';
+
 	const ruleSeverity =
-		severity || (result.stylelint.ruleSeverities && result.stylelint.ruleSeverities[ruleName]);
+		typeof ruleSeverityOption === 'function'
+			? ruleSeverityOption(...(messageArgs || [])) || defaultSeverity
+			: ruleSeverityOption;
 
 	// In quiet mode, mere warnings are ignored
 	if (result.stylelint.quiet && ruleSeverity !== 'error') {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -53,6 +53,10 @@ type RuleMessageFunc = {
 	bivariance(...args: (string | number | boolean | RegExp)[]): string;
 }['bivariance'];
 
+type RuleSeverityFunc = {
+	bivariance(...args: (string | number | boolean | RegExp)[]): stylelint.Severity | null;
+}['bivariance'];
+
 type RuleOptionsPossibleFunc = (value: unknown) => boolean;
 
 type DisableReportEntry = {
@@ -138,7 +142,7 @@ declare namespace stylelint {
 
 	/** @internal */
 	type StylelintPostcssResult = {
-		ruleSeverities: { [ruleName: string]: Severity };
+		ruleSeverities: { [ruleName: string]: RuleSeverity };
 		customMessages: { [ruleName: string]: RuleMessage };
 		ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
 		quiet?: boolean;
@@ -202,6 +206,9 @@ declare namespace stylelint {
 			| Record<string, RuleOptionsPossible[]>;
 		optional?: boolean;
 	};
+
+	/** @internal */
+	type RuleSeverity = Severity | RuleSeverityFunc;
 
 	/**
 	 * A rule context.
@@ -460,7 +467,7 @@ declare namespace stylelint {
 		/**
 		 * Optional severity override for the problem.
 		 */
-		severity?: Severity;
+		severity?: RuleSeverity;
 	};
 
 	/** @internal */


### PR DESCRIPTION
Let me know if I should add more tests (if so, where?), or change something in the docs.

I did implement the feature as described in the https://github.com/stylelint/stylelint/issues/6863#issuecomment-1567238888 comment.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/6863

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
