### PR TITLE
Add workaround for codecov-action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,7 @@ jobs:
           files: ./.coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          version: v0.6.0 # TODO: Workaround for https://github.com/codecov/codecov-action/issues/1487
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #7777

> Is there anything in the PR that needs further explanation?

This aims to avoid codecov-action upload failures in a PR by forked repositories. The old Codecov CLI version is used, instead of `latest`.

See also https://github.com/codecov/codecov-action/issues/1487
