### PR TITLE
Add `ignoreLonghands: []` to `declaration-block-no-redundant-longhand-properties`

### DIFF
--- a/.changeset/selfish-plums-dream.md
+++ b/.changeset/selfish-plums-dream.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `text-decoration`

--- a/.changeset/sharp-buses-drop.md
+++ b/.changeset/sharp-buses-drop.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `ignoreLonghands` option to `declaration-block-no-redundant-longhand-properties`
+Added: `ignoreLonghands: []` to `declaration-block-no-redundant-longhand-properties`

--- a/.changeset/sharp-buses-drop.md
+++ b/.changeset/sharp-buses-drop.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `ignoreLonghands` option to `declaration-block-no-redundant-longhand-properties`

--- a/lib/reference/properties.cjs
+++ b/lib/reference/properties.cjs
@@ -538,6 +538,7 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 			'text-decoration-line',
 			'text-decoration-style',
 			'text-decoration-color',
+			'text-decoration-thickness',
 		]),
 	],
 	[

--- a/lib/reference/properties.mjs
+++ b/lib/reference/properties.mjs
@@ -534,6 +534,7 @@ export const longhandSubPropertiesOfShorthandProperties = new Map([
 			'text-decoration-line',
 			'text-decoration-style',
 			'text-decoration-color',
+			'text-decoration-thickness',
 		]),
 	],
 	[

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -208,7 +208,7 @@ a {
 }
 ```
 
-The following pattern are _not_ considered problems:
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -174,6 +174,60 @@ a {
 
 ## Optional secondary options
 
+### `ignoreLonghands: ["string"]`
+
+Given:
+
+<!-- prettier-ignore -->
+```json
+["text-decoration-thickness", "background-size", "background-origin", "background-clip"]
+```
+
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
+```css
+a {
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-color: purple;
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+  background-repeat: repeat;
+  background-attachment: scroll;
+  background-position: 0% 0%;
+  background-color: transparent;
+  background-image: none;
+  background-size: contain;
+  background-origin: border-box;
+  background-clip: text;
+}
+```
+
+The following pattern are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a {
+  text-decoration: underline solid purple;
+  text-decoration-thickness: 1px;
+}
+```
+
+<!-- prettier-ignore -->
+```css
+a {
+  background: none 0% 0% repeat scroll transparent;
+  background-size: contain;
+  background-origin: border-box;
+  background-clip: text;
+}
+```
+
 ### `ignoreShorthands: ["/regex/", /regex/, "string"]`
 
 Given:

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -59,6 +59,14 @@ testRule({
 			code: 'a { transition-delay: 500ms, 1s; transition-duration: 250ms,2s; transition-timing-function: ease-in-out; transition-property: inherit; }',
 			description: 'transition property contains basic keyword (inherit)',
 		},
+		{
+			code: 'a { text-decoration-line: underline; text-decoration-style: solid; text-decoration-color: purple; }',
+			description: 'missing text-decoration-thickness',
+		},
+		{
+			code: 'a { background-repeat: repeat; background-attachment: scroll; background-position: 0% 0%; background-color: transparent; background-image: none; background-origin: border-box; background-clip: text; }',
+			description: 'missing background-size',
+		},
 	],
 
 	reject: [
@@ -386,6 +394,50 @@ testRule({
 			description:
 				'the repeat() notation has non-trivial semantics and is currently not fixable (rows)',
 			message: messages.expected('grid-template'),
+		},
+		{
+			code: 'a { text-decoration-color: purple; text-decoration-thickness: 1px; text-decoration-style: solid; text-decoration-line: underline; }',
+			fixed: 'a { text-decoration: underline solid purple 1px; }',
+			message: messages.expected('text-decoration'),
+			description: 'CSS Text Decoration Module Level 4',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [
+		true,
+		{
+			ignoreLonghands: [
+				'background-size',
+				'background-origin',
+				'background-clip',
+				'text-decoration-thickness',
+			],
+		},
+	],
+	fix: true,
+
+	reject: [
+		{
+			code: 'a { text-decoration-line: underline; text-decoration-style: solid; text-decoration-color: purple; }',
+			fixed: 'a { text-decoration: underline solid purple; }',
+			description: 'CSS Text Decoration Module Level 3',
+			message: messages.expected('text-decoration'),
+		},
+		{
+			code: 'a { text-decoration-color: purple; text-decoration-thickness: 1px; text-decoration-style: solid; text-decoration-line: underline; text-decoration-width: 1px; }',
+			fixed:
+				'a { text-decoration: underline solid purple; text-decoration-thickness: 1px; text-decoration-width: 1px; }',
+			description: 'ignore text-decoration-width by default',
+			message: messages.expected('text-decoration'),
+		},
+		{
+			code: 'a { background-repeat: repeat; background-attachment: scroll; background-position: 0% 0%; background-color: transparent; background-image: none; background-size: contain; background-origin: border-box; background-clip: text; }',
+			fixed:
+				'a { background: none 0% 0% repeat scroll transparent; background-size: contain; background-origin: border-box; background-clip: text; }',
+			message: messages.expected('background'),
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -231,6 +231,8 @@ const rule = (primary, secondaryOptions, context) => {
 
 		/** @type {Map<string, import('stylelint').ShorthandProperties[]>} */
 		const longhandToShorthands = new Map();
+		/** @type {string[]} */
+		const ignoreLonghands = secondaryOptions?.ignoreLonghands ?? [];
 
 		for (const [shorthand, longhandProps] of properties.longhandSubPropertiesOfShorthandProperties.entries()) {
 			if (optionsMatches(secondaryOptions, 'ignoreShorthands', shorthand)) {
@@ -238,7 +240,7 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			for (const longhand of longhandProps) {
-				if (secondaryOptions?.ignoreLonghands?.includes(longhand)) continue;
+				if (ignoreLonghands.includes(longhand)) continue;
 
 				const shorthands = longhandToShorthands.get(longhand) || [];
 
@@ -285,9 +287,7 @@ const rule = (primary, secondaryOptions, context) => {
 						properties.longhandSubPropertiesOfShorthandProperties.get(shorthandProperty),
 					);
 
-					secondaryOptions?.ignoreLonghands?.forEach((/** @type {string} */ value) => {
-						if (shorthandProps.has(value)) shorthandProps.delete(value);
-					});
+					ignoreLonghands.forEach((value) => shorthandProps.delete(value));
 					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -219,6 +219,7 @@ const rule = (primary, secondaryOptions, context) => {
 				actual: secondaryOptions,
 				possible: {
 					ignoreShorthands: [validateTypes.isString, validateTypes.isRegExp],
+					ignoreLonghands: [validateTypes.isString],
 				},
 				optional: true,
 			},
@@ -237,6 +238,8 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			for (const longhand of longhandProps) {
+				if (secondaryOptions?.ignoreLonghands?.includes(longhand)) continue;
+
 				const shorthands = longhandToShorthands.get(longhand) || [];
 
 				shorthands.push(shorthand);
@@ -278,11 +281,17 @@ const rule = (primary, secondaryOptions, context) => {
 					longhandDeclarationNode.push(decl);
 					longhandDeclarationNodes.set(prefixedShorthandProperty, longhandDeclarationNode);
 
-					const shorthandProps = properties.longhandSubPropertiesOfShorthandProperties.get(shorthandProperty);
-					const prefixedShorthandData = Array.from(shorthandProps || [], (item) => prefix + item);
+					const shorthandProps = new Set(
+						properties.longhandSubPropertiesOfShorthandProperties.get(shorthandProperty),
+					);
 
+					secondaryOptions?.ignoreLonghands?.forEach((/** @type {string} */ value) => {
+						if (shorthandProps.has(value)) shorthandProps.delete(value);
+					});
+					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 
+					// TODO use toSorted in the next major that supports it
 					if (!arrayEqual(copiedPrefixedShorthandData.sort(), longhandDeclaration.sort())) {
 						continue;
 					}

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -228,6 +228,8 @@ const rule = (primary, secondaryOptions, context) => {
 
 		/** @type {Map<string, import('stylelint').ShorthandProperties[]>} */
 		const longhandToShorthands = new Map();
+		/** @type {string[]} */
+		const ignoreLonghands = secondaryOptions?.ignoreLonghands ?? [];
 
 		for (const [shorthand, longhandProps] of longhandSubPropertiesOfShorthandProperties.entries()) {
 			if (optionsMatches(secondaryOptions, 'ignoreShorthands', shorthand)) {
@@ -235,7 +237,7 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			for (const longhand of longhandProps) {
-				if (secondaryOptions?.ignoreLonghands?.includes(longhand)) continue;
+				if (ignoreLonghands.includes(longhand)) continue;
 
 				const shorthands = longhandToShorthands.get(longhand) || [];
 
@@ -282,9 +284,7 @@ const rule = (primary, secondaryOptions, context) => {
 						longhandSubPropertiesOfShorthandProperties.get(shorthandProperty),
 					);
 
-					secondaryOptions?.ignoreLonghands?.forEach((/** @type {string} */ value) => {
-						if (shorthandProps.has(value)) shorthandProps.delete(value);
-					});
+					ignoreLonghands.forEach((value) => shorthandProps.delete(value));
 					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -216,6 +216,7 @@ const rule = (primary, secondaryOptions, context) => {
 				actual: secondaryOptions,
 				possible: {
 					ignoreShorthands: [isString, isRegExp],
+					ignoreLonghands: [isString],
 				},
 				optional: true,
 			},
@@ -234,6 +235,8 @@ const rule = (primary, secondaryOptions, context) => {
 			}
 
 			for (const longhand of longhandProps) {
+				if (secondaryOptions?.ignoreLonghands?.includes(longhand)) continue;
+
 				const shorthands = longhandToShorthands.get(longhand) || [];
 
 				shorthands.push(shorthand);
@@ -275,11 +278,17 @@ const rule = (primary, secondaryOptions, context) => {
 					longhandDeclarationNode.push(decl);
 					longhandDeclarationNodes.set(prefixedShorthandProperty, longhandDeclarationNode);
 
-					const shorthandProps = longhandSubPropertiesOfShorthandProperties.get(shorthandProperty);
-					const prefixedShorthandData = Array.from(shorthandProps || [], (item) => prefix + item);
+					const shorthandProps = new Set(
+						longhandSubPropertiesOfShorthandProperties.get(shorthandProperty),
+					);
 
+					secondaryOptions?.ignoreLonghands?.forEach((/** @type {string} */ value) => {
+						if (shorthandProps.has(value)) shorthandProps.delete(value);
+					});
+					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 
+					// TODO use toSorted in the next major that supports it
 					if (!arrayEqual(copiedPrefixedShorthandData.sort(), longhandDeclaration.sort())) {
 						continue;
 					}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #7232

> Is there anything in the PR that needs further explanation?

To understand why a fix is being accompanied by an option check the discussion starting with https://github.com/stylelint/stylelint/issues/7232#issuecomment-1762654301

tl;dr: CSS Text Decoration Module Level 3 vs CSS Text Decoration Module Level 4 means that a granular option is necessary for the `text-decoration` fix not be considered a downgrade