### PR TITLE
Bump css-functions-list from 3.2.0 to 3.2.1

### DIFF
--- a/.changeset/silver-pumas-rest.md
+++ b/.changeset/silver-pumas-rest.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-no-unknown` false positives for `light-dark`, `linear` and `xywh`

--- a/lib/rules/function-no-unknown/__tests__/index.mjs
+++ b/lib/rules/function-no-unknown/__tests__/index.mjs
@@ -31,6 +31,18 @@ testRule({
 			code: 'a { transform: color.adjust(1px); transform: rgb(color.adjust(1px)); }',
 			description: 'ignore scss namespaced functions',
 		},
+		{
+			code: 'a { color: light-dark(#777, #000); }',
+			description: 'explicit light-dark check (ref: #7226)',
+		},
+		{
+			code: 'a { offset-path: xywh(20px 30% 150% 200%); }',
+			description: 'explicit xywh check',
+		},
+		{
+			code: 'a { animation-timing-function: linear(0, 0.25, 1); }',
+			description: 'explicit linear check',
+		},
 	],
 
 	reject: [

--- a/lib/rules/function-no-unknown/index.js
+++ b/lib/rules/function-no-unknown/index.js
@@ -51,7 +51,6 @@ const rule = (primary, secondaryOptions) => {
 		const functionsList = [
 			...JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8')),
 			// #5960
-			'-webkit-gradient',
 			'color-stop',
 			'from',
 			'to',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
         "cosmiconfig": "^8.2.0",
-        "css-functions-list": "^3.2.0",
+        "css-functions-list": "^3.2.1",
         "css-tree": "^2.3.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.1",
@@ -4521,11 +4521,11 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.0.tgz",
-      "integrity": "sha512-d/jBMPyYybkkLVypgtGv12R+pIFw4/f/IHtCTxWpZc8ofTYOPigIgmA6vu5rMHartZC+WuXhBUHfnyNUIQSYrg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.1.tgz",
+      "integrity": "sha512-Nj5YcaGgBtuUmn1D7oHqPW0c9iui7xsTsj5lIX8ZgevdfhmjFfKB3r8moHJtNJnctnYXJyYX5I1pp90HM4TPgQ==",
       "engines": {
-        "node": ">=12.22"
+        "node": ">=12 || >=16"
       }
     },
     "node_modules/css-tree": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "balanced-match": "^2.0.0",
     "colord": "^2.9.3",
     "cosmiconfig": "^8.2.0",
-    "css-functions-list": "^3.2.0",
+    "css-functions-list": "^3.2.1",
     "css-tree": "^2.3.1",
     "debug": "^4.3.4",
     "fast-glob": "^3.3.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7236 and closes #7226 (and related to #7231).

> Is there anything in the PR that needs further explanation?

I intentionally broke this up into two commits so that you can see the failed test cases (false positives), and then showing how the version bump fixes them. 

Let me know if this PR's title should instead be the changeset entry!
