### PR TITLE
Fix `function-no-unknown` performance by reducing file read count

### DIFF
--- a/.changeset/quick-gifts-shop.md
+++ b/.changeset/quick-gifts-shop.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-no-unknown` performance by reducing file read count

--- a/lib/rules/function-no-unknown/index.cjs
+++ b/lib/rules/function-no-unknown/index.cjs
@@ -25,6 +25,9 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/function-no-unknown',
 };
 
+/** @type {string[] | undefined} */
+let functionsListMemo;
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -45,7 +48,10 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		const functionsList = JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
+		// Read the file lazily for performance.
+		functionsListMemo ??= JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
+
+		const functionsList = /** @type {string[]} */ (functionsListMemo);
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/lib/rules/function-no-unknown/index.cjs
+++ b/lib/rules/function-no-unknown/index.cjs
@@ -2,9 +2,8 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-const fs = require('node:fs');
+const node_module = require('node:module');
 const cssParserAlgorithms = require('@csstools/css-parser-algorithms');
-const functionsListPath = require('css-functions-list');
 const cssTokenizer = require('@csstools/css-tokenizer');
 const validateTypes = require('../../utils/validateTypes.cjs');
 const declarationValueIndex = require('../../utils/declarationValueIndex.cjs');
@@ -15,6 +14,13 @@ const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
 
+var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
+const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/rules/function-no-unknown/index.cjs', document.baseURI).href)));
+
+// TODO: Replace this with Import attributes when dropping the support for older Node.js versions.
+// See https://nodejs.org/api/esm.html#import-attributes
+const functionsList = require$1('css-functions-list/index.json');
+
 const ruleName = 'function-no-unknown';
 
 const messages = ruleMessages(ruleName, {
@@ -24,9 +30,6 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/function-no-unknown',
 };
-
-/** @type {string[] | undefined} */
-let functionsListMemo;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
@@ -47,11 +50,6 @@ const rule = (primary, secondaryOptions) => {
 		if (!validOptions) {
 			return;
 		}
-
-		// Read the file lazily for performance.
-		functionsListMemo ??= JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
-
-		const functionsList = /** @type {string[]} */ (functionsListMemo);
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/lib/rules/function-no-unknown/index.mjs
+++ b/lib/rules/function-no-unknown/index.mjs
@@ -1,7 +1,6 @@
-import fs from 'node:fs';
+import { createRequire } from 'node:module';
 
 import { isFunctionNode, parseListOfComponentValues, walk } from '@csstools/css-parser-algorithms';
-import functionsListPath from 'css-functions-list';
 import { tokenize } from '@csstools/css-tokenizer';
 
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
@@ -13,6 +12,12 @@ import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
 
+const require = createRequire(import.meta.url);
+
+// TODO: Replace this with Import attributes when dropping the support for older Node.js versions.
+// See https://nodejs.org/api/esm.html#import-attributes
+const functionsList = require('css-functions-list/index.json');
+
 const ruleName = 'function-no-unknown';
 
 const messages = ruleMessages(ruleName, {
@@ -22,9 +27,6 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/function-no-unknown',
 };
-
-/** @type {string[] | undefined} */
-let functionsListMemo;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
@@ -45,11 +47,6 @@ const rule = (primary, secondaryOptions) => {
 		if (!validOptions) {
 			return;
 		}
-
-		// Read the file lazily for performance.
-		functionsListMemo ??= JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
-
-		const functionsList = /** @type {string[]} */ (functionsListMemo);
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/lib/rules/function-no-unknown/index.mjs
+++ b/lib/rules/function-no-unknown/index.mjs
@@ -23,6 +23,9 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/function-no-unknown',
 };
 
+/** @type {string[] | undefined} */
+let functionsListMemo;
+
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -43,7 +46,10 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		const functionsList = JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
+		// Read the file lazily for performance.
+		functionsListMemo ??= JSON.parse(fs.readFileSync(functionsListPath.toString(), 'utf8'));
+
+		const functionsList = /** @type {string[]} */ (functionsListMemo);
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/lib/utils/mathMLTags.cjs
+++ b/lib/utils/mathMLTags.cjs
@@ -7,12 +7,11 @@ const node_module = require('node:module');
 var _documentCurrentScript = typeof document !== 'undefined' ? document.currentScript : null;
 const require$1 = node_module.createRequire((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('lib/utils/mathMLTags.cjs', document.baseURI).href)));
 
-// NOTE: mathml-tag-names v3 is a pure ESM package,
+// TODO: mathml-tag-names v3 is a pure ESM package,
 // so we cannot update it while supporting both ESM and CommonJS.
 //
 // In addition, mathml-tag-names v2 provides only a JSON file,
 // so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
-// @ts-expect-error -- mathml-tag-names v2 doesn't have type declarations.
-const mathMLTags = require$1('mathml-tag-names');
+const mathMLTags = require$1('mathml-tag-names/index.json');
 
 module.exports = mathMLTags;

--- a/lib/utils/mathMLTags.cjs
+++ b/lib/utils/mathMLTags.cjs
@@ -12,6 +12,7 @@ const require$1 = node_module.createRequire((typeof document === 'undefined' ? r
 //
 // In addition, mathml-tag-names v2 provides only a JSON file,
 // so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
+/** @type {string[]} */
 const mathMLTags = require$1('mathml-tag-names/index.json');
 
 module.exports = mathMLTags;

--- a/lib/utils/mathMLTags.mjs
+++ b/lib/utils/mathMLTags.mjs
@@ -7,6 +7,7 @@ const require = createRequire(import.meta.url);
 //
 // In addition, mathml-tag-names v2 provides only a JSON file,
 // so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
+/** @type {string[]} */
 const mathMLTags = require('mathml-tag-names/index.json');
 
 export default mathMLTags;

--- a/lib/utils/mathMLTags.mjs
+++ b/lib/utils/mathMLTags.mjs
@@ -2,12 +2,11 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
-// NOTE: mathml-tag-names v3 is a pure ESM package,
+// TODO: mathml-tag-names v3 is a pure ESM package,
 // so we cannot update it while supporting both ESM and CommonJS.
 //
 // In addition, mathml-tag-names v2 provides only a JSON file,
 // so ESM cannot import it (raises the "ERR_IMPORT_ASSERTION_TYPE_MISSING" error).
-// @ts-expect-error -- mathml-tag-names v2 doesn't have type declarations.
-const mathMLTags = require('mathml-tag-names');
+const mathMLTags = require('mathml-tag-names/index.json');
 
 export default mathMLTags;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
 		"noImplicitReturns": false,
 		"noUnusedParameters": true,
 		"noUncheckedIndexedAccess": true,
-		"resolveJsonModule": false,
+		"resolveJsonModule": true,
 		"esModuleInterop": true,
 		"skipLibCheck": false
 	},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

I happened to notice this chance for performance improvement.

In the `(root, result) => {}` function, `fs.readFileSync()` is called many times for each scanned file.
However, `functionsList` is immutable, so we can call it only once.

Benchmark:

```sh-session
$ cat tmp/stylelint.config.mjs
export default {
	rules: { 'function-no-unknown': true },
};

$ cat tmp/test.css
a {
  width: cal(1 + 2);
}

$ for i in $(seq 1 1000); do cp tmp/test.css "tmp/test-${i}.css"; done

$ time bin/stylelint.mjs -c tmp/stylelint.config.mjs "tmp/*.css" 2>/dev/null
```

On the main branch:

```
0.92s user 0.32s system 133% cpu 0.928 total
```

On this branch:

```
0.88s user 0.29s system 132% cpu 0.878 total
```
