### PR TITLE
Refactor `at-rule-no-vendor-prefix` to use `fix` callback instead of `context.fix` and fix false negatives

### DIFF
--- a/.changeset/afraid-windows-play.md
+++ b/.changeset/afraid-windows-play.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": patch
+"stylelint": minor
 ---
 
-Fixed: `at-rule-no-vendor-prefix` false negatives
+Fixed: `at-rule-no-vendor-prefix` false negatives for `@-moz-document` and `@-webkit-viewport`

--- a/.changeset/afraid-windows-play.md
+++ b/.changeset/afraid-windows-play.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `at-rule-no-vendor-prefix` false negatives

--- a/lib/rules/at-rule-no-vendor-prefix/index.cjs
+++ b/lib/rules/at-rule-no-vendor-prefix/index.cjs
@@ -20,7 +20,7 @@ const meta = {
 };
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondary, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
@@ -43,11 +43,11 @@ const rule = (primary, _secondary, context) => {
 				return;
 			}
 
-			if (context.fix) {
+			const fix = () => {
 				atRule.name = isAutoprefixable.unprefix(atRule.name);
 
-				return;
-			}
+				return atRule.rangeBy({ word: `@${atRule.name}` });
+			};
 
 			report({
 				message: messages.rejected,
@@ -56,6 +56,7 @@ const rule = (primary, _secondary, context) => {
 				word: `@${name}`,
 				result,
 				ruleName,
+				fix,
 			});
 		});
 	};

--- a/lib/rules/at-rule-no-vendor-prefix/index.mjs
+++ b/lib/rules/at-rule-no-vendor-prefix/index.mjs
@@ -16,7 +16,7 @@ const meta = {
 };
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondary, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
@@ -39,11 +39,11 @@ const rule = (primary, _secondary, context) => {
 				return;
 			}
 
-			if (context.fix) {
+			const fix = () => {
 				atRule.name = isAutoprefixable.unprefix(atRule.name);
 
-				return;
-			}
+				return atRule.rangeBy({ word: `@${atRule.name}` });
+			};
 
 			report({
 				message: messages.rejected,
@@ -52,6 +52,7 @@ const rule = (primary, _secondary, context) => {
 				word: `@${name}`,
 				result,
 				ruleName,
+				fix,
 			});
 		});
 	};

--- a/lib/utils/__tests__/isAutoprefixable.test.mjs
+++ b/lib/utils/__tests__/isAutoprefixable.test.mjs
@@ -4,7 +4,7 @@ describe('isAutoprefixable.atRuleName()', () => {
 	it('returns true', () => {
 		expect(isAutoprefixable.atRuleName('-moz-keyframes')).toBe(true);
 		expect(isAutoprefixable.atRuleName('-ms-viewport')).toBe(true);
-		expect(isAutoprefixable.atRuleName('resolution')).toBe(true);
+		expect(isAutoprefixable.atRuleName('-moz-document')).toBe(true);
 	});
 
 	it('returns false', () => {

--- a/lib/utils/isAutoprefixable.cjs
+++ b/lib/utils/isAutoprefixable.cjs
@@ -25,12 +25,13 @@ const vendor = require('./vendor.cjs');
 const AT_RULES = new Set([
 	'@-khtml-keyframes',
 	'@-moz-keyframes',
+	'@-moz-document',
 	'@-ms-keyframes',
 	'@-ms-viewport',
 	'@-o-keyframes',
 	'@-o-viewport',
 	'@-webkit-keyframes',
-	'@resolution',
+	'@-webkit-viewport',
 ]);
 
 /**

--- a/lib/utils/isAutoprefixable.cjs
+++ b/lib/utils/isAutoprefixable.cjs
@@ -23,7 +23,6 @@ const vendor = require('./vendor.cjs');
  * Object.keys(prefixes.remove).filter((s) => s.startsWith('@'));
  */
 const AT_RULES = new Set([
-	'@-khtml-keyframes',
 	'@-moz-keyframes',
 	'@-moz-document',
 	'@-ms-keyframes',

--- a/lib/utils/isAutoprefixable.mjs
+++ b/lib/utils/isAutoprefixable.mjs
@@ -21,12 +21,13 @@ import vendor from './vendor.mjs';
 const AT_RULES = new Set([
 	'@-khtml-keyframes',
 	'@-moz-keyframes',
+	'@-moz-document',
 	'@-ms-keyframes',
 	'@-ms-viewport',
 	'@-o-keyframes',
 	'@-o-viewport',
 	'@-webkit-keyframes',
-	'@resolution',
+	'@-webkit-viewport',
 ]);
 
 /**

--- a/lib/utils/isAutoprefixable.mjs
+++ b/lib/utils/isAutoprefixable.mjs
@@ -19,7 +19,6 @@ import vendor from './vendor.mjs';
  * Object.keys(prefixes.remove).filter((s) => s.startsWith('@'));
  */
 const AT_RULES = new Set([
-	'@-khtml-keyframes',
 	'@-moz-keyframes',
 	'@-moz-document',
 	'@-ms-keyframes',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#2643

> Is there anything in the PR that needs further explanation?

- false negatives
  - `@-moz-document`: https://developer.mozilla.org/en-US/docs/Web/CSS/@document#browser_compatibility
  - `@-webkit-viewport`
    - https://trac.webkit.org/browser/webkit/trunk/LayoutTests/css3/device-adapt/viewport-at-rule-parsing.html?rev=133084
    - https://github.com/WebKit/WebKit/commit/faab0fc796cf0ac3af2a05f928f032d433d3a726
- don't exist
  - `@resolution`
    - https://github.com/postcss/autoprefixer/blob/main/data/prefixes.js#L815-L823
    - https://caniuse.com/css-media-resolution
  - `@-khtml-keyframes`
    - https://github.com/postcss/autoprefixer/blob/main/data/prefixes.js#L109
    - https://github.com/postcss/autoprefixer/commit/fa4d7263ce9e6a3792201577d57ebcfdce8afde9