### PR TITLE
Refactor to remove redundant calls to `isStandardSyntaxSelector`

### DIFF
--- a/lib/rules/selector-max-attribute/index.cjs
+++ b/lib/rules/selector-max-attribute/index.cjs
@@ -7,7 +7,6 @@ const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelector
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -94,8 +93,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-attribute/index.mjs
+++ b/lib/rules/selector-max-attribute/index.mjs
@@ -3,7 +3,6 @@ import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsFor
 import isContextFunctionalPseudoClass from '../../utils/isContextFunctionalPseudoClass.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -90,8 +89,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-class/index.cjs
+++ b/lib/rules/selector-max-class/index.cjs
@@ -6,7 +6,6 @@ const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelector
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -68,11 +67,7 @@ const rule = (primary) => {
 		}
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
+			if (!isStandardSyntaxRule(ruleNode)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-class/index.mjs
+++ b/lib/rules/selector-max-class/index.mjs
@@ -2,7 +2,6 @@ import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsFor
 import isContextFunctionalPseudoClass from '../../utils/isContextFunctionalPseudoClass.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -64,11 +63,7 @@ const rule = (primary) => {
 		}
 
 		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
+			if (!isStandardSyntaxRule(ruleNode)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-combinators/index.cjs
+++ b/lib/rules/selector-max-combinators/index.cjs
@@ -5,7 +5,6 @@
 const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelectorsForRule.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -70,8 +69,6 @@ const rule = (primary) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-combinators/index.mjs
+++ b/lib/rules/selector-max-combinators/index.mjs
@@ -1,7 +1,6 @@
 import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsForRule.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -66,8 +65,6 @@ const rule = (primary) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-compound-selectors/index.cjs
+++ b/lib/rules/selector-max-compound-selectors/index.cjs
@@ -8,7 +8,6 @@ const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelector
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const pluralize = require('../../utils/pluralize.cjs');
 const report = require('../../utils/report.cjs');
@@ -117,8 +116,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-compound-selectors/index.mjs
+++ b/lib/rules/selector-max-compound-selectors/index.mjs
@@ -6,7 +6,6 @@ import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsFor
 import isContextFunctionalPseudoClass from '../../utils/isContextFunctionalPseudoClass.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import pluralize from '../../utils/pluralize.mjs';
 import report from '../../utils/report.mjs';
@@ -113,8 +112,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-id/index.cjs
+++ b/lib/rules/selector-max-id/index.cjs
@@ -7,7 +7,6 @@ const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelector
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -109,8 +108,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-id/index.mjs
+++ b/lib/rules/selector-max-id/index.mjs
@@ -3,7 +3,6 @@ import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsFor
 import isContextFunctionalPseudoClass from '../../utils/isContextFunctionalPseudoClass.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -105,8 +104,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-pseudo-class/index.cjs
+++ b/lib/rules/selector-max-pseudo-class/index.cjs
@@ -6,7 +6,6 @@ const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelector
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const selectors = require('../../reference/selectors.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -81,8 +80,6 @@ const rule = (primary) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-pseudo-class/index.mjs
+++ b/lib/rules/selector-max-pseudo-class/index.mjs
@@ -2,7 +2,6 @@ import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsFor
 import isContextFunctionalPseudoClass from '../../utils/isContextFunctionalPseudoClass.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import { levelOneAndTwoPseudoElements } from '../../reference/selectors.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -77,8 +76,6 @@ const rule = (primary) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-type/index.cjs
+++ b/lib/rules/selector-max-type/index.cjs
@@ -10,7 +10,6 @@ const isKeyframeSelector = require('../../utils/isKeyframeSelector.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isOnlyWhitespace = require('../../utils/isOnlyWhitespace.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const isStandardSyntaxTypeSelector = require('../../utils/isStandardSyntaxTypeSelector.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
@@ -122,15 +121,9 @@ const rule = (primary, secondaryOptions) => {
 		root.walkRules((ruleNode) => {
 			const selectors = ruleNode.selectors;
 
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
+			if (!isStandardSyntaxRule(ruleNode)) return;
 
-			if (selectors.some((s) => isKeyframeSelector(s))) {
-				return;
-			}
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
+			if (selectors.some((s) => isKeyframeSelector(s))) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-type/index.mjs
+++ b/lib/rules/selector-max-type/index.mjs
@@ -6,7 +6,6 @@ import isKeyframeSelector from '../../utils/isKeyframeSelector.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isOnlyWhitespace from '../../utils/isOnlyWhitespace.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import isStandardSyntaxTypeSelector from '../../utils/isStandardSyntaxTypeSelector.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
@@ -118,15 +117,9 @@ const rule = (primary, secondaryOptions) => {
 		root.walkRules((ruleNode) => {
 			const selectors = ruleNode.selectors;
 
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
+			if (!isStandardSyntaxRule(ruleNode)) return;
 
-			if (selectors.some((s) => isKeyframeSelector(s))) {
-				return;
-			}
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
+			if (selectors.some((s) => isKeyframeSelector(s))) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-universal/index.cjs
+++ b/lib/rules/selector-max-universal/index.cjs
@@ -5,7 +5,6 @@
 const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelectorsForRule.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const validateTypes = require('../../utils/validateTypes.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
@@ -91,8 +90,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-max-universal/index.mjs
+++ b/lib/rules/selector-max-universal/index.mjs
@@ -1,7 +1,6 @@
 import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsForRule.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import { isString } from '../../utils/validateTypes.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
@@ -87,8 +86,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkRules((ruleNode) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
-
-			if (!isStandardSyntaxSelector(ruleNode.selector)) return;
 
 			flattenNestedSelectorsForRule(ruleNode, result).forEach(({ selector, resolvedSelectors }) => {
 				resolvedSelectors.forEach((resolvedSelector) => {

--- a/lib/rules/selector-not-notation/index.cjs
+++ b/lib/rules/selector-not-notation/index.cjs
@@ -5,7 +5,6 @@
 const selectorParser = require('postcss-selector-parser');
 const validateTypes = require('../../utils/validateTypes.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const parseSelector = require('../../utils/parseSelector.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -79,8 +78,6 @@ const rule = (primary, _, context) => {
 			const selector = ruleNode.selector;
 
 			if (!selector.includes(':not(')) return;
-
-			if (!isStandardSyntaxSelector(selector)) return;
 
 			const selectorRoot = parseSelector(selector, result, ruleNode);
 

--- a/lib/rules/selector-not-notation/index.mjs
+++ b/lib/rules/selector-not-notation/index.mjs
@@ -4,7 +4,6 @@ const { isAttribute, isClassName, isIdentifier, isPseudoClass, isTag, isUniversa
 
 import { assert } from '../../utils/validateTypes.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -75,8 +74,6 @@ const rule = (primary, _, context) => {
 			const selector = ruleNode.selector;
 
 			if (!selector.includes(':not(')) return;
-
-			if (!isStandardSyntaxSelector(selector)) return;
 
 			const selectorRoot = parseSelector(selector, result, ruleNode);
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

`isStandardSyntaxRule` already calls `isStandardSyntaxSelector`.
see : https://github.com/stylelint/stylelint/blob/main/lib/utils/isStandardSyntaxRule.mjs#L19
