### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` autofix for `border`

### DIFF
--- a/.changeset/swift-jobs-fold.md
+++ b/.changeset/swift-jobs-fold.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `border`
+Fixed: `declaration-block-no-redundant-longhand-properties` false negatives for `border`

--- a/.changeset/swift-jobs-fold.md
+++ b/.changeset/swift-jobs-fold.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `border`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -143,6 +143,11 @@ testRule({
 			endColumn: 138,
 		},
 		{
+			code: 'a { border-width: 1px; border-style: double; border-color: green; }',
+			fixed: 'a { border: 1px double green; }',
+			message: messages.expected('border'),
+		},
+		{
 			code: 'a { border-top-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-right-width: 1px; }',
 			fixed: 'a { border-width: 1px 1px 1px 1px; }',
 			message: messages.expected('border-width'),

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -287,7 +287,14 @@ const rule = (primary, secondaryOptions, context) => {
 						properties.longhandSubPropertiesOfShorthandProperties.get(shorthandProperty),
 					);
 
-					ignoreLonghands.forEach((value) => shorthandProps.delete(value));
+					// see 9ab4fb2 for the historical reason behind the exception
+					const isBorder = shorthandProperty === 'border';
+
+					shorthandProps.forEach((value) => {
+						const mustDiscard = isBorder && value.length !== 12;
+
+						if (ignoreLonghands.includes(value) || mustDiscard) shorthandProps.delete(value);
+					});
 					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -289,9 +289,10 @@ const rule = (primary, secondaryOptions, context) => {
 
 					// see 9ab4fb2 for the historical reason behind the exception
 					const isBorder = shorthandProperty === 'border';
+					const borderSubPropertyLength = 12;
 
 					shorthandProps.forEach((value) => {
-						const mustDiscard = isBorder && value.length !== 12;
+						const mustDiscard = isBorder && value.length !== borderSubPropertyLength;
 
 						if (ignoreLonghands.includes(value) || mustDiscard) shorthandProps.delete(value);
 					});

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -284,7 +284,14 @@ const rule = (primary, secondaryOptions, context) => {
 						longhandSubPropertiesOfShorthandProperties.get(shorthandProperty),
 					);
 
-					ignoreLonghands.forEach((value) => shorthandProps.delete(value));
+					// see 9ab4fb2 for the historical reason behind the exception
+					const isBorder = shorthandProperty === 'border';
+
+					shorthandProps.forEach((value) => {
+						const mustDiscard = isBorder && value.length !== 12;
+
+						if (ignoreLonghands.includes(value) || mustDiscard) shorthandProps.delete(value);
+					});
 					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -286,9 +286,10 @@ const rule = (primary, secondaryOptions, context) => {
 
 					// see 9ab4fb2 for the historical reason behind the exception
 					const isBorder = shorthandProperty === 'border';
+					const borderSubPropertyLength = 12;
 
 					shorthandProps.forEach((value) => {
-						const mustDiscard = isBorder && value.length !== 12;
+						const mustDiscard = isBorder && value.length !== borderSubPropertyLength;
 
 						if (ignoreLonghands.includes(value) || mustDiscard) shorthandProps.delete(value);
 					});


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #7609

> Is there anything in the PR that needs further explanation?

To avoid regressions we didn't remove

```
    "border-top-width",
    "border-bottom-width",
    "border-left-width",
    "border-right-width",
    "border-top-style",
    "border-bottom-style",
    "border-left-style",
    "border-right-style",
    "border-top-color",
    "border-bottom-color",
    "border-left-color",
    "border-right-color",
```

in #7585.
The error was introduced in 2015; it's too late to fix because at this point it could be considered a feature.
These properties do get reset by `border` after all.
i.e. for `declaration-block-no-shorthand-property-overrides`
It's just not consistent with the rest nor with the original `shorthand.js` name intent.
Just a minor annoyance IMHO.