### PR TITLE
Fix `validateOptions` to report when secondary option object is an empty object or null

### DIFF
--- a/.changeset/olive-experts-breathe.md
+++ b/.changeset/olive-experts-breathe.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `validateOptions` to report when secondary option object is an empty object or null

--- a/lib/utils/__tests__/validateOptions.test.mjs
+++ b/lib/utils/__tests__/validateOptions.test.mjs
@@ -181,6 +181,30 @@ describe('validateOptions for `*-no-*` rule with no valid options', () => {
 		expect(result.warn).toHaveBeenCalledTimes(0);
 	});
 
+	it('with empty object as `possible`', () => {
+		validateOptions(result, 'no-dancing', {
+			possible: {},
+			actual: undefined,
+		});
+		expect(result.warn).toHaveBeenCalledTimes(0);
+	});
+
+	it('with undefined as `possible`', () => {
+		validateOptions(result, 'no-dancing', {
+			possible: undefined,
+			actual: undefined,
+		});
+		expect(result.warn).toHaveBeenCalledTimes(0);
+	});
+
+	it('with null as `possible`', () => {
+		validateOptions(result, 'no-dancing', {
+			possible: null,
+			actual: undefined,
+		});
+		expect(result.warn).toHaveBeenCalledTimes(0);
+	});
+
 	it('with `possible` left undefined', () => {
 		validateOptions(result, 'no-dancing', {
 			actual: undefined,

--- a/lib/utils/validateOptions.cjs
+++ b/lib/utils/validateOptions.cjs
@@ -45,23 +45,23 @@ function validateOptions(result, ruleName, ...optionDescriptions) {
  * @param {string} ruleName
  * @param {(message: string) => void} complain
  */
-function validate(opts, ruleName, complain) {
-	const possible = opts.possible;
-	const actual = opts.actual;
-	const optional = opts.optional;
-
+function validate({ possible, actual, optional }, ruleName, complain) {
 	if (actual === false && !ruleName.startsWith('report')) {
 		return complain(
 			`Invalid option value "false" for rule "${ruleName}". Are you trying to disable this rule? If so use "null" instead`,
 		);
 	}
 
+	// `null` means to turn off a rule.
 	if (actual === null || arrayEqual(actual, [null])) {
 		return;
 	}
 
 	const nothingPossible =
-		possible === undefined || (Array.isArray(possible) && possible.length === 0);
+		possible === undefined ||
+		possible === null ||
+		(Array.isArray(possible) && possible.length === 0) ||
+		(validateTypes.isPlainObject(possible) && Object.keys(possible).length === 0);
 
 	if (nothingPossible && actual === true) {
 		return;

--- a/lib/utils/validateOptions.mjs
+++ b/lib/utils/validateOptions.mjs
@@ -41,23 +41,23 @@ export default function validateOptions(result, ruleName, ...optionDescriptions)
  * @param {string} ruleName
  * @param {(message: string) => void} complain
  */
-function validate(opts, ruleName, complain) {
-	const possible = opts.possible;
-	const actual = opts.actual;
-	const optional = opts.optional;
-
+function validate({ possible, actual, optional }, ruleName, complain) {
 	if (actual === false && !ruleName.startsWith('report')) {
 		return complain(
 			`Invalid option value "false" for rule "${ruleName}". Are you trying to disable this rule? If so use "null" instead`,
 		);
 	}
 
+	// `null` means to turn off a rule.
 	if (actual === null || arrayEqual(actual, [null])) {
 		return;
 	}
 
 	const nothingPossible =
-		possible === undefined || (Array.isArray(possible) && possible.length === 0);
+		possible === undefined ||
+		possible === null ||
+		(Array.isArray(possible) && possible.length === 0) ||
+		(isPlainObject(possible) && Object.keys(possible).length === 0);
 
 	if (nothingPossible && actual === true) {
 		return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #6154

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
