### PR TITLE
Refactor `fixtures/broken-syntax/stylelint.config.js` to CJS

### DIFF
--- a/lib/__tests__/fixtures/broken-syntax/stylelint.config.cjs
+++ b/lib/__tests__/fixtures/broken-syntax/stylelint.config.cjs
@@ -1,4 +1,6 @@
-export default {
+'use strict';
+
+module.exports = {
 	rules: {
 		'length-zero-no-unit': true,
 	},

--- a/lib/__tests__/fixtures/broken-syntax/stylelint.config.mjs
+++ b/lib/__tests__/fixtures/broken-syntax/stylelint.config.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
 	rules: {
 		'length-zero-no-unit': true,
 	},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #5291

> Is there anything in the PR that needs further explanation?

If migrating to ESM, CI would fail due to SIGSEGV errors. For example:
https://github.com/stylelint/stylelint/actions/runs/6578275243/job/17871645000?pr=7265#step:8:890
