### PR TITLE
Document `--output-file` flag in migration guide for CLI stderr change

### DIFF
--- a/docs/migration-guide/to-16.md
+++ b/docs/migration-guide/to-16.md
@@ -328,7 +328,7 @@ We've changed the CLI to print problems to stderr instead of stdout.
 
 If you use the [`--fix`](../user-guide/cli.md#--fix) and [`--stdin`](../user-guide/cli.md#--stdin) options, the CLI will print the fixed code to stdout and any problems to stderr.
 
-If you use `>` to redirect standard output, e.g. from a custom formatter, can use use the [`--output-file`](../user-guide/cli.md#--output-file--o) flag instead:
+If you use `>` to redirect standard output, e.g. from a custom formatter, you can use the [`--output-file`](../user-guide/cli.md#--output-file--o) flag instead:
 
 ```diff shell
 -npx stylelint "*.css" --custom-formatter custom-formatter.js > output.txt

--- a/docs/migration-guide/to-16.md
+++ b/docs/migration-guide/to-16.md
@@ -328,6 +328,13 @@ We've changed the CLI to print problems to stderr instead of stdout.
 
 If you use the [`--fix`](../user-guide/cli.md#--fix) and [`--stdin`](../user-guide/cli.md#--stdin) options, the CLI will print the fixed code to stdout and any problems to stderr.
 
+If you use `>` to redirect standard output, e.g. from a custom formatter, can use use the [`--output-file`](../user-guide/cli.md#--output-file--o) flag instead:
+
+```diff shell
+-npx stylelint "*.css" --custom-formatter custom-formatter.js > output.txt
++npx stylelint "*.css" --custom-formatter custom-formatter.js --output-file output.txt
+```
+
 ### Changed CLI exit code for flag errors
 
 We've changed the exit code for CLI flag errors from `2` to `64` so that `2` is reserved for lint problems.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7441

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
