### PR TITLE
Add `media-query-no-invalid` specific problem messages

### DIFF
--- a/.changeset/healthy-donkeys-appear.md
+++ b/.changeset/healthy-donkeys-appear.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": patch
+"stylelint": minor
 ---
 
 Added: `media-query-no-invalid` specific problem messages

--- a/lib/rules/media-query-no-invalid/__tests__/index.mjs
+++ b/lib/rules/media-query-no-invalid/__tests__/index.mjs
@@ -159,7 +159,10 @@ testRule({
 		},
 		{
 			code: '@media (--foo: 2) {}',
-			message: messages.rejected('(--foo: 2)'),
+			message: messages.rejected(
+				'(--foo: 2)',
+				'custom media queries can only be used in boolean queries',
+			),
 			line: 1,
 			column: 8,
 			endLine: 1,
@@ -167,7 +170,10 @@ testRule({
 		},
 		{
 			code: '@media (min-width < 500px) {}',
-			message: messages.rejected('(min-width < 500px)'),
+			message: messages.rejected(
+				'(min-width < 500px)',
+				'"min-" and "max-" prefixes are not needed when using range queries',
+			),
 			line: 1,
 			column: 8,
 			endLine: 1,
@@ -175,7 +181,10 @@ testRule({
 		},
 		{
 			code: '@media (min-width) {}',
-			message: messages.rejected('(min-width)'),
+			message: messages.rejected(
+				'(min-width)',
+				'"min-" and "max-" prefixes are not needed in boolean queries',
+			),
 			line: 1,
 			column: 8,
 			endLine: 1,
@@ -183,7 +192,10 @@ testRule({
 		},
 		{
 			code: '@media (grid < 0) {}',
-			message: messages.rejected('(grid < 0)'),
+			message: messages.rejected(
+				'(grid < 0)',
+				'discrete features can only be used in plain and boolean queries',
+			),
 			line: 1,
 			column: 8,
 			endLine: 1,
@@ -248,7 +260,10 @@ testRule({
 		},
 		{
 			code: '@media (--foo: 300px) {}',
-			message: messages.rejected('(--foo: 300px)'),
+			message: messages.rejected(
+				'(--foo: 300px)',
+				'custom media queries can only be used in boolean queries',
+			),
 			line: 1,
 			column: 8,
 			endLine: 1,
@@ -256,7 +271,10 @@ testRule({
 		},
 		{
 			code: '@media (--foo < 300px) {}',
-			message: messages.rejected('(--foo < 300px)'),
+			message: messages.rejected(
+				'(--foo < 300px)',
+				'custom media queries can only be used in boolean queries',
+			),
 			line: 1,
 			column: 8,
 			endLine: 1,

--- a/lib/rules/media-query-no-invalid/index.cjs
+++ b/lib/rules/media-query-no-invalid/index.cjs
@@ -15,7 +15,11 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'media-query-no-invalid';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (query) => `Unexpected invalid media query "${query}"`,
+	rejected: (query, hint) => {
+		if (!hint) return `Unexpected invalid media query "${query}"`;
+
+		return `Unexpected invalid media query "${query}", ${hint}`;
+	},
 });
 
 const HAS_MIN_MAX_PREFIX = /^(?:min|max)-/i;
@@ -34,13 +38,12 @@ const rule = (primary) => {
 		}
 
 		root.walkAtRules(/^media$/i, (atRule) => {
-			/** @type {Array<{tokens(): Array<import('@csstools/css-tokenizer').CSSToken>}>} */
-			let invalidNodes = [];
+			const atRuleParamIndexValue = atRuleParamIndex(atRule);
 
 			parseMediaQuery(atRule).forEach((mediaQuery) => {
 				if (mediaQueryListParser.isMediaQueryInvalid(mediaQuery)) {
 					// Queries that fail to parse are invalid.
-					invalidNodes.push(mediaQuery);
+					complain(atRule, atRuleParamIndexValue, mediaQuery);
 
 					return;
 				}
@@ -48,7 +51,7 @@ const rule = (primary) => {
 				mediaQuery.walk(({ node, parent }) => {
 					// All general enclosed nodes are invalid.
 					if (mediaQueryListParser.isGeneralEnclosed(node)) {
-						invalidNodes.push(node);
+						complain(atRule, atRuleParamIndexValue, node);
 
 						return;
 					}
@@ -59,7 +62,12 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a plain context, custom media queries are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'custom media queries can only be used in boolean queries',
+							);
 
 							return;
 						}
@@ -73,21 +81,36 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a range context, custom media queries are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'custom media queries can only be used in boolean queries',
+							);
 
 							return;
 						}
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'"min-" and "max-" prefixes are not needed when using range queries',
+							);
 
 							return;
 						}
 
 						if (!mediaFeatures.rangeTypeMediaFeatureNames.has(name)) {
 							// In a range context, non-range typed features are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'discrete features can only be used in plain and boolean queries',
+							);
 
 							return;
 						}
@@ -101,30 +124,37 @@ const rule = (primary) => {
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'"min-" and "max-" prefixes are not needed in boolean queries',
+							);
 						}
 					}
 				});
 			});
-
-			if (invalidNodes.length === 0) return;
-
-			const atRuleParamIndexValue = atRuleParamIndex(atRule);
-
-			invalidNodes.forEach((invalidNode) => {
-				const [start, end] = cssParserAlgorithms.sourceIndices(invalidNode);
-
-				report({
-					message: messages.rejected,
-					messageArgs: [invalidNode.toString()],
-					index: atRuleParamIndexValue + start,
-					endIndex: atRuleParamIndexValue + end + 1,
-					node: atRule,
-					ruleName,
-					result,
-				});
-			});
 		});
+
+		/**
+		 * @param {import('postcss').AtRule} atRule
+		 * @param {number} index
+		 * @param {{tokens(): Array<import('@csstools/css-tokenizer').CSSToken>}} node
+		 * @param {string} messageHint
+		 */
+		function complain(atRule, index, node, messageHint = '') {
+			const [start, end] = cssParserAlgorithms.sourceIndices(node);
+
+			report({
+				message: messages.rejected,
+				messageArgs: [node.toString(), messageHint],
+				index: index + start,
+				endIndex: index + end + 1,
+				node: atRule,
+				ruleName,
+				result,
+			});
+		}
 	};
 };
 

