### PR TITLE
Refactor to simplify reduce in uniteSets

### DIFF
--- a/lib/utils/uniteSets.cjs
+++ b/lib/utils/uniteSets.cjs
@@ -9,7 +9,7 @@
  * @see {@link https://github.com/microsoft/TypeScript/issues/57228|GitHub}
  */
 function uniteSets(...args) {
-	return new Set([...args].reduce((result, set) => [...result, ...set], []));
+	return new Set([...args].flat());
 }
 
 module.exports = uniteSets;

--- a/lib/utils/uniteSets.mjs
+++ b/lib/utils/uniteSets.mjs
@@ -5,5 +5,5 @@
  * @see {@link https://github.com/microsoft/TypeScript/issues/57228|GitHub}
  */
 export default function uniteSets(...args) {
-	return new Set([...args].reduce((result, set) => [...result, ...set], []));
+	return new Set([...args].flat());
 }


### PR DESCRIPTION
I used native `flat` method instead of `reduce` + `spread`.