### PR TITLE
POC for #7784

### DIFF
--- a/lib/rules/alpha-value-notation/index.cjs
+++ b/lib/rules/alpha-value-notation/index.cjs
@@ -31,6 +31,8 @@ const ALPHA_FUNCTION = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
 const ALPHA_FUNCTION_NAME = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
 const DIGIT = /\d/;
 
+/** @import {Problem} from 'stylelint' */
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -102,14 +104,18 @@ const rule = (primary, secondaryOptions) => {
 				const unfixed = value;
 				const index = declarationValueIndex(decl) + alpha.sourceIndex;
 				const endIndex = index + alpha.value.length;
-				const fix = () => {
-					alpha.value = fixed;
-					setDeclarationValue(decl, parsedValue.toString());
-				};
 
-				fix.editInfo = {
-					// range: decl.rangeBy({ index, endIndex }),
-					text: fixed,
+				/** @type {Problem['fix']} */
+				const fix = (apply) => {
+					if (apply) {
+						alpha.value = fixed;
+						setDeclarationValue(decl, parsedValue.toString());
+					}
+
+					return {
+						// range: decl.rangeBy({ index, endIndex }),
+						text: fixed,
+					};
 				};
 
 				report({

--- a/lib/rules/alpha-value-notation/index.cjs
+++ b/lib/rules/alpha-value-notation/index.cjs
@@ -31,8 +31,6 @@ const ALPHA_FUNCTION = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
 const ALPHA_FUNCTION_NAME = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
 const DIGIT = /\d/;
 
-/** @import {Problem} from 'stylelint' */
-
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -105,17 +103,9 @@ const rule = (primary, secondaryOptions) => {
 				const index = declarationValueIndex(decl) + alpha.sourceIndex;
 				const endIndex = index + alpha.value.length;
 
-				/** @type {Problem['fix']} */
-				const fix = (apply) => {
-					if (apply) {
-						alpha.value = fixed;
-						setDeclarationValue(decl, parsedValue.toString());
-					}
-
-					return {
-						// range: decl.rangeBy({ index, endIndex }),
-						text: fixed,
-					};
+				const fix = () => {
+					alpha.value = fixed;
+					setDeclarationValue(decl, parsedValue.toString());
 				};
 
 				report({
@@ -127,6 +117,8 @@ const rule = (primary, secondaryOptions) => {
 					result,
 					ruleName,
 					fix,
+					replacement: fixed,
+					// range: decl.rangeBy({ index, endIndex }),
 				});
 			});
 		});

--- a/lib/rules/alpha-value-notation/index.cjs
+++ b/lib/rules/alpha-value-notation/index.cjs
@@ -107,6 +107,11 @@ const rule = (primary, secondaryOptions) => {
 					setDeclarationValue(decl, parsedValue.toString());
 				};
 
+				fix.editInfo = {
+					// range: decl.rangeBy({ index, endIndex }),
+					text: fixed,
+				};
+
 				report({
 					message: messages.expected,
 					messageArgs: [unfixed, fixed],

--- a/lib/rules/alpha-value-notation/index.mjs
+++ b/lib/rules/alpha-value-notation/index.mjs
@@ -28,8 +28,6 @@ const ALPHA_FUNCTION = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
 const ALPHA_FUNCTION_NAME = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
 const DIGIT = /\d/;
 
-/** @import {Problem} from 'stylelint' */
-
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -102,17 +100,9 @@ const rule = (primary, secondaryOptions) => {
 				const index = declarationValueIndex(decl) + alpha.sourceIndex;
 				const endIndex = index + alpha.value.length;
 
-				/** @type {Problem['fix']} */
-				const fix = (apply) => {
-					if (apply) {
-						alpha.value = fixed;
-						setDeclarationValue(decl, parsedValue.toString());
-					}
-
-					return {
-						// range: decl.rangeBy({ index, endIndex }),
-						text: fixed,
-					};
+				const fix = () => {
+					alpha.value = fixed;
+					setDeclarationValue(decl, parsedValue.toString());
 				};
 
 				report({
@@ -124,6 +114,8 @@ const rule = (primary, secondaryOptions) => {
 					result,
 					ruleName,
 					fix,
+					replacement: fixed,
+					// range: decl.rangeBy({ index, endIndex }),
 				});
 			});
 		});

--- a/lib/rules/alpha-value-notation/index.mjs
+++ b/lib/rules/alpha-value-notation/index.mjs
@@ -28,6 +28,8 @@ const ALPHA_FUNCTION = /(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)\(/i;
 const ALPHA_FUNCTION_NAME = /^(?:color|hsla?|rgba?|hwb|lab|lch|oklab|oklch)$/i;
 const DIGIT = /\d/;
 
+/** @import {Problem} from 'stylelint' */
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -99,14 +101,18 @@ const rule = (primary, secondaryOptions) => {
 				const unfixed = value;
 				const index = declarationValueIndex(decl) + alpha.sourceIndex;
 				const endIndex = index + alpha.value.length;
-				const fix = () => {
-					alpha.value = fixed;
-					setDeclarationValue(decl, parsedValue.toString());
-				};
 
-				fix.editInfo = {
-					// range: decl.rangeBy({ index, endIndex }),
-					text: fixed,
+				/** @type {Problem['fix']} */
+				const fix = (apply) => {
+					if (apply) {
+						alpha.value = fixed;
+						setDeclarationValue(decl, parsedValue.toString());
+					}
+
+					return {
+						// range: decl.rangeBy({ index, endIndex }),
+						text: fixed,
+					};
 				};
 
 				report({

--- a/lib/rules/alpha-value-notation/index.mjs
+++ b/lib/rules/alpha-value-notation/index.mjs
@@ -104,6 +104,11 @@ const rule = (primary, secondaryOptions) => {
 					setDeclarationValue(decl, parsedValue.toString());
 				};
 
+				fix.editInfo = {
+					// range: decl.rangeBy({ index, endIndex }),
+					text: fixed,
+				};
+
 				report({
 					message: messages.expected,
 					messageArgs: [unfixed, fixed],

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -470,9 +470,16 @@ describe('with fix callback', () => {
 		expect(v.fix).toHaveBeenCalledTimes(0);
 
 		const fixerData = fixersData.foo[0];
+		const position = expect.objectContaining({
+			line: expect.any(Number),
+			column: expect.any(Number),
+		});
 
 		expect(fixerData.fixed).toBe(false);
-		expect(fixerData.range).toBeUndefined();
+		expect(fixerData.range).toMatchObject({
+			start: position,
+			end: position,
+		});
 	});
 });
 
@@ -496,9 +503,16 @@ test('with fix callback missing', () => {
 	expect(v.result.warn).toHaveBeenCalledTimes(1);
 
 	const fixerData = fixersData.foo[1];
+	const position = expect.objectContaining({
+		line: expect.any(Number),
+		column: expect.any(Number),
+	});
 
 	expect(fixerData.fixed).toBe(false);
-	expect(fixerData.range).toBeUndefined();
+	expect(fixerData.range).toMatchObject({
+		start: position,
+		end: position,
+	});
 });
 
 test('with custom message', () => {

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -163,10 +163,9 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = result.stylelint;
 	const range = start && validateTypes.isNumber(end?.column) ? { start, end } : warnRange;
-	const editInfo = { range, ...fix?.editInfo };
 
 	if (!validateTypes.isFunction(fix)) {
-		addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
+		addFixData(fixersData, ruleName, { fixed: false, range });
 
 		return false;
 	}
@@ -175,14 +174,12 @@ function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleNam
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	if (mayFix) {
-		fix();
-		addFixData(fixersData, ruleName, { fixed: true, ...editInfo });
+	const editInfo = fix(mayFix);
+	const data = { fixed: mayFix, range, ...editInfo };
 
-		return true;
-	}
+	addFixData(fixersData, ruleName, data);
 
-	addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
+	if (mayFix) return true;
 
 	return false;
 }

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -46,7 +46,7 @@ function report(problem) {
 		);
 	}
 
-	if (isFixApplied({ ...problem, line: startLine, range })) return;
+	if (isFixApplied({ range, line: startLine, ...problem })) return;
 
 	if (isDisabled(ruleName, startLine, disabledRanges)) {
 		// Collect disabled warnings
@@ -160,26 +160,18 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 }
 
 /** @param {Problem & { line: number, range: Range }} problem */
-function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleName }) {
+function isFixApplied({ fix, line, range, result, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = result.stylelint;
-	const range = start && validateTypes.isNumber(end?.column) ? { start, end } : warnRange;
 
-	if (!validateTypes.isFunction(fix)) {
-		addFixData(fixersData, ruleName, { fixed: false, range });
-
-		return false;
-	}
+	if (!validateTypes.isFunction(fix)) return addFixData(fixersData, ruleName, { fixed: false, range }), false;
 
 	const shouldFix = Boolean(config.fix && !config.rules?.[ruleName][1]?.disableFix);
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	const editInfo = fix(mayFix);
-	const data = { fixed: mayFix, range, ...editInfo };
+	addFixData(fixersData, ruleName, { fixed: mayFix, range });
 
-	addFixData(fixersData, ruleName, data);
-
-	if (mayFix) return true;
+	if (mayFix) return fix(), true;
 
 	return false;
 }

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -46,7 +46,7 @@ function report(problem) {
 		);
 	}
 
-	if (isFixApplied({ ...problem, line: startLine })) return;
+	if (isFixApplied({ ...problem, line: startLine, range })) return;
 
 	if (isDisabled(ruleName, startLine, disabledRanges)) {
 		// Collect disabled warnings
@@ -108,6 +108,7 @@ function report(problem) {
 /** @typedef {import('stylelint').DisabledRangeObject} DisabledRangeObject */
 /** @typedef {import('stylelint').StylelintPostcssResult} StylelintPostcssResult */
 /** @typedef {import('stylelint').Range} Range */
+/** @typedef {import('stylelint').FixerData} FixerData */
 
 /**
  * @param {import('stylelint').RuleMessage} message
@@ -158,12 +159,14 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 	return false;
 }
 
-/** @param {Problem & { line: number }} problem */
-function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
-	const { disabledRanges, config = {}, fixersData } = stylelint;
+/** @param {Problem & { line: number, range: Range }} problem */
+function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleName }) {
+	const { disabledRanges, config = {}, fixersData } = result.stylelint;
+	const range = start && validateTypes.isNumber(end?.column) ? { start, end } : warnRange;
+	const editInfo = { range, ...fix?.editInfo };
 
 	if (!validateTypes.isFunction(fix)) {
-		addFixData({ fixersData, ruleName, fixed: false });
+		addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
 
 		return false;
 	}
@@ -173,28 +176,27 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
 	if (mayFix) {
-		addFixData({ fixersData, ruleName, fixed: true, range: fix() ?? undefined });
+		fix();
+		addFixData(fixersData, ruleName, { fixed: true, ...editInfo });
 
 		return true;
 	}
 
-	addFixData({ fixersData, ruleName, fixed: false });
+	addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
 
 	return false;
 }
 
 /**
- * @param {object} o
- * @param {StylelintPostcssResult['fixersData']} o.fixersData
- * @param {string} o.ruleName
- * @param {Range} [o.range] new range
- * @param {boolean} o.fixed
+ * @param {StylelintPostcssResult['fixersData']} fixersData
+ * @param {string} ruleName
+ * @param {FixerData} data
  * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range, fixed }) {
+function addFixData(fixersData, ruleName, data) {
 	const ruleFixers = (fixersData[ruleName] ??= []);
 
-	ruleFixers.push({ range, fixed });
+	ruleFixers.push(data);
 }
 
 module.exports = report;

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -42,7 +42,7 @@ export default function report(problem) {
 		);
 	}
 
-	if (isFixApplied({ ...problem, line: startLine })) return;
+	if (isFixApplied({ ...problem, line: startLine, range })) return;
 
 	if (isDisabled(ruleName, startLine, disabledRanges)) {
 		// Collect disabled warnings
@@ -104,6 +104,7 @@ export default function report(problem) {
 /** @typedef {import('stylelint').DisabledRangeObject} DisabledRangeObject */
 /** @typedef {import('stylelint').StylelintPostcssResult} StylelintPostcssResult */
 /** @typedef {import('stylelint').Range} Range */
+/** @typedef {import('stylelint').FixerData} FixerData */
 
 /**
  * @param {import('stylelint').RuleMessage} message
@@ -154,12 +155,14 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 	return false;
 }
 
-/** @param {Problem & { line: number }} problem */
-function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
-	const { disabledRanges, config = {}, fixersData } = stylelint;
+/** @param {Problem & { line: number, range: Range }} problem */
+function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleName }) {
+	const { disabledRanges, config = {}, fixersData } = result.stylelint;
+	const range = start && isNumber(end?.column) ? { start, end } : warnRange;
+	const editInfo = { range, ...fix?.editInfo };
 
 	if (!isFn(fix)) {
-		addFixData({ fixersData, ruleName, fixed: false });
+		addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
 
 		return false;
 	}
@@ -169,26 +172,25 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
 	if (mayFix) {
-		addFixData({ fixersData, ruleName, fixed: true, range: fix() ?? undefined });
+		fix();
+		addFixData(fixersData, ruleName, { fixed: true, ...editInfo });
 
 		return true;
 	}
 
-	addFixData({ fixersData, ruleName, fixed: false });
+	addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
 
 	return false;
 }
 
 /**
- * @param {object} o
- * @param {StylelintPostcssResult['fixersData']} o.fixersData
- * @param {string} o.ruleName
- * @param {Range} [o.range] new range
- * @param {boolean} o.fixed
+ * @param {StylelintPostcssResult['fixersData']} fixersData
+ * @param {string} ruleName
+ * @param {FixerData} data
  * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range, fixed }) {
+function addFixData(fixersData, ruleName, data) {
 	const ruleFixers = (fixersData[ruleName] ??= []);
 
-	ruleFixers.push({ range, fixed });
+	ruleFixers.push(data);
 }

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -159,10 +159,9 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = result.stylelint;
 	const range = start && isNumber(end?.column) ? { start, end } : warnRange;
-	const editInfo = { range, ...fix?.editInfo };
 
 	if (!isFn(fix)) {
-		addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
+		addFixData(fixersData, ruleName, { fixed: false, range });
 
 		return false;
 	}
@@ -171,14 +170,12 @@ function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleNam
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	if (mayFix) {
-		fix();
-		addFixData(fixersData, ruleName, { fixed: true, ...editInfo });
+	const editInfo = fix(mayFix);
+	const data = { fixed: mayFix, range, ...editInfo };
 
-		return true;
-	}
+	addFixData(fixersData, ruleName, data);
 
-	addFixData(fixersData, ruleName, { fixed: false, ...editInfo });
+	if (mayFix) return true;
 
 	return false;
 }

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -42,7 +42,7 @@ export default function report(problem) {
 		);
 	}
 
-	if (isFixApplied({ ...problem, line: startLine, range })) return;
+	if (isFixApplied({ range, line: startLine, ...problem })) return;
 
 	if (isDisabled(ruleName, startLine, disabledRanges)) {
 		// Collect disabled warnings
@@ -156,26 +156,18 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 }
 
 /** @param {Problem & { line: number, range: Range }} problem */
-function isFixApplied({ fix, line, start, end, range: warnRange, result, ruleName }) {
+function isFixApplied({ fix, line, range, result, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = result.stylelint;
-	const range = start && isNumber(end?.column) ? { start, end } : warnRange;
 
-	if (!isFn(fix)) {
-		addFixData(fixersData, ruleName, { fixed: false, range });
-
-		return false;
-	}
+	if (!isFn(fix)) return addFixData(fixersData, ruleName, { fixed: false, range }), false;
 
 	const shouldFix = Boolean(config.fix && !config.rules?.[ruleName][1]?.disableFix);
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	const editInfo = fix(mayFix);
-	const data = { fixed: mayFix, range, ...editInfo };
+	addFixData(fixersData, ruleName, { fixed: mayFix, range });
 
-	addFixData(fixersData, ruleName, data);
-
-	if (mayFix) return true;
+	if (mayFix) return fix(), true;
 
 	return false;
 }

--- a/types/stylelint/index.d.mts
+++ b/types/stylelint/index.d.mts
@@ -13,6 +13,7 @@ export {
 	DisabledRange,
 	DisabledRangeObject,
 	DisabledWarning,
+	FixerData,
 	Formatter,
 	FormatterType,
 	Formatters,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -261,9 +261,9 @@ declare namespace stylelint {
 	};
 
 	export type FixerData = {
-		range: Range | Range[];
+		range: Range;
 		fixed: boolean;
-		text?: string | string[];
+		text?: string;
 	};
 
 	/**
@@ -635,23 +635,13 @@ declare namespace stylelint {
 		 * @internal
 		 * WARNING: Don't use this feature now. It may change in the future.
 		 */
-		fix?: Fix;
+		fix?: (apply: boolean) => void | never | EditInfo;
 	};
 
-	type EditInfo =
-		| {
-				range?: Range;
-				text: string;
-		  }
-		| {
-				range: Range[];
-				text: string[];
-		  };
-
-	interface Fix {
-		(): void | never;
-		editInfo?: EditInfo;
-	}
+	type EditInfo = {
+		range?: Range;
+		text: string;
+	};
 
 	/** @internal */
 	export type ShorthandProperties =

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -260,9 +260,10 @@ declare namespace stylelint {
 		end: Position;
 	};
 
-	type FixerData = {
-		range?: Range;
+	export type FixerData = {
+		range: Range | Range[];
 		fixed: boolean;
+		text?: string | string[];
 	};
 
 	/**
@@ -634,8 +635,23 @@ declare namespace stylelint {
 		 * @internal
 		 * WARNING: Don't use this feature now. It may change in the future.
 		 */
-		fix?: () => void | never | Range;
+		fix?: Fix;
 	};
+
+	type EditInfo =
+		| {
+				range?: Range;
+				text: string;
+		  }
+		| {
+				range: Range[];
+				text: string[];
+		  };
+
+	interface Fix {
+		(): void | never;
+		editInfo?: EditInfo;
+	}
 
 	/** @internal */
 	export type ShorthandProperties =

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -635,12 +635,9 @@ declare namespace stylelint {
 		 * @internal
 		 * WARNING: Don't use this feature now. It may change in the future.
 		 */
-		fix?: (apply: boolean) => void | never | EditInfo;
-	};
-
-	type EditInfo = {
+		fix?: () => void | never;
 		range?: Range;
-		text: string;
+		replacement?: string;
 	};
 
 	/** @internal */


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#7192, #7784

> Is there anything in the PR that needs further explanation?

- [x] new `text`
- [x] old `range`
- [x] fallback to warn range
- [x] does not require `fix` to be called (store the data even for the warn path)
- [x] ~~handles non-consecutive ranges (e.g. `declaration-block-no-redundant-longhand-properties`)~~

> What's the purpose of this PR?

1. To bikeshed the name.
I chose `editInfo` but I am sure there's something better.
ref: https://eslint.org/docs/latest/integrate/nodejs-api#-editinfo-type

2. To confirm the type of the `fix` function

3. to discuss if `editInfo` should be set on `fix` or passed directly to `report` or returned by `fix`

> What is this PR not about?

- the refactor of `alpha-value-notation`
- the eventual test errors of the other rules