### PR TITLE
Refactor `standalone-parseErrors.test.mjs` to avoid CJS

### DIFF
--- a/lib/__tests__/standalone-parseErrors.test.mjs
+++ b/lib/__tests__/standalone-parseErrors.test.mjs
@@ -7,7 +7,7 @@ test('standalone with deprecations', async () => {
 		config: { rules: { 'selector-attribute-quotes': 'always' } },
 	});
 
-	expect(data.output).toContain('"stylelintType":"parseError"');
+	expect(data.report).toContain('"stylelintType":"parseError"');
 	expect(data.results).toHaveLength(1);
 	expect(data.results[0].parseErrors).toHaveLength(1);
 	expect(data.results[0].parseErrors[0].text).toBe(

--- a/lib/__tests__/standalone-parseErrors.test.mjs
+++ b/lib/__tests__/standalone-parseErrors.test.mjs
@@ -1,37 +1,18 @@
-import { createRequire } from 'node:module';
-import { jest } from '@jest/globals';
-
-import readJSONFile from '../testUtils/readJSONFile.mjs';
 import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import standalone from '../standalone.mjs';
 
-const configBlockNoEmpty = readJSONFile(
-	new URL('./fixtures/config-block-no-empty.json', import.meta.url),
-);
-
-jest.mock('../rules/block-no-empty/index.cjs');
-
-const require = createRequire(import.meta.url);
-const blockNoEmpty = require('../rules/block-no-empty/index.cjs');
-
-blockNoEmpty.mockImplementation(() => {
-	return (root, result) => {
-		result.warn('Some parseError', {
-			stylelintType: 'parseError',
-		});
-	};
-});
-
 test('standalone with deprecations', async () => {
 	const data = await standalone({
-		code: 'a {}',
-		config: configBlockNoEmpty,
+		code: 'a[=] {}',
+		config: { rules: { 'selector-attribute-quotes': 'always' } },
 	});
 
-	expect(data.output).toContain('Some parseError');
+	expect(data.output).toContain('"stylelintType":"parseError"');
 	expect(data.results).toHaveLength(1);
 	expect(data.results[0].parseErrors).toHaveLength(1);
-	expect(data.results[0].parseErrors[0].text).toBe('Some parseError');
+	expect(data.results[0].parseErrors[0].text).toBe(
+		'Cannot parse selector (Error: Expected an attribute.)',
+	);
 });
 
 test('file with correct syntax reported correctly', async () => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #5291

> Is there anything in the PR that needs further explanation?

I believe we should avoid mocking in tests if possible.
