### PR TITLE
Refactor `selector-max-specificity` tests to align with standard CSS

### DIFF
--- a/lib/rules/selector-max-specificity/__tests__/index.mjs
+++ b/lib/rules/selector-max-specificity/__tests__/index.mjs
@@ -439,22 +439,25 @@ testRule({
 	config: [
 		'0,1,0',
 		{
-			ignoreSelectors: [':global', ':local', '/my-/'],
+			ignoreSelectors: [':is', ':has', ':host', '/my-/'],
 		},
 	],
 
 	accept: [
 		{
-			code: ':global(.b) {}',
+			code: ':is(.b) {}',
 		},
 		{
-			code: ':global(.b, :local(.c)) {}',
+			code: ':is(.b, :has(.c)) {}',
 		},
 		{
-			code: ':local(.b) {}',
+			code: ':has(.b) {}',
 		},
 		{
-			code: ':local(.b, :global(.c)) {}',
+			code: ':has(.b, :is(.c)) {}',
+		},
+		{
+			code: ':has(.b, :is(a a)) {}',
 		},
 		{
 			code: 'my-tag.a {}',
@@ -462,48 +465,75 @@ testRule({
 		{
 			code: ':nth-child(even of my-tag) {}',
 		},
+		{
+			code: '.a:host {}',
+		},
+		{
+			code: '.a:host(:where(.b)) {}',
+		},
+		{
+			code: ':host(.a) {}',
+		},
 	],
 
 	reject: [
 		{
-			code: '.a:global(.b) {}',
-			message: messages.expected('.a:global(.b)', '0,1,0'),
+			code: '.a:is(.b) {}',
+			message: messages.expected('.a:is(.b)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
 		{
-			code: '.a:global(.b, .c) {}',
-			message: messages.expected('.a:global(.b, .c)', '0,1,0'),
+			code: '.a:is(.b, .c) {}',
+			message: messages.expected('.a:is(.b, .c)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
 		{
-			code: ':global(.b, .c.d) {}',
-			message: messages.expected(':global(.b, .c.d)', '0,1,0'),
+			code: ':is(.b, .c.d) {}',
+			message: messages.expected(':is(.b, .c.d)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
 		{
-			code: '.a:local(.b) {}',
-			message: messages.expected('.a:local(.b)', '0,1,0'),
+			code: '.a:has(.b) {}',
+			message: messages.expected('.a:has(.b)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
 		{
-			code: '.a:local(.b, .c) {}',
-			message: messages.expected('.a:local(.b, .c)', '0,1,0'),
+			code: '.a:has(.b, .c) {}',
+			message: messages.expected('.a:has(.b, .c)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
 		{
-			code: ':local(.b, .c.d) {}',
-			message: messages.expected(':local(.b, .c.d)', '0,1,0'),
+			code: ':has(.b, .c.d) {}',
+			message: messages.expected(':has(.b, .c.d)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
 		{
 			code: 'my-tag.a.b {}',
 			message: messages.expected('my-tag.a.b', '0,1,0'),
+			line: 1,
+			column: 1,
+		},
+		{
+			code: 'a.b:host {}',
+			message: messages.expected('a.b:host', '0,1,0'),
+			line: 1,
+			column: 1,
+		},
+		{
+			code: 'a:host(.b) {}',
+			message: messages.expected('a:host(.b)', '0,1,0'),
+			line: 1,
+			column: 1,
+		},
+		{
+			code: ':host(a.b) {}',
+			message: messages.expected(':host(a.b)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},
@@ -527,8 +557,8 @@ testRule({
 
 	reject: [
 		{
-			code: '.a:global(.b) {}',
-			message: messages.expected('.a:global(.b)', '0,1,0'),
+			code: '.a:is(.b) {}',
+			message: messages.expected('.a:is(.b)', '0,1,0'),
 			line: 1,
 			column: 1,
 		},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7495

> Is there anything in the PR that needs further explanation?

As explained in the linked issue `:global()` and `:local()` are non-standard functional pseudo classes that have these properties:
- they are non-standard
- have no specificity of their own
- do not support selector lists, only a single selector at a time (i.e. `:local(a), :local(b)` and not `:local(a, b)`)

But they were used in tests to verify the `ignoreSelectors` feature.
This feature acts like a hole punch. Only the ignored node is skipped when calculating specificity. The child nodes are part of the equation.

Given that `:global` and `:local` have no specificity of their own and do not allow lists, it isn't ideal that we are using these to test `ignoreSelectors`. All of the complexity for `ignoreSelectors` is in calculating the specificity of lists of child selectors.

This change replaces `:global` and `:local` with `:is` and `:has` because these do support lists of selectors (e.g. `:is(a, b)`).

It also adds tests with `:host` because `:host` does have its own specificity.

This gives us meaningful coverage for `ignoreSelectors` in a way that aligns with standard CSS.

------------

The goal of this change is to have coverage in a way that makes it easier to change the implementation of this rule.

The goal is not to make breaking changes that are noticeable to end users, only to make sure that we are testing the right things in the right way.

------------

Side note:

Calculating correct specificity for `:global`, `:local` or any other selector is purely an upstream concern in `@csstools/selector-specificity`. So I think it is fine if we don't have explicit coverage for these (non-standard) selectors.

We need coverage for the rule and for `ignoreSelectors` here, but not for the specificity of any individual selector. 