### PR TITLE
Refactor `function-calc-no-unspaced-operator` to have atomic fixes

### DIFF
--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -263,32 +263,32 @@ testRule({
 			fixed: 'a { top: calc(2px + 1px); }',
 			description: 'no space before or after operator',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 			],
 		},
 		{
 			code: 'a { transform: rotate(acos(2+1)); }',
 			fixed: 'a { transform: rotate(acos(2 + 1)); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
 			],
 		},
 		{
 			code: 'a { scale: rem(10+2, 1.7); }',
 			fixed: 'a { scale: rem(10 + 2, 1.7); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
 			],
 		},
 		{
 			code: 'a { rotate: rem(10turn, 2turn+1turn); }',
 			fixed: 'a { rotate: rem(10turn, 2turn + 1turn); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
 				{ message: messages.expectedAfter('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
 			],
 		},
 		{
@@ -586,32 +586,32 @@ testRule({
 			code: 'a { padding: calc(1px+2px+3px); }',
 			fixed: 'a { padding: calc(1px + 2px + 3px); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
 			],
 		},
 		{
 			code: 'a { padding: calc(1px+2px-3px); }',
 			fixed: 'a { padding: calc(1px + 2px - 3px); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
 			],
 		},
 		{
 			code: 'a { padding: calc(1px+2px-3px-4px); }',
 			fixed: 'a { padding: calc(1px + 2px - 3px - 4px); }',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
 			],
 		},
 		{
@@ -649,8 +649,8 @@ testRule({
 			fixed: 'a { font-size: clamp(1rem, 2.5vw, 1rem + 1rem); }',
 			description: 'multiple argument functions',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
 			],
 		},
 		{
@@ -659,8 +659,8 @@ testRule({
 			description: 'multiple argument functions',
 			warnings: [
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 			],
 		},
 		{
@@ -668,8 +668,8 @@ testRule({
 			fixed: 'a { width: min(25vw + 25vw); }',
 			description: 'multiple argument functions',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
 			],
 		},
 		{
@@ -687,14 +687,14 @@ testRule({
 				'a { top: rgb(from red calc(r + 1) calc(g - +2) calc(clamp(10px + 2px, g + 2, none))); }',
 			description: 'nested math expression',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
 				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
 				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
 				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
 			],
 		},
 		{

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -37,7 +37,7 @@ const NEWLINE_REGEX = /\n|\r\n/;
 /** @import { CommentNode, ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
@@ -119,10 +119,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								cssTokenizer.mutateUnit(token, unit.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									cssTokenizer.mutateUnit(token, unit.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -135,10 +142,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									cssTokenizer.mutateIdent(token, tokenValue.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -152,13 +166,21 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
-						if (context.fix) {
-							operation.insertOperatorBeforeSecondOperand(node);
+						complain(
+							messages.expectedAfter(operation.operatorChar),
+							decl,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
+							() => {
+								operation.insertOperatorBeforeSecondOperand(node);
 
-							// Remove an operator character from the second operand token
-							token[4].signCharacter = undefined;
-							token[1] = token[1].slice(1);
-						}
+								// Remove an operator character from the second operand token
+								token[4].signCharacter = undefined;
+								token[1] = token[1].slice(1);
+
+								fixDeclarationValue();
+							},
+						);
 					}
 				}
 			}
@@ -419,7 +441,7 @@ class Operation {
 	 */
 	insertOperatorAfterFirstOperand(node) {
 		validateTypes.assert(this.operator);
-		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, this.operator);
+		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, ...this.before, this.operator);
 	}
 
 	/**
@@ -427,7 +449,7 @@ class Operation {
 	 */
 	insertOperatorBeforeSecondOperand(node) {
 		validateTypes.assert(this.operator);
-		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator);
+		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator, ...this.after);
 	}
 
 	/**
@@ -446,7 +468,9 @@ class Operation {
 
 		if (type === 'append') {
 			this.after = this.before;
-			this.before = [];
+			this.before = [new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]])];
+		} else {
+			this.after = [new cssParserAlgorithms.WhitespaceNode([[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]])];
 		}
 	}
 }

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -59,7 +59,7 @@ const NEWLINE_REGEX = /\n|\r\n/;
 /** @import { CommentNode, ComponentValue, ContainerNode } from '@csstools/css-parser-algorithms' */
 
 /** @type {import('stylelint').Rule} */
-const rule = (primary, _secondaryOptions, context) => {
+const rule = (primary) => {
 	return (root, result) => {
 		const validOptions = validateOptions(result, ruleName, { actual: primary });
 
@@ -141,10 +141,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								mutateUnit(token, unit.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									mutateUnit(token, unit.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -157,10 +164,17 @@ const rule = (primary, _secondaryOptions, context) => {
 						if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 							operation.completeMissingOperator(operatorChar, endPos, 'append');
 
-							if (context.fix) {
-								operation.insertOperatorAfterFirstOperand(node);
-								mutateIdent(token, tokenValue.slice(0, -1));
-							}
+							complain(
+								messages.expectedBefore(operation.operatorChar),
+								decl,
+								valueIndex + operation.operatorCharPosition,
+								operation.operatorChar,
+								() => {
+									operation.insertOperatorAfterFirstOperand(node);
+									mutateIdent(token, tokenValue.slice(0, -1));
+									fixDeclarationValue();
+								},
+							);
 
 							return;
 						}
@@ -174,13 +188,21 @@ const rule = (primary, _secondaryOptions, context) => {
 					if (operatorChar && OPERATOR_REGEX.test(operatorChar)) {
 						operation.completeMissingOperator(operatorChar, startPos, 'prepend');
 
-						if (context.fix) {
-							operation.insertOperatorBeforeSecondOperand(node);
+						complain(
+							messages.expectedAfter(operation.operatorChar),
+							decl,
+							valueIndex + operation.operatorCharPosition,
+							operation.operatorChar,
+							() => {
+								operation.insertOperatorBeforeSecondOperand(node);
 
-							// Remove an operator character from the second operand token
-							token[4].signCharacter = undefined;
-							token[1] = token[1].slice(1);
-						}
+								// Remove an operator character from the second operand token
+								token[4].signCharacter = undefined;
+								token[1] = token[1].slice(1);
+
+								fixDeclarationValue();
+							},
+						);
 					}
 				}
 			}
@@ -441,7 +463,7 @@ class Operation {
 	 */
 	insertOperatorAfterFirstOperand(node) {
 		assert(this.operator);
-		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, this.operator);
+		node.value.splice(node.value.indexOf(this.firstOperand) + 1, 0, ...this.before, this.operator);
 	}
 
 	/**
@@ -449,7 +471,7 @@ class Operation {
 	 */
 	insertOperatorBeforeSecondOperand(node) {
 		assert(this.operator);
-		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator);
+		node.value.splice(node.value.indexOf(this.secondOperand), 0, this.operator, ...this.after);
 	}
 
 	/**
@@ -468,7 +490,9 @@ class Operation {
 
 		if (type === 'append') {
 			this.after = this.before;
-			this.before = [];
+			this.before = [new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]])];
+		} else {
+			this.after = [new WhitespaceNode([[TokenType.Whitespace, ' ', -1, -1, undefined]])];
 		}
 	}
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Each mutation of the AST now corresponds to a single warning and a single fix.

See : https://github.com/stylelint/stylelint/pull/7831

> Is there anything in the PR that needs further explanation?

The order of the warnings changes, but I hope this is fine?
