### PR TITLE
Refactor Cosmiconfig types

### DIFF
--- a/lib/getConfigForFile.cjs
+++ b/lib/getConfigForFile.cjs
@@ -11,15 +11,11 @@ const configurationError = require('./utils/configurationError.cjs');
 const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').Config} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} StylelintCosmiconfigResult */
-
 /**
- * @param {StylelintInternalApi} stylelint
+ * @param {import('stylelint').InternalApi} stylelint
  * @param {string} [searchPath]
  * @param {string} [filePath]
- * @returns {Promise<StylelintCosmiconfigResult>}
+ * @returns {Promise<import('stylelint').CosmiconfigResult>}
  */
 async function getConfigForFile(
 	stylelint,

--- a/lib/getConfigForFile.mjs
+++ b/lib/getConfigForFile.mjs
@@ -9,15 +9,11 @@ import configurationError from './utils/configurationError.mjs';
 const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').Config} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} StylelintCosmiconfigResult */
-
 /**
- * @param {StylelintInternalApi} stylelint
+ * @param {import('stylelint').InternalApi} stylelint
  * @param {string} [searchPath]
  * @param {string} [filePath]
- * @returns {Promise<StylelintCosmiconfigResult>}
+ * @returns {Promise<import('stylelint').CosmiconfigResult>}
  */
 export default async function getConfigForFile(
 	stylelint,

--- a/patches/cosmiconfig+9.0.0.patch
+++ b/patches/cosmiconfig+9.0.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/cosmiconfig/dist/types.d.ts b/node_modules/cosmiconfig/dist/types.d.ts
+index a7ddb91..f59591a 100644
+--- a/node_modules/cosmiconfig/dist/types.d.ts
++++ b/node_modules/cosmiconfig/dist/types.d.ts
+@@ -5,8 +5,8 @@ export type Config = any;
+ /**
+  * @public
+  */
+-export type CosmiconfigResult = {
+-    config: Config;
++export type CosmiconfigResult<T = Config> = {
++    config: T;
+     filepath: string;
+     isEmpty?: boolean;
+ } | null;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1,6 +1,6 @@
 import type * as PostCSS from 'postcss';
 import type { GlobbyOptions } from 'globby';
-import type { cosmiconfig, TransformSync as CosmiconfigTransformSync } from 'cosmiconfig';
+import type * as Cosmiconfig from 'cosmiconfig';
 
 type ConfigExtends = string | string[];
 
@@ -124,9 +124,7 @@ declare namespace stylelint {
 	export type DisablePropertyName = PropertyNamesOfType<Config, DisableSettings>;
 
 	/** @internal */
-	export type CosmiconfigResult =
-		| (ReturnType<CosmiconfigTransformSync> & { config: Config })
-		| null;
+	export type CosmiconfigResult = Cosmiconfig.CosmiconfigResult<Config>;
 
 	/** @internal */
 	export type DisabledRange = {
@@ -756,7 +754,7 @@ declare namespace stylelint {
 	 */
 	export type InternalApi = {
 		_options: LinterOptions & { cwd: string };
-		_extendExplorer: ReturnType<typeof cosmiconfig>;
+		_extendExplorer: Cosmiconfig.PublicExplorer;
 		_specifiedConfigCache: Map<Config, Promise<CosmiconfigResult>>;
 		_postcssResultCache: Map<string, PostCSS.Result>;
 		_fileCache: FileCache;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Allowing the `CosmiconfigResult` type to receive a type parameter can make the code a bit type-safer because the `any` type is no longer used.
Ref https://github.com/cosmiconfig/cosmiconfig/blob/v9.0.0/src/types.ts#L11

Note this change includes a patch for the type defined in the `cosmiconfig` package. I will open a pull request in the package repository soon.
