### PR TITLE
Revert "Add workaround for codecov-action"

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,6 @@ jobs:
           files: ./.coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          version: v0.6.0 # TODO: Workaround for https://github.com/codecov/codecov-action/issues/1487
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts stylelint/stylelint#7778

Closes #7783
Closes #7804 

The new CLI version is released: https://github.com/codecov/codecov-cli/releases/tag/v0.7.1
See also https://github.com/codecov/codecov-action/issues/1487