### PR TITLE
Refactor to jsonFormatter

### DIFF
--- a/lib/formatters/jsonFormatter.cjs
+++ b/lib/formatters/jsonFormatter.cjs
@@ -8,17 +8,9 @@
  * @type {import('stylelint').Formatter}
  */
 function jsonFormatter(results) {
-	const cleanedResults = results.map((result) =>
-		Object.entries(result)
-			.filter(([key]) => !key.startsWith('_'))
-			.reduce((/** @type {{ [key: string]: any }} */ obj, [key, value]) => {
-				obj[key] = value;
-
-				return obj;
-			}, {}),
-	);
-
-	return JSON.stringify(cleanedResults);
+	return JSON.stringify(results, (key, value) => {
+		return key[0] === '_' ? undefined : value;
+	});
 }
 
 module.exports = jsonFormatter;

--- a/lib/formatters/jsonFormatter.mjs
+++ b/lib/formatters/jsonFormatter.mjs
@@ -4,15 +4,7 @@
  * @type {import('stylelint').Formatter}
  */
 export default function jsonFormatter(results) {
-	const cleanedResults = results.map((result) =>
-		Object.entries(result)
-			.filter(([key]) => !key.startsWith('_'))
-			.reduce((/** @type {{ [key: string]: any }} */ obj, [key, value]) => {
-				obj[key] = value;
-
-				return obj;
-			}, {}),
-	);
-
-	return JSON.stringify(cleanedResults);
+	return JSON.stringify(results, (key, value) => {
+		return key[0] === '_' ? undefined : value;
+	});
 }


### PR DESCRIPTION
`JSON.stringify` has a second argument for filtering output. So we can easily simplify this function without reduce, filter, Object.entries.