### PR TITLE
Change TypeScript definitions for ESM

### DIFF
--- a/.changeset/sixty-lions-build.md
+++ b/.changeset/sixty-lions-build.md
@@ -1,0 +1,5 @@
+---
+"stylelint": major
+---
+
+Changed: TypeScript definitions for ESM

--- a/lib/augmentConfig.cjs
+++ b/lib/augmentConfig.cjs
@@ -12,7 +12,6 @@ const getModulePath = require('./utils/getModulePath.cjs');
 const normalizeAllRuleSettings = require('./normalizeAllRuleSettings.cjs');
 
 var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/augmentConfig.cjs', document.baseURI).href)));
 
 /** @typedef {import('stylelint').InternalApi} StylelintInternalApi */

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+
 const require = createRequire(import.meta.url);
 
 import { dirname, isAbsolute } from 'node:path';

--- a/lib/cli.mjs
+++ b/lib/cli.mjs
@@ -3,7 +3,7 @@ import { EOL } from 'node:os';
 import process from 'node:process';
 
 import { createRequire } from 'node:module';
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+
 const require = createRequire(import.meta.url);
 
 import picocolors from 'picocolors';
@@ -620,7 +620,6 @@ export function buildCLI(argv) {
 		// See also https://github.com/sindresorhus/meow/blob/v12.0.1/source/validate.js#L75
 		allowUnknownFlags: true,
 
-		// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 		importMeta: import.meta,
 	});
 }

