### PR TITLE
Fix outdated PostCSS API links in documentation

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -71,7 +71,7 @@ If your plugin rule supports [autofixing](rules.md#add-autofix), then `ruleFunct
 - the PostCSS Root (the parsed AST)
 - the PostCSS LazyResult
 
-You'll have to [learn about the PostCSS API](https://api.postcss.org/).
+You'll have to [learn about the PostCSS API](https://postcss.org/api/).
 
 ### Asynchronous rules
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -81,7 +81,7 @@ You should make use of the:
 
 #### PostCSS API
 
-Use the [PostCSS API](https://api.postcss.org/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes.
+Use the [PostCSS API](https://postcss.org/api/) to navigate and analyze the CSS syntax tree. We recommend using the `walk` iterators (e.g. `walkDecls`), rather than using `forEach` to loop through the nodes.
 
 When using array methods on nodes, e.g. `find`, `some`, `filter` etc, you should explicitly check the `type` property of the node before attempting to access other properties. For example:
 
@@ -184,7 +184,7 @@ If the rule has autofix use:
 
 ### Add autofix
 
-Depending on the rule, it might be possible to automatically fix the rule's problems by mutating the PostCSS AST (Abstract Syntax Tree) using the [PostCSS API](http://api.postcss.org/).
+Depending on the rule, it might be possible to automatically fix the rule's problems by mutating the PostCSS AST (Abstract Syntax Tree) using the [PostCSS API](https://postcss.org/api/).
 
 Add `context` variable to rule parameters:
 

--- a/docs/user-guide/node-api.md
+++ b/docs/user-guide/node-api.md
@@ -70,7 +70,7 @@ A string that contains either the:
 
 ### `postcssResults`
 
-An array containing all the accumulated [PostCSS LazyResults](https://api.postcss.org/LazyResult.html).
+An array containing all the accumulated [PostCSS LazyResults](https://postcss.org/api/#lazyresult).
 
 ### `report`
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Currently, <https://api.postcss.org/> is redirected to <https://postcss.org/api/>.
