### PR TITLE
Fix error message when a selector is duplicated inside a selector list

### DIFF
--- a/.changeset/gorgeous-maps-juggle.md
+++ b/.changeset/gorgeous-maps-juggle.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fix no-duplicated-selectors error position when duplication is in the same selector list

--- a/lib/__tests__/standalone-fix.test.mjs
+++ b/lib/__tests__/standalone-fix.test.mjs
@@ -593,7 +593,7 @@ it('two rules being disabled', async () => {
 	expect(result.code).toBe(code);
 	expect(getCleanOutput(result.report)).toBe(stripIndent`
 		test.css
-		  2:3   ×  Unexpected duplicate selector "a", first used at line 2  no-duplicate-selectors
+		  2:6   ×  Unexpected duplicate selector "a", first used at line 2  no-duplicate-selectors
 		  3:11  ×  Expected "#ffffff" to be "#fff"                          color-hex-length
 
 		× 2 problems (2 errors, 0 warnings)
@@ -644,7 +644,7 @@ it('one rule being disabled and another still autofixing', async () => {
 		}`);
 	expect(getCleanOutput(result.report)).toBe(stripIndent`
 		test.css
-		  2:3  ×  Unexpected duplicate selector "a", first used at line 2  no-duplicate-selectors
+		  2:6  ×  Unexpected duplicate selector "a", first used at line 2  no-duplicate-selectors
 
 		× 1 problem (1 error, 0 warnings)
 	`);

--- a/lib/rules/no-duplicate-selectors/__tests__/fixtures/many-duplicates.css
+++ b/lib/rules/no-duplicate-selectors/__tests__/fixtures/many-duplicates.css
@@ -1,0 +1,6 @@
+div,
+div,
+body,
+div {
+  color: #fd0;
+}

--- a/lib/rules/no-duplicate-selectors/__tests__/index.mjs
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.mjs
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
 
 import postcss from 'postcss';
 import postcssImport from 'postcss-import';
@@ -61,27 +62,14 @@ testRule({
 				{
 					message: messages.rejected('a', 1),
 					line: 1,
-					column: 1,
+					column: 4,
 					endLine: 1,
-					endColumn: 2,
+					endColumn: 5,
 				},
 			],
 		},
 		{
 			code: 'a,\na {}',
-			description: "duplicate within one rule's selector list. multiline",
-			warnings: [
-				{
-					message: messages.rejected('a', 1),
-					line: 1,
-					column: 1,
-					endLine: 1,
-					endColumn: 2,
-				},
-			],
-		},
-		{
-			code: 'b,\na,\na {}',
 			description: "duplicate within one rule's selector list. multiline",
 			warnings: [
 				{
@@ -94,13 +82,31 @@ testRule({
 			],
 		},
 		{
+			code: 'b,\na,\na {}',
+			description: "duplicate within one rule's selector list. multiline",
+			warnings: [
+				{
+					message: messages.rejected('a', 2),
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 2,
+				},
+			],
+		},
+		{
 			code: '.a, .a, .a {}',
 			description: "duplicated selectors within one rule's selector list. 3 duplicates",
 			warnings: [
 				{
 					message: messages.rejected('.a', 1),
 					line: 1,
-					column: 1,
+					column: 5,
+				},
+				{
+					message: messages.rejected('.a', 1),
+					line: 1,
+					column: 9,
 				},
 			],
 		},
@@ -166,7 +172,7 @@ testRule({
 				{
 					message: messages.rejected('a', 2),
 					line: 2,
-					column: 16,
+					column: 19,
 				},
 			],
 		},
@@ -201,6 +207,18 @@ testRule({
 					line: 1,
 					column: 5,
 				},
+			],
+		},
+
+		{
+			code: fs.readFileSync(
+				fileURLToPath(new URL('./fixtures/many-duplicates.css', import.meta.url)),
+				{ encoding: 'utf-8' },
+			),
+			description: 'error when there same selectors are in the same selector list',
+			warnings: [
+				{ message: messages.rejected('div', 1), line: 2 },
+				{ message: messages.rejected('div', 1), line: 4 },
 			],
 		},
 	],

--- a/lib/rules/no-duplicate-selectors/index.cjs
+++ b/lib/rules/no-duplicate-selectors/index.cjs
@@ -120,27 +120,41 @@ const rule = (primary, secondaryOptions) => {
 				});
 			}
 
+			/** @type {Set<string>} */
 			const presentedSelectors = new Set();
+			/** @type {Set<string>} */
 			const reportedSelectors = new Set();
+
+			/** clone the rule to replace his selector and calculate the correct selector position */
+			const cloneRule = ruleNode.clone();
 
 			// Or complain if one selector list contains the same selector more than once
 			for (const selector of ruleNode.selectors) {
 				const normalized = normalize(selector);
 
 				if (presentedSelectors.has(normalized)) {
-					if (reportedSelectors.has(normalized)) {
-						continue;
+					if (!reportedSelectors.has(normalized)) {
+						reportedSelectors.add(normalized);
 					}
+
+					const originalSelectorPosition = ruleNode.positionBy({ word: selector });
+
+					/**
+					 * every time we find a duplicated selector we replace it with a placeholder in
+					 * order to use {@link import('postcss').Rule.rangeBy} to get the correct duplicated selector position
+					 * and provide it to the reported to get the error on the duplicated selector.
+					 */
+					cloneRule.selector = cloneRule.selector.replace(selector, '%'.repeat(selector.length));
 
 					report({
 						result,
 						ruleName,
 						node: ruleNode,
 						message: messages.rejected,
-						messageArgs: [selector, selectorLine],
-						word: selector,
+						messageArgs: [selector, originalSelectorPosition.line],
+						...cloneRule.rangeBy({ word: selector }),
+						// word: selector,
 					});
-					reportedSelectors.add(normalized);
 				} else {
 					presentedSelectors.add(normalized);
 				}

--- a/lib/rules/no-duplicate-selectors/index.mjs
+++ b/lib/rules/no-duplicate-selectors/index.mjs
@@ -117,27 +117,41 @@ const rule = (primary, secondaryOptions) => {
 				});
 			}
 
+			/** @type {Set<string>} */
 			const presentedSelectors = new Set();
+			/** @type {Set<string>} */
 			const reportedSelectors = new Set();
+
+			/** clone the rule to replace his selector and calculate the correct selector position */
+			const cloneRule = ruleNode.clone();
 
 			// Or complain if one selector list contains the same selector more than once
 			for (const selector of ruleNode.selectors) {
 				const normalized = normalize(selector);
 
 				if (presentedSelectors.has(normalized)) {
-					if (reportedSelectors.has(normalized)) {
-						continue;
+					if (!reportedSelectors.has(normalized)) {
+						reportedSelectors.add(normalized);
 					}
+
+					const originalSelectorPosition = ruleNode.positionBy({ word: selector });
+
+					/**
+					 * every time we find a duplicated selector we replace it with a placeholder in
+					 * order to use {@link import('postcss').Rule.rangeBy} to get the correct duplicated selector position
+					 * and provide it to the reported to get the error on the duplicated selector.
+					 */
+					cloneRule.selector = cloneRule.selector.replace(selector, '%'.repeat(selector.length));
 
 					report({
 						result,
 						ruleName,
 						node: ruleNode,
 						message: messages.rejected,
-						messageArgs: [selector, selectorLine],
-						word: selector,
+						messageArgs: [selector, originalSelectorPosition.line],
+						...cloneRule.rangeBy({ word: selector }),
+						// word: selector,
 					});
-					reportedSelectors.add(normalized);
 				} else {
 					presentedSelectors.add(normalized);
 				}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Close #7583

> Is there anything in the PR that needs further explanation?

Information about the updated implementation can be found in the [comment below](https://github.com/stylelint/stylelint/pull/7866#issuecomment-2238582384).

<details>
<summary>Outdated description</summary>
I tackled a little with `no-duplicate-selectors`, unfortunately I wasn't able to find a clean and efficient way to highlight duplicate selectors inside a single selector list.
The alternative solution I'm proposing is to change the message of the rule adding to it the occurrences of the duplicated selector within the list.
Something like:
```text
`Selector "${selector}" is present ${count} times in selector list at line ${line}`
```
Inevitably this will affect other scenarios but I think that this make the error more understandable
</details>