### PR TITLE
Refactor code block languages in Markdown files

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -70,13 +70,13 @@ And the second argument (`returnValue`) is an object (type `LinterResult`) with 
 
 You can use environmental variables in your formatter. For example, pass `SKIP_WARNINGS`:
 
-```console
+```shell
 SKIP_WARNINGS=true stylelint "*.css" --custom-formatter ./my-formatter.js
 ```
 
 Alternatively, you can create a separate formatting program and pipe the output from the built-in JSON formatter into it:
 
-```console
+```shell
 stylelint -f json "*.css" | my-program-that-reads-JSON --option
 ```
 

--- a/docs/maintainer-guide/issues.md
+++ b/docs/maintainer-guide/issues.md
@@ -56,7 +56,7 @@ You should use [saved replies](https://help.github.com/en/github/writing-on-gith
 
 That doesn't use a template:
 
-```md
+```markdown
 Thank you for creating this issue. However, issues need to follow one of our templates so that we can clearly understand your particular circumstances.
 
 Please help us help you by [recreating the issue](https://github.com/stylelint/stylelint/issues/new/choose) using one of our templates.
@@ -64,7 +64,7 @@ Please help us help you by [recreating the issue](https://github.com/stylelint/s
 
 That is best suited as a plugin:
 
-```md
+```markdown
 Thank you for your suggestion. I think this is best-suited as a [plugin](https://stylelint.io/developer-guide/plugins).
 ```
 
@@ -72,7 +72,7 @@ Thank you for your suggestion. I think this is best-suited as a [plugin](https:/
 
 That fixes a bug in a rule:
 
-```md
+```markdown
 I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 
 There are [steps on how to fix a bug in a rule](https://stylelint.io/developer-guide/rules#fix-a-bug-in-a-rule) in the Developer guide.
@@ -80,7 +80,7 @@ There are [steps on how to fix a bug in a rule](https://stylelint.io/developer-g
 
 That adds a new option to a rule:
 
-```md
+```markdown
 I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 
 There are [steps on how to add a new option](https://stylelint.io/developer-guide/rules#add-an-option-to-a-rule) in the Developer guide.
@@ -88,7 +88,7 @@ There are [steps on how to add a new option](https://stylelint.io/developer-guid
 
 That adds a new rule:
 
-```md
+```markdown
 I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 
 There are [steps on how to add a new rule](https://stylelint.io/developer-guide/rules#add-a-rule) in the Developer guide.
@@ -96,6 +96,6 @@ There are [steps on how to add a new rule](https://stylelint.io/developer-guide/
 
 That is another type of improvement:
 
-```md
+```markdown
 I've labeled the issue as ready to implement. Please consider [contributing](https://stylelint.io/contributing) if you have time.
 ```

--- a/docs/user-guide/customize.md
+++ b/docs/user-guide/customize.md
@@ -116,7 +116,7 @@ You don't have to use the [CLI](./cli.md) either; we also provide a [Node.js API
 
 Whichever you choose, there are [many options](./options.md) in Stylelint that you can use to customize how Stylelint works. For example, you'll likely want to use the [`--fix` option](options.md#fix) to automatically fix as many problems as possible:
 
-```console
+```shell
 npx stylelint "**/*.css" --fix
 ```
 

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -34,7 +34,7 @@ For example, to lint SCSS you can extend the [SCSS community config](https://www
 
 1\. Use [npm](https://docs.npmjs.com/about-npm/) to install Stylelint and the config:
 
-```console
+```shell
 npm install --save-dev stylelint stylelint-config-standard-scss
 ```
 
@@ -103,6 +103,6 @@ For example, to lint CSS files and the CSS within Lit Elements you can update yo
 
 And then run Stylelint on both your CSS and JavaScript files:
 
-```console
+```shell
 npx stylelint "**/*.{css,js}"
 ```

--- a/lib/rules/no-unknown-custom-properties/README.md
+++ b/lib/rules/no-unknown-custom-properties/README.md
@@ -51,7 +51,7 @@ a { --foo: #f00; color: var(--bar, var(--foo)); }
 ```
 
 <!-- prettier-ignore -->
-``` css
+```css
 @property --foo { syntax: "<color>"; inherits: false; initial-value: #f00; }
 a { color: var(--foo); }
 ```


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

This change for consistency will enable us to deal with syntax highlighting more easily in the <https://stylelint.io> website.
