### PR TITLE
Fix `#{&}` as inline code in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -911,7 +911,7 @@
 - Fixed: `font-family-name-quotes` false positives for `system-ui` system font ([#3463](https://github.com/stylelint/stylelint/pull/3463)).
 - Fixed: `keyframes-name-pattern` support for raw JS RegExp ([#3437](https://github.com/stylelint/stylelint/pull/3437)).
 - Fixed: `media-feature-name-no-unknown` false positives for level 5 names ([#3397](https://github.com/stylelint/stylelint/pull/3397)).
-- Fixed: `no-descending-specificity` false positives for #{&} ([#3420](https://github.com/stylelint/stylelint/pull/3420)).
+- Fixed: `no-descending-specificity` false positives for `#{&}` ([#3420](https://github.com/stylelint/stylelint/pull/3420)).
 - Fixed: `no-missing-end-of-source-newline` false positives for style attributes ([#3485](https://github.com/stylelint/stylelint/pull/3485)).
 
 ## 9.3.0


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref stylelint/stylelint.io#357

> Is there anything in the PR that needs further explanation?

This change will make the hack unneeded in [stylelint.io](https://github.com/stylelint/stylelint.io). See https://github.com/stylelint/stylelint.io/pull/357/files#r1379011358
