### PR TITLE
Improve rewriting changelog to sort items with the same prefixes

### DIFF
--- a/.changeset/rewrite-changelog.mjs
+++ b/.changeset/rewrite-changelog.mjs
@@ -11,7 +11,13 @@ const byPrefixOrder = (a, b) => {
 	const aPrefix = entryPattern.exec(a)?.[1];
 	const bPrefix = entryPattern.exec(b)?.[1];
 
-	if (aPrefix && bPrefix) return ENTRY_PREFIXES.indexOf(aPrefix) - ENTRY_PREFIXES.indexOf(bPrefix);
+	if (aPrefix && bPrefix) {
+		const comparison = ENTRY_PREFIXES.indexOf(aPrefix) - ENTRY_PREFIXES.indexOf(bPrefix);
+
+		if (comparison !== 0) return comparison;
+
+		return a.localeCompare(b);
+	}
 
 	if (!aPrefix && bPrefix) return 1;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR will sorts the order:
https://github.com/stylelint/stylelint/blob/ac1d085255f355c90c64e48468958d85495edb21/CHANGELOG.md?plain=1#L6-L9

