### PR TITLE
Fix `no-duplicate-selectors` false positives with Less syntax

### DIFF
--- a/.changeset/cold-months-notice.md
+++ b/.changeset/cold-months-notice.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `no-duplicate-selectors` false positives with Less syntax

--- a/lib/rules/no-duplicate-selectors/__tests__/index.mjs
+++ b/lib/rules/no-duplicate-selectors/__tests__/index.mjs
@@ -521,5 +521,8 @@ testRule({
 			code: 'a { b, .@{var} {} b {} }',
 			description: 'Non standard Less nested interpolation (3',
 		},
+		{
+			code: '.foo() { .bar > & { color: #000; } &.readonly { color: #fff; } }',
+		},
 	],
 });

--- a/lib/rules/no-duplicate-selectors/index.cjs
+++ b/lib/rules/no-duplicate-selectors/index.cjs
@@ -122,9 +122,7 @@ const rule = (primary, secondaryOptions) => {
 			if (!flattenedNestedSelectors.length) return;
 
 			const combinedRoot = parser.root({
-				nodes: flattenNestedSelectorsForRule(ruleNode, result).flatMap(
-					({ resolvedSelectors }) => resolvedSelectors.nodes,
-				),
+				nodes: flattenedNestedSelectors,
 				value: '',
 			});
 

--- a/lib/rules/no-duplicate-selectors/index.cjs
+++ b/lib/rules/no-duplicate-selectors/index.cjs
@@ -115,6 +115,12 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {Map<string, { line: number }>} contextSelectorSet
 		 */
 		function checkSelectorListInDifferentRules(ruleNode, contextSelectorSet) {
+			const flattenedNestedSelectors = flattenNestedSelectorsForRule(ruleNode, result).flatMap(
+				({ resolvedSelectors }) => resolvedSelectors.nodes,
+			);
+
+			if (!flattenedNestedSelectors.length) return;
+
 			const combinedRoot = parser.root({
 				nodes: flattenNestedSelectorsForRule(ruleNode, result).flatMap(
 					({ resolvedSelectors }) => resolvedSelectors.nodes,

--- a/lib/rules/no-duplicate-selectors/index.mjs
+++ b/lib/rules/no-duplicate-selectors/index.mjs
@@ -119,9 +119,7 @@ const rule = (primary, secondaryOptions) => {
 			if (!flattenedNestedSelectors.length) return;
 
 			const combinedRoot = selectorParser.root({
-				nodes: flattenNestedSelectorsForRule(ruleNode, result).flatMap(
-					({ resolvedSelectors }) => resolvedSelectors.nodes,
-				),
+				nodes: flattenedNestedSelectors,
 				value: '',
 			});
 

--- a/lib/rules/no-duplicate-selectors/index.mjs
+++ b/lib/rules/no-duplicate-selectors/index.mjs
@@ -112,6 +112,12 @@ const rule = (primary, secondaryOptions) => {
 		 * @param {Map<string, { line: number }>} contextSelectorSet
 		 */
 		function checkSelectorListInDifferentRules(ruleNode, contextSelectorSet) {
+			const flattenedNestedSelectors = flattenNestedSelectorsForRule(ruleNode, result).flatMap(
+				({ resolvedSelectors }) => resolvedSelectors.nodes,
+			);
+
+			if (!flattenedNestedSelectors.length) return;
+
 			const combinedRoot = selectorParser.root({
 				nodes: flattenNestedSelectorsForRule(ruleNode, result).flatMap(
 					({ resolvedSelectors }) => resolvedSelectors.nodes,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7887

> Is there anything in the PR that needs further explanation?

`flattenNestedSelectorsForRule` can return an empty list on invalid syntax.
This forgiving behavior is intended as it also allows us to lint partially standard selector lists.

However in `no-duplicate-selectors` we also use these lists (after normalizing) to detect duplicates. And when the entire list is non-standard the resulting selector will be an empty string.

Each empty string is equal to any other empty string, so in turn each non-standard selector list is considered a duplicate of every other non-standard selector list.

Adding a check that `flattenNestedSelectorsForRule` did return at least one selector resolves any issues with non-standard syntaxes. 