### PR TITLE
Add support for multi-argument functions to `function-calc-no-unspaced-operator`

### DIFF
--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -239,6 +239,11 @@ testRule({
 		},
 		{
 			code: 'a { padding: 10px calc([10px+5px]); }',
+			description: 'simple blocks with square brackets are ignored',
+		},
+		{
+			code: 'a { padding: 10px calc({10px+5px}); }',
+			description: 'simple blocks with curly braces are ignored',
 		},
 		{
 			code: 'a { top: calc(5--6px-7px); }',
@@ -620,6 +625,16 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+		},
+		{
+			code: 'a { top: calc(calc(1px+ 1px)); }',
+			fixed: 'a { top: calc(calc(1px + 1px)); }',
+			description: 'nested math expression',
+			message: messages.expectedBefore('+'),
+			line: 1,
+			column: 23,
+			endLine: 1,
+			endColumn: 24,
 		},
 		{
 			code: 'a { top: calc(((1px+ 1px))); }',

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -225,12 +225,6 @@ testRule({
 			code: 'a { top: calc(10px/var(--foo)); }',
 		},
 		{
-			code: 'a { top: calc(10px*var(--foo, 10px 20px)); }',
-		},
-		{
-			code: 'a { top: calc(10px*var(--foo, 10px+20px)); }',
-		},
-		{
 			code: 'a { padding: calc(); }',
 		},
 		{
@@ -249,6 +243,12 @@ testRule({
 		{
 			code: 'a { top: calc(5--6px-7px); }',
 			description: 'custom units',
+		},
+		{
+			code: 'a { top: calc(10px*var(--foo, 10px 20px)); }',
+		},
+		{
+			code: 'a { top: calc(10px*var(--foo, 10px+20px)); }',
 		},
 	],
 

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -687,57 +687,57 @@ testRule({
 	],
 });
 
-// testRule({
-// 	ruleName,
-// 	config: [true],
-// 	customSyntax: 'postcss-scss',
-// 	fix: true,
+testRule({
+	ruleName,
+	config: [true],
+	customSyntax: 'postcss-scss',
+	fix: true,
 
-// 	accept: [
-// 		{
-// 			code: 'a { top: calc(100%*#{$foo}); }',
-// 		},
-// 		{
-// 			code: 'a { top: calc(100% *#{$foo}); }',
-// 		},
-// 		{
-// 			code: 'a { top: calc(100%* #{$foo}); }',
-// 		},
-// 		{
-// 			code: 'a { top: calc(100% * #{$foo}); }',
-// 		},
-// 		{
-// 			code: 'a { top: calc(100%/#{$foo}); }',
-// 		},
-// 		{
-// 			code: 'a { top: calc(100% /#{$foo}); }',
-// 		},
-// 		{
-// 			code: 'a { top: calc(100%/ #{$foo}); }',
-// 		},
-// 		{
-// 			code: 'a { top: calc(100% / #{$foo}); }',
-// 		},
-// 	],
+	accept: [
+		{
+			code: 'a { top: calc(100%*#{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100% *#{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100%* #{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100% * #{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100%/#{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100% /#{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100%/ #{$foo}); }',
+		},
+		{
+			code: 'a { top: calc(100% / #{$foo}); }',
+		},
+	],
 
-// 	reject: [
-// 		{
-// 			code: 'a { top: calc(100%- #{$foo}); }',
-// 			fixed: 'a { top: calc(100% - #{$foo}); }',
-// 			message: messages.expectedBefore('-'),
-// 			line: 1,
-// 			column: 19,
-// 			endLine: 1,
-// 			endColumn: 20,
-// 		},
-// 		{
-// 			code: 'a { top: calc(100% -#{$foo}); }',
-// 			fixed: 'a { top: calc(100% - #{$foo}); }',
-// 			message: messages.expectedAfter('-'),
-// 			line: 1,
-// 			column: 20,
-// 			endLine: 1,
-// 			endColumn: 21,
-// 		},
-// 	],
-// });
+	reject: [
+		{
+			code: 'a { top: calc(100%- #{$foo}); }',
+			fixed: 'a { top: calc(100% - #{$foo}); }',
+			message: messages.expectedBefore('-'),
+			line: 1,
+			column: 19,
+			endLine: 1,
+			endColumn: 20,
+		},
+		{
+			code: 'a { top: calc(100% -#{$foo}); }',
+			fixed: 'a { top: calc(100% - #{$foo}); }',
+			message: messages.expectedAfter('-'),
+			line: 1,
+			column: 20,
+			endLine: 1,
+			endColumn: 21,
+		},
+	],
+});

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -195,6 +195,10 @@ testRule({
 			description: 'CRLF newline and tab before operator',
 		},
 		{
+			code: 'a { top: calc(5--6px-7px); }',
+			description: 'custom units',
+		},
+		{
 			code: 'a { padding: 10px calc(calc(1px + 2px)* 3px); }',
 		},
 		{
@@ -225,17 +229,13 @@ testRule({
 			code: 'a { top: calc(10px/var(--foo)); }',
 		},
 		{
+			code: 'a { top: calc(10px*var(--foo, 10px 20px)); }',
+		},
+		{
+			code: 'a { top: calc(10px*var(--foo, 10px+20px)); }',
+		},
+		{
 			code: 'a { padding: calc(); }',
-		},
-		{
-			code: 'a { font-size: clamp(1rem, 2.5vw, 1rem+1rem); }',
-			description:
-				'multiple argument: functions that accept more than one argument are not supported yet',
-		},
-		{
-			code: 'a { width: min(25vw+25vw); }',
-			description:
-				'single argument: functions that accept more than one argument are not supported yet',
 		},
 		{
 			code: 'a { padding: calc(1px --2px); }',
@@ -246,6 +246,9 @@ testRule({
 		},
 		{
 			code: 'a { padding: calc(1px + 2- ); }',
+		},
+		{
+			code: 'a { padding: 10px calc([10px+5px]); }',
 		},
 	],
 
@@ -577,6 +580,16 @@ testRule({
 			endColumn: 24,
 		},
 		{
+			code: 'a { padding: calc(1px+2px+3px); }',
+			fixed: 'a { padding: calc(1px + 2px + 3px); }',
+			warnings: [
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+			],
+		},
+		{
 			code: 'a { padding: calc(1px+2px-3px); }',
 			fixed: 'a { padding: calc(1px + 2px - 3px); }',
 			warnings: [
@@ -586,60 +599,145 @@ testRule({
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
 			],
 		},
-	],
-});
-
-testRule({
-	ruleName,
-	config: [true],
-	customSyntax: 'postcss-scss',
-	fix: true,
-
-	accept: [
 		{
-			code: 'a { top: calc(100%*#{$foo}); }',
+			code: 'a { padding: calc(1px+2px-3px-4px); }',
+			fixed: 'a { padding: calc(1px + 2px - 3px - 4px); }',
+			warnings: [
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
+				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
+			],
 		},
 		{
-			code: 'a { top: calc(100% *#{$foo}); }',
-		},
-		{
-			code: 'a { top: calc(100%* #{$foo}); }',
-		},
-		{
-			code: 'a { top: calc(100% * #{$foo}); }',
-		},
-		{
-			code: 'a { top: calc(100%/#{$foo}); }',
-		},
-		{
-			code: 'a { top: calc(100% /#{$foo}); }',
-		},
-		{
-			code: 'a { top: calc(100%/ #{$foo}); }',
-		},
-		{
-			code: 'a { top: calc(100% / #{$foo}); }',
-		},
-	],
-
-	reject: [
-		{
-			code: 'a { top: calc(100%- #{$foo}); }',
-			fixed: 'a { top: calc(100% - #{$foo}); }',
-			message: messages.expectedBefore('-'),
+			code: 'a { top: calc((1px+ 1px)); }',
+			fixed: 'a { top: calc((1px + 1px)); }',
+			description: 'nested math expression',
+			message: messages.expectedBefore('+'),
 			line: 1,
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
 		},
 		{
-			code: 'a { top: calc(100% -#{$foo}); }',
-			fixed: 'a { top: calc(100% - #{$foo}); }',
-			message: messages.expectedAfter('-'),
+			code: 'a { top: calc(((1px+ 1px))); }',
+			fixed: 'a { top: calc(((1px + 1px))); }',
+			description: 'nested math expression',
+			message: messages.expectedBefore('+'),
 			line: 1,
 			column: 20,
 			endLine: 1,
 			endColumn: 21,
 		},
+		{
+			code: 'a { font-size: clamp(1rem, 2.5vw, 1rem+1rem); }',
+			fixed: 'a { font-size: clamp(1rem, 2.5vw, 1rem + 1rem); }',
+			description: 'multiple argument functions',
+			warnings: [
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
+			],
+		},
+		{
+			code: 'a { top: clamp(1px +2px, 3px-4px, none); }',
+			fixed: 'a { top: clamp(1px + 2px, 3px - 4px, none); }',
+			description: 'multiple argument functions',
+			warnings: [
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+			],
+		},
+		{
+			code: 'a { width: min(25vw+25vw); }',
+			fixed: 'a { width: min(25vw + 25vw); }',
+			description: 'multiple argument functions',
+			warnings: [
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
+			],
+		},
+		{
+			code: 'a { padding: calc(1px+ 2px) calc(3px+ 4px); }',
+			fixed: 'a { padding: calc(1px + 2px) calc(3px + 4px); }',
+			description: 'nested math expression',
+			warnings: [
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 37, endColumn: 38 },
+			],
+		},
+		{
+			code: 'a { top: rgb(from red calc(r+1) calc(g-+2) calc(clamp(10px+2px, g+2, none))); }',
+			fixed:
+				'a { top: rgb(from red calc(r + 1) calc(g- + 2) calc(clamp(10px + 2px, g + 2, none))); }',
+			description: 'nested math expression',
+			warnings: [
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 40, endColumn: 41 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 40, endColumn: 41 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+			],
+		},
 	],
 });
+
+// testRule({
+// 	ruleName,
+// 	config: [true],
+// 	customSyntax: 'postcss-scss',
+// 	fix: true,
+
+// 	accept: [
+// 		{
+// 			code: 'a { top: calc(100%*#{$foo}); }',
+// 		},
+// 		{
+// 			code: 'a { top: calc(100% *#{$foo}); }',
+// 		},
+// 		{
+// 			code: 'a { top: calc(100%* #{$foo}); }',
+// 		},
+// 		{
+// 			code: 'a { top: calc(100% * #{$foo}); }',
+// 		},
+// 		{
+// 			code: 'a { top: calc(100%/#{$foo}); }',
+// 		},
+// 		{
+// 			code: 'a { top: calc(100% /#{$foo}); }',
+// 		},
+// 		{
+// 			code: 'a { top: calc(100%/ #{$foo}); }',
+// 		},
+// 		{
+// 			code: 'a { top: calc(100% / #{$foo}); }',
+// 		},
+// 	],
+
+// 	reject: [
+// 		{
+// 			code: 'a { top: calc(100%- #{$foo}); }',
+// 			fixed: 'a { top: calc(100% - #{$foo}); }',
+// 			message: messages.expectedBefore('-'),
+// 			line: 1,
+// 			column: 19,
+// 			endLine: 1,
+// 			endColumn: 20,
+// 		},
+// 		{
+// 			code: 'a { top: calc(100% -#{$foo}); }',
+// 			fixed: 'a { top: calc(100% - #{$foo}); }',
+// 			message: messages.expectedAfter('-'),
+// 			line: 1,
+// 			column: 20,
+// 			endLine: 1,
+// 			endColumn: 21,
+// 		},
+// 	],
+// });

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -195,10 +195,6 @@ testRule({
 			description: 'CRLF newline and tab before operator',
 		},
 		{
-			code: 'a { top: calc(5--6px-7px); }',
-			description: 'custom units',
-		},
-		{
 			code: 'a { padding: 10px calc(calc(1px + 2px)* 3px); }',
 		},
 		{
@@ -249,6 +245,10 @@ testRule({
 		},
 		{
 			code: 'a { padding: 10px calc([10px+5px]); }',
+		},
+		{
+			code: 'a { top: calc(5--6px-7px); }',
+			description: 'custom units',
 		},
 	],
 

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -4,14 +4,12 @@
 
 const cssParserAlgorithms = require('@csstools/css-parser-algorithms');
 const cssTokenizer = require('@csstools/css-tokenizer');
-const keywords = require('../../reference/keywords.cjs');
 const declarationValueIndex = require('../../utils/declarationValueIndex.cjs');
 const getDeclarationValue = require('../../utils/getDeclarationValue.cjs');
-const validateTypes = require('../../utils/validateTypes.cjs');
+const functions = require('../../reference/functions.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const setDeclarationValue = require('../../utils/setDeclarationValue.cjs');
-const functions = require('../../reference/functions.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
 
 const ruleName = 'function-calc-no-unspaced-operator';
@@ -28,9 +26,8 @@ const meta = {
 
 const OPERATORS = new Set(['+', '-']);
 const OPERATOR_REGEX = /[+-]/;
-const ALL_OPERATORS = new Set([...OPERATORS, '*', '/']);
 // #7618
-const alternatives = [...functions.singleArgumentMathFunctions].join('|');
+const alternatives = [...functions.mathFunctions].join('|');
 const FUNC_NAMES_REGEX = new RegExp(`^(?:${alternatives})$`, 'i');
 const FUNC_CALLS_REGEX = new RegExp(`(?:${alternatives})\\(`, 'i');
 
@@ -65,18 +62,179 @@ const rule = (primary, _secondaryOptions, context) => {
 			let needsFix = false;
 			const valueIndex = declarationValueIndex(decl);
 
-			/**
-			 * @param {import('@csstools/css-parser-algorithms').TokenNode} operatorNode
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} parent
-			 * @param {number} index
-			 * @param {'before' | 'after'} position
-			 * @returns {void}
-			 */
-			function checkWhitespaceAroundOperator(operatorNode, parent, index, position) {
-				const aroundNode = parent.value[index + (position === 'before' ? -1 : 1)];
+			const tokens = cssTokenizer.tokenize({ css: value });
 
-				if (cssParserAlgorithms.isWhitespaceNode(aroundNode)) {
-					const whitespace = getWhitespace(aroundNode);
+			{
+				// Step 1
+				// Re-tokenize dimensions with units containing dashes.
+				// These might be typo's.
+				// For example: `10px-20px` has a unit of `px-20px`
+				for (let i = 0; i < tokens.length; i++) {
+					const token = tokens[i];
+
+					// NOTE:
+					// This is a mess, I am fairly certain that it is correct, but too much is happening with strings.
+					// This will be brittle and might break when the css-tokenizer is updated.
+					// It will also produce invalid CSS for exotic units, nu such units exists today.
+					if (!token || token[0] !== cssTokenizer.TokenType.Dimension) continue;
+
+					if (token[4].unit.startsWith('--')) continue;
+
+					const indexOfDash = token[4].unit.indexOf('-');
+
+					if (indexOfDash === -1) continue;
+
+					const remainder = token[4].unit.slice(indexOfDash);
+
+					if (remainder.length === 1) continue;
+
+					token[4].unit = token[4].unit.slice(0, indexOfDash);
+					token[1] = `${token[4].signCharacter === '+' ? '+' : ''}${token[4].value}${
+						token[4].unit
+					}`;
+					token[3] = token[2] + token[1].length;
+
+					const remainderTokens = cssTokenizer.tokenize({ css: remainder }).slice(0, -1);
+
+					remainderTokens.forEach((remainderToken) => {
+						remainderToken[2] += token[3];
+						remainderToken[3] += token[3];
+					});
+
+					tokens.splice(i + 1, 0, ...remainderTokens);
+				}
+			}
+
+			const nodes = cssParserAlgorithms.parseListOfComponentValues(tokens);
+
+			if (nodes.length === 0) return;
+
+			/**
+			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {CompleteOperation} operation
+			 */
+			function checkCompleteOperation(node, operation) {
+				if (operation.before.length && operation.after.length) return;
+
+				if (!operation.before.length) {
+					if (context.fix) {
+						needsFix = true;
+						node.value.splice(
+							node.value.indexOf(operation.operator),
+							0,
+							new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]]),
+						);
+					} else {
+						complain(
+							messages.expectedBefore(operation.operatorToken[4].value),
+							decl,
+							valueIndex + operation.operatorToken[2],
+							operation.operatorToken[4].value,
+						);
+					}
+				}
+
+				if (!operation.after.length) {
+					if (context.fix) {
+						needsFix = true;
+						node.value.splice(
+							node.value.indexOf(operation.operator) + 1,
+							0,
+							new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]]),
+						);
+					} else {
+						complain(
+							messages.expectedAfter(operation.operatorToken[4].value),
+							decl,
+							valueIndex + operation.operatorToken[2],
+							operation.operatorToken[4].value,
+						);
+					}
+				}
+			}
+
+			/**
+			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {OperationWithoutOperator} operation
+			 */
+			function checkOperationWithoutOperator(node, operation) {
+				if (
+					cssParserAlgorithms.isTokenNode(operation.firstOperand) &&
+					operation.firstOperand.value[0] === cssTokenizer.TokenType.Dimension
+				) {
+					const token = operation.firstOperand.value;
+					const operatorChar = operation.firstOperand.value[4].unit.slice(-1);
+
+					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+						operation.operatorToken = [
+							cssTokenizer.TokenType.Delim,
+							operatorChar,
+							token[3],
+							token[3] + 1,
+							{ value: operatorChar },
+						];
+						operation.operator = new cssParserAlgorithms.TokenNode(operation.operatorToken);
+						operation.after = operation.before;
+						operation.before = [];
+
+						if (context.fix) {
+							needsFix = true;
+
+							node.value.splice(
+								node.value.indexOf(operation.firstOperand) + 1,
+								0,
+								operation.operator,
+							);
+
+							token[4].unit = token[4].unit.slice(0, -1);
+							token[1] = token[1].slice(0, -1);
+						}
+
+						return;
+					}
+				}
+
+				if (
+					cssParserAlgorithms.isTokenNode(operation.secondOperand) &&
+					(operation.secondOperand.value[0] === cssTokenizer.TokenType.Dimension ||
+						operation.secondOperand.value[0] === cssTokenizer.TokenType.Percentage ||
+						operation.secondOperand.value[0] === cssTokenizer.TokenType.Number)
+				) {
+					const token = operation.secondOperand.value;
+					const operatorChar = token[4].signCharacter;
+
+					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+						operation.operatorToken = [
+							cssTokenizer.TokenType.Delim,
+							operatorChar,
+							token[2],
+							token[3],
+							{ value: operatorChar },
+						];
+						operation.operator = new cssParserAlgorithms.TokenNode(operation.operatorToken);
+
+						if (context.fix) {
+							needsFix = true;
+
+							node.value.splice(node.value.indexOf(operation.secondOperand), 0, operation.operator);
+
+							token[4].signCharacter = undefined;
+							token[1] = token[1].slice(1);
+						}
+					}
+				}
+			}
+
+			/**
+			 * @param {CompleteOperation} operation
+			 * @param {CompleteOperation["before"] | CompleteOperation["after"]} whitespaceNodes
+			 * @param {'before' | 'after'} position
+			 */
+			function checkOperandWhitespace(operation, whitespaceNodes, position) {
+				const firstWhitespaceNode = whitespaceNodes[0];
+
+				if (whitespaceNodes.length === 1 && cssParserAlgorithms.isWhitespaceNode(firstWhitespaceNode)) {
+					const whitespace = firstWhitespaceNode.toString();
 
 					if (whitespace === ' ') return;
 
@@ -87,150 +245,98 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (context.fix) {
 						needsFix = true;
 
-						const [token] = aroundNode.value;
-
-						if (token) {
-							token[1] = indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine);
-						}
-
-						return;
-					}
-				} else if (
-					cssParserAlgorithms.isTokenNode(aroundNode) &&
-					(isOperandNode(aroundNode) || isScssInterpolation(aroundNode, parent))
-				) {
-					if (context.fix) {
-						needsFix = true;
-
-						if (position === 'before') {
-							aroundNode.value[1] += ' ';
-						} else {
-							aroundNode.value[1] = ` ${aroundNode.value[1]}`;
-						}
-
-						return;
-					}
-				} else {
-					return;
-				}
-
-				const delimToken = getDelimToken(operatorNode);
-
-				if (!delimToken) return;
-
-				const { value: operator, startIndex } = delimToken;
-
-				const message =
-					position === 'before'
-						? messages.expectedBefore(operator)
-						: messages.expectedAfter(operator);
-
-				complain(message, decl, valueIndex + startIndex, operator);
-			}
-
-			/**
-			 * @param {import('@csstools/css-parser-algorithms').TokenNode} operandNode
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} parent
-			 * @param {number} index
-			 * @returns {void}
-			 */
-			function checkOperands(operandNode, parent, index) {
-				const operandToken = operandNode.value;
-
-				if (!isOperandToken(operandToken)) return;
-
-				const [, operand, operandIndex] = operandToken;
-
-				if (!OPERATOR_REGEX.test(operand)) return;
-
-				const beforeOperandNode = parent.value[index - 1];
-				const isFirstOperand = !parent.value.slice(0, index).some(cssParserAlgorithms.isTokenNode);
-				const isLastOperand = !parent.value.slice(index + 1).some(cssParserAlgorithms.isTokenNode);
-				const hasOperatorBeforeOperand = parent.value
-					.slice(0, index)
-					.findLast((node) => isOperatorNode(node, ALL_OPERATORS));
-
-				let fixedOperand = operand;
-				let fixedCount = 0;
-
-				// Scan operator characters in an operand token
-				for (const matched of operand.matchAll(new RegExp(OPERATOR_REGEX, 'g'))) {
-					const operator = matched[0];
-					const operatorIndex = matched.index;
-
-					// Ignore a number sign in the first operand, e.g. "calc(-1px)"
-					if (operatorIndex === 0 && isFirstOperand) continue;
-
-					// Ignore a suffixed operator in the last operand, e.g. "calc(1px-)"
-					if (operatorIndex === operand.length - 1 && isLastOperand) continue;
-
-					const beforeOperator = operand.charAt(operatorIndex - 1);
-
-					if ((beforeOperator && beforeOperator !== ' ') || isOperandNode(beforeOperandNode)) {
-						if (context.fix) {
-							fixedOperand = insertCharAtIndex(fixedOperand, operatorIndex + fixedCount, ' ');
-							fixedCount++;
-						} else {
-							complain(
-								messages.expectedBefore(operator),
-								decl,
-								valueIndex + operandIndex + operatorIndex,
-								operator,
-							);
-						}
-					}
-
-					const afterOperator = operand.charAt(operatorIndex + 1);
-
-					if (afterOperator && afterOperator !== ' ' && !hasOperatorBeforeOperand) {
-						if (context.fix) {
-							fixedOperand = insertCharAtIndex(fixedOperand, operatorIndex + fixedCount + 1, ' ');
-							fixedCount++;
-						} else {
-							complain(
-								messages.expectedAfter(operator),
-								decl,
-								valueIndex + operandIndex + operatorIndex,
-								operator,
-							);
-						}
-					}
-				}
-
-				if (fixedCount > 0) {
-					needsFix = true;
-					operandToken[1] = fixedOperand;
-				}
-			}
-
-			const nodes = cssParserAlgorithms.parseListOfComponentValues(cssTokenizer.tokenize({ css: value }));
-
-			if (nodes.length === 0) return;
-
-			cssParserAlgorithms.walk(nodes, ({ node: funcNode }) => {
-				if (!cssParserAlgorithms.isFunctionNode(funcNode)) return;
-
-				if (!FUNC_NAMES_REGEX.test(funcNode.getName())) return;
-
-				funcNode.forEach(({ node, parent }, index) => {
-					if (!validateTypes.isNumber(index)) return;
-
-					if (!cssParserAlgorithms.isTokenNode(node)) return;
-
-					if (isOperatorNode(node, OPERATORS)) {
-						// Skip when there are no tokens before the operator.
-						if (!parent.value.slice(0, index).some(cssParserAlgorithms.isTokenNode)) return;
-
-						// Skip when there are no tokens after the operator.
-						if (!parent.value.slice(index + 1).some(cssParserAlgorithms.isTokenNode)) return;
-
-						checkWhitespaceAroundOperator(node, parent, index, 'before');
-						checkWhitespaceAroundOperator(node, parent, index, 'after');
+						firstWhitespaceNode.value = [
+							[
+								cssTokenizer.TokenType.Whitespace,
+								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
+								-1,
+								-1,
+								undefined,
+							],
+						];
 					} else {
-						checkOperands(node, parent, index);
+						const message =
+							position === 'before' ? messages.expectedBefore : messages.expectedAfter;
+
+						complain(
+							message(operation.operatorToken[4].value),
+							decl,
+							valueIndex + operation.operatorToken[2],
+							operation.operatorToken[4].value,
+						);
 					}
-				});
-			});
+				}
+			}
+
+			cssParserAlgorithms.walk(
+				nodes,
+				({ node, state }) => {
+					if (!state) return;
+
+					// Step 2
+					// Make sure that we are in a math context.
+					// Once in a math context we remain in one until we encounter a non-math function.
+					// Simple blocks with parentheses are the same as `calc()`
+					if (cssParserAlgorithms.isFunctionNode(node)) {
+						state.inMathFunction = FUNC_NAMES_REGEX.test(node.getName().toLowerCase());
+					} else if (!cssParserAlgorithms.isSimpleBlockNode(node) || node.startToken[0] !== cssTokenizer.TokenType.OpenParen) {
+						state.inMathFunction = false;
+
+						return;
+					}
+
+					if (!state.inMathFunction) return;
+
+					let cursor = 0;
+					/** @type {Operation | undefined} */
+					let operation = undefined;
+
+					while (cursor !== -1 && cursor < node.value.length) {
+						// Step 3
+						// Parse into operations
+						// Each operation consumes as much whitespace before and after
+						// Each parse call tries to consume as much as possible up to the next comma or semicolon
+						// Operations consist of
+						// - first operand
+						// - operator
+						// - second operand
+						// - whitespace before and after
+						[operation, cursor] = parseOperation(node, cursor);
+
+						if (!operation) {
+							cursor++;
+							continue;
+						}
+
+						// Step 4
+						// If there is no operator, try to find one
+						if (isOperationWithoutOperator(operation)) {
+							checkOperationWithoutOperator(node, operation);
+						}
+
+						// Step 5
+						// If the operation is complete, ensure there is whitespace around the operator
+						// The operation might have started without an operator and might have been repaired by Step 4
+						if (isCompleteOperation(operation)) {
+							checkCompleteOperation(node, operation);
+
+							// Step 6
+							// Normalize the whitespace around the operands
+							checkOperandWhitespace(operation, operation.before, 'before');
+							checkOperandWhitespace(operation, operation.after, 'after');
+						}
+
+						if (operation.secondOperand) {
+							cursor = node.value.indexOf(operation.secondOperand);
+						} else {
+							cursor++;
+						}
+					}
+				},
+				{
+					inMathFunction: false,
+				},
+			);
 
 			if (needsFix) {
 				setDeclarationValue(decl, cssParserAlgorithms.stringify([nodes]));
@@ -239,94 +345,168 @@ const rule = (primary, _secondaryOptions, context) => {
 	};
 };
 
-/**
- * @param {string} str
- * @param {number} index
- * @param {string} char
- */
-function insertCharAtIndex(str, index, char) {
-	return str.slice(0, index) + char + str.slice(index, str.length);
-}
-
-/**
- * @param {import('@csstools/css-parser-algorithms').TokenNode} node
- * @returns {{value: string, startIndex: number, endIndex: number} | undefined}
- */
-function getDelimToken(node) {
-	const [type, value, startIndex, endIndex] = node.value;
-
-	if (type !== 'delim-token') return;
-
-	return { value, startIndex, endIndex };
-}
-
-/**
- * @param {import('@csstools/css-parser-algorithms').ComponentValue} node
- * @param {Set<string>} operators
- * @returns {boolean}
- */
-function isOperatorNode(node, operators) {
-	if (!cssParserAlgorithms.isTokenNode(node)) return false;
-
-	return operators.has(getDelimToken(node)?.value ?? '');
-}
-
-/**
- * @param {import('@csstools/css-parser-algorithms').WhitespaceNode} node
- * @returns {string}
- */
-function getWhitespace(node) {
-	return node.value[0]?.[1] ?? '';
-}
-
 /** @see https://drafts.csswg.org/css-values/#typedef-calc-value */
 const OPERAND_TOKEN_TYPES = new Set([
-	'number-token',
-	'dimension-token',
-	'percentage-token',
-	'ident-token',
+	cssTokenizer.TokenType.Number,
+	cssTokenizer.TokenType.Dimension,
+	cssTokenizer.TokenType.Percentage,
+	cssTokenizer.TokenType.Ident,
 ]);
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken} token
- * @returns {boolean}
- */
-function isOperandToken(token) {
-	const [type, value] = token;
-
-	if (!OPERAND_TOKEN_TYPES.has(type)) return false;
-
-	if (type === 'ident-token' && !keywords.calcKeywords.has(value)) return false;
-
-	return true;
-}
 
 /**
  * @param {import('@csstools/css-parser-algorithms').ComponentValue | undefined} node
  * @returns {boolean}
  */
 function isOperandNode(node) {
-	return cssParserAlgorithms.isTokenNode(node) && isOperandToken(node.value);
+	if (cssParserAlgorithms.isSimpleBlockNode(node)) return true;
+
+	if (cssParserAlgorithms.isFunctionNode(node)) {
+		const name = node.getName().toLowerCase();
+
+		if (functions.mathFunctions.has(name) || name === 'var') return true;
+
+		return false;
+	}
+
+	if (!cssParserAlgorithms.isTokenNode(node)) return false;
+
+	return OPERAND_TOKEN_TYPES.has(node.value[0]);
 }
 
 /**
- * @deprecated This support for SCSS interpolation will be removed in the future. It remains only for backward compatiblity.
+ * NOTE: this is messy.
  *
- * @param {import('@csstools/css-parser-algorithms').TokenNode} node
- * @param {import('@csstools/css-parser-algorithms').ContainerNode} parent
- * @returns {boolean}
+ * @typedef {{
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
+ * }} Operation
+ *
+ * @typedef {{
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   operator: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
+ * }} CompleteOperation
+ *
+ * @typedef {{
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
+ * }} OperationWithoutOperator
  */
-function isScssInterpolation(node, parent) {
-	// E.g. "#{$foo}"
-	if (getDelimToken(node)?.value !== '#') return false;
 
-	const afterNode = parent.at(Number(parent.indexOf(node)) + 1);
+/**
+ * @param {Operation} operation
+ * @returns {operation is CompleteOperation}
+ */
+function isCompleteOperation(operation) {
+	return (
+		Boolean(operation.firstOperand) &&
+		Boolean(operation.secondOperand) &&
+		Boolean(operation.operator) &&
+		Boolean(operation.operatorToken)
+	);
+}
 
-	if (!cssParserAlgorithms.isSimpleBlockNode(afterNode)) return false;
+/**
+ * @param {Operation} operation
+ * @returns {operation is OperationWithoutOperator}
+ */
+function isOperationWithoutOperator(operation) {
+	return (
+		Boolean(operation.firstOperand) &&
+		Boolean(operation.secondOperand) &&
+		!operation.operator &&
+		!operation.operatorToken
+	);
+}
 
-	const varNode = afterNode.at(0);
+/**
+ * @param {import('@csstools/css-parser-algorithms').ContainerNode} container
+ * @param {number} cursor
+ * @returns {[Operation | undefined, number]}
+ */
+function parseOperation(container, cursor) {
+	/** @type {Operation} */
+	const operation = {
+		firstOperand: undefined,
+		before: [],
+		secondOperand: undefined,
+		after: [],
+		operator: undefined,
+		operatorToken: undefined,
+	};
 
-	return cssParserAlgorithms.isTokenNode(varNode) && getDelimToken(varNode)?.value === '$';
+	let currentNode = container.value[cursor];
+
+	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
+		currentNode = container.value[++cursor];
+	}
+
+	if (isOperandNode(currentNode)) {
+		operation.firstOperand = currentNode;
+
+		currentNode = container.value[++cursor];
+	}
+
+	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
+		operation.before.push(currentNode);
+
+		currentNode = container.value[++cursor];
+	}
+
+	if (
+		cssParserAlgorithms.isTokenNode(currentNode) &&
+		currentNode.value[0] === cssTokenizer.TokenType.Delim &&
+		OPERATORS.has(currentNode.value[4].value)
+	) {
+		operation.operator = currentNode;
+		operation.operatorToken = currentNode.value;
+
+		currentNode = container.value[++cursor];
+	}
+
+	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
+		operation.after.push(currentNode);
+
+		currentNode = container.value[++cursor];
+	}
+
+	if (isOperandNode(currentNode)) {
+		operation.secondOperand = currentNode;
+
+		currentNode = container.value[++cursor];
+	}
+
+	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
+		currentNode = container.value[++cursor];
+	}
+
+	if (!operation.firstOperand || !operation.secondOperand) {
+		while (currentNode) {
+			if (
+				cssParserAlgorithms.isTokenNode(currentNode) &&
+				(currentNode.value[0] === cssTokenizer.TokenType.Comma || currentNode.value[0] === cssTokenizer.TokenType.Semicolon)
+			) {
+				return [undefined, cursor];
+			}
+
+			currentNode = container.value[++cursor];
+		}
+
+		return [undefined, container.value.length];
+	}
+
+	return [operation, cursor];
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -140,7 +140,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			function checkCompleteOperation(node, operation) {
 				if (operation.before.length && operation.after.length) return;
 
-				if (!operation.before.length) {
+				if (!operation.before.find(cssParserAlgorithms.isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -158,7 +158,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					}
 				}
 
-				if (!operation.after.length) {
+				if (!operation.after.find(cssParserAlgorithms.isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -255,10 +255,10 @@ const rule = (primary, _secondaryOptions, context) => {
 			 * @param {'before' | 'after'} position
 			 */
 			function checkOperandWhitespace(operation, whitespaceNodes, position) {
-				const firstWhitespaceNode = whitespaceNodes[0];
+				whitespaceNodes.forEach((whitespaceNode) => {
+					if (!cssParserAlgorithms.isWhitespaceNode(whitespaceNode)) return;
 
-				if (whitespaceNodes.length === 1 && cssParserAlgorithms.isWhitespaceNode(firstWhitespaceNode)) {
-					const whitespace = firstWhitespaceNode.toString();
+					const whitespace = whitespaceNode.toString();
 
 					if (whitespace === ' ') return;
 
@@ -269,7 +269,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (context.fix) {
 						needsFix = true;
 
-						firstWhitespaceNode.value = [
+						whitespaceNode.value = [
 							[
 								cssTokenizer.TokenType.Whitespace,
 								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
@@ -289,7 +289,7 @@ const rule = (primary, _secondaryOptions, context) => {
 							operation.operatorToken[4].value,
 						);
 					}
-				}
+				});
 			}
 
 			cssParserAlgorithms.walk(

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -26,12 +26,16 @@ const meta = {
 
 const OPERATORS = new Set(['+', '-']);
 const OPERATOR_REGEX = /[+-]/;
-// #7618
 const alternatives = [...functions.mathFunctions].join('|');
 const FUNC_NAMES_REGEX = new RegExp(`^(?:${alternatives})$`, 'i');
 const FUNC_CALLS_REGEX = new RegExp(`(?:${alternatives})\\(`, 'i');
 
 const NEWLINE_REGEX = /\n|\r\n/;
+
+/**
+ * @typedef {import ('@csstools/css-parser-algorithms').ComponentValue} ComponentValue
+ * @typedef {import ('@csstools/css-parser-algorithms').ContainerNode} ContainerNode
+ */
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
@@ -76,7 +80,12 @@ const rule = (primary, _secondaryOptions, context) => {
 					// NOTE:
 					// This is a mess, I am fairly certain that it is correct, but too much is happening with strings.
 					// This will be brittle and might break when the css-tokenizer is updated.
-					// It will also produce invalid CSS for exotic units, nu such units exists today.
+
+					// Note:
+					// This will produce invalid CSS for exotic units (e.g. `1\\23`).
+					// No such units are specified today.
+					// Correctly serializing units would resolve any issues.
+
 					if (!token || token[0] !== cssTokenizer.TokenType.Dimension) continue;
 
 					if (token[4].unit.startsWith('--')) continue;
@@ -134,7 +143,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			if (nodes.length === 0) return;
 
 			/**
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {ContainerNode} node
 			 * @param {CompleteOperation} operation
 			 */
 			function checkCompleteOperation(node, operation) {
@@ -178,7 +187,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			}
 
 			/**
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {ContainerNode} node
 			 * @param {Operation} operation
 			 */
 			function checkOperationWithoutOperator(node, operation) {
@@ -374,7 +383,7 @@ const OPERAND_TOKEN_TYPES = new Set([
 ]);
 
 /**
- * @param {import('@csstools/css-parser-algorithms').ComponentValue | undefined} node
+ * @param {ComponentValue | undefined} node
  * @returns {boolean}
  */
 function isOperandNode(node) {
@@ -397,20 +406,20 @@ function isOperandNode(node) {
  * NOTE: this is messy.
  *
  * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   firstOperand: ComponentValue,
+ *   before: Array<ComponentValue>,
+ *   secondOperand: ComponentValue,
+ *   after: Array<ComponentValue>,
+ *   operator: ComponentValue | undefined,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
  * }} Operation
  *
  * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   operator: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   firstOperand: ComponentValue,
+ *   before: Array<ComponentValue>,
+ *   secondOperand: ComponentValue,
+ *   after: Array<ComponentValue>,
+ *   operator: ComponentValue,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
  * }} CompleteOperation
  */
@@ -442,20 +451,20 @@ function isOperationWithoutOperator(operation) {
 }
 
 /**
- * @param {import('@csstools/css-parser-algorithms').ContainerNode} container
+ * @param {ContainerNode} container
  * @param {number} cursor
  * @returns {[Operation | undefined, number]}
  */
 function parseOperation(container, cursor) {
-	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	/** @type {ComponentValue | undefined} */
 	let firstOperand = undefined;
-	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	/** @type {ComponentValue | undefined} */
 	let secondOperand = undefined;
-	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	/** @type {Array<ComponentValue>} */
 	const before = [];
-	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	/** @type {Array<ComponentValue>} */
 	const after = [];
-	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	/** @type {ComponentValue | undefined} */
 	let operator = undefined;
 	/** @type {import ('@csstools/css-tokenizer').TokenDelim | undefined} */
 	let operatorToken = undefined;

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -179,7 +179,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			/**
 			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
-			 * @param {OperationWithoutOperator} operation
+			 * @param {Operation} operation
 			 */
 			function checkOperationWithoutOperator(node, operation) {
 				if (
@@ -350,11 +350,7 @@ const rule = (primary, _secondaryOptions, context) => {
 							checkOperandWhitespace(operation, operation.after, 'after');
 						}
 
-						if (operation.secondOperand) {
-							cursor = node.value.indexOf(operation.secondOperand);
-						} else {
-							cursor++;
-						}
+						cursor = node.value.indexOf(operation.secondOperand);
 					}
 				},
 				{
@@ -401,9 +397,9 @@ function isOperandNode(node) {
  * NOTE: this is messy.
  *
  * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
  *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
  *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
  *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
@@ -417,15 +413,6 @@ function isOperandNode(node) {
  *   operator: import ('@csstools/css-parser-algorithms').ComponentValue,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
  * }} CompleteOperation
- *
- * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
- *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
- * }} OperationWithoutOperator
  */
 
 /**
@@ -443,7 +430,7 @@ function isCompleteOperation(operation) {
 
 /**
  * @param {Operation} operation
- * @returns {operation is OperationWithoutOperator}
+ * @returns {operation is Operation}
  */
 function isOperationWithoutOperator(operation) {
 	return (
@@ -460,62 +447,77 @@ function isOperationWithoutOperator(operation) {
  * @returns {[Operation | undefined, number]}
  */
 function parseOperation(container, cursor) {
-	/** @type {Operation} */
-	const operation = {
-		firstOperand: undefined,
-		before: [],
-		secondOperand: undefined,
-		after: [],
-		operator: undefined,
-		operatorToken: undefined,
-	};
+	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	let firstOperand = undefined;
+	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	let secondOperand = undefined;
+	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	const before = [];
+	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	const after = [];
+	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	let operator = undefined;
+	/** @type {import ('@csstools/css-tokenizer').TokenDelim | undefined} */
+	let operatorToken = undefined;
 
 	let currentNode = container.value[cursor];
 
+	// Consume as much whitespace and comments as possible
 	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
 		currentNode = container.value[++cursor];
 	}
 
+	// If the current node is an operand, consume it
 	if (isOperandNode(currentNode)) {
-		operation.firstOperand = currentNode;
+		firstOperand = currentNode;
 
 		currentNode = container.value[++cursor];
 	}
 
+	// Consume as much whitespace and comments as possible
+	// Assign to `before`
 	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
-		operation.before.push(currentNode);
+		before.push(currentNode);
 
 		currentNode = container.value[++cursor];
 	}
 
+	// If the current node is an operator, consume it
 	if (
 		cssParserAlgorithms.isTokenNode(currentNode) &&
 		currentNode.value[0] === cssTokenizer.TokenType.Delim &&
 		OPERATORS.has(currentNode.value[4].value)
 	) {
-		operation.operator = currentNode;
-		operation.operatorToken = currentNode.value;
+		operator = currentNode;
+		operatorToken = currentNode.value;
 
 		currentNode = container.value[++cursor];
 	}
 
+	// Consume as much whitespace and comments as possible
+	// Assign to `after`
 	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
-		operation.after.push(currentNode);
+		after.push(currentNode);
 
 		currentNode = container.value[++cursor];
 	}
 
+	// If the current node is an operand, consume it
 	if (isOperandNode(currentNode)) {
-		operation.secondOperand = currentNode;
+		secondOperand = currentNode;
 
 		currentNode = container.value[++cursor];
 	}
 
+	// Consume as much whitespace and comments as possible
 	while (cssParserAlgorithms.isWhitespaceNode(currentNode) || cssParserAlgorithms.isCommentNode(currentNode)) {
 		currentNode = container.value[++cursor];
 	}
 
-	if (!operation.firstOperand || !operation.secondOperand) {
+	// If we have not consumed any operands, we are not in an operation
+	// Do error recovery by consuming until the next comma or semicolon
+	// If no comma or semicolon is found, consume until the end of the container
+	if (!firstOperand || !secondOperand) {
 		while (currentNode) {
 			if (
 				cssParserAlgorithms.isTokenNode(currentNode) &&
@@ -530,7 +532,17 @@ function parseOperation(container, cursor) {
 		return [undefined, container.value.length];
 	}
 
-	return [operation, cursor];
+	return [
+		{
+			firstOperand,
+			before,
+			secondOperand,
+			after,
+			operator,
+			operatorToken,
+		},
+		cursor,
+	];
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -95,7 +95,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					}`;
 					token[3] = token[2] + token[1].length;
 
-					const remainderTokens = cssTokenizer.tokenize({ css: remainder }).slice(0, -1);
+					const remainderTokens = cssTokenizer.tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
 
 					remainderTokens.forEach((remainderToken) => {
 						remainderToken[2] += token[3];

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -1,4 +1,7 @@
 import {
+	TokenNode,
+	WhitespaceNode,
+	isCommentNode,
 	isFunctionNode,
 	isSimpleBlockNode,
 	isTokenNode,
@@ -7,16 +10,14 @@ import {
 	stringify,
 	walk,
 } from '@csstools/css-parser-algorithms';
-import { tokenize } from '@csstools/css-tokenizer';
+import { TokenType, tokenize } from '@csstools/css-tokenizer';
 
-import { calcKeywords } from '../../reference/keywords.mjs';
 import declarationValueIndex from '../../utils/declarationValueIndex.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
-import { isNumber } from '../../utils/validateTypes.mjs';
+import { mathFunctions } from '../../reference/functions.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import setDeclarationValue from '../../utils/setDeclarationValue.mjs';
-import { singleArgumentMathFunctions } from '../../reference/functions.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
 
 const ruleName = 'function-calc-no-unspaced-operator';
@@ -33,9 +34,8 @@ const meta = {
 
 const OPERATORS = new Set(['+', '-']);
 const OPERATOR_REGEX = /[+-]/;
-const ALL_OPERATORS = new Set([...OPERATORS, '*', '/']);
 // #7618
-const alternatives = [...singleArgumentMathFunctions].join('|');
+const alternatives = [...mathFunctions].join('|');
 const FUNC_NAMES_REGEX = new RegExp(`^(?:${alternatives})$`, 'i');
 const FUNC_CALLS_REGEX = new RegExp(`(?:${alternatives})\\(`, 'i');
 
@@ -70,18 +70,179 @@ const rule = (primary, _secondaryOptions, context) => {
 			let needsFix = false;
 			const valueIndex = declarationValueIndex(decl);
 
-			/**
-			 * @param {import('@csstools/css-parser-algorithms').TokenNode} operatorNode
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} parent
-			 * @param {number} index
-			 * @param {'before' | 'after'} position
-			 * @returns {void}
-			 */
-			function checkWhitespaceAroundOperator(operatorNode, parent, index, position) {
-				const aroundNode = parent.value[index + (position === 'before' ? -1 : 1)];
+			const tokens = tokenize({ css: value });
 
-				if (isWhitespaceNode(aroundNode)) {
-					const whitespace = getWhitespace(aroundNode);
+			{
+				// Step 1
+				// Re-tokenize dimensions with units containing dashes.
+				// These might be typo's.
+				// For example: `10px-20px` has a unit of `px-20px`
+				for (let i = 0; i < tokens.length; i++) {
+					const token = tokens[i];
+
+					// NOTE:
+					// This is a mess, I am fairly certain that it is correct, but too much is happening with strings.
+					// This will be brittle and might break when the css-tokenizer is updated.
+					// It will also produce invalid CSS for exotic units, nu such units exists today.
+					if (!token || token[0] !== TokenType.Dimension) continue;
+
+					if (token[4].unit.startsWith('--')) continue;
+
+					const indexOfDash = token[4].unit.indexOf('-');
+
+					if (indexOfDash === -1) continue;
+
+					const remainder = token[4].unit.slice(indexOfDash);
+
+					if (remainder.length === 1) continue;
+
+					token[4].unit = token[4].unit.slice(0, indexOfDash);
+					token[1] = `${token[4].signCharacter === '+' ? '+' : ''}${token[4].value}${
+						token[4].unit
+					}`;
+					token[3] = token[2] + token[1].length;
+
+					const remainderTokens = tokenize({ css: remainder }).slice(0, -1);
+
+					remainderTokens.forEach((remainderToken) => {
+						remainderToken[2] += token[3];
+						remainderToken[3] += token[3];
+					});
+
+					tokens.splice(i + 1, 0, ...remainderTokens);
+				}
+			}
+
+			const nodes = parseListOfComponentValues(tokens);
+
+			if (nodes.length === 0) return;
+
+			/**
+			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {CompleteOperation} operation
+			 */
+			function checkCompleteOperation(node, operation) {
+				if (operation.before.length && operation.after.length) return;
+
+				if (!operation.before.length) {
+					if (context.fix) {
+						needsFix = true;
+						node.value.splice(
+							node.value.indexOf(operation.operator),
+							0,
+							new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]]),
+						);
+					} else {
+						complain(
+							messages.expectedBefore(operation.operatorToken[4].value),
+							decl,
+							valueIndex + operation.operatorToken[2],
+							operation.operatorToken[4].value,
+						);
+					}
+				}
+
+				if (!operation.after.length) {
+					if (context.fix) {
+						needsFix = true;
+						node.value.splice(
+							node.value.indexOf(operation.operator) + 1,
+							0,
+							new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]]),
+						);
+					} else {
+						complain(
+							messages.expectedAfter(operation.operatorToken[4].value),
+							decl,
+							valueIndex + operation.operatorToken[2],
+							operation.operatorToken[4].value,
+						);
+					}
+				}
+			}
+
+			/**
+			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {OperationWithoutOperator} operation
+			 */
+			function checkOperationWithoutOperator(node, operation) {
+				if (
+					isTokenNode(operation.firstOperand) &&
+					operation.firstOperand.value[0] === TokenType.Dimension
+				) {
+					const token = operation.firstOperand.value;
+					const operatorChar = operation.firstOperand.value[4].unit.slice(-1);
+
+					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+						operation.operatorToken = [
+							TokenType.Delim,
+							operatorChar,
+							token[3],
+							token[3] + 1,
+							{ value: operatorChar },
+						];
+						operation.operator = new TokenNode(operation.operatorToken);
+						operation.after = operation.before;
+						operation.before = [];
+
+						if (context.fix) {
+							needsFix = true;
+
+							node.value.splice(
+								node.value.indexOf(operation.firstOperand) + 1,
+								0,
+								operation.operator,
+							);
+
+							token[4].unit = token[4].unit.slice(0, -1);
+							token[1] = token[1].slice(0, -1);
+						}
+
+						return;
+					}
+				}
+
+				if (
+					isTokenNode(operation.secondOperand) &&
+					(operation.secondOperand.value[0] === TokenType.Dimension ||
+						operation.secondOperand.value[0] === TokenType.Percentage ||
+						operation.secondOperand.value[0] === TokenType.Number)
+				) {
+					const token = operation.secondOperand.value;
+					const operatorChar = token[4].signCharacter;
+
+					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+						operation.operatorToken = [
+							TokenType.Delim,
+							operatorChar,
+							token[2],
+							token[3],
+							{ value: operatorChar },
+						];
+						operation.operator = new TokenNode(operation.operatorToken);
+
+						if (context.fix) {
+							needsFix = true;
+
+							node.value.splice(node.value.indexOf(operation.secondOperand), 0, operation.operator);
+
+							token[4].signCharacter = undefined;
+							token[1] = token[1].slice(1);
+						}
+					}
+				}
+			}
+
+			/**
+			 * @param {CompleteOperation} operation
+			 * @param {CompleteOperation["before"] | CompleteOperation["after"]} whitespaceNodes
+			 * @param {'before' | 'after'} position
+			 */
+			function checkOperandWhitespace(operation, whitespaceNodes, position) {
+				const firstWhitespaceNode = whitespaceNodes[0];
+
+				if (whitespaceNodes.length === 1 && isWhitespaceNode(firstWhitespaceNode)) {
+					const whitespace = firstWhitespaceNode.toString();
 
 					if (whitespace === ' ') return;
 
@@ -92,150 +253,98 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (context.fix) {
 						needsFix = true;
 
-						const [token] = aroundNode.value;
-
-						if (token) {
-							token[1] = indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine);
-						}
-
-						return;
-					}
-				} else if (
-					isTokenNode(aroundNode) &&
-					(isOperandNode(aroundNode) || isScssInterpolation(aroundNode, parent))
-				) {
-					if (context.fix) {
-						needsFix = true;
-
-						if (position === 'before') {
-							aroundNode.value[1] += ' ';
-						} else {
-							aroundNode.value[1] = ` ${aroundNode.value[1]}`;
-						}
-
-						return;
-					}
-				} else {
-					return;
-				}
-
-				const delimToken = getDelimToken(operatorNode);
-
-				if (!delimToken) return;
-
-				const { value: operator, startIndex } = delimToken;
-
-				const message =
-					position === 'before'
-						? messages.expectedBefore(operator)
-						: messages.expectedAfter(operator);
-
-				complain(message, decl, valueIndex + startIndex, operator);
-			}
-
-			/**
-			 * @param {import('@csstools/css-parser-algorithms').TokenNode} operandNode
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} parent
-			 * @param {number} index
-			 * @returns {void}
-			 */
-			function checkOperands(operandNode, parent, index) {
-				const operandToken = operandNode.value;
-
-				if (!isOperandToken(operandToken)) return;
-
-				const [, operand, operandIndex] = operandToken;
-
-				if (!OPERATOR_REGEX.test(operand)) return;
-
-				const beforeOperandNode = parent.value[index - 1];
-				const isFirstOperand = !parent.value.slice(0, index).some(isTokenNode);
-				const isLastOperand = !parent.value.slice(index + 1).some(isTokenNode);
-				const hasOperatorBeforeOperand = parent.value
-					.slice(0, index)
-					.findLast((node) => isOperatorNode(node, ALL_OPERATORS));
-
-				let fixedOperand = operand;
-				let fixedCount = 0;
-
-				// Scan operator characters in an operand token
-				for (const matched of operand.matchAll(new RegExp(OPERATOR_REGEX, 'g'))) {
-					const operator = matched[0];
-					const operatorIndex = matched.index;
-
-					// Ignore a number sign in the first operand, e.g. "calc(-1px)"
-					if (operatorIndex === 0 && isFirstOperand) continue;
-
-					// Ignore a suffixed operator in the last operand, e.g. "calc(1px-)"
-					if (operatorIndex === operand.length - 1 && isLastOperand) continue;
-
-					const beforeOperator = operand.charAt(operatorIndex - 1);
-
-					if ((beforeOperator && beforeOperator !== ' ') || isOperandNode(beforeOperandNode)) {
-						if (context.fix) {
-							fixedOperand = insertCharAtIndex(fixedOperand, operatorIndex + fixedCount, ' ');
-							fixedCount++;
-						} else {
-							complain(
-								messages.expectedBefore(operator),
-								decl,
-								valueIndex + operandIndex + operatorIndex,
-								operator,
-							);
-						}
-					}
-
-					const afterOperator = operand.charAt(operatorIndex + 1);
-
-					if (afterOperator && afterOperator !== ' ' && !hasOperatorBeforeOperand) {
-						if (context.fix) {
-							fixedOperand = insertCharAtIndex(fixedOperand, operatorIndex + fixedCount + 1, ' ');
-							fixedCount++;
-						} else {
-							complain(
-								messages.expectedAfter(operator),
-								decl,
-								valueIndex + operandIndex + operatorIndex,
-								operator,
-							);
-						}
-					}
-				}
-
-				if (fixedCount > 0) {
-					needsFix = true;
-					operandToken[1] = fixedOperand;
-				}
-			}
-
-			const nodes = parseListOfComponentValues(tokenize({ css: value }));
-
-			if (nodes.length === 0) return;
-
-			walk(nodes, ({ node: funcNode }) => {
-				if (!isFunctionNode(funcNode)) return;
-
-				if (!FUNC_NAMES_REGEX.test(funcNode.getName())) return;
-
-				funcNode.forEach(({ node, parent }, index) => {
-					if (!isNumber(index)) return;
-
-					if (!isTokenNode(node)) return;
-
-					if (isOperatorNode(node, OPERATORS)) {
-						// Skip when there are no tokens before the operator.
-						if (!parent.value.slice(0, index).some(isTokenNode)) return;
-
-						// Skip when there are no tokens after the operator.
-						if (!parent.value.slice(index + 1).some(isTokenNode)) return;
-
-						checkWhitespaceAroundOperator(node, parent, index, 'before');
-						checkWhitespaceAroundOperator(node, parent, index, 'after');
+						firstWhitespaceNode.value = [
+							[
+								TokenType.Whitespace,
+								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
+								-1,
+								-1,
+								undefined,
+							],
+						];
 					} else {
-						checkOperands(node, parent, index);
+						const message =
+							position === 'before' ? messages.expectedBefore : messages.expectedAfter;
+
+						complain(
+							message(operation.operatorToken[4].value),
+							decl,
+							valueIndex + operation.operatorToken[2],
+							operation.operatorToken[4].value,
+						);
 					}
-				});
-			});
+				}
+			}
+
+			walk(
+				nodes,
+				({ node, state }) => {
+					if (!state) return;
+
+					// Step 2
+					// Make sure that we are in a math context.
+					// Once in a math context we remain in one until we encounter a non-math function.
+					// Simple blocks with parentheses are the same as `calc()`
+					if (isFunctionNode(node)) {
+						state.inMathFunction = FUNC_NAMES_REGEX.test(node.getName().toLowerCase());
+					} else if (!isSimpleBlockNode(node) || node.startToken[0] !== TokenType.OpenParen) {
+						state.inMathFunction = false;
+
+						return;
+					}
+
+					if (!state.inMathFunction) return;
+
+					let cursor = 0;
+					/** @type {Operation | undefined} */
+					let operation = undefined;
+
+					while (cursor !== -1 && cursor < node.value.length) {
+						// Step 3
+						// Parse into operations
+						// Each operation consumes as much whitespace before and after
+						// Each parse call tries to consume as much as possible up to the next comma or semicolon
+						// Operations consist of
+						// - first operand
+						// - operator
+						// - second operand
+						// - whitespace before and after
+						[operation, cursor] = parseOperation(node, cursor);
+
+						if (!operation) {
+							cursor++;
+							continue;
+						}
+
+						// Step 4
+						// If there is no operator, try to find one
+						if (isOperationWithoutOperator(operation)) {
+							checkOperationWithoutOperator(node, operation);
+						}
+
+						// Step 5
+						// If the operation is complete, ensure there is whitespace around the operator
+						// The operation might have started without an operator and might have been repaired by Step 4
+						if (isCompleteOperation(operation)) {
+							checkCompleteOperation(node, operation);
+
+							// Step 6
+							// Normalize the whitespace around the operands
+							checkOperandWhitespace(operation, operation.before, 'before');
+							checkOperandWhitespace(operation, operation.after, 'after');
+						}
+
+						if (operation.secondOperand) {
+							cursor = node.value.indexOf(operation.secondOperand);
+						} else {
+							cursor++;
+						}
+					}
+				},
+				{
+					inMathFunction: false,
+				},
+			);
 
 			if (needsFix) {
 				setDeclarationValue(decl, stringify([nodes]));
@@ -244,94 +353,168 @@ const rule = (primary, _secondaryOptions, context) => {
 	};
 };
 
-/**
- * @param {string} str
- * @param {number} index
- * @param {string} char
- */
-function insertCharAtIndex(str, index, char) {
-	return str.slice(0, index) + char + str.slice(index, str.length);
-}
-
-/**
- * @param {import('@csstools/css-parser-algorithms').TokenNode} node
- * @returns {{value: string, startIndex: number, endIndex: number} | undefined}
- */
-function getDelimToken(node) {
-	const [type, value, startIndex, endIndex] = node.value;
-
-	if (type !== 'delim-token') return;
-
-	return { value, startIndex, endIndex };
-}
-
-/**
- * @param {import('@csstools/css-parser-algorithms').ComponentValue} node
- * @param {Set<string>} operators
- * @returns {boolean}
- */
-function isOperatorNode(node, operators) {
-	if (!isTokenNode(node)) return false;
-
-	return operators.has(getDelimToken(node)?.value ?? '');
-}
-
-/**
- * @param {import('@csstools/css-parser-algorithms').WhitespaceNode} node
- * @returns {string}
- */
-function getWhitespace(node) {
-	return node.value[0]?.[1] ?? '';
-}
-
 /** @see https://drafts.csswg.org/css-values/#typedef-calc-value */
 const OPERAND_TOKEN_TYPES = new Set([
-	'number-token',
-	'dimension-token',
-	'percentage-token',
-	'ident-token',
+	TokenType.Number,
+	TokenType.Dimension,
+	TokenType.Percentage,
+	TokenType.Ident,
 ]);
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken} token
- * @returns {boolean}
- */
-function isOperandToken(token) {
-	const [type, value] = token;
-
-	if (!OPERAND_TOKEN_TYPES.has(type)) return false;
-
-	if (type === 'ident-token' && !calcKeywords.has(value)) return false;
-
-	return true;
-}
 
 /**
  * @param {import('@csstools/css-parser-algorithms').ComponentValue | undefined} node
  * @returns {boolean}
  */
 function isOperandNode(node) {
-	return isTokenNode(node) && isOperandToken(node.value);
+	if (isSimpleBlockNode(node)) return true;
+
+	if (isFunctionNode(node)) {
+		const name = node.getName().toLowerCase();
+
+		if (mathFunctions.has(name) || name === 'var') return true;
+
+		return false;
+	}
+
+	if (!isTokenNode(node)) return false;
+
+	return OPERAND_TOKEN_TYPES.has(node.value[0]);
 }
 
 /**
- * @deprecated This support for SCSS interpolation will be removed in the future. It remains only for backward compatiblity.
+ * NOTE: this is messy.
  *
- * @param {import('@csstools/css-parser-algorithms').TokenNode} node
- * @param {import('@csstools/css-parser-algorithms').ContainerNode} parent
- * @returns {boolean}
+ * @typedef {{
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
+ * }} Operation
+ *
+ * @typedef {{
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   operator: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
+ * }} CompleteOperation
+ *
+ * @typedef {{
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
+ *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
+ * }} OperationWithoutOperator
  */
-function isScssInterpolation(node, parent) {
-	// E.g. "#{$foo}"
-	if (getDelimToken(node)?.value !== '#') return false;
 
-	const afterNode = parent.at(Number(parent.indexOf(node)) + 1);
+/**
+ * @param {Operation} operation
+ * @returns {operation is CompleteOperation}
+ */
+function isCompleteOperation(operation) {
+	return (
+		Boolean(operation.firstOperand) &&
+		Boolean(operation.secondOperand) &&
+		Boolean(operation.operator) &&
+		Boolean(operation.operatorToken)
+	);
+}
 
-	if (!isSimpleBlockNode(afterNode)) return false;
+/**
+ * @param {Operation} operation
+ * @returns {operation is OperationWithoutOperator}
+ */
+function isOperationWithoutOperator(operation) {
+	return (
+		Boolean(operation.firstOperand) &&
+		Boolean(operation.secondOperand) &&
+		!operation.operator &&
+		!operation.operatorToken
+	);
+}
 
-	const varNode = afterNode.at(0);
+/**
+ * @param {import('@csstools/css-parser-algorithms').ContainerNode} container
+ * @param {number} cursor
+ * @returns {[Operation | undefined, number]}
+ */
+function parseOperation(container, cursor) {
+	/** @type {Operation} */
+	const operation = {
+		firstOperand: undefined,
+		before: [],
+		secondOperand: undefined,
+		after: [],
+		operator: undefined,
+		operatorToken: undefined,
+	};
 
-	return isTokenNode(varNode) && getDelimToken(varNode)?.value === '$';
+	let currentNode = container.value[cursor];
+
+	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
+		currentNode = container.value[++cursor];
+	}
+
+	if (isOperandNode(currentNode)) {
+		operation.firstOperand = currentNode;
+
+		currentNode = container.value[++cursor];
+	}
+
+	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
+		operation.before.push(currentNode);
+
+		currentNode = container.value[++cursor];
+	}
+
+	if (
+		isTokenNode(currentNode) &&
+		currentNode.value[0] === TokenType.Delim &&
+		OPERATORS.has(currentNode.value[4].value)
+	) {
+		operation.operator = currentNode;
+		operation.operatorToken = currentNode.value;
+
+		currentNode = container.value[++cursor];
+	}
+
+	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
+		operation.after.push(currentNode);
+
+		currentNode = container.value[++cursor];
+	}
+
+	if (isOperandNode(currentNode)) {
+		operation.secondOperand = currentNode;
+
+		currentNode = container.value[++cursor];
+	}
+
+	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
+		currentNode = container.value[++cursor];
+	}
+
+	if (!operation.firstOperand || !operation.secondOperand) {
+		while (currentNode) {
+			if (
+				isTokenNode(currentNode) &&
+				(currentNode.value[0] === TokenType.Comma || currentNode.value[0] === TokenType.Semicolon)
+			) {
+				return [undefined, cursor];
+			}
+
+			currentNode = container.value[++cursor];
+		}
+
+		return [undefined, container.value.length];
+	}
+
+	return [operation, cursor];
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -103,7 +103,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					}`;
 					token[3] = token[2] + token[1].length;
 
-					const remainderTokens = tokenize({ css: remainder }).slice(0, -1);
+					const remainderTokens = tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
 
 					remainderTokens.forEach((remainderToken) => {
 						remainderToken[2] += token[3];

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -187,7 +187,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			/**
 			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
-			 * @param {OperationWithoutOperator} operation
+			 * @param {Operation} operation
 			 */
 			function checkOperationWithoutOperator(node, operation) {
 				if (
@@ -358,11 +358,7 @@ const rule = (primary, _secondaryOptions, context) => {
 							checkOperandWhitespace(operation, operation.after, 'after');
 						}
 
-						if (operation.secondOperand) {
-							cursor = node.value.indexOf(operation.secondOperand);
-						} else {
-							cursor++;
-						}
+						cursor = node.value.indexOf(operation.secondOperand);
 					}
 				},
 				{
@@ -409,9 +405,9 @@ function isOperandNode(node) {
  * NOTE: this is messy.
  *
  * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
  *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
  *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
  *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
@@ -425,15 +421,6 @@ function isOperandNode(node) {
  *   operator: import ('@csstools/css-parser-algorithms').ComponentValue,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
  * }} CompleteOperation
- *
- * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
- *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
- * }} OperationWithoutOperator
  */
 
 /**
@@ -451,7 +438,7 @@ function isCompleteOperation(operation) {
 
 /**
  * @param {Operation} operation
- * @returns {operation is OperationWithoutOperator}
+ * @returns {operation is Operation}
  */
 function isOperationWithoutOperator(operation) {
 	return (
@@ -468,62 +455,77 @@ function isOperationWithoutOperator(operation) {
  * @returns {[Operation | undefined, number]}
  */
 function parseOperation(container, cursor) {
-	/** @type {Operation} */
-	const operation = {
-		firstOperand: undefined,
-		before: [],
-		secondOperand: undefined,
-		after: [],
-		operator: undefined,
-		operatorToken: undefined,
-	};
+	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	let firstOperand = undefined;
+	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	let secondOperand = undefined;
+	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	const before = [];
+	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	const after = [];
+	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	let operator = undefined;
+	/** @type {import ('@csstools/css-tokenizer').TokenDelim | undefined} */
+	let operatorToken = undefined;
 
 	let currentNode = container.value[cursor];
 
+	// Consume as much whitespace and comments as possible
 	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
 		currentNode = container.value[++cursor];
 	}
 
+	// If the current node is an operand, consume it
 	if (isOperandNode(currentNode)) {
-		operation.firstOperand = currentNode;
+		firstOperand = currentNode;
 
 		currentNode = container.value[++cursor];
 	}
 
+	// Consume as much whitespace and comments as possible
+	// Assign to `before`
 	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
-		operation.before.push(currentNode);
+		before.push(currentNode);
 
 		currentNode = container.value[++cursor];
 	}
 
+	// If the current node is an operator, consume it
 	if (
 		isTokenNode(currentNode) &&
 		currentNode.value[0] === TokenType.Delim &&
 		OPERATORS.has(currentNode.value[4].value)
 	) {
-		operation.operator = currentNode;
-		operation.operatorToken = currentNode.value;
+		operator = currentNode;
+		operatorToken = currentNode.value;
 
 		currentNode = container.value[++cursor];
 	}
 
+	// Consume as much whitespace and comments as possible
+	// Assign to `after`
 	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
-		operation.after.push(currentNode);
+		after.push(currentNode);
 
 		currentNode = container.value[++cursor];
 	}
 
+	// If the current node is an operand, consume it
 	if (isOperandNode(currentNode)) {
-		operation.secondOperand = currentNode;
+		secondOperand = currentNode;
 
 		currentNode = container.value[++cursor];
 	}
 
+	// Consume as much whitespace and comments as possible
 	while (isWhitespaceNode(currentNode) || isCommentNode(currentNode)) {
 		currentNode = container.value[++cursor];
 	}
 
-	if (!operation.firstOperand || !operation.secondOperand) {
+	// If we have not consumed any operands, we are not in an operation
+	// Do error recovery by consuming until the next comma or semicolon
+	// If no comma or semicolon is found, consume until the end of the container
+	if (!firstOperand || !secondOperand) {
 		while (currentNode) {
 			if (
 				isTokenNode(currentNode) &&
@@ -538,7 +540,17 @@ function parseOperation(container, cursor) {
 		return [undefined, container.value.length];
 	}
 
-	return [operation, cursor];
+	return [
+		{
+			firstOperand,
+			before,
+			secondOperand,
+			after,
+			operator,
+			operatorToken,
+		},
+		cursor,
+	];
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -148,7 +148,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			function checkCompleteOperation(node, operation) {
 				if (operation.before.length && operation.after.length) return;
 
-				if (!operation.before.length) {
+				if (!operation.before.find(isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -166,7 +166,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					}
 				}
 
-				if (!operation.after.length) {
+				if (!operation.after.find(isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -263,10 +263,10 @@ const rule = (primary, _secondaryOptions, context) => {
 			 * @param {'before' | 'after'} position
 			 */
 			function checkOperandWhitespace(operation, whitespaceNodes, position) {
-				const firstWhitespaceNode = whitespaceNodes[0];
+				whitespaceNodes.forEach((whitespaceNode) => {
+					if (!isWhitespaceNode(whitespaceNode)) return;
 
-				if (whitespaceNodes.length === 1 && isWhitespaceNode(firstWhitespaceNode)) {
-					const whitespace = firstWhitespaceNode.toString();
+					const whitespace = whitespaceNode.toString();
 
 					if (whitespace === ' ') return;
 
@@ -277,7 +277,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (context.fix) {
 						needsFix = true;
 
-						firstWhitespaceNode.value = [
+						whitespaceNode.value = [
 							[
 								TokenType.Whitespace,
 								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
@@ -297,7 +297,7 @@ const rule = (primary, _secondaryOptions, context) => {
 							operation.operatorToken[4].value,
 						);
 					}
-				}
+				});
 			}
 
 			walk(

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -34,12 +34,16 @@ const meta = {
 
 const OPERATORS = new Set(['+', '-']);
 const OPERATOR_REGEX = /[+-]/;
-// #7618
 const alternatives = [...mathFunctions].join('|');
 const FUNC_NAMES_REGEX = new RegExp(`^(?:${alternatives})$`, 'i');
 const FUNC_CALLS_REGEX = new RegExp(`(?:${alternatives})\\(`, 'i');
 
 const NEWLINE_REGEX = /\n|\r\n/;
+
+/**
+ * @typedef {import ('@csstools/css-parser-algorithms').ComponentValue} ComponentValue
+ * @typedef {import ('@csstools/css-parser-algorithms').ContainerNode} ContainerNode
+ */
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
@@ -84,7 +88,12 @@ const rule = (primary, _secondaryOptions, context) => {
 					// NOTE:
 					// This is a mess, I am fairly certain that it is correct, but too much is happening with strings.
 					// This will be brittle and might break when the css-tokenizer is updated.
-					// It will also produce invalid CSS for exotic units, nu such units exists today.
+
+					// Note:
+					// This will produce invalid CSS for exotic units (e.g. `1\\23`).
+					// No such units are specified today.
+					// Correctly serializing units would resolve any issues.
+
 					if (!token || token[0] !== TokenType.Dimension) continue;
 
 					if (token[4].unit.startsWith('--')) continue;
@@ -142,7 +151,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			if (nodes.length === 0) return;
 
 			/**
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {ContainerNode} node
 			 * @param {CompleteOperation} operation
 			 */
 			function checkCompleteOperation(node, operation) {
@@ -186,7 +195,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			}
 
 			/**
-			 * @param {import('@csstools/css-parser-algorithms').ContainerNode} node
+			 * @param {ContainerNode} node
 			 * @param {Operation} operation
 			 */
 			function checkOperationWithoutOperator(node, operation) {
@@ -382,7 +391,7 @@ const OPERAND_TOKEN_TYPES = new Set([
 ]);
 
 /**
- * @param {import('@csstools/css-parser-algorithms').ComponentValue | undefined} node
+ * @param {ComponentValue | undefined} node
  * @returns {boolean}
  */
 function isOperandNode(node) {
@@ -405,20 +414,20 @@ function isOperandNode(node) {
  * NOTE: this is messy.
  *
  * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   operator: import ('@csstools/css-parser-algorithms').ComponentValue | undefined,
+ *   firstOperand: ComponentValue,
+ *   before: Array<ComponentValue>,
+ *   secondOperand: ComponentValue,
+ *   after: Array<ComponentValue>,
+ *   operator: ComponentValue | undefined,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
  * }} Operation
  *
  * @typedef {{
- *   firstOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   before: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   secondOperand: import ('@csstools/css-parser-algorithms').ComponentValue,
- *   after: Array<import ('@csstools/css-parser-algorithms').ComponentValue>,
- *   operator: import ('@csstools/css-parser-algorithms').ComponentValue,
+ *   firstOperand: ComponentValue,
+ *   before: Array<ComponentValue>,
+ *   secondOperand: ComponentValue,
+ *   after: Array<ComponentValue>,
+ *   operator: ComponentValue,
  *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
  * }} CompleteOperation
  */
@@ -450,20 +459,20 @@ function isOperationWithoutOperator(operation) {
 }
 
 /**
- * @param {import('@csstools/css-parser-algorithms').ContainerNode} container
+ * @param {ContainerNode} container
  * @param {number} cursor
  * @returns {[Operation | undefined, number]}
  */
 function parseOperation(container, cursor) {
-	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	/** @type {ComponentValue | undefined} */
 	let firstOperand = undefined;
-	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	/** @type {ComponentValue | undefined} */
 	let secondOperand = undefined;
-	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	/** @type {Array<ComponentValue>} */
 	const before = [];
-	/** @type {Array<import ('@csstools/css-parser-algorithms').ComponentValue>} */
+	/** @type {Array<ComponentValue>} */
 	const after = [];
-	/** @type {import ('@csstools/css-parser-algorithms').ComponentValue | undefined} */
+	/** @type {ComponentValue | undefined} */
 	let operator = undefined;
 	/** @type {import ('@csstools/css-tokenizer').TokenDelim | undefined} */
 	let operatorToken = undefined;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #7618

<hr />

@ybiquitous This rule and the implementation was a lot more complex that I originally thought it would be. Doing pure code review was tricky for me and I needed to take a deep dive.

_The code in this PR is a mess, but it also isn't intended to be used as is.
It can be used, we can continue work from this. But I haven't spend much time on self-review to get it into a really good state._

As I understand it know there are multiple issues and layers.

Steps:
1. Fix units : `10px-20px` -> `10px -20px` (`px-20px` is the entire unit here)
2. Fix missing operators : `10px -20px` -> `10px -|20px` (`|` to indicate that these are separate)
3. Insert whitespace : `10px -|20px` -> `10px - 20px`
4. Normalize whitespace : `10px -\t20px` -> `10px - 20px`


The csstools tokenizer and parsing packages have several aspects that help with some of these steps.

The tokenizer is just arrays, strings and numbers. So Step 1 can be handled purely on the token stream. It is a messy function, but it gives us more control and nice separation of concerns.

The parsing algorithm walker can be stateful. This is useful to keep track of being in a math context or not e.g. `calc((((10px+2px))))`

In general I try to do as much work and analysis on the parsed values (e.g. `token[4].value`, `token[4].unit`, ...) and as little as possible on the string representation (e.g. `token[1]`, `node.toString()`)

My hope is that doing the same work from different angles is a good way to transfer some knowledge :)

Ref #7655