### PR TITLE
Add `stylelint-test-rule-node` to migration guide for 16.0.0

### DIFF
--- a/docs/migration-guide/to-16.md
+++ b/docs/migration-guide/to-16.md
@@ -128,40 +128,59 @@ For example, to migrate your plugin to use `import` and `export`:
 -const stylelint = require("stylelint");
 +import stylelint from "stylelint";
 
-const {
-  createPlugin,
-  utils: { report, validateOptions },
-} = stylelint;
+ const {
+   createPlugin,
+   utils: { report, validateOptions },
+ } = stylelint;
 
-const ruleFunction = (primary, secondaryOptions) => { /* .. */ };
+ const ruleFunction = (primary, secondaryOptions) => { /* .. */ };
 
-ruleFunction.ruleName = ruleName;
-ruleFunction.messages = messages;
-ruleFunction.meta = meta;
+ ruleFunction.ruleName = ruleName;
+ ruleFunction.messages = messages;
+ ruleFunction.meta = meta;
 
-- module.exports = createPlugin(ruleName, ruleFunction);
-+ export default createPlugin(ruleName, ruleFunction);
+-module.exports = createPlugin(ruleName, ruleFunction);
++export default createPlugin(ruleName, ruleFunction);
 ```
 
-We've published a new version of [Jest preset](https://github.com/stylelint/jest-preset-stylelint) for plugin tests. If you use it, you should update your npm-run-script:
+We've published a new version of [Jest preset](https://www.npmjs.com/package/jest-preset-stylelint) for plugin tests. If you use it, you should update your npm-run-script:
 
 ```diff json
-{
-  "scripts": {
+ {
+   "scripts": {
 -    "test": "jest",
 +    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest --runInBand",
-  }
-}
+   }
+ }
 ```
 
-If you get a segmentation fault while running the preset on Node.js 18, you can use [jest-light-runner](https://www.npmjs.com/package/jest-light-runner):
+If you get a segmentation fault while running the preset on Node.js 18, you can use [`jest-light-runner`](https://www.npmjs.com/package/jest-light-runner):
 
 ```diff js
-export default {
-  preset: "jest-preset-stylelint",
-  setupFiles: ["./jest.setup.js"],
-+ runner: "jest-light-runner",
-};
+ export default {
+   preset: "jest-preset-stylelint",
+   setupFiles: ["./jest.setup.js"],
++  runner: "jest-light-runner",
+ };
+```
+
+Alternatively, you can try our new [`stylelint-test-rule-node`](https://www.npmjs.com/package/stylelint-test-rule-node) package that uses the test runner and assertions built into Node.js:
+
+```diff js
++import { testRule } from "stylelint-test-rule-node";
+
+ testRule({
+   /* .. */
+ });
+```
+
+```diff json
+ {
+   "scripts": {
+-    "test": "jest"
++    "test": "node --test"
+   }
+ }
 ```
 
 #### `stylelint.lint()`
@@ -169,12 +188,12 @@ export default {
 For example, to migrate your code that uses `stylelint.lint()` to use `import` and top-level `await`:
 
 ```diff js
-- const stylelint = require("stylelint");
-+ import stylelint from "stylelint";
+-const stylelint = require("stylelint");
++import stylelint from "stylelint";
 
-- stylelint.lint(options).then((result) => { console.log(result); });
-+ const result = await stylelint.lint(options);
-+ console.log(result);
+-stylelint.lint(options).then((result) => { console.log(result); });
++const result = await stylelint.lint(options);
++console.log(result);
 ```
 
 You'll find more details about the [ESM Node.js API in the user guide](../user-guide/node-api.md).
@@ -182,12 +201,12 @@ You'll find more details about the [ESM Node.js API in the user guide](../user-g
 Using the CommonJS Node.js API will trigger a deprecation warning. If you're not quite ready to migrate to ESM yet, you can use the [`quietDeprecationWarnings`](../user-guide/options.md#quietdeprecationwarnings) option to hide the warning.
 
 ```diff js
-const stylelint = require("stylelint");
+ const stylelint = require("stylelint");
 
-const resultPromise = stylelint.lint({
-  /* .. */
-+ quietDeprecationWarnings: true
-});
+ const resultPromise = stylelint.lint({
+   /* .. */
++  quietDeprecationWarnings: true
+ });
 ```
 
 ### Refactored to use `.mjs` and `.cjs` extensions internally
@@ -199,11 +218,11 @@ We recommended copying files to your project instead of importing them as we'll 
 However, you can unsafely continue to `import` or `require` the files before the next major release by updating your imports:
 
 ```diff js
-// ESM
+ // ESM
 -import('stylelint/lib/utils/typeGuards.js');
 +import('stylelint/lib/utils/typeGuards.mjs');
 
-// CommonJS
+ // CommonJS
 -require('stylelint/lib/utils/typeGuards.js');
 +require('stylelint/lib/utils/typeGuards.cjs');
 ```
@@ -246,15 +265,13 @@ We've deprecated the [`output`](../user-guide/node-api.md#output) property in fa
 If you use `stylelint.lint()` to lint a source string and the `fix` option is `true`, the `report` property will contain the formatted problems and the `code` property will contain the fixed code.
 
 ```diff js
-async function lint() {
-  const result = await stylelint.lint({
-    code: "a {}",
-    fix: true
-  });
-- const fixedCode = result.output;
-+ const formattedProblems = result.report;
-+ const fixedCode = result.code;
-}
+ const result = await stylelint.lint({
+   code: "a {}",
+   fix: true
+ });
+-const fixedCode = result.output;
++const formattedProblems = result.report;
++const fixedCode = result.code;
 ```
 
 The `code` property will always be `undefined` if you use `stylelint.lint()` to lint files.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint-test-rule-node/pull/4#pullrequestreview-1770870717

> Is there anything in the PR that needs further explanation?

We've published the new package `stylelint-test-rule-node`, which is an alternative to `jest-preset-stylelint`
See https://www.npmjs.com/package/stylelint-test-rule-node

Also, this change fixes indentation in `diff` code blocks.
