### PR TITLE
Provide repository info to `gh` command in GitHub action

### DIFF
--- a/.github/workflows/commenting-on-old-issues.yml
+++ b/.github/workflows/commenting-on-old-issues.yml
@@ -26,7 +26,7 @@ jobs:
             gh issue edit "${url}" --add-label 'status: ask to implement' --remove-label 'status: ready to implement'
           done
         env:
-          GH_REPO: ${{ env.GITHUB_REPOSITORY }}
+          GH_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           issue_comment: |-
             This issue is older than one month. Please ask before opening a pull request, as it may no longer be relevant.

--- a/.github/workflows/commenting-on-old-issues.yml
+++ b/.github/workflows/commenting-on-old-issues.yml
@@ -26,6 +26,7 @@ jobs:
             gh issue edit "${url}" --add-label 'status: ask to implement' --remove-label 'status: ready to implement'
           done
         env:
+          GH_REPO: ${{ env.GITHUB_REPOSITORY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           issue_comment: |-
             This issue is older than one month. Please ask before opening a pull request, as it may no longer be relevant.


### PR DESCRIPTION
This fixes the following error in the GitHub action:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

https://github.com/stylelint/stylelint/actions/runs/7609612527/job/20721207993#step:2:19

The failure reason is that the `gh` command tries reading the `.git` repository.
This change provides the repository info through an environment variable supported by `gh`.
(see also https://cli.github.com/manual/gh_help_environment)

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #7486

> Is there anything in the PR that needs further explanation?

By the way, if cli/cli#3556 was realized, this PR would be no longer needed.