### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties`/`declaration-block-no-shorthand-property-overrides` false negatives for `font-variant`

### DIFF
--- a/.changeset/three-cars-pull.md
+++ b/.changeset/three-cars-pull.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties`/`declaration-block-no-shorthand-property-overrides` false negatives for `font-variant`

--- a/lib/reference/properties.cjs
+++ b/lib/reference/properties.cjs
@@ -305,6 +305,19 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 		]),
 	],
 	[
+		'font-variant',
+		new Set([
+			// prettier-ignore
+			'font-variant-alternates',
+			'font-variant-caps',
+			'font-variant-east-asian',
+			'font-variant-emoji',
+			'font-variant-ligatures',
+			'font-variant-numeric',
+			'font-variant-position',
+		]),
+	],
+	[
 		'gap',
 		new Set([
 			// prettier-ignore

--- a/lib/reference/properties.cjs
+++ b/lib/reference/properties.cjs
@@ -308,13 +308,13 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 		'font-variant',
 		new Set([
 			// prettier-ignore
-			'font-variant-alternates',
+			'font-variant-ligatures',
+			'font-variant-position',
 			'font-variant-caps',
+			'font-variant-numeric',
+			'font-variant-alternates',
 			'font-variant-east-asian',
 			'font-variant-emoji',
-			'font-variant-ligatures',
-			'font-variant-numeric',
-			'font-variant-position',
 		]),
 	],
 	[

--- a/lib/reference/properties.mjs
+++ b/lib/reference/properties.mjs
@@ -301,6 +301,19 @@ export const longhandSubPropertiesOfShorthandProperties = new Map([
 		]),
 	],
 	[
+		'font-variant',
+		new Set([
+			// prettier-ignore
+			'font-variant-alternates',
+			'font-variant-caps',
+			'font-variant-east-asian',
+			'font-variant-emoji',
+			'font-variant-ligatures',
+			'font-variant-numeric',
+			'font-variant-position',
+		]),
+	],
+	[
 		'gap',
 		new Set([
 			// prettier-ignore

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -50,6 +50,7 @@ This rule complains when the following shorthand properties can be used:
 - `flex-flow`
 - `font`
 - `font-synthesis`
+- `font-variant`
 - `gap`
 - `grid`
 - `grid-area`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -925,6 +925,77 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [true],
+
+	accept: [
+		{
+			code: stripIndent`
+					a {
+						font-variant: foo foo foo foo foo foo foo;
+					}
+				`,
+		},
+	],
+
+	reject: [
+		{
+			code: stripIndent`
+					a {	
+						font-variant-ligatures: foo;
+						font-variant-position: foo;
+						font-variant-caps: foo;
+						font-variant-numeric: foo;
+						font-variant-alternates: foo;
+						font-variant-east-asian: foo;
+						font-variant-emoji: foo;
+						font-variant: foo;
+					}
+				`,
+			message: messages.expected('font-variant'),
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [true, { ignoreShorthands: ['/^font-variant/'] }],
+
+	accept: [
+		{
+			code: stripIndent`
+				a {
+					font-variant-ligatures: foo;
+					font-variant-position: foo;
+					font-variant-caps: foo;
+					font-variant-numeric: foo;
+					font-variant-alternates: foo;
+					font-variant-east-asian: foo;
+					font-variant-emoji: foo;
+					font-variant: foo;
+				}
+			`,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [true, { ignoreLonghands: ['font-variant-emoji'] }],
+
+	accept: [
+		{
+			code: stripIndent`
+				a {
+					font-variant: foo;
+					font-variant-emoji: foo;
+				}
+			`,
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: [true, { ignoreShorthands: [/border/] }],
 
 	accept: [

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -870,16 +870,16 @@ testRule({
 		},
 		{
 			code: stripIndent`
