### PR TITLE
Fix `no-descending-specificity` false positives for nested selectors

### DIFF
--- a/.changeset/hot-pens-joke.md
+++ b/.changeset/hot-pens-joke.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `no-descending-specificity` false positives for nested selectors

--- a/lib/rules/no-descending-specificity/__tests__/index.mjs
+++ b/lib/rules/no-descending-specificity/__tests__/index.mjs
@@ -104,6 +104,9 @@ testRule({
 		{
 			code: ':is(.foo) {} :host { .bar {} }',
 		},
+		{
+			code: 'a { .foo.bar & {} } b { .foo & {} }',
+		},
 	],
 
 	reject: [
@@ -238,6 +241,25 @@ testRule({
 					column: 49,
 					endLine: 1,
 					endColumn: 51,
+				},
+			],
+		},
+		{
+			code: 'a { .foo.bar & {} } a { .foo & {} }',
+			warnings: [
+				{
+					message: messages.rejected('a', '.foo.bar a'),
+					line: 1,
+					column: 21,
+					endLine: 1,
+					endColumn: 22,
+				},
+				{
+					message: messages.rejected('.foo &', '.foo.bar a'),
+					line: 1,
+					column: 25,
+					endLine: 1,
+					endColumn: 31,
 				},
 			],
 		},

--- a/lib/rules/no-descending-specificity/index.cjs
+++ b/lib/rules/no-descending-specificity/index.cjs
@@ -90,7 +90,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {Map<string, Entry[]>} comparisonContext
 		 */
 		function checkSelector(resolvedSelectorNode, selectorNode, ruleNode, comparisonContext) {
-			const referenceSelector = lastCompoundSelectorWithoutPseudoClasses(selectorNode);
+			const referenceSelector = lastCompoundSelectorWithoutPseudoClasses(resolvedSelectorNode);
 
 			if (!referenceSelector) return;
 

--- a/lib/rules/no-descending-specificity/index.mjs
+++ b/lib/rules/no-descending-specificity/index.mjs
@@ -87,7 +87,7 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {Map<string, Entry[]>} comparisonContext
 		 */
 		function checkSelector(resolvedSelectorNode, selectorNode, ruleNode, comparisonContext) {
-			const referenceSelector = lastCompoundSelectorWithoutPseudoClasses(selectorNode);
+			const referenceSelector = lastCompoundSelectorWithoutPseudoClasses(resolvedSelectorNode);
 
 			if (!referenceSelector) return;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7723

> Is there anything in the PR that needs further explanation?

We didn't have coverage for nested selectors where the nested part is the same while the parent is different.

I should have double checked this when refactoring this rule.

I am certain that this case is very common.
Do we have capacity to ship a patch in the next few days?