### PR TITLE
Fix broken link "processors" in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1458,7 +1458,7 @@ Changes:
 - Changed: `time-no-imperceptible` now checks vendor prefixed properties.
 - Changed: `unit-*` rules now check `@media` values too.
 - Added: plugins can allow primary option arrays by setting `ruleFunction.primaryOptionArray = true`.
-- Added: [processors](/docs/user-guide/configure.md#processors).
+- Added: processors.
 - Added: `media-feature-parentheses-space-inside` rule.
 - Added: `no-missing-end-of-source-newline` rule.
 - Added: `property-no-unknown` rule.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Stylelint 15.0.0 removed the support for processors.

EDIT: Also, I feel like it's inconsistent that only this item has a link. See https://github.com/stylelint/stylelint/pull/7508#discussion_r1474480259
