### PR TITLE
Add `ignore: ["keyframe-selectors"]` to `selector-disallowed-list`

### DIFF
--- a/.changeset/sixty-lamps-type.md
+++ b/.changeset/sixty-lamps-type.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `ignore: ["keyframe-selectors"]` to `selector-disallowed-list`

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -115,3 +115,29 @@ The following pattern is _not_ considered a problem:
   .foo {}
 }
 ```
+
+### `ignore: ["keyframe-selectors"]`
+
+Ignore selectors that are keyframe selectors.
+
+Given:
+
+```json
+[/from/, { ignore: ['keyframe-selectors'] }]
+```
+
+The following pattern is _not_ considered a problem:
+
+<!-- prettier-ignore -->
+```css
+@keyframes fade-in {
+  from {}
+}
+```
+
+The following pattern is considered a problem:
+
+<!-- prettier-ignore -->
+```css
+.from {}
+```

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -123,7 +123,7 @@ Ignore keyframe selectors.
 Given:
 
 ```json
-["/from/", { "ignore": ["keyframe-selectors}"] }]
+["/from/", { "ignore": ["keyframe-selectors"] }]
 ```
 
 The following pattern is _not_ considered a problem:

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -80,7 +80,7 @@ For example, with `true`.
 Given:
 
 ```json
-[".foo"]
+[".foo", { "splitList": true }]
 ```
 
 The following pattern is considered a problem:
@@ -104,7 +104,7 @@ Ignore selectors that are inside a block.
 Given:
 
 ```json
-[".foo"]
+[".foo", { "ignore": ["inside-block"] }]
 ```
 
 The following pattern is _not_ considered a problem:

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -123,7 +123,7 @@ Ignore selectors that are keyframe selectors.
 Given:
 
 ```json
-[/from/, { ignore: ['keyframe-selectors'] }]
+["/from/", { "ignore": ["keyframe-selectors}"] }]
 ```
 
 The following pattern is _not_ considered a problem:
@@ -133,11 +133,4 @@ The following pattern is _not_ considered a problem:
 @keyframes fade-in {
   from {}
 }
-```
-
-The following pattern is considered a problem:
-
-<!-- prettier-ignore -->
-```css
-.from {}
 ```

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -118,7 +118,7 @@ The following pattern is _not_ considered a problem:
 
 ### `ignore: ["keyframe-selectors"]`
 
