### PR TITLE
Document CLI piping example

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -77,7 +77,7 @@ SKIP_WARNINGS=true stylelint "*.css" --custom-formatter ./my-formatter.js
 Alternatively, you can create a separate formatting program and pipe the output from the built-in JSON formatter into it:
 
 ```shell
-stylelint -f json "*.css" | my-program-that-reads-JSON --option
+stylelint -f json "*.css" 2>&1 | my-program-that-reads-JSON --option
 ```
 
 ## `stylelint.formatters`

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -214,6 +214,14 @@ Print a configuration used for the given input file:
 stylelint test.css --print-config
 ```
 
+### Example K - piping a report to another command
+
+Use a report as input for another command through piping:
+
+```shell
+stylelint -f json "*.css" 2>&1 | jq '[.[] | .warnings | length] | add'
+```
+
 ## Exit codes
 
 The CLI can exit the process with the following exit codes:


### PR DESCRIPTION
Previously the documentation did not include the piping of stderr to stdout which meant that in error cases stylint would write to stderr and the stdin of the consuming process never received anything. This remedies the situation by writing both stdout & stderr to stdin of the consuming process

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/7467

> Is there anything in the PR that needs further explanation?

Pretty much a one liner documentation update. The explanation from the commit body should hopefully suffice. 
