### PR TITLE
Fix `allowEmptyInput` option ignored in configuration object regression

### DIFF
--- a/.changeset/friendly-garlics-jog.md
+++ b/.changeset/friendly-garlics-jog.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `allowEmptyInput` option ignored in configuration files
+Fixed: `allowEmptyInput` option ignored in configuration file

--- a/.changeset/friendly-garlics-jog.md
+++ b/.changeset/friendly-garlics-jog.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `allowEmptyInput` option ignored in configuration files

--- a/.changeset/friendly-garlics-jog.md
+++ b/.changeset/friendly-garlics-jog.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `allowEmptyInput` option ignored in configuration file
+Fixed: `allowEmptyInput` option ignored in configuration object regression

--- a/lib/__tests__/standalone.test.mjs
+++ b/lib/__tests__/standalone.test.mjs
@@ -194,6 +194,16 @@ it('standalone with nonexistent-file and allowEmptyInput enabled (in config file
 	expect(report).toBe('[]');
 });
 
+it('standalone ignoring passed "allowEmptyInput: false" option', async () => {
+	const { errored } = await standalone({
+		files: `${fixturesPath}/nonexistent-file.css`,
+		configFile: `${fixturesPath}/config-allow-empty-input.json`,
+		allowEmptyInput: false,
+	});
+
+	expect(errored).toBe(false);
+});
+
 describe('standalone passing code with syntax error', () => {
 	let results;
 

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -257,7 +257,7 @@ async function standalone({
 		});
 
 		stylelintResults = await Promise.all(getStylelintResults);
-	} else if (allowEmptyInput ?? config?.allowEmptyInput ?? (await canAllowEmptyInput(stylelint))) {
+	} else if (allowEmptyInput || config?.allowEmptyInput || (await canAllowEmptyInput(stylelint))) {
 		stylelintResults = await Promise.all([]);
 	} else if (filePathsLengthBeforeIgnore) {
 		// All input files ignored

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -255,7 +255,7 @@ export default async function standalone({
 		});
 
 		stylelintResults = await Promise.all(getStylelintResults);
-	} else if (allowEmptyInput ?? config?.allowEmptyInput ?? (await canAllowEmptyInput(stylelint))) {
+	} else if (allowEmptyInput || config?.allowEmptyInput || (await canAllowEmptyInput(stylelint))) {
 		stylelintResults = await Promise.all([]);
 	} else if (filePathsLengthBeforeIgnore) {
 		// All input files ignored


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7440

> Is there anything in the PR that needs further explanation?

[`meow`](https://github.com/sindresorhus/meow) automatically sets the default value `false` for boolean flags when the flags are unspecified.

https://github.com/stylelint/stylelint/blob/804bb24c75248aba55b009994e4bfb561593a990/lib/cli.mjs#L203-L206