--- a/lib/createPlugin.cjs
+++ b/lib/createPlugin.cjs
@@ -3,7 +3,7 @@
 'use strict';
 
 /**
- * @type {import('stylelint')['createPlugin']}
+ * @type {import('stylelint').PublicApi['createPlugin']}
  */
 function createPlugin(ruleName, rule) {
 	return {

--- a/lib/createPlugin.mjs
+++ b/lib/createPlugin.mjs
@@ -1,5 +1,5 @@
 /**
- * @type {import('stylelint')['createPlugin']}
+ * @type {import('stylelint').PublicApi['createPlugin']}
  */
 export default function createPlugin(ruleName, rule) {
 	return {

--- a/lib/createStylelint.cjs
+++ b/lib/createStylelint.cjs
@@ -11,7 +11,7 @@ const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
 /**
- * @type {import('stylelint')['_createLinter']}
+ * @type {import('stylelint').PublicApi['_createLinter']}
  */
 function createStylelint(options = {}) {
 	const cwd = options.cwd || process.cwd();

--- a/lib/createStylelint.mjs
+++ b/lib/createStylelint.mjs
@@ -9,7 +9,7 @@ const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
 /**
- * @type {import('stylelint')['_createLinter']}
+ * @type {import('stylelint').PublicApi['_createLinter']}
  */
 export default function createStylelint(options = {}) {
 	const cwd = options.cwd || process.cwd();

--- a/lib/formatters/index.cjs
+++ b/lib/formatters/index.cjs
@@ -4,7 +4,7 @@
 
 const _interopNamespaceDefaultOnly = e => Object.freeze({ __proto__: null, default: e });
 
-/** @type {import('stylelint').Formatters} */
+/** @type {import('stylelint').PublicApi['formatters']} */
 const formatters = {
 	get compact() {
 		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./compactFormatter.cjs'))).then((m) => m.default);

--- a/lib/formatters/index.mjs
+++ b/lib/formatters/index.mjs
@@ -1,4 +1,4 @@
-/** @type {import('stylelint').Formatters} */
+/** @type {import('stylelint').PublicApi['formatters']} */
 const formatters = {
 	get compact() {
 		return import('./compactFormatter.mjs').then((m) => m.default);

--- a/lib/getPostcssResult.cjs
+++ b/lib/getPostcssResult.cjs
@@ -10,7 +10,6 @@ const postcss = require('postcss');
 const getModulePath = require('./utils/getModulePath.cjs');
 
 var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/getPostcssResult.cjs', document.baseURI).href)));
 
 /** @typedef {import('postcss').Result} Result */

--- a/lib/getPostcssResult.mjs
+++ b/lib/getPostcssResult.mjs
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+
 const require = createRequire(import.meta.url);
 
 import { extname } from 'node:path';

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -15,7 +15,7 @@ const index = require('./rules/index.cjs');
 const standalone = require('./standalone.cjs');
 const validateOptions = require('./utils/validateOptions.cjs');
 
-/** @type {import('stylelint')} */
+/** @type {import('stylelint').PublicApi} */
 const stylelint = Object.assign(postcssPlugin, {
 	lint: standalone,
 	rules: index,

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -11,7 +11,7 @@ import rules from './rules/index.mjs';
 import standalone from './standalone.mjs';
 import validateOptions from './utils/validateOptions.mjs';
 
-/** @type {import('stylelint')} */
+/** @type {import('stylelint').PublicApi} */
 const stylelint = Object.assign(postcssPlugin, {
 	lint: standalone,
 	rules,

--- a/lib/resolveConfig.cjs
+++ b/lib/resolveConfig.cjs
@@ -8,7 +8,7 @@ const createStylelint = require('./createStylelint.cjs');
 const getConfigForFile = require('./getConfigForFile.cjs');
 
 /**
- * @type {import('stylelint')['resolveConfig']}
+ * @type {import('stylelint').PublicApi['resolveConfig']}
  */
 async function resolveConfig(
 	filePath,

--- a/lib/resolveConfig.mjs
+++ b/lib/resolveConfig.mjs
@@ -5,7 +5,7 @@ import createStylelint from './createStylelint.mjs';
 import getConfigForFile from './getConfigForFile.mjs';
 
 /**
- * @type {import('stylelint')['resolveConfig']}
+ * @type {import('stylelint').PublicApi['resolveConfig']}
  */
 export default async function resolveConfig(
 	filePath,

--- a/lib/resolveCustomFormatter.cjs
+++ b/lib/resolveCustomFormatter.cjs
@@ -7,7 +7,6 @@ const node_fs = require('node:fs');
 const node_path = require('node:path');
 
 var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
 const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/resolveCustomFormatter.cjs', document.baseURI).href)));
 
 /**

--- a/lib/resolveCustomFormatter.mjs
+++ b/lib/resolveCustomFormatter.mjs
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module';
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+
 const require = createRequire(import.meta.url);
 
 import { existsSync } from 'node:fs';

--- a/lib/rules/color-named/colordUtils.cjs
+++ b/lib/rules/color-named/colordUtils.cjs
@@ -33,7 +33,8 @@ const colord = colord$1.colord;
 /**
  * Parses a valid hwb with comma CSS color function
  * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hwb()#syntax
- * @type {import('colord/types').ParseFunction<string>}
+ * @param {string} input
+ * @returns {import('colord').RgbaColor | null}
  */
 function parseHwbWithCommaString(input) {
 	input = input.toLowerCase();
@@ -62,7 +63,8 @@ function parseHwbWithCommaString(input) {
 
 /**
  * Parses a valid gray() CSS color function
- * @type {import('colord/types').ParseFunction<string>}
+ * @param {string} input
+ * @returns {import('colord').RgbaColor | null}
  */
 function parseGrayString(input) {
 	input = input.toLowerCase();
@@ -84,7 +86,7 @@ function parseGrayString(input) {
 	}
 
 	/**
-	 * @type {import('colord/types').LabColor | import('colord/types').LabaColor}
+	 * @type {import('colord').LabColor | import('colord').LabaColor}
 	 */
 	let colorObject = {
 		l: Number(lightnessWithUnit.number),

--- a/lib/rules/color-named/colordUtils.mjs
+++ b/lib/rules/color-named/colordUtils.mjs
@@ -31,7 +31,8 @@ export const colord = colord_;
 /**
  * Parses a valid hwb with comma CSS color function
  * https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hwb()#syntax
- * @type {import('colord/types').ParseFunction<string>}
+ * @param {string} input
+ * @returns {import('colord').RgbaColor | null}
  */
 function parseHwbWithCommaString(input) {
 	input = input.toLowerCase();
@@ -60,7 +61,8 @@ function parseHwbWithCommaString(input) {
 
 /**
  * Parses a valid gray() CSS color function
- * @type {import('colord/types').ParseFunction<string>}
+ * @param {string} input
+ * @returns {import('colord').RgbaColor | null}
  */
 function parseGrayString(input) {
 	input = input.toLowerCase();
@@ -82,7 +84,7 @@ function parseGrayString(input) {
 	}
 
 	/**
-	 * @type {import('colord/types').LabColor | import('colord/types').LabaColor}
+	 * @type {import('colord').LabColor | import('colord').LabaColor}
 	 */
 	let colorObject = {
 		l: Number(lightnessWithUnit.number),

--- a/lib/rules/index.cjs
+++ b/lib/rules/index.cjs
@@ -4,7 +4,7 @@
 
 const _interopNamespaceDefaultOnly = e => Object.freeze({ __proto__: null, default: e });
 
-/** @type {import('stylelint').BuiltInRules} */
+/** @type {import('stylelint').PublicApi['rules']} */
 const rules = {
 	get 'alpha-value-notation'() {
 		return Promise.resolve().then(() => /*#__PURE__*/_interopNamespaceDefaultOnly(require('./alpha-value-notation/index.cjs'))).then((m) => m.default);

--- a/lib/rules/index.mjs
+++ b/lib/rules/index.mjs
@@ -1,4 +1,4 @@
-/** @type {import('stylelint').BuiltInRules} */
+/** @type {import('stylelint').PublicApi['rules']} */
 const rules = {
 	get 'alpha-value-notation'() {
 		return import('./alpha-value-notation/index.mjs').then((m) => m.default);

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -31,7 +31,7 @@ const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 /** @typedef {import('stylelint').FormatterType} FormatterType */
 
 /**
- * @type {import('stylelint')['lint']}
+ * @type {import('stylelint').PublicApi['lint']}
  */
 async function standalone({
 	allowEmptyInput,

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -29,7 +29,7 @@ const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 /** @typedef {import('stylelint').FormatterType} FormatterType */
 
 /**
- * @type {import('stylelint')['lint']}
+ * @type {import('stylelint').PublicApi['lint']}
  */
 export default async function standalone({
 	allowEmptyInput,

--- a/lib/utils/FileCache.cjs
+++ b/lib/utils/FileCache.cjs
@@ -13,7 +13,7 @@ const hash = require('./hash.cjs');
 
 var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
 const debug = createDebug('stylelint:file-cache');
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+
 const pkg = JSON.parse(node_fs.readFileSync(new URL('../../package.json', (typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/utils/FileCache.cjs', document.baseURI).href))), 'utf8'));
 
 /** @typedef {import('file-entry-cache').FileDescriptor["meta"] & { hashOfConfig?: string }} CacheMetadata */

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -15,7 +15,7 @@ import getCacheFile from './getCacheFile.mjs';
 import hash from './hash.mjs';
 
 const debug = createDebug('stylelint:file-cache');
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'.
+
 const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
 
 /** @typedef {import('file-entry-cache').FileDescriptor["meta"] & { hashOfConfig?: string }} CacheMetadata */

--- a/lib/utils/mathMLTags.cjs
+++ b/lib/utils/mathMLTags.cjs
@@ -5,7 +5,6 @@
 const node_module = require('node:module');
 
 var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'
 const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/utils/mathMLTags.cjs', document.baseURI).href)));
 
 // NOTE: mathml-tag-names v3 is a pure ESM package,
@@ -13,6 +12,7 @@ const require$1 = node_module.createRequire((typeof document === 'undefined' ? r
 //
 // In addition, mathml-tag-names v2 provides only a JSON file,
 // so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
+// @ts-expect-error -- mathml-tag-names v2 doesn't have type declarations.
 const mathMLTags = require$1('mathml-tag-names');
 
 module.exports = mathMLTags;

--- a/lib/utils/mathMLTags.mjs
+++ b/lib/utils/mathMLTags.mjs
@@ -1,6 +1,5 @@
 import { createRequire } from 'node:module';
 
-// @ts-expect-error -- TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', or 'nodenext'
 const require = createRequire(import.meta.url);
 
 // NOTE: mathml-tag-names v3 is a pure ESM package,
@@ -8,6 +7,7 @@ const require = createRequire(import.meta.url);
 //
 // In addition, mathml-tag-names v2 provides only a JSON file,
 // so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
+// @ts-expect-error -- mathml-tag-names v2 doesn't have type declarations.
 const mathMLTags = require('mathml-tag-names');
 
 export default mathMLTags;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,18 @@
   },
   "license": "MIT",
   "author": "stylelint",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/stylelint/index.d.ts",
+        "default": "./lib/index.mjs"
+      },
+      "require": "./lib/index.cjs"
+    },
+    "./package.json": "./package.json",
+    "./lib/utils/*": "./lib/utils/*"
+  },
   "main": "lib/index.cjs",
   "types": "types/stylelint/index.d.ts",
   "bin": {

--- a/patches/is-plain-object+5.0.0.patch
+++ b/patches/is-plain-object+5.0.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/is-plain-object/package.json b/node_modules/is-plain-object/package.json
+index 3ea169a..622dff4 100644
+--- a/node_modules/is-plain-object/package.json
++++ b/node_modules/is-plain-object/package.json
+@@ -25,7 +25,10 @@
+   ],
+   "exports": {
+     ".": {
+-      "import": "./dist/is-plain-object.mjs",
++      "import": {
++        "types": "./is-plain-object.d.ts",
++        "default": "./dist/is-plain-object.mjs"
++      },
+       "require": "./dist/is-plain-object.js"
+     },
+     "./package.json": "./package.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"compilerOptions": {
-		"target": "ES2021",
-		"module": "commonjs",
-		"lib": ["ES2021", "DOM"],
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"target": "ES2022",
+		"lib": ["ES2022"],
 		"checkJs": true,
 		"noEmit": true,
 		"strict": true,
@@ -12,13 +13,13 @@
 		"noImplicitReturns": false,
 		"noUnusedParameters": true,
 		"noUncheckedIndexedAccess": true,
-		"resolveJsonModule": true,
+		"resolveJsonModule": false,
 		"esModuleInterop": true,
 		"skipLibCheck": false,
 		"paths": {
-			"*": ["./node_modules/@types/*", "./types/*"]
+			"stylelint": ["./types/stylelint/index.d.ts"]
 		}
 	},
-	"include": ["lib", "types", "package.json"],
-	"exclude": ["**/*.test.{js,mjs}", "**/__tests__/", "lib/**/*.cjs"]
+	"include": ["lib/**/*.mjs", "types/**/*.ts"],
+	"exclude": ["**/__tests__/**"]
 }

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -3,17 +3,20 @@ import type { GlobbyOptions } from 'globby';
 import type { cosmiconfig, TransformSync as CosmiconfigTransformSync } from 'cosmiconfig';
 
 type ConfigExtends = string | string[];
-type ConfigPlugins = string | stylelint.Plugin | (string | stylelint.Plugin)[];
+
+type ConfigPlugins = string | Plugin | (string | Plugin)[];
+
 type ConfigIgnoreFiles = string | string[];
 
 type ConfigRules = {
-	[ruleName: string]: stylelint.ConfigRuleSettings<any, Object>;
+	[ruleName: string]: ConfigRuleSettings<any, Object>;
 };
-type ConfigOverride = Omit<stylelint.Config, 'overrides'> & {
+
+type ConfigOverride = Omit<Config, 'overrides'> & {
 	files: string | string[];
 };
 
-type DisableSettings = stylelint.ConfigRuleSettings<boolean, stylelint.DisableOptions>;
+type DisableSettings = ConfigRuleSettings<boolean, DisableOptions>;
 
 // A meta-type that returns a union over all properties of `T` whose values
 // have type `U`.
@@ -22,7 +25,7 @@ type PropertyNamesOfType<T, U> = {
 }[keyof T];
 
 type FileCache = {
-	calcHashOfConfig: (config: stylelint.Config) => void;
+	calcHashOfConfig: (config: Config) => void;
 	hasFileChanged: (absoluteFilepath: string) => boolean;
 	reconcile: () => void;
 	destroy: () => void;
@@ -54,714 +57,717 @@ type RuleMessageFunc = {
 }['bivariance'];
 
 type RuleSeverityFunc = {
-	bivariance(...args: (string | number | boolean | RegExp)[]): stylelint.Severity | null;
+	bivariance(...args: (string | number | boolean | RegExp)[]): Severity | null;
 }['bivariance'];
 
 type RuleOptionsPossibleFunc = (value: unknown) => boolean;
 
 type DisableReportEntry = {
 	source?: string;
-	ranges: stylelint.DisableReportRange[];
+	ranges: DisableReportRange[];
 };
 
-declare namespace stylelint {
+/**
+ * Rule severity.
+ */
+export type Severity = 'warning' | 'error';
+
+/**
+ * A Stylelint plugin.
+ */
+export type Plugin =
+	| { default?: { ruleName: string; rule: Rule } }
+	| { ruleName: string; rule: Rule };
+
+/** @internal */
+export type ConfigRuleSettings<T, O extends Object> =
+	| null
+	| undefined
+	| NonNullable<T>
+	| [NonNullable<T>]
+	| [NonNullable<T>, O];
+
+/** @internal */
+export type DisableOptions = {
+	except?: (string | RegExp)[];
+	severity?: Severity;
+};
+
+/**
+ * Configuration.
+ */
+export type Config = {
+	extends?: ConfigExtends;
+	plugins?: ConfigPlugins;
+	pluginFunctions?: {
+		[pluginName: string]: Rule;
+	};
+	ignoreFiles?: ConfigIgnoreFiles;
+	ignorePatterns?: string;
+	rules?: ConfigRules;
+	quiet?: boolean;
+	defaultSeverity?: Severity;
+	ignoreDisables?: DisableSettings;
+	reportNeedlessDisables?: DisableSettings;
+	reportInvalidScopeDisables?: DisableSettings;
+	reportDescriptionlessDisables?: DisableSettings;
+	configurationComment?: string;
+	overrides?: ConfigOverride[];
+	customSyntax?: CustomSyntax;
+	allowEmptyInput?: boolean;
+	cache?: boolean;
+	fix?: boolean;
+};
+
+/** @internal */
+export type DisablePropertyName = PropertyNamesOfType<Config, DisableSettings>;
+
+/** @internal */
+export type CosmiconfigResult = (ReturnType<CosmiconfigTransformSync> & { config: Config }) | null;
+
+/** @internal */
+export type DisabledRange = {
+	comment: PostCSS.Comment;
+	start: number;
+	strictStart: boolean;
+	end?: number;
+	strictEnd?: boolean;
+	rules?: string[];
+	description?: string;
+};
+
+/** @internal */
+export type DisabledRangeObject = {
+	[ruleName: string]: DisabledRange[];
+};
+
+/** @internal */
+export type DisabledWarning = { line: number; rule: string };
+
+/** @internal */
+export type StylelintPostcssResult = {
+	ruleSeverities: { [ruleName: string]: RuleSeverity };
+	customMessages: { [ruleName: string]: RuleMessage };
+	ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
+	quiet?: boolean;
+	disabledRanges: DisabledRangeObject;
+	disabledWarnings?: DisabledWarning[];
+	ignored?: boolean;
+	stylelintError?: boolean;
+	stylelintWarning?: boolean;
+	disableWritingFix?: boolean;
+	config?: Config;
+};
+
+/** @internal */
+export type WarningOptions = PostCSS.WarningOptions & {
+	stylelintType?: string;
+	severity?: Severity;
+	rule?: string;
+};
+
+/** @internal */
+export type PostcssResult = (PostCSS.Result | EmptyResult) & {
+	stylelint: StylelintPostcssResult;
+	warn(message: string, options?: WarningOptions): void;
+};
+
+/** @internal */
+export type Formatter = (results: LintResult[], returnValue: LinterResult) => string;
+
+type Formatters = {
+	readonly compact: Promise<Formatter>;
+	readonly github: Promise<Formatter>;
+	readonly json: Promise<Formatter>;
+	readonly string: Promise<Formatter>;
+	readonly tap: Promise<Formatter>;
+	readonly unix: Promise<Formatter>;
+	readonly verbose: Promise<Formatter>;
+};
+
+/** @internal */
+export type FormatterType = keyof Formatters;
+
+/** @internal */
+export type CustomSyntax = string | PostCSS.Syntax;
+
+/** @internal */
+export type RuleMessage = string | RuleMessageFunc;
+
+/** @internal */
+export type RuleMessages = { [message: string]: RuleMessage };
+
+/** @internal */
+export type RuleOptionsPossible = boolean | number | string | RuleOptionsPossibleFunc;
+
+/** @internal */
+export type RuleOptions = {
+	actual: unknown;
+	possible?:
+		| RuleOptionsPossibleFunc
+		| RuleOptionsPossible[]
+		| Record<string, RuleOptionsPossible[]>;
+	optional?: boolean;
+};
+
+/** @internal */
+type RuleSeverity = Severity | RuleSeverityFunc;
+
+/**
+ * A rule context.
+ */
+export type RuleContext = {
+	configurationComment?: string | undefined;
+	fix?: boolean | undefined;
+	newline?: string | undefined;
+};
+
+/** @internal */
+export type RuleBase<P = any, S = any> = (
+	primaryOption: P,
+	secondaryOptions: Record<string, S>,
+	context: RuleContext,
+) => (root: PostCSS.Root, result: PostcssResult) => Promise<void> | void;
+
+/** @internal */
+export type RuleMeta = {
+	url: string;
+	deprecated?: boolean;
+	fixable?: boolean;
+};
+
+/**
+ * A rule.
+ */
+export type Rule<P = any, S = any> = RuleBase<P, S> & {
+	ruleName: string;
+	messages: RuleMessages;
+	primaryOptionArray?: boolean;
+	meta?: RuleMeta;
+};
+
+type BuiltInRules = {
+	readonly 'alpha-value-notation': Promise<Rule>;
+	readonly 'annotation-no-unknown': Promise<Rule>;
+	readonly 'at-rule-allowed-list': Promise<Rule>;
+	readonly 'at-rule-disallowed-list': Promise<Rule>;
+	readonly 'at-rule-empty-line-before': Promise<Rule>;
+	readonly 'at-rule-no-unknown': Promise<Rule>;
+	readonly 'at-rule-no-vendor-prefix': Promise<Rule>;
+	readonly 'at-rule-property-required-list': Promise<Rule>;
+	readonly 'block-no-empty': Promise<Rule>;
+	readonly 'color-function-notation': Promise<Rule>;
+	readonly 'color-hex-alpha': Promise<Rule>;
+	readonly 'color-hex-length': Promise<Rule>;
+	readonly 'color-named': Promise<Rule>;
+	readonly 'color-no-hex': Promise<Rule>;
+	readonly 'color-no-invalid-hex': Promise<Rule>;
+	readonly 'comment-empty-line-before': Promise<Rule>;
+	readonly 'comment-no-empty': Promise<Rule>;
+	readonly 'comment-pattern': Promise<Rule>;
+	readonly 'comment-whitespace-inside': Promise<Rule>;
+	readonly 'comment-word-disallowed-list': Promise<Rule>;
+	readonly 'custom-media-pattern': Promise<Rule>;
+	readonly 'custom-property-empty-line-before': Promise<Rule>;
+	readonly 'custom-property-no-missing-var-function': Promise<Rule>;
+	readonly 'custom-property-pattern': Promise<Rule>;
+	readonly 'declaration-block-no-duplicate-custom-properties': Promise<Rule>;
+	readonly 'declaration-block-no-duplicate-properties': Promise<Rule>;
+	readonly 'declaration-block-no-redundant-longhand-properties': Promise<Rule>;
+	readonly 'declaration-block-no-shorthand-property-overrides': Promise<Rule>;
+	readonly 'declaration-block-single-line-max-declarations': Promise<Rule>;
+	readonly 'declaration-empty-line-before': Promise<Rule>;
+	readonly 'declaration-no-important': Promise<Rule>;
+	readonly 'declaration-property-max-values': Promise<Rule>;
+	readonly 'declaration-property-unit-allowed-list': Promise<Rule>;
+	readonly 'declaration-property-unit-disallowed-list': Promise<Rule>;
+	readonly 'declaration-property-value-allowed-list': Promise<Rule>;
+	readonly 'declaration-property-value-disallowed-list': Promise<Rule>;
+	readonly 'declaration-property-value-no-unknown': Promise<Rule>;
+	readonly 'font-family-name-quotes': Promise<Rule>;
+	readonly 'font-family-no-duplicate-names': Promise<Rule>;
+	readonly 'font-family-no-missing-generic-family-keyword': Promise<Rule>;
+	readonly 'font-weight-notation': Promise<Rule>;
+	readonly 'function-allowed-list': Promise<Rule>;
+	readonly 'function-calc-no-unspaced-operator': Promise<Rule>;
+	readonly 'function-disallowed-list': Promise<Rule>;
+	readonly 'function-linear-gradient-no-nonstandard-direction': Promise<Rule>;
+	readonly 'function-name-case': Promise<Rule>;
+	readonly 'function-no-unknown': Promise<Rule>;
+	readonly 'function-url-no-scheme-relative': Promise<Rule>;
+	readonly 'function-url-quotes': Promise<Rule>;
+	readonly 'function-url-scheme-allowed-list': Promise<Rule>;
+	readonly 'function-url-scheme-disallowed-list': Promise<Rule>;
+	readonly 'hue-degree-notation': Promise<Rule>;
+	readonly 'import-notation': Promise<Rule>;
+	readonly 'keyframe-block-no-duplicate-selectors': Promise<Rule>;
+	readonly 'keyframe-declaration-no-important': Promise<Rule>;
+	readonly 'keyframe-selector-notation': Promise<Rule>;
+	readonly 'keyframes-name-pattern': Promise<Rule>;
+	readonly 'length-zero-no-unit': Promise<Rule>;
+	readonly 'max-nesting-depth': Promise<Rule>;
+	readonly 'media-feature-name-allowed-list': Promise<Rule>;
+	readonly 'media-feature-name-disallowed-list': Promise<Rule>;
+	readonly 'media-feature-name-no-unknown': Promise<Rule>;
+	readonly 'media-feature-name-no-vendor-prefix': Promise<Rule>;
+	readonly 'media-feature-name-unit-allowed-list': Promise<Rule>;
+	readonly 'media-feature-name-value-allowed-list': Promise<Rule>;
+	readonly 'media-feature-name-value-no-unknown': Promise<Rule>;
+	readonly 'media-feature-range-notation': Promise<Rule>;
+	readonly 'media-query-no-invalid': Promise<Rule>;
+	readonly 'named-grid-areas-no-invalid': Promise<Rule>;
+	readonly 'no-descending-specificity': Promise<Rule>;
+	readonly 'no-duplicate-at-import-rules': Promise<Rule>;
+	readonly 'no-duplicate-selectors': Promise<Rule>;
+	readonly 'no-empty-source': Promise<Rule>;
+	readonly 'no-invalid-double-slash-comments': Promise<Rule>;
+	readonly 'no-invalid-position-at-import-rule': Promise<Rule>;
+	readonly 'no-irregular-whitespace': Promise<Rule>;
+	readonly 'no-unknown-animations': Promise<Rule>;
+	readonly 'no-unknown-custom-properties': Promise<Rule>;
+	readonly 'number-max-precision': Promise<Rule>;
+	readonly 'property-allowed-list': Promise<Rule>;
+	readonly 'property-disallowed-list': Promise<Rule>;
+	readonly 'property-no-unknown': Promise<Rule>;
+	readonly 'property-no-vendor-prefix': Promise<Rule>;
+	readonly 'rule-empty-line-before': Promise<Rule>;
+	readonly 'rule-selector-property-disallowed-list': Promise<Rule>;
+	readonly 'selector-anb-no-unmatchable': Promise<Rule>;
+	readonly 'selector-attribute-name-disallowed-list': Promise<Rule>;
+	readonly 'selector-attribute-operator-allowed-list': Promise<Rule>;
+	readonly 'selector-attribute-operator-disallowed-list': Promise<Rule>;
+	readonly 'selector-attribute-quotes': Promise<Rule>;
+	readonly 'selector-class-pattern': Promise<Rule>;
+	readonly 'selector-combinator-allowed-list': Promise<Rule>;
+	readonly 'selector-combinator-disallowed-list': Promise<Rule>;
+	readonly 'selector-disallowed-list': Promise<Rule>;
+	readonly 'selector-id-pattern': Promise<Rule>;
+	readonly 'selector-max-attribute': Promise<Rule>;
+	readonly 'selector-max-class': Promise<Rule>;
+	readonly 'selector-max-combinators': Promise<Rule>;
+	readonly 'selector-max-compound-selectors': Promise<Rule>;
+	readonly 'selector-max-id': Promise<Rule>;
+	readonly 'selector-max-pseudo-class': Promise<Rule>;
+	readonly 'selector-max-specificity': Promise<Rule>;
+	readonly 'selector-max-type': Promise<Rule>;
+	readonly 'selector-max-universal': Promise<Rule>;
+	readonly 'selector-nested-pattern': Promise<Rule>;
+	readonly 'selector-no-qualifying-type': Promise<Rule>;
+	readonly 'selector-no-vendor-prefix': Promise<Rule>;
+	readonly 'selector-not-notation': Promise<Rule>;
+	readonly 'selector-pseudo-class-allowed-list': Promise<Rule>;
+	readonly 'selector-pseudo-class-disallowed-list': Promise<Rule>;
+	readonly 'selector-pseudo-class-no-unknown': Promise<Rule>;
+	readonly 'selector-pseudo-element-allowed-list': Promise<Rule>;
+	readonly 'selector-pseudo-element-colon-notation': Promise<Rule>;
+	readonly 'selector-pseudo-element-disallowed-list': Promise<Rule>;
+	readonly 'selector-pseudo-element-no-unknown': Promise<Rule>;
+	readonly 'selector-type-case': Promise<Rule>;
+	readonly 'selector-type-no-unknown': Promise<Rule>;
+	readonly 'shorthand-property-no-redundant-values': Promise<Rule>;
+	readonly 'string-no-newline': Promise<Rule>;
+	readonly 'time-min-milliseconds': Promise<Rule>;
+	readonly 'unit-allowed-list': Promise<Rule>;
+	readonly 'unit-disallowed-list': Promise<Rule>;
+	readonly 'unit-no-unknown': Promise<Rule>;
+	readonly 'value-keyword-case': Promise<Rule>;
+	readonly 'value-no-vendor-prefix': Promise<Rule>;
+};
+
+/** @internal */
+export type GetPostcssOptions = {
+	code?: string;
+	codeFilename?: string;
+	filePath?: string;
+	customSyntax?: CustomSyntax;
+};
+
+/** @internal */
+export type GetLintSourceOptions = GetPostcssOptions & {
+	existingPostcssResult?: PostCSS.Result;
+	cache?: boolean;
+};
+
+/**
+ * Linter options.
+ */
+export type LinterOptions = {
+	files?: string | string[];
+	globbyOptions?: GlobbyOptions;
+	cache?: boolean;
+	cacheLocation?: string;
+	cacheStrategy?: string;
+	code?: string;
+	codeFilename?: string;
+	config?: Config;
+	configFile?: string;
+	configBasedir?: string;
 	/**
-	 * Rule severity.
+	 * The working directory to resolve files from. Defaults to the
+	 * current working directory.
 	 */
-	type Severity = 'warning' | 'error';
+	cwd?: string;
+	ignoreDisables?: boolean;
+	ignorePath?: string | string[];
+	ignorePattern?: string[];
+	reportDescriptionlessDisables?: boolean;
+	reportNeedlessDisables?: boolean;
+	reportInvalidScopeDisables?: boolean;
+	maxWarnings?: number;
+	customSyntax?: CustomSyntax;
+	formatter?: FormatterType | Formatter;
+	disableDefaultIgnores?: boolean;
+	fix?: boolean;
+	allowEmptyInput?: boolean;
+	quiet?: boolean;
+	quietDeprecationWarnings?: boolean;
+};
 
-	/**
-	 * A Stylelint plugin.
-	 */
-	type Plugin = { default?: { ruleName: string; rule: Rule } } | { ruleName: string; rule: Rule };
-
-	/** @internal */
-	type ConfigRuleSettings<T, O extends Object> =
-		| null
-		| undefined
-		| NonNullable<T>
-		| [NonNullable<T>]
-		| [NonNullable<T>, O];
-
-	/** @internal */
-	type DisableOptions = {
-		except?: (string | RegExp)[];
-		severity?: Severity;
-	};
-
-	/**
-	 * Configuration.
-	 */
-	type Config = {
-		extends?: ConfigExtends;
-		plugins?: ConfigPlugins;
-		pluginFunctions?: {
-			[pluginName: string]: Rule;
-		};
-		ignoreFiles?: ConfigIgnoreFiles;
-		ignorePatterns?: string;
-		rules?: ConfigRules;
-		quiet?: boolean;
-		defaultSeverity?: Severity;
-		ignoreDisables?: DisableSettings;
-		reportNeedlessDisables?: DisableSettings;
-		reportInvalidScopeDisables?: DisableSettings;
-		reportDescriptionlessDisables?: DisableSettings;
-		configurationComment?: string;
-		overrides?: ConfigOverride[];
-		customSyntax?: CustomSyntax;
-		allowEmptyInput?: boolean;
-		cache?: boolean;
-		fix?: boolean;
-	};
-
-	/** @internal */
-	type DisablePropertyName = PropertyNamesOfType<Config, DisableSettings>;
-
-	/** @internal */
-	type CosmiconfigResult = (ReturnType<CosmiconfigTransformSync> & { config: Config }) | null;
-
-	/** @internal */
-	type DisabledRange = {
-		comment: PostCSS.Comment;
-		start: number;
-		strictStart: boolean;
-		end?: number;
-		strictEnd?: boolean;
-		rules?: string[];
-		description?: string;
-	};
-
-	/** @internal */
-	type DisabledRangeObject = {
-		[ruleName: string]: DisabledRange[];
-	};
-
-	/** @internal */
-	type DisabledWarning = { line: number; rule: string };
-
-	/** @internal */
-	type StylelintPostcssResult = {
-		ruleSeverities: { [ruleName: string]: RuleSeverity };
-		customMessages: { [ruleName: string]: RuleMessage };
-		ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
-		quiet?: boolean;
-		disabledRanges: DisabledRangeObject;
-		disabledWarnings?: DisabledWarning[];
-		ignored?: boolean;
-		stylelintError?: boolean;
-		stylelintWarning?: boolean;
-		disableWritingFix?: boolean;
-		config?: Config;
-	};
-
-	/** @internal */
-	type WarningOptions = PostCSS.WarningOptions & {
-		stylelintType?: string;
-		severity?: Severity;
-		rule?: string;
-	};
-
-	/** @internal */
-	type PostcssResult = (PostCSS.Result | EmptyResult) & {
-		stylelint: StylelintPostcssResult;
-		warn(message: string, options?: WarningOptions): void;
-	};
-
-	/** @internal */
-	type Formatter = (results: LintResult[], returnValue: LinterResult) => string;
-
-	/** @internal */
-	type Formatters = {
-		readonly compact: Promise<Formatter>;
-		readonly github: Promise<Formatter>;
-		readonly json: Promise<Formatter>;
-		readonly string: Promise<Formatter>;
-		readonly tap: Promise<Formatter>;
-		readonly unix: Promise<Formatter>;
-		readonly verbose: Promise<Formatter>;
-	};
-
-	/** @internal */
-	type FormatterType = keyof Formatters;
-
-	/** @internal */
-	type CustomSyntax = string | PostCSS.Syntax;
-
-	/** @internal */
-	type RuleMessage = string | RuleMessageFunc;
-
-	/** @internal */
-	type RuleMessages = { [message: string]: RuleMessage };
-
-	/** @internal */
-	type RuleOptionsPossible = boolean | number | string | RuleOptionsPossibleFunc;
-
-	/** @internal */
-	type RuleOptions = {
-		actual: unknown;
-		possible?:
-			| RuleOptionsPossibleFunc
-			| RuleOptionsPossible[]
-			| Record<string, RuleOptionsPossible[]>;
-		optional?: boolean;
-	};
-
-	/** @internal */
-	type RuleSeverity = Severity | RuleSeverityFunc;
-
-	/**
-	 * A rule context.
-	 */
-	type RuleContext = {
-		configurationComment?: string | undefined;
-		fix?: boolean | undefined;
-		newline?: string | undefined;
-	};
-
-	/** @internal */
-	type RuleBase<P = any, S = any> = (
-		primaryOption: P,
-		secondaryOptions: Record<string, S>,
-		context: RuleContext,
-	) => (root: PostCSS.Root, result: PostcssResult) => Promise<void> | void;
-
-	/** @internal */
-	type RuleMeta = {
-		url: string;
-		deprecated?: boolean;
-		fixable?: boolean;
-	};
-
-	/**
-	 * A rule.
-	 */
-	type Rule<P = any, S = any> = RuleBase<P, S> & {
-		ruleName: string;
-		messages: RuleMessages;
-		primaryOptionArray?: boolean;
-		meta?: RuleMeta;
-	};
-
-	/** @internal */
-	type BuiltInRules = {
-		readonly 'alpha-value-notation': Promise<Rule>;
-		readonly 'annotation-no-unknown': Promise<Rule>;
-		readonly 'at-rule-allowed-list': Promise<Rule>;
-		readonly 'at-rule-disallowed-list': Promise<Rule>;
-		readonly 'at-rule-empty-line-before': Promise<Rule>;
-		readonly 'at-rule-no-unknown': Promise<Rule>;
-		readonly 'at-rule-no-vendor-prefix': Promise<Rule>;
-		readonly 'at-rule-property-required-list': Promise<Rule>;
-		readonly 'block-no-empty': Promise<Rule>;
-		readonly 'color-function-notation': Promise<Rule>;
-		readonly 'color-hex-alpha': Promise<Rule>;
-		readonly 'color-hex-length': Promise<Rule>;
-		readonly 'color-named': Promise<Rule>;
-		readonly 'color-no-hex': Promise<Rule>;
-		readonly 'color-no-invalid-hex': Promise<Rule>;
-		readonly 'comment-empty-line-before': Promise<Rule>;
-		readonly 'comment-no-empty': Promise<Rule>;
-		readonly 'comment-pattern': Promise<Rule>;
-		readonly 'comment-whitespace-inside': Promise<Rule>;
-		readonly 'comment-word-disallowed-list': Promise<Rule>;
-		readonly 'custom-media-pattern': Promise<Rule>;
-		readonly 'custom-property-empty-line-before': Promise<Rule>;
-		readonly 'custom-property-no-missing-var-function': Promise<Rule>;
-		readonly 'custom-property-pattern': Promise<Rule>;
-		readonly 'declaration-block-no-duplicate-custom-properties': Promise<Rule>;
-		readonly 'declaration-block-no-duplicate-properties': Promise<Rule>;
-		readonly 'declaration-block-no-redundant-longhand-properties': Promise<Rule>;
-		readonly 'declaration-block-no-shorthand-property-overrides': Promise<Rule>;
-		readonly 'declaration-block-single-line-max-declarations': Promise<Rule>;
-		readonly 'declaration-empty-line-before': Promise<Rule>;
-		readonly 'declaration-no-important': Promise<Rule>;
-		readonly 'declaration-property-max-values': Promise<Rule>;
-		readonly 'declaration-property-unit-allowed-list': Promise<Rule>;
-		readonly 'declaration-property-unit-disallowed-list': Promise<Rule>;
-		readonly 'declaration-property-value-allowed-list': Promise<Rule>;
-		readonly 'declaration-property-value-disallowed-list': Promise<Rule>;
-		readonly 'declaration-property-value-no-unknown': Promise<Rule>;
-		readonly 'font-family-name-quotes': Promise<Rule>;
-		readonly 'font-family-no-duplicate-names': Promise<Rule>;
-		readonly 'font-family-no-missing-generic-family-keyword': Promise<Rule>;
-		readonly 'font-weight-notation': Promise<Rule>;
-		readonly 'function-allowed-list': Promise<Rule>;
-		readonly 'function-calc-no-unspaced-operator': Promise<Rule>;
-		readonly 'function-disallowed-list': Promise<Rule>;
-		readonly 'function-linear-gradient-no-nonstandard-direction': Promise<Rule>;
-		readonly 'function-name-case': Promise<Rule>;
-		readonly 'function-no-unknown': Promise<Rule>;
-		readonly 'function-url-no-scheme-relative': Promise<Rule>;
-		readonly 'function-url-quotes': Promise<Rule>;
-		readonly 'function-url-scheme-allowed-list': Promise<Rule>;
-		readonly 'function-url-scheme-disallowed-list': Promise<Rule>;
-		readonly 'hue-degree-notation': Promise<Rule>;
-		readonly 'import-notation': Promise<Rule>;
-		readonly 'keyframe-block-no-duplicate-selectors': Promise<Rule>;
-		readonly 'keyframe-declaration-no-important': Promise<Rule>;
-		readonly 'keyframe-selector-notation': Promise<Rule>;
-		readonly 'keyframes-name-pattern': Promise<Rule>;
-		readonly 'length-zero-no-unit': Promise<Rule>;
-		readonly 'max-nesting-depth': Promise<Rule>;
-		readonly 'media-feature-name-allowed-list': Promise<Rule>;
-		readonly 'media-feature-name-disallowed-list': Promise<Rule>;
-		readonly 'media-feature-name-no-unknown': Promise<Rule>;
-		readonly 'media-feature-name-no-vendor-prefix': Promise<Rule>;
-		readonly 'media-feature-name-unit-allowed-list': Promise<Rule>;
-		readonly 'media-feature-name-value-allowed-list': Promise<Rule>;
-		readonly 'media-feature-name-value-no-unknown': Promise<Rule>;
-		readonly 'media-feature-range-notation': Promise<Rule>;
-		readonly 'media-query-no-invalid': Promise<Rule>;
-		readonly 'named-grid-areas-no-invalid': Promise<Rule>;
-		readonly 'no-descending-specificity': Promise<Rule>;
-		readonly 'no-duplicate-at-import-rules': Promise<Rule>;
-		readonly 'no-duplicate-selectors': Promise<Rule>;
-		readonly 'no-empty-source': Promise<Rule>;
-		readonly 'no-invalid-double-slash-comments': Promise<Rule>;
-		readonly 'no-invalid-position-at-import-rule': Promise<Rule>;
-		readonly 'no-irregular-whitespace': Promise<Rule>;
-		readonly 'no-unknown-animations': Promise<Rule>;
-		readonly 'no-unknown-custom-properties': Promise<Rule>;
-		readonly 'number-max-precision': Promise<Rule>;
-		readonly 'property-allowed-list': Promise<Rule>;
-		readonly 'property-disallowed-list': Promise<Rule>;
-		readonly 'property-no-unknown': Promise<Rule>;
-		readonly 'property-no-vendor-prefix': Promise<Rule>;
-		readonly 'rule-empty-line-before': Promise<Rule>;
-		readonly 'rule-selector-property-disallowed-list': Promise<Rule>;
-		readonly 'selector-anb-no-unmatchable': Promise<Rule>;
-		readonly 'selector-attribute-name-disallowed-list': Promise<Rule>;
-		readonly 'selector-attribute-operator-allowed-list': Promise<Rule>;
-		readonly 'selector-attribute-operator-disallowed-list': Promise<Rule>;
-		readonly 'selector-attribute-quotes': Promise<Rule>;
-		readonly 'selector-class-pattern': Promise<Rule>;
-		readonly 'selector-combinator-allowed-list': Promise<Rule>;
-		readonly 'selector-combinator-disallowed-list': Promise<Rule>;
-		readonly 'selector-disallowed-list': Promise<Rule>;
-		readonly 'selector-id-pattern': Promise<Rule>;
-		readonly 'selector-max-attribute': Promise<Rule>;
-		readonly 'selector-max-class': Promise<Rule>;
-		readonly 'selector-max-combinators': Promise<Rule>;
-		readonly 'selector-max-compound-selectors': Promise<Rule>;
-		readonly 'selector-max-id': Promise<Rule>;
-		readonly 'selector-max-pseudo-class': Promise<Rule>;
-		readonly 'selector-max-specificity': Promise<Rule>;
-		readonly 'selector-max-type': Promise<Rule>;
-		readonly 'selector-max-universal': Promise<Rule>;
-		readonly 'selector-nested-pattern': Promise<Rule>;
-		readonly 'selector-no-qualifying-type': Promise<Rule>;
-		readonly 'selector-no-vendor-prefix': Promise<Rule>;
-		readonly 'selector-not-notation': Promise<Rule>;
-		readonly 'selector-pseudo-class-allowed-list': Promise<Rule>;
-		readonly 'selector-pseudo-class-disallowed-list': Promise<Rule>;
-		readonly 'selector-pseudo-class-no-unknown': Promise<Rule>;
-		readonly 'selector-pseudo-element-allowed-list': Promise<Rule>;
-		readonly 'selector-pseudo-element-colon-notation': Promise<Rule>;
-		readonly 'selector-pseudo-element-disallowed-list': Promise<Rule>;
-		readonly 'selector-pseudo-element-no-unknown': Promise<Rule>;
-		readonly 'selector-type-case': Promise<Rule>;
-		readonly 'selector-type-no-unknown': Promise<Rule>;
-		readonly 'shorthand-property-no-redundant-values': Promise<Rule>;
-		readonly 'string-no-newline': Promise<Rule>;
-		readonly 'time-min-milliseconds': Promise<Rule>;
-		readonly 'unit-allowed-list': Promise<Rule>;
-		readonly 'unit-disallowed-list': Promise<Rule>;
-		readonly 'unit-no-unknown': Promise<Rule>;
-		readonly 'value-keyword-case': Promise<Rule>;
-		readonly 'value-no-vendor-prefix': Promise<Rule>;
-	};
-
-	/** @internal */
-	type GetPostcssOptions = {
-		code?: string;
-		codeFilename?: string;
-		filePath?: string;
-		customSyntax?: CustomSyntax;
-	};
-
-	/** @internal */
-	type GetLintSourceOptions = GetPostcssOptions & {
-		existingPostcssResult?: PostCSS.Result;
-		cache?: boolean;
-	};
-
-	/**
-	 * Linter options.
-	 */
-	type LinterOptions = {
-		files?: string | string[];
-		globbyOptions?: GlobbyOptions;
-		cache?: boolean;
-		cacheLocation?: string;
-		cacheStrategy?: string;
-		code?: string;
-		codeFilename?: string;
-		config?: Config;
-		configFile?: string;
-		configBasedir?: string;
-		/**
-		 * The working directory to resolve files from. Defaults to the
-		 * current working directory.
-		 */
-		cwd?: string;
-		ignoreDisables?: boolean;
-		ignorePath?: string | string[];
-		ignorePattern?: string[];
-		reportDescriptionlessDisables?: boolean;
-		reportNeedlessDisables?: boolean;
-		reportInvalidScopeDisables?: boolean;
-		maxWarnings?: number;
-		customSyntax?: CustomSyntax;
-		formatter?: FormatterType | Formatter;
-		disableDefaultIgnores?: boolean;
-		fix?: boolean;
-		allowEmptyInput?: boolean;
-		quiet?: boolean;
-		quietDeprecationWarnings?: boolean;
-	};
-
-	/**
-	 * A CSS syntax error.
-	 */
-	type CssSyntaxError = {
-		file?: string;
-		input: {
-			column: number;
-			file?: string;
-			line: number;
-			source: string;
-		};
-		/**
-		 * The line of the inclusive start position of the error.
-		 */
-		line: number;
-		/**
-		 * The column of the inclusive start position of the error.
-		 */
+/**
+ * A CSS syntax error.
+ */
+export type CssSyntaxError = {
+	file?: string;
+	input: {
 		column: number;
-		/**
-		 * The line of the exclusive end position of the error.
-		 */
-		endLine?: number;
-		/**
-		 * The column of the exclusive end position of the error.
-		 */
-		endColumn?: number;
-		message: string;
-		name: string;
-		reason: string;
+		file?: string;
+		line: number;
 		source: string;
 	};
-
 	/**
-	 * A lint warning.
+	 * The line of the inclusive start position of the error.
 	 */
-	type Warning = {
-		/**
-		 * The line of the inclusive start position of the warning.
-		 */
-		line: number;
-		/**
-		 * The column of the inclusive start position of the warning.
-		 */
-		column: number;
-		/**
-		 * The line of the exclusive end position of the warning.
-		 */
-		endLine?: number;
-		/**
-		 * The column of the exclusive end position of the warning.
-		 */
-		endColumn?: number;
-		rule: string;
-		severity: Severity;
+	line: number;
+	/**
+	 * The column of the inclusive start position of the error.
+	 */
+	column: number;
+	/**
+	 * The line of the exclusive end position of the error.
+	 */
+	endLine?: number;
+	/**
+	 * The column of the exclusive end position of the error.
+	 */
+	endColumn?: number;
+	message: string;
+	name: string;
+	reason: string;
+	source: string;
+};
+
+/**
+ * A lint warning.
+ */
+export type Warning = {
+	/**
+	 * The line of the inclusive start position of the warning.
+	 */
+	line: number;
+	/**
+	 * The column of the inclusive start position of the warning.
+	 */
+	column: number;
+	/**
+	 * The line of the exclusive end position of the warning.
+	 */
+	endLine?: number;
+	/**
+	 * The column of the exclusive end position of the warning.
+	 */
+	endColumn?: number;
+	rule: string;
+	severity: Severity;
+	text: string;
+	stylelintType?: string;
+};
+
+/**
+ * A lint result.
+ */
+export type LintResult = {
+	source?: string;
+	deprecations: {
 		text: string;
-		stylelintType?: string;
-	};
-
+		reference?: string;
+	}[];
+	invalidOptionWarnings: {
+		text: string;
+	}[];
+	parseErrors: (PostCSS.Warning & { stylelintType: string })[];
+	errored?: boolean;
+	warnings: Warning[];
+	ignored?: boolean;
 	/**
-	 * A lint result.
-	 */
-	type LintResult = {
-		source?: string;
-		deprecations: {
-			text: string;
-			reference?: string;
-		}[];
-		invalidOptionWarnings: {
-			text: string;
-		}[];
-		parseErrors: (PostCSS.Warning & { stylelintType: string })[];
-		errored?: boolean;
-		warnings: Warning[];
-		ignored?: boolean;
-		/**
-		 * Internal use only. Do not use or rely on this property. It may
-		 * change at any time.
-		 * @internal
-		 */
-		_postcssResult?: PostcssResult;
-	};
-
-	/** @internal */
-	type DisableReportRange = {
-		rule: string;
-		start: number;
-		end?: number;
-	};
-
-	/**
-	 * A linter result.
-	 */
-	type LinterResult = {
-		/**
-		 * The working directory from which the linter was run when the
-		 * results were generated.
-		 */
-		cwd: string;
-		results: LintResult[];
-		errored: boolean;
-		/**
-		 * @deprecated Use `report` for the formatted problems, or use `code`
-		 *   for the autofixed code instead. This will be removed in the next major version.
-		 */
-		output: string;
-		/** @internal To show the deprecation warning. */
-		_output?: string;
-		/** @internal To show the deprecation warning. */
-		_outputWarned?: boolean;
-		/**
-		 * A string that contains the formatted problems.
-		 */
-		report: string;
-		/**
-		 * A string that contains the autofixed code, if the `fix` option is set to `true`
-		 * and the `code` option is provided.
-		 */
-		code?: string;
-		maxWarningsExceeded?: {
-			maxWarnings: number;
-			foundWarnings: number;
-		};
-		reportedDisables: DisableOptionsReport;
-		descriptionlessDisables?: DisableOptionsReport;
-		needlessDisables?: DisableOptionsReport;
-		invalidScopeDisables?: DisableOptionsReport;
-		/**
-		 * Each rule metadata by name.
-		 */
-		ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
-	};
-
-	/**
-	 * A lint problem.
-	 */
-	type Problem = {
-		ruleName: string;
-		result: PostcssResult;
-		message: RuleMessage;
-		messageArgs?: Parameters<RuleMessageFunc> | undefined;
-		node: PostCSS.Node;
-		/**
-		 * The inclusive start index of the problem, relative to the node's
-		 * source text.
-		 */
-		index?: number;
-		/**
-		 * The exclusive end index of the problem, relative to the node's
-		 * source text.
-		 */
-		endIndex?: number;
-		/**
-		 * The inclusive start position of the problem, relative to the
-		 * node's source text. If provided, this will be used instead of
-		 * `index`.
-		 */
-		start?: {
-			line: number;
-			column: number;
-		};
-		/**
-		 * The exclusive end position of the problem, relative to the
-		 * node's source text. If provided, this will be used instead of
-		 * `endIndex`.
-		 */
-		end?: {
-			line: number;
-			column: number;
-		};
-		word?: string;
-		line?: number;
-		/**
-		 * Optional severity override for the problem.
-		 */
-		severity?: RuleSeverity;
-	};
-
-	/** @internal */
-	type ShorthandProperties =
-		| 'animation'
-		| 'background'
-		| 'border'
-		| 'border-block'
-		| 'border-block-end'
-		| 'border-block-start'
-		| 'border-inline'
-		| 'border-inline-end'
-		| 'border-inline-start'
-		| 'border-bottom'
-		| 'border-color'
-		| 'border-image'
-		| 'border-inline-end'
-		| 'border-inline-start'
-		| 'border-left'
-		| 'border-radius'
-		| 'border-right'
-		| 'border-style'
-		| 'border-top'
-		| 'border-width'
-		| 'column-rule'
-		| 'columns'
-		| 'flex'
-		| 'flex-flow'
-		| 'font'
-		| 'font-synthesis'
-		| 'gap'
-		| 'grid'
-		| 'grid-area'
-		| 'grid-column'
-		| 'grid-gap'
-		| 'grid-row'
-		| 'grid-template'
-		| 'inset'
-		| 'inset-block'
-		| 'inset-inline'
-		| 'list-style'
-		| 'margin'
-		| 'margin-block'
-		| 'margin-inline'
-		| 'mask'
-		| 'outline'
-		| 'overflow'
-		| 'overscroll-behavior'
-		| 'padding'
-		| 'padding-block'
-		| 'padding-inline'
-		| 'place-content'
-		| 'place-items'
-		| 'place-self'
-		| 'scroll-margin'
-		| 'scroll-margin-block'
-		| 'scroll-margin-inline'
-		| 'scroll-padding'
-		| 'scroll-padding-block'
-		| 'scroll-padding-inline'
-		| 'text-decoration'
-		| 'text-emphasis'
-		| 'transition';
-
-	/** @internal */
-	type LonghandSubPropertiesOfShorthandProperties = ReadonlyMap<
-		ShorthandProperties,
-		ReadonlySet<string>
-	>;
-
-	/**
-	 * Utility functions.
-	 */
-	type Utils = {
-		/**
-		 * Report a problem.
-		 *
-		 * This function accounts for `disabledRanges` attached to the result.
-		 * That is, if the reported problem is within a disabledRange,
-		 * it is ignored. Otherwise, it is attached to the result as a
-		 * postcss warning.
-		 *
-		 * It also accounts for the rule's severity.
-		 *
-		 * You *must* pass *either* a node or a line number.
-		 *
-		 * @param problem - A problem
-		 */
-		report: (problem: Problem) => void;
-
-		/**
-		 * Given an object of problem messages, return another
-		 * that provides the same messages postfixed with the rule
-		 * that has been violated.
-		 *
-		 * @param ruleName - A rule name
-		 * @param messages - An object whose keys are message identifiers
-		 *   and values are either message strings or functions that return message strings
-		 * @returns New message object, whose messages will be marked with the rule name
-		 */
-		ruleMessages: <T extends RuleMessages, R extends { [K in keyof T]: T[K] }>(
-			ruleName: string,
-			messages: T,
-		) => R;
-
-		/**
-		 * Validate a rule's options.
-		 *
-		 * See existing rules for examples.
-		 *
-		 * @param result - PostCSS result
-		 * @param ruleName - A rule name
-		 * @param optionDescriptions - Each optionDescription can have the following properties:
-		 *   - `actual` (required): the actual passed option value or object.
-		 *   - `possible` (required): a schema representation of what values are
-		 *      valid for those options. `possible` should be an object if the
-		 *      options are an object, with corresponding keys; if the options are not an
-		 *      object, `possible` isn't, either. All `possible` value representations
-		 *      should be **arrays of either values or functions**. Values are === checked
-		 *      against `actual`. Functions are fed `actual` as an argument and their
-		 *      return value is interpreted: truthy = valid, falsy = invalid.
-		 *    - `optional` (optional): If this is `true`, `actual` can be undefined.
-		 * @returns Whether or not the options are valid (`true` = valid)
-		 */
-		validateOptions: (
-			result: PostcssResult,
-			ruleName: string,
-			...optionDescriptions: RuleOptions[]
-		) => boolean;
-
-		/**
-		 * Useful for third-party code (e.g. plugins) to run a PostCSS Root
-		 * against a specific rule and do something with the warnings.
-		 */
-		checkAgainstRule: <T, O extends Object>(
-			options: {
-				ruleName: string;
-				ruleSettings: ConfigRuleSettings<T, O>;
-				root: PostCSS.Root;
-				result?: PostcssResult;
-				context?: RuleContext;
-			},
-			callback: (warning: PostCSS.Warning) => void,
-		) => void;
-	};
-
-	/**
-	 * Internal use only. Do not use or rely on this type. It may change at
-	 * any time.
+	 * Internal use only. Do not use or rely on this property. It may
+	 * change at any time.
 	 * @internal
 	 */
-	type InternalApi = {
-		_options: LinterOptions & { cwd: string };
-		_extendExplorer: ReturnType<typeof cosmiconfig>;
-		_specifiedConfigCache: Map<Config, Promise<CosmiconfigResult>>;
-		_postcssResultCache: Map<string, PostCSS.Result>;
-		_fileCache: FileCache;
+	_postcssResult?: PostcssResult;
+};
+
+/** @internal */
+export type DisableReportRange = {
+	rule: string;
+	start: number;
+	end?: number;
+};
+
+/**
+ * A linter result.
+ */
+export type LinterResult = {
+	/**
+	 * The working directory from which the linter was run when the
+	 * results were generated.
+	 */
+	cwd: string;
+	results: LintResult[];
+	errored: boolean;
+	/**
+	 * @deprecated Use `report` for the formatted problems, or use `code`
+	 *   for the autofixed code instead. This will be removed in the next major version.
+	 */
+	output: string;
+	/** @internal To show the deprecation warning. */
+	_output?: string;
+	/** @internal To show the deprecation warning. */
+	_outputWarned?: boolean;
+	/**
+	 * A string that contains the formatted problems.
+	 */
+	report: string;
+	/**
+	 * A string that contains the autofixed code, if the `fix` option is set to `true`
+	 * and the `code` option is provided.
+	 */
+	code?: string;
+	maxWarningsExceeded?: {
+		maxWarnings: number;
+		foundWarnings: number;
 	};
+	reportedDisables: DisableOptionsReport;
+	descriptionlessDisables?: DisableOptionsReport;
+	needlessDisables?: DisableOptionsReport;
+	invalidScopeDisables?: DisableOptionsReport;
+	/**
+	 * Each rule metadata by name.
+	 */
+	ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
+};
 
-	type DisableOptionsReport = DisableReportEntry[];
+/**
+ * A lint problem.
+ */
+export type Problem = {
+	ruleName: string;
+	result: PostcssResult;
+	message: RuleMessage;
+	messageArgs?: Parameters<RuleMessageFunc> | undefined;
+	node: PostCSS.Node;
+	/**
+	 * The inclusive start index of the problem, relative to the node's
+	 * source text.
+	 */
+	index?: number;
+	/**
+	 * The exclusive end index of the problem, relative to the node's
+	 * source text.
+	 */
+	endIndex?: number;
+	/**
+	 * The inclusive start position of the problem, relative to the
+	 * node's source text. If provided, this will be used instead of
+	 * `index`.
+	 */
+	start?: {
+		line: number;
+		column: number;
+	};
+	/**
+	 * The exclusive end position of the problem, relative to the
+	 * node's source text. If provided, this will be used instead of
+	 * `endIndex`.
+	 */
+	end?: {
+		line: number;
+		column: number;
+	};
+	word?: string;
+	line?: number;
+	/**
+	 * Optional severity override for the problem.
+	 */
+	severity?: RuleSeverity;
+};
 
-	type PostcssPluginOptions = Omit<LinterOptions, 'customSyntax'> | Config;
-}
+/** @internal */
+export type ShorthandProperties =
+	| 'animation'
+	| 'background'
+	| 'border'
+	| 'border-block'
+	| 'border-block-end'
+	| 'border-block-start'
+	| 'border-inline'
+	| 'border-inline-end'
+	| 'border-inline-start'
+	| 'border-bottom'
+	| 'border-color'
+	| 'border-image'
+	| 'border-inline-end'
+	| 'border-inline-start'
+	| 'border-left'
+	| 'border-radius'
+	| 'border-right'
+	| 'border-style'
+	| 'border-top'
+	| 'border-width'
+	| 'column-rule'
+	| 'columns'
+	| 'flex'
+	| 'flex-flow'
+	| 'font'
+	| 'font-synthesis'
+	| 'gap'
+	| 'grid'
+	| 'grid-area'
+	| 'grid-column'
+	| 'grid-gap'
+	| 'grid-row'
+	| 'grid-template'
+	| 'inset'
+	| 'inset-block'
+	| 'inset-inline'
+	| 'list-style'
+	| 'margin'
+	| 'margin-block'
+	| 'margin-inline'
+	| 'mask'
+	| 'outline'
+	| 'overflow'
+	| 'overscroll-behavior'
+	| 'padding'
+	| 'padding-block'
+	| 'padding-inline'
+	| 'place-content'
+	| 'place-items'
+	| 'place-self'
+	| 'scroll-margin'
+	| 'scroll-margin-block'
+	| 'scroll-margin-inline'
+	| 'scroll-padding'
+	| 'scroll-padding-block'
+	| 'scroll-padding-inline'
+	| 'text-decoration'
+	| 'text-emphasis'
+	| 'transition';
 
-type PublicApi = PostCSS.PluginCreator<stylelint.PostcssPluginOptions> & {
+/** @internal */
+export type LonghandSubPropertiesOfShorthandProperties = ReadonlyMap<
+	ShorthandProperties,
+	ReadonlySet<string>
+>;
+
+/**
+ * Utility functions.
+ */
+export type Utils = {
+	/**
+	 * Report a problem.
+	 *
+	 * This function accounts for `disabledRanges` attached to the result.
+	 * That is, if the reported problem is within a disabledRange,
+	 * it is ignored. Otherwise, it is attached to the result as a
+	 * postcss warning.
+	 *
+	 * It also accounts for the rule's severity.
+	 *
+	 * You *must* pass *either* a node or a line number.
+	 *
+	 * @param problem - A problem
+	 */
+	report: (problem: Problem) => void;
+
+	/**
+	 * Given an object of problem messages, return another
+	 * that provides the same messages postfixed with the rule
+	 * that has been violated.
+	 *
+	 * @param ruleName - A rule name
+	 * @param messages - An object whose keys are message identifiers
+	 *   and values are either message strings or functions that return message strings
+	 * @returns New message object, whose messages will be marked with the rule name
+	 */
+	ruleMessages: <T extends RuleMessages, R extends { [K in keyof T]: T[K] }>(
+		ruleName: string,
+		messages: T,
+	) => R;
+
+	/**
+	 * Validate a rule's options.
+	 *
+	 * See existing rules for examples.
+	 *
+	 * @param result - PostCSS result
+	 * @param ruleName - A rule name
+	 * @param optionDescriptions - Each optionDescription can have the following properties:
+	 *   - `actual` (required): the actual passed option value or object.
+	 *   - `possible` (required): a schema representation of what values are
+	 *      valid for those options. `possible` should be an object if the
+	 *      options are an object, with corresponding keys; if the options are not an
+	 *      object, `possible` isn't, either. All `possible` value representations
+	 *      should be **arrays of either values or functions**. Values are === checked
+	 *      against `actual`. Functions are fed `actual` as an argument and their
+	 *      return value is interpreted: truthy = valid, falsy = invalid.
+	 *    - `optional` (optional): If this is `true`, `actual` can be undefined.
+	 * @returns Whether or not the options are valid (`true` = valid)
+	 */
+	validateOptions: (
+		result: PostcssResult,
+		ruleName: string,
+		...optionDescriptions: RuleOptions[]
+	) => boolean;
+
+	/**
+	 * Useful for third-party code (e.g. plugins) to run a PostCSS Root
+	 * against a specific rule and do something with the warnings.
+	 */
+	checkAgainstRule: <T, O extends Object>(
+		options: {
+			ruleName: string;
+			ruleSettings: ConfigRuleSettings<T, O>;
+			root: PostCSS.Root;
+			result?: PostcssResult;
+			context?: RuleContext;
+		},
+		callback: (warning: PostCSS.Warning) => void,
+	) => void;
+};
+
+/**
+ * Internal use only. Do not use or rely on this type. It may change at
+ * any time.
+ * @internal
+ */
+export type InternalApi = {
+	_options: LinterOptions & { cwd: string };
+	_extendExplorer: ReturnType<typeof cosmiconfig>;
+	_specifiedConfigCache: Map<Config, Promise<CosmiconfigResult>>;
+	_postcssResultCache: Map<string, PostCSS.Result>;
+	_fileCache: FileCache;
+};
+
+/** @internal */
+export type DisableOptionsReport = DisableReportEntry[];
+
+/** @internal */
+export type PostcssPluginOptions = Omit<LinterOptions, 'customSyntax'> | Config;
+
+/**
+ * The Stylelint public API.
+ */
+export type PublicApi = PostCSS.PluginCreator<PostcssPluginOptions> & {
 	/**
 	 * Runs Stylelint with the given options and returns a Promise that
 	 * resolves to the results.
@@ -769,22 +775,22 @@ type PublicApi = PostCSS.PluginCreator<stylelint.PostcssPluginOptions> & {
 	 * @param options - A lint options object
 	 * @returns A lint result
 	 */
-	lint: (options: stylelint.LinterOptions) => Promise<stylelint.LinterResult>;
+	lint: (options: LinterOptions) => Promise<LinterResult>;
 
 	/**
 	 * Available rules.
 	 */
-	rules: stylelint.BuiltInRules;
+	rules: BuiltInRules;
 
 	/**
 	 * Result report formatters by name.
 	 */
-	formatters: stylelint.Formatters;
+	formatters: Formatters;
 
 	/**
 	 * Creates a Stylelint plugin.
 	 */
-	createPlugin: (ruleName: string, rule: stylelint.Rule) => stylelint.Plugin;
+	createPlugin: (ruleName: string, rule: Rule) => Plugin;
 
 	/**
 	 * The Stylelint "internal API" is passed among functions
@@ -793,7 +799,7 @@ type PublicApi = PostCSS.PluginCreator<stylelint.PostcssPluginOptions> & {
 	 *
 	 * @internal
 	 */
-	_createLinter: (options: stylelint.LinterOptions) => stylelint.InternalApi;
+	_createLinter: (options: LinterOptions) => InternalApi;
 
 	/**
 	 * Resolves the effective configuration for a given file. Resolves to
@@ -805,22 +811,22 @@ type PublicApi = PostCSS.PluginCreator<stylelint.PostcssPluginOptions> & {
 	 */
 	resolveConfig: (
 		filePath: string,
-		options?: Pick<stylelint.LinterOptions, 'cwd' | 'config' | 'configBasedir' | 'configFile'>,
-	) => Promise<stylelint.Config | undefined>;
+		options?: Pick<LinterOptions, 'cwd' | 'config' | 'configBasedir' | 'configFile'>,
+	) => Promise<Config | undefined>;
 
 	/**
 	 * Utility functions.
 	 */
-	utils: stylelint.Utils;
+	utils: Utils;
 
 	/**
 	 * Reference objects.
 	 */
 	reference: {
-		longhandSubPropertiesOfShorthandProperties: stylelint.LonghandSubPropertiesOfShorthandProperties;
+		longhandSubPropertiesOfShorthandProperties: LonghandSubPropertiesOfShorthandProperties;
 	};
 };
 
 declare const stylelint: PublicApi;
 
-export = stylelint;
+export default stylelint;

--- a/types/stylelint/test.d.ts
+++ b/types/stylelint/test.d.ts
@@ -1,1 +1,0 @@
-declare var testRule: import('jest-preset-stylelint').TestRule;

--- a/types/stylelint/type-test.ts
+++ b/types/stylelint/type-test.ts
@@ -16,7 +16,7 @@ import type {
 	RuleMeta,
 	Warning,
 } from 'stylelint';
-import * as stylelint from 'stylelint';
+import stylelint from 'stylelint';
 
 const options: Partial<LinterOptions> = {
 	allowEmptyInput: true,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #5291
~~Wait for #7307~~
Block #7160

> Is there anything in the PR that needs further explanation?

This Pull Request mainly updates the TypeScript definitions for ESM.

Summary:
- Rewrite TypeScript definitions to use ESM syntax, avoiding the specific syntax like `namespace`.
- Update `tsconfig.json` for ESM and Node.js 18.
- Remove no longer needed `test.d.ts`.
- Add a patch for the `is-plain-object` package to avoid type-check errors.

See also:
- https://www.typescriptlang.org/tsconfig
- https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing
- https://github.com/jonschlinkert/is-plain-object/pull/28
