### PR TITLE
Refactor to use JSDoc `@import` tag in some files

### DIFF
--- a/lib/assignDisabledRanges.cjs
+++ b/lib/assignDisabledRanges.cjs
@@ -7,12 +7,8 @@ const configurationComment = require('./utils/configurationComment.cjs');
 const validateTypes = require('./utils/validateTypes.cjs');
 const isStandardSyntaxComment = require('./utils/isStandardSyntaxComment.cjs');
 
-/** @typedef {import('postcss').Comment} PostcssComment */
-/** @typedef {import('postcss').Root} PostcssRoot */
-/** @typedef {import('postcss').Document} PostcssDocument */
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').DisabledRangeObject} DisabledRangeObject */
-/** @typedef {import('stylelint').DisabledRange} DisabledRange */
+/** @import {Comment as PostcssComment, Document as PostcssDocument, Root as PostcssRoot} from 'postcss' */
+/** @import {DisabledRange, DisabledRangeObject, PostcssResult} from 'stylelint' */
 
 /**
  * @param {PostcssComment} comment

--- a/lib/assignDisabledRanges.mjs
+++ b/lib/assignDisabledRanges.mjs
@@ -12,12 +12,8 @@ import {
 import { assert, assertNumber, assertString } from './utils/validateTypes.mjs';
 import isStandardSyntaxComment from './utils/isStandardSyntaxComment.mjs';
 
-/** @typedef {import('postcss').Comment} PostcssComment */
-/** @typedef {import('postcss').Root} PostcssRoot */
-/** @typedef {import('postcss').Document} PostcssDocument */
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').DisabledRangeObject} DisabledRangeObject */
-/** @typedef {import('stylelint').DisabledRange} DisabledRange */
+/** @import {Comment as PostcssComment, Document as PostcssDocument, Root as PostcssRoot} from 'postcss' */
+/** @import {DisabledRange, DisabledRangeObject, PostcssResult} from 'stylelint' */
 
 /**
  * @param {PostcssComment} comment

--- a/lib/augmentConfig.cjs
+++ b/lib/augmentConfig.cjs
@@ -13,9 +13,7 @@ const dynamicImport = require('./utils/dynamicImport.cjs');
 const getModulePath = require('./utils/getModulePath.cjs');
 const normalizeAllRuleSettings = require('./normalizeAllRuleSettings.cjs');
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').Config} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} StylelintCosmiconfigResult */
+/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi} from 'stylelint' */
 
 /**
  * @param {string} glob

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -11,9 +11,7 @@ import dynamicImport from './utils/dynamicImport.mjs';
 import getModulePath from './utils/getModulePath.mjs';
 import normalizeAllRuleSettings from './normalizeAllRuleSettings.mjs';
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').Config} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} StylelintCosmiconfigResult */
+/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi} from 'stylelint' */
 
 /**
  * @param {string} glob

--- a/lib/createPartialStylelintResult.cjs
+++ b/lib/createPartialStylelintResult.cjs
@@ -2,8 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').LintResult} StylelintResult */
+/** @import {LintResult as StylelintResult, PostcssResult} from 'stylelint' */
 
 /**
  * @param {PostcssResult} [postcssResult]

--- a/lib/createPartialStylelintResult.mjs
+++ b/lib/createPartialStylelintResult.mjs
@@ -1,5 +1,4 @@
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').LintResult} StylelintResult */
+/** @import {LintResult as StylelintResult, PostcssResult} from 'stylelint' */
 
 /**
  * @param {PostcssResult} [postcssResult]

--- a/lib/formatters/calcSeverityCounts.cjs
+++ b/lib/formatters/calcSeverityCounts.cjs
@@ -3,7 +3,7 @@
 'use strict';
 
 /**
- * @typedef {import('stylelint').Severity} Severity
+ * @import {Severity} from 'stylelint'
  *
  * @param {Severity} severity
  * @param {Record<Severity, number>} counts

--- a/lib/formatters/calcSeverityCounts.mjs
+++ b/lib/formatters/calcSeverityCounts.mjs
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('stylelint').Severity} Severity
+ * @import {Severity} from 'stylelint'
  *
  * @param {Severity} severity
  * @param {Record<Severity, number>} counts

--- a/lib/formatters/preprocessWarnings.cjs
+++ b/lib/formatters/preprocessWarnings.cjs
@@ -2,7 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-/** @typedef {import('stylelint').LintResult} LintResult */
+/** @import {LintResult} from 'stylelint' */
 /** @typedef {LintResult['parseErrors'][0]} ParseError */
 /** @typedef {LintResult['warnings'][0]} Warning */
 /** @typedef {Warning['severity']} Severity */

