### PR TITLE
Check uncommitted build files on pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,2 @@
-npm run build
+npm run build -- --silent
 npm run build-check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+npm run build
+npm run build-check

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -46,6 +46,7 @@ export default inputFiles.map((input) => {
 			plugins: [addWarningForCommonJS()],
 		},
 		treeshake: false,
+		logLevel: 'silent',
 	};
 });
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This aims to prevent us from forgetting commits of built files (`*.cjs`).

Additionally, this lower the log level of Rollup.

Example:

```sh-session
$ git push
...
You must commit the following files:
lib/utils/matchesStringOrRegExp.cjs
husky - pre-push script failed (code 1)
error: failed to push some refs to 'https://github.com/stylelint/stylelint.git'
```

If you want to bypass the pre-push hook, use `--no-verify`:

```sh-session
$ git push --no-verify
```