### PR TITLE
Fix `selector-max-compound-selectors` document in website

### DIFF
--- a/lib/rules/selector-max-compound-selectors/README.md
+++ b/lib/rules/selector-max-compound-selectors/README.md
@@ -14,9 +14,8 @@ A [compound selector](https://www.w3.org/TR/selectors4/#compound) is a chain of 
 
 This rule resolves nested selectors before counting the depth of a selector. Each selector in a [selector list](https://www.w3.org/TR/selectors4/#selector-list) is evaluated separately.
 
-<!-- prettier-ignore -->
 > [!WARNING]
-> `:not()` is considered one compound selector irrespective to the complexity of the selector inside it. The rule _does_ process that inner selector, but does so separately, independent of the main selector.
+> The `:not()` pseudo-class is considered one compound selector irrespective to the complexity of the selector inside it. The rule _does_ process that inner selector, but does so separately, independent of the main selector.
 
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 


### PR DESCRIPTION
I noticed the `[!WARNING]` section is broken the our website (stylelint.io)
because starting with an inline code (`:not()`).

<img width="539" alt="image" src="https://github.com/stylelint/stylelint/assets/473530/c5af67ae-ec6d-46fd-8f7e-eeb1c6c81459">

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #7544

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory. Just a document fix.
