### PR TITLE
Add recommended parser packages to developer guide

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -102,6 +102,7 @@ Depending on the rule, we also recommend using:
 - [@csstools/css-parser-algorithms](https://www.npmjs.com/package/@csstools/css-parser-algorithms)
 - [@csstools/css-tokenizer](https://www.npmjs.com/package/@csstools/css-tokenizer)
 - [@csstools/media-query-list-parser](https://www.npmjs.com/package/@csstools/media-query-list-parser)
+- [css-tree](https://www.npmjs.com/package/css-tree)
 
 There are significant benefits to using these parsers instead of regular expressions or `indexOf` searches (even if they aren't always the most performant method).
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -97,9 +97,11 @@ Use `node.raws` instead of `node.raw()` when accessing raw strings from the [Pos
 
 Depending on the rule, we also recommend using:
 
-- [media-query-list-parser](https://www.npmjs.com/package/@csstools/media-query-list-parser)
-- [postcss-value-parser](https://github.com/TrySound/postcss-value-parser)
-- [postcss-selector-parser](https://github.com/postcss/postcss-selector-parser)
+- [postcss-value-parser](https://www.npmjs.com/package/postcss-value-parser)
+- [postcss-selector-parser](https://www.npmjs.com/package/postcss-selector-parser)
+- [@csstools/css-parser-algorithms](https://www.npmjs.com/package/@csstools/css-parser-algorithms)
+- [@csstools/css-tokenizer](https://www.npmjs.com/package/@csstools/css-tokenizer)
+- [@csstools/media-query-list-parser](https://www.npmjs.com/package/@csstools/media-query-list-parser)
 
 There are significant benefits to using these parsers instead of regular expressions or `indexOf` searches (even if they aren't always the most performant method).
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Change summary:
- Add `@csstools/css-parser-algorithms`, `@csstools/css-tokenizer`, and `css-tree` that we have used heavily.
- Unify the package link URLs to `https://www.npmjs.com`.

See also:

```sh-session
$ npm ls | grep -E '@csstools|css-tree'
├── @csstools/css-parser-algorithms@2.6.3
├── @csstools/css-tokenizer@2.3.1
├── @csstools/media-query-list-parser@2.1.11
├── @csstools/selector-specificity@3.1.1
├── @types/css-tree@2.3.8
├── css-tree@2.3.1
```