--- a/lib/formatters/preprocessWarnings.mjs
+++ b/lib/formatters/preprocessWarnings.mjs
@@ -1,4 +1,4 @@
-/** @typedef {import('stylelint').LintResult} LintResult */
+/** @import {LintResult} from 'stylelint' */
 /** @typedef {LintResult['parseErrors'][0]} ParseError */
 /** @typedef {LintResult['warnings'][0]} Warning */
 /** @typedef {Warning['severity']} Severity */

--- a/lib/formatters/tapFormatter.cjs
+++ b/lib/formatters/tapFormatter.cjs
@@ -5,7 +5,7 @@
 const validateTypes = require('../utils/validateTypes.cjs');
 const preprocessWarnings = require('./preprocessWarnings.cjs');
 
-/** @typedef {import('stylelint').Warning} Warning */
+/** @import {Warning} from 'stylelint' */
 /** @typedef {Array<Omit<Warning, 'rule'>>} Warnings */
 
 /** @type {import('stylelint').Formatter} */

--- a/lib/formatters/tapFormatter.mjs
+++ b/lib/formatters/tapFormatter.mjs
@@ -1,7 +1,7 @@
 import { isNumber } from '../utils/validateTypes.mjs';
 import preprocessWarnings from './preprocessWarnings.mjs';
 
-/** @typedef {import('stylelint').Warning} Warning */
+/** @import {Warning} from 'stylelint' */
 /** @typedef {Array<Omit<Warning, 'rule'>>} Warnings */
 
 /** @type {import('stylelint').Formatter} */

--- a/lib/formatters/verboseFormatter.cjs
+++ b/lib/formatters/verboseFormatter.cjs
@@ -9,11 +9,7 @@ const terminalLink = require('./terminalLink.cjs');
 
 const { underline, red, yellow, dim, green } = picocolors;
 
-/** @typedef {import('stylelint').Formatter} Formatter */
-/** @typedef {import('stylelint').LintResult} LintResult */
-/** @typedef {import('stylelint').Warning} Warning */
-/** @typedef {import('stylelint').Severity} Severity */
-/** @typedef {import('stylelint').RuleMeta} RuleMeta */
+/** @import {Formatter, LintResult, RuleMeta, Severity, Warning} from 'stylelint' */
 
 /**
  * @type {Formatter}

--- a/lib/formatters/verboseFormatter.mjs
+++ b/lib/formatters/verboseFormatter.mjs
@@ -5,11 +5,7 @@ import pluralize from '../utils/pluralize.mjs';
 import stringFormatter from './stringFormatter.mjs';
 import terminalLink from './terminalLink.mjs';
 
-/** @typedef {import('stylelint').Formatter} Formatter */
-/** @typedef {import('stylelint').LintResult} LintResult */
-/** @typedef {import('stylelint').Warning} Warning */
-/** @typedef {import('stylelint').Severity} Severity */
-/** @typedef {import('stylelint').RuleMeta} RuleMeta */
+/** @import {Formatter, LintResult, RuleMeta, Severity, Warning} from 'stylelint' */
 
 /**
  * @type {Formatter}

--- a/lib/getConfigForFile.cjs
+++ b/lib/getConfigForFile.cjs
@@ -11,9 +11,7 @@ const configurationError = require('./utils/configurationError.cjs');
 const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').Config} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} StylelintCosmiconfigResult */
