### PR TITLE
Refactor `declaration-block-no-redundant-longhand-properties` to use `fix` callback instead of `context.fix`

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -219,7 +219,7 @@ const resolveShorthandValue = (
 };
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, secondaryOptions, context) => {
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -274,7 +274,6 @@ const rule = (primary, secondaryOptions, context) => {
 				const prop = decl.prop.toLowerCase();
 				const unprefixedProp = vendor.unprefixed(prop);
 				const prefix = vendor.prefix(prop);
-
 				const shorthandProperties = longhandToShorthands.get(unprefixedProp);
 
 				if (!shorthandProperties) {
@@ -306,21 +305,25 @@ const rule = (primary, secondaryOptions, context) => {
 						continue;
 					}
 
-					if (context.fix) {
-						const declNodes = longhandDeclarationNodes.get(prefixedShorthandProperty) || [];
-						const [firstDeclNode] = declNodes;
+					const declNodes = longhandDeclarationNodes.get(prefixedShorthandProperty) || [];
+					const [firstDeclNode] = declNodes;
+					let resolvedShorthandValue = undefined;
 
-						if (firstDeclNode) {
-							const transformedDeclarationNodes = new Map(
-								declNodes.map((d) => [d.prop.toLowerCase(), d]),
-							);
-							const resolvedShorthandValue = resolveShorthandValue(
-								prefixedShorthandProperty,
-								prefixedShorthandData,
-								transformedDeclarationNodes,
-							);
+					if (firstDeclNode) {
+						const transformedDeclarationNodes = new Map(
+							declNodes.map((d) => [d.prop.toLowerCase(), d]),
+						);
 
-							if (resolvedShorthandValue) {
+						resolvedShorthandValue = resolveShorthandValue(
+							prefixedShorthandProperty,
+							prefixedShorthandData,
+							transformedDeclarationNodes,
+						);
+					}
+
+					const hasFix = firstDeclNode && resolvedShorthandValue;
+					const fix = hasFix
+						? () => {
 								const newShorthandDeclarationNode = firstDeclNode.clone({
 									prop: prefixedShorthandProperty,
 									value: resolvedShorthandValue,
@@ -330,17 +333,15 @@ const rule = (primary, secondaryOptions, context) => {
 								declNodes.forEach((node) => node.remove());
 
 								if (haveConflicts.includes(shorthandProperty)) {
-									longhandDeclarations.forEach((v, k) => {
-										const array = v.filter((element) => !longhandDeclaration.includes(element));
-
-										longhandDeclarations.set(k, array);
+									longhandDeclarations.forEach((longhands, shorthand) => {
+										longhandDeclarations.set(
+											shorthand,
+											longhands.filter((longhand) => !longhandDeclaration.includes(longhand)),
+										);
 									});
 								}
-
-								return;
-							}
-						}
-					}
+						  }
+						: undefined;
 
 					report({
 						ruleName,
@@ -349,6 +350,7 @@ const rule = (primary, secondaryOptions, context) => {
 						word: decl.prop,
 						message: messages.expected,
 						messageArgs: [prefixedShorthandProperty],
+						fix,
 					});
 				}
 			});

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -216,7 +216,7 @@ const resolveShorthandValue = (
 };
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, secondaryOptions, context) => {
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
 			result,
@@ -271,7 +271,6 @@ const rule = (primary, secondaryOptions, context) => {
 				const prop = decl.prop.toLowerCase();
 				const unprefixedProp = vendor.unprefixed(prop);
 				const prefix = vendor.prefix(prop);
-
 				const shorthandProperties = longhandToShorthands.get(unprefixedProp);
 
 				if (!shorthandProperties) {
@@ -303,21 +302,25 @@ const rule = (primary, secondaryOptions, context) => {
 						continue;
 					}
 
-					if (context.fix) {
-						const declNodes = longhandDeclarationNodes.get(prefixedShorthandProperty) || [];
-						const [firstDeclNode] = declNodes;
+					const declNodes = longhandDeclarationNodes.get(prefixedShorthandProperty) || [];
+					const [firstDeclNode] = declNodes;
+					let resolvedShorthandValue = undefined;
 
-						if (firstDeclNode) {
-							const transformedDeclarationNodes = new Map(
-								declNodes.map((d) => [d.prop.toLowerCase(), d]),
-							);
-							const resolvedShorthandValue = resolveShorthandValue(
-								prefixedShorthandProperty,
-								prefixedShorthandData,
-								transformedDeclarationNodes,
-							);
+					if (firstDeclNode) {
+						const transformedDeclarationNodes = new Map(
+							declNodes.map((d) => [d.prop.toLowerCase(), d]),
+						);
 
-							if (resolvedShorthandValue) {
+						resolvedShorthandValue = resolveShorthandValue(
+							prefixedShorthandProperty,
+							prefixedShorthandData,
+							transformedDeclarationNodes,
+						);
+					}
+
+					const hasFix = firstDeclNode && resolvedShorthandValue;
+					const fix = hasFix
+						? () => {
 								const newShorthandDeclarationNode = firstDeclNode.clone({
 									prop: prefixedShorthandProperty,
 									value: resolvedShorthandValue,
@@ -327,17 +330,15 @@ const rule = (primary, secondaryOptions, context) => {
 								declNodes.forEach((node) => node.remove());
 
 								if (haveConflicts.includes(shorthandProperty)) {
-									longhandDeclarations.forEach((v, k) => {
-										const array = v.filter((element) => !longhandDeclaration.includes(element));
-
-										longhandDeclarations.set(k, array);
+									longhandDeclarations.forEach((longhands, shorthand) => {
+										longhandDeclarations.set(
+											shorthand,
+											longhands.filter((longhand) => !longhandDeclaration.includes(longhand)),
+										);
 									});
 								}
-
-								return;
-							}
-						}
-					}
+						  }
+						: undefined;
 
 					report({
 						ruleName,
@@ -346,6 +347,7 @@ const rule = (primary, secondaryOptions, context) => {
 						word: decl.prop,
 						message: messages.expected,
 						messageArgs: [prefixedShorthandProperty],
+						fix,
 					});
 				}
 			});


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#2643

> Is there anything in the PR that needs further explanation?

N/A