### PR TITLE
Fix `quietDeprecationWarnings` to suppress with `stylelint:003` warning

### DIFF
--- a/.changeset/pretty-crabs-battle.md
+++ b/.changeset/pretty-crabs-battle.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `quietDeprecationWarnings` to suppress `stylelint:003` warning

--- a/lib/__tests__/standalone-deprecations.test.mjs
+++ b/lib/__tests__/standalone-deprecations.test.mjs
@@ -63,4 +63,15 @@ describe('standalone with the `output` property deprecation', () => {
 			type: 'DeprecationWarning',
 		});
 	});
+
+	it('quiets the warning when the flag is turned on', async () => {
+		const result = await standalone({
+			code: 'a {}',
+			config: { rules: {} },
+			quietDeprecationWarnings: true,
+		});
+
+		expect(result.output).toBeTruthy();
+		expect(process.emitWarning).not.toHaveBeenCalled();
+	});
 });

--- a/lib/prepareReturnValue.cjs
+++ b/lib/prepareReturnValue.cjs
@@ -4,22 +4,28 @@
 
 const emitDeprecationWarning = require('./utils/emitDeprecationWarning.cjs');
 
-/** @import {Formatter, LinterOptions, LinterResult, LintResult as StylelintResult} from 'stylelint' */
-/** @typedef {LinterOptions["maxWarnings"]} maxWarnings */
+/** @import { Formatter, LinterOptions, LinterResult, LintResult } from 'stylelint' */
 
 
 /**
- * @param {StylelintResult[]} stylelintResults
- * @param {maxWarnings} maxWarnings
- * @param {Formatter} formatter
- * @param {string} cwd
- *
+ * @param {object} args
+ * @param {LintResult[]} args.results
+ * @param {LinterOptions['maxWarnings']} args.maxWarnings
+ * @param {LinterOptions['quietDeprecationWarnings']} args.quietDeprecationWarnings
+ * @param {Formatter} args.formatter
+ * @param {string} args.cwd
  * @returns {LinterResult}
  */
