### PR TITLE
Fix `selector-type-no-unknown` false positives for experimental and deprecated HTML tags

### DIFF
--- a/.changeset/flat-bananas-hug.md
+++ b/.changeset/flat-bananas-hug.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `selector-type-no-unknown` false positives

--- a/.changeset/flat-bananas-hug.md
+++ b/.changeset/flat-bananas-hug.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `selector-type-no-unknown` false positives
+Fixed: `selector-type-no-unknown` false positives for experimental and deprecated HTML tags

--- a/.changeset/flat-bananas-hug.md
+++ b/.changeset/flat-bananas-hug.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": minor
+"stylelint": patch
 ---
 
 Fixed: `selector-type-no-unknown` false positives

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -10,6 +10,7 @@ const deprecatedHtmlTypeSelectors = new Set([
 	'applet',
 	'basefont',
 	'big',
+	'bgsound',
 	'blink',
 	'center',
 	'content',
@@ -17,14 +18,17 @@ const deprecatedHtmlTypeSelectors = new Set([
 	'font',
 	'frame',
 	'frameset',
-	'hgroup',
 	'isindex',
 	'keygen',
 	'listing',
 	'marquee',
+	'multicol',
+	'nextid',
 	'nobr',
 	'noembed',
+	'noframes',
 	'plaintext',
+	'param',
 	'spacer',
 	'strike',
 	'tt',
@@ -35,7 +39,13 @@ const deprecatedHtmlTypeSelectors = new Set([
 /** @type {Set<string>} */
 const standardHtmlTypeSelectors = new Set(htmlTags);
 
-const htmlTypeSelectors = uniteSets(deprecatedHtmlTypeSelectors, standardHtmlTypeSelectors);
+const experimentalHtmlTypeSelectors = new Set(['fencedframe', 'listbox', 'portal', 'selectlist']);
+
+const htmlTypeSelectors = uniteSets(
+	deprecatedHtmlTypeSelectors,
+	standardHtmlTypeSelectors,
+	experimentalHtmlTypeSelectors,
+);
 
 const mixedCaseSvgTypeSelectors = new Set([
 	'altGlyph',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -7,6 +7,7 @@ const deprecatedHtmlTypeSelectors = new Set([
 	'applet',
 	'basefont',
 	'big',
+	'bgsound',
 	'blink',
 	'center',
 	'content',
@@ -14,14 +15,17 @@ const deprecatedHtmlTypeSelectors = new Set([
 	'font',
 	'frame',
 	'frameset',
-	'hgroup',
 	'isindex',
 	'keygen',
 	'listing',
 	'marquee',
+	'multicol',
+	'nextid',
 	'nobr',
 	'noembed',
+	'noframes',
 	'plaintext',
+	'param',
 	'spacer',
 	'strike',
 	'tt',
@@ -32,7 +36,13 @@ const deprecatedHtmlTypeSelectors = new Set([
 /** @type {Set<string>} */
 const standardHtmlTypeSelectors = new Set(htmlTags);
 
-export const htmlTypeSelectors = uniteSets(deprecatedHtmlTypeSelectors, standardHtmlTypeSelectors);
+const experimentalHtmlTypeSelectors = new Set(['fencedframe', 'listbox', 'portal', 'selectlist']);
+
+export const htmlTypeSelectors = uniteSets(
+	deprecatedHtmlTypeSelectors,
+	standardHtmlTypeSelectors,
+	experimentalHtmlTypeSelectors,
+);
 
 export const mixedCaseSvgTypeSelectors = new Set([
 	'altGlyph',

--- a/lib/rules/selector-type-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.mjs
@@ -85,6 +85,9 @@ testRule({
 			description: 'svg tags',
 		},
 		{
+			code: 'fencedframe, listbox, portal, selectlist {}',
+		},
+		{
 			code: 'foreignObject {}',
 			description: 'case-sensitive svg tags',
 		},

--- a/lib/utils/isCustomElement.cjs
+++ b/lib/utils/isCustomElement.cjs
@@ -3,7 +3,6 @@
 'use strict';
 
 const svgTags = require('svg-tags');
-const selectors = require('../reference/selectors.cjs');
 const mathMLTags = require('./mathMLTags.cjs');
 
 /**
@@ -28,10 +27,6 @@ function isCustomElement(selector) {
 	}
 
 	if (svgTags.includes(selectorLowerCase)) {
-		return false;
-	}
-
-	if (selectors.htmlTypeSelectors.has(selectorLowerCase)) {
 		return false;
 	}
 

--- a/lib/utils/isCustomElement.mjs
+++ b/lib/utils/isCustomElement.mjs
@@ -1,6 +1,5 @@
 import svgTags from 'svg-tags';
 
-import { htmlTypeSelectors } from '../reference/selectors.mjs';
 import mathMLTags from './mathMLTags.mjs';
 
 /**
@@ -25,10 +24,6 @@ export default function isCustomElement(selector) {
 	}
 
 	if (svgTags.includes(selectorLowerCase)) {
-		return false;
-	}
-
-	if (htmlTypeSelectors.has(selectorLowerCase)) {
 		return false;
 	}
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

check the "concrete example" in #7510

> Is there anything in the PR that needs further explanation?

compare https://github.com/sindresorhus/html-tags/blob/main/html-tags.json and https://github.com/sindresorhus/html-tags/commit/d3b931ee8dc7c5bbbe20761ebbe4dad257cf39bc

- `selectlist`: https://github.com/openui/open-ui/issues/773#issuecomment-1664421419
- `listbox`: https://issues.chromium.org/issues/40146374#comment98
- `portal`: https://caniuse.com/mdn-html_elements_portal
- for the rest check https://developer.mozilla.org/en-US/docs/Web/HTML/Element/

I chose not to include the previous names of the tag names that I am introducing; we need to settle #7510 first.
e.g. not `selectmenu`