### PR TITLE
Refactor to turn on `reportUnusedDisableDirectives` for ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
       "testRule": "readonly",
       "testRuleConfigs": "readonly"
     },
+    "reportUnusedDisableDirectives": true,
     "root": true
   },
   "remarkConfig": {


### PR DESCRIPTION
This `reportUnusedDisableDirectives` option reports unused `// eslint-disable` comments.

For example, assume the following JS file:

```js
const a = 1; // eslint-disable-line no-unused-vars

a;
```

Run ESLint with this option on or off:

```sh-session
# reportUnusedDisableDirectives: false
$ npx eslint tmp/eslint-test.js
(success)

# reportUnusedDisableDirectives: true
$ npx eslint tmp/eslint-test.js

/Users/masafumi.koba/git/stylelint/stylelint/tmp/eslint-test.js
  1:14  warning  Unused eslint-disable directive (no problems were reported from 'no-unused-vars')
```

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
