### PR TITLE
Refactor to simplify initialization of `PostcssResult.stylelint` property

### DIFF
--- a/lib/__tests__/disableRanges.test.mjs
+++ b/lib/__tests__/disableRanges.test.mjs
@@ -1006,7 +1006,10 @@ function expectDisableRange(actual, expected) {
 
 function testDisableRanges(source, options) {
 	return postcss()
-		.use(assignDisabledRanges)
+		.use((root, result) => {
+			result.stylelint = { disabledRanges: {} };
+			assignDisabledRanges(root, result);
+		})
 		.process(source, { from: undefined, ...options });
 }
 

--- a/lib/assignDisabledRanges.cjs
+++ b/lib/assignDisabledRanges.cjs
@@ -41,13 +41,6 @@ function createDisableRange(comment, start, strictStart, description, end, stric
  * @returns {PostcssResult}
  */
 function assignDisabledRanges(root, result) {
-	result.stylelint = result.stylelint || {
-		disabledRanges: {},
-		ruleSeverities: {},
-		customMessages: {},
-		ruleMetadata: {},
-	};
-
 	/**
 	 * Most of the functions below work via side effects mutating this object
 	 * @type {DisabledRangeObject}

--- a/lib/assignDisabledRanges.mjs
+++ b/lib/assignDisabledRanges.mjs
@@ -46,13 +46,6 @@ function createDisableRange(comment, start, strictStart, description, end, stric
  * @returns {PostcssResult}
  */
 export default function assignDisabledRanges(root, result) {
-	result.stylelint = result.stylelint || {
-		disabledRanges: {},
-		ruleSeverities: {},
-		customMessages: {},
-		ruleMetadata: {},
-	};
-
 	/**
 	 * Most of the functions below work via side effects mutating this object
 	 * @type {DisabledRangeObject}

--- a/lib/lintPostcssResult.cjs
+++ b/lib/lintPostcssResult.cjs
@@ -21,9 +21,6 @@ const index = require('./rules/index.cjs');
  * @returns {Promise<any>}
  */
 async function lintPostcssResult(stylelintOptions, postcssResult, config) {
-	postcssResult.stylelint.ruleSeverities = {};
-	postcssResult.stylelint.customMessages = {};
-	postcssResult.stylelint.ruleMetadata = {};
 	postcssResult.stylelint.stylelintError = false;
 	postcssResult.stylelint.stylelintWarning = false;
 	postcssResult.stylelint.quiet = config.quiet;

--- a/lib/lintPostcssResult.mjs
+++ b/lib/lintPostcssResult.mjs
@@ -18,9 +18,6 @@ import rules from './rules/index.mjs';
  * @returns {Promise<any>}
  */
 export default async function lintPostcssResult(stylelintOptions, postcssResult, config) {
-	postcssResult.stylelint.ruleSeverities = {};
-	postcssResult.stylelint.customMessages = {};
-	postcssResult.stylelint.ruleMetadata = {};
 	postcssResult.stylelint.stylelintError = false;
 	postcssResult.stylelint.stylelintWarning = false;
 	postcssResult.stylelint.quiet = config.quiet;

--- a/lib/lintSource.cjs
+++ b/lib/lintSource.cjs
@@ -91,14 +91,6 @@ async function lintSource(stylelint, options = {}) {
 		}
 	}
 
-	/** @type {StylelintPostcssResult} */
-	const stylelintResult = {
-		ruleSeverities: {},
-		customMessages: {},
-		ruleMetadata: {},
-		disabledRanges: {},
-	};
-
 	const postcssResult =
 		existingPostcssResult ||
 		(await getPostcssResult(stylelint, {
@@ -109,7 +101,12 @@ async function lintSource(stylelint, options = {}) {
 		}));
 
 	const stylelintPostcssResult = Object.assign(postcssResult, {
-		stylelint: stylelintResult,
+		stylelint: {
+			ruleSeverities: {},
+			customMessages: {},
+			ruleMetadata: {},
+			disabledRanges: {},
+		},
 	});
 
 	await lintPostcssResult(stylelint._options, stylelintPostcssResult, config);

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -88,14 +88,6 @@ export default async function lintSource(stylelint, options = {}) {
 		}
 	}
 
-	/** @type {StylelintPostcssResult} */
-	const stylelintResult = {
-		ruleSeverities: {},
-		customMessages: {},
-		ruleMetadata: {},
-		disabledRanges: {},
-	};
-
 	const postcssResult =
 		existingPostcssResult ||
 		(await getPostcssResult(stylelint, {
@@ -106,7 +98,12 @@ export default async function lintSource(stylelint, options = {}) {
 		}));
 
 	const stylelintPostcssResult = Object.assign(postcssResult, {
-		stylelint: stylelintResult,
+		stylelint: {
+			ruleSeverities: {},
+			customMessages: {},
+			ruleMetadata: {},
+			disabledRanges: {},
+		},
 	});
 
 	await lintPostcssResult(stylelint._options, stylelintPostcssResult, config);

--- a/lib/rules/no-duplicate-selectors/__tests__/index.mjs
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.mjs
@@ -260,7 +260,12 @@ testRule({
 });
 
 it('with postcss-import and duplicates within a file, a warning strikes', () => {
-	return postcss([postcssImport(), rule()])
+	return postcss()
+		.use(postcssImport())
+		.use((root, result) => {
+			result.stylelint = { ruleSeverities: {} };
+			rule(true)(root, result);
+		})
 		.process("@import 'fixtures/using-foo-twice.css';", {
 			from: fileURLToPath(new URL('./test.css', import.meta.url)),
 		})
@@ -270,7 +275,12 @@ it('with postcss-import and duplicates within a file, a warning strikes', () => 
 });
 
 it('with postcss-import and duplicates across files, no warnings', () => {
-	return postcss([postcssImport(), rule()])
+	return postcss()
+		.use(postcssImport())
+		.use((root, result) => {
+			result.stylelint = { ruleSeverities: {} };
+			rule(true)(root, result);
+		})
 		.process("@import 'fixtures/using-foo.css'; @import 'fixtures/also-using-foo.css';", {
 			from: fileURLToPath(new URL('./test.css', import.meta.url)),
 		})

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -9,6 +9,9 @@ test('without disabledRanges', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
+			stylelint: {
+				ruleSeverities: {},
+			},
 		},
 		message: 'bar',
 		node: {
@@ -32,6 +35,7 @@ test('with irrelevant general disabledRange', () => {
 				disabledRanges: {
 					all: [{ start: 5, end: 8 }],
 				},
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -56,6 +60,7 @@ test('with relevant general disabledRange', () => {
 				disabledRanges: {
 					all: [{ start: 5, end: 8 }],
 				},
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -78,6 +83,7 @@ test('with irrelevant rule-specific disabledRange', () => {
 					all: [],
 					bar: [{ start: 5, end: 8 }],
 				},
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -103,6 +109,7 @@ test('with relevant rule-specific disabledRange', () => {
 					all: [],
 					foo: [{ start: 5, end: 8 }],
 				},
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -127,6 +134,7 @@ test('with relevant general disabledRange, among others', () => {
 						{ start: 5, end: 8 },
 					],
 				},
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -152,6 +160,7 @@ test('with relevant rule-specific disabledRange, among others', () => {
 						{ start: 5, end: 8, rules: ['foo'] },
 					],
 				},
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -174,6 +183,7 @@ test('with relevant rule-specific disabledRange with range report', () => {
 					all: [],
 					foo: [{ start: 2, end: 2 }],
 				},
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -359,6 +369,9 @@ test('with message function', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
+			stylelint: {
+				ruleSeverities: {},
+			},
 		},
 		message: (a, b, c, d) => `a=${a}, b=${b}, c=${c}, d=${d}`,
 		messageArgs: ['str', true, 10, /regex/],
@@ -381,6 +394,7 @@ test('with custom message', () => {
 			warn: jest.fn(),
 			stylelint: {
 				customMessages: { foo: 'A custom message: %s, %s, %d, %s' },
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -404,6 +418,7 @@ test('with custom message function', () => {
 			warn: jest.fn(),
 			stylelint: {
 				customMessages: { foo: (a, b) => `a=${a}, b=${b}` },
+				ruleSeverities: {},
 			},
 		},
 		message: 'bar',
@@ -423,7 +438,11 @@ test('with custom message function', () => {
 test('without node nor line', () => {
 	const v = {
 		ruleName: 'foo',
-		result: {},
+		result: {
+			stylelint: {
+				ruleSeverities: {},
+			},
+		},
 	};
 
 	expect(() => report(v)).toThrow(

--- a/lib/utils/__tests__/validateOptions.test.mjs
+++ b/lib/utils/__tests__/validateOptions.test.mjs
@@ -3,7 +3,10 @@ import validateOptions from '../validateOptions.mjs';
 import { jest } from '@jest/globals';
 
 function mockResult() {
-	return { warn: jest.fn() };
+	return {
+		warn: jest.fn(),
+		stylelint: {},
+	};
 }
 
 describe('validateOptions for primary options', () => {

--- a/lib/utils/checkAgainstRule.cjs
+++ b/lib/utils/checkAgainstRule.cjs
@@ -42,6 +42,17 @@ async function checkAgainstRule(options, callback) {
 		undefined,
 	);
 
+	/** @type {import('stylelint').StylelintPostcssResult} */
+	const stylelint = {
+		ruleSeverities: {},
+		customMessages: {},
+		ruleMetadata: {},
+		disabledRanges: {},
+	};
+
+	// @ts-expect-error -- TS2339: Property 'stylelint' does not exist on type 'Result<undefined>'.
+	tmpPostcssResult.stylelint = stylelint;
+
 	const [primary, secondary] = settings;
 	const ruleFunc = rule(primary, secondary || {}, context);
 

--- a/lib/utils/checkAgainstRule.mjs
+++ b/lib/utils/checkAgainstRule.mjs
@@ -39,6 +39,17 @@ export default async function checkAgainstRule(options, callback) {
 		undefined,
 	);
 
+	/** @type {import('stylelint').StylelintPostcssResult} */
+	const stylelint = {
+		ruleSeverities: {},
+		customMessages: {},
+		ruleMetadata: {},
+		disabledRanges: {},
+	};
+
+	// @ts-expect-error -- TS2339: Property 'stylelint' does not exist on type 'Result<undefined>'.
+	tmpPostcssResult.stylelint = stylelint;
+
 	const [primary, secondary] = settings;
 	const ruleFunc = rule(primary, secondary || {}, context);
 

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -22,13 +22,7 @@ function report(problem) {
 	const { ruleName, result, message, messageArgs, line, node, index, endIndex, word, severity } =
 		problem;
 
-	result.stylelint = result.stylelint || {
-		ruleSeverities: {},
-		customMessages: {},
-		ruleMetadata: {},
-	};
-
-	const ruleSeverityOption = severity || result.stylelint.ruleSeverities?.[ruleName];
+	const ruleSeverityOption = severity || result.stylelint.ruleSeverities[ruleName];
 
 	const defaultSeverity = result.stylelint.config?.defaultSeverity || 'error';
 

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -18,13 +18,7 @@ export default function report(problem) {
 	const { ruleName, result, message, messageArgs, line, node, index, endIndex, word, severity } =
 		problem;
 
-	result.stylelint = result.stylelint || {
-		ruleSeverities: {},
-		customMessages: {},
-		ruleMetadata: {},
-	};
-
-	const ruleSeverityOption = severity || result.stylelint.ruleSeverities?.[ruleName];
+	const ruleSeverityOption = severity || result.stylelint.ruleSeverities[ruleName];
 
 	const defaultSeverity = result.stylelint.config?.defaultSeverity || 'error';
 

--- a/lib/utils/validateOptions.cjs
+++ b/lib/utils/validateOptions.cjs
@@ -28,12 +28,6 @@ function validateOptions(result, ruleName, ...optionDescriptions) {
 		result.warn(message, {
 			stylelintType: 'invalidOption',
 		});
-		result.stylelint = result.stylelint || {
-			disabledRanges: {},
-			ruleSeverities: {},
-			customMessages: {},
-			ruleMetadata: {},
-		};
 		result.stylelint.stylelintError = true;
 	}
 

--- a/lib/utils/validateOptions.mjs
+++ b/lib/utils/validateOptions.mjs
@@ -24,12 +24,6 @@ export default function validateOptions(result, ruleName, ...optionDescriptions)
 		result.warn(message, {
 			stylelintType: 'invalidOption',
 		});
-		result.stylelint = result.stylelint || {
-			disabledRanges: {},
-			ruleSeverities: {},
-			customMessages: {},
-			ruleMetadata: {},
-		};
 		result.stylelint.stylelintError = true;
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #7706

> Is there anything in the PR that needs further explanation?

When reviewing PR #7706, I noticed that we can reduce the repetitive initialization of the `PostcssResult.stylelint` property. This refactoring PR will help us easily add a new property to `PostcssResult.stylelint` in the future.

See also the type definitions:
- https://github.com/stylelint/stylelint/blob/d902c0b7cc1233b74cc4959eff864cb3e2d87f73/types/stylelint/index.d.ts#L178-L181
- https://github.com/stylelint/stylelint/blob/d902c0b7cc1233b74cc4959eff864cb3e2d87f73/types/stylelint/index.d.ts#L156-L168
