### PR TITLE
Ignore `tmp/` from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@
 scripts/**/*.css
 system-tests/**/*.css
 system-tests/**/*.scss
+tmp/
 
 # This unit test required a parent directory structure and therefore is not inside /fixtures/globs
 **/standalone-glob-parent-test/**/*.css


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

The `.gitignore` file already has the same setting:
https://github.com/stylelint/stylelint/blob/62b58bc2616fd1420c0adb7090e1e3c03b64597a/.gitignore#L10
