### PR TITLE
Add functional support for `message` to rules with uneven arguments

### DIFF
--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -11,6 +11,8 @@ a { color: black }
 
 This rule ignores `$sass` and `@less` variable syntaxes.
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `string`: `"always-where-possible"|"never"`

--- a/lib/rules/color-named/index.js
+++ b/lib/rules/color-named/index.js
@@ -110,7 +110,8 @@ const rule = (primary, secondaryOptions) => {
 					namedColorsKeywords.has(value.toLowerCase())
 				) {
 					complain(
-						messages.rejected(value),
+						messages.rejected,
+						[value],
 						decl,
 						declarationValueIndex(decl) + sourceIndex,
 						value.length,
@@ -150,7 +151,8 @@ const rule = (primary, secondaryOptions) => {
 
 				if (namedColor && namedColor.toLowerCase() !== 'transparent') {
 					complain(
-						messages.expected(namedColor, colorString),
+						messages.expected,
+						[namedColor, colorString],
 						decl,
 						declarationValueIndex(decl) + sourceIndex,
 						rawColorString.length,
@@ -160,16 +162,18 @@ const rule = (primary, secondaryOptions) => {
 		});
 
 		/**
-		 * @param {string} message
+		 * @param {((named: string, original: string) => string) | ((original: string) => string)} message
+		 * @param {[string, string] | [string]} messageArgs
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {number} length
 		 */
-		function complain(message, node, index, length) {
+		function complain(message, messageArgs, node, index, length) {
 			report({
 				result,
 				ruleName,
 				message,
+				messageArgs,
 				node,
 				index,
 				endIndex: index + length,

--- a/lib/rules/font-weight-notation/README.md
+++ b/lib/rules/font-weight-notation/README.md
@@ -21,6 +21,8 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `string`: `"numeric"|"named-where-possible"`

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -165,7 +165,7 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			/**
-			 * @param {((named: string, original: string) => string) | ((original: string) => string)} message
+			 * @param {((actual: string, expected: string) => string) | ((type: string) => string)} message
 			 * @param {[string, string] | [string]} messageArgs
 			 * @param {import('postcss-value-parser').Node} valueNode
 			 */

--- a/lib/rules/font-weight-notation/index.js
+++ b/lib/rules/font-weight-notation/index.js
@@ -134,11 +134,13 @@ const rule = (primary, secondaryOptions, context) => {
 						}
 					}
 
-					const msg = numericValue
-						? messages.expectedWithActual(weightValue, numericValue)
-						: messages.expected('numeric');
+					const message = numericValue ? messages.expectedWithActual : messages.expected;
 
-					complain(msg, weightValueNode);
+					complain(
+						message,
+						numericValue ? [weightValue, numericValue] : ['numeric'],
+						weightValueNode,
+					);
 
 					return true;
 				}
@@ -156,17 +158,18 @@ const rule = (primary, secondaryOptions, context) => {
 						return true;
 					}
 
-					complain(messages.expectedWithActual(weightValue, namedValue), weightValueNode);
+					complain(messages.expectedWithActual, [weightValue, namedValue], weightValueNode);
 
 					return true;
 				}
 			}
 
 			/**
-			 * @param {string} message
+			 * @param {((named: string, original: string) => string) | ((original: string) => string)} message
+			 * @param {[string, string] | [string]} messageArgs
 			 * @param {import('postcss-value-parser').Node} valueNode
 			 */
-			function complain(message, valueNode) {
+			function complain(message, messageArgs, valueNode) {
 				const index = declarationValueIndex(decl) + valueNode.sourceIndex;
 				const endIndex = index + valueNode.value.length;
 
@@ -174,6 +177,7 @@ const rule = (primary, secondaryOptions, context) => {
 					ruleName,
 					result,
 					message,
+					messageArgs,
 					node: decl,
 					index,
 					endIndex,

--- a/lib/rules/function-calc-no-unspaced-operator/README.md
+++ b/lib/rules/function-calc-no-unspaced-operator/README.md
@@ -13,6 +13,8 @@ This rule checks that there is a single whitespace or a newline plus indentation
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/function-calc-no-unspaced-operator/index.js
+++ b/lib/rules/function-calc-no-unspaced-operator/index.js
@@ -36,15 +36,16 @@ const rule = (primary, _secondaryOptions, context) => {
 		if (!validOptions) return;
 
 		/**
-		 * @param {string} message
+		 * @param {((operator: string) => string)} message
+		 * @param {[string]} messageArgs
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {string} operator
 		 */
-		function complain(message, node, index, operator) {
+		function complain(message, messageArgs, node, index, operator) {
 			const endIndex = index + operator.length;
 
-			report({ message, node, index, endIndex, result, ruleName });
+			report({ message, messageArgs, node, index, endIndex, result, ruleName });
 		}
 
 		root.walkDecls((decl) => {
@@ -78,7 +79,8 @@ const rule = (primary, _secondaryOptions, context) => {
 								}
 
 								complain(
-									messages.expectedOperatorBeforeSign(operator),
+									messages.expectedOperatorBeforeSign,
+									[operator],
 									decl,
 									operatorSourceIndex,
 									operator,
@@ -96,7 +98,7 @@ const rule = (primary, _secondaryOptions, context) => {
 									return true;
 								}
 
-								complain(messages.expectedAfter(operator), decl, operatorSourceIndex, operator);
+								complain(messages.expectedAfter, [operator], decl, operatorSourceIndex, operator);
 
 								return true;
 							}
@@ -109,12 +111,9 @@ const rule = (primary, _secondaryOptions, context) => {
 							return true;
 						}
 
-						complain(
-							isBeforeOp ? messages.expectedBefore(operator) : messages.expectedAfter(operator),
-							decl,
-							valueIndex + operatorSourceIndex,
-							operator,
-						);
+						const message = isBeforeOp ? messages.expectedBefore : messages.expectedAfter;
+
+						complain(message, [operator], decl, valueIndex + operatorSourceIndex, operator);
 
 						return true;
 					}
@@ -132,11 +131,9 @@ const rule = (primary, _secondaryOptions, context) => {
 							return true;
 						}
 
-						const message = isBeforeOp
-							? messages.expectedBefore(operator)
-							: messages.expectedAfter(operator);
+						const message = isBeforeOp ? messages.expectedBefore : messages.expectedAfter;
 
-						complain(message, decl, valueIndex + operatorSourceIndex, operator);
+						complain(message, [operator], decl, valueIndex + operatorSourceIndex, operator);
 
 						return true;
 					}
@@ -149,11 +146,9 @@ const rule = (primary, _secondaryOptions, context) => {
 							return true;
 						}
 
-						const message = isBeforeOp
-							? messages.expectedBefore(operator)
-							: messages.expectedAfter(operator);
+						const message = isBeforeOp ? messages.expectedBefore : messages.expectedAfter;
 
-						complain(message, decl, valueIndex + operatorSourceIndex, operator);
+						complain(message, [operator], decl, valueIndex + operatorSourceIndex, operator);
 
 						return true;
 					}
@@ -189,13 +184,15 @@ const rule = (primary, _secondaryOptions, context) => {
 						firstNode.value = insertCharAtIndex(firstNode.value, operatorIndex, ' ');
 					} else {
 						complain(
-							messages.expectedBefore(operator),
+							messages.expectedBefore,
+							[operator],
 							decl,
 							valueIndex + firstNode.sourceIndex + operatorIndex,
 							operator,
 						);
 						complain(
-							messages.expectedAfter(operator),
+							messages.expectedAfter,
+							[operator],
 							decl,
 							valueIndex + firstNode.sourceIndex + operatorIndex + 1,
 							operator,
@@ -207,7 +204,8 @@ const rule = (primary, _secondaryOptions, context) => {
 						firstNode.value = insertCharAtIndex(firstNode.value, operatorIndex, ' ');
 					} else {
 						complain(
-							messages.expectedBefore(operator),
+							messages.expectedBefore,
+							[operator],
 							decl,
 							valueIndex + firstNode.sourceIndex + operatorIndex,
 							operator,
@@ -219,7 +217,8 @@ const rule = (primary, _secondaryOptions, context) => {
 						firstNode.value = insertCharAtIndex(firstNode.value, operatorIndex, ' ');
 					} else {
 						complain(
-							messages.expectedAfter(operator),
+							messages.expectedAfter,
+							[operator],
 							decl,
 							valueIndex + firstNode.sourceIndex + operatorIndex + 1,
 							operator,
@@ -267,7 +266,8 @@ const rule = (primary, _secondaryOptions, context) => {
 				const operator = lastNode.value.charAt(operatorIndex);
 
 				complain(
-					messages.expectedOperatorBeforeSign(operator),
+					messages.expectedOperatorBeforeSign,
+					[operator],
 					decl,
 					valueIndex + lastNode.sourceIndex + operatorIndex,
 					operator,
@@ -294,7 +294,7 @@ const rule = (primary, _secondaryOptions, context) => {
 								continue;
 							}
 
-							complain(messages.expectedBefore(lastChar), decl, node.sourceIndex, lastChar);
+							complain(messages.expectedBefore, [lastChar], decl, node.sourceIndex, lastChar);
 						} else if (index === nodes.length && OPERATORS.has(firstChar)) {
 							if (context.fix) {
 								node.value = `${firstChar} ${node.value.slice(1)}`;
@@ -303,7 +303,8 @@ const rule = (primary, _secondaryOptions, context) => {
 							}
 
 							complain(
-								messages.expectedOperatorBeforeSign(firstChar),
+								messages.expectedOperatorBeforeSign,
+								[firstChar],
 								decl,
 								node.sourceIndex,
 								firstChar,

--- a/lib/rules/function-url-quotes/README.md
+++ b/lib/rules/function-url-quotes/README.md
@@ -11,6 +11,8 @@ a { background: url("x.jpg") }
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix most of the problems reported by this rule.
 
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+
 ## Options
 
 `string`: `"always"|"never"`

--- a/lib/rules/function-url-quotes/index.js
+++ b/lib/rules/function-url-quotes/index.js
@@ -154,7 +154,7 @@ const rule = (primary, secondaryOptions, context) => {
 					return;
 				}
 
-				complain(messages.expected(functionName), node, complaintIndex, complaintEndIndex);
+				complain(messages.expected, [functionName], node, complaintIndex, complaintEndIndex);
 			} else {
 				if (!hasQuotes) {
 					return;
@@ -166,19 +166,21 @@ const rule = (primary, secondaryOptions, context) => {
 					return;
 				}
 
-				complain(messages.rejected(functionName), node, complaintIndex, complaintEndIndex);
+				complain(messages.rejected, [functionName], node, complaintIndex, complaintEndIndex);
 			}
 		}
 
 		/**
-		 * @param {string} message
+		 * @param {(functionName: string) => string} message
+		 * @param {[string]} messageArgs
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {number} endIndex
 		 */
-		function complain(message, node, index, endIndex) {
+		function complain(message, messageArgs, node, index, endIndex) {
 			report({
 				message,
+				messageArgs,
 				node,
 				index,
 				endIndex,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of (but does not close) #6966; related to #7194.

> Is there anything in the PR that needs further explanation?

Still draft for now, but I'm choosing to split things up just to make things easier to review; I'm also still waiting on other opinions on how we should handle rules with no arguments & documentation.
