### PR TITLE
Refactor to use `@csstools/css-parser-algorithms` `walk` helper

### DIFF
--- a/lib/rules/function-no-unknown/index.cjs
+++ b/lib/rules/function-no-unknown/index.cjs
@@ -60,13 +60,10 @@ const rule = (primary, secondaryOptions) => {
 
 			if (!isStandardSyntaxValue(value)) return;
 
-			/**
-			 * @param {import('@csstools/css-parser-algorithms').ComponentValue} componentValue
-			 */
-			const walker = (componentValue) => {
-				if (!cssParserAlgorithms.isFunctionNode(componentValue)) return;
+			cssParserAlgorithms.walk(cssParserAlgorithms.parseListOfComponentValues(cssTokenizer.tokenize({ css: value })), ({ node }) => {
+				if (!cssParserAlgorithms.isFunctionNode(node)) return;
 
-				const name = componentValue.getName();
+				const name = node.getName();
 
 				if (isCustomFunction(name)) return;
 
@@ -78,21 +75,11 @@ const rule = (primary, secondaryOptions) => {
 					message: messages.rejected,
 					messageArgs: [name],
 					node: decl,
-					index: declarationValueIndex(decl) + componentValue.name[2],
+					index: declarationValueIndex(decl) + node.name[2],
 					result,
 					ruleName,
 					word: name,
 				});
-			};
-
-			cssParserAlgorithms.parseListOfComponentValues(cssTokenizer.tokenize({ css: value })).forEach((componentValue) => {
-				if (cssParserAlgorithms.isFunctionNode(componentValue) || cssParserAlgorithms.isSimpleBlockNode(componentValue)) {
-					walker(componentValue);
-
-					componentValue.walk(({ node }) => {
-						walker(node);
-					});
-				}
 			});
 		});
 	};

--- a/lib/rules/function-no-unknown/index.mjs
+++ b/lib/rules/function-no-unknown/index.mjs
@@ -1,10 +1,6 @@
 import fs from 'node:fs';
 
-import {
-	isFunctionNode,
-	isSimpleBlockNode,
-	parseListOfComponentValues,
-} from '@csstools/css-parser-algorithms';
+import { isFunctionNode, parseListOfComponentValues, walk } from '@csstools/css-parser-algorithms';
 import functionsListPath from 'css-functions-list';
 import { tokenize } from '@csstools/css-tokenizer';
 
@@ -62,13 +58,10 @@ const rule = (primary, secondaryOptions) => {
 
 			if (!isStandardSyntaxValue(value)) return;
 
-			/**
-			 * @param {import('@csstools/css-parser-algorithms').ComponentValue} componentValue
-			 */
-			const walker = (componentValue) => {
-				if (!isFunctionNode(componentValue)) return;
+			walk(parseListOfComponentValues(tokenize({ css: value })), ({ node }) => {
+				if (!isFunctionNode(node)) return;
 
-				const name = componentValue.getName();
+				const name = node.getName();
 
 				if (isCustomFunction(name)) return;
 
@@ -80,21 +73,11 @@ const rule = (primary, secondaryOptions) => {
 					message: messages.rejected,
 					messageArgs: [name],
 					node: decl,
-					index: declarationValueIndex(decl) + componentValue.name[2],
+					index: declarationValueIndex(decl) + node.name[2],
 					result,
 					ruleName,
 					word: name,
 				});
-			};
-
-			parseListOfComponentValues(tokenize({ css: value })).forEach((componentValue) => {
-				if (isFunctionNode(componentValue) || isSimpleBlockNode(componentValue)) {
-					walker(componentValue);
-
-					componentValue.walk(({ node }) => {
-						walker(node);
-					});
-				}
 			});
 		});
 	};

