### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for `:seeking`, the media loading state and sound state pseudo-classes

### DIFF
--- a/.changeset/friendly-poems-taste.md
+++ b/.changeset/friendly-poems-taste.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for `:seeking`, the media loading state and sound state pseudo-classes

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -254,11 +254,23 @@ const webkitScrollbarPseudoClasses = new Set([
 	'window-inactive',
 ]);
 
+// https://www.w3.org/TR/selectors-4/#resource-pseudos
+const resourceStatePseudoClasses = new Set([
+	'buffering',
+	'muted',
+	'paused',
+	'playing',
+	'seeking',
+	'stalled',
+	'volume-locked',
+]);
+
 const pseudoClasses = uniteSets(
 	aNPlusBNotationPseudoClasses,
 	linguisticPseudoClasses,
 	logicalCombinationsPseudoClasses,
 	aNPlusBOfSNotationPseudoClasses,
+	resourceStatePseudoClasses,
 	vendorSpecificPseudoClasses,
 	[
 		'active',
@@ -295,9 +307,7 @@ const pseudoClasses = uniteSets(
 		'optional',
 		'out-of-range',
 		'past',
-		'paused',
 		'placeholder-shown',
-		'playing',
 		'picture-in-picture',
 		'popover-open',
 		'read-only',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -251,11 +251,23 @@ export const webkitScrollbarPseudoClasses = new Set([
 	'window-inactive',
 ]);
 
+// https://www.w3.org/TR/selectors-4/#resource-pseudos
+const resourceStatePseudoClasses = new Set([
+	'buffering',
+	'muted',
+	'paused',
+	'playing',
+	'seeking',
+	'stalled',
+	'volume-locked',
+]);
+
 export const pseudoClasses = uniteSets(
 	aNPlusBNotationPseudoClasses,
 	linguisticPseudoClasses,
 	logicalCombinationsPseudoClasses,
 	aNPlusBOfSNotationPseudoClasses,
+	resourceStatePseudoClasses,
 	vendorSpecificPseudoClasses,
 	[
 		'active',
@@ -292,9 +304,7 @@ export const pseudoClasses = uniteSets(
 		'optional',
 		'out-of-range',
 		'past',
-		'paused',
 		'placeholder-shown',
-		'playing',
 		'picture-in-picture',
 		'popover-open',
 		'read-only',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -122,6 +122,9 @@ testRule({
 			code: ':popover-open {}',
 			description: 'explicit :popover-open test; see #7424',
 		},
+		{
+			code: ':seeking, :stalled, :buffering, :volume-locked, :muted {}',
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #7477

> Is there anything in the PR that needs further explanation?

I am planning a followup PR for the missing media pseudo-elements.
see https://github.com/stylelint/stylelint/pull/5959#issuecomment-1065330459