### PR TITLE
Improve links to PostCSS documentation

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -66,7 +66,7 @@ For your plugin rule to work with the [standard configuration format](../user-gu
 
 If your plugin rule supports [autofixing](rules.md#add-autofix), then `ruleFunction` should also accept a third argument: `context`.
 
-`ruleFunction` should return a function that is essentially a little [PostCSS plugin](https://github.com/postcss/postcss/blob/main/docs/writing-a-plugin.md). It takes 2 arguments:
+`ruleFunction` should return a function that is essentially a little [PostCSS plugin](https://postcss.org/docs/writing-a-postcss-plugin). It takes 2 arguments:
 
 - the PostCSS Root (the parsed AST)
 - the PostCSS LazyResult

--- a/docs/developer-guide/syntaxes.md
+++ b/docs/developer-guide/syntaxes.md
@@ -2,7 +2,7 @@
 
 Custom syntaxes are [PostCSS](https://github.com/postcss/postcss) syntaxes written by the community to support other styling languages, e.g. SCSS, and containers, e.g. HTML, using the [`customSyntax` option](../user-guide/options.md#customsyntax).
 
-To write one, familiarize yourself with PostCSS's [how to write custom syntax](https://github.com/postcss/postcss/blob/main/docs/syntax.md) guide. You can use one of the existing custom syntaxes from [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint/#readme) for reference.
+To write one, familiarize yourself with PostCSS's [how to write custom syntax](https://postcss.org/docs/how-to-write-custom-syntax) guide. You can use one of the existing custom syntaxes from [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint/#readme) for reference.
 
 After publishing your custom syntax, we recommend creating a shared config that:
 

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -70,7 +70,7 @@ This option should be a string that resolves to a JS module that exports a [Post
 
 If you want to lint two or more different languages, you can combine `customSyntax` with the [`overrides`](./configure.md#overrides) configuration property.
 
-Using the Node.js API, the `customSyntax` option can also accept a [Syntax object](https://github.com/postcss/postcss/blob/abfaa7122a0f480bc5be0905df3c24a6a51a82d9/lib/postcss.d.ts#L223-L232). Stylelint treats the `parse` property as a required value.
+Using the Node.js API, the `customSyntax` option can also accept a [Syntax object](https://postcss.org/docs/how-to-write-custom-syntax#syntax). Stylelint treats the `parse` property as a required value.
 
 > [!NOTE]
 > Stylelint can provide no guarantee that core rules work with custom syntaxes.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Links to the PostCSS website should be more understandable than links to Markdown file blobs on GitHub.