--- a/lib/rules/number-max-precision/index.cjs
+++ b/lib/rules/number-max-precision/index.cjs
@@ -84,24 +84,22 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			cssParserAlgorithms.parseListOfComponentValues(cssTokenizer.tokenize({ css: value })).forEach((componentValue) => {
-				const initialState = {
-					ignored: false,
-					precision: primary,
-				};
+			const initialState = {
+				ignored: false,
+				precision: primary,
+			};
 
-				walker(node, getIndex, componentValue, initialState);
+			cssParserAlgorithms.walk(
+				cssParserAlgorithms.parseListOfComponentValues(cssTokenizer.tokenize({ css: value })),
+				({ node: mediaNode, state }) => {
+					if (!state) return;
 
-				if (cssParserAlgorithms.isFunctionNode(componentValue) || cssParserAlgorithms.isSimpleBlockNode(componentValue)) {
-					componentValue.walk(({ node: mediaNode, state }) => {
-						if (!state) return;
+					if (state.ignored) return;
 
-						if (state.ignored) return;
-
-						walker(node, getIndex, mediaNode, state);
-					}, initialState);
-				}
-			});
+					walker(node, getIndex, mediaNode, state);
+				},
+				initialState,
+			);
 		}
 
 		/**

--- a/lib/rules/number-max-precision/index.mjs
+++ b/lib/rules/number-max-precision/index.mjs
@@ -1,9 +1,9 @@
 import { TokenType, tokenize } from '@csstools/css-tokenizer';
 import {
 	isFunctionNode,
-	isSimpleBlockNode,
 	isTokenNode,
 	parseListOfComponentValues,
+	walk,
 } from '@csstools/css-parser-algorithms';
 
 import { isNumber, isRegExp, isString } from '../../utils/validateTypes.mjs';
@@ -86,24 +86,22 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			parseListOfComponentValues(tokenize({ css: value })).forEach((componentValue) => {
-				const initialState = {
-					ignored: false,
-					precision: primary,
-				};
+			const initialState = {
+				ignored: false,
+				precision: primary,
+			};
 
-				walker(node, getIndex, componentValue, initialState);
+			walk(
+				parseListOfComponentValues(tokenize({ css: value })),
+				({ node: mediaNode, state }) => {
+					if (!state) return;
 
-				if (isFunctionNode(componentValue) || isSimpleBlockNode(componentValue)) {
-					componentValue.walk(({ node: mediaNode, state }) => {
-						if (!state) return;
+					if (state.ignored) return;
 
-						if (state.ignored) return;
-
-						walker(node, getIndex, mediaNode, state);
-					}, initialState);
-				}
-			});
+					walker(node, getIndex, mediaNode, state);
+				},
+				initialState,
+			);
 		}
 
 		/**

--- a/lib/rules/unit-disallowed-list/index.cjs
+++ b/lib/rules/unit-disallowed-list/index.cjs
@@ -150,26 +150,13 @@ const rule = (primary, secondaryOptions) => {
 
 			if (!hasDimension(value)) return;
 
-			cssParserAlgorithms.parseListOfComponentValues(tokenizeWithoutPercentages(value)).forEach((componentValue) => {
-				if (cssParserAlgorithms.isTokenNode(componentValue)) {
-					check(
-						decl,
-						declarationValueIndex,
-						componentValue,
-						decl.prop,
-						secondaryOptions?.ignoreProperties,
-					);
+			const initialState = {
+				ignored: false,
+			};
 
-					return;
-				}
-
-				if (!cssParserAlgorithms.isFunctionNode(componentValue) && !cssParserAlgorithms.isSimpleBlockNode(componentValue)) return;
-
-				const initialState = {
-					ignored: componentValueIsIgnored(componentValue),
-				};
-
-				componentValue.walk(({ node, state }) => {
+			cssParserAlgorithms.walk(
+				cssParserAlgorithms.parseListOfComponentValues(tokenizeWithoutPercentages(value)),
+				({ node, state }) => {
 					if (!state) return;
 
 					if (state.ignored) return;
@@ -183,8 +170,9 @@ const rule = (primary, secondaryOptions) => {
 					if (componentValueIsIgnored(node)) {
 						state.ignored = true;
 					}
-				}, initialState);
-			});
+				},
+				initialState,
+			);
 		});
 	};
 };

--- a/lib/rules/unit-disallowed-list/index.mjs
+++ b/lib/rules/unit-disallowed-list/index.mjs
@@ -1,9 +1,9 @@
 import { NumberType, TokenType, tokenize } from '@csstools/css-tokenizer';
 import {
 	isFunctionNode,
-	isSimpleBlockNode,
 	isTokenNode,
 	parseListOfComponentValues,
+	walk,
 } from '@csstools/css-parser-algorithms';
 import { isMediaFeature, parseFromTokens } from '@csstools/media-query-list-parser';
 
@@ -152,26 +152,13 @@ const rule = (primary, secondaryOptions) => {
 
 			if (!hasDimension(value)) return;
 
-			parseListOfComponentValues(tokenizeWithoutPercentages(value)).forEach((componentValue) => {
-				if (isTokenNode(componentValue)) {
-					check(
-						decl,
-						declarationValueIndex,
-						componentValue,
-						decl.prop,
-						secondaryOptions?.ignoreProperties,
-					);
+			const initialState = {
+				ignored: false,
+			};
 
-					return;
-				}
-
-				if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) return;
-
-				const initialState = {
-					ignored: componentValueIsIgnored(componentValue),
-				};
-
-				componentValue.walk(({ node, state }) => {
+			walk(
+				parseListOfComponentValues(tokenizeWithoutPercentages(value)),
+				({ node, state }) => {
 					if (!state) return;
 
 					if (state.ignored) return;
@@ -185,8 +172,9 @@ const rule = (primary, secondaryOptions) => {
 					if (componentValueIsIgnored(node)) {
 						state.ignored = true;
 					}
-				}, initialState);
-			});
+				},
+				initialState,
+			);
 		});
 	};
 };

--- a/lib/rules/unit-no-unknown/index.cjs
+++ b/lib/rules/unit-no-unknown/index.cjs
@@ -178,21 +178,14 @@ const rule = (primary, secondaryOptions) => {
 
 			const isImageResolutionProp = decl.prop.toLowerCase() === 'image-resolution';
 
-			cssParserAlgorithms.parseListOfComponentValues(tokens).forEach((componentValue) => {
-				const initialState = {
-					ignored: false,
-					allowX: isImageResolutionProp,
-				};
+			const initialState = {
+				ignored: false,
+				allowX: isImageResolutionProp,
+			};
 
-				if (cssParserAlgorithms.isFunctionNode(componentValue) || cssParserAlgorithms.isTokenNode(componentValue)) {
-					check(decl, declarationValueIndex, componentValue, initialState);
-				}
-
-				if (!cssParserAlgorithms.isFunctionNode(componentValue) && !cssParserAlgorithms.isSimpleBlockNode(componentValue)) {
-					return;
-				}
-
-				componentValue.walk(({ node, state }) => {
+			cssParserAlgorithms.walk(
+				cssParserAlgorithms.parseListOfComponentValues(tokens),
+				({ node, state }) => {
 					if (!state) return;
 
 					if (state.ignored) return;
@@ -200,8 +193,9 @@ const rule = (primary, secondaryOptions) => {
 					if (cssParserAlgorithms.isFunctionNode(node) || cssParserAlgorithms.isTokenNode(node)) {
 						check(decl, declarationValueIndex, node, state);
 					}
-				}, initialState);
-			});
+				},
+				initialState,
+			);
 		});
 	};
 };

--- a/lib/rules/unit-no-unknown/index.mjs
+++ b/lib/rules/unit-no-unknown/index.mjs
@@ -1,9 +1,9 @@
 import { TokenType, tokenize } from '@csstools/css-tokenizer';
 import {
 	isFunctionNode,
-	isSimpleBlockNode,
 	isTokenNode,
 	parseListOfComponentValues,
+	walk,
 } from '@csstools/css-parser-algorithms';
 import { isMediaFeature, parseFromTokens } from '@csstools/media-query-list-parser';
 
@@ -180,21 +180,14 @@ const rule = (primary, secondaryOptions) => {
 
 			const isImageResolutionProp = decl.prop.toLowerCase() === 'image-resolution';
 
-			parseListOfComponentValues(tokens).forEach((componentValue) => {
-				const initialState = {
-					ignored: false,
-					allowX: isImageResolutionProp,
-				};
+			const initialState = {
+				ignored: false,
+				allowX: isImageResolutionProp,
+			};
 
-				if (isFunctionNode(componentValue) || isTokenNode(componentValue)) {
-					check(decl, declarationValueIndex, componentValue, initialState);
-				}
-
-				if (!isFunctionNode(componentValue) && !isSimpleBlockNode(componentValue)) {
-					return;
-				}
-
-				componentValue.walk(({ node, state }) => {
+			walk(
+				parseListOfComponentValues(tokens),
+				({ node, state }) => {
 					if (!state) return;
 
 					if (state.ignored) return;
@@ -202,8 +195,9 @@ const rule = (primary, secondaryOptions) => {
 					if (isFunctionNode(node) || isTokenNode(node)) {
 						check(decl, declarationValueIndex, node, state);
 					}
-				}, initialState);
-			});
+				},
+				initialState,
+			);
 		});
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "16.1.0",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^2.4.0",
-        "@csstools/css-tokenizer": "^2.2.2",
-        "@csstools/media-query-list-parser": "^2.1.6",
+        "@csstools/css-parser-algorithms": "^2.5.0",
+        "@csstools/css-tokenizer": "^2.2.3",
+        "@csstools/media-query-list-parser": "^2.1.7",
         "@csstools/selector-specificity": "^3.0.1",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
@@ -1196,9 +1196,9 @@
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.4.0.tgz",
-      "integrity": "sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.5.0.tgz",
+      "integrity": "sha512-abypo6m9re3clXA00eu5syw+oaPHbJTPapu9C4pzNsJ4hdZDzushT50Zhu+iIYXgEe1CxnRMn7ngsbV+MLrlpQ==",
       "funding": [
         {
           "type": "github",
@@ -1213,13 +1213,13 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^2.2.2"
+        "@csstools/css-tokenizer": "^2.2.3"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.2.tgz",
-      "integrity": "sha512-wCDUe/MAw7npAHFLyW3QjSyLA66S5QFaV1jIXlNQvdJ8RzXDSgALa49eWcUO6P55ARQaz0TsDdAgdRgkXFYY8g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.3.tgz",
+      "integrity": "sha512-pp//EvZ9dUmGuGtG1p+n17gTHEOqu9jO+FiCUjNN3BDmyhdA2Jq9QsVeR7K8/2QCK17HSsioPlTW9ZkzoWb3Lg==",
       "funding": [
         {
           "type": "github",
@@ -1235,9 +1235,9 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.6.tgz",
-      "integrity": "sha512-R6AKl9vaU0It7D7TR2lQn0pre5aQfdeqHRePlaRCY8rHL3l9eVlNRpsEVDKFi/zAjzv68CxH2M5kqbhPFPKjvw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.7.tgz",
+      "integrity": "sha512-lHPKJDkPUECsyAvD60joYfDmp8UERYxHGkFfyLJFTVK/ERJe0sVlIFLXU5XFxdjNDTerp5L4KeaKG+Z5S94qxQ==",
       "funding": [
         {
           "type": "github",
@@ -1252,8 +1252,8 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^2.4.0",
-        "@csstools/css-tokenizer": "^2.2.2"
+        "@csstools/css-parser-algorithms": "^2.5.0",
+        "@csstools/css-tokenizer": "^2.2.3"
       }
     },
     "node_modules/@csstools/selector-specificity": {

--- a/package.json
+++ b/package.json
@@ -158,9 +158,9 @@
     ]
   },
   "dependencies": {
-    "@csstools/css-parser-algorithms": "^2.4.0",
-    "@csstools/css-tokenizer": "^2.2.2",
-    "@csstools/media-query-list-parser": "^2.1.6",
+    "@csstools/css-parser-algorithms": "^2.5.0",
+    "@csstools/css-tokenizer": "^2.2.3",
+    "@csstools/media-query-list-parser": "^2.1.7",
     "@csstools/selector-specificity": "^3.0.1",
     "balanced-match": "^2.0.0",
     "colord": "^2.9.3",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, this is a refactor after an upstream API addition

> Is there anything in the PR that needs further explanation?

Starting an AST walk when you have a list of component values was a bit cumbersome because the list is plain JavaScript array. So you have to iterate the top levels manually and do all your checks there first and then start walking down simple blocks and functions.

I've added a `walk` function that takes a list of component values as its argument.
This makes it possible to remove some duplicate code here.

-----

_This isn't a user facing change so I don't think a changelog entry is needed._
