### PR TITLE
Fix Codecov upload by specifying token

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,6 +51,8 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ./.coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR fixes the Codecov upload error below:

```
Error: Codecov token not found. Please provide Codecov token with -t flag.
```

For example, see https://github.com/stylelint/stylelint/actions/runs/8654881284/job/23732901535#step:7:31

See also the reference of Codecov GitHub Action: https://github.com/codecov/codecov-action
