### PR TITLE
Fix `shorthand-property-no-redundant-values` false negatives for functions

### DIFF
--- a/.changeset/famous-deers-build.md
+++ b/.changeset/famous-deers-build.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `shorthand-property-no-redundant-values` false negatives for functions

--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
@@ -78,23 +78,11 @@ testRule({
 			description: 'ignore not shorthandable property',
 		},
 		{
-			code: 'a { border-radius: 1px / 1px }',
+			code: 'a { border-radius: 1px / 1px; }',
 			description: 'ignore ellipse',
 		},
 		{
-			code: 'a { margin: calc(1px + 1px) calc(1px + 1px); }',
-			description: 'ignore calc function',
-		},
-		{
-			code: 'a { margin: some-function(1px + 1px) some-function(1px + 1px); }',
-			description: 'ignore all function',
-		},
-		{
-			code: 'a { margin: var(--margin) var(--margin); }',
-			description: 'ignore variables',
-		},
-		{
-			code: 'a { border-color: #FFFFFF transparent transparent }',
+			code: 'a { border-color: #FFFFFF transparent transparent; }',
 			description: 'ignore upper case value',
 		},
 		{
@@ -378,6 +366,30 @@ testRule({
 			code: 'a { inset: 1px 0 1px 0; }',
 			fixed: 'a { inset: 1px 0; }',
 			message: messages.rejected('1px 0 1px 0', '1px 0'),
+			line: 1,
+			column: 5,
+		},
+		{
+			code: 'a { margin: var(--margin) var(--margin); }',
+			fixed: 'a { margin: var(--margin); }',
+			message: messages.rejected('var(--margin) var(--margin)', 'var(--margin)'),
+			line: 1,
+			column: 5,
+		},
+		{
+			code: 'a { margin: calc(1px + 1px) calc(1px + 1px); }',
+			fixed: 'a { margin: calc(1px + 1px); }',
+			message: messages.rejected('calc(1px + 1px) calc(1px + 1px)', 'calc(1px + 1px)'),
+			line: 1,
+			column: 5,
+		},
+		{
+			code: 'a { margin: some-function(1px + 1px) some-function(1px + 1px); }',
+			fixed: 'a { margin: some-function(1px + 1px); }',
+			message: messages.rejected(
+				'some-function(1px + 1px) some-function(1px + 1px)',
+				'some-function(1px + 1px)',
+			),
 			line: 1,
 			column: 5,
 		},

--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
@@ -82,6 +82,10 @@ testRule({
 			description: 'ignore ellipse',
 		},
 		{
+			code: 'a { border-radius: 1px 1px / 1px; }',
+			description: 'ignore ellipse',
+		},
+		{
 			code: 'a { border-color: #FFFFFF transparent transparent; }',
 			description: 'ignore upper case value',
 		},

--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
@@ -86,6 +86,10 @@ testRule({
 			description: 'ignore ellipse',
 		},
 		{
+			code: 'a { margin: var(--margin) var(--margin); }',
+			description: 'ignore variables',
+		},
+		{
 			code: 'a { border-color: #FFFFFF transparent transparent; }',
 			description: 'ignore upper case value',
 		},
@@ -370,13 +374,6 @@ testRule({
 			code: 'a { inset: 1px 0 1px 0; }',
 			fixed: 'a { inset: 1px 0; }',
 			message: messages.rejected('1px 0 1px 0', '1px 0'),
-			line: 1,
-			column: 5,
-		},
-		{
-			code: 'a { margin: var(--margin) var(--margin); }',
-			fixed: 'a { margin: var(--margin); }',
-			message: messages.rejected('var(--margin) var(--margin)', 'var(--margin)'),
 			line: 1,
 			column: 5,
 		},

--- a/lib/rules/shorthand-property-no-redundant-values/index.cjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.cjs
@@ -5,10 +5,12 @@
 const valueParser = require('postcss-value-parser');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration.cjs');
 const isStandardSyntaxProperty = require('../../utils/isStandardSyntaxProperty.cjs');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
 const vendor = require('../../utils/vendor.cjs');
+const typeGuards = require('../../utils/typeGuards.cjs');
 
 const ruleName = 'shorthand-property-no-redundant-values';
 
@@ -31,16 +33,6 @@ const propertiesWithShorthandNotation = new Set([
 	'grid-gap',
 	'inset',
 ]);
-
-const ignoredCharacters = ['+', '*', '/', '(', ')', '$', '@', '--', 'var('];
-
-/**
- * @param {string} value
- * @returns {boolean}
- */
-function hasIgnoredCharacters(value) {
-	return ignoredCharacters.some((char) => value.includes(char));
-}
 
 /**
  * @param {string} property
@@ -125,40 +117,44 @@ const rule = (primary, _secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
-			if (!isStandardSyntaxDeclaration(decl) || !isStandardSyntaxProperty(decl.prop)) {
-				return;
-			}
+			if (!isStandardSyntaxDeclaration(decl)) return;
 
-			const prop = decl.prop;
-			const value = decl.value;
+			const { prop, value } = decl;
+
+			if (!isStandardSyntaxProperty(prop)) return;
+
+			if (!isStandardSyntaxValue(value)) return;
 
 			const normalizedProp = vendor.unprefixed(prop.toLowerCase());
 
-			if (hasIgnoredCharacters(value) || !isShorthandProperty(normalizedProp)) {
-				return;
-			}
+			if (!isShorthandProperty(normalizedProp)) return;
 
 			/** @type {string[]} */
 			const valuesToShorthand = [];
 
-			valueParser(value).walk((valueNode) => {
-				if (valueNode.type !== 'word') {
-					return;
+			let shouldIgnore = false;
+
+			for (const valueNode of valueParser(value).nodes) {
+				if (typeGuards.isValueDiv(valueNode)) {
+					shouldIgnore = true;
+					break;
+				}
+
+				if (!(typeGuards.isValueWord(valueNode) || typeGuards.isValueFunction(valueNode))) {
+					continue;
 				}
 
 				valuesToShorthand.push(valueParser.stringify(valueNode));
-			});
+			}
+
+			if (shouldIgnore) return;
 
 			if (valuesToShorthand.length <= 1 || valuesToShorthand.length > 4) {
 				return;
 			}
 
-			const shortestForm = canCondense(
-				valuesToShorthand[0] || '',
-				valuesToShorthand[1] || '',
-				valuesToShorthand[2] || '',
-				valuesToShorthand[3] || '',
-			);
+			const [top, right, bottom, left] = valuesToShorthand;
+			const shortestForm = canCondense(top ?? '', right ?? '', bottom ?? '', left ?? '');
 			const shortestFormString = shortestForm.filter(Boolean).join(' ');
 			const valuesFormString = valuesToShorthand.join(' ');
 

--- a/lib/rules/shorthand-property-no-redundant-values/index.cjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.cjs
@@ -140,6 +140,16 @@ const rule = (primary, _secondaryOptions, context) => {
 					break;
 				}
 
+				// `var()` should be ignored. E.g.
+				//
+				//   --padding: 20px 5px;
+				//   padding: 0 var(--padding) 0;
+				//
+				if (typeGuards.isValueFunction(valueNode) && valueNode.value.toLowerCase() === 'var') {
+					shouldIgnore = true;
+					break;
+				}
+
 				if (typeGuards.isValueWord(valueNode) || typeGuards.isValueFunction(valueNode)) {
 					valuesToShorthand.push(valueParser.stringify(valueNode));
 				}

--- a/lib/rules/shorthand-property-no-redundant-values/index.cjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.cjs
@@ -23,7 +23,7 @@ const meta = {
 	fixable: true,
 };
 
-const propertiesWithShorthandNotation = new Set([
+const SUPPORTED_SHORTHANDS = new Set([
 	'margin',
 	'padding',
 	'border-color',
@@ -38,8 +38,8 @@ const propertiesWithShorthandNotation = new Set([
  * @param {string} property
  * @returns {boolean}
  */
-function isShorthandProperty(property) {
-	return propertiesWithShorthandNotation.has(property);
+function isSupportedShorthand(property) {
+	return SUPPORTED_SHORTHANDS.has(property);
 }
 
 /**
@@ -127,7 +127,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			const normalizedProp = vendor.unprefixed(prop.toLowerCase());
 
-			if (!isShorthandProperty(normalizedProp)) return;
+			if (!isSupportedShorthand(normalizedProp)) return;
 
 			/** @type {string[]} */
 			const valuesToShorthand = [];

--- a/lib/rules/shorthand-property-no-redundant-values/index.cjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.cjs
@@ -140,11 +140,9 @@ const rule = (primary, _secondaryOptions, context) => {
 					break;
 				}
 
-				if (!(typeGuards.isValueWord(valueNode) || typeGuards.isValueFunction(valueNode))) {
-					continue;
+				if (typeGuards.isValueWord(valueNode) || typeGuards.isValueFunction(valueNode)) {
+					valuesToShorthand.push(valueParser.stringify(valueNode));
 				}
-
-				valuesToShorthand.push(valueParser.stringify(valueNode));
 			}
 
 			if (shouldIgnore) return;

--- a/lib/rules/shorthand-property-no-redundant-values/index.cjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.cjs
@@ -132,12 +132,9 @@ const rule = (primary, _secondaryOptions, context) => {
 			/** @type {string[]} */
 			const valuesToShorthand = [];
 
-			let shouldIgnore = false;
-
 			for (const valueNode of valueParser(value).nodes) {
 				if (typeGuards.isValueDiv(valueNode)) {
-					shouldIgnore = true;
-					break;
+					return;
 				}
 
 				// `var()` should be ignored. E.g.
@@ -146,16 +143,13 @@ const rule = (primary, _secondaryOptions, context) => {
 				//   padding: 0 var(--padding) 0;
 				//
 				if (typeGuards.isValueFunction(valueNode) && valueNode.value.toLowerCase() === 'var') {
-					shouldIgnore = true;
-					break;
+					return;
 				}
 
 				if (typeGuards.isValueWord(valueNode) || typeGuards.isValueFunction(valueNode)) {
 					valuesToShorthand.push(valueParser.stringify(valueNode));
 				}
 			}
-
-			if (shouldIgnore) return;
 
 			if (valuesToShorthand.length <= 1 || valuesToShorthand.length > 4) {
 				return;

--- a/lib/rules/shorthand-property-no-redundant-values/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.mjs
@@ -138,11 +138,9 @@ const rule = (primary, _secondaryOptions, context) => {
 					break;
 				}
 
-				if (!(isValueWord(valueNode) || isValueFunction(valueNode))) {
-					continue;
+				if (isValueWord(valueNode) || isValueFunction(valueNode)) {
+					valuesToShorthand.push(valueParser.stringify(valueNode));
 				}
-
-				valuesToShorthand.push(valueParser.stringify(valueNode));
 			}
 
 			if (shouldIgnore) return;

--- a/lib/rules/shorthand-property-no-redundant-values/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.mjs
@@ -138,6 +138,16 @@ const rule = (primary, _secondaryOptions, context) => {
 					break;
 				}
 
+				// `var()` should be ignored. E.g.
+				//
+				//   --padding: 20px 5px;
+				//   padding: 0 var(--padding) 0;
+				//
+				if (isValueFunction(valueNode) && valueNode.value.toLowerCase() === 'var') {
+					shouldIgnore = true;
+					break;
+				}
+
 				if (isValueWord(valueNode) || isValueFunction(valueNode)) {
 					valuesToShorthand.push(valueParser.stringify(valueNode));
 				}

--- a/lib/rules/shorthand-property-no-redundant-values/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.mjs
@@ -2,10 +2,13 @@ import valueParser from 'postcss-value-parser';
 
 import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
 import isStandardSyntaxProperty from '../../utils/isStandardSyntaxProperty.mjs';
+import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
 import vendor from '../../utils/vendor.mjs';
+
+import { isValueDiv, isValueFunction, isValueWord } from '../../utils/typeGuards.mjs';
 
 const ruleName = 'shorthand-property-no-redundant-values';
 
@@ -28,16 +31,6 @@ const propertiesWithShorthandNotation = new Set([
 	'grid-gap',
 	'inset',
 ]);
-
-const ignoredCharacters = ['+', '*', '/', '(', ')', '$', '@', '--', 'var('];
-
-/**
- * @param {string} value
- * @returns {boolean}
- */
-function hasIgnoredCharacters(value) {
-	return ignoredCharacters.some((char) => value.includes(char));
-}
 
 /**
  * @param {string} property
@@ -122,40 +115,44 @@ const rule = (primary, _secondaryOptions, context) => {
 		}
 
 		root.walkDecls((decl) => {
-			if (!isStandardSyntaxDeclaration(decl) || !isStandardSyntaxProperty(decl.prop)) {
-				return;
-			}
+			if (!isStandardSyntaxDeclaration(decl)) return;
 
-			const prop = decl.prop;
-			const value = decl.value;
+			const { prop, value } = decl;
+
+			if (!isStandardSyntaxProperty(prop)) return;
+
+			if (!isStandardSyntaxValue(value)) return;
 
 			const normalizedProp = vendor.unprefixed(prop.toLowerCase());
 
-			if (hasIgnoredCharacters(value) || !isShorthandProperty(normalizedProp)) {
-				return;
-			}
+			if (!isShorthandProperty(normalizedProp)) return;
 
 			/** @type {string[]} */
 			const valuesToShorthand = [];
 
-			valueParser(value).walk((valueNode) => {
-				if (valueNode.type !== 'word') {
-					return;
+			let shouldIgnore = false;
+
+			for (const valueNode of valueParser(value).nodes) {
+				if (isValueDiv(valueNode)) {
+					shouldIgnore = true;
+					break;
+				}
+
+				if (!(isValueWord(valueNode) || isValueFunction(valueNode))) {
+					continue;
 				}
 
 				valuesToShorthand.push(valueParser.stringify(valueNode));
-			});
+			}
+
+			if (shouldIgnore) return;
 
 			if (valuesToShorthand.length <= 1 || valuesToShorthand.length > 4) {
 				return;
 			}
 
-			const shortestForm = canCondense(
-				valuesToShorthand[0] || '',
-				valuesToShorthand[1] || '',
-				valuesToShorthand[2] || '',
-				valuesToShorthand[3] || '',
-			);
+			const [top, right, bottom, left] = valuesToShorthand;
+			const shortestForm = canCondense(top ?? '', right ?? '', bottom ?? '', left ?? '');
 			const shortestFormString = shortestForm.filter(Boolean).join(' ');
 			const valuesFormString = valuesToShorthand.join(' ');
 

--- a/lib/rules/shorthand-property-no-redundant-values/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.mjs
@@ -21,7 +21,7 @@ const meta = {
 	fixable: true,
 };
 
-const propertiesWithShorthandNotation = new Set([
+const SUPPORTED_SHORTHANDS = new Set([
 	'margin',
 	'padding',
 	'border-color',
@@ -36,8 +36,8 @@ const propertiesWithShorthandNotation = new Set([
  * @param {string} property
  * @returns {boolean}
  */
-function isShorthandProperty(property) {
-	return propertiesWithShorthandNotation.has(property);
+function isSupportedShorthand(property) {
+	return SUPPORTED_SHORTHANDS.has(property);
 }
 
 /**
@@ -125,7 +125,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			const normalizedProp = vendor.unprefixed(prop.toLowerCase());
 
-			if (!isShorthandProperty(normalizedProp)) return;
+			if (!isSupportedShorthand(normalizedProp)) return;
 
 			/** @type {string[]} */
 			const valuesToShorthand = [];

--- a/lib/rules/shorthand-property-no-redundant-values/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.mjs
@@ -130,12 +130,9 @@ const rule = (primary, _secondaryOptions, context) => {
 			/** @type {string[]} */
 			const valuesToShorthand = [];
 
-			let shouldIgnore = false;
-
 			for (const valueNode of valueParser(value).nodes) {
 				if (isValueDiv(valueNode)) {
-					shouldIgnore = true;
-					break;
+					return;
 				}
 
 				// `var()` should be ignored. E.g.
@@ -144,16 +141,13 @@ const rule = (primary, _secondaryOptions, context) => {
 				//   padding: 0 var(--padding) 0;
 				//
 				if (isValueFunction(valueNode) && valueNode.value.toLowerCase() === 'var') {
-					shouldIgnore = true;
-					break;
+					return;
 				}
 
 				if (isValueWord(valueNode) || isValueFunction(valueNode)) {
 					valuesToShorthand.push(valueParser.stringify(valueNode));
 				}
 			}
-
-			if (shouldIgnore) return;
 
 			if (valuesToShorthand.length <= 1 || valuesToShorthand.length > 4) {
 				return;

--- a/lib/utils/typeGuards.cjs
+++ b/lib/utils/typeGuards.cjs
@@ -55,6 +55,14 @@ function isDocument(node) {
 
 /**
  * @param {import('postcss-value-parser').Node} node
+ * @returns {node is import('postcss-value-parser').DivNode}
+ */
+function isValueDiv(node) {
+	return node.type === 'div';
+}
+
+/**
+ * @param {import('postcss-value-parser').Node} node
  * @returns {node is import('postcss-value-parser').FunctionNode}
  */
 function isValueFunction(node) {
@@ -92,6 +100,7 @@ exports.isDeclaration = isDeclaration;
 exports.isDocument = isDocument;
 exports.isRoot = isRoot;
 exports.isRule = isRule;
+exports.isValueDiv = isValueDiv;
 exports.isValueFunction = isValueFunction;
 exports.isValueSpace = isValueSpace;
 exports.isValueWord = isValueWord;

--- a/lib/utils/typeGuards.mjs
+++ b/lib/utils/typeGuards.mjs
@@ -51,6 +51,14 @@ export function isDocument(node) {
 
 /**
  * @param {import('postcss-value-parser').Node} node
+ * @returns {node is import('postcss-value-parser').DivNode}
+ */
+export function isValueDiv(node) {
+	return node.type === 'div';
+}
+
+/**
+ * @param {import('postcss-value-parser').Node} node
  * @returns {node is import('postcss-value-parser').FunctionNode}
  */
 export function isValueFunction(node) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #7656

> Is there anything in the PR that needs further explanation?

I think supporting all functions makes sense, including ~~`var()`~~ or `calc()` etc.
-> Dropped `var()` support. See https://github.com/stylelint/stylelint/issues/7656#issuecomment-2079826514