### PR TITLE
Add `exports` field to `package.json`

### DIFF
--- a/.changeset/loud-insects-camp.md
+++ b/.changeset/loud-insects-camp.md
@@ -1,0 +1,5 @@
+---
+"stylelint": major
+---
+
+Changed: `.js` extension to `.mjs` and `.cjs`

--- a/.changeset/weak-crews-swim.md
+++ b/.changeset/weak-crews-swim.md
@@ -2,4 +2,4 @@
 "stylelint": major
 ---
 
-Added: `type` and `exports` fields to `package.json` for Conditional Exports (ESM/CJS)
+Added: `exports` field to `package.json` for Conditional Exports (ESM/CJS)

--- a/.changeset/weak-crews-swim.md
+++ b/.changeset/weak-crews-swim.md
@@ -1,0 +1,5 @@
+---
+"stylelint": major
+---
+
+Added: `type` and `exports` fields to `package.json` for Conditional Exports (ESM/CJS)

--- a/docs/migration-guide/to-16.md
+++ b/docs/migration-guide/to-16.md
@@ -4,6 +4,7 @@ This release contains breaking changes. We've:
 
 - removed deprecated stylistic rules
 - removed support for Node.js less than 18.12.0
+- changed `.js` extension to `.mjs` and `.cjs`
 - changed Node.js API returned resolved object
 - changed CLI to print problems to stderr
 - changed CLI exit code for flag errors
@@ -19,6 +20,31 @@ You should remove the rules from your configuration object. See the [15.0.0 migr
 Node.js 14 and 16 have reached end-of-life. We've removed support for them so that we could update some of our dependencies.
 
 You should use the 18.12.0 or higher versions of Node.js.
+
+## Changed `.js` extensions to `.mjs` and `.cjs`
+
+We've changed the file extension `.js` to `.mjs` and `.cjs` to support ESM and CJS.
+
+You should modify your code if using `.js` for `import` or `require`. For example:
+
+ESM:
+
+```diff js
+-import('stylelint/lib/utils/typeGuards.js');
++import('stylelint/lib/utils/typeGuards.mjs');
+```
+
+CJS:
+
+```diff js
+-require('stylelint/lib/utils/typeGuards.js');
++require('stylelint/lib/utils/typeGuards.cjs');
+```
+
+> [!WARNING]
+> We've strongly recommended copying the internal utilities to your project instead of importing them.
+> You can unsafely continue to `import` or `require` the files, but we will disallow access to them in the next major release.
+> See also [`stylelint.utils`](../developer-guide/plugins.md#stylelintutils) in the developer guide.
 
 ## Changed Node.js API returned resolved object
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "require": "./lib/index.cjs"
     },
     "./package.json": "./package.json",
-    "./lib/utils/isStandardSyntax*": "./lib/utils/isStandardSyntax*"
+    "./lib/utils/*": "./lib/utils/*"
   },
   "main": "lib/index.cjs",
   "types": "types/stylelint/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,62 +29,7 @@
       "require": "./lib/index.cjs"
     },
     "./package.json": "./package.json",
