### PR TITLE
Fix missing GitHub Sponsor for `npm fund`

### DIFF
--- a/.changeset/tricky-pigs-talk.md
+++ b/.changeset/tricky-pigs-talk.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fix: missing GitHub Sponsor for `npm fund`

--- a/.changeset/tricky-pigs-talk.md
+++ b/.changeset/tricky-pigs-talk.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fix: missing GitHub Sponsor for `npm fund`
+Fixed: missing GitHub Sponsor for `npm fund`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,11 +67,8 @@ After we review and merge your pull request, we'll invite you to become a mainta
 
 ## Financial contributions
 
-We welcome financial contributions in full transparency on our [Open Collective](https://opencollective.com/stylelint).
+We welcome financial contributions in full transparency on our [Open Collective](https://opencollective.com/stylelint) or [GitHub Sponsor](https://github.com/sponsors/stylelint).
 
 Anyone can file an expense. We will "merge" the expense into the ledger if it makes sense for the development of the community. Open Collective then reimburses the person who filed the expense.
 
-You can financially support us by becoming a:
-
-- [backer](https://opencollective.com/stylelint#backer)
-- [sponsor](https://opencollective.com/stylelint#sponsor)
+You can financially support us by becoming a [backer or sponsor on Open Collective](https://opencollective.com/stylelint) on Open Collective or a [sponsor on GitHub](https://github.com/sponsors/stylelint).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,4 +71,4 @@ We welcome financial contributions in full transparency on our [Open Collective]
 
 Anyone can file an expense. We will "merge" the expense into the ledger if it makes sense for the development of the community. Open Collective then reimburses the person who filed the expense.
 
-You can financially support us by becoming a [backer or sponsor on Open Collective](https://opencollective.com/stylelint) on Open Collective or a [sponsor on GitHub](https://github.com/sponsors/stylelint).
+You can financially support us by becoming a [backer or sponsor on Open Collective](https://opencollective.com/stylelint) or a [sponsor on GitHub](https://github.com/sponsors/stylelint).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,16 @@
     "": {
       "name": "stylelint",
       "version": "16.5.0",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.6.3",
@@ -99,10 +109,6 @@
       },
       "engines": {
         "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/stylelint"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,16 @@
   ],
   "homepage": "https://stylelint.io",
   "repository": "stylelint/stylelint",
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/stylelint"
-  },
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/stylelint"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stylelint"
+    }
+  ],
   "license": "MIT",
   "author": "stylelint",
   "exports": {


### PR DESCRIPTION
We forgot to add our [GitHub Sponsor](https://github.com/sponsors/stylelint) to `package.json` (`funding`) when we started it.

```sh-session
$ npm fund stylelint
1: opencollective funding available at the following URL: https://opencollective.com/stylelint
2: github funding available at the following URL: https://github.com/sponsors/stylelint
Run `npm fund [<package-spec>] --which=1`, for example, to open the first funding URL listed in that package
```

In addition, this improves the financial section in the contribution guide:

- Add GitHub Sponsor
- Simplify links to Open Collective, including unsupported `#backer` or `#sponsor`

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

I've also added a changelog item so that users can notice this `npm fund` change, but I can remove it if anyone don't consider it appropriate in the changelog.