--- a/lib/rules/media-query-no-invalid/index.cjs
+++ b/lib/rules/media-query-no-invalid/index.cjs
@@ -15,12 +15,19 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'media-query-no-invalid';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (query, hint) => {
-		if (!hint) return `Unexpected invalid media query "${query}"`;
+	rejected: (query, reason) => {
+		if (!reason) return `Unexpected invalid media query "${query}"`;
 
-		return `Unexpected invalid media query "${query}", ${hint}`;
+		return `Unexpected invalid media query "${query}", ${reason}`;
 	},
 });
+
+const reasons = {
+	custom: 'custom media queries can only be used in boolean queries',
+	min_max_in_range: '"min-" and "max-" prefixes are not needed when using range queries',
+	min_max_in_boolean: '"min-" and "max-" prefixes are not needed in boolean queries',
+	discrete: 'discrete features can only be used in plain and boolean queries',
+};
 
 const HAS_MIN_MAX_PREFIX = /^(?:min|max)-/i;
 
@@ -62,12 +69,7 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a plain context, custom media queries are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'custom media queries can only be used in boolean queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'custom');
 
 							return;
 						}
@@ -81,36 +83,21 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a range context, custom media queries are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'custom media queries can only be used in boolean queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'custom');
 
 							return;
 						}
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'"min-" and "max-" prefixes are not needed when using range queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'min_max_in_range');
 
 							return;
 						}
 
 						if (!mediaFeatures.rangeTypeMediaFeatureNames.has(name)) {
 							// In a range context, non-range typed features are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'discrete features can only be used in plain and boolean queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'discrete');
 
 							return;
 						}
@@ -120,16 +107,11 @@ const rule = (primary) => {
 
 					// Invalid boolean media features.
 					if (mediaQueryListParser.isMediaFeatureBoolean(node)) {
-						const name = node.getName().toLowerCase();
+						const name = node.getName();
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
-							// In a range context, min- and max- prefixed feature names are invalid
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'"min-" and "max-" prefixes are not needed in boolean queries',
-							);
+							// In a boolean feature, min- and max- prefixed feature names are invalid
+							complain(atRule, atRuleParamIndexValue, parent, 'min_max_in_boolean');
 						}
 					}
 				});
