### PR TITLE
Fix `function-calc-no-unspaced-operator` unit and ident escaping

### DIFF
--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -686,17 +686,27 @@ testRule({
 		{
 			code: 'a { top: rgb(from red calc(r+1) calc(g-+2) calc(clamp(10px+2px, g+2, none))); }',
 			fixed:
-				'a { top: rgb(from red calc(r + 1) calc(g- + 2) calc(clamp(10px + 2px, g + 2, none))); }',
+				'a { top: rgb(from red calc(r + 1) calc(g - +2) calc(clamp(10px + 2px, g + 2, none))); }',
 			description: 'nested math expression',
 			warnings: [
 				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 40, endColumn: 41 },
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 40, endColumn: 41 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
+				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
 				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
 				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+			],
+		},
+		{
+			code: 'a { padding: calc(1\\23 - 2px) calc(1\\23 a- 2px) calc(1\\23g- 2px); }',
+			fixed: 'a { padding: calc(1\\23  - 2px) calc(1\\23 a - 2px) calc(1\\23g - 2px); }',
+			description: 'escape sequences as units',
+			warnings: [
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 24, endColumn: 25 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 42, endColumn: 43 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 59, endColumn: 60 },
 			],
 		},
 	],

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -11,7 +11,6 @@ const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const setDeclarationValue = require('../../utils/setDeclarationValue.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
-const typeGuards = require('../../utils/typeGuards.cjs');
 
 const ruleName = 'function-calc-no-unspaced-operator';
 
@@ -77,18 +76,9 @@ const rule = (primary, _secondaryOptions, context) => {
 				// These might be typo's.
 				// For example: `10px-20px` has a unit of `px-20px`
 				tokens.forEach((token, i) => {
-					// NOTE:
-					// This is a mess, I am fairly certain that it is correct, but too much is happening with strings.
-					// This will be brittle and might break when the css-tokenizer is updated.
+					if (!cssTokenizer.isTokenDimension(token)) return;
 
-					// Note:
-					// This will produce invalid CSS for exotic units (e.g. `1\\23`).
-					// No such units are specified today.
-					// Correctly serializing units would resolve any issues.
-
-					if (!typeGuards.isTokenDimension(token)) return;
-
-					const { unit, signCharacter, value: dimensionValue } = token[4];
+					const { unit } = token[4];
 
 					if (unit.startsWith('--')) return;
 
@@ -100,8 +90,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 					if (remainder.length === 1) return;
 
-					token[4].unit = unit.slice(0, indexOfDash);
-					token[1] = `${signCharacter === '+' ? '+' : ''}${dimensionValue}${token[4].unit}`;
+					cssTokenizer.mutateUnit(token, unit.slice(0, indexOfDash));
 					token[3] = token[2] + token[1].length;
 
 					const remainderTokens = cssTokenizer.tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
@@ -119,15 +108,15 @@ const rule = (primary, _secondaryOptions, context) => {
 				// Grouping `#` and `{` into a single token allows us to parse these as simple blocks with curly braces.
 				// For example: `#{$foo}`
 				tokens.forEach((currentToken, i) => {
-					if (!typeGuards.isTokenDelim(currentToken) || currentToken[4].value !== '#') return;
+					if (!cssTokenizer.isTokenDelim(currentToken) || currentToken[4].value !== '#') return;
 
 					const nextToken = tokens[i + 1];
 
-					if (!typeGuards.isTokenOpenCurly(nextToken)) return;
+					if (!cssTokenizer.isTokenOpenCurly(nextToken)) return;
 
 					const nextNextToken = tokens[i + 2];
 
-					if (!typeGuards.isTokenDelim(nextNextToken) || nextNextToken[4].value !== '$') return;
+					if (!cssTokenizer.isTokenDelim(nextNextToken) || nextNextToken[4].value !== '$') return;
 
 					// Set the string representation of the open curly to `#{`
 					nextToken[1] = '#{';
@@ -185,50 +174,80 @@ const rule = (primary, _secondaryOptions, context) => {
 			}
 
 			/**
+			 * @param {Operation} operation
+			 * @param {import('@csstools/css-tokenizer').CSSToken} token
+			 * @param {string} operator
+			 * @returns {asserts operation is CompleteOperation}
+			 */
+			function fixOperationWithoutOperator(operation, token, operator) {
+				operation.operatorToken = [
+					cssTokenizer.TokenType.Delim,
+					operator,
+					token[3],
+					token[3] + 1,
+					{ value: operator },
+				];
+				operation.operator = new cssParserAlgorithms.TokenNode(operation.operatorToken);
+				operation.after = operation.before;
+				operation.before = [];
+			}
+
+			/**
 			 * @param {ContainerNode} node
 			 * @param {Operation} operation
 			 */
 			function checkOperationWithoutOperator(node, operation) {
-				if (cssParserAlgorithms.isTokenNode(operation.firstOperand) && typeGuards.isTokenDimension(operation.firstOperand.value)) {
+				if (cssParserAlgorithms.isTokenNode(operation.firstOperand)) {
 					const token = operation.firstOperand.value;
-					const { unit } = token[4];
-					const operatorChar = unit.slice(-1);
 
-					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-						operation.operatorToken = [
-							cssTokenizer.TokenType.Delim,
-							operatorChar,
-							token[3],
-							token[3] + 1,
-							{ value: operatorChar },
-						];
-						operation.operator = new cssParserAlgorithms.TokenNode(operation.operatorToken);
-						operation.after = operation.before;
-						operation.before = [];
+					if (cssTokenizer.isTokenDimension(token)) {
+						const { unit } = token[4];
+						const operatorChar = unit.slice(-1);
 
-						if (context.fix) {
-							needsFix = true;
+						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+							fixOperationWithoutOperator(operation, token, operatorChar);
 
-							node.value.splice(
-								node.value.indexOf(operation.firstOperand) + 1,
-								0,
-								operation.operator,
-							);
+							if (context.fix) {
+								needsFix = true;
 
-							token[4].unit = unit.slice(0, -1);
-							token[1] = token[1].slice(0, -1);
+								node.value.splice(
+									node.value.indexOf(operation.firstOperand) + 1,
+									0,
+									operation.operator,
+								);
+
+								cssTokenizer.mutateUnit(token, unit.slice(0, -1));
+							}
+
+							return;
 						}
+					}
 
-						return;
+					if (cssTokenizer.isTokenIdent(token)) {
+						const { value: tokenValue } = token[4];
+						const operatorChar = tokenValue.slice(-1);
+
+						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+							fixOperationWithoutOperator(operation, token, operatorChar);
+
+							if (context.fix) {
+								needsFix = true;
+
+								node.value.splice(
+									node.value.indexOf(operation.firstOperand) + 1,
+									0,
+									operation.operator,
+								);
+
+								cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
+							}
+
+							return;
+						}
 					}
 				}
 
-				if (
-					cssParserAlgorithms.isTokenNode(operation.secondOperand) &&
-					(typeGuards.isTokenDimension(operation.secondOperand.value) ||
-						typeGuards.isTokenPercentage(operation.secondOperand.value) ||
-						typeGuards.isTokenNumber(operation.secondOperand.value))
-				) {
+				if (cssParserAlgorithms.isTokenNode(operation.secondOperand) && cssTokenizer.isTokenNumeric(operation.secondOperand.value)) {
 					const token = operation.secondOperand.value;
 					const { signCharacter: operatorChar } = token[4];
 
@@ -308,7 +327,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					// Simple blocks with parentheses are the same as `calc()`
 					if (cssParserAlgorithms.isFunctionNode(node)) {
 						state.inMathFunction = FUNC_NAMES_REGEX.test(node.getName().toLowerCase());
-					} else if (!cssParserAlgorithms.isSimpleBlockNode(node) || !typeGuards.isTokenOpenParen(node.startToken)) {
+					} else if (!cssParserAlgorithms.isSimpleBlockNode(node) || !cssTokenizer.isTokenOpenParen(node.startToken)) {
 						state.inMathFunction = false;
 
 						return;
@@ -490,7 +509,7 @@ function parseOperation(container, cursor) {
 	// If the current node is an operator, consume it
 	if (
 		cssParserAlgorithms.isTokenNode(currentNode) &&
-		typeGuards.isTokenDelim(currentNode.value) &&
+		cssTokenizer.isTokenDelim(currentNode.value) &&
 		OPERATORS.has(currentNode.value[4].value)
 	) {
 		operator = currentNode;
@@ -526,7 +545,7 @@ function parseOperation(container, cursor) {
 		while (currentNode) {
 			if (
 				cssParserAlgorithms.isTokenNode(currentNode) &&
-				(typeGuards.isTokenComma(currentNode.value) || typeGuards.isTokenSemicolon(currentNode.value))
+				(cssTokenizer.isTokenComma(currentNode.value) || cssTokenizer.isTokenSemicolon(currentNode.value))
 			) {
 				return [undefined, cursor];
 			}

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -10,7 +10,20 @@ import {
 	stringify,
 	walk,
 } from '@csstools/css-parser-algorithms';
-import { TokenType, tokenize } from '@csstools/css-tokenizer';
+import {
+	TokenType,
+	isTokenComma,
+	isTokenDelim,
+	isTokenDimension,
+	isTokenIdent,
+	isTokenNumeric,
+	isTokenOpenCurly,
+	isTokenOpenParen,
+	isTokenSemicolon,
+	mutateIdent,
+	mutateUnit,
+	tokenize,
+} from '@csstools/css-tokenizer';
 
 import declarationValueIndex from '../../utils/declarationValueIndex.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
@@ -19,17 +32,6 @@ import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import setDeclarationValue from '../../utils/setDeclarationValue.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
-
-import {
-	isTokenComma,
-	isTokenDelim,
-	isTokenDimension,
-	isTokenNumber,
-	isTokenOpenCurly,
-	isTokenOpenParen,
-	isTokenPercentage,
-	isTokenSemicolon,
-} from '../../utils/typeGuards.mjs';
 
 const ruleName = 'function-calc-no-unspaced-operator';
 
@@ -95,18 +97,9 @@ const rule = (primary, _secondaryOptions, context) => {
 				// These might be typo's.
 				// For example: `10px-20px` has a unit of `px-20px`
 				tokens.forEach((token, i) => {
-					// NOTE:
-					// This is a mess, I am fairly certain that it is correct, but too much is happening with strings.
-					// This will be brittle and might break when the css-tokenizer is updated.
-
-					// Note:
-					// This will produce invalid CSS for exotic units (e.g. `1\\23`).
-					// No such units are specified today.
-					// Correctly serializing units would resolve any issues.
-
 					if (!isTokenDimension(token)) return;
 
-					const { unit, signCharacter, value: dimensionValue } = token[4];
+					const { unit } = token[4];
 
 					if (unit.startsWith('--')) return;
 
@@ -118,8 +111,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 					if (remainder.length === 1) return;
 
-					token[4].unit = unit.slice(0, indexOfDash);
-					token[1] = `${signCharacter === '+' ? '+' : ''}${dimensionValue}${token[4].unit}`;
+					mutateUnit(token, unit.slice(0, indexOfDash));
 					token[3] = token[2] + token[1].length;
 
 					const remainderTokens = tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
@@ -203,50 +195,80 @@ const rule = (primary, _secondaryOptions, context) => {
 			}
 
 			/**
+			 * @param {Operation} operation
+			 * @param {import('@csstools/css-tokenizer').CSSToken} token
+			 * @param {string} operator
+			 * @returns {asserts operation is CompleteOperation}
+			 */
+			function fixOperationWithoutOperator(operation, token, operator) {
+				operation.operatorToken = [
+					TokenType.Delim,
+					operator,
+					token[3],
+					token[3] + 1,
+					{ value: operator },
+				];
+				operation.operator = new TokenNode(operation.operatorToken);
+				operation.after = operation.before;
+				operation.before = [];
+			}
+
+			/**
 			 * @param {ContainerNode} node
 			 * @param {Operation} operation
 			 */
 			function checkOperationWithoutOperator(node, operation) {
-				if (isTokenNode(operation.firstOperand) && isTokenDimension(operation.firstOperand.value)) {
+				if (isTokenNode(operation.firstOperand)) {
 					const token = operation.firstOperand.value;
-					const { unit } = token[4];
-					const operatorChar = unit.slice(-1);
 
-					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-						operation.operatorToken = [
-							TokenType.Delim,
-							operatorChar,
-							token[3],
-							token[3] + 1,
-							{ value: operatorChar },
-						];
-						operation.operator = new TokenNode(operation.operatorToken);
-						operation.after = operation.before;
-						operation.before = [];
+					if (isTokenDimension(token)) {
+						const { unit } = token[4];
+						const operatorChar = unit.slice(-1);
 
-						if (context.fix) {
-							needsFix = true;
+						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+							fixOperationWithoutOperator(operation, token, operatorChar);
 
-							node.value.splice(
-								node.value.indexOf(operation.firstOperand) + 1,
-								0,
-								operation.operator,
-							);
+							if (context.fix) {
+								needsFix = true;
 
-							token[4].unit = unit.slice(0, -1);
-							token[1] = token[1].slice(0, -1);
+								node.value.splice(
+									node.value.indexOf(operation.firstOperand) + 1,
+									0,
+									operation.operator,
+								);
+
+								mutateUnit(token, unit.slice(0, -1));
+							}
+
+							return;
 						}
+					}
 
-						return;
+					if (isTokenIdent(token)) {
+						const { value: tokenValue } = token[4];
+						const operatorChar = tokenValue.slice(-1);
+
+						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
+							fixOperationWithoutOperator(operation, token, operatorChar);
+
+							if (context.fix) {
+								needsFix = true;
+
+								node.value.splice(
+									node.value.indexOf(operation.firstOperand) + 1,
+									0,
+									operation.operator,
+								);
+
+								mutateIdent(token, tokenValue.slice(0, -1));
+							}
+
+							return;
+						}
 					}
 				}
 
-				if (
-					isTokenNode(operation.secondOperand) &&
-					(isTokenDimension(operation.secondOperand.value) ||
-						isTokenPercentage(operation.secondOperand.value) ||
-						isTokenNumber(operation.secondOperand.value))
-				) {
+				if (isTokenNode(operation.secondOperand) && isTokenNumeric(operation.secondOperand.value)) {
 					const token = operation.secondOperand.value;
 					const { signCharacter: operatorChar } = token[4];
 

--- a/lib/utils/typeGuards.cjs
+++ b/lib/utils/typeGuards.cjs
@@ -2,8 +2,6 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-const cssTokenizer = require('@csstools/css-tokenizer');
-
 /** @typedef {import('postcss').Node} Node */
 /** @typedef {import('postcss').Source} NodeSource */
 
@@ -95,70 +93,6 @@ function hasSource(node) {
 	return Boolean(node.source);
 }
 
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenComma}
- */
-function isTokenComma(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.Comma;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenDelim}
- */
-function isTokenDelim(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.Delim;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenDimension}
- */
-function isTokenDimension(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.Dimension;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenNumber}
- */
-function isTokenNumber(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.Number;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenOpenCurly}
- */
-function isTokenOpenCurly(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.OpenCurly;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenOpenParen}
- */
-function isTokenOpenParen(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.OpenParen;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenPercentage}
- */
-function isTokenPercentage(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.Percentage;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenSemicolon}
- */
-function isTokenSemicolon(token) {
-	return token !== undefined && token[0] === cssTokenizer.TokenType.Semicolon;
-}
-
 exports.hasSource = hasSource;
 exports.isAtRule = isAtRule;
 exports.isComment = isComment;
@@ -166,14 +100,6 @@ exports.isDeclaration = isDeclaration;
 exports.isDocument = isDocument;
 exports.isRoot = isRoot;
 exports.isRule = isRule;
-exports.isTokenComma = isTokenComma;
-exports.isTokenDelim = isTokenDelim;
-exports.isTokenDimension = isTokenDimension;
-exports.isTokenNumber = isTokenNumber;
-exports.isTokenOpenCurly = isTokenOpenCurly;
-exports.isTokenOpenParen = isTokenOpenParen;
-exports.isTokenPercentage = isTokenPercentage;
-exports.isTokenSemicolon = isTokenSemicolon;
 exports.isValueDiv = isValueDiv;
 exports.isValueFunction = isValueFunction;
 exports.isValueSpace = isValueSpace;

--- a/lib/utils/typeGuards.mjs
+++ b/lib/utils/typeGuards.mjs
@@ -1,5 +1,3 @@
-import { TokenType } from '@csstools/css-tokenizer';
-
 /** @typedef {import('postcss').Node} Node */
 /** @typedef {import('postcss').Source} NodeSource */
 
@@ -89,68 +87,4 @@ export function isValueWord({ type }) {
  */
 export function hasSource(node) {
 	return Boolean(node.source);
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenComma}
- */
-export function isTokenComma(token) {
-	return token !== undefined && token[0] === TokenType.Comma;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenDelim}
- */
-export function isTokenDelim(token) {
-	return token !== undefined && token[0] === TokenType.Delim;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenDimension}
- */
-export function isTokenDimension(token) {
-	return token !== undefined && token[0] === TokenType.Dimension;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenNumber}
- */
-export function isTokenNumber(token) {
-	return token !== undefined && token[0] === TokenType.Number;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenOpenCurly}
- */
-export function isTokenOpenCurly(token) {
-	return token !== undefined && token[0] === TokenType.OpenCurly;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenOpenParen}
- */
-export function isTokenOpenParen(token) {
-	return token !== undefined && token[0] === TokenType.OpenParen;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenPercentage}
- */
-export function isTokenPercentage(token) {
-	return token !== undefined && token[0] === TokenType.Percentage;
-}
-
-/**
- * @param {import('@csstools/css-tokenizer').CSSToken | undefined} token
- * @returns {token is import('@csstools/css-tokenizer').TokenSemicolon}
- */
-export function isTokenSemicolon(token) {
-	return token !== undefined && token[0] === TokenType.Semicolon;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "16.4.0",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^2.6.1",
-        "@csstools/css-tokenizer": "^2.2.4",
-        "@csstools/media-query-list-parser": "^2.1.9",
+        "@csstools/css-parser-algorithms": "^2.6.3",
+        "@csstools/css-tokenizer": "^2.3.1",
+        "@csstools/media-query-list-parser": "^2.1.11",
         "@csstools/selector-specificity": "^3.0.3",
         "@dual-bundle/import-meta-resolve": "^4.0.0",
         "balanced-match": "^2.0.0",
@@ -1125,9 +1125,9 @@
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.1.tgz",
-      "integrity": "sha512-ubEkAaTfVZa+WwGhs5jbo5Xfqpeaybr/RvWzvFxRs4jfq16wH8l8Ty/QEEpINxll4xhuGfdMbipRyz5QZh9+FA==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
+      "integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
       "funding": [
         {
           "type": "github",
@@ -1142,13 +1142,13 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^2.2.4"
+        "@csstools/css-tokenizer": "^2.3.1"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.4.tgz",
-      "integrity": "sha512-PuWRAewQLbDhGeTvFuq2oClaSCKPIBmHyIobCV39JHRYN0byDcUWJl5baPeNUcqrjtdMNqFooE0FGl31I3JOqw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
+      "integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g==",
       "funding": [
         {
           "type": "github",
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.9.tgz",
-      "integrity": "sha512-qqGuFfbn4rUmyOB0u8CVISIp5FfJ5GAR3mBrZ9/TKndHakdnm6pY0L/fbLcpPnrzwCyyTEZl1nUcXAYHEWneTA==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
+      "integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
       "funding": [
         {
           "type": "github",
@@ -1181,8 +1181,8 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^2.6.1",
-        "@csstools/css-tokenizer": "^2.2.4"
+        "@csstools/css-parser-algorithms": "^2.6.3",
+        "@csstools/css-tokenizer": "^2.3.1"
       }
     },
     "node_modules/@csstools/selector-specificity": {

--- a/package.json
+++ b/package.json
@@ -161,9 +161,9 @@
     ]
   },
   "dependencies": {
-    "@csstools/css-parser-algorithms": "^2.6.1",
-    "@csstools/css-tokenizer": "^2.2.4",
-    "@csstools/media-query-list-parser": "^2.1.9",
+    "@csstools/css-parser-algorithms": "^2.6.3",
+    "@csstools/css-tokenizer": "^2.3.1",
+    "@csstools/media-query-list-parser": "^2.1.11",
     "@csstools/selector-specificity": "^3.0.3",
     "@dual-bundle/import-meta-resolve": "^4.0.0",
     "balanced-match": "^2.0.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See : https://github.com/stylelint/stylelint/pull/7655

> Is there anything in the PR that needs further explanation?

- Switch to upstream type guards
- Use the ident and unit mutation helpers from `@csstools/css-tokenizer`
- Also support trailing `-` found in ident tokens `calc(g- 10px)`
