### PR TITLE
Document CLI user guide to fix typo for `—custom-syntax`

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -195,7 +195,7 @@ stylelint "foo/**/*.css" --config bar/mySpecialConfig.json
 Recursively linting all `.css` files in the `foo` directory using a custom syntax:
 
 ```shell
-stylelint "foo/**/*.css" --customSyntax path/to/my-custom-syntax.js
+stylelint "foo/**/*.css" --custom-syntax path/to/my-custom-syntax.js
 ```
 
 ### Example I - print on success


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

See: https://github.com/stylelint/stylelint/blob/382961fb6eb67557910a1ff7430a7a180f888bcc/lib/cli.mjs#L81