+/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi} from 'stylelint' */
 
 /**
  * @param {StylelintInternalApi} stylelint

--- a/lib/getConfigForFile.mjs
+++ b/lib/getConfigForFile.mjs
@@ -9,9 +9,7 @@ import configurationError from './utils/configurationError.mjs';
 const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').Config} StylelintConfig */
-/** @typedef {import('stylelint').CosmiconfigResult} StylelintCosmiconfigResult */
+/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi} from 'stylelint' */
 
 /**
  * @param {StylelintInternalApi} stylelint

--- a/lib/getPostcssResult.cjs
+++ b/lib/getPostcssResult.cjs
@@ -8,11 +8,8 @@ const postcss = require('postcss');
 const dynamicImport = require('./utils/dynamicImport.cjs');
 const getModulePath = require('./utils/getModulePath.cjs');
 
-/** @typedef {import('postcss').Result} Result */
-/** @typedef {import('postcss').Syntax} Syntax */
-/** @typedef {import('stylelint').CustomSyntax} CustomSyntax */
-/** @typedef {import('stylelint').GetPostcssOptions} GetPostcssOptions */
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
+/** @import {Result, Syntax} from 'postcss' */
+/** @import {CustomSyntax, GetPostcssOptions, InternalApi as StylelintInternalApi} from 'stylelint' */
 
 const postcssProcessor = postcss();
 

--- a/lib/getPostcssResult.mjs
+++ b/lib/getPostcssResult.mjs
@@ -6,11 +6,8 @@ import postcss from 'postcss';
 import dynamicImport from './utils/dynamicImport.mjs';
 import getModulePath from './utils/getModulePath.mjs';
 
-/** @typedef {import('postcss').Result} Result */
-/** @typedef {import('postcss').Syntax} Syntax */
-/** @typedef {import('stylelint').CustomSyntax} CustomSyntax */
-/** @typedef {import('stylelint').GetPostcssOptions} GetPostcssOptions */
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
+/** @import {Result, Syntax} from 'postcss' */
+/** @import {CustomSyntax, GetPostcssOptions, InternalApi as StylelintInternalApi} from 'stylelint' */
 
 const postcssProcessor = postcss();
 

--- a/lib/lintPostcssResult.cjs
+++ b/lib/lintPostcssResult.cjs
@@ -10,9 +10,7 @@ const getStylelintRule = require('./utils/getStylelintRule.cjs');
 const reportUnknownRuleNames = require('./reportUnknownRuleNames.cjs');
 const index = require('./rules/index.cjs');
 
