### PR TITLE
Fix import errors for configs and plugins omitting `/index.js`

### DIFF
--- a/.changeset/three-pumas-help.md
+++ b/.changeset/three-pumas-help.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fix an issue where the expected config for `/index.js` could not be loaded
+Fix an issue where config for `/index.js` could not be loaded

--- a/.changeset/three-pumas-help.md
+++ b/.changeset/three-pumas-help.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fix an issue where config for `/index.js` could not be loaded
+Fixed: import errors for configs and plugins omitting `/index.js`

--- a/.changeset/three-pumas-help.md
+++ b/.changeset/three-pumas-help.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fix an issue where the expected config for `/index.js` could not be loaded

--- a/lib/utils/__tests__/resolveSilent.test.mjs
+++ b/lib/utils/__tests__/resolveSilent.test.mjs
@@ -10,4 +10,5 @@ it('should resolve ESM over commonjs for dual package', () => {
 	expect(resolveSilent(fixturesPath, '@stylelint/dual-package')).toBe(
 		path.resolve(fixturesPath, 'node_modules/@stylelint/dual-package/index.mjs'),
 	);
+	expect(resolveSilent(fixturesPath, '.')).toBe(path.resolve(fixturesPath, 'index.js'));
 });

--- a/lib/utils/resolveSilent.cjs
+++ b/lib/utils/resolveSilent.cjs
@@ -24,6 +24,7 @@ const specifierSuffixes = ['', '.js', '.json', '/index.js', '/index.json'];
 function existsFile(filename) {
 	return fs.existsSync(filename) && fs.statSync(filename).isFile();
 }
+
 /**
  * @param {string} parent
  * @param {string} lookup

--- a/lib/utils/resolveSilent.cjs
+++ b/lib/utils/resolveSilent.cjs
@@ -22,7 +22,7 @@ const specifierSuffixes = ['', '.js', '.json', '/index.js', '/index.json'];
  * @returns {boolean} `true` if the file exists and is a file, otherwise `false`.
  */
 function existsFile(filename) {
-	return fs.existsSync(filename) && fs.statSync(filename).isFile();
+	return fs.statSync(filename, { throwIfNoEntry: false })?.isFile() ?? false;
 }
 
 /**

--- a/lib/utils/resolveSilent.cjs
+++ b/lib/utils/resolveSilent.cjs
@@ -17,6 +17,14 @@ const pathSuffixes = ['', '.js', '.json', `${path.sep}index.js`, `${path.sep}ind
 const specifierSuffixes = ['', '.js', '.json', '/index.js', '/index.json'];
 
 /**
+ * Checks whether the given file exists as a file.
+ * @param {string} filename The file to check.
+ * @returns {boolean} `true` if the file exists and is a file, otherwise `false`.
+ */
+function existsFile(filename) {
+	return fs.existsSync(filename) && fs.statSync(filename).isFile();
+}
+/**
  * @param {string} parent
  * @param {string} lookup
  * @return {string | undefined}
@@ -26,7 +34,7 @@ function resolveSilent(parent, lookup) {
 		for (const suffix of pathSuffixes) {
 			const filename = lookup + suffix;
 
-			if (fs.existsSync(filename)) {
+			if (existsFile(filename)) {
 				return filename;
 			}
 		}
@@ -40,7 +48,7 @@ function resolveSilent(parent, lookup) {
 		try {
 			const resolved = node_url.fileURLToPath(importMetaResolve.resolve(lookup + suffix, base));
 
-			if (fs.existsSync(resolved)) {
+			if (existsFile(resolved)) {
 				return resolved;
 			}
 		} catch {

--- a/lib/utils/resolveSilent.mjs
+++ b/lib/utils/resolveSilent.mjs
@@ -21,7 +21,7 @@ const specifierSuffixes = ['', '.js', '.json', '/index.js', '/index.json'];
  * @returns {boolean} `true` if the file exists and is a file, otherwise `false`.
  */
 function existsFile(filename) {
-	return fs.existsSync(filename) && fs.statSync(filename).isFile();
+	return fs.statSync(filename, { throwIfNoEntry: false })?.isFile() ?? false;
 }
 
 /**

--- a/lib/utils/resolveSilent.mjs
+++ b/lib/utils/resolveSilent.mjs
@@ -16,6 +16,15 @@ const pathSuffixes = ['', '.js', '.json', `${path.sep}index.js`, `${path.sep}ind
 const specifierSuffixes = ['', '.js', '.json', '/index.js', '/index.json'];
 
 /**
+ * Checks whether the given file exists as a file.
+ * @param {string} filename The file to check.
+ * @returns {boolean} `true` if the file exists and is a file, otherwise `false`.
+ */
+function existsFile(filename) {
+	return fs.existsSync(filename) && fs.statSync(filename).isFile();
+}
+
+/**
  * @param {string} parent
  * @param {string} lookup
  * @return {string | undefined}
@@ -25,7 +34,7 @@ export default function resolveSilent(parent, lookup) {
 		for (const suffix of pathSuffixes) {
 			const filename = lookup + suffix;
 
-			if (fs.existsSync(filename)) {
+			if (existsFile(filename)) {
 				return filename;
 			}
 		}
@@ -39,7 +48,7 @@ export default function resolveSilent(parent, lookup) {
 		try {
 			const resolved = fileURLToPath(resolve(lookup + suffix, base));
 
-			if (fs.existsSync(resolved)) {
+			if (existsFile(resolved)) {
 				return resolved;
 			}
 		} catch {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7576
Closes #7577

Ref #7532

> Is there anything in the PR that needs further explanation?

This PR fixes an issue where cannot resolve paths in configurations that expect `index.js` to resolve implicitly by Node.js.
