### PR TITLE
Refactor `comment-whitespace-inside` to use `fix` callback instead of `context.fix`

### DIFF
--- a/lib/rules/comment-whitespace-inside/index.cjs
+++ b/lib/rules/comment-whitespace-inside/index.cjs
@@ -121,16 +121,14 @@ const rule = (primary) => {
 						comment.raws.left = '';
 						comment.raws.right = '';
 						comment.text = comment.text.replace(/^(\*+)(\s+)?/, '$1').replace(/(\s+)?(\*+)$/, '$2');
+					} else {
+						const mutate =
+							message === messages.expectedClosing ? addWhitespaceAfter : addWhitespaceBefore;
 
-						return comment.rangeBy({ index, endIndex: index });
+						mutate(comment);
 					}
 
-					const mutate =
-						message === messages.expectedClosing ? addWhitespaceAfter : addWhitespaceBefore;
-
-					mutate(comment);
-
-					return comment.rangeBy({ index, endIndex: index + 1 });
+					return comment.rangeBy({ index, endIndex: index });
 				};
 
 				report({

--- a/lib/rules/comment-whitespace-inside/index.cjs
+++ b/lib/rules/comment-whitespace-inside/index.cjs
@@ -45,7 +45,7 @@ function addWhitespaceAfter(comment) {
 }
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -116,23 +116,22 @@ const rule = (primary, _secondaryOptions, context) => {
 			 * @param {number} endIndex
 			 */
 			function complain(message, index, endIndex = index) {
-				if (context.fix) {
+				const fix = () => {
 					if (primary === 'never') {
 						comment.raws.left = '';
 						comment.raws.right = '';
 						comment.text = comment.text.replace(/^(\*+)(\s+)?/, '$1').replace(/(\s+)?(\*+)$/, '$2');
-					} else {
-						if (!leftSpace) {
-							addWhitespaceBefore(comment);
-						}
 
-						if (!rightSpace) {
-							addWhitespaceAfter(comment);
-						}
+						return comment.rangeBy({ index, endIndex: index });
 					}
 
-					return;
-				}
+					const mutate =
+						message === messages.expectedClosing ? addWhitespaceAfter : addWhitespaceBefore;
+
+					mutate(comment);
+
+					return comment.rangeBy({ index, endIndex: index + 1 });
+				};
 
 				report({
 					message,
@@ -141,6 +140,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					result,
 					ruleName,
 					node: comment,
+					fix,
 				});
 			}
 		});

--- a/lib/rules/comment-whitespace-inside/index.mjs
+++ b/lib/rules/comment-whitespace-inside/index.mjs
@@ -41,7 +41,7 @@ function addWhitespaceAfter(comment) {
 }
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -112,23 +112,22 @@ const rule = (primary, _secondaryOptions, context) => {
 			 * @param {number} endIndex
 			 */
 			function complain(message, index, endIndex = index) {
-				if (context.fix) {
+				const fix = () => {
 					if (primary === 'never') {
 						comment.raws.left = '';
 						comment.raws.right = '';
 						comment.text = comment.text.replace(/^(\*+)(\s+)?/, '$1').replace(/(\s+)?(\*+)$/, '$2');
-					} else {
-						if (!leftSpace) {
-							addWhitespaceBefore(comment);
-						}
 
-						if (!rightSpace) {
-							addWhitespaceAfter(comment);
-						}
+						return comment.rangeBy({ index, endIndex: index });
 					}
 
-					return;
-				}
+					const mutate =
+						message === messages.expectedClosing ? addWhitespaceAfter : addWhitespaceBefore;
+
+					mutate(comment);
+
+					return comment.rangeBy({ index, endIndex: index + 1 });
+				};
 
 				report({
 					message,
@@ -137,6 +136,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					result,
 					ruleName,
 					node: comment,
+					fix,
 				});
 			}
 		});

--- a/lib/rules/comment-whitespace-inside/index.mjs
+++ b/lib/rules/comment-whitespace-inside/index.mjs
@@ -117,16 +117,14 @@ const rule = (primary) => {
 						comment.raws.left = '';
 						comment.raws.right = '';
 						comment.text = comment.text.replace(/^(\*+)(\s+)?/, '$1').replace(/(\s+)?(\*+)$/, '$2');
+					} else {
+						const mutate =
+							message === messages.expectedClosing ? addWhitespaceAfter : addWhitespaceBefore;
 
-						return comment.rangeBy({ index, endIndex: index });
+						mutate(comment);
 					}
 
-					const mutate =
-						message === messages.expectedClosing ? addWhitespaceAfter : addWhitespaceBefore;
-
-					mutate(comment);
-
-					return comment.rangeBy({ index, endIndex: index + 1 });
+					return comment.rangeBy({ index, endIndex: index });
 				};
 
 				report({


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#2643

> Is there anything in the PR that needs further explanation?

It used to fix both sides for `"always"` regardless of the current `complain`.
i.e. in certain cases it was attempting 2 more fixes for nothing