### PR TITLE
Fix `at-rule-no-unknown` false positives for `@historical-forms` and `@font-palette-values`

### DIFF
--- a/.changeset/lucky-grapes-listen.md
+++ b/.changeset/lucky-grapes-listen.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `at-rule-no-unknown` false positives for `@historical-forms` and `@font-palette-values`

--- a/lib/reference/atKeywords.cjs
+++ b/lib/reference/atKeywords.cjs
@@ -34,32 +34,43 @@ const pageMarginAtKeywords = new Set([
 	'right-bottom',
 ]);
 
-// https://developer.mozilla.org/en/docs/Web/CSS/At-rule
-const atKeywords = uniteSets(nestingSupportedAtKeywords, pageMarginAtKeywords, [
+// https://www.w3.org/TR/css-fonts-4/#font-feature-values-font-feature-value-type
+const fontFeatureValueTypes = new Set([
 	'annotation',
-	'apply',
 	'character-variant',
-	'charset',
-	'counter-style',
-	'custom-media',
-	'custom-selector',
-	'document',
-	'font-face',
-	'font-feature-values',
-	'import',
-	'keyframes',
-	'namespace',
-	'nest',
+	'historical-forms',
 	'ornaments',
-	'page',
-	'property',
-	'scroll-timeline',
 	'styleset',
 	'stylistic',
 	'swash',
-	'view-transition',
-	'viewport',
 ]);
+
+// https://developer.mozilla.org/en/docs/Web/CSS/At-rule
+const atKeywords = uniteSets(
+	nestingSupportedAtKeywords,
+	pageMarginAtKeywords,
+	fontFeatureValueTypes,
+	[
+		'apply',
+		'charset',
+		'counter-style',
+		'custom-media',
+		'custom-selector',
+		'document',
+		'font-face',
+		'font-feature-values',
+		'font-palette-values',
+		'import',
+		'keyframes',
+		'namespace',
+		'nest',
+		'page',
+		'property',
+		'scroll-timeline',
+		'view-transition',
+		'viewport',
+	],
+);
 
 exports.atKeywords = atKeywords;
 exports.nestingSupportedAtKeywords = nestingSupportedAtKeywords;

--- a/lib/reference/atKeywords.mjs
+++ b/lib/reference/atKeywords.mjs
@@ -30,29 +30,40 @@ const pageMarginAtKeywords = new Set([
 	'right-bottom',
 ]);
 
-// https://developer.mozilla.org/en/docs/Web/CSS/At-rule
-export const atKeywords = uniteSets(nestingSupportedAtKeywords, pageMarginAtKeywords, [
+// https://www.w3.org/TR/css-fonts-4/#font-feature-values-font-feature-value-type
+const fontFeatureValueTypes = new Set([
 	'annotation',
-	'apply',
 	'character-variant',
-	'charset',
-	'counter-style',
-	'custom-media',
-	'custom-selector',
-	'document',
-	'font-face',
-	'font-feature-values',
-	'import',
-	'keyframes',
-	'namespace',
-	'nest',
+	'historical-forms',
 	'ornaments',
-	'page',
-	'property',
-	'scroll-timeline',
 	'styleset',
 	'stylistic',
 	'swash',
-	'view-transition',
-	'viewport',
 ]);
+
+// https://developer.mozilla.org/en/docs/Web/CSS/At-rule
+export const atKeywords = uniteSets(
+	nestingSupportedAtKeywords,
+	pageMarginAtKeywords,
+	fontFeatureValueTypes,
+	[
+		'apply',
+		'charset',
+		'counter-style',
+		'custom-media',
+		'custom-selector',
+		'document',
+		'font-face',
+		'font-feature-values',
+		'font-palette-values',
+		'import',
+		'keyframes',
+		'namespace',
+		'nest',
+		'page',
+		'property',
+		'scroll-timeline',
+		'view-transition',
+		'viewport',
+	],
+);

--- a/lib/rules/at-rule-no-unknown/__tests__/index.mjs
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.mjs
@@ -96,10 +96,6 @@ testRule({
 		{
 			code: '@scroll-timeline foo {}',
 		},
-		{
-			code: '@color-profile --swop5c {}',
-			skip: true,
-		},
 	],
 
 	reject: [

--- a/lib/rules/at-rule-no-unknown/__tests__/index.mjs
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.mjs
@@ -96,6 +96,10 @@ testRule({
 		{
 			code: '@scroll-timeline foo {}',
 		},
+		{
+			code: '@color-profile --swop5c {}',
+			skip: true,
+		},
 	],
 
 	reject: [


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#1515

> Is there anything in the PR that needs further explanation?

1.
`@historical-forms` was added after #1537 was merged.
ref: https://www.w3.org/TR/2018/WD-css-fonts-4-20180920/#font-feature-values-syntax

2.
[`@font-palette-values`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-palette-values)