@@ -140,14 +122,14 @@ const rule = (primary) => {
 		 * @param {import('postcss').AtRule} atRule
 		 * @param {number} index
 		 * @param {{tokens(): Array<import('@csstools/css-tokenizer').CSSToken>}} node
-		 * @param {string} messageHint
+		 * @param {keyof reasons} [reason]
 		 */
-		function complain(atRule, index, node, messageHint = '') {
+		function complain(atRule, index, node, reason) {
 			const [start, end] = cssParserAlgorithms.sourceIndices(node);
 
 			report({
 				message: messages.rejected,
-				messageArgs: [node.toString(), messageHint],
+				messageArgs: [node.toString(), reason ? reasons[reason] : ''],
 				index: index + start,
 				endIndex: index + end + 1,
 				node: atRule,

--- a/lib/rules/media-query-no-invalid/index.mjs
+++ b/lib/rules/media-query-no-invalid/index.mjs
@@ -18,7 +18,11 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'media-query-no-invalid';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (query) => `Unexpected invalid media query "${query}"`,
+	rejected: (query, hint) => {
+		if (!hint) return `Unexpected invalid media query "${query}"`;
+
+		return `Unexpected invalid media query "${query}", ${hint}`;
+	},
 });
 
 const HAS_MIN_MAX_PREFIX = /^(?:min|max)-/i;
@@ -37,13 +41,12 @@ const rule = (primary) => {
 		}
 
 		root.walkAtRules(/^media$/i, (atRule) => {
-			/** @type {Array<{tokens(): Array<import('@csstools/css-tokenizer').CSSToken>}>} */
-			let invalidNodes = [];
+			const atRuleParamIndexValue = atRuleParamIndex(atRule);
 
 			parseMediaQuery(atRule).forEach((mediaQuery) => {
 				if (isMediaQueryInvalid(mediaQuery)) {
 					// Queries that fail to parse are invalid.
-					invalidNodes.push(mediaQuery);
+					complain(atRule, atRuleParamIndexValue, mediaQuery);
 
 					return;
 				}
@@ -51,7 +54,7 @@ const rule = (primary) => {
 				mediaQuery.walk(({ node, parent }) => {
 					// All general enclosed nodes are invalid.
 					if (isGeneralEnclosed(node)) {
-						invalidNodes.push(node);
+						complain(atRule, atRuleParamIndexValue, node);
 
 						return;
 					}
@@ -62,7 +65,12 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a plain context, custom media queries are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'custom media queries can only be used in boolean queries',
+							);
 
 							return;
 						}
@@ -76,21 +84,36 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a range context, custom media queries are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'custom media queries can only be used in boolean queries',
+							);
 
 							return;
 						}
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'"min-" and "max-" prefixes are not needed when using range queries',
+							);
 
 							return;
 						}
 
 						if (!rangeTypeMediaFeatureNames.has(name)) {
 							// In a range context, non-range typed features are invalid.
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'discrete features can only be used in plain and boolean queries',
+							);
 
 							return;
 						}
@@ -104,30 +127,37 @@ const rule = (primary) => {
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid
-							invalidNodes.push(parent);
+							complain(
+								atRule,
+								atRuleParamIndexValue,
+								parent,
+								'"min-" and "max-" prefixes are not needed in boolean queries',
+							);
 						}
 					}
 				});
 			});
-
-			if (invalidNodes.length === 0) return;
-
-			const atRuleParamIndexValue = atRuleParamIndex(atRule);
-
-			invalidNodes.forEach((invalidNode) => {
-				const [start, end] = sourceIndices(invalidNode);
-
-				report({
-					message: messages.rejected,
-					messageArgs: [invalidNode.toString()],
-					index: atRuleParamIndexValue + start,
-					endIndex: atRuleParamIndexValue + end + 1,
-					node: atRule,
-					ruleName,
-					result,
-				});
-			});
 		});