-function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
+function prepareReturnValue({
+	results,
+	maxWarnings,
+	quietDeprecationWarnings,
+	formatter,
+	cwd,
+}) {
 	let errored = false;
 
-	for (const result of stylelintResults) {
+	for (const result of results) {
 		if (
 			result.errored ||
 			result.parseErrors.length > 0 ||
@@ -39,7 +45,7 @@ function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
 
 		// TODO: Deprecated. Remove in the next major version.
 		get output() {
-			if (!this._outputWarned) {
+			if (!quietDeprecationWarnings && !this._outputWarned) {
 				emitDeprecationWarning(
 					'`output` is deprecated.',
 					'RESULT_OUTPUT_PROPERTY',
@@ -52,7 +58,7 @@ function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
 		},
 
 		reportedDisables: [],
-		ruleMetadata: getRuleMetadata(stylelintResults),
+		ruleMetadata: getRuleMetadata(results),
 	};
 
 	// TODO: Deprecated. Remove in the next major version.
@@ -60,22 +66,22 @@ function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
 	Object.defineProperty(returnValue, '_outputWarned', { value: false, writable: true });
 
 	if (maxWarnings !== undefined) {
-		const foundWarnings = stylelintResults.reduce((count, file) => count + file.warnings.length, 0);
+		const foundWarnings = results.reduce((count, file) => count + file.warnings.length, 0);
 
 		if (foundWarnings > maxWarnings) {
 			returnValue.maxWarningsExceeded = { maxWarnings, foundWarnings };
 		}
 	}
 
-	returnValue.report = formatter(stylelintResults, returnValue);
+	returnValue.report = formatter(results, returnValue);
 	returnValue._output = returnValue.report; // TODO: Deprecated. Remove in the next major version.
-	returnValue.results = stylelintResults;
+	returnValue.results = results;
 
 	return returnValue;
 }
 
 /**
- * @param {StylelintResult[]} lintResults
+ * @param {LintResult[]} lintResults
  */
 function getRuleMetadata(lintResults) {
 	const [lintResult] = lintResults;

--- a/lib/prepareReturnValue.mjs
+++ b/lib/prepareReturnValue.mjs
@@ -1,20 +1,26 @@
-/** @import {Formatter, LinterOptions, LinterResult, LintResult as StylelintResult} from 'stylelint' */
-/** @typedef {LinterOptions["maxWarnings"]} maxWarnings */
+/** @import { Formatter, LinterOptions, LinterResult, LintResult } from 'stylelint' */
 
 import emitDeprecationWarning from './utils/emitDeprecationWarning.mjs';
 
 /**
- * @param {StylelintResult[]} stylelintResults
- * @param {maxWarnings} maxWarnings
- * @param {Formatter} formatter
- * @param {string} cwd
- *
+ * @param {object} args
+ * @param {LintResult[]} args.results
+ * @param {LinterOptions['maxWarnings']} args.maxWarnings
+ * @param {LinterOptions['quietDeprecationWarnings']} args.quietDeprecationWarnings
+ * @param {Formatter} args.formatter
+ * @param {string} args.cwd
  * @returns {LinterResult}
  */
-export default function prepareReturnValue(stylelintResults, maxWarnings, formatter, cwd) {
+export default function prepareReturnValue({
+	results,
+	maxWarnings,
+	quietDeprecationWarnings,
+	formatter,
+	cwd,
+}) {
 	let errored = false;
 
-	for (const result of stylelintResults) {
+	for (const result of results) {
 		if (
 			result.errored ||
 			result.parseErrors.length > 0 ||
@@ -34,7 +40,7 @@ export default function prepareReturnValue(stylelintResults, maxWarnings, format
 
 		// TODO: Deprecated. Remove in the next major version.
 		get output() {
-			if (!this._outputWarned) {
+			if (!quietDeprecationWarnings && !this._outputWarned) {
 				emitDeprecationWarning(
 					'`output` is deprecated.',
 					'RESULT_OUTPUT_PROPERTY',
@@ -47,7 +53,7 @@ export default function prepareReturnValue(stylelintResults, maxWarnings, format
 		},
 
 		reportedDisables: [],
-		ruleMetadata: getRuleMetadata(stylelintResults),
+		ruleMetadata: getRuleMetadata(results),
 	};
 
 	// TODO: Deprecated. Remove in the next major version.
@@ -55,22 +61,22 @@ export default function prepareReturnValue(stylelintResults, maxWarnings, format
 	Object.defineProperty(returnValue, '_outputWarned', { value: false, writable: true });
 
 	if (maxWarnings !== undefined) {
-		const foundWarnings = stylelintResults.reduce((count, file) => count + file.warnings.length, 0);
+		const foundWarnings = results.reduce((count, file) => count + file.warnings.length, 0);
 
 		if (foundWarnings > maxWarnings) {
 			returnValue.maxWarningsExceeded = { maxWarnings, foundWarnings };
 		}
 	}
 
-	returnValue.report = formatter(stylelintResults, returnValue);
+	returnValue.report = formatter(results, returnValue);
 	returnValue._output = returnValue.report; // TODO: Deprecated. Remove in the next major version.
-	returnValue.results = stylelintResults;
+	returnValue.results = results;
 
 	return returnValue;
 }
 
 /**
- * @param {StylelintResult[]} lintResults
+ * @param {LintResult[]} lintResults
  */
 function getRuleMetadata(lintResults) {
 	const [lintResult] = lintResults;

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -121,7 +121,13 @@ async function standalone({
 			absoluteCodeFilename &&
 			!filterFilePaths(ignorer, [path.relative(cwd, absoluteCodeFilename)]).length
 		) {
-			return prepareReturnValue([], maxWarnings, formatterFunction, cwd);
+			return prepareReturnValue({
+				results: [],
+				maxWarnings,
+				quietDeprecationWarnings,
+				formatter: formatterFunction,
+				cwd,
+			});
 		}
 
 		let stylelintResult;
@@ -140,7 +146,13 @@ async function standalone({
 		await postProcessStylelintResult(stylelint, stylelintResult, absoluteCodeFilename);
 
 		const postcssResult = stylelintResult._postcssResult;
-		const returnValue = prepareReturnValue([stylelintResult], maxWarnings, formatterFunction, cwd);
+		const returnValue = prepareReturnValue({
+			results: [stylelintResult],
+			maxWarnings,
+			quietDeprecationWarnings,
+			formatter: formatterFunction,
+			cwd,
+		});
 
 		const autofix = fix ?? config?.fix ?? false;
 
@@ -272,7 +284,13 @@ async function standalone({
 		stylelint._fileCache.reconcile();
 	}
 
-	const result = prepareReturnValue(stylelintResults, maxWarnings, formatterFunction, cwd);
+	const result = prepareReturnValue({
+		results: stylelintResults,
+		maxWarnings,
+		quietDeprecationWarnings,
+		formatter: formatterFunction,
+		cwd,
+	});
 
 	debug(`Linting complete in ${Date.now() - startTime}ms`);
 

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -119,7 +119,13 @@ export default async function standalone({
 			absoluteCodeFilename &&
 			!filterFilePaths(ignorer, [relative(cwd, absoluteCodeFilename)]).length
 		) {
-			return prepareReturnValue([], maxWarnings, formatterFunction, cwd);
+			return prepareReturnValue({
+				results: [],
+				maxWarnings,
+				quietDeprecationWarnings,
+				formatter: formatterFunction,
+				cwd,
+			});
 		}
 
 		let stylelintResult;
@@ -138,7 +144,13 @@ export default async function standalone({
 		await postProcessStylelintResult(stylelint, stylelintResult, absoluteCodeFilename);
 
 		const postcssResult = stylelintResult._postcssResult;
-		const returnValue = prepareReturnValue([stylelintResult], maxWarnings, formatterFunction, cwd);
+		const returnValue = prepareReturnValue({
+			results: [stylelintResult],
+			maxWarnings,
+			quietDeprecationWarnings,
+			formatter: formatterFunction,
+			cwd,
+		});
 
 		const autofix = fix ?? config?.fix ?? false;
 
@@ -270,7 +282,13 @@ export default async function standalone({
 		stylelint._fileCache.reconcile();
 	}
 
-	const result = prepareReturnValue(stylelintResults, maxWarnings, formatterFunction, cwd);
+	const result = prepareReturnValue({
+		results: stylelintResults,
+		maxWarnings,
+		quietDeprecationWarnings,
+		formatter: formatterFunction,
+		cwd,
+	});
 
 	debug(`Linting complete in ${Date.now() - startTime}ms`);
 


### PR DESCRIPTION
This change fixes `quietDeprecationWarnings: true` to suppress the `stylelint:003` warning.

For example:

```js
// test.mjs
import stylelint from 'stylelint';

const result = await stylelint.lint({
	code: 'a {}',
	config: { rules: {} },
	quietDeprecationWarnings: true,
});
console.log(result.output);
```

When running before this change, the warning is shown regardless of `quietDeprecationWarnings: true`:

```sh-session
$ node test.mjs
[{"source":"<input css B6wTu8>","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":false,"warnings":[]}]
(node:30570) [stylelint:003] DeprecationWarning: `output` is deprecated.
Use `report` or `code` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

When running after this change, no warning is shown:

```sh-session
$ node test.mjs
[{"source":"<input css hoeByJ>","deprecations":[],"invalidOptionWarnings":[],"parseErrors":[],"errored":false,"warnings":[]}]
```

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR is based on @Mouvedia's review (<https://github.com/stylelint/stylelint/pull/7834#discussion_r1671408666>).
