### PR TITLE
Fix `utils.checkAgainstRule()` to support `fix` callback in `utils.report()`

### DIFF
--- a/.changeset/short-goats-mix.md
+++ b/.changeset/short-goats-mix.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `stylelint.utils.checkAgainstRule()` to use `result.stylelint` if possible
+Fixed: `stylelint.utils.checkAgainstRule()` to use `result.stylelint` if present

--- a/.changeset/short-goats-mix.md
+++ b/.changeset/short-goats-mix.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `stylelint.utils.checkAgainstRule()` to use `result.stylelint` if possible

--- a/lib/rules/no-duplicate-selectors/__tests__/index.mjs
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.mjs
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 
 import postcss from 'postcss';
 import postcssImport from 'postcss-import';
+import postcssStylelint from '../../../postcssPlugin.mjs';
 
 import naiveCssInJs from '../../../__tests__/fixtures/postcss-naive-css-in-js.cjs';
 
@@ -262,28 +263,32 @@ testRule({
 it('with postcss-import and duplicates within a file, a warning strikes', () => {
 	return postcss()
 		.use(postcssImport())
-		.use((root, result) => {
-			result.stylelint = {
-				ruleSeverities: {},
-				fixersData: {},
-			};
-			rule(true)(root, result);
-		})
+		.use(
+			postcssStylelint({
+				config: {
+					rules: { [ruleName]: true },
+				},
+			}),
+		)
 		.process("@import 'fixtures/using-foo-twice.css';", {
 			from: fileURLToPath(new URL('./test.css', import.meta.url)),
 		})
 		.then((result) => {
 			expect(result.warnings()).toHaveLength(1);
+			expect(result.warnings()[0]).toHaveProperty('text', messages.rejected('.foo', 1));
 		});
 });
 
 it('with postcss-import and duplicates across files, no warnings', () => {
 	return postcss()
 		.use(postcssImport())
-		.use((root, result) => {
-			result.stylelint = { ruleSeverities: {} };
-			rule(true)(root, result);
-		})
+		.use(
+			postcssStylelint({
+				config: {
+					rules: { [ruleName]: true },
+				},
+			}),
+		)
 		.process("@import 'fixtures/using-foo.css'; @import 'fixtures/also-using-foo.css';", {
 			from: fileURLToPath(new URL('./test.css', import.meta.url)),
 		})

--- a/lib/utils/__tests__/checkAgainstRule.test.mjs
+++ b/lib/utils/__tests__/checkAgainstRule.test.mjs
@@ -26,6 +26,8 @@ const mockResult = {
 				},
 			},
 		},
+		ruleSeverities: {},
+		fixersData: {},
 	},
 };
 
@@ -87,25 +89,31 @@ describe('checkAgainstRule', () => {
 		expect(warnings[0].column).toBe(1);
 	});
 
