### PR TITLE
Fix benchmark script

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
   },
   "prettier": "@stylelint/prettier-config",
   "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 2023
+    },
     "extends": [
       "stylelint",
       "stylelint/jest"

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -12,8 +12,6 @@ const { bold, yellow } = picocolors;
 
 const [, , ruleName, ruleOptions, ruleContext] = argv;
 
-const ruleFunc = rules[ruleName];
-
 function printHelp() {
 	const script = 'node benchmark-rule.mjs';
 
@@ -32,7 +30,7 @@ function printHelp() {
 	);
 }
 
-if (!ruleFunc || !ruleOptions) {
+if (!ruleName || !(ruleName in rules) || !ruleOptions) {
 	printHelp();
 	exit(-1);
 }
@@ -65,7 +63,7 @@ const ruleSettings = normalizeRuleSettings(parsedOptions);
 const [primary, secondary] = ruleSettings;
 const context = ruleContext ? JSON.parse(ruleContext) : {};
 
-const rule = ruleFunc(primary, secondary, context);
+const rule = (await rules[ruleName])(primary, secondary, context);
 
 const processor = postcss().use(rule);
 


### PR DESCRIPTION
This fixes the broken benchmark script (`npm run benchmark`)
The error reason is that `rules[ruleName]` has returned a `Promise` since 16.0.0.

```sh-session
$ npm run benchmark-rule -- value-keyword-case lower
...
const rule = ruleFunc(primary, secondary, context);
             ^

TypeError: ruleFunc is not a function
...
```

Also, this changes `parserOptions.ecmaVersion` in the ESLint config to allow top-level `await`.

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

If we release `eslint-config-stylelint` including stylelint/eslint-config-stylelint#252 and bump the package version first, the ESLint config's change in this PR will be needless.

Of course, we can revisit it later.
