### PR TITLE
Encourage using common keywords for plugins, configs, and formatters in documentation

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -83,3 +83,13 @@ stylelint -f json "*.css" 2>&1 | my-program-that-reads-JSON --option
 ## `stylelint.formatters`
 
 Stylelint's internal formatters are exposed publicly in `stylelint.formatters`.
+
+## Sharing formatters
+
+Use the `stylelint-formatter` keyword within your `package.json`. For example:
+
+```json
+{
+  "keywords": ["stylelint", "stylelint-formatter"]
+}
+```

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -362,4 +362,32 @@ To make a single module provide multiple rules, export an array of plugin object
 
 ## Sharing plugins and plugin packs
 
-Use the `stylelint-plugin` keyword within your `package.json`.
+Use the `stylelint-plugin` keyword within your `package.json`. For example:
+
+```json
+{
+  "keywords": ["stylelint", "stylelint-plugin"]
+}
+```
+
+## Sharing configurations
+
+You may want to create a shareable configuration for your plugins to provide a default ruleset. For example:
+
+```json
+{
+  "plugins": ["stylelint-plugin-foo"],
+  "rules": {
+    "foo/rule-1": true,
+    "foo/rule-2": true
+  }
+}
+```
+
+When publishing such configurations, use the `stylelint-config` keyword within your `package.json`. For example:
+
+```json
+{
+  "keywords": ["stylelint", "stylelint-config"]
+}
+```


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #7838

> Is there anything in the PR that needs further explanation?

These keywords would help us find packages more easily.

Common keywords: `stylelint-plugin`, `stylelint-config`, `stylelint-formatter`

See:
- https://www.npmjs.com/search?q=keywords%3Astylelint-plugin
- https://www.npmjs.com/search?q=keywords%3Astylelint-config
- https://www.npmjs.com/search?q=keywords%3Astylelint-formatter
