### PR TITLE
Fix `selector-no-vendor-prefix` autofix

### DIFF
--- a/.changeset/silly-insects-ring.md
+++ b/.changeset/silly-insects-ring.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-no-vendor-prefix` autofix

--- a/lib/rules/selector-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/selector-no-vendor-prefix/__tests__/index.mjs
@@ -107,6 +107,15 @@ testRule({
 			endLine: 1,
 			endColumn: 33,
 		},
+		{
+			code: 'input::-ms-clear + input::-moz-placeholder {}',
+			fixed: 'input::-ms-clear + input::placeholder {}',
+			message: messages.rejected('::-moz-placeholder'),
+			line: 1,
+			column: 25,
+			endLine: 1,
+			endColumn: 43,
+		},
 	],
 });
 

--- a/lib/rules/selector-no-vendor-prefix/index.cjs
+++ b/lib/rules/selector-no-vendor-prefix/index.cjs
@@ -52,7 +52,11 @@ const rule = (primary, secondaryOptions, context) => {
 
 			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, ruleNode)?.walkPseudos((pseudoNode) => {
+			const resolvedRoot = parseSelector(selector, result, ruleNode);
+
+			if (!resolvedRoot) return;
+
+			resolvedRoot.walkPseudos((pseudoNode) => {
 				const { value } = pseudoNode;
 
 				if (!isAutoprefixable.selector(value)) {
@@ -64,7 +68,8 @@ const rule = (primary, secondaryOptions, context) => {
 				}
 
 				if (context.fix) {
-					ruleNode.selector = isAutoprefixable.unprefix(selector);
+					pseudoNode.value = isAutoprefixable.unprefix(value);
+					ruleNode.selector = resolvedRoot.toString();
 
 					return;
 				}

--- a/lib/rules/selector-no-vendor-prefix/index.mjs
+++ b/lib/rules/selector-no-vendor-prefix/index.mjs
@@ -48,7 +48,11 @@ const rule = (primary, secondaryOptions, context) => {
 
 			const selector = ruleNode.selector;
 
-			parseSelector(selector, result, ruleNode)?.walkPseudos((pseudoNode) => {
+			const resolvedRoot = parseSelector(selector, result, ruleNode);
+
+			if (!resolvedRoot) return;
+
+			resolvedRoot.walkPseudos((pseudoNode) => {
 				const { value } = pseudoNode;
 
 				if (!isAutoprefixable.selector(value)) {
@@ -60,7 +64,8 @@ const rule = (primary, secondaryOptions, context) => {
 				}
 
 				if (context.fix) {
-					ruleNode.selector = isAutoprefixable.unprefix(selector);
+					pseudoNode.value = isAutoprefixable.unprefix(value);
+					ruleNode.selector = resolvedRoot.toString();
 
 					return;
 				}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#4856

> Is there anything in the PR that needs further explanation?

1.
[demo](https://stylelint.io/demo/#N4Igxg9gJgpiBcICWA7ADgVwC73gWgFsBnPMAGxgEMAnAAgGpbVMd8CIAvPNMysGABYQysOsAC+AHRQgANCABmSCgDlKBOIhgAPdTxgA6MESJzwEFEoDmCEMGm1akkNQwUiz+LXspHj50QwFGBYENR4KBB4AG4wKFBh3NQwStqetFiuMA60UijiZpCWSFYAYmEElFi2AFZEFmawaKaIPv4gRFgAnhRkqFjpzrxYMJ3OsjkB3b39pBbWeJ2U8TRQgyDDowMg0gXiQA)

2.
A node of type `"pseudo"` cannot be passed directly to `report`.

3.
codecov can be ignored.