### PR TITLE
Refactor `matchesStringOrRegExp()` utility

### DIFF
--- a/lib/utils/matchesStringOrRegExp.cjs
+++ b/lib/utils/matchesStringOrRegExp.cjs
@@ -10,10 +10,11 @@
  * Any strings starting and ending with `/` are interpreted
  * as regular expressions.
  *
+ * @typedef {{match: string, pattern: (string | RegExp), substring: string} | false} MatchResult
+ *
  * @param {string | Array<string>} input
  * @param {string | RegExp | Array<string | RegExp>} comparison
- *
- * @returns {false | {match: string, pattern: (string | RegExp), substring: string}}
+ * @returns {MatchResult}
  */
 function matchesStringOrRegExp(input, comparison) {
 	if (!Array.isArray(input)) {
@@ -34,6 +35,7 @@ function matchesStringOrRegExp(input, comparison) {
 /**
  * @param {string} value
  * @param {string | RegExp | Array<string | RegExp>} comparison
+ * @returns {MatchResult}
  */
 function testAgainstStringOrRegExpOrArray(value, comparison) {
 	if (!Array.isArray(comparison)) {
@@ -53,37 +55,45 @@ function testAgainstStringOrRegExpOrArray(value, comparison) {
 
 /**
  * @param {string} value
+ * @param {RegExp} pattern
+ * @returns {MatchResult}
+ */
+function matchValue(value, pattern) {
+	const match = value.match(pattern);
+
+	return match ? { match: value, pattern, substring: match[0] ?? '' } : false;
+}
+
+/**
+ * @param {string} value
  * @param {string | RegExp} comparison
+ * @returns {MatchResult}
  */
 function testAgainstStringOrRegExp(value, comparison) {
 	// If it's a RegExp, test directly
 	if (comparison instanceof RegExp) {
-		const match = value.match(comparison);
-
-		return match ? { match: value, pattern: comparison, substring: match[0] || '' } : false;
+		return matchValue(value, comparison);
 	}
 
 	// Check if it's RegExp in a string
-	const firstComparisonChar = comparison[0];
-	const lastComparisonChar = comparison[comparison.length - 1];
-	const secondToLastComparisonChar = comparison[comparison.length - 2];
-
+	const regexFlag = 'i';
 	const comparisonIsRegex =
-		firstComparisonChar === '/' &&
-		(lastComparisonChar === '/' ||
-			(secondToLastComparisonChar === '/' && lastComparisonChar === 'i'));
-
-	const hasCaseInsensitiveFlag = comparisonIsRegex && lastComparisonChar === 'i';
+		comparison.startsWith('/') &&
+		(comparison.endsWith('/') || comparison.endsWith(`/${regexFlag}`));
 
 	// If so, create a new RegExp from it
 	if (comparisonIsRegex) {
-		const valueMatch = hasCaseInsensitiveFlag
-			? value.match(new RegExp(comparison.slice(1, -2), 'i'))
-			: value.match(new RegExp(comparison.slice(1, -1)));
+		const pattern = comparison.endsWith(regexFlag)
+			? new RegExp(comparison.slice(1, -2), regexFlag)
+			: new RegExp(comparison.slice(1, -1));
 
-		return valueMatch
-			? { match: value, pattern: comparison, substring: valueMatch[0] || '' }
-			: false;
+		const result = matchValue(value, pattern);
+
+		if (result) {
+			result.pattern = comparison;
+		}
+
+		return result;
 	}
 
 	// Otherwise, it's a string. Do a strict comparison

--- a/lib/utils/matchesStringOrRegExp.mjs
+++ b/lib/utils/matchesStringOrRegExp.mjs
@@ -6,10 +6,11 @@
  * Any strings starting and ending with `/` are interpreted
  * as regular expressions.
  *
+ * @typedef {{match: string, pattern: (string | RegExp), substring: string} | false} MatchResult
+ *
  * @param {string | Array<string>} input
  * @param {string | RegExp | Array<string | RegExp>} comparison
- *
- * @returns {false | {match: string, pattern: (string | RegExp), substring: string}}
+ * @returns {MatchResult}
  */
 export default function matchesStringOrRegExp(input, comparison) {
 	if (!Array.isArray(input)) {
@@ -30,6 +31,7 @@ export default function matchesStringOrRegExp(input, comparison) {
 /**
  * @param {string} value
  * @param {string | RegExp | Array<string | RegExp>} comparison
+ * @returns {MatchResult}
  */
 function testAgainstStringOrRegExpOrArray(value, comparison) {
 	if (!Array.isArray(comparison)) {
@@ -49,37 +51,45 @@ function testAgainstStringOrRegExpOrArray(value, comparison) {
 
 /**
  * @param {string} value
+ * @param {RegExp} pattern
+ * @returns {MatchResult}
+ */
+function matchValue(value, pattern) {
+	const match = value.match(pattern);
+
+	return match ? { match: value, pattern, substring: match[0] ?? '' } : false;
+}
+
+/**
+ * @param {string} value
  * @param {string | RegExp} comparison
+ * @returns {MatchResult}
  */
 function testAgainstStringOrRegExp(value, comparison) {
 	// If it's a RegExp, test directly
 	if (comparison instanceof RegExp) {
-		const match = value.match(comparison);
-
-		return match ? { match: value, pattern: comparison, substring: match[0] || '' } : false;
+		return matchValue(value, comparison);
 	}
 
 	// Check if it's RegExp in a string
-	const firstComparisonChar = comparison[0];
-	const lastComparisonChar = comparison[comparison.length - 1];
-	const secondToLastComparisonChar = comparison[comparison.length - 2];
-
+	const regexFlag = 'i';
 	const comparisonIsRegex =
-		firstComparisonChar === '/' &&
-		(lastComparisonChar === '/' ||
-			(secondToLastComparisonChar === '/' && lastComparisonChar === 'i'));
-
-	const hasCaseInsensitiveFlag = comparisonIsRegex && lastComparisonChar === 'i';
+		comparison.startsWith('/') &&
+		(comparison.endsWith('/') || comparison.endsWith(`/${regexFlag}`));
 
 	// If so, create a new RegExp from it
 	if (comparisonIsRegex) {
-		const valueMatch = hasCaseInsensitiveFlag
-			? value.match(new RegExp(comparison.slice(1, -2), 'i'))
-			: value.match(new RegExp(comparison.slice(1, -1)));
+		const pattern = comparison.endsWith(regexFlag)
+			? new RegExp(comparison.slice(1, -2), regexFlag)
+			: new RegExp(comparison.slice(1, -1));
 
-		return valueMatch
-			? { match: value, pattern: comparison, substring: valueMatch[0] || '' }
-			: false;
+		const result = matchValue(value, pattern);
+
+		if (result) {
+			result.pattern = comparison;
+		}
+
+		return result;
 	}
 
 	// Otherwise, it's a string. Do a strict comparison


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This change aims to improve readability in the `matchesStringOrRegExp()` utility module.
