### PR TITLE
Refactor `font-family-name-quotes` to use `fix` callback instead of `context.fix` and fix false negatives

### DIFF
--- a/.changeset/khaki-eels-love.md
+++ b/.changeset/khaki-eels-love.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `font-family-name-quotes` false negatives for `-moz-*`/`-webkit-*` keywords

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
           files: ./.coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          version: '0.6.0' # TODO: Workaround for https://github.com/codecov/codecov-action/issues/1487
+          version: v0.6.0 # TODO: Workaround for https://github.com/codecov/codecov-action/issues/1487
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,7 @@ jobs:
           files: ./.coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          version: '0.6.0' # TODO: Workaround for https://github.com/codecov/codecov-action/issues/1487
 
   build:
     runs-on: ubuntu-latest

--- a/lib/reference/keywords.cjs
+++ b/lib/reference/keywords.cjs
@@ -6,7 +6,6 @@ const uniteSets = require('../utils/uniteSets.cjs');
 
 const basicKeywords = new Set(['initial', 'inherit', 'revert', 'revert-layer', 'unset']);
 
-/** @todo add to {@link fontFamilyKeywords} */
 const systemFontKeywords = uniteSets(basicKeywords, [
 	'caption',
 	'icon',

--- a/lib/reference/keywords.cjs
+++ b/lib/reference/keywords.cjs
@@ -6,6 +6,7 @@ const uniteSets = require('../utils/uniteSets.cjs');
 
 const basicKeywords = new Set(['initial', 'inherit', 'revert', 'revert-layer', 'unset']);
 
+/** @todo add to {@link fontFamilyKeywords} */
 const systemFontKeywords = uniteSets(basicKeywords, [
 	'caption',
 	'icon',
@@ -27,6 +28,56 @@ const fontFamilyKeywords = uniteSets(basicKeywords, [
 	'ui-monospace',
 	'ui-rounded',
 ]);
+
+const appleSystemFonts = new Set([
+	'-apple-system',
+	'-apple-system-headline',
+	'-apple-system-body',
+	'-apple-system-subheadline',
+	'-apple-system-footnote',
+	'-apple-system-caption1',
+	'-apple-system-caption2',
+	'-apple-system-short-headline',
+	'-apple-system-short-body',
+	'-apple-system-short-subheadline',
+	'-apple-system-short-footnote',
+	'-apple-system-short-caption1',
+	'-apple-system-tall-body',
+	'-apple-system-title0',
+	'-apple-system-title1',
+	'-apple-system-title2',
+	'-apple-system-title3',
+	'-apple-system-title4',
+]);
+
+const mozillaSystemFonts = new Set([
+	'-moz-button',
+	'-moz-desktop',
+	'-moz-dialog',
+	'-moz-document',
+	'-moz-field',
+	'-moz-fixed',
+	'-moz-info',
+	'-moz-list',
+	'-moz-pull-down-menu',
+	'-moz-window',
+	'-moz-workspace',
+]);
+
+const webkitSystemFonts = new Set([
+	'-webkit-body',
+	'-webkit-control',
+	'-webkit-mini-control',
+	'-webkit-pictograph',
+	'-webkit-small-control',
+	'-webkit-standard',
+]);
+
+const prefixedSystemFonts = uniteSets(
+	appleSystemFonts,
+	mozillaSystemFonts,
+	webkitSystemFonts,
+);
 
 const fontWeightRelativeKeywords = new Set(['bolder', 'lighter']);
 
@@ -501,5 +552,6 @@ exports.listStylePositionKeywords = listStylePositionKeywords;
 exports.listStyleShorthandKeywords = listStyleShorthandKeywords;
 exports.listStyleTypeKeywords = listStyleTypeKeywords;
 exports.namedColorsKeywords = namedColorsKeywords;
+exports.prefixedSystemFonts = prefixedSystemFonts;
 exports.systemColorsKeywords = systemColorsKeywords;
 exports.systemFontKeywords = systemFontKeywords;

--- a/lib/reference/keywords.mjs
+++ b/lib/reference/keywords.mjs
@@ -2,7 +2,6 @@ import uniteSets from '../utils/uniteSets.mjs';
 
 export const basicKeywords = new Set(['initial', 'inherit', 'revert', 'revert-layer', 'unset']);
 
-/** @todo add to {@link fontFamilyKeywords} */
 export const systemFontKeywords = uniteSets(basicKeywords, [
 	'caption',
 	'icon',

--- a/lib/reference/keywords.mjs
+++ b/lib/reference/keywords.mjs
@@ -2,6 +2,7 @@ import uniteSets from '../utils/uniteSets.mjs';
 
 export const basicKeywords = new Set(['initial', 'inherit', 'revert', 'revert-layer', 'unset']);
 
+/** @todo add to {@link fontFamilyKeywords} */
 export const systemFontKeywords = uniteSets(basicKeywords, [
 	'caption',
 	'icon',
@@ -23,6 +24,56 @@ export const fontFamilyKeywords = uniteSets(basicKeywords, [
 	'ui-monospace',
 	'ui-rounded',
 ]);
+
+const appleSystemFonts = new Set([
+	'-apple-system',
+	'-apple-system-headline',
+	'-apple-system-body',
+	'-apple-system-subheadline',
+	'-apple-system-footnote',
+	'-apple-system-caption1',
+	'-apple-system-caption2',
+	'-apple-system-short-headline',
+	'-apple-system-short-body',
+	'-apple-system-short-subheadline',
+	'-apple-system-short-footnote',
+	'-apple-system-short-caption1',
+	'-apple-system-tall-body',
+	'-apple-system-title0',
+	'-apple-system-title1',
+	'-apple-system-title2',
+	'-apple-system-title3',
+	'-apple-system-title4',
+]);
+
+const mozillaSystemFonts = new Set([
+	'-moz-button',
+	'-moz-desktop',
+	'-moz-dialog',
+	'-moz-document',
+	'-moz-field',
+	'-moz-fixed',
+	'-moz-info',
+	'-moz-list',
+	'-moz-pull-down-menu',
+	'-moz-window',
+	'-moz-workspace',
+]);
+
+const webkitSystemFonts = new Set([
+	'-webkit-body',
+	'-webkit-control',
+	'-webkit-mini-control',
+	'-webkit-pictograph',
+	'-webkit-small-control',
+	'-webkit-standard',
+]);
+
+export const prefixedSystemFonts = uniteSets(
+	appleSystemFonts,
+	mozillaSystemFonts,
+	webkitSystemFonts,
+);
 
 export const fontWeightRelativeKeywords = new Set(['bolder', 'lighter']);
 

--- a/lib/rules/font-family-name-quotes/__tests__/index.mjs
+++ b/lib/rules/font-family-name-quotes/__tests__/index.mjs
@@ -587,6 +587,26 @@ testRule({
 			message: messages.rejected('BlinkMacSystemFont'),
 		},
 		{
+			code: "a { font-family: '-webkit-control', '-moz-button'; }",
+			fixed: 'a { font-family: -webkit-control, -moz-button; }',
+			warnings: [
+				{
+					message: messages.rejected('-webkit-control'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 35,
+				},
+				{
+					message: messages.rejected('-moz-button'),
+					line: 1,
+					column: 37,
+					endLine: 1,
+					endColumn: 50,
+				},
+			],
+		},
+		{
 			code: 'a { font: italic 300 16px/30px Arial, serif; }',
 			fixed: 'a { font: italic 300 16px/30px "Arial", serif; }',
 			message: messages.expected('Arial'),

--- a/lib/rules/font-family-name-quotes/index.cjs
+++ b/lib/rules/font-family-name-quotes/index.cjs
@@ -109,6 +109,8 @@ const makeMutableFontFamilies = (fontFamilies, decl) => {
 				this.hasQuotes = false;
 				decl.value = decl.value.slice(0, openIndex) + this.name + decl.value.substring(closeIndex);
 				this.resetIndexes(-2);
+
+				return decl.rangeBy({ word: this.name });
 			},
 			addQuotes() {
 				if (this.hasQuotes === true) return;
@@ -121,6 +123,8 @@ const makeMutableFontFamilies = (fontFamilies, decl) => {
 
 				decl.value = decl.value.slice(0, openIndex) + fixedName + decl.value.substring(closeIndex);
 				this.resetIndexes(2);
+
+				return decl.rangeBy({ word: fixedName });
 			},
 		};
 
@@ -213,20 +217,16 @@ const rule = (primary) => {
 		}
 
 		/**
-		 * @param {'expected'|'rejected'} messageType
+		 * @param {keyof messages} messageType
 		 * @param {MutableNode} fontFamilyNode
 		 * @param {import('postcss').Declaration} decl
 		 */
 		function complain(messageType, fontFamilyNode, decl) {
 			const { name, rawName } = fontFamilyNode;
 			const fix = () => {
-				const mutate = messageType === 'expected' ? 'addQuotes' : 'removeQuotes';
-				const end = rawName.length - 1;
-				const word = messageType === 'expected' ? `"${rawName}"` : rawName.slice(1, end);
-
-				fontFamilyNode[mutate]();
-
-				return decl.rangeBy({ word });
+				return messageType === 'expected'
+					? fontFamilyNode.addQuotes()
+					: fontFamilyNode.removeQuotes();
 			};
 
 			report({

--- a/lib/rules/font-family-name-quotes/index.cjs
+++ b/lib/rules/font-family-name-quotes/index.cjs
@@ -2,8 +2,8 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-const findFontFamily = require('../../utils/findFontFamily.cjs');
 const keywords = require('../../reference/keywords.cjs');
+const findFontFamily = require('../../utils/findFontFamily.cjs');
 const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue.cjs');
 const isVariable = require('../../utils/isVariable.cjs');
 const report = require('../../utils/report.cjs');
@@ -27,7 +27,7 @@ const meta = {
  * @returns {boolean}
  */
 function isSystemFontKeyword(font) {
-	if (font.startsWith('-apple-')) {
+	if (keywords.prefixedSystemFonts.has(font)) {
 		return true;
 	}
 
@@ -131,7 +131,7 @@ const makeMutableFontFamilies = (fontFamilies, decl) => {
 };
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondary, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -173,13 +173,7 @@ const rule = (primary, _secondary, context) => {
 			// and system font keywords in all cases
 			if (keywords.fontFamilyKeywords.has(family.toLowerCase()) || isSystemFontKeyword(family)) {
 				if (hasQuotes) {
-					if (context.fix) {
-						fontFamilyNode.removeQuotes();
-
-						return;
-					}
-
-					return complain(messages.rejected(family), rawFamily, decl);
+					return complain('rejected', fontFamilyNode, decl);
 				}
 
 				return;
@@ -191,75 +185,57 @@ const rule = (primary, _secondary, context) => {
 			switch (primary) {
 				case 'always-unless-keyword':
 					if (!hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.addQuotes();
-
-							return;
-						}
-
-						return complain(messages.expected(family), rawFamily, decl);
+						return complain('expected', fontFamilyNode, decl);
 					}
 
 					return;
 
 				case 'always-where-recommended':
 					if (!recommended && hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.removeQuotes();
-
-							return;
-						}
-
-						return complain(messages.rejected(family), rawFamily, decl);
+						return complain('rejected', fontFamilyNode, decl);
 					}
 
 					if (recommended && !hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.addQuotes();
-
-							return;
-						}
-
-						return complain(messages.expected(family), rawFamily, decl);
+						return complain('expected', fontFamilyNode, decl);
 					}
 
 					return;
 
 				case 'always-where-required':
 					if (!required && hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.removeQuotes();
-
-							return;
-						}
-
-						return complain(messages.rejected(family), rawFamily, decl);
+						return complain('rejected', fontFamilyNode, decl);
 					}
 
 					if (required && !hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.addQuotes();
-
-							return;
-						}
-
-						return complain(messages.expected(family), rawFamily, decl);
+						return complain('expected', fontFamilyNode, decl);
 					}
 			}
 		}
 
 		/**
-		 * @param {string} message
-		 * @param {string} family
+		 * @param {'expected'|'rejected'} messageType
+		 * @param {MutableNode} fontFamilyNode
 		 * @param {import('postcss').Declaration} decl
 		 */
-		function complain(message, family, decl) {
+		function complain(messageType, fontFamilyNode, decl) {
+			const { name, rawName } = fontFamilyNode;
+			const fix = () => {
+				const mutate = messageType === 'expected' ? 'addQuotes' : 'removeQuotes';
+				const end = rawName.length - 1;
+				const word = messageType === 'expected' ? `"${rawName}"` : rawName.slice(1, end);
+
+				fontFamilyNode[mutate]();
+
+				return decl.rangeBy({ word });
+			};
+
 			report({
 				result,
 				ruleName,
-				message,
+				message: messages[messageType](name),
 				node: decl,
-				word: family,
+				word: rawName,
+				fix,
 			});
 		}
 	};

--- a/lib/rules/font-family-name-quotes/index.mjs
+++ b/lib/rules/font-family-name-quotes/index.mjs
@@ -1,5 +1,5 @@
+import { fontFamilyKeywords, prefixedSystemFonts } from '../../reference/keywords.mjs';
 import findFontFamily from '../../utils/findFontFamily.mjs';
-import { fontFamilyKeywords } from '../../reference/keywords.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
 import isVariable from '../../utils/isVariable.mjs';
 import report from '../../utils/report.mjs';
@@ -23,7 +23,7 @@ const meta = {
  * @returns {boolean}
  */
 function isSystemFontKeyword(font) {
-	if (font.startsWith('-apple-')) {
+	if (prefixedSystemFonts.has(font)) {
 		return true;
 	}
 
@@ -127,7 +127,7 @@ const makeMutableFontFamilies = (fontFamilies, decl) => {
 };
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondary, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, {
 			actual: primary,
@@ -169,13 +169,7 @@ const rule = (primary, _secondary, context) => {
 			// and system font keywords in all cases
 			if (fontFamilyKeywords.has(family.toLowerCase()) || isSystemFontKeyword(family)) {
 				if (hasQuotes) {
-					if (context.fix) {
-						fontFamilyNode.removeQuotes();
-
-						return;
-					}
-
-					return complain(messages.rejected(family), rawFamily, decl);
+					return complain('rejected', fontFamilyNode, decl);
 				}
 
 				return;
@@ -187,75 +181,57 @@ const rule = (primary, _secondary, context) => {
 			switch (primary) {
 				case 'always-unless-keyword':
 					if (!hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.addQuotes();
-
-							return;
-						}
-
-						return complain(messages.expected(family), rawFamily, decl);
+						return complain('expected', fontFamilyNode, decl);
 					}
 
 					return;
 
 				case 'always-where-recommended':
 					if (!recommended && hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.removeQuotes();
-
-							return;
-						}
-
-						return complain(messages.rejected(family), rawFamily, decl);
+						return complain('rejected', fontFamilyNode, decl);
 					}
 
 					if (recommended && !hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.addQuotes();
-
-							return;
-						}
-
-						return complain(messages.expected(family), rawFamily, decl);
+						return complain('expected', fontFamilyNode, decl);
 					}
 
 					return;
 
 				case 'always-where-required':
 					if (!required && hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.removeQuotes();
-
-							return;
-						}
-
-						return complain(messages.rejected(family), rawFamily, decl);
+						return complain('rejected', fontFamilyNode, decl);
 					}
 
 					if (required && !hasQuotes) {
-						if (context.fix) {
-							fontFamilyNode.addQuotes();
-
-							return;
-						}
-
-						return complain(messages.expected(family), rawFamily, decl);
+						return complain('expected', fontFamilyNode, decl);
 					}
 			}
 		}
 
 		/**
-		 * @param {string} message
-		 * @param {string} family
+		 * @param {'expected'|'rejected'} messageType
+		 * @param {MutableNode} fontFamilyNode
 		 * @param {import('postcss').Declaration} decl
 		 */
-		function complain(message, family, decl) {
+		function complain(messageType, fontFamilyNode, decl) {
+			const { name, rawName } = fontFamilyNode;
+			const fix = () => {
+				const mutate = messageType === 'expected' ? 'addQuotes' : 'removeQuotes';
+				const end = rawName.length - 1;
+				const word = messageType === 'expected' ? `"${rawName}"` : rawName.slice(1, end);
+
+				fontFamilyNode[mutate]();
+
+				return decl.rangeBy({ word });
+			};
+
 			report({
 				result,
 				ruleName,
-				message,
+				message: messages[messageType](name),
 				node: decl,
-				word: family,
+				word: rawName,
+				fix,
 			});
 		}
 	};

--- a/lib/rules/font-family-name-quotes/index.mjs
+++ b/lib/rules/font-family-name-quotes/index.mjs
@@ -105,6 +105,8 @@ const makeMutableFontFamilies = (fontFamilies, decl) => {
 				this.hasQuotes = false;
 				decl.value = decl.value.slice(0, openIndex) + this.name + decl.value.substring(closeIndex);
 				this.resetIndexes(-2);
+
+				return decl.rangeBy({ word: this.name });
 			},
 			addQuotes() {
 				if (this.hasQuotes === true) return;
@@ -117,6 +119,8 @@ const makeMutableFontFamilies = (fontFamilies, decl) => {
 
 				decl.value = decl.value.slice(0, openIndex) + fixedName + decl.value.substring(closeIndex);
 				this.resetIndexes(2);
+
+				return decl.rangeBy({ word: fixedName });
 			},
 		};
 
@@ -209,20 +213,16 @@ const rule = (primary) => {
 		}
 
 		/**
-		 * @param {'expected'|'rejected'} messageType
+		 * @param {keyof messages} messageType
 		 * @param {MutableNode} fontFamilyNode
 		 * @param {import('postcss').Declaration} decl
 		 */
 		function complain(messageType, fontFamilyNode, decl) {
 			const { name, rawName } = fontFamilyNode;
 			const fix = () => {
-				const mutate = messageType === 'expected' ? 'addQuotes' : 'removeQuotes';
-				const end = rawName.length - 1;
-				const word = messageType === 'expected' ? `"${rawName}"` : rawName.slice(1, end);
-
-				fontFamilyNode[mutate]();
-
-				return decl.rangeBy({ word });
+				return messageType === 'expected'
+					? fontFamilyNode.addQuotes()
+					: fontFamilyNode.removeQuotes();
 			};
 
 			report({


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#2643

> Is there anything in the PR that needs further explanation?

ref
https://github.com/WebKit/WebKit/blob/main/Source/WebCore/css/CSSValueKeywords.in
https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266-font
https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#font-family
http://help.dottoro.com/lclmgrtl.php
https://groups.google.com/a/chromium.org/g/blink-dev/c/TVRkV9XrFGo