### PR TITLE
Refactor to remove reference to `postcss-resolve-nested-selector`

### DIFF
--- a/lib/rules/selector-max-universal/index.cjs
+++ b/lib/rules/selector-max-universal/index.cjs
@@ -55,7 +55,7 @@ const rule = (primary, secondaryOptions) => {
 		function checkSelector(resolvedSelectorNode, selectorNode, ruleNode) {
 			const count = resolvedSelectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors
-				// All logical combinations will be resolved as nested selector in `postcss-resolve-nested-selector`
+				// All logical combinations will be resolved as nested selector
 				if (childNode.type === 'selector') {
 					checkSelector(childNode, selectorNode, ruleNode);
 				}

--- a/lib/rules/selector-max-universal/index.mjs
+++ b/lib/rules/selector-max-universal/index.mjs
@@ -51,7 +51,7 @@ const rule = (primary, secondaryOptions) => {
 		function checkSelector(resolvedSelectorNode, selectorNode, ruleNode) {
 			const count = resolvedSelectorNode.reduce((total, childNode) => {
 				// Only traverse inside actual selectors
-				// All logical combinations will be resolved as nested selector in `postcss-resolve-nested-selector`
+				// All logical combinations will be resolved as nested selector
 				if (childNode.type === 'selector') {
 					checkSelector(childNode, selectorNode, ruleNode);
 				}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

This rule no longer uses `postcss-resolve-nested-selector` directly.

Removing this part of the comment to:
- make it easier to search for "postcss-resolve-nested-selector" and get relevant results
- avoid confusion after the planned changes to `flattenNestedSelectorsForRule` in a later major