### PR TITLE
Fix `custom-property-no-missing-var-function` false positives for properties that can contain author-defined identifiers

### DIFF
--- a/.changeset/curly-seals-confess.md
+++ b/.changeset/curly-seals-confess.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `custom-property-no-missing-var-function` false positives for properties that can contain author-defined identifiers

--- a/lib/rules/custom-property-no-missing-var-function/README.md
+++ b/lib/rules/custom-property-no-missing-var-function/README.md
@@ -10,7 +10,10 @@ Disallow missing `var` function for custom properties.
  *             This custom property */
 ```
 
-This rule only reports custom properties that are defined within the same source.
+This rule has the following limitations:
+
+- It only reports custom properties that are defined within the same source.
+- It does not check properties that can contain author-defined identifiers, e.g. `transition-property`.
 
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
@@ -44,4 +47,10 @@ a { color: var(--foo); }
 ```css
 @property --foo {}
 a { color: var(--foo); }
+```
+
+<!-- prettier-ignore -->
+```css
+@property --foo {}
+a { transition-property: --foo; }
 ```

--- a/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
@@ -52,6 +52,10 @@ testRule({
 			code: '@media(--foo) {}',
 			description: 'custom media query',
 		},
+		{
+			code: '@property --foo {} a { transition: --foo; }',
+			description: 'ignore a property that can receive a custom-ident',
+		},
 	],
 
 	reject: [

--- a/lib/rules/custom-property-no-missing-var-function/index.cjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.cjs
@@ -18,6 +18,28 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
 
+const IGNORED_PROPERTIES = new Set([
+	// In alphabetical order
+
+	// Properties that can receive a custom-ident
+	'animation',
+	'animation-name',
+	'counter-increment',
+	'counter-reset',
+	'counter-set',
+	'grid-column',
+	'grid-column-end',
+	'grid-column-start',
+	'grid-row',
+	'grid-row-end',
+	'grid-row-start',
+	'list-style',
+	'list-style-type',
+	'transition',
+	'transition-property',
+	'will-change',
+]);
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -28,8 +50,8 @@ const rule = (primary) => {
 		/** @type {Set<string>} */
 		const knownCustomProperties = new Set();
 
-		root.walkAtRules(/^property$/i, (atRule) => {
-			knownCustomProperties.add(atRule.params);
+		root.walkAtRules(/^property$/i, ({ params }) => {
+			knownCustomProperties.add(params);
 		});
 
 		root.walkDecls(/^--/, ({ prop }) => {
@@ -37,13 +59,13 @@ const rule = (primary) => {
 		});
 
 		root.walkDecls((decl) => {
-			const { value } = decl;
+			const { prop, value } = decl;
 
 			if (!value.includes('--')) return;
 
-			const parsedValue = valueParser(value);
+			if (IGNORED_PROPERTIES.has(prop.toLowerCase())) return;
 
-			parsedValue.walk((node) => {
+			valueParser(value).walk((node) => {
 				if (isVarFunction(node)) return false;
 
 				if (!isDashedIdent(node)) return;

--- a/lib/rules/custom-property-no-missing-var-function/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.mjs
@@ -15,6 +15,28 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
 
+const IGNORED_PROPERTIES = new Set([
+	// In alphabetical order
+
+	// Properties that can receive a custom-ident
+	'animation',
+	'animation-name',
+	'counter-increment',
+	'counter-reset',
+	'counter-set',
+	'grid-column',
+	'grid-column-end',
+	'grid-column-start',
+	'grid-row',
+	'grid-row-end',
+	'grid-row-start',
+	'list-style',
+	'list-style-type',
+	'transition',
+	'transition-property',
+	'will-change',
+]);
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -25,8 +47,8 @@ const rule = (primary) => {
 		/** @type {Set<string>} */
 		const knownCustomProperties = new Set();
 
-		root.walkAtRules(/^property$/i, (atRule) => {
-			knownCustomProperties.add(atRule.params);
+		root.walkAtRules(/^property$/i, ({ params }) => {
+			knownCustomProperties.add(params);
 		});
 
 		root.walkDecls(/^--/, ({ prop }) => {
@@ -34,13 +56,13 @@ const rule = (primary) => {
 		});
 
 		root.walkDecls((decl) => {
-			const { value } = decl;
+			const { prop, value } = decl;
 
 			if (!value.includes('--')) return;
 
-			const parsedValue = valueParser(value);
+			if (IGNORED_PROPERTIES.has(prop.toLowerCase())) return;
 
-			parsedValue.walk((node) => {
+			valueParser(value).walk((node) => {
 				if (isVarFunction(node)) return false;
 
 				if (!isDashedIdent(node)) return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #5742

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