-    "./lib/utils/isStandardSyntaxAtRule": {
-      "import": "./lib/utils/isStandardSyntaxAtRule.mjs",
-      "require": "./lib/utils/isStandardSyntaxAtRule.cjs"
-    },
-    "./lib/utils/isStandardSyntaxColorFunction": {
-      "import": "./lib/utils/isStandardSyntaxColorFunction.mjs",
-      "require": "./lib/utils/isStandardSyntaxColorFunction.cjs"
-    },
-    "./lib/utils/isStandardSyntaxCombinator": {
-      "import": "./lib/utils/isStandardSyntaxCombinator.mjs",
-      "require": "./lib/utils/isStandardSyntaxCombinator.cjs"
-    },
-    "./lib/utils/isStandardSyntaxComment": {
-      "import": "./lib/utils/isStandardSyntaxComment.mjs",
-      "require": "./lib/utils/isStandardSyntaxComment.cjs"
-    },
-    "./lib/utils/isStandardSyntaxDeclaration": {
-      "import": "./lib/utils/isStandardSyntaxDeclaration.mjs",
-      "require": "./lib/utils/isStandardSyntaxDeclaration.cjs"
-    },
-    "./lib/utils/isStandardSyntaxFunction": {
-      "import": "./lib/utils/isStandardSyntaxFunction.mjs",
-      "require": "./lib/utils/isStandardSyntaxFunction.cjs"
-    },
-    "./lib/utils/isStandardSyntaxHexColor": {
-      "import": "./lib/utils/isStandardSyntaxHexColor.mjs",
-      "require": "./lib/utils/isStandardSyntaxHexColor.cjs"
-    },
-    "./lib/utils/isStandardSyntaxKeyframesName": {
-      "import": "./lib/utils/isStandardSyntaxKeyframesName.mjs",
-      "require": "./lib/utils/isStandardSyntaxKeyframesName.cjs"
-    },
-    "./lib/utils/isStandardSyntaxProperty": {
-      "import": "./lib/utils/isStandardSyntaxProperty.mjs",
-      "require": "./lib/utils/isStandardSyntaxProperty.cjs"
-    },
-    "./lib/utils/isStandardSyntaxRule": {
-      "import": "./lib/utils/isStandardSyntaxRule.mjs",
-      "require": "./lib/utils/isStandardSyntaxRule.cjs"
-    },
-    "./lib/utils/isStandardSyntaxSelector": {
-      "import": "./lib/utils/isStandardSyntaxSelector.mjs",
-      "require": "./lib/utils/isStandardSyntaxSelector.cjs"
-    },
-    "./lib/utils/isStandardSyntaxTypeSelector": {
-      "import": "./lib/utils/isStandardSyntaxTypeSelector.mjs",
-      "require": "./lib/utils/isStandardSyntaxTypeSelector.cjs"
-    },
-    "./lib/utils/isStandardSyntaxUrl": {
-      "import": "./lib/utils/isStandardSyntaxUrl.mjs",
-      "require": "./lib/utils/isStandardSyntaxUrl.cjs"
-    },
-    "./lib/utils/isStandardSyntaxValue": {
-      "import": "./lib/utils/isStandardSyntaxValue.mjs",
-      "require": "./lib/utils/isStandardSyntaxValue.cjs"
-    }
+    "./lib/utils/isStandardSyntax*": "./lib/utils/isStandardSyntax*"
   },
   "main": "lib/index.cjs",
   "types": "types/stylelint/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "license": "MIT",
   "author": "stylelint",
