### PR TITLE
Revert "Bump postcss-safe-parser from 6.0.0 to 7.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "picocolors": "^1.0.0",
         "postcss": "^8.4.31",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^7.0.0",
+        "postcss-safe-parser": "^6.0.0",
         "postcss-selector-parser": "^6.0.13",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
@@ -14995,22 +14995,6 @@
       "integrity": "sha512-3AGrZT6tuMm1ZWWn9mLXh7XMfi2YtiLNPALCVxBCiUVq0LD1OQMxV/AdS/s7rLJU5o9i/jBZw/N4vXXL5dm29A==",
       "dev": true
     },
-    "node_modules/postcss-html/node_modules/postcss-safe-parser": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.3"
-      }
-    },
     "node_modules/postcss-import": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
@@ -15046,28 +15030,18 @@
       "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw=="
     },
     "node_modules/postcss-safe-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
-      "integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
       "engines": {
-        "node": ">=18.0"
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.3.3"
       }
     },
     "node_modules/postcss-sass": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "picocolors": "^1.0.0",
     "postcss": "^8.4.31",
     "postcss-resolve-nested-selector": "^0.1.1",
-    "postcss-safe-parser": "^7.0.0",
+    "postcss-safe-parser": "^6.0.0",
     "postcss-selector-parser": "^6.0.13",
     "postcss-value-parser": "^4.2.0",
     "resolve-from": "^5.0.0",


### PR DESCRIPTION
Reverts stylelint/stylelint#7223

We should revert the update to `postcss-safe-parser@7.0.0` because the version drops the support of Node.js 16. We need to support Node.js 16 until the next major version (v16.0.0) of Stylelint. See #7240.

---

```console
$ npm view postcss-safe-parser@7.0.0 engines
{ node: '>=18.0' }

$ npm view postcss-safe-parser@6.0.0 engines
{ node: '>=12.0' }
```