### PR TITLE
Reduce package size by removing rule README files

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lib/**/*.mjs",
     "!**/__tests__/**",
     "!lib/testUtils/**",
+    "!lib/rules/*/README.md",
     "types/stylelint/index.d.ts"
   ],
   "scripts": {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

For some reason, the `lib/rules/*/README.md` addition to the `files` field is necessary.

The following is the report by `npm pack --dry-run`: **-37 kB** (266.9 kB - 303.9 kB)

Before:

```
npm notice === Tarball Details ===
npm notice name:          stylelint
npm notice version:       16.0.0-3
npm notice filename:      stylelint-16.0.0-3.tgz
npm notice package size:  303.9 kB
npm notice unpacked size: 1.6 MB
npm notice shasum:        a403d04490cd9c56f0c5dfb9c0d42c4062dc8733
npm notice integrity:     sha512-s3x9tg3tEZyhy[...]a416SkvGgWtzg==
npm notice total files:   717
```

After:

```
npm notice === Tarball Details ===
npm notice name:          stylelint
npm notice version:       16.0.0-3
npm notice filename:      stylelint-16.0.0-3.tgz
npm notice package size:  266.9 kB
npm notice unpacked size: 1.4 MB
npm notice shasum:        ffbd39805a30e93df34a212516f82bc046d9a8c4
npm notice integrity:     sha512-qpEnfAapWVhXZ[...]vQBeKiN9VefKg==
npm notice total files:   592
```
