### PR TITLE
Fix `declaration-property-value-no-unknown` false negatives for `@starting-style`

### DIFF
--- a/.changeset/cyan-mice-enjoy.md
+++ b/.changeset/cyan-mice-enjoy.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": patch
+"stylelint": minor
 ---
 
 Fixed: `declaration-property-value-no-unknown` false negatives for `@starting-style`

--- a/.changeset/cyan-mice-enjoy.md
+++ b/.changeset/cyan-mice-enjoy.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-property-value-no-unknown` false negatives for `@starting-style`

--- a/lib/reference/atKeywords.cjs
+++ b/lib/reference/atKeywords.cjs
@@ -11,6 +11,7 @@ const nestingSupportedAtKeywords = new Set([
 	'media',
 	'scope',
 	'supports',
+	'starting-style',
 ]);
 
 // https://www.w3.org/TR/css-page-3/#syntax-page-selector

--- a/lib/reference/atKeywords.cjs
+++ b/lib/reference/atKeywords.cjs
@@ -10,8 +10,8 @@ const nestingSupportedAtKeywords = new Set([
 	'layer',
 	'media',
 	'scope',
-	'supports',
 	'starting-style',
+	'supports',
 ]);
 
 // https://www.w3.org/TR/css-page-3/#syntax-page-selector
@@ -35,12 +35,11 @@ const pageMarginAtKeywords = new Set([
 ]);
 
 // https://developer.mozilla.org/en/docs/Web/CSS/At-rule
-const atKeywords = uniteSets(pageMarginAtKeywords, [
+const atKeywords = uniteSets(nestingSupportedAtKeywords, pageMarginAtKeywords, [
 	'annotation',
 	'apply',
 	'character-variant',
 	'charset',
-	'container',
 	'counter-style',
 	'custom-media',
 	'custom-selector',
@@ -49,19 +48,14 @@ const atKeywords = uniteSets(pageMarginAtKeywords, [
 	'font-feature-values',
 	'import',
 	'keyframes',
-	'layer',
-	'media',
 	'namespace',
 	'nest',
 	'ornaments',
 	'page',
 	'property',
 	'scroll-timeline',
-	'scope',
-	'starting-style',
 	'styleset',
 	'stylistic',
-	'supports',
 	'swash',
 	'viewport',
 ]);

--- a/lib/reference/atKeywords.mjs
+++ b/lib/reference/atKeywords.mjs
@@ -6,8 +6,8 @@ export const nestingSupportedAtKeywords = new Set([
 	'layer',
 	'media',
 	'scope',
-	'supports',
 	'starting-style',
+	'supports',
 ]);
 
 // https://www.w3.org/TR/css-page-3/#syntax-page-selector
@@ -31,12 +31,11 @@ const pageMarginAtKeywords = new Set([
 ]);
 
 // https://developer.mozilla.org/en/docs/Web/CSS/At-rule
-export const atKeywords = uniteSets(pageMarginAtKeywords, [
+export const atKeywords = uniteSets(nestingSupportedAtKeywords, pageMarginAtKeywords, [
 	'annotation',
 	'apply',
 	'character-variant',
 	'charset',
-	'container',
 	'counter-style',
 	'custom-media',
 	'custom-selector',
@@ -45,19 +44,14 @@ export const atKeywords = uniteSets(pageMarginAtKeywords, [
 	'font-feature-values',
 	'import',
 	'keyframes',
-	'layer',
-	'media',
 	'namespace',
 	'nest',
 	'ornaments',
 	'page',
 	'property',
 	'scroll-timeline',
-	'scope',
-	'starting-style',
 	'styleset',
 	'stylistic',
-	'supports',
 	'swash',
 	'viewport',
 ]);

--- a/lib/reference/atKeywords.mjs
+++ b/lib/reference/atKeywords.mjs
@@ -7,6 +7,7 @@ export const nestingSupportedAtKeywords = new Set([
 	'media',
 	'scope',
 	'supports',
+	'starting-style',
 ]);
 
 // https://www.w3.org/TR/css-page-3/#syntax-page-selector

--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
@@ -12,6 +12,9 @@ testRule({
 			code: 'a { top: 0; }',
 		},
 		{
+			code: 'a { @starting-style { opacity: 0; } }',
+		},
+		{
 			code: 'a { @media screen { top: 0; } }',
 		},
 		{
@@ -147,6 +150,14 @@ testRule({
 			column: 26,
 			endLine: 1,
 			endColumn: 33,
+		},
+		{
+			code: 'a { @starting-style { padding: auto; } }',
+			message: messages.rejected('padding', 'auto'),
+			line: 1,
+			column: 32,
+			endLine: 1,
+			endColumn: 36,
 		},
 		{
 			code: 'a { top: red; }',


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, it's a false negative fix for `declaration-property-value-no-unknown` rule.

> Is there anything in the PR that needs further explanation?

This false negative is explained here - https://github.com/stylelint/stylelint/pull/7438#discussion_r1439118910