### PR TITLE
Fix `at-rule-no-unknown` false positives for `@view-transition`

### DIFF
--- a/.changeset/selfish-birds-smash.md
+++ b/.changeset/selfish-birds-smash.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `at-rule-no-unknown` false positives for `@view-transition`

--- a/lib/reference/atKeywords.cjs
+++ b/lib/reference/atKeywords.cjs
@@ -57,6 +57,7 @@ const atKeywords = uniteSets(nestingSupportedAtKeywords, pageMarginAtKeywords, [
 	'styleset',
 	'stylistic',
 	'swash',
+	'view-transition',
 	'viewport',
 ]);
 

--- a/lib/reference/atKeywords.mjs
+++ b/lib/reference/atKeywords.mjs
@@ -53,5 +53,6 @@ export const atKeywords = uniteSets(nestingSupportedAtKeywords, pageMarginAtKeyw
 	'styleset',
 	'stylistic',
 	'swash',
+	'view-transition',
 	'viewport',
 ]);


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #7750 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory. Only adds view-transition to the list of known keywords.


Apologies if I missed something!
