### PR TITLE
Fix `rule-selector-property-disallowed-list` false positives for nesting selectors

### DIFF
--- a/.changeset/four-roses-refuse.md
+++ b/.changeset/four-roses-refuse.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `rule-selector-property-disallowed-list` false positives for nesting selectors

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
@@ -104,3 +104,49 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: {
+		'/^((?!input).)*$/': 'color',
+	},
+
+	accept: [
+		{
+			code: '.foo input { color: red; }',
+		},
+		{
+			code: '.foo { & input { color: red; } }',
+		},
+		{
+			code: 'input .foo { color: red; }',
+		},
+	],
+
+	reject: [
+		{
+			code: '.foo form { color: red; }',
+			message: messages.rejected('.foo form', 'color'),
+			line: 1,
+			column: 13,
+			endLine: 1,
+			endColumn: 18,
+		},
+		{
+			code: '.search { & form { color: red; } }',
+			message: messages.rejected('& form', 'color'),
+			line: 1,
+			column: 20,
+			endLine: 1,
+			endColumn: 25,
+		},
+		{
+			code: 'input { & .foo { color: red; } }',
+			message: messages.rejected('& .foo', 'color'),
+			line: 1,
+			column: 18,
+			endLine: 1,
+			endColumn: 23,
+		},
+	],
+});

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
@@ -47,6 +47,14 @@ testRule({
 			endColumn: 27,
 		},
 		{
+			code: 'a { @media screen { color: red; } }',
+			message: messages.rejected('a', 'color'),
+			line: 1,
+			column: 21,
+			endLine: 1,
+			endColumn: 26,
+		},
+		{
 			code: 'a { margin-top: 0px; }',
 			message: messages.rejected('a', 'margin-top'),
 			line: 1,
@@ -88,6 +96,14 @@ testRule({
 			column: 18,
 			endLine: 1,
 			endColumn: 27,
+		},
+		{
+			code: 'a { b { width: 100% } color: red; }',
+			message: messages.rejected('a', 'color'),
+			line: 1,
+			column: 23,
+			endLine: 1,
+			endColumn: 28,
 		},
 	],
 });

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
@@ -19,6 +19,12 @@ testRule({
 			code: 'a { background-color: red; }',
 		},
 		{
+			code: 'a { b { color: red; } }',
+		},
+		{
+			code: 'b { & a { color: red; } }',
+		},
+		{
 			code: 'a[href="#"] { color: red; }',
 		},
 		{
@@ -96,6 +102,14 @@ testRule({
 			column: 18,
 			endLine: 1,
 			endColumn: 27,
+		},
+		{
+			code: 'b { a { color: red; } }',
+			message: messages.rejected('a', 'color'),
+			line: 1,
+			column: 9,
+			endLine: 1,
+			endColumn: 14,
 		},
 		{
 			code: 'a { b { width: 100% } color: red; }',

--- a/lib/rules/rule-selector-property-disallowed-list/index.cjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.cjs
@@ -53,18 +53,16 @@ const rule = (primary) => {
 				return;
 			}
 
-			ruleNode.walk((node) => {
-				if (node.type !== 'decl') return;
+			ruleNode.walkDecls((decl) => {
+				if (!declarationIsAChildOfRule(decl, ruleNode)) return;
 
-				if (!declarationIsAChildOfRule(node, ruleNode)) return;
-
-				const { prop } = node;
+				const { prop } = decl;
 
 				if (matchesStringOrRegExp(prop, disallowedProperties)) {
 					report({
 						message: messages.rejected,
 						messageArgs: [ruleNode.selector, prop],
-						node,
+						node: decl,
 						result,
 						ruleName,
 						word: prop,
@@ -88,7 +86,7 @@ rule.meta = meta;
 function declarationIsAChildOfRule(decl, ruleNode) {
 	if (decl.parent === ruleNode) return true;
 
-	/** @type {import('postcss').Document|import('postcss').Root|import('postcss').Container|undefined} */
+	/** @type {import('postcss').Container['parent']} */
 	let parent = decl.parent;
 
 	while (parent) {

--- a/lib/rules/rule-selector-property-disallowed-list/index.cjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.cjs
@@ -53,7 +53,9 @@ const rule = (primary) => {
 				return;
 			}
 
-			ruleNode.walkDecls((decl) => {
+			ruleNode.each((decl) => {
+				if (decl.type !== 'decl') return;
+
 				const { prop } = decl;
 
 				if (matchesStringOrRegExp(prop, disallowedProperties)) {

--- a/lib/rules/rule-selector-property-disallowed-list/index.cjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.cjs
@@ -84,8 +84,6 @@ rule.meta = meta;
  * @param {import('postcss').Rule} ruleNode
  */
 function declarationIsAChildOfRule(decl, ruleNode) {
-	if (decl.parent === ruleNode) return true;
-
 	/** @type {import('postcss').Container['parent']} */
 	let parent = decl.parent;
 

--- a/lib/rules/rule-selector-property-disallowed-list/index.cjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.cjs
@@ -53,16 +53,18 @@ const rule = (primary) => {
 				return;
 			}
 
-			ruleNode.each((decl) => {
-				if (decl.type !== 'decl') return;
+			ruleNode.walk((node) => {
+				if (node.type !== 'decl') return;
 
-				const { prop } = decl;
+				if (!declarationIsAChildOfRule(node, ruleNode)) return;
+
+				const { prop } = node;
 
 				if (matchesStringOrRegExp(prop, disallowedProperties)) {
 					report({
 						message: messages.rejected,
 						messageArgs: [ruleNode.selector, prop],
-						node: decl,
+						node,
 						result,
 						ruleName,
 						word: prop,
@@ -76,5 +78,28 @@ const rule = (primary) => {
 rule.ruleName = ruleName;
 rule.messages = messages;
 rule.meta = meta;
+
+/**
+ * Check that a given declaration is a child of this rule and not a nested rule
+ *
+ * @param {import('postcss').Declaration} decl
+ * @param {import('postcss').Rule} ruleNode
+ */
+function declarationIsAChildOfRule(decl, ruleNode) {
+	if (decl.parent === ruleNode) return true;
+
+	/** @type {import('postcss').Document|import('postcss').Root|import('postcss').Container|undefined} */
+	let parent = decl.parent;
+
+	while (parent) {
+		if (parent === ruleNode) return true;
+
+		if (parent.type === 'rule') return false;
+
+		parent = parent.parent;
+	}
+
+	return false;
+}
 
 module.exports = rule;

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -85,7 +85,7 @@ export default rule;
 function declarationIsAChildOfRule(decl, ruleNode) {
 	if (decl.parent === ruleNode) return true;
 
-	/** @type {import('postcss').Document|import('postcss').Root|import('postcss').Container|undefined} */
+	/** @type {import('postcss').Container['parent']} */
 	let parent = decl.parent;
 
 	while (parent) {

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -49,7 +49,9 @@ const rule = (primary) => {
 				return;
 			}
 
-			ruleNode.walkDecls((decl) => {
+			ruleNode.each((decl) => {
+				if (decl.type !== 'decl') return;
+
 				const { prop } = decl;
 
 				if (matchesStringOrRegExp(prop, disallowedProperties)) {

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -50,16 +50,15 @@ const rule = (primary) => {
 			}
 
 			ruleNode.walkDecls((decl) => {
+				if (!declarationIsAChildOfRule(decl, ruleNode)) return;
 
-				if (!declarationIsAChildOfRule(node, ruleNode)) return;
-
-				const { prop } = node;
+				const { prop } = decl;
 
 				if (matchesStringOrRegExp(prop, disallowedProperties)) {
 					report({
 						message: messages.rejected,
 						messageArgs: [ruleNode.selector, prop],
-						node,
+						node: decl,
 						result,
 						ruleName,
 						word: prop,

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -49,16 +49,18 @@ const rule = (primary) => {
 				return;
 			}
 
-			ruleNode.each((decl) => {
-				if (decl.type !== 'decl') return;
+			ruleNode.walk((node) => {
+				if (node.type !== 'decl') return;
 
-				const { prop } = decl;
+				if (!declarationIsAChildOfRule(node, ruleNode)) return;
+
+				const { prop } = node;
 
 				if (matchesStringOrRegExp(prop, disallowedProperties)) {
 					report({
 						message: messages.rejected,
 						messageArgs: [ruleNode.selector, prop],
-						node: decl,
+						node,
 						result,
 						ruleName,
 						word: prop,
@@ -73,3 +75,26 @@ rule.ruleName = ruleName;
 rule.messages = messages;
 rule.meta = meta;
 export default rule;
+
+/**
+ * Check that a given declaration is a child of this rule and not a nested rule
+ *
+ * @param {import('postcss').Declaration} decl
+ * @param {import('postcss').Rule} ruleNode
+ */
+function declarationIsAChildOfRule(decl, ruleNode) {
+	if (decl.parent === ruleNode) return true;
+
+	/** @type {import('postcss').Document|import('postcss').Root|import('postcss').Container|undefined} */
+	let parent = decl.parent;
+
+	while (parent) {
+		if (parent === ruleNode) return true;
+
+		if (parent.type === 'rule') return false;
+
+		parent = parent.parent;
+	}
+
+	return false;
+}

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -81,7 +81,6 @@ export default rule;
  * @param {import('postcss').Rule} ruleNode
  */
 function declarationIsAChildOfRule(decl, ruleNode) {
-	if (decl.parent === ruleNode) return true;
 
 	/** @type {import('postcss').Container['parent']} */
 	let parent = decl.parent;

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -49,8 +49,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			ruleNode.walk((node) => {
-				if (node.type !== 'decl') return;
+			ruleNode.walkDecls((decl) => {
 
 				if (!declarationIsAChildOfRule(node, ruleNode)) return;
 

--- a/lib/rules/rule-selector-property-disallowed-list/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/index.mjs
@@ -81,7 +81,6 @@ export default rule;
  * @param {import('postcss').Rule} ruleNode
  */
 function declarationIsAChildOfRule(decl, ruleNode) {
-
 	/** @type {import('postcss').Container['parent']} */
 	let parent = decl.parent;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7488

> Is there anything in the PR that needs further explanation?

I noticed that this walks down the entire sub tree for each rule node.
This might not be what users expect.

But changing it to `.each()` also has issues.
It will no longer give errors on :

```css
.bad-selector {
  @media screen {
    color: red;
  }
}
```

Edit: I've found a more complete patch