### PR TITLE
Refactor `selector-attribute-quotes` to use `fix` callback instead of `context.fix`

### DIFF
--- a/lib/rules/selector-attribute-quotes/index.cjs
+++ b/lib/rules/selector-attribute-quotes/index.cjs
@@ -50,7 +50,7 @@ const rule = (primary) => {
 			if (!selectorTree) return;
 
 			/**
-			 * @param {'expected'|'rejected'} messageType
+			 * @param {keyof messages} messageType
 			 * @param {import('postcss-selector-parser').Attribute} attrNode
 			 */
 			const complain = (messageType, attrNode) => {

--- a/lib/rules/selector-attribute-quotes/index.cjs
+++ b/lib/rules/selector-attribute-quotes/index.cjs
@@ -22,10 +22,8 @@ const meta = {
 	fixable: true,
 };
 
-const acceptedQuoteMark = '"';
-
 /** @type {import('stylelint').Rule<'always' | 'never'>} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -51,7 +49,35 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			if (!selectorTree) return;
 
-			let selectorFixed = false;
+			/**
+			 * @param {'expected'|'rejected'} messageType
+			 * @param {import('postcss-selector-parser').Attribute} attrNode
+			 */
+			const complain = (messageType, attrNode) => {
+				const index = attrNode.sourceIndex + attrNode.offsetOf('value');
+				const value = attrNode.value || '';
+				const endIndex = index + (attrNode.raws.value ?? value).length;
+
+				const fix = () => {
+					const quoteMark = messageType === 'expected' ? '"' : null;
+					const offset = messageType === 'expected' ? 2 : -2;
+
+					attrNode.quoteMark = quoteMark;
+					ruleNode.selector = selectorTree.toString();
+
+					return ruleNode.rangeBy({ index, endIndex: endIndex + offset });
+				};
+
+				report({
+					message: messages[messageType](value),
+					index,
+					endIndex,
+					result,
+					ruleName,
+					node: ruleNode,
+					fix,
+				});
+			};
 
 			selectorTree.walkAttributes((attributeNode) => {
 				const { operator, value, quoted } = attributeNode;
@@ -61,12 +87,7 @@ const rule = (primary, _secondaryOptions, context) => {
 				}
 
 				if (!quoted && primary === 'always') {
-					if (context.fix) {
-						selectorFixed = true;
-						attributeNode.quoteMark = acceptedQuoteMark;
-					} else {
-						complain(messages.expected(value), attributeNode);
-					}
+					complain('expected', attributeNode);
 				}
 
 				if (quoted && primary === 'never') {
@@ -81,37 +102,9 @@ const rule = (primary, _secondaryOptions, context) => {
 						return;
 					}
 
-					if (context.fix) {
-						selectorFixed = true;
-						attributeNode.quoteMark = null;
-					} else {
-						complain(messages.rejected(value), attributeNode);
-					}
+					complain('rejected', attributeNode);
 				}
 			});
-
-			if (selectorFixed) {
-				ruleNode.selector = selectorTree.toString();
-			}
-
-			/**
-			 * @param {string} message
-			 * @param {import('postcss-selector-parser').Attribute} attrNode
-			 */
-			function complain(message, attrNode) {
-				const index = attrNode.sourceIndex + attrNode.offsetOf('value');
-				const value = attrNode.raws.value || attrNode.value || '';
-				const endIndex = index + value.length;
-
-				report({
-					message,
-					index,
-					endIndex,
-					result,
-					ruleName,
-					node: ruleNode,
-				});
-			}
 		});
 	};
 };

--- a/lib/rules/selector-attribute-quotes/index.mjs
+++ b/lib/rules/selector-attribute-quotes/index.mjs
@@ -46,7 +46,7 @@ const rule = (primary) => {
 			if (!selectorTree) return;
 
 			/**
-			 * @param {'expected'|'rejected'} messageType
+			 * @param {keyof messages} messageType
 			 * @param {import('postcss-selector-parser').Attribute} attrNode
 			 */
 			const complain = (messageType, attrNode) => {

--- a/lib/rules/selector-attribute-quotes/index.mjs
+++ b/lib/rules/selector-attribute-quotes/index.mjs
@@ -18,10 +18,8 @@ const meta = {
 	fixable: true,
 };
 
-const acceptedQuoteMark = '"';
-
 /** @type {import('stylelint').Rule<'always' | 'never'>} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -47,7 +45,35 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			if (!selectorTree) return;
 
-			let selectorFixed = false;
+			/**
+			 * @param {'expected'|'rejected'} messageType
+			 * @param {import('postcss-selector-parser').Attribute} attrNode
+			 */
+			const complain = (messageType, attrNode) => {
+				const index = attrNode.sourceIndex + attrNode.offsetOf('value');
+				const value = attrNode.value || '';
+				const endIndex = index + (attrNode.raws.value ?? value).length;
+
+				const fix = () => {
+					const quoteMark = messageType === 'expected' ? '"' : null;
+					const offset = messageType === 'expected' ? 2 : -2;
+
+					attrNode.quoteMark = quoteMark;
+					ruleNode.selector = selectorTree.toString();
+
+					return ruleNode.rangeBy({ index, endIndex: endIndex + offset });
+				};
+
+				report({
+					message: messages[messageType](value),
+					index,
+					endIndex,
+					result,
+					ruleName,
+					node: ruleNode,
+					fix,
+				});
+			};
 
 			selectorTree.walkAttributes((attributeNode) => {
 				const { operator, value, quoted } = attributeNode;
@@ -57,12 +83,7 @@ const rule = (primary, _secondaryOptions, context) => {
 				}
 
 				if (!quoted && primary === 'always') {
-					if (context.fix) {
-						selectorFixed = true;
-						attributeNode.quoteMark = acceptedQuoteMark;
-					} else {
-						complain(messages.expected(value), attributeNode);
-					}
+					complain('expected', attributeNode);
 				}
 
 				if (quoted && primary === 'never') {
@@ -77,37 +98,9 @@ const rule = (primary, _secondaryOptions, context) => {
 						return;
 					}
 
-					if (context.fix) {
-						selectorFixed = true;
-						attributeNode.quoteMark = null;
-					} else {
-						complain(messages.rejected(value), attributeNode);
-					}
+					complain('rejected', attributeNode);
 				}
 			});
-
-			if (selectorFixed) {
-				ruleNode.selector = selectorTree.toString();
-			}
-
-			/**
-			 * @param {string} message
-			 * @param {import('postcss-selector-parser').Attribute} attrNode
-			 */
-			function complain(message, attrNode) {
-				const index = attrNode.sourceIndex + attrNode.offsetOf('value');
-				const value = attrNode.raws.value || attrNode.value || '';
-				const endIndex = index + value.length;
-
-				report({
-					message,
-					index,
-					endIndex,
-					result,
-					ruleName,
-					node: ruleNode,
-				});
-			}
 		});
 	};
 };


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#2643

> Is there anything in the PR that needs further explanation?

nit
off-topic
`color-hex-alpha` and `no-irregular-whitespace` should be refactored to follow the `rejected` convention