### PR TITLE
Refactor tests to remove deprecated `output` property as possible

### DIFF
--- a/lib/__tests__/extends.test.mjs
+++ b/lib/__tests__/extends.test.mjs
@@ -19,42 +19,42 @@ const configExtendingThreeWithOverride = readJSONFile(
 const fixturesPath = fileURLToPath(new URL('./fixtures', import.meta.url));
 
 it('basic extending', async () => {
-	const linted = await standalone({
+	const { report, results } = await standalone({
 		code: 'a {}',
 		config: configExtendingOne,
 		configBasedir: fixturesPath,
 	});
 
-	expect(typeof linted.output).toBe('string');
-	expect(linted.results).toHaveLength(1);
-	expect(linted.results[0].warnings).toHaveLength(1);
-	expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
+	expect(report).toContain('block-no-empty');
+	expect(results).toHaveLength(1);
+	expect(results[0].warnings).toHaveLength(1);
+	expect(results[0].warnings[0].rule).toBe('block-no-empty');
 });
 
 it('basic extending with object', async () => {
-	const linted = await standalone({
+	const { report, results } = await standalone({
 		code: 'a {}',
 		config: configExtendingWithObject,
 		configBasedir: fixturesPath,
 	});
 
-	expect(typeof linted.output).toBe('string');
-	expect(linted.results).toHaveLength(1);
-	expect(linted.results[0].warnings).toHaveLength(1);
-	expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
+	expect(report).toContain('block-no-empty');
+	expect(results).toHaveLength(1);
+	expect(results[0].warnings).toHaveLength(1);
+	expect(results[0].warnings[0].rule).toBe('block-no-empty');
 });
 
 it('recursive extending', async () => {
-	const linted = await standalone({
+	const { report, results } = await standalone({
 		code: 'a {}',
 		config: configExtendingAnotherExtend,
 		configBasedir: fixturesPath,
 	});
 
-	expect(typeof linted.output).toBe('string');
-	expect(linted.results).toHaveLength(1);
-	expect(linted.results[0].warnings).toHaveLength(1);
-	expect(linted.results[0].warnings[0].rule).toBe('block-no-empty');
+	expect(report).toContain('block-no-empty');
+	expect(results).toHaveLength(1);
+	expect(results[0].warnings).toHaveLength(1);
+	expect(results[0].warnings[0].rule).toBe('block-no-empty');
 });
 
 it('extending with overrides', async () => {

--- a/lib/__tests__/standalone-deprecations.test.mjs
+++ b/lib/__tests__/standalone-deprecations.test.mjs
@@ -17,12 +17,12 @@ const configBlockNoEmpty = readJSONFile(
 
 describe('standalone with deprecations', () => {
 	it('works', async () => {
-		const { output, results } = await standalone({
+		const { report, results } = await standalone({
 			code: 'a {}',
 			config: configBlockNoEmpty,
 		});
 
-		expect(output).toContain('Some deprecation');
+		expect(report).toContain('Some deprecation');
 		expect(results).toHaveLength(1);
 		expect(results[0].deprecations).toHaveLength(1);
 		expect(results[0].deprecations[0].text).toBe('Some deprecation');

--- a/lib/__tests__/standalone-fix.test.mjs
+++ b/lib/__tests__/standalone-fix.test.mjs
@@ -28,7 +28,6 @@ it('outputs fixed code when input is code string', async () => {
 
 	expect(result.code).toBe('a { color: #fff; }');
 	expect(result.report).toBe('');
-	expect(result.output).toBe('a { color: #fff; }'); // TODO: Deprecated. Remove in the next major version.
 });
 
 it('fixes when enabled in config', async () => {
@@ -45,7 +44,6 @@ it('fixes when enabled in config', async () => {
 
 	expect(result.code).toBe('a { color: #fff; }');
 	expect(result.report).toBe('');
-	expect(result.output).toBe('a { color: #fff; }'); // TODO: Deprecated. Remove in the next major version.
 });
 
 it("doesn't fix with stylelint-disable commands", async () => {
@@ -66,7 +64,6 @@ it("doesn't fix with stylelint-disable commands", async () => {
 
 	expect(result.code).toBe(code);
 	expect(result.report).toBe('');
-	expect(result.output).toBe(code); // TODO: Deprecated. Remove in the next major version.
 });
 
 it("doesn't fix with scoped stylelint-disable commands", async () => {
@@ -178,7 +175,6 @@ describe('writing fixes to files', () => {
 
 			2 problems (2 errors, 0 warnings)
 		`);
-		expect(result.output).toMatch('stylesheet.css'); // TODO: Deprecated. Remove in the next major version.
 	});
 
 	it("doesn't write to ignored file", async () => {

--- a/lib/__tests__/standalone-formatter.test.mjs
+++ b/lib/__tests__/standalone-formatter.test.mjs
@@ -9,30 +9,26 @@ const configBlockNoEmpty = readJSONFile(
 );
 
 it('standalone with input css and alternate formatter specified by keyword', async () => {
-	const { output } = await standalone({
+	const { report } = await standalone({
 		code: 'a {}',
 		config: configBlockNoEmpty,
 		formatter: 'string',
 	});
 
-	expect(typeof output).toBe('string');
-
-	const strippedOutput = stripAnsi(output);
+	const strippedOutput = stripAnsi(report);
 
 	expect(strippedOutput).toContain('1:3');
 	expect(strippedOutput).toContain('block-no-empty');
 });
 
 it('standalone with input css and alternate formatter function', async () => {
-	const { output } = await standalone({
+	const { report } = await standalone({
 		code: 'a {}',
 		config: configBlockNoEmpty,
 		formatter: stringFormatter,
 	});
 
-	expect(typeof output).toBe('string');
-
-	const strippedOutput = stripAnsi(output);
+	const strippedOutput = stripAnsi(report);
 
 	expect(strippedOutput).toContain('1:3');
 	expect(strippedOutput).toContain('block-no-empty');
@@ -51,7 +47,7 @@ it('standalone with invalid formatter option', async () => {
 });
 
 it('standalone with input css and custom promised formatter', async () => {
-	const { output } = await standalone({
+	const { report } = await standalone({
 		code: 'a {}',
 		config: configBlockNoEmpty,
 		formatter: Promise.resolve((results) => {
@@ -59,5 +55,5 @@ it('standalone with input css and custom promised formatter', async () => {
 		}),
 	});
 
-	expect(output).toContain('block-no-empty');
+	expect(report).toContain('block-no-empty');
 });

--- a/lib/__tests__/standalone.test.mjs
+++ b/lib/__tests__/standalone.test.mjs
@@ -16,7 +16,7 @@ const fixturesPath = replaceBackslashes(new URL('./fixtures', import.meta.url));
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 describe('standalone with one input file', () => {
-	let output;
+	let report;
 	let results;
 
 	beforeEach(async () => {
@@ -26,12 +26,12 @@ describe('standalone with one input file', () => {
 			configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
 		});
 
-		output = data.output;
+		report = data.report;
 		results = data.results;
 	});
 
 	it('triggers warning', () => {
-		expect(output).toContain('block-no-empty');
+		expect(report).toContain('block-no-empty');
 		expect(results).toHaveLength(1);
 		expect(results[0].warnings).toHaveLength(1);
 		expect(results[0].warnings[0].rule).toBe('block-no-empty');
@@ -39,15 +39,15 @@ describe('standalone with one input file', () => {
 });
 
 it('standalone with two file-specific globs', async () => {
-	const { output, results } = await standalone({
+	const { report, results } = await standalone({
 		files: [`${fixturesPath}/e*y-block.*`, `${fixturesPath}/invalid-h*.css`],
 		config: {
 			rules: { 'block-no-empty': true, 'color-no-invalid-hex': true },
 		},
 	});
 
-	expect(output).toContain('block-no-empty');
-	expect(output).toContain('color-no-invalid-hex');
+	expect(report).toContain('block-no-empty');
+	expect(report).toContain('color-no-invalid-hex');
 	expect(results).toHaveLength(2);
 	expect(results[0].warnings).toHaveLength(1);
 	expect(results[1].warnings).toHaveLength(1);
@@ -81,7 +81,7 @@ it('standalone with two file-specific globs', async () => {
 });
 
 describe('standalone with files and globbyOptions', () => {
-	let output;
+	let report;
 	let results;
 
 	beforeEach(async () => {
@@ -92,12 +92,12 @@ describe('standalone with files and globbyOptions', () => {
 			configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
 		});
 
-		output = data.output;
+		report = data.report;
 		results = data.results;
 	});
 
 	it('triggers warning', () => {
-		expect(output).toContain('block-no-empty');
+		expect(report).toContain('block-no-empty');
 		expect(results).toHaveLength(1);
 		expect(results[0].warnings).toHaveLength(1);
 		expect(results[0].warnings[0].rule).toBe('block-no-empty');
@@ -105,7 +105,7 @@ describe('standalone with files and globbyOptions', () => {
 });
 
 describe('standalone with files and cwd', () => {
-	let output;
+	let report;
 	let results;
 
 	beforeEach(async () => {
@@ -116,12 +116,12 @@ describe('standalone with files and cwd', () => {
 			configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
 		});
 
-		output = data.output;
+		report = data.report;
 		results = data.results;
 	});
 
 	it('triggers warning', () => {
-		expect(output).toContain('block-no-empty');
+		expect(report).toContain('block-no-empty');
 		expect(results).toHaveLength(1);
 		expect(results[0].warnings).toHaveLength(1);
 		expect(results[0].warnings[0].rule).toBe('block-no-empty');
@@ -129,12 +129,12 @@ describe('standalone with files and cwd', () => {
 });
 
 it('standalone with input css', async () => {
-	const { output, results } = await standalone({
+	const { report, results } = await standalone({
 		code: 'a {}',
 		config: configBlockNoEmpty,
 	});
 
-	expect(typeof output).toBe('string');
+	expect(report).toContain('block-no-empty');
 	expect(results).toHaveLength(1);
 	expect(results[0].warnings).toHaveLength(1);
 	expect(results[0].warnings[0].rule).toBe('block-no-empty');
@@ -161,7 +161,7 @@ it('standalone with nonexistent-file throws an error', async () => {
 });
 
 it('standalone with nonexistent-file and allowEmptyInput enabled quietly exits', async () => {
-	const { results, errored, output } = await standalone({
+	const { results, errored, report } = await standalone({
 		files: `${fixturesPath}/nonexistent-file.css`,
 		config: configBlockNoEmpty,
 		allowEmptyInput: true,
@@ -169,29 +169,29 @@ it('standalone with nonexistent-file and allowEmptyInput enabled quietly exits',
 
 	expect(results).toHaveLength(0);
 	expect(errored).toBe(false);
-	expect(output).toBe('[]');
+	expect(report).toBe('[]');
 });
 
 it('standalone with nonexistent-file and allowEmptyInput enabled (in config) quietly exits', async () => {
-	const { results, errored, output } = await standalone({
+	const { results, errored, report } = await standalone({
 		files: `${fixturesPath}/nonexistent-file.css`,
 		config: { ...configBlockNoEmpty, allowEmptyInput: true },
 	});
 
 	expect(results).toHaveLength(0);
 	expect(errored).toBe(false);
-	expect(output).toBe('[]');
+	expect(report).toBe('[]');
 });
 
 it('standalone with nonexistent-file and allowEmptyInput enabled (in config file) quietly exits', async () => {
-	const { results, errored, output } = await standalone({
+	const { results, errored, report } = await standalone({
 		files: `${fixturesPath}/nonexistent-file.css`,
 		configFile: `${fixturesPath}/config-allow-empty-input.json`,
 	});
 
 	expect(results).toHaveLength(0);
 	expect(errored).toBe(false);
-	expect(output).toBe('[]');
+	expect(report).toBe('[]');
 });
 
 describe('standalone passing code with syntax error', () => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #7183

> Is there anything in the PR that needs further explanation?

This change aims to reduce redundant warnings in test reports.
Note that it still cannot be removed completely where needed.
