### PR TITLE
Update `fontSizeKeywords` set and fix `fontShorthandKeywords` set

### DIFF
--- a/.changeset/slow-timers-relax.md
+++ b/.changeset/slow-timers-relax.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `font-family-no-missing-generic-family-keyword` false negatives for font families which names match a CSS3 `font-variant` keyword

--- a/lib/reference/keywords.cjs
+++ b/lib/reference/keywords.cjs
@@ -107,44 +107,7 @@ const fontWeightKeywords = uniteSets(
 
 const fontStyleKeywords = uniteSets(basicKeywords, ['normal', 'italic', 'oblique']);
 
-const fontVariantKeywords = uniteSets(basicKeywords, [
-	'normal',
-	'none',
-	'historical-forms',
-	'none',
-	'common-ligatures',
-	'no-common-ligatures',
-	'discretionary-ligatures',
-	'no-discretionary-ligatures',
-	'historical-ligatures',
-	'no-historical-ligatures',
-	'contextual',
-	'no-contextual',
-	'small-caps',
-	'small-caps',
-	'all-small-caps',
-	'petite-caps',
-	'all-petite-caps',
-	'unicase',
-	'titling-caps',
-	'lining-nums',
-	'oldstyle-nums',
-	'proportional-nums',
-	'tabular-nums',
-	'diagonal-fractions',
-	'stacked-fractions',
-	'ordinal',
-	'slashed-zero',
-	'jis78',
-	'jis83',
-	'jis90',
-	'jis04',
-	'simplified',
-	'traditional',
-	'full-width',
-	'proportional-width',
-	'ruby',
-]);
+const fontVariantCSS2Keywords = uniteSets(basicKeywords, ['normal', 'none', 'small-caps']);
 
 const fontStretchKeywords = uniteSets(basicKeywords, [
 	'semi-condensed',
@@ -165,8 +128,10 @@ const fontSizeKeywords = uniteSets(basicKeywords, [
 	'large',
 	'x-large',
 	'xx-large',
+	'xxx-large',
 	'larger',
 	'smaller',
+	'math',
 ]);
 
 const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);
@@ -174,7 +139,7 @@ const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);
 const fontShorthandKeywords = uniteSets(
 	basicKeywords,
 	fontStyleKeywords,
-	fontVariantKeywords,
+	fontVariantCSS2Keywords,
 	fontWeightKeywords,
 	fontStretchKeywords,
 	fontSizeKeywords,

--- a/lib/reference/keywords.mjs
+++ b/lib/reference/keywords.mjs
@@ -103,44 +103,7 @@ export const fontWeightKeywords = uniteSets(
 
 const fontStyleKeywords = uniteSets(basicKeywords, ['normal', 'italic', 'oblique']);
 
-const fontVariantKeywords = uniteSets(basicKeywords, [
-	'normal',
-	'none',
-	'historical-forms',
-	'none',
-	'common-ligatures',
-	'no-common-ligatures',
-	'discretionary-ligatures',
-	'no-discretionary-ligatures',
-	'historical-ligatures',
-	'no-historical-ligatures',
-	'contextual',
-	'no-contextual',
-	'small-caps',
-	'small-caps',
-	'all-small-caps',
-	'petite-caps',
-	'all-petite-caps',
-	'unicase',
-	'titling-caps',
-	'lining-nums',
-	'oldstyle-nums',
-	'proportional-nums',
-	'tabular-nums',
-	'diagonal-fractions',
-	'stacked-fractions',
-	'ordinal',
-	'slashed-zero',
-	'jis78',
-	'jis83',
-	'jis90',
-	'jis04',
-	'simplified',
-	'traditional',
-	'full-width',
-	'proportional-width',
-	'ruby',
-]);
+const fontVariantCSS2Keywords = uniteSets(basicKeywords, ['normal', 'none', 'small-caps']);
 
 const fontStretchKeywords = uniteSets(basicKeywords, [
 	'semi-condensed',
@@ -161,8 +124,10 @@ export const fontSizeKeywords = uniteSets(basicKeywords, [
 	'large',
 	'x-large',
 	'xx-large',
+	'xxx-large',
 	'larger',
 	'smaller',
+	'math',
 ]);
 
 const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);
@@ -170,7 +135,7 @@ const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);
 export const fontShorthandKeywords = uniteSets(
 	basicKeywords,
 	fontStyleKeywords,
-	fontVariantKeywords,
+	fontVariantCSS2Keywords,
 	fontWeightKeywords,
 	fontStretchKeywords,
 	fontSizeKeywords,

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
@@ -160,6 +160,14 @@ testRule({
 			endLine: 1,
 			endColumn: 49,
 		},
+		{
+			code: 'a { font: 1em "ruby"; }',
+			message: messages.rejected,
+			line: 1,
+			column: 15,
+			endLine: 1,
+			endColumn: 21,
+		},
 	],
 });
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

This _might_ impact these rules:

- `font-family-name-quotes`
- `font-family-no-duplicate-names`
- `font-family-no-missing-generic-family-keyword`

https://github.com/stylelint/stylelint/blob/4ccec36357b9669f1ea5158c5fd2be10f434c1e8/lib/utils/findFontFamily.mjs#L75-L91

> References

https://developer.mozilla.org/en-US/docs/Web/CSS/font
https://developer.mozilla.org/en-US/docs/Web/CSS/font-size