### PR TITLE
Fix `selector-max-specificity` false positives with `ignoreSelectors` option for `of <selector>` syntax

### DIFF
--- a/.changeset/gold-donkeys-lie.md
+++ b/.changeset/gold-donkeys-lie.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-max-specificity` false positives with `ignoreSelectors` option for `of <selector>` syntax

--- a/lib/rules/selector-max-specificity/__tests__/index.mjs
+++ b/lib/rules/selector-max-specificity/__tests__/index.mjs
@@ -461,7 +461,6 @@ testRule({
 		},
 		{
 			code: ':nth-child(even of my-tag) {}',
-			skip: true, // see #6615
 		},
 	],
 

--- a/lib/rules/selector-max-specificity/index.cjs
+++ b/lib/rules/selector-max-specificity/index.cjs
@@ -119,10 +119,10 @@ const rule = (primary, secondaryOptions) => {
 		 */
 		const ignoreOfSelectorIfAny = (pseudo) => {
 			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
-			const isOfSelector = (node) => Boolean(node && node.type === 'tag' && node.value === 'of');
+			const isOfSelector = (node) => node?.type === 'tag' && node.value === 'of';
 
 			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
-			const isSpace = (node) => Boolean(node && node.type === 'combinator' && node.value === ' ');
+			const isSpace = (node) => node?.type === 'combinator' && node.value === ' ';
 
 			const nodes = pseudo.nodes[0]?.nodes ?? [];
 			const ofSelectorIndex = nodes.findIndex((child, i, children) => {

--- a/lib/rules/selector-max-specificity/index.cjs
+++ b/lib/rules/selector-max-specificity/index.cjs
@@ -77,6 +77,10 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
+		/** @type {(selector: string) => boolean} */
+		const isSelectorIgnored = (selector) =>
+			optionsMatches(secondaryOptions, 'ignoreSelectors', selector);
+
 		/**
 		 * Calculate the specificity of a simple selector (type, attribute, class, ID, or pseudos's own value).
 		 *
@@ -84,7 +88,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @returns {Specificity}
 		 */
 		const simpleSpecificity = (node) => {
-			if (optionsMatches(secondaryOptions, 'ignoreSelectors', node.toString())) {
+			if (isSelectorIgnored(node.toString())) {
 				return zeroSpecificity();
 			}
 
@@ -105,6 +109,45 @@ const rule = (primary, secondaryOptions) => {
 			}, zeroSpecificity());
 
 		/**
+		 * If a `of <selector>` (`An+B of S`) is found in the specified pseudo node,
+		 * returns a copy of the pseudo node, ignoring a `of` selector (`An+B of S`).
+		 * Otherwise, returns the specified node as-is.
+		 *
+		 * @see https://drafts.csswg.org/selectors/#the-nth-child-pseudo
+		 * @param {import('postcss-selector-parser').Pseudo} pseudo
+		 * @returns {import('postcss-selector-parser').Pseudo}
+		 */
+		const ignoreOfSelectorIfAny = (pseudo) => {
+			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
+			const isOfSelector = (node) => Boolean(node && node.type === 'tag' && node.value === 'of');
+
+			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
+			const isSpace = (node) => Boolean(node && node.type === 'combinator' && node.value === ' ');
+
+			const nodes = pseudo.nodes[0]?.nodes ?? [];
+			const ofSelectorIndex = nodes.findIndex((child, i, children) => {
+				// Find ' of <selector>' nodes
+				return isSpace(child) && isOfSelector(children[i + 1]) && isSpace(children[i + 2]);
+			});
+
+			const ofSelector = nodes[ofSelectorIndex + 3];
+
+			if (!ofSelector || !ofSelector.value) return pseudo;
+
+			if (!isSelectorIgnored(ofSelector.value)) return pseudo;
+
+			const copy = pseudo.clone();
+			const rootSelector = copy.nodes[0];
+
+			if (rootSelector) {
+				// Remove ' of <selector>' nodes
+				rootSelector.nodes = rootSelector.nodes.slice(0, ofSelectorIndex);
+			}
+
+			return copy;
+		};
+
+		/**
 		 * Calculate the specificity of a pseudo selector including own value and children.
 		 *
 		 * @param {import('postcss-selector-parser').Pseudo} node
@@ -121,10 +164,10 @@ const rule = (primary, secondaryOptions) => {
 
 			let ownSpecificity;
 
-			if (optionsMatches(secondaryOptions, 'ignoreSelectors', ownValue)) {
+			if (isSelectorIgnored(ownValue)) {
 				ownSpecificity = zeroSpecificity();
 			} else if (selectors.aNPlusBOfSNotationPseudoClasses.has(ownValue.replace(/^:/, ''))) {
-				return selectorSpecificity.selectorSpecificity(node);
+				return selectorSpecificity.selectorSpecificity(ignoreOfSelectorIfAny(node));
 			} else {
 				ownSpecificity = selectorSpecificity.selectorSpecificity(node.clone({ nodes: [] }));
 			}

--- a/lib/rules/selector-max-specificity/index.mjs
+++ b/lib/rules/selector-max-specificity/index.mjs
@@ -120,10 +120,10 @@ const rule = (primary, secondaryOptions) => {
 		 */
 		const ignoreOfSelectorIfAny = (pseudo) => {
 			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
-			const isOfSelector = (node) => Boolean(node && node.type === 'tag' && node.value === 'of');
+			const isOfSelector = (node) => node?.type === 'tag' && node.value === 'of';
 
 			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
-			const isSpace = (node) => Boolean(node && node.type === 'combinator' && node.value === ' ');
+			const isSpace = (node) => node?.type === 'combinator' && node.value === ' ';
 
 			const nodes = pseudo.nodes[0]?.nodes ?? [];
 			const ofSelectorIndex = nodes.findIndex((child, i, children) => {

--- a/lib/rules/selector-max-specificity/index.mjs
+++ b/lib/rules/selector-max-specificity/index.mjs
@@ -78,6 +78,10 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
+		/** @type {(selector: string) => boolean} */
+		const isSelectorIgnored = (selector) =>
+			optionsMatches(secondaryOptions, 'ignoreSelectors', selector);
+
 		/**
 		 * Calculate the specificity of a simple selector (type, attribute, class, ID, or pseudos's own value).
 		 *
@@ -85,7 +89,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @returns {Specificity}
 		 */
 		const simpleSpecificity = (node) => {
-			if (optionsMatches(secondaryOptions, 'ignoreSelectors', node.toString())) {
+			if (isSelectorIgnored(node.toString())) {
 				return zeroSpecificity();
 			}
 
@@ -106,6 +110,45 @@ const rule = (primary, secondaryOptions) => {
 			}, zeroSpecificity());
 
 		/**
+		 * If a `of <selector>` (`An+B of S`) is found in the specified pseudo node,
+		 * returns a copy of the pseudo node, ignoring a `of` selector (`An+B of S`).
+		 * Otherwise, returns the specified node as-is.
+		 *
+		 * @see https://drafts.csswg.org/selectors/#the-nth-child-pseudo
+		 * @param {import('postcss-selector-parser').Pseudo} pseudo
+		 * @returns {import('postcss-selector-parser').Pseudo}
+		 */
+		const ignoreOfSelectorIfAny = (pseudo) => {
+			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
+			const isOfSelector = (node) => Boolean(node && node.type === 'tag' && node.value === 'of');
+
+			/** @type {(node: import('postcss-selector-parser').Node | undefined) => boolean} */
+			const isSpace = (node) => Boolean(node && node.type === 'combinator' && node.value === ' ');
+
+			const nodes = pseudo.nodes[0]?.nodes ?? [];
+			const ofSelectorIndex = nodes.findIndex((child, i, children) => {
+				// Find ' of <selector>' nodes
+				return isSpace(child) && isOfSelector(children[i + 1]) && isSpace(children[i + 2]);
+			});
+
+			const ofSelector = nodes[ofSelectorIndex + 3];
+
+			if (!ofSelector || !ofSelector.value) return pseudo;
+
+			if (!isSelectorIgnored(ofSelector.value)) return pseudo;
+
+			const copy = pseudo.clone();
+			const rootSelector = copy.nodes[0];
+
+			if (rootSelector) {
+				// Remove ' of <selector>' nodes
+				rootSelector.nodes = rootSelector.nodes.slice(0, ofSelectorIndex);
+			}
+
+			return copy;
+		};
+
+		/**
 		 * Calculate the specificity of a pseudo selector including own value and children.
 		 *
 		 * @param {import('postcss-selector-parser').Pseudo} node
@@ -122,10 +165,10 @@ const rule = (primary, secondaryOptions) => {
 
 			let ownSpecificity;
 
-			if (optionsMatches(secondaryOptions, 'ignoreSelectors', ownValue)) {
+			if (isSelectorIgnored(ownValue)) {
 				ownSpecificity = zeroSpecificity();
 			} else if (aNPlusBOfSNotationPseudoClasses.has(ownValue.replace(/^:/, ''))) {
-				return selectorSpecificity(node);
+				return selectorSpecificity(ignoreOfSelectorIfAny(node));
 			} else {
 				ownSpecificity = selectorSpecificity(node.clone({ nodes: [] }));
 			}


### PR DESCRIPTION
Config:

```json
{"ignoreSelectors": [".foo"]}
```

CSS code:

```css
:nth-child(even of .foo) {}

/* ↓ Calculates specificity ignoring 'of .foo' in `ignoreSelectors` */
:nth-child(even) {}
```

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6615

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
