### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for `:active-view-transition` and `:active-view-transition-type()`

### DIFF
--- a/.changeset/grumpy-insects-compete.md
+++ b/.changeset/grumpy-insects-compete.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for `:active-view-transition` and `:active-view-transition-type()`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -290,6 +290,8 @@ const pseudoClasses = uniteSets(
 	vendorSpecificPseudoClasses,
 	[
 		'active',
+		'active-view-transition',
+		'active-view-transition-type',
 		'any-link',
 		'autofill',
 		'blank',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -287,6 +287,8 @@ export const pseudoClasses = uniteSets(
 	vendorSpecificPseudoClasses,
 	[
 		'active',
+		'active-view-transition',
+		'active-view-transition-type',
 		'any-link',
 		'autofill',
 		'blank',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -120,7 +120,10 @@ testRule({
 		},
 		{
 			code: ':popover-open {}',
-			description: 'explicit :popover-open test; see #7424',
+			description: 'explicit :popover-open test',
+		},
+		{
+			code: ':active-view-transition, :active-view-transition-type() {}',
 		},
 		{
 			code: ':seeking, :stalled, :buffering, :volume-locked, :muted {}',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #7861

> Is there anything in the PR that needs further explanation?

N/A