### PR TITLE
Update stylelint-stylistic plugin link

### DIFF
--- a/docs/migration-guide/to-15.md
+++ b/docs/migration-guide/to-15.md
@@ -124,10 +124,7 @@ We've removed the deprecated rules from the latest version of the [standard conf
 
 There are lots of other rules we don't turn on in the [standard config](https://www.npmjs.com/package/stylelint-config-standard) and you can learn more about using them to customize Stylelint to your exact needs in our [new guide](../user-guide/customize.md).
 
-Alternatively, you can continue to enforce stylistic consistency with Stylelint by using one of the community plugins that have migrated the deprecated rules:
-
-- [stylelint-stylistic](https://www.npmjs.com/package/stylelint-stylistic)
-- [stylelint-codeguide](https://www.npmjs.com/package/stylelint-codeguide)
+Alternatively, you can continue to enforce stylistic consistency with Stylelint by using the community plugins [stylelint-stylistic](https://www.npmjs.com/package/@stylistic/stylelint-plugin) that have migrated the deprecated rules.
 
 You can use the [`quietDeprecationWarnings`](../user-guide/options.md#quietdeprecationwarnings) option to silence the deprecation warnings.
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

The links to the plugins are out of date.

> Is there anything in the PR that needs further explanation?

Both plugins with stylistic rules have been declared deprecated in favor of one (my renamed plugin) that we decided to join forces on.