### PR TITLE
Document `fixable: true` meta

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -190,7 +190,7 @@ Add `fixable: true` to the rule's `meta`:
 
 ```diff js
 const meta = {
-	url: /* .. */,
+  url: /* .. */,
 + fixable: true,
 };
 ```

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -186,7 +186,7 @@ If the rule has autofix use:
 
 Depending on the rule, it might be possible to automatically fix the rule's problems by mutating the PostCSS AST (Abstract Syntax Tree) using the [PostCSS API](http://api.postcss.org/).
 
-Add `fixable: true` to the rule's `meta`:
+Set `meta.fixable = true` to the rule:
 
 ```diff js
 const meta = {

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -186,10 +186,20 @@ If the rule has autofix use:
 
 Depending on the rule, it might be possible to automatically fix the rule's problems by mutating the PostCSS AST (Abstract Syntax Tree) using the [PostCSS API](http://api.postcss.org/).
 
+Add `fixable: true` to the rule's `meta`:
+
+```diff js
+const meta = {
+	url: /* .. */,
++ fixable: true,
+};
+```
+
 Add `context` variable to rule parameters:
 
-```js
-function rule(primary, secondary, context) {
+```diff js
+-function rule(primary, secondary) {
++function rule(primary, secondary, context) {
   return (root, result) => {
     /* .. */
   };

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -206,7 +206,7 @@ Add `context` variable to rule parameters:
 }
 ```
 
-`context` is an object which could have two properties:
+`context` is an object which could have three properties:
 
 - `configurationComment`(string): String that prefixes configuration comments like `/* stylelint-disable */`.
 - `fix`(boolean): If `true`, your rule can apply autofixes.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

It's a documentation fix related to https://github.com/stylelint/stylelint/issues/7338

> Is there anything in the PR that needs further explanation?

Although already used by the `verbose` formatter, the `fixable` `meta` property becomes more important if we tally the fixable problems in the default `string` formatter, especially for plugin authors. 
