### PR TITLE
Prevent `import("mathml-tag-names")` error

### DIFF
--- a/lib/rules/selector-type-no-unknown/index.cjs
+++ b/lib/rules/selector-type-no-unknown/index.cjs
@@ -1,6 +1,5 @@
 'use strict';
 
-const mathMLTags = require('mathml-tag-names');
 const svgTags = require('svg-tags');
 const validateTypes = require('../../utils/validateTypes.cjs');
 const selectors = require('../../reference/selectors.cjs');
@@ -8,6 +7,7 @@ const isCustomElement = require('../../utils/isCustomElement.cjs');
 const isKeyframeSelector = require('../../utils/isKeyframeSelector.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
 const isStandardSyntaxTypeSelector = require('../../utils/isStandardSyntaxTypeSelector.cjs');
+const mathMLTags = require('../../utils/mathMLTags.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const parseSelector = require('../../utils/parseSelector.cjs');
 const report = require('../../utils/report.cjs');

--- a/lib/rules/selector-type-no-unknown/index.mjs
+++ b/lib/rules/selector-type-no-unknown/index.mjs
@@ -1,4 +1,3 @@
-import mathMLTags from 'mathml-tag-names';
 import svgTags from 'svg-tags';
 
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
@@ -7,6 +6,7 @@ import isCustomElement from '../../utils/isCustomElement.mjs';
 import isKeyframeSelector from '../../utils/isKeyframeSelector.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import isStandardSyntaxTypeSelector from '../../utils/isStandardSyntaxTypeSelector.mjs';
+import mathMLTags from '../../utils/mathMLTags.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';

--- a/lib/utils/isCustomElement.cjs
+++ b/lib/utils/isCustomElement.cjs
@@ -1,8 +1,8 @@
 'use strict';
 
-const mathMLTags = require('mathml-tag-names');
 const svgTags = require('svg-tags');
 const selectors = require('../reference/selectors.cjs');
+const mathMLTags = require('./mathMLTags.cjs');
 
 /**
  * Check whether a type selector is a custom element

--- a/lib/utils/isCustomElement.mjs
+++ b/lib/utils/isCustomElement.mjs
@@ -1,7 +1,7 @@
-import mathMLTags from 'mathml-tag-names';
 import svgTags from 'svg-tags';
 
 import { htmlTypeSelectors } from '../reference/selectors.mjs';
+import mathMLTags from './mathMLTags.mjs';
 
 /**
  * Check whether a type selector is a custom element

--- a/lib/utils/mathMLTags.cjs
+++ b/lib/utils/mathMLTags.cjs
@@ -1,0 +1,16 @@
+'use strict';
+
+const node_module = require('node:module');
+
+var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
+// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'
+const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/utils/mathMLTags.cjs', document.baseURI).href)));
+
+// NOTE: mathml-tag-names v3 is a pure ESM package,
+// so we cannot update it while supporting both ESM and CJS.
+//
+// In addition, mathml-tag-names v2 provides only a JSON file,
+// so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
+const mathMLTags = require$1('mathml-tag-names');
+
+module.exports = mathMLTags;

--- a/lib/utils/mathMLTags.mjs
+++ b/lib/utils/mathMLTags.mjs
@@ -1,0 +1,13 @@
+import { createRequire } from 'node:module';
+
+// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'
+const require = createRequire(import.meta.url);
+
+// NOTE: mathml-tag-names v3 is a pure ESM package,
+// so we cannot update it while supporting both ESM and CJS.
+//
+// In addition, mathml-tag-names v2 provides only a JSON file,
+// so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
+const mathMLTags = require('mathml-tag-names');
+
+export default mathMLTags;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2021",
 		"module": "commonjs",
-		"lib": ["ES2021"],
+		"lib": ["ES2021", "DOM"],
 		"checkJs": true,
 		"noEmit": true,
 		"strict": true,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #5291

> Is there anything in the PR that needs further explanation?

- `mathml-tag-names` v3 is a pure ESM package, so we cannot update it while supporting both ESM and CJS.
- `mathml-tag-names` v2 provides only a JSON file, so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).

```console
$ node -e 'import("mathml-tag-names")'
node:internal/errors:497
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "file:///Users/masafumi.koba/git/stylelint/stylelint/node_modules/mathml-tag-names/index.json" needs an import assertion of type "json"
    at new NodeError (node:internal/errors:406:5)
    at validateAssertions (node:internal/modules/esm/assert:94:15)
    at defaultLoad (node:internal/modules/esm/load:122:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:396:13)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:278:56)
    at new ModuleJob (node:internal/modules/esm/module_job:65:26)
    at #createModuleJob (node:internal/modules/esm/loader:290:17)
    at ModuleLoader.getJobFromResolveResult (node:internal/modules/esm/loader:248:34)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:229:17)
    at async ModuleLoader.import (node:internal/modules/esm/loader:315:23) {
  code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING'
}
```

See https://github.com/wooorm/mathml-tag-names/releases/tag/3.0.0
