### PR TITLE
Require `meta.fixable` to be truthy when using `fix` callback for `report()`

### DIFF
--- a/lib/__tests__/fixtures/plugin-fixer-buggy.mjs
+++ b/lib/__tests__/fixtures/plugin-fixer-buggy.mjs
@@ -40,5 +40,6 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = { fixable: true };
 
 export default createPlugin(ruleName, rule);

--- a/lib/__tests__/fixtures/plugin-fixer.mjs
+++ b/lib/__tests__/fixtures/plugin-fixer.mjs
@@ -43,5 +43,6 @@ const rule = (primary) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = { fixable: true };
 
 export default createPlugin(ruleName, rule);

--- a/lib/__tests__/fixtures/plugin-fixes.mjs
+++ b/lib/__tests__/fixtures/plugin-fixes.mjs
@@ -55,5 +55,6 @@ const rule = (primary, _, context) => {
 
 rule.ruleName = ruleName;
 rule.messages = messages;
+rule.meta = { fixable: true };
 
 export default createPlugin(ruleName, rule);

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -411,6 +411,7 @@ describe('with fix callback', () => {
 			result: {
 				warn: jest.fn(),
 				stylelint: {
+					ruleMetadata: { foo: { fixable: true } },
 					ruleSeverities: {},
 					fixersData,
 					config: {
@@ -451,6 +452,7 @@ describe('with fix callback', () => {
 			result: {
 				warn: jest.fn(),
 				stylelint: {
+					ruleMetadata: { foo: { fixable: true } },
 					ruleSeverities: {},
 					fixersData,
 					config: {
@@ -473,6 +475,25 @@ describe('with fix callback', () => {
 
 		expect(fixerData.fixed).toBe(false);
 		expect(fixerData.range).toBeUndefined();
+	});
+
+	test('failing due to non-fixable metadata', () => {
+		const v = {
+			ruleName: 'foo',
+			result: {
+				stylelint: {
+					ruleMetadata: { foo: { fixable: false } },
+					ruleSeverities: {},
+					fixersData: {},
+				},
+			},
+			node: {
+				rangeBy: defaultRangeBy,
+			},
+			fix: () => {},
+		};
+
+		expect(() => report(v)).toThrow('The "foo" rule requires "fixable=true" metadata for autofix');
 	});
 });
 

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -493,7 +493,9 @@ describe('with fix callback', () => {
 			fix: () => {},
 		};
 
-		expect(() => report(v)).toThrow('The "foo" rule requires "fixable=true" metadata for autofix');
+		expect(() => report(v)).toThrow(
+			'The "foo" rule requires "meta.fixable" to be truthy if the "fix" callback is being passed',
+		);
 	});
 });
 

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -20,7 +20,7 @@ const constants = require('../constants.cjs');
  * @type {import('stylelint').Utils['report']}
  */
 function report(problem) {
-	const { node, index, endIndex, line, start, end, result, ruleName, word, ...rest } = problem;
+	const { node, index, endIndex, line, start, end, result, ruleName, word, fix, ...rest } = problem;
 	const {
 		disabledRanges,
 		quiet,
@@ -28,9 +28,14 @@ function report(problem) {
 		config: { defaultSeverity = 'error', ignoreDisables } = {},
 		customMessages: { [ruleName]: message = rest.message } = {},
 		customUrls: { [ruleName]: customUrl } = {},
+		ruleMetadata: { [ruleName]: metadata } = {},
 	} = result.stylelint;
 	const { messageArgs = [], severity = ruleSeverities[ruleName] } = rest;
 	const ruleSeverity = validateTypes.isFunction(severity) ? severity(...messageArgs) || defaultSeverity : severity;
+
+	if (validateTypes.isFunction(fix) && metadata && !metadata.fixable) {
+		throw new Error(`The "${ruleName}" rule requires "fixable=true" metadata for autofix`);
+	}
 
 	// In quiet mode, mere warnings are ignored
 	if (quiet && ruleSeverity !== 'error') return;

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -33,12 +33,14 @@ function report(problem) {
 	const { messageArgs = [], severity = ruleSeverities[ruleName] } = rest;
 	const ruleSeverity = validateTypes.isFunction(severity) ? severity(...messageArgs) || defaultSeverity : severity;
 
-	if (validateTypes.isFunction(fix) && metadata && !metadata.fixable) {
-		throw new Error(`The "${ruleName}" rule requires "fixable=true" metadata for autofix`);
-	}
-
 	// In quiet mode, mere warnings are ignored
 	if (quiet && ruleSeverity !== 'error') return;
+
+	if (validateTypes.isFunction(fix) && metadata && !metadata.fixable) {
+		throw new Error(
+			`The "${ruleName}" rule requires "meta.fixable" to be truthy if the "fix" callback is being passed`,
+		);
+	}
 
 	const range = node?.rangeBy({ index, endIndex }) ?? {};
 	// If a line is not passed, use the node.rangeBy method to get the

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -29,12 +29,14 @@ export default function report(problem) {
 	const { messageArgs = [], severity = ruleSeverities[ruleName] } = rest;
 	const ruleSeverity = isFn(severity) ? severity(...messageArgs) || defaultSeverity : severity;
 
-	if (isFn(fix) && metadata && !metadata.fixable) {
-		throw new Error(`The "${ruleName}" rule requires "fixable=true" metadata for autofix`);
-	}
-
 	// In quiet mode, mere warnings are ignored
 	if (quiet && ruleSeverity !== 'error') return;
+
+	if (isFn(fix) && metadata && !metadata.fixable) {
+		throw new Error(
+			`The "${ruleName}" rule requires "meta.fixable" to be truthy if the "fix" callback is being passed`,
+		);
+	}
 
 	const range = node?.rangeBy({ index, endIndex }) ?? {};
 	// If a line is not passed, use the node.rangeBy method to get the

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -16,7 +16,7 @@ import { RULE_NAME_ALL } from '../constants.mjs';
  * @type {import('stylelint').Utils['report']}
  */
 export default function report(problem) {
-	const { node, index, endIndex, line, start, end, result, ruleName, word, ...rest } = problem;
+	const { node, index, endIndex, line, start, end, result, ruleName, word, fix, ...rest } = problem;
 	const {
 		disabledRanges,
 		quiet,
@@ -24,9 +24,14 @@ export default function report(problem) {
 		config: { defaultSeverity = 'error', ignoreDisables } = {},
 		customMessages: { [ruleName]: message = rest.message } = {},
 		customUrls: { [ruleName]: customUrl } = {},
+		ruleMetadata: { [ruleName]: metadata } = {},
 	} = result.stylelint;
 	const { messageArgs = [], severity = ruleSeverities[ruleName] } = rest;
 	const ruleSeverity = isFn(severity) ? severity(...messageArgs) || defaultSeverity : severity;
+
+	if (isFn(fix) && metadata && !metadata.fixable) {
+		throw new Error(`The "${ruleName}" rule requires "fixable=true" metadata for autofix`);
+	}
 
 	// In quiet mode, mere warnings are ignored
 	if (quiet && ruleSeverity !== 'error') return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #7784

> Is there anything in the PR that needs further explanation?

This change aims to prevent inconsistency between `fixable` metadata and `fix` callback.

> [!NOTE]
> The `fix` callback is not published yet, so this PR doesn't need a changelog entry.