### PR TITLE
Refactor to add `isHexColor` utility

### DIFF
--- a/lib/rules/color-hex-alpha/index.js
+++ b/lib/rules/color-hex-alpha/index.js
@@ -2,7 +2,7 @@
 
 const declarationValueIndex = require('../../utils/declarationValueIndex');
 const hasValidHex = require('../../utils/hasValidHex');
-const isValidHex = require('../../utils/isValidHex');
+const isHexColor = require('../../utils/isHexColor');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
@@ -67,13 +67,6 @@ const rule = (primary) => {
  */
 function isUrlFunction({ type, value }) {
 	return type === 'function' && value === 'url';
-}
-
-/**
- * @param {import('postcss-value-parser').Node} node
- */
-function isHexColor({ type, value }) {
-	return type === 'word' && isValidHex(value);
 }
 
 /**

--- a/lib/rules/color-hex-length/index.js
+++ b/lib/rules/color-hex-length/index.js
@@ -8,6 +8,7 @@ const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const setDeclarationValue = require('../../utils/setDeclarationValue');
 const validateOptions = require('../../utils/validateOptions');
+const isHexColor = require('../../utils/isHexColor');
 
 const ruleName = 'color-hex-length';
 
@@ -20,7 +21,6 @@ const meta = {
 	fixable: true,
 };
 
-const HEX = /^#[\da-z]+$/i;
 const CONTAINS_HEX = /#[\da-z]+/i;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
@@ -133,13 +133,6 @@ function longer(hex) {
  */
 function isIgnoredFunction({ type, value }) {
 	return type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase());
-}
-
-/**
- * @param {import('postcss-value-parser').Node} node
- */
-function isHexColor({ type, value }) {
-	return type === 'word' && HEX.test(value);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-no-hex/index.js
+++ b/lib/rules/color-no-hex/index.js
@@ -7,7 +7,6 @@ const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
-const isHexColor = require('../../utils/isHexColor');
 
 const ruleName = 'color-no-hex';
 
@@ -19,6 +18,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/color-no-hex',
 };
 
+const HEX = /^#[\da-z]+$/i;
 const CONTAINS_HEX = /#[\da-z]+/i;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
@@ -63,6 +63,13 @@ const rule = (primary) => {
  */
 function isIgnoredFunction({ type, value }) {
 	return type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase());
+}
+
+/**
+ * @param {import('postcss-value-parser').Node} node
+ */
+function isHexColor({ type, value }) {
+	return type === 'word' && HEX.test(value);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/color-no-hex/index.js
+++ b/lib/rules/color-no-hex/index.js
@@ -7,6 +7,7 @@ const getDeclarationValue = require('../../utils/getDeclarationValue');
 const report = require('../../utils/report');
 const ruleMessages = require('../../utils/ruleMessages');
 const validateOptions = require('../../utils/validateOptions');
+const isHexColor = require('../../utils/isHexColor');
 
 const ruleName = 'color-no-hex';
 
@@ -18,7 +19,6 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/color-no-hex',
 };
 
-const HEX = /^#[\da-z]+$/i;
 const CONTAINS_HEX = /#[\da-z]+/i;
 const IGNORED_FUNCTIONS = new Set(['url']);
 
@@ -63,13 +63,6 @@ const rule = (primary) => {
  */
 function isIgnoredFunction({ type, value }) {
 	return type === 'function' && IGNORED_FUNCTIONS.has(value.toLowerCase());
-}
-
-/**
- * @param {import('postcss-value-parser').Node} node
- */
-function isHexColor({ type, value }) {
-	return type === 'word' && HEX.test(value);
 }
 
 rule.ruleName = ruleName;

--- a/lib/utils/__tests__/isHexColor.test.mjs
+++ b/lib/utils/__tests__/isHexColor.test.mjs
@@ -10,6 +10,8 @@ test.each([
 	['#123123', true],
 	['#0080FF44', true],
 	['ffffff', false],
+	['#12345', false],
+	['#123456a', false],
 	['#-111', false],
 	[' #fff', false],
 ])('isHexColor(%s)', (argument, expected) => {

--- a/lib/utils/__tests__/isHexColor.test.mjs
+++ b/lib/utils/__tests__/isHexColor.test.mjs
@@ -1,0 +1,17 @@
+import isHexColor from '../isHexColor.js';
+import { test } from '@jest/globals';
+import valueParser from 'postcss-value-parser';
+
+test.each([
+	['#fff', true],
+	['#abcabc', true],
+	['#f1f2f3', true],
+	['#123', true],
+	['#123123', true],
+	['#0080FF44', true],
+	['ffffff', false],
+	['#-111', false],
+	[' #fff', false],
+])('isHexColor(%s)', (argument, expected) => {
+	expect(isHexColor(valueParser(argument).nodes[0])).toBe(expected);
+});

--- a/lib/utils/isHexColor.js
+++ b/lib/utils/isHexColor.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const isValidHex = require('./isValidHex');
+
+/**
+ * @param {import('postcss-value-parser').Node} node
+ * @returns {boolean}
+ */
+module.exports = function isHexColor({ type, value }) {
+	return type === 'word' && isValidHex(value);
+};


### PR DESCRIPTION
Added `isHexcolor` utility function and replaced duplicated isHexColor functions and added unit test for the function.
Also removed unused `isValidHex` in `.../color-hex-alpha/index.js`.


<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7245

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
