### PR TITLE
Correct the flag for `npx`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,4 @@
 
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no-install lint-staged
+npx --no lint-staged


### PR DESCRIPTION
As of `npm@7` (the default in `node.js@15`), the `--no-install` flag is deprecated. If `node.js@14` is no longer supported, it should be replaced with the new `--no` flag.

See also: https://docs.npmjs.com/cli/v10/commands/npm-exec#:~:text=The%20%2D%2Dno%2Dinstall%20option%20is%20deprecated%2C%20and%20will%20be%20converted%20to%20%2D%2D%2Dno.