-  "type": "module",
   "exports": {
     ".": {
       "import": "./lib/index.mjs",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,71 @@
   },
   "license": "MIT",
   "author": "stylelint",
-  "main": "lib/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.cjs"
+    },
+    "./package.json": "./package.json",
+    "./lib/utils/isStandardSyntaxAtRule": {
+      "import": "./lib/utils/isStandardSyntaxAtRule.mjs",
+      "require": "./lib/utils/isStandardSyntaxAtRule.cjs"
+    },
+    "./lib/utils/isStandardSyntaxColorFunction": {
+      "import": "./lib/utils/isStandardSyntaxColorFunction.mjs",
+      "require": "./lib/utils/isStandardSyntaxColorFunction.cjs"
+    },
+    "./lib/utils/isStandardSyntaxCombinator": {
+      "import": "./lib/utils/isStandardSyntaxCombinator.mjs",
+      "require": "./lib/utils/isStandardSyntaxCombinator.cjs"
+    },
+    "./lib/utils/isStandardSyntaxComment": {
+      "import": "./lib/utils/isStandardSyntaxComment.mjs",
+      "require": "./lib/utils/isStandardSyntaxComment.cjs"
+    },
+    "./lib/utils/isStandardSyntaxDeclaration": {
+      "import": "./lib/utils/isStandardSyntaxDeclaration.mjs",
+      "require": "./lib/utils/isStandardSyntaxDeclaration.cjs"
+    },
+    "./lib/utils/isStandardSyntaxFunction": {
+      "import": "./lib/utils/isStandardSyntaxFunction.mjs",
+      "require": "./lib/utils/isStandardSyntaxFunction.cjs"
+    },
+    "./lib/utils/isStandardSyntaxHexColor": {
+      "import": "./lib/utils/isStandardSyntaxHexColor.mjs",
+      "require": "./lib/utils/isStandardSyntaxHexColor.cjs"
+    },
+    "./lib/utils/isStandardSyntaxKeyframesName": {
+      "import": "./lib/utils/isStandardSyntaxKeyframesName.mjs",
+      "require": "./lib/utils/isStandardSyntaxKeyframesName.cjs"
+    },
+    "./lib/utils/isStandardSyntaxProperty": {
+      "import": "./lib/utils/isStandardSyntaxProperty.mjs",
+      "require": "./lib/utils/isStandardSyntaxProperty.cjs"
+    },
+    "./lib/utils/isStandardSyntaxRule": {
+      "import": "./lib/utils/isStandardSyntaxRule.mjs",
+      "require": "./lib/utils/isStandardSyntaxRule.cjs"
+    },
+    "./lib/utils/isStandardSyntaxSelector": {
+      "import": "./lib/utils/isStandardSyntaxSelector.mjs",
+      "require": "./lib/utils/isStandardSyntaxSelector.cjs"
+    },
+    "./lib/utils/isStandardSyntaxTypeSelector": {
+      "import": "./lib/utils/isStandardSyntaxTypeSelector.mjs",
+      "require": "./lib/utils/isStandardSyntaxTypeSelector.cjs"
+    },
+    "./lib/utils/isStandardSyntaxUrl": {
+      "import": "./lib/utils/isStandardSyntaxUrl.mjs",
+      "require": "./lib/utils/isStandardSyntaxUrl.cjs"
+    },
+    "./lib/utils/isStandardSyntaxValue": {
+      "import": "./lib/utils/isStandardSyntaxValue.mjs",
+      "require": "./lib/utils/isStandardSyntaxValue.cjs"
+    }
+  },
+  "main": "lib/index.cjs",
   "types": "types/stylelint/index.d.ts",
   "bin": {
     "stylelint": "bin/stylelint.mjs"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6258
Ref #5291

> Is there anything in the PR that needs further explanation?

This Pull Request is necessary for [Conditional exports](https://nodejs.org/api/packages.html#conditional-exports) (ESM and CJS).

Note: For backward compatibility, we may need to export `stylelint/lib/utils/*` files.
The following script can easily output many `lib/utils/` settings.

<details><summary>Script</summary>
<p>

```js
import path from 'node:path';

import fg from 'fast-glob';

const exports = {
	'.': {
		import: './lib/index.mjs',
		require: './lib/index.cjs',
	},
	'./package.json': './package.json',
};

const files = fg.sync('lib/utils/isStandardSyntax*.mjs', { ignore: '**/__tests__/**' });

for (const file of files) {
	const base = path.basename(file, '.mjs');
	exports[`./lib/utils/${base}`] = {
		import: `./lib/utils/${base}.mjs`,
		require: `./lib/utils/${base}.cjs`,
	};
}

console.log(JSON.stringify(exports, null, 2));
```

</p>
</details> 


I'd like to hear feedback about exporting `lib/**` files. Should we export all files? I worry about frequent breaking changes in the future, if we exposed all modules (including internal ones).

Ideally, we should export utilities only through `stylelint.utils`, but actually we don't. Especially, `isStandardSyntax*` utilities are necessary to write a plugin or a custom rule.