-Ignore selectors that are keyframe selectors.
+Ignore keyframe selectors.
 
 Given:
 

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -225,7 +225,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [[/from/, /[0-9]/], { ignore: ['keyframe-selectors'] }],
+	config: [[/[A-Za-z]/], { ignore: ['keyframe-selectors'] }],
 
 	accept: [
 		{
@@ -238,7 +238,7 @@ testRule({
 		{
 			code: stripIndent`
 				@keyframes fade-in {
-					0% {}
+					to {}
 				}
 			`,
 		},
@@ -261,12 +261,12 @@ testRule({
 			endColumn: 6,
 		},
 		{
-			code: '.color-0% {}',
-			message: messages.rejected('.color-0%'),
+			code: '.to {}',
+			message: messages.rejected('.to'),
 			line: 1,
 			column: 1,
 			endLine: 1,
-			endColumn: 10,
+			endColumn: 4,
 		},
 	],
 });

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -262,11 +262,11 @@ testRule({
 			endColumn: 10,
 		},
 		{
-			code: stripIndent(`
+			code: stripIndent`
 				@keyframes fade-in {
 					from, to {}
 				}
-			`),
+			`,
 			message: messages.rejected('from, to'),
 			line: 2,
 			column: 2,
@@ -282,20 +282,18 @@ testRule({
 
 	accept: [
 		{
-			code: stripIndent(`
+			code: stripIndent`
 				@keyframes fade-in {
 					from {}
 				}
-			`),
+			`,
 		},
 		{
-			code: stripIndent(`
+			code: stripIndent`
 				@keyframes fade-in {
-					from, to {
-						opacity: 0;
-					}
+					from, to {}
 				}
-			`),
+			`,
 		},
 	],
 });

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -231,7 +231,7 @@ testRule({
 		{
 			code: stripIndent`
 				@keyframes fade-in {
-					from { opacity: 0; }
+					from {}
 				}
 			`,
 		},

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -1,4 +1,6 @@
 import rule from '../index.mjs';
+import { stripIndent } from 'common-tags';
+
 const { messages, ruleName } = rule;
 
 testRule({
@@ -217,6 +219,51 @@ testRule({
 			message: messages.rejected('.foo, .bar'),
 			line: 1,
 			column: 1,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [/from/, { ignore: ['keyframe-selectors'] }],
+
+	accept: [
+		{
+			code: stripIndent(`
+				@keyframes fade-in {
+					from {
+						opacity: 0;
+					}
+				}
+			`),
+		},
+	],
+
+	reject: [
+		{
+			code: '.from {}',
+			message: messages.rejected('.from'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 6,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [/from/, { ignore: ['keyframe-selectors'], splitList: true }],
+
+	accept: [
+		{
+			code: stripIndent(`
+				@keyframes fade-in {
+					from, to {
+						opacity: 0;
+					}
+				}
+			`),
 		},
 	],
 });

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -231,18 +231,14 @@ testRule({
 		{
 			code: stripIndent(`
 				@keyframes fade-in {
-					from {
-						opacity: 0;
-					}
+					from { opacity: 0; }
 				}
 			`),
 		},
 		{
 			code: stripIndent(`
 				@keyframes fade-in {
-					0% {
-						opacity: 0;
-					}
+					0% {}
 				}
 			`),
 		},
@@ -268,9 +264,7 @@ testRule({
 		{
 			code: stripIndent(`
 				@keyframes fade-in {
-					from, to {
-						opacity: 0;
-					}
+					from, to {}
 				}
 			`),
 			message: messages.rejected('from, to'),
@@ -290,9 +284,7 @@ testRule({
 		{
 			code: stripIndent(`
 				@keyframes fade-in {
-					from {
-						opacity: 0;
-					}
+					from {}
 				}
 			`),
 		},

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -229,18 +229,18 @@ testRule({
 
 	accept: [
 		{
-			code: stripIndent(`
+			code: stripIndent`
 				@keyframes fade-in {
 					from { opacity: 0; }
 				}
-			`),
+			`,
 		},
 		{
-			code: stripIndent(`
+			code: stripIndent`
 				@keyframes fade-in {
 					0% {}
 				}
-			`),
+			`,
 		},
 	],
 

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -225,13 +225,22 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [/from/, { ignore: ['keyframe-selectors'] }],
+	config: [[/from/, /[0-9]/], { ignore: ['keyframe-selectors'] }],
 
 	accept: [
 		{
 			code: stripIndent(`
 				@keyframes fade-in {
 					from {
+						opacity: 0;
+					}
+				}
+			`),
+		},
+		{
+			code: stripIndent(`
+				@keyframes fade-in {
+					0% {
 						opacity: 0;
 					}
 				}
@@ -248,6 +257,28 @@ testRule({
 			endLine: 1,
 			endColumn: 6,
 		},
+		{
+			code: '.color-0% {}',
+			message: messages.rejected('.color-0%'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 10,
+		},
+		{
+			code: stripIndent(`
+				@keyframes fade-in {
+					from, to {
+						opacity: 0;
+					}
+				}
+			`),
+			message: messages.rejected('from, to'),
+			line: 2,
+			column: 2,
+			endLine: 2,
+			endColumn: 10,
+		},
 	],
 });
 
@@ -256,6 +287,15 @@ testRule({
 	config: [/from/, { ignore: ['keyframe-selectors'], splitList: true }],
 
 	accept: [
+		{
+			code: stripIndent(`
+				@keyframes fade-in {
+					from {
+						opacity: 0;
+					}
+				}
+			`),
+		},
 		{
 			code: stripIndent(`
 				@keyframes fade-in {

--- a/lib/rules/selector-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-disallowed-list/__tests__/index.mjs
@@ -242,6 +242,13 @@ testRule({
 				}
 			`,
 		},
+		{
+			code: stripIndent`
+				@keyframes fade-in {
+					from, to {}
+				}
+			`,
+		},
 	],
 
 	reject: [
@@ -259,18 +266,6 @@ testRule({
 			line: 1,
 			column: 1,
 			endLine: 1,
-			endColumn: 10,
-		},
-		{
-			code: stripIndent`
-				@keyframes fade-in {
-					from, to {}
-				}
-			`,
-			message: messages.rejected('from, to'),
-			line: 2,
-			column: 2,
-			endLine: 2,
 			endColumn: 10,
 		},
 	],

--- a/lib/rules/selector-disallowed-list/index.cjs
+++ b/lib/rules/selector-disallowed-list/index.cjs
@@ -74,7 +74,6 @@ const rule = (primary, secondaryOptions) => {
 
 			if (splitList) {
 				ruleNode.selectors.forEach((selector) => {
-
 					if (matchesStringOrRegExp(selector, primary)) {
 						report({
 							result,

--- a/lib/rules/selector-disallowed-list/index.cjs
+++ b/lib/rules/selector-disallowed-list/index.cjs
@@ -3,7 +3,7 @@
 'use strict';
 
 const validateTypes = require('../../utils/validateTypes.cjs');
-const isKeyframeSelector = require('../../utils/isKeyframeSelector.cjs');
+const isKeyframeRule = require('../../utils/isKeyframeRule.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
@@ -59,6 +59,10 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
+			if (ignoreKeyframeSelectors && isKeyframeRule(ruleNode)) {
+				return;
+			}
+
 			if (ignoreInsideBlock) {
 				const { parent } = ruleNode;
 				const isInsideBlock = parent && parent.type !== 'root';
@@ -70,9 +74,6 @@ const rule = (primary, secondaryOptions) => {
 
 			if (splitList) {
 				ruleNode.selectors.forEach((selector) => {
-					if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
-						return;
-					}
 
 					if (matchesStringOrRegExp(selector, primary)) {
 						report({
@@ -87,10 +88,6 @@ const rule = (primary, secondaryOptions) => {
 				});
 			} else {
 				const { selector, raws } = ruleNode;
-
-				if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
-					return;
-				}
 
 				if (matchesStringOrRegExp(selector, primary)) {
 					const word = (raws.selector && raws.selector.raw) || selector;

--- a/lib/rules/selector-disallowed-list/index.cjs
+++ b/lib/rules/selector-disallowed-list/index.cjs
@@ -3,6 +3,7 @@
 'use strict';
 
 const validateTypes = require('../../utils/validateTypes.cjs');
+const isKeyframeSelector = require('../../utils/isKeyframeSelector.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
@@ -33,7 +34,7 @@ const rule = (primary, secondaryOptions) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: ['inside-block'],
+					ignore: ['inside-block', 'keyframe-selectors'],
 					splitList: [validateTypes.isBoolean],
 				},
 				optional: true,
@@ -45,6 +46,12 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		const ignoreInsideBlock = optionsMatches(secondaryOptions, 'ignore', 'inside-block');
+		const ignoreKeyframeSelectors = optionsMatches(
+			secondaryOptions,
+			'ignore',
+			'keyframe-selectors',
+		);
+
 		const splitList = secondaryOptions && secondaryOptions.splitList;
 
 		root.walkRules((ruleNode) => {
@@ -63,6 +70,10 @@ const rule = (primary, secondaryOptions) => {
 
 			if (splitList) {
 				ruleNode.selectors.forEach((selector) => {
+					if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
+						return;
+					}
+
 					if (matchesStringOrRegExp(selector, primary)) {
 						report({
 							result,
@@ -76,6 +87,10 @@ const rule = (primary, secondaryOptions) => {
 				});
 			} else {
 				const { selector, raws } = ruleNode;
+
+				if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
+					return;
+				}
 
 				if (matchesStringOrRegExp(selector, primary)) {
 					const word = (raws.selector && raws.selector.raw) || selector;

--- a/lib/rules/selector-disallowed-list/index.mjs
+++ b/lib/rules/selector-disallowed-list/index.mjs
@@ -1,5 +1,5 @@
 import { isBoolean, isRegExp, isString } from '../../utils/validateTypes.mjs';
-import isKeyframeSelector from '../../utils/isKeyframeSelector.mjs';
+import isKeyframeRule from '../../utils/isKeyframeRule.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -55,6 +55,10 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
+			if (ignoreKeyframeSelectors && isKeyframeRule(ruleNode)) {
+				return;
+			}
+
 			if (ignoreInsideBlock) {
 				const { parent } = ruleNode;
 				const isInsideBlock = parent && parent.type !== 'root';
@@ -66,10 +70,6 @@ const rule = (primary, secondaryOptions) => {
 
 			if (splitList) {
 				ruleNode.selectors.forEach((selector) => {
-					if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
-						return;
-					}
-
 					if (matchesStringOrRegExp(selector, primary)) {
 						report({
 							result,
@@ -83,10 +83,6 @@ const rule = (primary, secondaryOptions) => {
 				});
 			} else {
 				const { selector, raws } = ruleNode;
-
-				if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
-					return;
-				}
 
 				if (matchesStringOrRegExp(selector, primary)) {
 					const word = (raws.selector && raws.selector.raw) || selector;

--- a/lib/rules/selector-disallowed-list/index.mjs
+++ b/lib/rules/selector-disallowed-list/index.mjs
@@ -1,4 +1,5 @@
 import { isBoolean, isRegExp, isString } from '../../utils/validateTypes.mjs';
+import isKeyframeSelector from '../../utils/isKeyframeSelector.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -29,7 +30,7 @@ const rule = (primary, secondaryOptions) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					ignore: ['inside-block'],
+					ignore: ['inside-block', 'keyframe-selectors'],
 					splitList: [isBoolean],
 				},
 				optional: true,
@@ -41,6 +42,12 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		const ignoreInsideBlock = optionsMatches(secondaryOptions, 'ignore', 'inside-block');
+		const ignoreKeyframeSelectors = optionsMatches(
+			secondaryOptions,
+			'ignore',
+			'keyframe-selectors',
+		);
+
 		const splitList = secondaryOptions && secondaryOptions.splitList;
 
 		root.walkRules((ruleNode) => {
@@ -59,6 +66,10 @@ const rule = (primary, secondaryOptions) => {
 
 			if (splitList) {
 				ruleNode.selectors.forEach((selector) => {
+					if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
+						return;
+					}
+
 					if (matchesStringOrRegExp(selector, primary)) {
 						report({
 							result,
@@ -72,6 +83,10 @@ const rule = (primary, secondaryOptions) => {
 				});
 			} else {
 				const { selector, raws } = ruleNode;
+
+				if (ignoreKeyframeSelectors && isKeyframeSelector(selector)) {
+					return;
+				}
 
 				if (matchesStringOrRegExp(selector, primary)) {
 					const word = (raws.selector && raws.selector.raw) || selector;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7162.

> Is there anything in the PR that needs further explanation?

Two quick questions:

1. ~~I used the `isKeyframeSelector` util (used elsewhere) to heuristically guess if the item is a keyframe selector, rather than seeing if it's actually *in* a keyframe. Does this make sense?~~ Am now using `isKeyframeRule` instead!
2. ~~I assumed that there should be nothing "special" about this option's interaction with `splitList`; in particular, if the list is not split, given `/from/` the current implementation will still flag `from, to`; it's only if the rule is given `/from/, { splitList: true }` that `from, to` is properly ignored. However, it'd be simple for me to reverse this behaviour - what are our thoughts?~~ Resolved by the former :) 