-					a {
-						font-variant-ligatures: foo1;
-						font-variant-position: foo2;
-						font-variant-caps: foo3;
-						font-variant-numeric: foo4;
-						font-variant-alternates: foo5;
-						font-variant-east-asian: foo6;
-						font-variant-emoji: foo7;
-					}
-				`,
+				a {
+					font-variant-ligatures: foo1;
+					font-variant-position: foo2;
+					font-variant-caps: foo3;
+					font-variant-numeric: foo4;
+					font-variant-alternates: foo5;
+					font-variant-east-asian: foo6;
+					font-variant-emoji: foo7;
+				}
+			`,
 			fixed: stripIndent`
 				a {
 					font-variant: foo1 foo2 foo3 foo4 foo5 foo6 foo7;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -68,6 +68,13 @@ testRule({
 			code: 'a { background-repeat: repeat; background-attachment: scroll; background-position: 0% 0%; background-color: transparent; background-image: none; background-origin: border-box; background-clip: text; }',
 			description: 'missing background-size',
 		},
+		{
+			code: stripIndent`
+					a {
+						font-variant: foo1 foo2 foo3 foo4 foo5 foo6 foo7;
+					}
+				`,
+		},
 	],
 
 	reject: [
@@ -861,6 +868,25 @@ testRule({
 			message: messages.expected('text-decoration'),
 			description: 'CSS Text Decoration Module Level 4',
 		},
+		{
+			code: stripIndent`
+					a {
+						font-variant-ligatures: foo1;
+						font-variant-position: foo2;
+						font-variant-caps: foo3;
+						font-variant-numeric: foo4;
+						font-variant-alternates: foo5;
+						font-variant-east-asian: foo6;
+						font-variant-emoji: foo7;
+					}
+				`,
+			message: messages.expected('font-variant'),
+			fixed: stripIndent`
+				a {
+					font-variant: foo1 foo2 foo3 foo4 foo5 foo6 foo7;
+				}
+			`,
+		},
 	],
 });
 
@@ -919,39 +945,6 @@ testRule({
 		{
 			code: 'a { margin-left: 10px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }',
 			message: messages.expected('margin'),
-		},
-	],
-});
-
-testRule({
-	ruleName,
-	config: [true],
-
-	accept: [
-		{
-			code: stripIndent`
-					a {
-						font-variant: foo foo foo foo foo foo foo;
-					}
-				`,
-		},
-	],
-
-	reject: [
-		{
-			code: stripIndent`
-					a {	
-						font-variant-ligatures: foo;
-						font-variant-position: foo;
-						font-variant-caps: foo;
-						font-variant-numeric: foo;
-						font-variant-alternates: foo;
-						font-variant-east-asian: foo;
-						font-variant-emoji: foo;
-						font-variant: foo;
-					}
-				`,
-			message: messages.expected('font-variant'),
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -951,28 +951,6 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreShorthands: ['/^font-variant/'] }],
-
-	accept: [
-		{
-			code: stripIndent`
-				a {
-					font-variant-ligatures: foo1;
-					font-variant-position: foo2;
-					font-variant-caps: foo3;
-					font-variant-numeric: foo4;
-					font-variant-alternates: foo5;
-					font-variant-east-asian: foo6;
-					font-variant-emoji: foo7;
-					font-variant: foo;
-				}
-			`,
-		},
-	],
-});
-
-testRule({
-	ruleName,
 	config: [true, { ignoreShorthands: [/border/] }],
 
 	accept: [

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -70,10 +70,10 @@ testRule({
 		},
 		{
 			code: stripIndent`
-					a {
-						font-variant: foo1 foo2 foo3 foo4 foo5 foo6 foo7;
-					}
-				`,
+				a {
+					font-variant: foo1 foo2 foo3 foo4 foo5 foo6 foo7;
+				}
+			`,
 		},
 	],
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -980,22 +980,6 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreLonghands: ['font-variant-emoji'] }],
-
-	accept: [
-		{
-			code: stripIndent`
-				a {
-					font-variant: foo;
-					font-variant-emoji: foo;
-				}
-			`,
-		},
-	],
-});
-
-testRule({
-	ruleName,
 	config: [true, { ignoreShorthands: [/border/] }],
 
 	accept: [

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -957,13 +957,13 @@ testRule({
 		{
 			code: stripIndent`
 				a {
-					font-variant-ligatures: foo;
-					font-variant-position: foo;
-					font-variant-caps: foo;
-					font-variant-numeric: foo;
-					font-variant-alternates: foo;
-					font-variant-east-asian: foo;
-					font-variant-emoji: foo;
+					font-variant-ligatures: foo1;
+					font-variant-position: foo2;
+					font-variant-caps: foo3;
+					font-variant-numeric: foo4;
+					font-variant-alternates: foo5;
+					font-variant-east-asian: foo6;
+					font-variant-emoji: foo7;
 					font-variant: foo;
 				}
 			`,

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -880,12 +880,12 @@ testRule({
 						font-variant-emoji: foo7;
 					}
 				`,
-			message: messages.expected('font-variant'),
 			fixed: stripIndent`
 				a {
 					font-variant: foo1 foo2 foo3 foo4 foo5 foo6 foo7;
 				}
-			`,
+				`,
+			message: messages.expected('font-variant'),
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.mjs
@@ -208,7 +208,6 @@ testRule({
 			message: messages.rejected('font-variant', 'font-variant-caps'),
 			line: 1,
 			endLine: 1,
-			skip: true,
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.mjs
@@ -207,7 +207,9 @@ testRule({
 			code: 'a { font-variant-caps: small-caps; font-variant: normal; }',
 			message: messages.rejected('font-variant', 'font-variant-caps'),
 			line: 1,
+			column: 36
 			endLine: 1,
+			endColumn: 48
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/__tests__/index.mjs
@@ -207,9 +207,9 @@ testRule({
 			code: 'a { font-variant-caps: small-caps; font-variant: normal; }',
 			message: messages.rejected('font-variant', 'font-variant-caps'),
 			line: 1,
-			column: 36
+			column: 36,
 			endLine: 1,
-			endColumn: 48
+			endColumn: 48,
 		},
 	],
 });

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -647,6 +647,7 @@ declare namespace stylelint {
 		| 'flex-flow'
 		| 'font'
 		| 'font-synthesis'
+		| 'font-variant'
 		| 'gap'
 		| 'grid'
 		| 'grid-area'


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7620

> Is there anything in the PR that needs further explanation?

Hi, I have updated the properties file and added few tests, let me know if there is anything missing or can be improved