-/** @typedef {import('stylelint').LinterOptions} LinterOptions */
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig, LinterOptions, PostcssResult} from 'stylelint' */
 
 /**
  * @param {LinterOptions} stylelintOptions

--- a/lib/lintPostcssResult.mjs
+++ b/lib/lintPostcssResult.mjs
@@ -7,9 +7,7 @@ import getStylelintRule from './utils/getStylelintRule.mjs';
 import reportUnknownRuleNames from './reportUnknownRuleNames.mjs';
 import rules from './rules/index.mjs';
 
-/** @typedef {import('stylelint').LinterOptions} LinterOptions */
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig, LinterOptions, PostcssResult} from 'stylelint' */
 
 /**
  * @param {LinterOptions} stylelintOptions

--- a/lib/lintSource.cjs
+++ b/lib/lintSource.cjs
@@ -13,11 +13,8 @@ const lintPostcssResult = require('./lintPostcssResult.cjs');
 const needlessDisables = require('./needlessDisables.cjs');
 const reportDisables = require('./reportDisables.cjs');
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').GetLintSourceOptions} Options */
-/** @typedef {import('postcss').Result} Result */
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').StylelintPostcssResult} StylelintPostcssResult */
+/** @import {Result} from 'postcss' */
+/** @import {GetLintSourceOptions as Options, InternalApi as StylelintInternalApi, PostcssResult, StylelintPostcssResult} from 'stylelint' */
 
 /**
  * Run stylelint on a PostCSS Result, either one that is provided

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -10,11 +10,8 @@ import lintPostcssResult from './lintPostcssResult.mjs';
 import needlessDisables from './needlessDisables.mjs';
 import reportDisables from './reportDisables.mjs';
 
-/** @typedef {import('stylelint').InternalApi} StylelintInternalApi */
-/** @typedef {import('stylelint').GetLintSourceOptions} Options */
-/** @typedef {import('postcss').Result} Result */
-/** @typedef {import('stylelint').PostcssResult} PostcssResult */
-/** @typedef {import('stylelint').StylelintPostcssResult} StylelintPostcssResult */
+/** @import {Result} from 'postcss' */
+/** @import {GetLintSourceOptions as Options, InternalApi as StylelintInternalApi, PostcssResult, StylelintPostcssResult} from 'stylelint' */
 
 /**
  * Run stylelint on a PostCSS Result, either one that is provided

--- a/lib/normalizeAllRuleSettings.cjs
+++ b/lib/normalizeAllRuleSettings.cjs
@@ -5,7 +5,7 @@
 const getStylelintRule = require('./utils/getStylelintRule.cjs');
 const normalizeRuleSettings = require('./normalizeRuleSettings.cjs');
 
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig} from 'stylelint' */
 
 /**
  * @param {StylelintConfig} config

--- a/lib/normalizeAllRuleSettings.mjs
+++ b/lib/normalizeAllRuleSettings.mjs
@@ -1,7 +1,7 @@
 import getStylelintRule from './utils/getStylelintRule.mjs';
 import normalizeRuleSettings from './normalizeRuleSettings.mjs';
 
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig} from 'stylelint' */
 
 /**
  * @param {StylelintConfig} config

--- a/lib/postcssPlugin.cjs
+++ b/lib/postcssPlugin.cjs
@@ -8,8 +8,7 @@ const createStylelint = require('./createStylelint.cjs');
 const validateTypes = require('./utils/validateTypes.cjs');
 const lintSource = require('./lintSource.cjs');
 
-/** @typedef {import('stylelint').PostcssPluginOptions} PostcssPluginOptions */
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig, PostcssPluginOptions} from 'stylelint' */
 
 /**
  * @type {import('postcss').PluginCreator<PostcssPluginOptions>}

--- a/lib/postcssPlugin.mjs
+++ b/lib/postcssPlugin.mjs
@@ -5,8 +5,7 @@ import createStylelint from './createStylelint.mjs';
 import { isString } from './utils/validateTypes.mjs';
 import lintSource from './lintSource.mjs';
 
-/** @typedef {import('stylelint').PostcssPluginOptions} PostcssPluginOptions */
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig, PostcssPluginOptions} from 'stylelint' */
 
 /**
  * @type {import('postcss').PluginCreator<PostcssPluginOptions>}

--- a/lib/prepareReturnValue.cjs
+++ b/lib/prepareReturnValue.cjs
@@ -4,10 +4,8 @@
 
 const process = require('node:process');
 
-/** @typedef {import('stylelint').Formatter} Formatter */
-/** @typedef {import('stylelint').LintResult} StylelintResult */
-/** @typedef {import('stylelint').LinterOptions["maxWarnings"]} maxWarnings */
-/** @typedef {import('stylelint').LinterResult} LinterResult */
+/** @import {Formatter, LinterOptions, LinterResult, LintResult as StylelintResult} from 'stylelint' */
+/** @typedef {LinterOptions["maxWarnings"]} maxWarnings */
 
 
 /**

--- a/lib/prepareReturnValue.mjs
+++ b/lib/prepareReturnValue.mjs
@@ -1,7 +1,5 @@
-/** @typedef {import('stylelint').Formatter} Formatter */
-/** @typedef {import('stylelint').LintResult} StylelintResult */
-/** @typedef {import('stylelint').LinterOptions["maxWarnings"]} maxWarnings */
-/** @typedef {import('stylelint').LinterResult} LinterResult */
+/** @import {Formatter, LinterOptions, LinterResult, LintResult as StylelintResult} from 'stylelint' */
+/** @typedef {LinterOptions["maxWarnings"]} maxWarnings */
 
 import process from 'node:process';
 