-	/** @todo remove once all fixable rules have been been migrated from context.fix */
-	it('outputs fixed code when provided a context object', async () => {
-		const root = postcss.parse('a { top: calc(1px+2px); }');
-		const context = { fix: true };
-
+	it('outputs fixed code when autofix is enabled', async () => {
+		const root = postcss.parse('@import url(foo.css);');
+		const ruleName = 'function-url-quotes';
+		const result = {
+			stylelint: {
+				ruleMetadata: { [ruleName]: { fixable: true } },
+				ruleSeverities: {},
+				fixersData: {},
+				config: { fix: true },
+			},
+		};
 		const warnings = [];
 
 		await checkAgainstRule(
 			{
-				ruleName: 'function-calc-no-unspaced-operator',
-				ruleSettings: true,
+				ruleName,
+				ruleSettings: 'always',
 				root,
-				context,
+				result,
 			},
 			(warning) => warnings.push(warning),
 		);
 
 		expect(warnings).toHaveLength(0);
-		expect(root.toString()).toBe('a { top: calc(1px + 2px); }');
+		expect(root.toString()).toBe('@import url("foo.css");');
 	});
 
 	it('checks against custom rule (passing)', async () => {
@@ -162,6 +170,8 @@ describe('checkAgainstRule', () => {
 								[customRuleAsync.ruleName]: customRuleAsync.rule,
 							},
 						},
+						ruleSeverities: {},
+						fixersData: {},
 					},
 				},
 				ruleSettings: true,

--- a/lib/utils/__tests__/checkAgainstRule.test.mjs
+++ b/lib/utils/__tests__/checkAgainstRule.test.mjs
@@ -1,13 +1,23 @@
+import postcss from 'postcss';
+
 import checkAgainstRule from '../checkAgainstRule.mjs';
 import customRuleAsync from './fixtures/custom-rule-async.mjs';
 import report from '../report.mjs';
 import validateOptions from '../validateOptions.mjs';
 
-import postcss from 'postcss';
+const resultStylelint = (props) => ({
+	ruleSeverities: {},
+	ruleMetadata: {},
+	customMessages: {},
+	customUrls: {},
+	disabledRanges: {},
+	fixersData: {},
+	...props,
+});
 
 const mockRuleName = 'custom/no-empty-source';
 const mockResult = {
-	stylelint: {
+	stylelint: resultStylelint({
 		config: {
 			pluginFunctions: {
 				[mockRuleName]: (primary) => (root, result) => {
@@ -26,9 +36,7 @@ const mockResult = {
 				},
 			},
 		},
-		ruleSeverities: {},
-		fixersData: {},
-	},
+	}),
 };
 
 describe('checkAgainstRule', () => {
@@ -93,12 +101,10 @@ describe('checkAgainstRule', () => {
 		const root = postcss.parse('@import url(foo.css);');
 		const ruleName = 'function-url-quotes';
 		const result = {
-			stylelint: {
+			stylelint: resultStylelint({
 				ruleMetadata: { [ruleName]: { fixable: true } },
-				ruleSeverities: {},
-				fixersData: {},
 				config: { fix: true },
-			},
+			}),
 		};
 		const warnings = [];
 
@@ -164,15 +170,13 @@ describe('checkAgainstRule', () => {
 			{
 				ruleName: customRuleAsync.ruleName,
 				result: {
-					stylelint: {
+					stylelint: resultStylelint({
 						config: {
 							pluginFunctions: {
 								[customRuleAsync.ruleName]: customRuleAsync.rule,
 							},
 						},
-						ruleSeverities: {},
-						fixersData: {},
-					},
+					}),
 				},
 				ruleSettings: true,
 				root,

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -4,15 +4,22 @@ import { jest } from '@jest/globals';
 
 const defaultRangeBy = () => ({ start: { line: 2, column: 1 }, end: { line: 2, column: 2 } });
 
+const resultStylelint = (props) => ({
+	ruleSeverities: {},
+	ruleMetadata: {},
+	customMessages: {},
+	customUrls: {},
+	disabledRanges: {},
+	fixersData: {},
+	...props,
+});
+
 test('without disabledRanges', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			stylelint: resultStylelint(),
 		},
 		message: 'bar',
 		node: {
@@ -32,13 +39,11 @@ test('with irrelevant general disabledRange', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				disabledRanges: {
 					all: [{ start: 5, end: 8 }],
 				},
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -58,13 +63,11 @@ test('with relevant general disabledRange', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				disabledRanges: {
 					all: [{ start: 5, end: 8 }],
 				},
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -81,14 +84,12 @@ test('with irrelevant rule-specific disabledRange', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				disabledRanges: {
 					all: [],
 					bar: [{ start: 5, end: 8 }],
 				},
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -108,14 +109,12 @@ test('with relevant rule-specific disabledRange', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				disabledRanges: {
 					all: [],
 					foo: [{ start: 5, end: 8 }],
 				},
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -132,16 +131,14 @@ test('with relevant general disabledRange, among others', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				disabledRanges: {
 					all: [
 						{ start: 1, end: 3 },
 						{ start: 5, end: 8 },
 					],
 				},
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -158,7 +155,7 @@ test('with relevant rule-specific disabledRange, among others', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				disabledRanges: {
 					all: [],
 					foo: [
@@ -166,9 +163,7 @@ test('with relevant rule-specific disabledRange, among others', () => {
 						{ start: 5, end: 8, rules: ['foo'] },
 					],
 				},
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -185,14 +180,12 @@ test('with relevant rule-specific disabledRange with range report', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				disabledRanges: {
 					all: [],
 					foo: [{ start: 2, end: 2 }],
 				},
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -209,13 +202,12 @@ test("with quiet mode on and rule severity of 'warning'", () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				quiet: true,
 				ruleSeverities: {
 					foo: 'warning',
 				},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -232,13 +224,12 @@ test("with quiet mode on and rule severity of 'error'", () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				quiet: true,
 				ruleSeverities: {
 					foo: 'error',
 				},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -256,12 +247,11 @@ test('with custom rule severity', () => {
 		severity: 'warning',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				ruleSeverities: {
 					foo: 'error',
 				},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -283,13 +273,12 @@ test("with quiet mode on and custom rule severity of 'error'", () => {
 		severity: 'error',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				quiet: true,
 				ruleSeverities: {
 					foo: 'warning',
 				},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -307,13 +296,12 @@ test("with quiet mode on and custom rule severity of 'warning'", () => {
 		severity: 'warning',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				quiet: true,
 				ruleSeverities: {
 					foo: 'error',
 				},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		node: {
@@ -331,13 +319,12 @@ test("with quiet mode on and with functional rule severity of 'error'", () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				quiet: true,
 				ruleSeverities: {
 					foo: customSeverity,
 				},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		messageArgs: ['baz'],
@@ -358,13 +345,12 @@ test("with quiet mode on and with functional rule severity of 'warning'", () => 
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				quiet: true,
 				ruleSeverities: {
 					foo: customSeverity,
 				},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		messageArgs: ['baz'],
@@ -384,10 +370,7 @@ test('with message function', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			stylelint: resultStylelint(),
 		},
 		message: (a, b, c, d) => `a=${a}, b=${b}, c=${c}, d=${d}`,
 		messageArgs: ['str', true, 10, /regex/],
@@ -410,14 +393,13 @@ describe('with fix callback', () => {
 			ruleName: 'foo',
 			result: {
 				warn: jest.fn(),
-				stylelint: {
+				stylelint: resultStylelint({
 					ruleMetadata: { foo: { fixable: true } },
-					ruleSeverities: {},
 					fixersData,
 					config: {
 						fix: true,
 					},
-				},
+				}),
 			},
 			index: 0,
 			endIndex: 1,
@@ -451,14 +433,13 @@ describe('with fix callback', () => {
 			ruleName: 'foo',
 			result: {
 				warn: jest.fn(),
-				stylelint: {
+				stylelint: resultStylelint({
 					ruleMetadata: { foo: { fixable: true } },
-					ruleSeverities: {},
 					fixersData,
 					config: {
 						fix: false,
 					},
-				},
+				}),
 			},
 			message: 'bar',
 			index: 0,
@@ -481,11 +462,9 @@ describe('with fix callback', () => {
 		const v = {
 			ruleName: 'foo',
 			result: {
-				stylelint: {
+				stylelint: resultStylelint({
 					ruleMetadata: { foo: { fixable: false } },
-					ruleSeverities: {},
-					fixersData: {},
-				},
+				}),
 			},
 			node: {
 				rangeBy: defaultRangeBy,
@@ -505,10 +484,9 @@ test('with fix callback missing', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
-				ruleSeverities: {},
+			stylelint: resultStylelint({
 				fixersData,
-			},
+			}),
 		},
 		index: 0,
 		message: 'bar',
@@ -529,11 +507,9 @@ test('with custom message', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				customMessages: { foo: 'A custom message: %s, %s, %d, %s' },
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		messageArgs: ['str', true, 10, /regex/, 'should_be_ignored'],
@@ -554,11 +530,9 @@ test('with custom message function', () => {
 		ruleName: 'foo',
 		result: {
 			warn: jest.fn(),
-			stylelint: {
+			stylelint: resultStylelint({
 				customMessages: { foo: (a, b) => `a=${a}, b=${b}` },
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			}),
 		},
 		message: 'bar',
 		messageArgs: ['str', 123],
@@ -578,10 +552,7 @@ test('without node nor line', () => {
 	const v = {
 		ruleName: 'foo',
 		result: {
-			stylelint: {
-				ruleSeverities: {},
-				fixersData: {},
-			},
+			stylelint: resultStylelint(),
 		},
 	};
 

--- a/lib/utils/checkAgainstRule.cjs
+++ b/lib/utils/checkAgainstRule.cjs
@@ -43,7 +43,7 @@ async function checkAgainstRule(options, callback) {
 	);
 
 	/** @type {import('stylelint').StylelintPostcssResult} */
-	const stylelint = {
+	const stylelint = result?.stylelint ?? {
 		ruleSeverities: {},
 		customMessages: {},
 		customUrls: {},

--- a/lib/utils/checkAgainstRule.mjs
+++ b/lib/utils/checkAgainstRule.mjs
@@ -40,7 +40,7 @@ export default async function checkAgainstRule(options, callback) {
 	);
 
 	/** @type {import('stylelint').StylelintPostcssResult} */
-	const stylelint = {
+	const stylelint = result?.stylelint ?? {
 		ruleSeverities: {},
 		customMessages: {},
 		customUrls: {},

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -26,9 +26,9 @@ function report(problem) {
 		quiet,
 		ruleSeverities,
 		config: { defaultSeverity = 'error', ignoreDisables } = {},
-		customMessages: { [ruleName]: message = rest.message } = {},
-		customUrls: { [ruleName]: customUrl } = {},
-		ruleMetadata: { [ruleName]: metadata } = {},
+		customMessages: { [ruleName]: message = rest.message },
+		customUrls: { [ruleName]: customUrl },
+		ruleMetadata: { [ruleName]: metadata },
 	} = result.stylelint;
 	const { messageArgs = [], severity = ruleSeverities[ruleName] } = rest;
 	const ruleSeverity = validateTypes.isFunction(severity) ? severity(...messageArgs) || defaultSeverity : severity;
@@ -146,8 +146,6 @@ function printfLike(format, ...args) {
  * @param {DisabledRangeObject} disabledRanges
  */
 function isDisabled(ruleName, startLine, disabledRanges) {
-	if (!disabledRanges) return false;
-
 	const ranges = disabledRanges[ruleName] ?? disabledRanges[constants.RULE_NAME_ALL] ?? [];
 
 	for (const range of ranges) {

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -22,9 +22,9 @@ export default function report(problem) {
 		quiet,
 		ruleSeverities,
 		config: { defaultSeverity = 'error', ignoreDisables } = {},
-		customMessages: { [ruleName]: message = rest.message } = {},
-		customUrls: { [ruleName]: customUrl } = {},
-		ruleMetadata: { [ruleName]: metadata } = {},
+		customMessages: { [ruleName]: message = rest.message },
+		customUrls: { [ruleName]: customUrl },
+		ruleMetadata: { [ruleName]: metadata },
 	} = result.stylelint;
 	const { messageArgs = [], severity = ruleSeverities[ruleName] } = rest;
 	const ruleSeverity = isFn(severity) ? severity(...messageArgs) || defaultSeverity : severity;
@@ -142,8 +142,6 @@ function printfLike(format, ...args) {
  * @param {DisabledRangeObject} disabledRanges
  */
 function isDisabled(ruleName, startLine, disabledRanges) {
-	if (!disabledRanges) return false;
-
 	const ranges = disabledRanges[ruleName] ?? disabledRanges[RULE_NAME_ALL] ?? [];
 
 	for (const range of ranges) {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #7730

> Is there anything in the PR that needs further explanation?

To make the `fix` callback work with `utils.checkAgainstRule()`, we need to use `result.stylelint` in `checkAgainstRule()` because `report()` now depends on `result.stylelint.config.fix` instead of `context.fix`.

See:
https://github.com/stylelint/stylelint/blob/2dfe7cea14159b536b83a35ab9423cd643b36a7e/lib/utils/report.mjs#L174

