### PR TITLE
Fix `function-no-unknown|value-keyword-case` false positives for template literals with line breaks

### DIFF
--- a/.changeset/beige-peaches-add.md
+++ b/.changeset/beige-peaches-add.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fix: `Template literal` behavior with line breaks is incorrect
+Fixed: `function-no-unknown|value-keyword-case` false positives for template literals with line breaks

--- a/.changeset/beige-peaches-add.md
+++ b/.changeset/beige-peaches-add.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fix: `Template literal` behavior with line breaks is incorrect

--- a/lib/utils/__tests__/hasInterpolation.test.mjs
+++ b/lib/utils/__tests__/hasInterpolation.test.mjs
@@ -14,4 +14,6 @@ it('hasInterpolation', () => {
 	expect(hasInterpolation("$sass-variable + 'foo'")).toBeFalsy();
 	expect(hasInterpolation('10px')).toBeFalsy();
 	expect(hasInterpolation("@less-variable + 'foo'")).toBeFalsy();
+	expect(hasInterpolation('${value}')).toBeTruthy();
+	expect(hasInterpolation('${\nvalue\n}')).toBeTruthy();
 });

--- a/lib/utils/hasTplInterpolation.cjs
+++ b/lib/utils/hasTplInterpolation.cjs
@@ -2,7 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-const HAS_TPL_INTERPOLATION = /\{.+?\}/;
+const HAS_TPL_INTERPOLATION = /\{.+?\}/s;
 
 /**
  * Check whether a string has JS template literal interpolation or HTML-like template

--- a/lib/utils/hasTplInterpolation.mjs
+++ b/lib/utils/hasTplInterpolation.mjs
@@ -1,4 +1,4 @@
-const HAS_TPL_INTERPOLATION = /\{.+?\}/;
+const HAS_TPL_INTERPOLATION = /\{.+?\}/s;
 
 /**
  * Check whether a string has JS template literal interpolation or HTML-like template


### PR DESCRIPTION


<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?


#7442 

> Is there anything in the PR that needs further explanation?

The regular expression that checks template literals in js has been changed.