### PR TITLE
Add GitHub action to change the label and add a warning comment on issues older than a month

### DIFF
--- a/.github/workflows/commenting-on-old-issues.yml
+++ b/.github/workflows/commenting-on-old-issues.yml
@@ -28,5 +28,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           issue_comment: |-
-            This issue is older than 1 month. Even though it is labelled as "ask to implement", please ask before opening a pull request as it may no longer be relevant.
+            This issue is older than one month. Please ask before opening a pull request, as it may no longer be relevant.
           label: stale # Avoid duplicate comments by labeling

--- a/.github/workflows/commenting-on-old-issues.yml
+++ b/.github/workflows/commenting-on-old-issues.yml
@@ -1,0 +1,32 @@
+name: Commenting on old issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment on old issues
+        run: |
+          one_month_ago=$(date --date '1 month ago' '+%Y-%m-%d')
+
+          # For the search syntax, see https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
+          old_issue_urls=$(gh issue list \
+            --search "is:open updated:<${one_month_ago} label:\"status: ask to implement\" -label:\"${label}\"" \
+            --json 'url' \
+            --jq '.[] | .url')
+
+          for url in ${old_issue_urls}; do
+            gh issue comment "${url}" --body "${issue_comment}"
+            gh issue edit "${url}" --add-label "${label}"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          issue_comment: |-
+            This issue is older than 1 month. Even though it is labelled as "ask to implement", please ask before opening a pull request as it may no longer be relevant.
+          label: stale # Avoid duplicate comments by labeling

--- a/.github/workflows/commenting-on-old-issues.yml
+++ b/.github/workflows/commenting-on-old-issues.yml
@@ -17,16 +17,15 @@ jobs:
 
           # For the search syntax, see https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests
           old_issue_urls=$(gh issue list \
-            --search "is:open updated:<${one_month_ago} label:\"status: ask to implement\" -label:\"${label}\"" \
+            --search "is:open updated:<${one_month_ago} label:\"status: ready to implement\"" \
             --json 'url' \
             --jq '.[] | .url')
 
           for url in ${old_issue_urls}; do
             gh issue comment "${url}" --body "${issue_comment}"
-            gh issue edit "${url}" --add-label "${label}"
+            gh issue edit "${url}" --add-label 'status: ask to implement' --remove-label 'status: ready to implement'
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           issue_comment: |-
             This issue is older than one month. Please ask before opening a pull request, as it may no longer be relevant.
-          label: stale # Avoid duplicate comments by labeling


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7459

> Is there anything in the PR that needs further explanation?

~~How about labeling with `stale` to avoid duplicate comments? Is this irregular label acceptable only for this action?~~
This action will comment on older issues than one month, and will replace the "ready to implement" label with "ask to implement". See https://github.com/stylelint/stylelint/pull/7486#discussion_r1460976731
