### PR TITLE
Fix `selector-not-notation` autofix of the `"simple"` option

### DIFF
--- a/.changeset/eight-falcons-scream.md
+++ b/.changeset/eight-falcons-scream.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-not-notation` autofix of the `"simple"` option

--- a/lib/rules/selector-not-notation/__tests__/index.mjs
+++ b/lib/rules/selector-not-notation/__tests__/index.mjs
@@ -68,6 +68,15 @@ testRule({
 			endColumn: 13,
 		},
 		{
+			code: 'p, :not(a, div) {}',
+			fixed: 'p, :not(a):not(div) {}',
+			message: messages.expected('simple'),
+			line: 1,
+			column: 4,
+			endLine: 1,
+			endColumn: 16,
+		},
+		{
 			code: ':not(.bar, .baz, .foo) {}',
 			fixed: ':not(.bar):not(.baz):not(.foo) {}',
 			message: messages.expected('simple'),

--- a/lib/rules/selector-not-notation/index.cjs
+++ b/lib/rules/selector-not-notation/index.cjs
@@ -166,8 +166,10 @@ function fixSimple(not) {
 
 	for (const s of simpleSelectors) {
 		const last = getLastConsecutiveNot(not);
+		const clone = last.clone({ nodes: [s] });
 
-		not.parent.insertAfter(last, last.clone({ nodes: [s] }));
+		clone.rawSpaceBefore = '';
+		not.parent.insertAfter(last, clone);
 	}
 }
 

--- a/lib/rules/selector-not-notation/index.mjs
+++ b/lib/rules/selector-not-notation/index.mjs
@@ -162,8 +162,10 @@ function fixSimple(not) {
 
 	for (const s of simpleSelectors) {
 		const last = getLastConsecutiveNot(not);
+		const clone = last.clone({ nodes: [s] });
 
-		not.parent.insertAfter(last, last.clone({ nodes: [s] }));
+		clone.rawSpaceBefore = '';
+		not.parent.insertAfter(last, clone);
 	}
 }
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

While I was working on #2643 I uncovered a bug.
`:not()` is mostly used as a suffix so no one reported it.
@ybiquitous  we should release once that's merged.

i.e. `foo:not()` is not affected