### PR TITLE
Refactor to remove `word` from the object passed to `rangeBy` in `report` util

### DIFF
--- a/lib/rules/no-invalid-double-slash-comments/index.cjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.cjs
@@ -39,6 +39,7 @@ const rule = (primary) => {
 		root.walkRules((ruleNode) => {
 			// ruleNode.selectors elements are trimmed
 			const selectors = ruleNode.selector.split(',');
+			const ruleStringified = ruleNode.toString();
 			let index = 0;
 
 			for (const value of selectors) {
@@ -47,7 +48,7 @@ const rule = (primary) => {
 				if (selector.startsWith('//')) {
 					const offset = value.length - selector.length;
 					const i = index + offset;
-					const lines = ruleNode.toString().slice(i).split('\n');
+					const lines = ruleStringified.slice(i).split('\n');
 					let comment = lines[0] ?? '';
 
 					if (lines.length > 1) comment += '\n';

--- a/lib/rules/no-invalid-double-slash-comments/index.cjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.cjs
@@ -2,6 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
+const validateTypes = require('../../utils/validateTypes.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -51,13 +52,15 @@ const rule = (primary) => {
 					const comment = lines[0];
 					const word = lines.length > 1 ? `${comment}\n` : comment;
 
+					validateTypes.assert(word);
+
 					report({
 						message: messages.rejected,
 						node: ruleNode,
 						result,
 						ruleName,
 						index: i,
-						word,
+						endIndex: i + word.length,
 					});
 				}
 

--- a/lib/rules/no-invalid-double-slash-comments/index.cjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.cjs
@@ -2,7 +2,6 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-const validateTypes = require('../../utils/validateTypes.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -49,10 +48,9 @@ const rule = (primary) => {
 					const offset = value.length - selector.length;
 					const i = index + offset;
 					const lines = ruleNode.toString().slice(i).split('\n');
-					const comment = lines[0];
-					const word = lines.length > 1 ? `${comment}\n` : comment;
+					let comment = lines[0] ?? '';
 
-					validateTypes.assert(word);
+					if (lines.length > 1) comment += '\n';
 
 					report({
 						message: messages.rejected,
@@ -60,7 +58,7 @@ const rule = (primary) => {
 						result,
 						ruleName,
 						index: i,
-						endIndex: i + word.length,
+						endIndex: i + comment.length,
 					});
 				}
 

--- a/lib/rules/no-invalid-double-slash-comments/index.mjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.mjs
@@ -1,4 +1,3 @@
-import { assert } from '../../utils/validateTypes.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -45,10 +44,9 @@ const rule = (primary) => {
 					const offset = value.length - selector.length;
 					const i = index + offset;
 					const lines = ruleNode.toString().slice(i).split('\n');
-					const comment = lines[0];
-					const word = lines.length > 1 ? `${comment}\n` : comment;
+					let comment = lines[0] ?? '';
 
-					assert(word);
+					if (lines.length > 1) comment += '\n';
 
 					report({
 						message: messages.rejected,
@@ -56,7 +54,7 @@ const rule = (primary) => {
 						result,
 						ruleName,
 						index: i,
-						endIndex: i + word.length,
+						endIndex: i + comment.length,
 					});
 				}
 

--- a/lib/rules/no-invalid-double-slash-comments/index.mjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.mjs
@@ -35,6 +35,7 @@ const rule = (primary) => {
 		root.walkRules((ruleNode) => {
 			// ruleNode.selectors elements are trimmed
 			const selectors = ruleNode.selector.split(',');
+			const ruleStringified = ruleNode.toString();
 			let index = 0;
 
 			for (const value of selectors) {
@@ -43,7 +44,7 @@ const rule = (primary) => {
 				if (selector.startsWith('//')) {
 					const offset = value.length - selector.length;
 					const i = index + offset;
-					const lines = ruleNode.toString().slice(i).split('\n');
+					const lines = ruleStringified.slice(i).split('\n');
 					let comment = lines[0] ?? '';
 
 					if (lines.length > 1) comment += '\n';

--- a/lib/rules/no-invalid-double-slash-comments/index.mjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.mjs
@@ -1,3 +1,4 @@
+import { assert } from '../../utils/validateTypes.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -47,13 +48,15 @@ const rule = (primary) => {
 					const comment = lines[0];
 					const word = lines.length > 1 ? `${comment}\n` : comment;
 
+					assert(word);
+
 					report({
 						message: messages.rejected,
 						node: ruleNode,
 						result,
 						ruleName,
 						index: i,
-						word,
+						endIndex: i + word.length,
 					});
 				}
 

--- a/lib/rules/selector-no-vendor-prefix/index.cjs
+++ b/lib/rules/selector-no-vendor-prefix/index.cjs
@@ -68,11 +68,11 @@ const rule = (primary, secondaryOptions) => {
 				}
 
 				const fix = () => {
-					const index = pseudoNode.sourceIndex;
-					const endIndex = index + pseudoNode.value.length;
-
 					pseudoNode.value = isAutoprefixable.unprefix(value);
 					ruleNode.selector = resolvedRoot.toString();
+
+					const index = pseudoNode.sourceIndex;
+					const endIndex = index + pseudoNode.value.length;
 
 					return ruleNode.rangeBy({ index, endIndex });
 				};

--- a/lib/rules/selector-no-vendor-prefix/index.cjs
+++ b/lib/rules/selector-no-vendor-prefix/index.cjs
@@ -68,10 +68,13 @@ const rule = (primary, secondaryOptions) => {
 				}
 
 				const fix = () => {
+					const index = pseudoNode.sourceIndex;
+					const endIndex = index + pseudoNode.value.length;
+
 					pseudoNode.value = isAutoprefixable.unprefix(value);
 					ruleNode.selector = resolvedRoot.toString();
 
-					return ruleNode.rangeBy({ index: pseudoNode.sourceIndex, word: pseudoNode.value });
+					return ruleNode.rangeBy({ index, endIndex });
 				};
 
 				report({

--- a/lib/rules/selector-no-vendor-prefix/index.mjs
+++ b/lib/rules/selector-no-vendor-prefix/index.mjs
@@ -64,11 +64,11 @@ const rule = (primary, secondaryOptions) => {
 				}
 
 				const fix = () => {
-					const index = pseudoNode.sourceIndex;
-					const endIndex = index + pseudoNode.value.length;
-
 					pseudoNode.value = isAutoprefixable.unprefix(value);
 					ruleNode.selector = resolvedRoot.toString();
+
+					const index = pseudoNode.sourceIndex;
+					const endIndex = index + pseudoNode.value.length;
 
 					return ruleNode.rangeBy({ index, endIndex });
 				};

--- a/lib/rules/selector-no-vendor-prefix/index.mjs
+++ b/lib/rules/selector-no-vendor-prefix/index.mjs
@@ -64,10 +64,13 @@ const rule = (primary, secondaryOptions) => {
 				}
 
 				const fix = () => {
+					const index = pseudoNode.sourceIndex;
+					const endIndex = index + pseudoNode.value.length;
+
 					pseudoNode.value = isAutoprefixable.unprefix(value);
 					ruleNode.selector = resolvedRoot.toString();
 
-					return ruleNode.rangeBy({ index: pseudoNode.sourceIndex, word: pseudoNode.value });
+					return ruleNode.rangeBy({ index, endIndex });
 				};
 
 				report({

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -35,7 +35,7 @@ function report(problem) {
 	// In quiet mode, mere warnings are ignored
 	if (quiet && ruleSeverity !== 'error') return;
 
-	const range = node?.rangeBy({ index, endIndex, word }) ?? {};
+	const range = node?.rangeBy({ index, endIndex }) ?? {};
 	// If a line is not passed, use the node.rangeBy method to get the
 	// line number that the complaint pertains to
 	const startLine = line ?? range.start?.line;

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -31,7 +31,7 @@ export default function report(problem) {
 	// In quiet mode, mere warnings are ignored
 	if (quiet && ruleSeverity !== 'error') return;
 
-	const range = node?.rangeBy({ index, endIndex, word }) ?? {};
+	const range = node?.rangeBy({ index, endIndex }) ?? {};
 	// If a line is not passed, use the node.rangeBy method to get the
 	// line number that the complaint pertains to
 	const startLine = line ?? range.start?.line;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #7779

> Is there anything in the PR that needs further explanation?

This PR

1. revert this change

```diff
-rangeBy({ index, endIndex })
+rangeBy({ index, endIndex, word })
```

2. addresses the recent changes that assumed that `index` would shift the search for the needle when used with `word`

</hr>

As an aside, we have legitimate cases where passing just `node` is simpler than passing let's say `node`+`word`.
e.g. if we have to take into account the last semicolon
i.e. we cannot be as strict as not allowing passing `word` or at least it won't be covered by that PR