### PR TITLE
Refactor `function-calc-no-unspaced-operator` to use `fix` callback instead of `context.fix`

### DIFF
--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -280,18 +280,16 @@ testRule({
 			fixed: 'a { scale: rem(10 + 2, 1.7); }',
 			warnings: [
 				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
-				{ message: messages.expectedAfter('+'), line: 1, column: 19, endLine: 1, endColumn: 20 },
+				{ message: messages.expectedAfter('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 			],
-			skip: true,
 		},
 		{
 			code: 'a { rotate: rem(10turn, 2turn+1turn); }',
 			fixed: 'a { rotate: rem(10turn, 2turn + 1turn); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1 },
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
+				{ message: messages.expectedAfter('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
 			],
-			skip: true,
 		},
 		{
 			code: 'a { top: calc(1px +\t-1px); }',

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -263,32 +263,32 @@ testRule({
 			fixed: 'a { top: calc(2px + 1px); }',
 			description: 'no space before or after operator',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 			],
 		},
 		{
 			code: 'a { transform: rotate(acos(2+1)); }',
 			fixed: 'a { transform: rotate(acos(2 + 1)); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
 			],
 		},
 		{
 			code: 'a { scale: rem(10+2, 1.7); }',
 			fixed: 'a { scale: rem(10 + 2, 1.7); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 			],
 		},
 		{
 			code: 'a { rotate: rem(10turn, 2turn+1turn); }',
 			fixed: 'a { rotate: rem(10turn, 2turn + 1turn); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
 			],
 		},
 		{
@@ -586,32 +586,32 @@ testRule({
 			code: 'a { padding: calc(1px+2px+3px); }',
 			fixed: 'a { padding: calc(1px + 2px + 3px); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
 			],
 		},
 		{
 			code: 'a { padding: calc(1px+2px-3px); }',
 			fixed: 'a { padding: calc(1px + 2px - 3px); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
 			],
 		},
 		{
 			code: 'a { padding: calc(1px+2px-3px-4px); }',
 			fixed: 'a { padding: calc(1px + 2px - 3px - 4px); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
 			],
 		},
 		{
@@ -649,8 +649,8 @@ testRule({
 			fixed: 'a { font-size: clamp(1rem, 2.5vw, 1rem + 1rem); }',
 			description: 'multiple argument functions',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
 			],
 		},
 		{
@@ -659,8 +659,8 @@ testRule({
 			description: 'multiple argument functions',
 			warnings: [
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 			],
 		},
 		{
@@ -668,8 +668,8 @@ testRule({
 			fixed: 'a { width: min(25vw + 25vw); }',
 			description: 'multiple argument functions',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
 			],
 		},
 		{
@@ -687,14 +687,14 @@ testRule({
 				'a { top: rgb(from red calc(r + 1) calc(g - +2) calc(clamp(10px + 2px, g + 2, none))); }',
 			description: 'nested math expression',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
 			],
 		},
 		{

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -210,15 +210,9 @@ const rule = (primary) => {
 						valueIndex + operation.operatorCharPosition,
 						operation.operatorChar,
 						() => {
-							whitespaceNode.value = [
-								[
-									cssTokenizer.TokenType.Whitespace,
-									indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
-									-1,
-									-1,
-									undefined,
-								],
-							];
+							whitespaceNode.value = newWhitespaceNode(
+								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
+							).value;
 							fixDeclarationValue();
 						},
 					);
@@ -386,6 +380,13 @@ function isOperandNode(node) {
 	return OPERAND_TOKEN_TYPES.has(node.value[0]);
 }
 
+/**
+ * @param {string} whitespace
+ */
+function newWhitespaceNode(whitespace = ' ') {
+	return new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, whitespace, -1, -1, undefined]]);
+}
+
 class Operation {
 	/**
 	 * @param {ComponentValue} firstOperand
@@ -432,7 +433,7 @@ class Operation {
 		node.value.splice(
 			node.value.indexOf(this.operator) + (position === 'before' ? 0 : 1),
 			0,
-			new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]]),
+			newWhitespaceNode(),
 		);
 	}
 
@@ -468,9 +469,9 @@ class Operation {
 
 		if (type === 'append') {
 			this.after = this.before;
-			this.before = [new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]])];
+			this.before = [newWhitespaceNode()];
 		} else {
-			this.after = [new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]])];
+			this.after = [newWhitespaceNode()];
 		}
 	}
 }

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -37,7 +37,7 @@ const NEWLINE_REGEX = /\n|\r\n/;
 /** @import { CommentNode, ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
@@ -119,10 +119,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								cssTokenizer.mutateUnit(token, unit.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									cssTokenizer.mutateUnit(token, unit.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -135,10 +142,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -152,13 +166,21 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
-						if (context.fix) {
-							operation.insertOperatorBeforeSecondOperand(node);
+						complain(
+							messages.expectedAfter(operation.operatorChar),
+							decl,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
+							() => {
+								operation.insertOperatorBeforeSecondOperand(node);
 
-							// Remove an operator character from the second operand token
-							token[4].signCharacter = undefined;
-							token[1] = token[1].slice(1);
-						}
+								// Remove an operator character from the second operand token
+								token[4].signCharacter = undefined;
+								token[1] = token[1].slice(1);
+
+								fixDeclarationValue();
+							},
+						);
 					}
 				}
 			}
@@ -419,7 +441,7 @@ class Operation {
 	 */
 	insertOperatorAfterFirstOperand(node) {
 		validateTypes.assert(this.operator);
-		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, this.operator);
+		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, ...this.before, this.operator);
 	}
 
 	/**
@@ -427,7 +449,7 @@ class Operation {
 	 */
 	insertOperatorBeforeSecondOperand(node) {
 		validateTypes.assert(this.operator);
-		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator);
+		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator, ...this.after);
 	}
 
 	/**
@@ -446,7 +468,9 @@ class Operation {
 
 		if (type === 'append') {
 			this.after = this.before;
-			this.before = [];
+			this.before = [new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]])];
+		} else {
+			this.after = [new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]])];
 		}
 	}
 }

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -48,11 +48,12 @@ const rule = (primary, _secondaryOptions, context) => {
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {string} operator
+		 * @param {() => void} fix
 		 */
-		function complain(message, node, index, operator) {
+		function complain(message, node, index, operator, fix) {
 			const endIndex = index + operator.length;
 
-			report({ message, node, index, endIndex, result, ruleName });
+			report({ message, node, index, endIndex, result, ruleName, fix });
 		}
 
 		root.walkDecls((decl) => {
@@ -62,12 +63,12 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			if (!FUNC_CALLS_REGEX.test(value)) return;
 
-			let needsFix = false;
-			const valueIndex = declarationValueIndex(decl);
-
 			const nodes = tokenizeDeclarationValue(value);
 
 			if (nodes.length === 0) return;
+
+			const valueIndex = declarationValueIndex(decl);
+			const fixDeclarationValue = () => setDeclarationValue(decl, cssParserAlgorithms.stringify([nodes]));
 
 			/**
 			 * @param {ContainerNode} node
@@ -77,31 +78,29 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (operation.before.length && operation.after.length) return;
 
 				if (!operation.before.some(cssParserAlgorithms.isWhitespaceNode)) {
-					if (context.fix) {
-						needsFix = true;
-						operation.insertWhitespace(node, 'before');
-					} else {
-						complain(
-							messages.expectedBefore(operation.operatorChar),
-							decl,
-							valueIndex + operation.operatorCharPosition,
-							operation.operatorChar,
-						);
-					}
+					complain(
+						messages.expectedBefore(operation.operatorChar),
+						decl,
+						valueIndex + operation.operatorCharPosition,
+						operation.operatorChar,
+						() => {
+							operation.insertWhitespace(node, 'before');
+							fixDeclarationValue();
+						},
+					);
 				}
 
 				if (!operation.after.some(cssParserAlgorithms.isWhitespaceNode)) {
-					if (context.fix) {
-						needsFix = true;
-						operation.insertWhitespace(node, 'after');
-					} else {
-						complain(
-							messages.expectedAfter(operation.operatorChar),
-							decl,
-							valueIndex + operation.operatorCharPosition,
-							operation.operatorChar,
-						);
-					}
+					complain(
+						messages.expectedAfter(operation.operatorChar),
+						decl,
+						valueIndex + operation.operatorCharPosition,
+						operation.operatorChar,
+						() => {
+							operation.insertWhitespace(node, 'after');
+							fixDeclarationValue();
+						},
+					);
 				}
 			}
 
@@ -121,7 +120,6 @@ const rule = (primary, _secondaryOptions, context) => {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
-								needsFix = true;
 								operation.insertOperatorAfterFirstOperand(node);
 								cssTokenizer.mutateUnit(token, unit.slice(0, -1));
 							}
@@ -138,7 +136,6 @@ const rule = (primary, _secondaryOptions, context) => {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
-								needsFix = true;
 								operation.insertOperatorAfterFirstOperand(node);
 								cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
 							}
@@ -156,8 +153,6 @@ const rule = (primary, _secondaryOptions, context) => {
 						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
 						if (context.fix) {
-							needsFix = true;
-
 							operation.insertOperatorBeforeSecondOperand(node);
 
 							// Remove an operator character from the second operand token
@@ -185,29 +180,26 @@ const rule = (primary, _secondaryOptions, context) => {
 
 					if (indexOfFirstNewLine === 0) return;
 
-					if (context.fix) {
-						needsFix = true;
+					const message = position === 'before' ? messages.expectedBefore : messages.expectedAfter;
 
-						whitespaceNode.value = [
-							[
-								cssTokenizer.TokenType.Whitespace,
-								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
-								-1,
-								-1,
-								undefined,
-							],
-						];
-					} else {
-						const message =
-							position === 'before' ? messages.expectedBefore : messages.expectedAfter;
-
-						complain(
-							message(operation.operatorChar),
-							decl,
-							valueIndex + operation.operatorCharPosition,
-							operation.operatorChar,
-						);
-					}
+					complain(
+						message(operation.operatorChar),
+						decl,
+						valueIndex + operation.operatorCharPosition,
+						operation.operatorChar,
+						() => {
+							whitespaceNode.value = [
+								[
+									cssTokenizer.TokenType.Whitespace,
+									indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
+									-1,
+									-1,
+									undefined,
+								],
+							];
+							fixDeclarationValue();
+						},
+					);
 				});
 			}
 
@@ -276,10 +268,6 @@ const rule = (primary, _secondaryOptions, context) => {
 					inMathFunction: false,
 				},
 			);
-
-			if (needsFix) {
-				setDeclarationValue(decl, cssParserAlgorithms.stringify([nodes]));
-			}
 		});
 	};
 };

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -178,11 +178,10 @@ const rule = (primary) => {
 
 			/**
 			 * @param {Operation} operation
-			 * @param {Operation["before"] | Operation["after"]} whitespaceNodes
 			 * @param {'before' | 'after'} position
 			 */
-			function checkOperandWhitespace(operation, whitespaceNodes, position) {
-				whitespaceNodes.forEach((whitespaceNode) => {
+			function checkOperandWhitespace(operation, position) {
+				operation[position].forEach((whitespaceNode) => {
 					if (!cssParserAlgorithms.isWhitespaceNode(whitespaceNode)) return;
 
 					const whitespace = whitespaceNode.toString();
@@ -265,8 +264,8 @@ const rule = (primary) => {
 
 							// Step 6
 							// Normalize the whitespace around the operands
-							checkOperandWhitespace(operation, operation.before, 'before');
-							checkOperandWhitespace(operation, operation.after, 'after');
+							checkOperandWhitespace(operation, 'before');
+							checkOperandWhitespace(operation, 'after');
 						}
 
 						cursor = node.value.indexOf(operation.secondOperand);

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -67,65 +67,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			let needsFix = false;
 			const valueIndex = declarationValueIndex(decl);
 
-			const tokens = cssTokenizer.tokenize({ css: value });
-
-			{
-				// Step 1
-				// Step 1.1
-				// Re-tokenize dimensions with units containing dashes.
-				// These might be typo's.
-				// For example: `10px-20px` has a unit of `px-20px`
-				tokens.forEach((token, i) => {
-					if (!cssTokenizer.isTokenDimension(token)) return;
-
-					const { unit } = token[4];
-
-					if (unit.startsWith('--')) return;
-
-					const indexOfDash = unit.indexOf('-');
-
-					if (indexOfDash === -1) return;
-
-					const remainder = unit.slice(indexOfDash);
-
-					if (remainder.length === 1) return;
-
-					cssTokenizer.mutateUnit(token, unit.slice(0, indexOfDash));
-					token[3] = token[2] + token[1].length;
-
-					const remainderTokens = cssTokenizer.tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
-
-					remainderTokens.forEach((remainderToken) => {
-						remainderToken[2] += token[3];
-						remainderToken[3] += token[3];
-					});
-
-					tokens.splice(i + 1, 0, ...remainderTokens);
-				});
-
-				// Step 1.2
-				// Re-tokenize scss interpolation blocks
-				// Grouping `#` and `{` into a single token allows us to parse these as simple blocks with curly braces.
-				// For example: `#{$foo}`
-				tokens.forEach((currentToken, i) => {
-					if (!cssTokenizer.isTokenDelim(currentToken) || currentToken[4].value !== '#') return;
-
-					const nextToken = tokens[i + 1];
-
-					if (!cssTokenizer.isTokenOpenCurly(nextToken)) return;
-
-					const nextNextToken = tokens[i + 2];
-
-					if (!cssTokenizer.isTokenDelim(nextNextToken) || nextNextToken[4].value !== '$') return;
-
-					// Set the string representation of the open curly to `#{`
-					nextToken[1] = '#{';
-					// Remove the `#` token
-					tokens.splice(i, 1);
-				});
-			}
-
-			const nodes = cssParserAlgorithms.parseListOfComponentValues(tokens);
+			const nodes = tokenizeDeclarationValue(value);
 
 			if (nodes.length === 0) return;
 
@@ -136,7 +78,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			function checkCompleteOperation(node, operation) {
 				if (operation.before.length && operation.after.length) return;
 
-				if (!operation.before.find(cssParserAlgorithms.isWhitespaceNode)) {
+				if (!operation.before.some(cssParserAlgorithms.isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -154,7 +96,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					}
 				}
 
-				if (!operation.after.find(cssParserAlgorithms.isWhitespaceNode)) {
+				if (!operation.after.some(cssParserAlgorithms.isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -388,6 +330,69 @@ const rule = (primary, _secondaryOptions, context) => {
 		});
 	};
 };
+
+/**
+ * @param {string} value
+ */
+function tokenizeDeclarationValue(value) {
+	const tokens = cssTokenizer.tokenize({ css: value });
+
+	// Step 1
+	// Step 1.1
+	// Re-tokenize dimensions with units containing dashes.
+	// These might be typo's.
+	// For example: `10px-20px` has a unit of `px-20px`
+	tokens.forEach((token, i) => {
+		if (!cssTokenizer.isTokenDimension(token)) return;
+
+		const { unit } = token[4];
+
+		if (unit.startsWith('--')) return;
+
+		const indexOfDash = unit.indexOf('-');
+
+		if (indexOfDash === -1) return;
+
+		const remainder = unit.slice(indexOfDash);
+
+		if (remainder.length === 1) return;
+
+		cssTokenizer.mutateUnit(token, unit.slice(0, indexOfDash));
+		token[3] = token[2] + token[1].length;
+
+		const remainderTokens = cssTokenizer.tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
+
+		remainderTokens.forEach((remainderToken) => {
+			remainderToken[2] += token[3];
+			remainderToken[3] += token[3];
+		});
+
+		tokens.splice(i + 1, 0, ...remainderTokens);
+	});
+
+	// Step 1.2
+	// Re-tokenize scss interpolation blocks
+	// Grouping `#` and `{` into a single token allows us to parse these as simple blocks with curly braces.
+	// For example: `#{$foo}`
+	tokens.forEach((currentToken, i) => {
+		if (!cssTokenizer.isTokenDelim(currentToken) || currentToken[4].value !== '#') return;
+
+		const nextToken = tokens[i + 1];
+
+		if (!cssTokenizer.isTokenOpenCurly(nextToken)) return;
+
+		const nextNextToken = tokens[i + 2];
+
+		if (!cssTokenizer.isTokenDelim(nextNextToken) || nextNextToken[4].value !== '$') return;
+
+		// Set the string representation of the open curly to `#{`
+		nextToken[1] = '#{';
+		// Remove the `#` token
+		tokens.splice(i, 1);
+	});
+
+	return cssParserAlgorithms.parseListOfComponentValues(tokens);
+}
 
 /** @see https://drafts.csswg.org/css-values/#typedef-calc-value */
 const OPERAND_TOKEN_TYPES = new Set([

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -73,35 +73,23 @@ const rule = (primary) => {
 			/**
 			 * @param {ContainerNode} node
 			 * @param {Operation} operation
+			 * @param {'before' | 'after'} position
 			 */
-			function checkCompleteOperation(node, operation) {
-				if (operation.before.length && operation.after.length) return;
+			function checkCompleteOperation(node, operation, position) {
+				if (operation[position].some(cssParserAlgorithms.isWhitespaceNode)) return;
 
-				if (!operation.before.some(cssParserAlgorithms.isWhitespaceNode)) {
-					complain(
-						messages.expectedBefore(operation.operatorChar),
-						decl,
-						valueIndex + operation.operatorCharPosition,
-						operation.operatorChar,
-						() => {
-							operation.insertWhitespace(node, 'before');
-							fixDeclarationValue();
-						},
-					);
-				}
+				const messageKey = position === 'before' ? 'expectedBefore' : 'expectedAfter';
 
-				if (!operation.after.some(cssParserAlgorithms.isWhitespaceNode)) {
-					complain(
-						messages.expectedAfter(operation.operatorChar),
-						decl,
-						valueIndex + operation.operatorCharPosition,
-						operation.operatorChar,
-						() => {
-							operation.insertWhitespace(node, 'after');
-							fixDeclarationValue();
-						},
-					);
-				}
+				complain(
+					messages[messageKey](operation.operatorChar),
+					decl,
+					valueIndex + operation.operatorCharPosition,
+					operation.operatorChar,
+					() => {
+						operation.insertWhitespace(node, position);
+						fixDeclarationValue();
+					},
+				);
 			}
 
 			/**
@@ -269,7 +257,8 @@ const rule = (primary) => {
 						// If the operation is complete, ensure there is whitespace around the operator
 						// The operation might have started without an operator and might have been repaired by Step 4
 						if (operation.operator) {
-							checkCompleteOperation(node, operation);
+							checkCompleteOperation(node, operation, 'before');
+							checkCompleteOperation(node, operation, 'after');
 
 							// Step 6
 							// Normalize the whitespace around the operands

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -100,48 +100,51 @@ const rule = (primary) => {
 				if (cssParserAlgorithms.isTokenNode(operation.firstOperand)) {
 					const token = operation.firstOperand.value;
 
+					/**
+					 * @param {string | undefined} operatorChar
+					 * @param {() => void} mutator
+					 * @returns {boolean}
+					 */
+					const complainToFirstOperand = (operatorChar, mutator) => {
+						if (!(operatorChar && OPERATOR_REGEX.test(operatorChar))) return false;
+
+						const [, , , endPos] = token;
+
+						operation.completeMissingOperator(operatorChar, endPos, 'append');
+
+						complain(
+							messages.expectedBefore(operation.operatorChar),
+							decl,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
+							() => {
+								operation.insertOperatorAfterFirstOperand(node);
+								mutator();
+								fixDeclarationValue();
+							},
+						);
+
+						return true;
+					};
+
 					if (cssTokenizer.isTokenDimension(token)) {
-						const [, , , endPos, { unit }] = token;
+						// E.g. '2px+' → ['2px', '+']
+						const [, , , , { unit }] = token;
 						const operatorChar = unit.at(-1);
+						const newUnit = unit.slice(0, -1);
 
-						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							operation.completeMissingOperator(operatorChar, endPos, 'append');
-
-							complain(
-								messages.expectedBefore(operation.operatorChar),
-								decl,
-								valueIndex + operation.operatorCharPosition,
-								operation.operatorChar,
-								() => {
-									operation.insertOperatorAfterFirstOperand(node);
-									cssTokenizer.mutateUnit(token, unit.slice(0, -1));
-									fixDeclarationValue();
-								},
-							);
-
+						if (complainToFirstOperand(operatorChar, () => cssTokenizer.mutateUnit(token, newUnit))) {
 							return;
 						}
 					}
 
 					if (cssTokenizer.isTokenIdent(token)) {
-						const [, , , endPos, { value: tokenValue }] = token;
+						// E.g. 'id+' → ['id', '+']
+						const [, , , , { value: tokenValue }] = token;
 						const operatorChar = tokenValue.at(-1);
+						const newTokenValue = tokenValue.slice(0, -1);
 
-						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							operation.completeMissingOperator(operatorChar, endPos, 'append');
-
-							complain(
-								messages.expectedBefore(operation.operatorChar),
-								decl,
-								valueIndex + operation.operatorCharPosition,
-								operation.operatorChar,
-								() => {
-									operation.insertOperatorAfterFirstOperand(node);
-									cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
-									fixDeclarationValue();
-								},
-							);
-
+						if (complainToFirstOperand(operatorChar, () => cssTokenizer.mutateIdent(token, newTokenValue))) {
 							return;
 						}
 					}

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -33,10 +33,8 @@ const FUNC_CALLS_REGEX = new RegExp(`(?:${MATH_FUNCS_REGEX_SOURCE})\\(`, 'i');
 
 const NEWLINE_REGEX = /\n|\r\n/;
 
-/**
- * @typedef {import ('@csstools/css-parser-algorithms').ComponentValue} ComponentValue
- * @typedef {import ('@csstools/css-parser-algorithms').ContainerNode} ContainerNode
- */
+/** @import { CSSToken, TokenDelim } from '@csstools/css-tokenizer' */
+/** @import { ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
@@ -117,7 +115,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			/**
 			 * @param {Operation} operation
-			 * @param {import('@csstools/css-tokenizer').CSSToken} token
+			 * @param {CSSToken} token
 			 * @param {string} operator
 			 * @returns {asserts operation is CompleteOperation}
 			 */
@@ -431,7 +429,7 @@ function isOperandNode(node) {
  *   secondOperand: ComponentValue,
  *   after: Array<ComponentValue>,
  *   operator: ComponentValue | undefined,
- *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
+ *   operatorToken: TokenDelim | undefined,
  * }} Operation
  *
  * @typedef {{
@@ -440,7 +438,7 @@ function isOperandNode(node) {
  *   secondOperand: ComponentValue,
  *   after: Array<ComponentValue>,
  *   operator: ComponentValue,
- *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
+ *   operatorToken: TokenDelim,
  * }} CompleteOperation
  */
 
@@ -486,7 +484,7 @@ function parseOperation(container, cursor) {
 	const after = [];
 	/** @type {ComponentValue | undefined} */
 	let operator = undefined;
-	/** @type {import ('@csstools/css-tokenizer').TokenDelim | undefined} */
+	/** @type {TokenDelim | undefined} */
 	let operatorToken = undefined;
 
 	let currentNode = container.value[cursor];

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -11,6 +11,7 @@ const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const setDeclarationValue = require('../../utils/setDeclarationValue.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
+const validateTypes = require('../../utils/validateTypes.cjs');
 
 const ruleName = 'function-calc-no-unspaced-operator';
 
@@ -33,8 +34,7 @@ const FUNC_CALLS_REGEX = new RegExp(`(?:${MATH_FUNCS_REGEX_SOURCE})\\(`, 'i');
 
 const NEWLINE_REGEX = /\n|\r\n/;
 
-/** @import { CSSToken, TokenDelim } from '@csstools/css-tokenizer' */
-/** @import { ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
+/** @import { CommentNode, ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
@@ -71,7 +71,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			/**
 			 * @param {ContainerNode} node
-			 * @param {CompleteOperation} operation
+			 * @param {Operation} operation
 			 */
 			function checkCompleteOperation(node, operation) {
 				if (operation.before.length && operation.after.length) return;
@@ -79,17 +79,13 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (!operation.before.some(cssParserAlgorithms.isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
-						node.value.splice(
-							node.value.indexOf(operation.operator),
-							0,
-							new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]]),
-						);
+						operation.insertWhitespace(node, 'before');
 					} else {
 						complain(
-							messages.expectedBefore(operation.operatorToken[4].value),
+							messages.expectedBefore(operation.operatorChar),
 							decl,
-							valueIndex + operation.operatorToken[2],
-							operation.operatorToken[4].value,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
 						);
 					}
 				}
@@ -97,39 +93,16 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (!operation.after.some(cssParserAlgorithms.isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
-						node.value.splice(
-							node.value.indexOf(operation.operator) + 1,
-							0,
-							new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]]),
-						);
+						operation.insertWhitespace(node, 'after');
 					} else {
 						complain(
-							messages.expectedAfter(operation.operatorToken[4].value),
+							messages.expectedAfter(operation.operatorChar),
 							decl,
-							valueIndex + operation.operatorToken[2],
-							operation.operatorToken[4].value,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
 						);
 					}
 				}
-			}
-
-			/**
-			 * @param {Operation} operation
-			 * @param {CSSToken} token
-			 * @param {string} operator
-			 * @returns {asserts operation is CompleteOperation}
-			 */
-			function fixOperationWithoutOperator(operation, token, operator) {
-				operation.operatorToken = [
-					cssTokenizer.TokenType.Delim,
-					operator,
-					token[3],
-					token[3] + 1,
-					{ value: operator },
-				];
-				operation.operator = new cssParserAlgorithms.TokenNode(operation.operatorToken);
-				operation.after = operation.before;
-				operation.before = [];
 			}
 
 			/**
@@ -141,21 +114,15 @@ const rule = (primary, _secondaryOptions, context) => {
 					const token = operation.firstOperand.value;
 
 					if (cssTokenizer.isTokenDimension(token)) {
-						const { unit } = token[4];
-						const operatorChar = unit.slice(-1);
+						const [, , , endPos, { unit }] = token;
+						const operatorChar = unit.at(-1);
 
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							fixOperationWithoutOperator(operation, token, operatorChar);
+							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
 								needsFix = true;
-
-								node.value.splice(
-									node.value.indexOf(operation.firstOperand) + 1,
-									0,
-									operation.operator,
-								);
-
+								operation.insertOperatorAfterFirstOperand(node);
 								cssTokenizer.mutateUnit(token, unit.slice(0, -1));
 							}
 
@@ -164,21 +131,15 @@ const rule = (primary, _secondaryOptions, context) => {
 					}
 
 					if (cssTokenizer.isTokenIdent(token)) {
-						const { value: tokenValue } = token[4];
-						const operatorChar = tokenValue.slice(-1);
+						const [, , , endPos, { value: tokenValue }] = token;
+						const operatorChar = tokenValue.at(-1);
 
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							fixOperationWithoutOperator(operation, token, operatorChar);
+							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
 								needsFix = true;
-
-								node.value.splice(
-									node.value.indexOf(operation.firstOperand) + 1,
-									0,
-									operation.operator,
-								);
-
+								operation.insertOperatorAfterFirstOperand(node);
 								cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
 							}
 
@@ -189,23 +150,17 @@ const rule = (primary, _secondaryOptions, context) => {
 
 				if (cssParserAlgorithms.isTokenNode(operation.secondOperand) && cssTokenizer.isTokenNumeric(operation.secondOperand.value)) {
 					const token = operation.secondOperand.value;
-					const { signCharacter: operatorChar } = token[4];
+					const [, , startPos, , { signCharacter: operatorChar }] = token;
 
 					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-						operation.operatorToken = [
-							cssTokenizer.TokenType.Delim,
-							operatorChar,
-							token[2],
-							token[3],
-							{ value: operatorChar },
-						];
-						operation.operator = new cssParserAlgorithms.TokenNode(operation.operatorToken);
+						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
 						if (context.fix) {
 							needsFix = true;
 
-							node.value.splice(node.value.indexOf(operation.secondOperand), 0, operation.operator);
+							operation.insertOperatorBeforeSecondOperand(node);
 
+							// Remove an operator character from the second operand token
 							token[4].signCharacter = undefined;
 							token[1] = token[1].slice(1);
 						}
@@ -214,8 +169,8 @@ const rule = (primary, _secondaryOptions, context) => {
 			}
 
 			/**
-			 * @param {CompleteOperation} operation
-			 * @param {CompleteOperation["before"] | CompleteOperation["after"]} whitespaceNodes
+			 * @param {Operation} operation
+			 * @param {Operation["before"] | Operation["after"]} whitespaceNodes
 			 * @param {'before' | 'after'} position
 			 */
 			function checkOperandWhitespace(operation, whitespaceNodes, position) {
@@ -247,10 +202,10 @@ const rule = (primary, _secondaryOptions, context) => {
 							position === 'before' ? messages.expectedBefore : messages.expectedAfter;
 
 						complain(
-							message(operation.operatorToken[4].value),
+							message(operation.operatorChar),
 							decl,
-							valueIndex + operation.operatorToken[2],
-							operation.operatorToken[4].value,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
 						);
 					}
 				});
@@ -298,14 +253,14 @@ const rule = (primary, _secondaryOptions, context) => {
 
 						// Step 4
 						// If there is no operator, try to find one
-						if (isOperationWithoutOperator(operation)) {
+						if (!operation.operator) {
 							checkOperationWithoutOperator(node, operation);
 						}
 
 						// Step 5
 						// If the operation is complete, ensure there is whitespace around the operator
 						// The operation might have started without an operator and might have been repaired by Step 4
-						if (isCompleteOperation(operation)) {
+						if (operation.operator) {
 							checkCompleteOperation(node, operation);
 
 							// Step 6
@@ -331,6 +286,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 /**
  * @param {string} value
+ * @returns {Array<ComponentValue>}
  */
 function tokenizeDeclarationValue(value) {
 	const tokens = cssTokenizer.tokenize({ css: value });
@@ -420,52 +376,91 @@ function isOperandNode(node) {
 	return OPERAND_TOKEN_TYPES.has(node.value[0]);
 }
 
-/**
- * NOTE: this is messy.
- *
- * @typedef {{
- *   firstOperand: ComponentValue,
- *   before: Array<ComponentValue>,
- *   secondOperand: ComponentValue,
- *   after: Array<ComponentValue>,
- *   operator: ComponentValue | undefined,
- *   operatorToken: TokenDelim | undefined,
- * }} Operation
- *
- * @typedef {{
- *   firstOperand: ComponentValue,
- *   before: Array<ComponentValue>,
- *   secondOperand: ComponentValue,
- *   after: Array<ComponentValue>,
- *   operator: ComponentValue,
- *   operatorToken: TokenDelim,
- * }} CompleteOperation
- */
+class Operation {
+	/**
+	 * @param {ComponentValue} firstOperand
+	 * @param {Array<WhitespaceNode | CommentNode>} before
+	 * @param {ComponentValue} secondOperand
+	 * @param {Array<WhitespaceNode | CommentNode>} after
+	 * @param {TokenNode | undefined} operator
+	 */
+	constructor(firstOperand, before, secondOperand, after, operator) {
+		/** @type {typeof firstOperand} */
+		this.firstOperand = firstOperand;
+		/** @type {typeof before} */
+		this.before = before;
+		/** @type {typeof secondOperand} */
+		this.secondOperand = secondOperand;
+		/** @type {typeof after} */
+		this.after = after;
+		/** @type {typeof operator} */
+		this.operator = operator;
+	}
 
-/**
- * @param {Operation} operation
- * @returns {operation is CompleteOperation}
- */
-function isCompleteOperation(operation) {
-	return (
-		Boolean(operation.firstOperand) &&
-		Boolean(operation.secondOperand) &&
-		Boolean(operation.operator) &&
-		Boolean(operation.operatorToken)
-	);
-}
+	get #operatorToken() {
+		validateTypes.assert(cssTokenizer.isTokenDelim(this.operator?.value));
 
-/**
- * @param {Operation} operation
- * @returns {operation is Operation}
- */
-function isOperationWithoutOperator(operation) {
-	return (
-		Boolean(operation.firstOperand) &&
-		Boolean(operation.secondOperand) &&
-		!operation.operator &&
-		!operation.operatorToken
-	);
+		return this.operator.value;
+	}
+
+	/** @returns {string} */
+	get operatorChar() {
+		return this.#operatorToken[4].value;
+	}
+
+	/** @returns {number} */
+	get operatorCharPosition() {
+		return this.#operatorToken[2];
+	}
+
+	/**
+	 * @param {ContainerNode} node
+	 * @param {'before' | 'after'} position
+	 */
+	insertWhitespace(node, position) {
+		validateTypes.assert(this.operator);
+		node.value.splice(
+			node.value.indexOf(this.operator) + (position === 'before' ? 0 : 1),
+			0,
+			new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]]),
+		);
+	}
+
+	/**
+	 * @param {ContainerNode} node
+	 */
+	insertOperatorAfterFirstOperand(node) {
+		validateTypes.assert(this.operator);
+		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, this.operator);
+	}
+
+	/**
+	 * @param {ContainerNode} node
+	 */
+	insertOperatorBeforeSecondOperand(node) {
+		validateTypes.assert(this.operator);
+		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator);
+	}
+
+	/**
+	 * @param {string} operatorChar
+	 * @param {number} operatorCharPosition
+	 * @param {'append' | 'prepend'} type
+	 */
+	completeMissingOperator(operatorChar, operatorCharPosition, type) {
+		this.operator = new cssParserAlgorithms.TokenNode([
+			cssTokenizer.TokenType.Delim,
+			operatorChar,
+			operatorCharPosition,
+			operatorCharPosition + operatorChar.length,
+			{ value: operatorChar },
+		]);
+
+		if (type === 'append') {
+			this.after = this.before;
+			this.before = [];
+		}
+	}
 }
 
 /**
@@ -474,18 +469,11 @@ function isOperationWithoutOperator(operation) {
  * @returns {[Operation | undefined, number]}
  */
 function parseOperation(container, cursor) {
-	/** @type {ComponentValue | undefined} */
 	let firstOperand = undefined;
-	/** @type {ComponentValue | undefined} */
 	let secondOperand = undefined;
-	/** @type {Array<ComponentValue>} */
 	const before = [];
-	/** @type {Array<ComponentValue>} */
 	const after = [];
-	/** @type {ComponentValue | undefined} */
 	let operator = undefined;
-	/** @type {TokenDelim | undefined} */
-	let operatorToken = undefined;
 
 	let currentNode = container.value[cursor];
 
@@ -516,7 +504,6 @@ function parseOperation(container, cursor) {
 		OPERATORS.has(currentNode.value[4].value)
 	) {
 		operator = currentNode;
-		operatorToken = currentNode.value;
 
 		currentNode = container.value[++cursor];
 	}
@@ -559,17 +546,7 @@ function parseOperation(container, cursor) {
 		return [undefined, container.value.length];
 	}
 
-	return [
-		{
-			firstOperand,
-			before,
-			secondOperand,
-			after,
-			operator,
-			operatorToken,
-		},
-		cursor,
-	];
+	return [new Operation(firstOperand, before, secondOperand, after, operator), cursor];
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -59,7 +59,7 @@ const NEWLINE_REGEX = /\n|\r\n/;
 /** @import { CommentNode, ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
@@ -141,10 +141,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								mutateUnit(token, unit.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									mutateUnit(token, unit.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -157,10 +164,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								mutateIdent(token, tokenValue.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									mutateIdent(token, tokenValue.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -174,13 +188,21 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
-						if (context.fix) {
-							operation.insertOperatorBeforeSecondOperand(node);
+						complain(
+							messages.expectedAfter(operation.operatorChar),
+							decl,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
+							() => {
+								operation.insertOperatorBeforeSecondOperand(node);
 
-							// Remove an operator character from the second operand token
-							token[4].signCharacter = undefined;
-							token[1] = token[1].slice(1);
-						}
+								// Remove an operator character from the second operand token
+								token[4].signCharacter = undefined;
+								token[1] = token[1].slice(1);
+
+								fixDeclarationValue();
+							},
+						);
 					}
 				}
 			}
@@ -441,7 +463,7 @@ class Operation {
 	 */
 	insertOperatorAfterFirstOperand(node) {
 		assert(this.operator);
-		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, this.operator);
+		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, ...this.before, this.operator);
 	}
 
 	/**
@@ -449,7 +471,7 @@ class Operation {
 	 */
 	insertOperatorBeforeSecondOperand(node) {
 		assert(this.operator);
-		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator);
+		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator, ...this.after);
 	}
 
 	/**
@@ -468,7 +490,9 @@ class Operation {
 
 		if (type === 'append') {
 			this.after = this.before;
-			this.before = [];
+			this.before = [new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]])];
+		} else {
+			this.after = [new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]])];
 		}
 	}
 }

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -122,48 +122,51 @@ const rule = (primary) => {
 				if (isTokenNode(operation.firstOperand)) {
 					const token = operation.firstOperand.value;
 
+					/**
+					 * @param {string | undefined} operatorChar
+					 * @param {() => void} mutator
+					 * @returns {boolean}
+					 */
+					const complainToFirstOperand = (operatorChar, mutator) => {
+						if (!(operatorChar && OPERATOR_REGEX.test(operatorChar))) return false;
+
+						const [, , , endPos] = token;
+
+						operation.completeMissingOperator(operatorChar, endPos, 'append');
+
+						complain(
+							messages.expectedBefore(operation.operatorChar),
+							decl,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
+							() => {
+								operation.insertOperatorAfterFirstOperand(node);
+								mutator();
+								fixDeclarationValue();
+							},
+						);
+
+						return true;
+					};
+
 					if (isTokenDimension(token)) {
-						const [, , , endPos, { unit }] = token;
+						// E.g. '2px+' → ['2px', '+']
+						const [, , , , { unit }] = token;
 						const operatorChar = unit.at(-1);
+						const newUnit = unit.slice(0, -1);
 
-						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							operation.completeMissingOperator(operatorChar, endPos, 'append');
-
-							complain(
-								messages.expectedBefore(operation.operatorChar),
-								decl,
-								valueIndex + operation.operatorCharPosition,
-								operation.operatorChar,
-								() => {
-									operation.insertOperatorAfterFirstOperand(node);
-									mutateUnit(token, unit.slice(0, -1));
-									fixDeclarationValue();
-								},
-							);
-
+						if (complainToFirstOperand(operatorChar, () => mutateUnit(token, newUnit))) {
 							return;
 						}
 					}
 
 					if (isTokenIdent(token)) {
-						const [, , , endPos, { value: tokenValue }] = token;
+						// E.g. 'id+' → ['id', '+']
+						const [, , , , { value: tokenValue }] = token;
 						const operatorChar = tokenValue.at(-1);
+						const newTokenValue = tokenValue.slice(0, -1);
 
-						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							operation.completeMissingOperator(operatorChar, endPos, 'append');
-
-							complain(
-								messages.expectedBefore(operation.operatorChar),
-								decl,
-								valueIndex + operation.operatorCharPosition,
-								operation.operatorChar,
-								() => {
-									operation.insertOperatorAfterFirstOperand(node);
-									mutateIdent(token, tokenValue.slice(0, -1));
-									fixDeclarationValue();
-								},
-							);
-
+						if (complainToFirstOperand(operatorChar, () => mutateIdent(token, newTokenValue))) {
 							return;
 						}
 					}

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -200,11 +200,10 @@ const rule = (primary) => {
 
 			/**
 			 * @param {Operation} operation
-			 * @param {Operation["before"] | Operation["after"]} whitespaceNodes
 			 * @param {'before' | 'after'} position
 			 */
-			function checkOperandWhitespace(operation, whitespaceNodes, position) {
-				whitespaceNodes.forEach((whitespaceNode) => {
+			function checkOperandWhitespace(operation, position) {
+				operation[position].forEach((whitespaceNode) => {
 					if (!isWhitespaceNode(whitespaceNode)) return;
 
 					const whitespace = whitespaceNode.toString();
@@ -287,8 +286,8 @@ const rule = (primary) => {
 
 							// Step 6
 							// Normalize the whitespace around the operands
-							checkOperandWhitespace(operation, operation.before, 'before');
-							checkOperandWhitespace(operation, operation.after, 'after');
+							checkOperandWhitespace(operation, 'before');
+							checkOperandWhitespace(operation, 'after');
 						}
 
 						cursor = node.value.indexOf(operation.secondOperand);

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -70,11 +70,12 @@ const rule = (primary, _secondaryOptions, context) => {
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {string} operator
+		 * @param {() => void} fix
 		 */
-		function complain(message, node, index, operator) {
+		function complain(message, node, index, operator, fix) {
 			const endIndex = index + operator.length;
 
-			report({ message, node, index, endIndex, result, ruleName });
+			report({ message, node, index, endIndex, result, ruleName, fix });
 		}
 
 		root.walkDecls((decl) => {
@@ -84,12 +85,12 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			if (!FUNC_CALLS_REGEX.test(value)) return;
 
-			let needsFix = false;
-			const valueIndex = declarationValueIndex(decl);
-
 			const nodes = tokenizeDeclarationValue(value);
 
 			if (nodes.length === 0) return;
+
+			const valueIndex = declarationValueIndex(decl);
+			const fixDeclarationValue = () => setDeclarationValue(decl, stringify([nodes]));
 
 			/**
 			 * @param {ContainerNode} node
@@ -99,31 +100,29 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (operation.before.length && operation.after.length) return;
 
 				if (!operation.before.some(isWhitespaceNode)) {
-					if (context.fix) {
-						needsFix = true;
-						operation.insertWhitespace(node, 'before');
-					} else {
-						complain(
-							messages.expectedBefore(operation.operatorChar),
-							decl,
-							valueIndex + operation.operatorCharPosition,
-							operation.operatorChar,
-						);
-					}
+					complain(
+						messages.expectedBefore(operation.operatorChar),
+						decl,
+						valueIndex + operation.operatorCharPosition,
+						operation.operatorChar,
+						() => {
+							operation.insertWhitespace(node, 'before');
+							fixDeclarationValue();
+						},
+					);
 				}
 
 				if (!operation.after.some(isWhitespaceNode)) {
-					if (context.fix) {
-						needsFix = true;
-						operation.insertWhitespace(node, 'after');
-					} else {
-						complain(
-							messages.expectedAfter(operation.operatorChar),
-							decl,
-							valueIndex + operation.operatorCharPosition,
-							operation.operatorChar,
-						);
-					}
+					complain(
+						messages.expectedAfter(operation.operatorChar),
+						decl,
+						valueIndex + operation.operatorCharPosition,
+						operation.operatorChar,
+						() => {
+							operation.insertWhitespace(node, 'after');
+							fixDeclarationValue();
+						},
+					);
 				}
 			}
 
@@ -143,7 +142,6 @@ const rule = (primary, _secondaryOptions, context) => {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
-								needsFix = true;
 								operation.insertOperatorAfterFirstOperand(node);
 								mutateUnit(token, unit.slice(0, -1));
 							}
@@ -160,7 +158,6 @@ const rule = (primary, _secondaryOptions, context) => {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
-								needsFix = true;
 								operation.insertOperatorAfterFirstOperand(node);
 								mutateIdent(token, tokenValue.slice(0, -1));
 							}
@@ -178,8 +175,6 @@ const rule = (primary, _secondaryOptions, context) => {
 						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
 						if (context.fix) {
-							needsFix = true;
-
 							operation.insertOperatorBeforeSecondOperand(node);
 
 							// Remove an operator character from the second operand token
@@ -207,29 +202,26 @@ const rule = (primary, _secondaryOptions, context) => {
 
 					if (indexOfFirstNewLine === 0) return;
 
-					if (context.fix) {
-						needsFix = true;
+					const message = position === 'before' ? messages.expectedBefore : messages.expectedAfter;
 
-						whitespaceNode.value = [
-							[
-								TokenType.Whitespace,
-								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
-								-1,
-								-1,
-								undefined,
-							],
-						];
-					} else {
-						const message =
-							position === 'before' ? messages.expectedBefore : messages.expectedAfter;
-
-						complain(
-							message(operation.operatorChar),
-							decl,
-							valueIndex + operation.operatorCharPosition,
-							operation.operatorChar,
-						);
-					}
+					complain(
+						message(operation.operatorChar),
+						decl,
+						valueIndex + operation.operatorCharPosition,
+						operation.operatorChar,
+						() => {
+							whitespaceNode.value = [
+								[
+									TokenType.Whitespace,
+									indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
+									-1,
+									-1,
+									undefined,
+								],
+							];
+							fixDeclarationValue();
+						},
+					);
 				});
 			}
 
@@ -298,10 +290,6 @@ const rule = (primary, _secondaryOptions, context) => {
 					inMathFunction: false,
 				},
 			);
-
-			if (needsFix) {
-				setDeclarationValue(decl, stringify([nodes]));
-			}
 		});
 	};
 };

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -95,35 +95,23 @@ const rule = (primary) => {
 			/**
 			 * @param {ContainerNode} node
 			 * @param {Operation} operation
+			 * @param {'before' | 'after'} position
 			 */
-			function checkCompleteOperation(node, operation) {
-				if (operation.before.length && operation.after.length) return;
+			function checkCompleteOperation(node, operation, position) {
+				if (operation[position].some(isWhitespaceNode)) return;
 
-				if (!operation.before.some(isWhitespaceNode)) {
-					complain(
-						messages.expectedBefore(operation.operatorChar),
-						decl,
-						valueIndex + operation.operatorCharPosition,
-						operation.operatorChar,
-						() => {
-							operation.insertWhitespace(node, 'before');
-							fixDeclarationValue();
-						},
-					);
-				}
+				const messageKey = position === 'before' ? 'expectedBefore' : 'expectedAfter';
 
-				if (!operation.after.some(isWhitespaceNode)) {
-					complain(
-						messages.expectedAfter(operation.operatorChar),
-						decl,
-						valueIndex + operation.operatorCharPosition,
-						operation.operatorChar,
-						() => {
-							operation.insertWhitespace(node, 'after');
-							fixDeclarationValue();
-						},
-					);
-				}
+				complain(
+					messages[messageKey](operation.operatorChar),
+					decl,
+					valueIndex + operation.operatorCharPosition,
+					operation.operatorChar,
+					() => {
+						operation.insertWhitespace(node, position);
+						fixDeclarationValue();
+					},
+				);
 			}
 
 			/**
@@ -291,7 +279,8 @@ const rule = (primary) => {
 						// If the operation is complete, ensure there is whitespace around the operator
 						// The operation might have started without an operator and might have been repaired by Step 4
 						if (operation.operator) {
-							checkCompleteOperation(node, operation);
+							checkCompleteOperation(node, operation, 'before');
+							checkCompleteOperation(node, operation, 'after');
 
 							// Step 6
 							// Normalize the whitespace around the operands

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -54,10 +54,8 @@ const FUNC_CALLS_REGEX = new RegExp(`(?:${MATH_FUNCS_REGEX_SOURCE})\\(`, 'i');
 
 const NEWLINE_REGEX = /\n|\r\n/;
 
-/**
- * @typedef {import ('@csstools/css-parser-algorithms').ComponentValue} ComponentValue
- * @typedef {import ('@csstools/css-parser-algorithms').ContainerNode} ContainerNode
- */
+/** @import { CSSToken, TokenDelim } from '@csstools/css-tokenizer' */
+/** @import { ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
@@ -138,7 +136,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			/**
 			 * @param {Operation} operation
-			 * @param {import('@csstools/css-tokenizer').CSSToken} token
+			 * @param {CSSToken} token
 			 * @param {string} operator
 			 * @returns {asserts operation is CompleteOperation}
 			 */
@@ -452,7 +450,7 @@ function isOperandNode(node) {
  *   secondOperand: ComponentValue,
  *   after: Array<ComponentValue>,
  *   operator: ComponentValue | undefined,
- *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim | undefined,
+ *   operatorToken: TokenDelim | undefined,
  * }} Operation
  *
  * @typedef {{
@@ -461,7 +459,7 @@ function isOperandNode(node) {
  *   secondOperand: ComponentValue,
  *   after: Array<ComponentValue>,
  *   operator: ComponentValue,
- *   operatorToken: import ('@csstools/css-tokenizer').TokenDelim,
+ *   operatorToken: TokenDelim,
  * }} CompleteOperation
  */
 
@@ -507,7 +505,7 @@ function parseOperation(container, cursor) {
 	const after = [];
 	/** @type {ComponentValue | undefined} */
 	let operator = undefined;
-	/** @type {import ('@csstools/css-tokenizer').TokenDelim | undefined} */
+	/** @type {TokenDelim | undefined} */
 	let operatorToken = undefined;
 
 	let currentNode = container.value[cursor];

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -33,6 +33,8 @@ import ruleMessages from '../../utils/ruleMessages.mjs';
 import setDeclarationValue from '../../utils/setDeclarationValue.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
 
+import { assert } from '../../utils/validateTypes.mjs';
+
 const ruleName = 'function-calc-no-unspaced-operator';
 
 const messages = ruleMessages(ruleName, {
@@ -54,8 +56,7 @@ const FUNC_CALLS_REGEX = new RegExp(`(?:${MATH_FUNCS_REGEX_SOURCE})\\(`, 'i');
 
 const NEWLINE_REGEX = /\n|\r\n/;
 
-/** @import { CSSToken, TokenDelim } from '@csstools/css-tokenizer' */
-/** @import { ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
+/** @import { CommentNode, ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, _secondaryOptions, context) => {
@@ -92,7 +93,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 			/**
 			 * @param {ContainerNode} node
-			 * @param {CompleteOperation} operation
+			 * @param {Operation} operation
 			 */
 			function checkCompleteOperation(node, operation) {
 				if (operation.before.length && operation.after.length) return;
@@ -100,17 +101,13 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (!operation.before.some(isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
-						node.value.splice(
-							node.value.indexOf(operation.operator),
-							0,
-							new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]]),
-						);
+						operation.insertWhitespace(node, 'before');
 					} else {
 						complain(
-							messages.expectedBefore(operation.operatorToken[4].value),
+							messages.expectedBefore(operation.operatorChar),
 							decl,
-							valueIndex + operation.operatorToken[2],
-							operation.operatorToken[4].value,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
 						);
 					}
 				}
@@ -118,39 +115,16 @@ const rule = (primary, _secondaryOptions, context) => {
 				if (!operation.after.some(isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
-						node.value.splice(
-							node.value.indexOf(operation.operator) + 1,
-							0,
-							new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]]),
-						);
+						operation.insertWhitespace(node, 'after');
 					} else {
 						complain(
-							messages.expectedAfter(operation.operatorToken[4].value),
+							messages.expectedAfter(operation.operatorChar),
 							decl,
-							valueIndex + operation.operatorToken[2],
-							operation.operatorToken[4].value,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
 						);
 					}
 				}
-			}
-
-			/**
-			 * @param {Operation} operation
-			 * @param {CSSToken} token
-			 * @param {string} operator
-			 * @returns {asserts operation is CompleteOperation}
-			 */
-			function fixOperationWithoutOperator(operation, token, operator) {
-				operation.operatorToken = [
-					TokenType.Delim,
-					operator,
-					token[3],
-					token[3] + 1,
-					{ value: operator },
-				];
-				operation.operator = new TokenNode(operation.operatorToken);
-				operation.after = operation.before;
-				operation.before = [];
 			}
 
 			/**
@@ -162,21 +136,15 @@ const rule = (primary, _secondaryOptions, context) => {
 					const token = operation.firstOperand.value;
 
 					if (isTokenDimension(token)) {
-						const { unit } = token[4];
-						const operatorChar = unit.slice(-1);
+						const [, , , endPos, { unit }] = token;
+						const operatorChar = unit.at(-1);
 
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							fixOperationWithoutOperator(operation, token, operatorChar);
+							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
 								needsFix = true;
-
-								node.value.splice(
-									node.value.indexOf(operation.firstOperand) + 1,
-									0,
-									operation.operator,
-								);
-
+								operation.insertOperatorAfterFirstOperand(node);
 								mutateUnit(token, unit.slice(0, -1));
 							}
 
@@ -185,21 +153,15 @@ const rule = (primary, _secondaryOptions, context) => {
 					}
 
 					if (isTokenIdent(token)) {
-						const { value: tokenValue } = token[4];
-						const operatorChar = tokenValue.slice(-1);
+						const [, , , endPos, { value: tokenValue }] = token;
+						const operatorChar = tokenValue.at(-1);
 
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-							fixOperationWithoutOperator(operation, token, operatorChar);
+							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
 							if (context.fix) {
 								needsFix = true;
-
-								node.value.splice(
-									node.value.indexOf(operation.firstOperand) + 1,
-									0,
-									operation.operator,
-								);
-
+								operation.insertOperatorAfterFirstOperand(node);
 								mutateIdent(token, tokenValue.slice(0, -1));
 							}
 
@@ -210,23 +172,17 @@ const rule = (primary, _secondaryOptions, context) => {
 
 				if (isTokenNode(operation.secondOperand) && isTokenNumeric(operation.secondOperand.value)) {
 					const token = operation.secondOperand.value;
-					const { signCharacter: operatorChar } = token[4];
+					const [, , startPos, , { signCharacter: operatorChar }] = token;
 
 					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
-						operation.operatorToken = [
-							TokenType.Delim,
-							operatorChar,
-							token[2],
-							token[3],
-							{ value: operatorChar },
-						];
-						operation.operator = new TokenNode(operation.operatorToken);
+						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
 						if (context.fix) {
 							needsFix = true;
 
-							node.value.splice(node.value.indexOf(operation.secondOperand), 0, operation.operator);
+							operation.insertOperatorBeforeSecondOperand(node);
 
+							// Remove an operator character from the second operand token
 							token[4].signCharacter = undefined;
 							token[1] = token[1].slice(1);
 						}
@@ -235,8 +191,8 @@ const rule = (primary, _secondaryOptions, context) => {
 			}
 
 			/**
-			 * @param {CompleteOperation} operation
-			 * @param {CompleteOperation["before"] | CompleteOperation["after"]} whitespaceNodes
+			 * @param {Operation} operation
+			 * @param {Operation["before"] | Operation["after"]} whitespaceNodes
 			 * @param {'before' | 'after'} position
 			 */
 			function checkOperandWhitespace(operation, whitespaceNodes, position) {
@@ -268,10 +224,10 @@ const rule = (primary, _secondaryOptions, context) => {
 							position === 'before' ? messages.expectedBefore : messages.expectedAfter;
 
 						complain(
-							message(operation.operatorToken[4].value),
+							message(operation.operatorChar),
 							decl,
-							valueIndex + operation.operatorToken[2],
-							operation.operatorToken[4].value,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
 						);
 					}
 				});
@@ -319,14 +275,14 @@ const rule = (primary, _secondaryOptions, context) => {
 
 						// Step 4
 						// If there is no operator, try to find one
-						if (isOperationWithoutOperator(operation)) {
+						if (!operation.operator) {
 							checkOperationWithoutOperator(node, operation);
 						}
 
 						// Step 5
 						// If the operation is complete, ensure there is whitespace around the operator
 						// The operation might have started without an operator and might have been repaired by Step 4
-						if (isCompleteOperation(operation)) {
+						if (operation.operator) {
 							checkCompleteOperation(node, operation);
 
 							// Step 6
@@ -352,6 +308,7 @@ const rule = (primary, _secondaryOptions, context) => {
 
 /**
  * @param {string} value
+ * @returns {Array<ComponentValue>}
  */
 function tokenizeDeclarationValue(value) {
 	const tokens = tokenize({ css: value });
@@ -441,52 +398,91 @@ function isOperandNode(node) {
 	return OPERAND_TOKEN_TYPES.has(node.value[0]);
 }
 
-/**
- * NOTE: this is messy.
- *
- * @typedef {{
- *   firstOperand: ComponentValue,
- *   before: Array<ComponentValue>,
- *   secondOperand: ComponentValue,
- *   after: Array<ComponentValue>,
- *   operator: ComponentValue | undefined,
- *   operatorToken: TokenDelim | undefined,
- * }} Operation
- *
- * @typedef {{
- *   firstOperand: ComponentValue,
- *   before: Array<ComponentValue>,
- *   secondOperand: ComponentValue,
- *   after: Array<ComponentValue>,
- *   operator: ComponentValue,
- *   operatorToken: TokenDelim,
- * }} CompleteOperation
- */
+class Operation {
+	/**
+	 * @param {ComponentValue} firstOperand
+	 * @param {Array<WhitespaceNode | CommentNode>} before
+	 * @param {ComponentValue} secondOperand
+	 * @param {Array<WhitespaceNode | CommentNode>} after
+	 * @param {TokenNode | undefined} operator
+	 */
+	constructor(firstOperand, before, secondOperand, after, operator) {
+		/** @type {typeof firstOperand} */
+		this.firstOperand = firstOperand;
+		/** @type {typeof before} */
+		this.before = before;
+		/** @type {typeof secondOperand} */
+		this.secondOperand = secondOperand;
+		/** @type {typeof after} */
+		this.after = after;
+		/** @type {typeof operator} */
+		this.operator = operator;
+	}
 
-/**
- * @param {Operation} operation
- * @returns {operation is CompleteOperation}
- */
-function isCompleteOperation(operation) {
-	return (
-		Boolean(operation.firstOperand) &&
-		Boolean(operation.secondOperand) &&
-		Boolean(operation.operator) &&
-		Boolean(operation.operatorToken)
-	);
-}
+	get #operatorToken() {
+		assert(isTokenDelim(this.operator?.value));
 
-/**
- * @param {Operation} operation
- * @returns {operation is Operation}
- */
-function isOperationWithoutOperator(operation) {
-	return (
-		Boolean(operation.firstOperand) &&
-		Boolean(operation.secondOperand) &&
-		!operation.operator &&
-		!operation.operatorToken
-	);
+		return this.operator.value;
+	}
+
+	/** @returns {string} */
+	get operatorChar() {
+		return this.#operatorToken[4].value;
+	}
+
+	/** @returns {number} */
+	get operatorCharPosition() {
+		return this.#operatorToken[2];
+	}
+
+	/**
+	 * @param {ContainerNode} node
+	 * @param {'before' | 'after'} position
+	 */
+	insertWhitespace(node, position) {
+		assert(this.operator);
+		node.value.splice(
+			node.value.indexOf(this.operator) + (position === 'before' ? 0 : 1),
+			0,
+			new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]]),
+		);
+	}
+
+	/**
+	 * @param {ContainerNode} node
+	 */
+	insertOperatorAfterFirstOperand(node) {
+		assert(this.operator);
+		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, this.operator);
+	}
+
+	/**
+	 * @param {ContainerNode} node
+	 */
+	insertOperatorBeforeSecondOperand(node) {
+		assert(this.operator);
+		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator);
+	}
+
+	/**
+	 * @param {string} operatorChar
+	 * @param {number} operatorCharPosition
+	 * @param {'append' | 'prepend'} type
+	 */
+	completeMissingOperator(operatorChar, operatorCharPosition, type) {
+		this.operator = new TokenNode([
+			TokenType.Delim,
+			operatorChar,
+			operatorCharPosition,
+			operatorCharPosition + operatorChar.length,
+			{ value: operatorChar },
+		]);
+
+		if (type === 'append') {
+			this.after = this.before;
+			this.before = [];
+		}
+	}
 }
 
 /**
@@ -495,18 +491,11 @@ function isOperationWithoutOperator(operation) {
  * @returns {[Operation | undefined, number]}
  */
 function parseOperation(container, cursor) {
-	/** @type {ComponentValue | undefined} */
 	let firstOperand = undefined;
-	/** @type {ComponentValue | undefined} */
 	let secondOperand = undefined;
-	/** @type {Array<ComponentValue>} */
 	const before = [];
-	/** @type {Array<ComponentValue>} */
 	const after = [];
-	/** @type {ComponentValue | undefined} */
 	let operator = undefined;
-	/** @type {TokenDelim | undefined} */
-	let operatorToken = undefined;
 
 	let currentNode = container.value[cursor];
 
@@ -537,7 +526,6 @@ function parseOperation(container, cursor) {
 		OPERATORS.has(currentNode.value[4].value)
 	) {
 		operator = currentNode;
-		operatorToken = currentNode.value;
 
 		currentNode = container.value[++cursor];
 	}
@@ -580,17 +568,7 @@ function parseOperation(container, cursor) {
 		return [undefined, container.value.length];
 	}
 
-	return [
-		{
-			firstOperand,
-			before,
-			secondOperand,
-			after,
-			operator,
-			operatorToken,
-		},
-		cursor,
-	];
+	return [new Operation(firstOperand, before, secondOperand, after, operator), cursor];
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -88,65 +88,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			let needsFix = false;
 			const valueIndex = declarationValueIndex(decl);
 
-			const tokens = tokenize({ css: value });
-
-			{
-				// Step 1
-				// Step 1.1
-				// Re-tokenize dimensions with units containing dashes.
-				// These might be typo's.
-				// For example: `10px-20px` has a unit of `px-20px`
-				tokens.forEach((token, i) => {
-					if (!isTokenDimension(token)) return;
-
-					const { unit } = token[4];
-
-					if (unit.startsWith('--')) return;
-
-					const indexOfDash = unit.indexOf('-');
-
-					if (indexOfDash === -1) return;
-
-					const remainder = unit.slice(indexOfDash);
-
-					if (remainder.length === 1) return;
-
-					mutateUnit(token, unit.slice(0, indexOfDash));
-					token[3] = token[2] + token[1].length;
-
-					const remainderTokens = tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
-
-					remainderTokens.forEach((remainderToken) => {
-						remainderToken[2] += token[3];
-						remainderToken[3] += token[3];
-					});
-
-					tokens.splice(i + 1, 0, ...remainderTokens);
-				});
-
-				// Step 1.2
-				// Re-tokenize scss interpolation blocks
-				// Grouping `#` and `{` into a single token allows us to parse these as simple blocks with curly braces.
-				// For example: `#{$foo}`
-				tokens.forEach((currentToken, i) => {
-					if (!isTokenDelim(currentToken) || currentToken[4].value !== '#') return;
-
-					const nextToken = tokens[i + 1];
-
-					if (!isTokenOpenCurly(nextToken)) return;
-
-					const nextNextToken = tokens[i + 2];
-
-					if (!isTokenDelim(nextNextToken) || nextNextToken[4].value !== '$') return;
-
-					// Set the string representation of the open curly to `#{`
-					nextToken[1] = '#{';
-					// Remove the `#` token
-					tokens.splice(i, 1);
-				});
-			}
-
-			const nodes = parseListOfComponentValues(tokens);
+			const nodes = tokenizeDeclarationValue(value);
 
 			if (nodes.length === 0) return;
 
@@ -157,7 +99,7 @@ const rule = (primary, _secondaryOptions, context) => {
 			function checkCompleteOperation(node, operation) {
 				if (operation.before.length && operation.after.length) return;
 
-				if (!operation.before.find(isWhitespaceNode)) {
+				if (!operation.before.some(isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -175,7 +117,7 @@ const rule = (primary, _secondaryOptions, context) => {
 					}
 				}
 
-				if (!operation.after.find(isWhitespaceNode)) {
+				if (!operation.after.some(isWhitespaceNode)) {
 					if (context.fix) {
 						needsFix = true;
 						node.value.splice(
@@ -409,6 +351,69 @@ const rule = (primary, _secondaryOptions, context) => {
 		});
 	};
 };
+
+/**
+ * @param {string} value
+ */
+function tokenizeDeclarationValue(value) {
+	const tokens = tokenize({ css: value });
+
+	// Step 1
+	// Step 1.1
+	// Re-tokenize dimensions with units containing dashes.
+	// These might be typo's.
+	// For example: `10px-20px` has a unit of `px-20px`
+	tokens.forEach((token, i) => {
+		if (!isTokenDimension(token)) return;
+
+		const { unit } = token[4];
+
+		if (unit.startsWith('--')) return;
+
+		const indexOfDash = unit.indexOf('-');
+
+		if (indexOfDash === -1) return;
+
+		const remainder = unit.slice(indexOfDash);
+
+		if (remainder.length === 1) return;
+
+		mutateUnit(token, unit.slice(0, indexOfDash));
+		token[3] = token[2] + token[1].length;
+
+		const remainderTokens = tokenize({ css: remainder }).slice(0, -1); // Trim EOF token
+
+		remainderTokens.forEach((remainderToken) => {
+			remainderToken[2] += token[3];
+			remainderToken[3] += token[3];
+		});
+
+		tokens.splice(i + 1, 0, ...remainderTokens);
+	});
+
+	// Step 1.2
+	// Re-tokenize scss interpolation blocks
+	// Grouping `#` and `{` into a single token allows us to parse these as simple blocks with curly braces.
+	// For example: `#{$foo}`
+	tokens.forEach((currentToken, i) => {
+		if (!isTokenDelim(currentToken) || currentToken[4].value !== '#') return;
+
+		const nextToken = tokens[i + 1];
+
+		if (!isTokenOpenCurly(nextToken)) return;
+
+		const nextNextToken = tokens[i + 2];
+
+		if (!isTokenDelim(nextNextToken) || nextNextToken[4].value !== '$') return;
+
+		// Set the string representation of the open curly to `#{`
+		nextToken[1] = '#{';
+		// Remove the `#` token
+		tokens.splice(i, 1);
+	});
+
+	return parseListOfComponentValues(tokens);
+}
 
 /** @see https://drafts.csswg.org/css-values/#typedef-calc-value */
 const OPERAND_TOKEN_TYPES = new Set([

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -232,15 +232,9 @@ const rule = (primary) => {
 						valueIndex + operation.operatorCharPosition,
 						operation.operatorChar,
 						() => {
-							whitespaceNode.value = [
-								[
-									TokenType.Whitespace,
-									indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
-									-1,
-									-1,
-									undefined,
-								],
-							];
+							whitespaceNode.value = newWhitespaceNode(
+								indexOfFirstNewLine === -1 ? ' ' : whitespace.slice(indexOfFirstNewLine),
+							).value;
 							fixDeclarationValue();
 						},
 					);
@@ -408,6 +402,13 @@ function isOperandNode(node) {
 	return OPERAND_TOKEN_TYPES.has(node.value[0]);
 }
 
+/**
+ * @param {string} whitespace
+ */
+function newWhitespaceNode(whitespace = ' ') {
+	return new WhitespaceNode([[TokenType.Whitespace, whitespace, -1, -1, undefined]]);
+}
+
 class Operation {
 	/**
 	 * @param {ComponentValue} firstOperand
@@ -454,7 +455,7 @@ class Operation {
 		node.value.splice(
 			node.value.indexOf(this.operator) + (position === 'before' ? 0 : 1),
 			0,
-			new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]]),
+			newWhitespaceNode(),
 		);
 	}
 
@@ -490,9 +491,9 @@ class Operation {
 
 		if (type === 'append') {
 			this.after = this.before;
-			this.before = [new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]])];
+			this.before = [newWhitespaceNode()];
 		} else {
-			this.after = [new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]])];
+			this.after = [newWhitespaceNode()];
 		}
 	}
 }

--- a/lib/utils/__tests__/checkAgainstRule.test.mjs
+++ b/lib/utils/__tests__/checkAgainstRule.test.mjs
@@ -87,27 +87,6 @@ describe('checkAgainstRule', () => {
 		expect(warnings[0].column).toBe(1);
 	});
 
-	/** @todo remove once all fixable rules have been been migrated from context.fix */
-	it('outputs fixed code when provided a context object', async () => {
-		const root = postcss.parse('a { top: calc(1px+2px); }');
-		const context = { fix: true };
-
-		const warnings = [];
-
-		await checkAgainstRule(
-			{
-				ruleName: 'function-calc-no-unspaced-operator',
-				ruleSettings: true,
-				root,
-				context,
-			},
-			(warning) => warnings.push(warning),
-		);
-
-		expect(warnings).toHaveLength(0);
-		expect(root.toString()).toBe('a { top: calc(1px + 2px); }');
-	});
-
 	it('checks against custom rule (passing)', async () => {
 		const root = postcss.parse('.not-empty {}');
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #2643

> Is there anything in the PR that needs further explanation?

This PR aims to perform refactoring for #2643. But, this work was not as easy as just replacing `context.fix` with the `fix` callback. Before switching to the `fix` callback, I needed a big refactoring to rewrite the code to class-based logic for the code readability. Please look at each commit for details.
