### PR TITLE
Refactor to silence PostCSS stderr warning 

### DIFF
--- a/lib/utils/__tests__/parseSelectorAST.test.mjs
+++ b/lib/utils/__tests__/parseSelectorAST.test.mjs
@@ -4,7 +4,7 @@ import parseSelectorAST from '../parseSelectorAST.mjs';
 
 describe('parseSelectorAST', () => {
 	it('parses selectors into an AST', async () => {
-		const result = await postcss().process('a .foo, b::before {}');
+		const result = await postcss().process('a .foo, b::before {}', { from: undefined });
 		const rule = result.root.first;
 		const ast = parseSelectorAST(rule.selector, result, rule);
 
@@ -13,7 +13,7 @@ describe('parseSelectorAST', () => {
 	});
 
 	it('returns `undefined` when there is no selector', async () => {
-		const result = await postcss().process('{}');
+		const result = await postcss().process('{}', { from: undefined });
 		const rule = result.root.first;
 		const ast = parseSelectorAST(rule.selector, result, rule);
 
@@ -22,7 +22,7 @@ describe('parseSelectorAST', () => {
 	});
 
 	it('warns on invalid selectors, but does not throw', async () => {
-		const result = await postcss().process('[&] {}');
+		const result = await postcss().process('[&] {}', { from: undefined });
 		const rule = result.root.first;
 		const ast = parseSelectorAST(rule.selector, result, rule);
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

relates to #7518

> Is there anything in the PR that needs further explanation?

```sh
  console.warn
    Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.

      at warnOnce (node_modules/postcss/lib/warn-once.js:11:13)
      at NoWorkResult.then (node_modules/postcss/lib/no-work-result.js:67:9)
```
