### PR TITLE
Bump known-css-properties from 0.28.0 to 0.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.28.0",
+        "known-css-properties": "^0.29.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^10.1.5",
         "micromatch": "^4.0.5",
@@ -9968,9 +9968,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.28.0.tgz",
-      "integrity": "sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
+      "integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ=="
     },
     "node_modules/latest-version": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "import-lazy": "^4.0.0",
     "imurmurhash": "^0.1.4",
     "is-plain-object": "^5.0.0",
-    "known-css-properties": "^0.28.0",
+    "known-css-properties": "^0.29.0",
     "mathml-tag-names": "^2.1.3",
     "meow": "^10.1.5",
     "micromatch": "^4.0.5",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7237; ref https://github.com/stylelint/stylelint/issues/7243#issuecomment-1765472324.

> Is there anything in the PR that needs further explanation?

Getting dependabot to update `main` instead of `v16` was a bit of a struggle earlier, hence the manual PR :( 
