### PR TITLE
Save range of replaced text instead of range of original text in `report()`

### DIFF
--- a/lib/rules/keyframe-selector-notation/index.cjs
+++ b/lib/rules/keyframe-selector-notation/index.cjs
@@ -115,7 +115,9 @@ const rule = (primary) => {
 						result,
 						ruleName,
 						word: selector,
-						fix: () => (tag.value = fixedSelector),
+						fix: () => {
+							tag.value = fixedSelector;
+						},
 					});
 				}
 			});

--- a/lib/rules/keyframe-selector-notation/index.mjs
+++ b/lib/rules/keyframe-selector-notation/index.mjs
@@ -111,7 +111,9 @@ const rule = (primary) => {
 						result,
 						ruleName,
 						word: selector,
-						fix: () => (tag.value = fixedSelector),
+						fix: () => {
+							tag.value = fixedSelector;
+						},
 					});
 				}
 			});

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -11,6 +11,7 @@ test('without disabledRanges', () => {
 			warn: jest.fn(),
 			stylelint: {
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -36,6 +37,7 @@ test('with irrelevant general disabledRange', () => {
 					all: [{ start: 5, end: 8 }],
 				},
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -61,6 +63,7 @@ test('with relevant general disabledRange', () => {
 					all: [{ start: 5, end: 8 }],
 				},
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -84,6 +87,7 @@ test('with irrelevant rule-specific disabledRange', () => {
 					bar: [{ start: 5, end: 8 }],
 				},
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -110,6 +114,7 @@ test('with relevant rule-specific disabledRange', () => {
 					foo: [{ start: 5, end: 8 }],
 				},
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -135,6 +140,7 @@ test('with relevant general disabledRange, among others', () => {
 					],
 				},
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -161,6 +167,7 @@ test('with relevant rule-specific disabledRange, among others', () => {
 					],
 				},
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -184,6 +191,7 @@ test('with relevant rule-specific disabledRange with range report', () => {
 					foo: [{ start: 2, end: 2 }],
 				},
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -206,6 +214,7 @@ test("with quiet mode on and rule severity of 'warning'", () => {
 				ruleSeverities: {
 					foo: 'warning',
 				},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -228,6 +237,7 @@ test("with quiet mode on and rule severity of 'error'", () => {
 				ruleSeverities: {
 					foo: 'error',
 				},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -250,6 +260,7 @@ test('with custom rule severity', () => {
 				ruleSeverities: {
 					foo: 'error',
 				},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -277,6 +288,7 @@ test("with quiet mode on and custom rule severity of 'error'", () => {
 				ruleSeverities: {
 					foo: 'warning',
 				},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -300,6 +312,7 @@ test("with quiet mode on and custom rule severity of 'warning'", () => {
 				ruleSeverities: {
 					foo: 'error',
 				},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -323,6 +336,7 @@ test("with quiet mode on and with functional rule severity of 'error'", () => {
 				ruleSeverities: {
 					foo: customSeverity,
 				},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -349,6 +363,7 @@ test("with quiet mode on and with functional rule severity of 'warning'", () => 
 				ruleSeverities: {
 					foo: customSeverity,
 				},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -371,6 +386,7 @@ test('with message function', () => {
 			warn: jest.fn(),
 			stylelint: {
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: (a, b, c, d) => `a=${a}, b=${b}, c=${c}, d=${d}`,
@@ -387,6 +403,104 @@ test('with message function', () => {
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
+describe('with fix callback', () => {
+	test('fixing', () => {
+		const fixersData = {};
+		const v = {
+			ruleName: 'foo',
+			result: {
+				warn: jest.fn(),
+				stylelint: {
+					ruleSeverities: {},
+					fixersData,
+					config: {
+						fix: true,
+					},
+				},
+			},
+			index: 0,
+			endIndex: 1,
+			node: { rangeBy: defaultRangeBy },
+			fix: jest.fn(() => ({
+				start: { line: 1, column: 1 },
+				end: { line: 1, column: 2 },
+			})),
+		};
+
+		report(v);
+		expect(v.result.warn).toHaveBeenCalledTimes(0);
+		expect(v.fix).toHaveBeenCalledTimes(1);
+
+		const fixerData = fixersData.foo[0];
+		const position = expect.objectContaining({
+			line: expect.any(Number),
+			column: expect.any(Number),
+		});
+
+		expect(fixerData.range).toMatchObject({
+			start: position,
+			end: position,
+		});
+		expect(fixerData.fixed).toBe(true);
+	});
+
+	test('not fixing', () => {
+		const fixersData = {};
+		const v = {
+			ruleName: 'foo',
+			result: {
+				warn: jest.fn(),
+				stylelint: {
+					ruleSeverities: {},
+					fixersData,
+					config: {
+						fix: false,
+					},
+				},
+			},
+			message: 'bar',
+			index: 0,
+			endIndex: 1,
+			node: { rangeBy: defaultRangeBy },
+			fix: jest.fn(),
+		};
+
+		report(v);
+		expect(v.result.warn).toHaveBeenCalledTimes(1);
+		expect(v.fix).toHaveBeenCalledTimes(0);
+
+		const fixerData = fixersData.foo[0];
+
+		expect(fixerData.fixed).toBe(false);
+		expect(fixerData.range).toBeUndefined();
+	});
+});
+
+test('with fix callback missing', () => {
+	const fixersData = { foo: [{}] };
+	const v = {
+		ruleName: 'foo',
+		result: {
+			warn: jest.fn(),
+			stylelint: {
+				ruleSeverities: {},
+				fixersData,
+			},
+		},
+		index: 0,
+		message: 'bar',
+		node: { rangeBy: defaultRangeBy },
+	};
+
+	report(v);
+	expect(v.result.warn).toHaveBeenCalledTimes(1);
+
+	const fixerData = fixersData.foo[1];
+
+	expect(fixerData.fixed).toBe(false);
+	expect(fixerData.range).toBeUndefined();
+});
+
 test('with custom message', () => {
 	const v = {
 		ruleName: 'foo',
@@ -395,6 +509,7 @@ test('with custom message', () => {
 			stylelint: {
 				customMessages: { foo: 'A custom message: %s, %s, %d, %s' },
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -419,6 +534,7 @@ test('with custom message function', () => {
 			stylelint: {
 				customMessages: { foo: (a, b) => `a=${a}, b=${b}` },
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 		message: 'bar',
@@ -441,6 +557,7 @@ test('without node nor line', () => {
 		result: {
 			stylelint: {
 				ruleSeverities: {},
+				fixersData: {},
 			},
 		},
 	};

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -197,7 +197,7 @@ function isFixApplied(problem) {
 		hasFix && (config.ignoreDisables || !isDisabled(ruleName, range.start.line, disabledRanges));
 
 	if (fixed) {
-		addFixData({ fixersData, ruleName, fixed, range: fix() });
+		addFixData({ fixersData, ruleName, fixed, range: fix() ?? undefined });
 
 		return true;
 	}
@@ -211,7 +211,7 @@ function isFixApplied(problem) {
  * @param {object} o
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
- * @param {Range | void} [o.range] new range
+ * @param {Range} [o.range] new range
  * @param {boolean} o.fixed
  * @todo stylelint/stylelint#7192
  */

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -176,46 +176,47 @@ function isFixApplied(problem) {
 	const hasIndexes = validateTypes.isNumber(index) && validateTypes.isNumber(endIndex);
 	const hasRangeData = hasRange || hasIndexes || word;
 	const { disabledRanges, config = {}, fixersData } = result.stylelint;
-	const range = hasRange ? { start, end } : node?.rangeBy({ index, endIndex, word });
 
 	if (typeof fix !== 'function') {
-		if (hasRangeData) addFixData({ fixersData, ruleName, range, fixed: false });
+		addFixData({ fixersData, ruleName, fixed: false });
 
 		return false;
 	}
 
 	// even though stylelint-disable comments cannot be inserted inside a declaration or a selector list,
-	// new lines cannot be disregarded because Range is exposed through StylelintPostcssResult['fixersData']
-	// i.e. ranges must be accurate to be exploited
+	// a complete range is requested as a prerequisite
 	if (!hasRangeData) {
 		throw new Error(
 			`The fix callback for rule "${ruleName}" requires index/endIndex or start/end or word to be passed to the \`report()\` function.`,
 		);
 	}
 
-	const hasFix = config.fix && !config.rules?.[ruleName][1]?.disableFix;
-	const mayFix = config.ignoreDisables || !isDisabled(ruleName, range.start.line, disabledRanges);
-	const fixed = Boolean(hasFix) && mayFix;
+	const range = hasRange ? { start, end } : node?.rangeBy({ index, endIndex, word });
+	const hasFix = Boolean(config.fix && !config.rules?.[ruleName][1]?.disableFix);
+	const fixed =
+		hasFix && (config.ignoreDisables || !isDisabled(ruleName, range.start.line, disabledRanges));
 
-	addFixData({ fixersData, ruleName, range, fixed });
+	if (fixed) {
+		addFixData({ fixersData, ruleName, fixed, range: fix() });
 
-	if (!fixed) return false;
+		return true;
+	}
 
-	fix();
+	addFixData({ fixersData, ruleName, fixed });
 
-	return true;
+	return false;
 }
 
 /**
  * @param {object} o
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
- * @param {Range} o.range
+ * @param {Range | void} [o.range] new range
  * @param {boolean} o.fixed
- * @todo move under utils folder
+ * @todo stylelint/stylelint#7192
  */
 function addFixData({ fixersData, ruleName, range, fixed }) {
-	const array = fixersData[ruleName] || (fixersData[ruleName] = []);
+	const array = (fixersData[ruleName] ??= []);
 
 	array.push({ range, fixed });
 }

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -172,46 +172,47 @@ function isFixApplied(problem) {
 	const hasIndexes = isNumber(index) && isNumber(endIndex);
 	const hasRangeData = hasRange || hasIndexes || word;
 	const { disabledRanges, config = {}, fixersData } = result.stylelint;
-	const range = hasRange ? { start, end } : node?.rangeBy({ index, endIndex, word });
 
 	if (typeof fix !== 'function') {
-		if (hasRangeData) addFixData({ fixersData, ruleName, range, fixed: false });
+		addFixData({ fixersData, ruleName, fixed: false });
 
 		return false;
 	}
 
 	// even though stylelint-disable comments cannot be inserted inside a declaration or a selector list,
-	// new lines cannot be disregarded because Range is exposed through StylelintPostcssResult['fixersData']
-	// i.e. ranges must be accurate to be exploited
+	// a complete range is requested as a prerequisite
 	if (!hasRangeData) {
 		throw new Error(
 			`The fix callback for rule "${ruleName}" requires index/endIndex or start/end or word to be passed to the \`report()\` function.`,
 		);
 	}
 
-	const hasFix = config.fix && !config.rules?.[ruleName][1]?.disableFix;
-	const mayFix = config.ignoreDisables || !isDisabled(ruleName, range.start.line, disabledRanges);
-	const fixed = Boolean(hasFix) && mayFix;
+	const range = hasRange ? { start, end } : node?.rangeBy({ index, endIndex, word });
+	const hasFix = Boolean(config.fix && !config.rules?.[ruleName][1]?.disableFix);
+	const fixed =
+		hasFix && (config.ignoreDisables || !isDisabled(ruleName, range.start.line, disabledRanges));
 
-	addFixData({ fixersData, ruleName, range, fixed });
+	if (fixed) {
+		addFixData({ fixersData, ruleName, fixed, range: fix() });
 
-	if (!fixed) return false;
+		return true;
+	}
 
-	fix();
+	addFixData({ fixersData, ruleName, fixed });
 
-	return true;
+	return false;
 }
 
 /**
  * @param {object} o
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
- * @param {Range} o.range
+ * @param {Range | void} [o.range] new range
  * @param {boolean} o.fixed
- * @todo move under utils folder
+ * @todo stylelint/stylelint#7192
  */
 function addFixData({ fixersData, ruleName, range, fixed }) {
-	const array = fixersData[ruleName] || (fixersData[ruleName] = []);
+	const array = (fixersData[ruleName] ??= []);
 
 	array.push({ range, fixed });
 }

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -193,7 +193,7 @@ function isFixApplied(problem) {
 		hasFix && (config.ignoreDisables || !isDisabled(ruleName, range.start.line, disabledRanges));
 
 	if (fixed) {
-		addFixData({ fixersData, ruleName, fixed, range: fix() });
+		addFixData({ fixersData, ruleName, fixed, range: fix() ?? undefined });
 
 		return true;
 	}
@@ -207,7 +207,7 @@ function isFixApplied(problem) {
  * @param {object} o
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
- * @param {Range | void} [o.range] new range
+ * @param {Range} [o.range] new range
  * @param {boolean} o.fixed
  * @todo stylelint/stylelint#7192
  */

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -259,7 +259,7 @@ declare namespace stylelint {
 	};
 
 	type FixerData = {
-		range: Range | void;
+		range?: Range;
 		fixed: boolean;
 	};
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -259,7 +259,7 @@ declare namespace stylelint {
 	};
 
 	type FixerData = {
-		range: Range;
+		range: Range | void;
 		fixed: boolean;
 	};
 
@@ -627,7 +627,7 @@ declare namespace stylelint {
 		 * Optional severity override for the problem.
 		 */
 		severity?: RuleSeverity;
-		fix?: () => void | never;
+		fix?: () => void | never | Range;
 	};
 
 	/** @internal */


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#7730 and #7192

> Is there anything in the PR that needs further explanation?

What was actually missing wasn't the original range but the range of the replaced text.
i.e. `fix` return type is now `void | never | Range`
Returning the new range from the fixer is not a hard requirement for refactors though.
Nothing was exploiting `range` yet so it's safe.
Ill stop sending new rule refactor PRs until this is merged.

see discussion starting with https://github.com/stylelint/stylelint/issues/7192#issuecomment-2159321591