+
+		/**
+		 * @param {import('postcss').AtRule} atRule
+		 * @param {number} index
+		 * @param {{tokens(): Array<import('@csstools/css-tokenizer').CSSToken>}} node
+		 * @param {string} messageHint
+		 */
+		function complain(atRule, index, node, messageHint = '') {
+			const [start, end] = sourceIndices(node);
+
+			report({
+				message: messages.rejected,
+				messageArgs: [node.toString(), messageHint],
+				index: index + start,
+				endIndex: index + end + 1,
+				node: atRule,
+				ruleName,
+				result,
+			});
+		}
 	};
 };
 

--- a/lib/rules/media-query-no-invalid/index.mjs
+++ b/lib/rules/media-query-no-invalid/index.mjs
@@ -18,12 +18,19 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'media-query-no-invalid';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (query, hint) => {
-		if (!hint) return `Unexpected invalid media query "${query}"`;
+	rejected: (query, reason) => {
+		if (!reason) return `Unexpected invalid media query "${query}"`;
 
-		return `Unexpected invalid media query "${query}", ${hint}`;
+		return `Unexpected invalid media query "${query}", ${reason}`;
 	},
 });
+
+const reasons = {
+	custom: 'custom media queries can only be used in boolean queries',
+	min_max_in_range: '"min-" and "max-" prefixes are not needed when using range queries',
+	min_max_in_boolean: '"min-" and "max-" prefixes are not needed in boolean queries',
+	discrete: 'discrete features can only be used in plain and boolean queries',
+};
 
 const HAS_MIN_MAX_PREFIX = /^(?:min|max)-/i;
 
@@ -65,12 +72,7 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a plain context, custom media queries are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'custom media queries can only be used in boolean queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'custom');
 
 							return;
 						}
@@ -84,36 +86,21 @@ const rule = (primary) => {
 
 						if (isCustomMediaQuery(name)) {
 							// In a range context, custom media queries are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'custom media queries can only be used in boolean queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'custom');
 
 							return;
 						}
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
 							// In a range context, min- and max- prefixed feature names are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'"min-" and "max-" prefixes are not needed when using range queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'min_max_in_range');
 
 							return;
 						}
 
 						if (!rangeTypeMediaFeatureNames.has(name)) {
 							// In a range context, non-range typed features are invalid.
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'discrete features can only be used in plain and boolean queries',
-							);
+							complain(atRule, atRuleParamIndexValue, parent, 'discrete');
 
 							return;
 						}
@@ -123,16 +110,11 @@ const rule = (primary) => {
 
 					// Invalid boolean media features.
 					if (isMediaFeatureBoolean(node)) {
-						const name = node.getName().toLowerCase();
+						const name = node.getName();
 
 						if (HAS_MIN_MAX_PREFIX.test(name)) {
-							// In a range context, min- and max- prefixed feature names are invalid
-							complain(
-								atRule,
-								atRuleParamIndexValue,
-								parent,
-								'"min-" and "max-" prefixes are not needed in boolean queries',
-							);
+							// In a boolean feature, min- and max- prefixed feature names are invalid
+							complain(atRule, atRuleParamIndexValue, parent, 'min_max_in_boolean');
 						}
 					}
 				});
@@ -143,14 +125,14 @@ const rule = (primary) => {
 		 * @param {import('postcss').AtRule} atRule
 		 * @param {number} index
 		 * @param {{tokens(): Array<import('@csstools/css-tokenizer').CSSToken>}} node
-		 * @param {string} messageHint
+		 * @param {keyof reasons} [reason]
 		 */
-		function complain(atRule, index, node, messageHint = '') {
+		function complain(atRule, index, node, reason) {
 			const [start, end] = sourceIndices(node);
 
 			report({
 				message: messages.rejected,
-				messageArgs: [node.toString(), messageHint],
+				messageArgs: [node.toString(), reason ? reasons[reason] : ''],
 				index: index + start,
 				endIndex: index + end + 1,
 				node: atRule,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7401

> Is there anything in the PR that needs further explanation?

I've added a second argument for the `rejected` message.
- is there an existing pattern in other rules for what I want to do here?
- is `hint` a good name for the second argument? (maybe `reason`, ...)

I am also unsure what the best wording is.
I don't think most people are familiar with the wording of the specification, e.g. `range context`, `plain feature`, ...
So I've opted to label everything as a query : `range query`, `boolean query`.