### PR TITLE
Fix flaky system test case for CommonJS

### DIFF
--- a/system-tests/005/commonjs.test.cjs
+++ b/system-tests/005/commonjs.test.cjs
@@ -8,14 +8,18 @@ const stylelint = require('../../lib/index.cjs');
 const [nodeMajorVersion] = process.versions.node.split('.', 1);
 const testFn = Number(nodeMajorVersion) >= 20 ? test : test.skip;
 
-testFn('CommonJS API and config', async () => {
-	const result = await stylelint.lint({
-		files: [caseFilePath('stylesheet.css')],
-		configFile: caseFilePath('config.cjs'),
-	});
+testFn(
+	'CommonJS API and config',
+	async () => {
+		const result = await stylelint.lint({
+			files: [caseFilePath('stylesheet.css')],
+			configFile: caseFilePath('config.cjs'),
+		});
 
-	expect(normalizeResult(result)).toMatchSnapshot();
-});
+		expect(normalizeResult(result)).toMatchSnapshot();
+	},
+	20000,
+);
 
 function caseFilePath(basename) {
 	return path.join(__dirname, basename).replaceAll('\\', '/');


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None. Just test fix.

> Is there anything in the PR that needs further explanation?

This change tries fixing a flaky system test case for CommonJS.
The case sometimes fails only on Node.js 20 and Windows OS. See the example:

```
FAIL system-tests/005/commonjs.test.cjs (8.098 s)
  ● CommonJS API and config

    thrown: "Exceeded timeout of 5000 ms for a test.
    Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

       9 | const testFn = Number(nodeMajorVersion) >= 20 ? test : test.skip;
      10 |
    > 11 | testFn('CommonJS API and config', async () => {
         | ^
      12 | 	const result = await stylelint.lint({
      13 | 		files: [caseFilePath('stylesheet.css')],
      14 | 		configFile: caseFilePath('config.cjs'),

      at Object.<anonymous> (system-tests/005/commonjs.test.cjs:11:1)
```

https://github.com/stylelint/stylelint/actions/runs/6878175633/job/18707274491#step:8:645
