### PR TITLE
fix: deduplicate `border-style` and `border-color`

### DIFF
--- a/.changeset/new-chefs-give.md
+++ b/.changeset/new-chefs-give.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+fix: deduplicate `border-style` and `border-color`

--- a/lib/reference/properties.cjs
+++ b/lib/reference/properties.cjs
@@ -65,6 +65,14 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 		]),
 	],
 	[
+		'border',
+		new Set([
+			// prettier-ignore
+			'border-style',
+			'border-color',
+		]),
+	],
+	[
 		'border-block',
 		new Set([
 			// prettier-ignore

--- a/lib/reference/properties.mjs
+++ b/lib/reference/properties.mjs
@@ -61,6 +61,14 @@ export const longhandSubPropertiesOfShorthandProperties = new Map([
 		]),
 	],
 	[
+		'border',
+		new Set([
+			// prettier-ignore
+			'border-style',
+			'border-color',
+		]),
+	],
+	[
 		'border-block',
 		new Set([
 			// prettier-ignore

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -48,6 +48,15 @@ testRule({
 			code: 'a { top: 0; right: 0; bottom: 0; }',
 		},
 		{
+			code: 'a { border: solid; }',
+		},
+		{
+			code: 'a { border-style: solid; }',
+		},
+		{
+			code: 'a { border-color: green; }',
+		},
+		{
 			code: 'a { top: 0; right: 0; bottom: initial; left: 0; }',
 			description: 'contains basic keyword (initial)',
 		},
@@ -228,6 +237,12 @@ testRule({
 			fixed: 'a { border-width: 0px 1px 2px 3px; }',
 			description: 'explicit border-width test',
 			message: messages.expected('border-width'),
+		},
+		{
+			code: 'a { border-style: outset; border-color: #f33; }',
+			fixed: 'a { border: outset #f33; }',
+			description: 'explicit border-style-color test',
+			message: messages.expected('border'),
 		},
 		{
 			code: 'a { inset-block-start: 1px; inset-block-end: 2px; }',


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates to #7506

> Is there anything in the PR that needs further explanation?

From what I can tell, I think it'll be a lot more work to support deduplicating `border-width` (because you can have multiple values, so it's only safe to interact when there's just one value) and with `border` (because you need to consider what options are already support).

I've done this in the meantime because it's safe and easy improvement to land straight away.

~I've not added a changeset yet because it seems to want a GitHub Personal Token which doesn't seem right - if someone wants to handle that instead, be my guest :)~