### PR TITLE
Temporarily exclude `eslint` from Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       changesets:
         patterns: ['@changesets/*']
       eslint:
-        patterns: ['eslint', 'eslint-*']
+        patterns: ['eslint-*'] # TODO: Include 'eslint' when we're ready for ESLint v9.
       jest:
         patterns: ['jest', 'jest-*', '@jest/*']
       stylelint:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #7695

> Is there anything in the PR that needs further explanation?

We cannot bump `eslint` to v9 until all dependent plugins support v9.