--- a/lib/printConfig.cjs
+++ b/lib/printConfig.cjs
@@ -6,7 +6,7 @@ const process = require('node:process');
 const globby = require('globby');
 const resolveConfig = require('./resolveConfig.cjs');
 
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig} from 'stylelint' */
 
 /**
  * @param {import('stylelint').LinterOptions} options

--- a/lib/printConfig.mjs
+++ b/lib/printConfig.mjs
@@ -4,7 +4,7 @@ import globby from 'globby';
 
 import resolveConfig from './resolveConfig.mjs';
 
-/** @typedef {import('stylelint').Config} StylelintConfig */
+/** @import {Config as StylelintConfig} from 'stylelint' */
 
 /**
  * @param {import('stylelint').LinterOptions} options

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -27,8 +27,7 @@ const debug = createDebug('stylelint:standalone');
 
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 
-/** @typedef {import('stylelint').Formatter} Formatter */
-/** @typedef {import('stylelint').FormatterType} FormatterType */
+/** @import {Formatter, FormatterType} from 'stylelint' */
 
 /**
  * @type {import('stylelint').PublicApi['lint']}
@@ -305,7 +304,7 @@ function getFormatterFunction(selected) {
 }
 
 /**
- * @typedef {import('stylelint').CssSyntaxError} CssSyntaxError
+ * @import {CssSyntaxError} from 'stylelint'
  *
  * @param {unknown} error
  * @return {import('stylelint').LintResult}

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -25,8 +25,7 @@ import prepareReturnValue from './prepareReturnValue.mjs';
 
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 
-/** @typedef {import('stylelint').Formatter} Formatter */
-/** @typedef {import('stylelint').FormatterType} FormatterType */
+/** @import {Formatter, FormatterType} from 'stylelint' */
 
 /**
  * @type {import('stylelint').PublicApi['lint']}
@@ -303,7 +302,7 @@ function getFormatterFunction(selected) {
 }
 
 /**
- * @typedef {import('stylelint').CssSyntaxError} CssSyntaxError
+ * @import {CssSyntaxError} from 'stylelint'
  *
  * @param {unknown} error
  * @return {import('stylelint').LintResult}

--- a/lib/validateDisableSettings.cjs
+++ b/lib/validateDisableSettings.cjs
@@ -5,9 +5,7 @@
 const validateTypes = require('./utils/validateTypes.cjs');
 const validateOptions = require('./utils/validateOptions.cjs');
 
-/**
- * @typedef {import('stylelint').DisableOptions} DisableOptions
- */
+/** @import {DisableOptions} from 'stylelint' */
 
 /**
  * Validates that the stylelint config for `result` has a valid disable field

--- a/lib/validateDisableSettings.mjs
+++ b/lib/validateDisableSettings.mjs
@@ -1,9 +1,7 @@
 import { isRegExp, isString } from './utils/validateTypes.mjs';
 import validateOptions from './utils/validateOptions.mjs';
 
-/**
- * @typedef {import('stylelint').DisableOptions} DisableOptions
- */
+/** @import {DisableOptions} from 'stylelint' */
 
 /**
  * Validates that the stylelint config for `result` has a valid disable field


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #7797

> Is there anything in the PR that needs further explanation?

This introduces the JSDoc `@import` tag since TypeScript 5.5, see below:
https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#the-jsdoc-import-tag

Note that this replaces only `lib/*.mjs` files because there are so many files to be refactored.
We can gradually change other files.

```sh-session
$ git grep '@typedef \{import' lib/*.mjs || echo '(no match)'
(no match)
```
