### PR TITLE
Fix `no-invalid-double-slash-comments` reported ranges

### DIFF
--- a/.changeset/giant-days-play.md
+++ b/.changeset/giant-days-play.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `no-invalid-double-slash-comments` reported ranges

--- a/lib/rules/no-invalid-double-slash-comments/__tests__/index.mjs
+++ b/lib/rules/no-invalid-double-slash-comments/__tests__/index.mjs
@@ -1,6 +1,8 @@
 import rule from '../index.mjs';
 const { messages, ruleName } = rule;
 
+import { stripIndent } from 'common-tags';
+
 testRule({
 	ruleName,
 	config: [true],
@@ -17,6 +19,18 @@ testRule({
 		{
 			code: 'a { background: url(//foo.com/bar.png) }',
 			description: 'url with double slash',
+		},
+		{
+			code: stripIndent`
+				/* stylelint-disable-next-line no-invalid-double-slash-comments */
+				.a, // Comment 1
+				/* stylelint-disable-next-line no-invalid-double-slash-comments */
+				.b, // Comment 2
+				.c {
+					color: red;
+				}
+			`,
+			description: 'configuration commands interleaved with double slash comments',
 		},
 	],
 
@@ -74,6 +88,33 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 13,
+		},
+		{
+			code: stripIndent`
+				.a, // Comment 1
+				/* foo */
+				.b, // Comment 2
+				.c {
+					color: red;
+				}
+			`,
+			description: 'regular comments interleaved with double slash comments',
+			warnings: [
+				{
+					message: messages.rejected,
+					line: 1,
+					column: 5,
+					endLine: 2,
+					endColumn: 1,
+				},
+				{
+					message: messages.rejected,
+					line: 3,
+					column: 5,
+					endLine: 4,
+					endColumn: 1,
+				},
+			],
 		},
 	],
 });

--- a/lib/rules/no-invalid-double-slash-comments/index.cjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.cjs
@@ -2,6 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
+const getRuleSelector = require('../../utils/getRuleSelector.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -37,7 +38,7 @@ const rule = (primary) => {
 		});
 
 		root.walkRules((ruleNode) => {
-			const selectors = (ruleNode.raws?.selector?.raw ?? ruleNode.selector).split(',');
+			const selectors = getRuleSelector(ruleNode).split(',');
 
 			let ruleStringified;
 			let index = 0;

--- a/lib/rules/no-invalid-double-slash-comments/index.cjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.cjs
@@ -37,9 +37,9 @@ const rule = (primary) => {
 		});
 
 		root.walkRules((ruleNode) => {
-			// ruleNode.selectors elements are trimmed
-			const selectors = ruleNode.selector.split(',');
-			const ruleStringified = ruleNode.toString();
+			const selectors = (ruleNode.raws?.selector?.raw ?? ruleNode.selector).split(',');
+
+			let ruleStringified;
 			let index = 0;
 
 			for (const value of selectors) {
@@ -48,6 +48,8 @@ const rule = (primary) => {
 				if (selector.startsWith('//')) {
 					const offset = value.length - selector.length;
 					const i = index + offset;
+
+					ruleStringified ??= ruleNode.toString();
 					const lines = ruleStringified.slice(i).split('\n');
 					let comment = lines[0] ?? '';
 

--- a/lib/rules/no-invalid-double-slash-comments/index.mjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.mjs
@@ -33,9 +33,9 @@ const rule = (primary) => {
 		});
 
 		root.walkRules((ruleNode) => {
-			// ruleNode.selectors elements are trimmed
-			const selectors = ruleNode.selector.split(',');
-			const ruleStringified = ruleNode.toString();
+			const selectors = (ruleNode.raws?.selector?.raw ?? ruleNode.selector).split(',');
+
+			let ruleStringified;
 			let index = 0;
 
 			for (const value of selectors) {
@@ -44,6 +44,8 @@ const rule = (primary) => {
 				if (selector.startsWith('//')) {
 					const offset = value.length - selector.length;
 					const i = index + offset;
+
+					ruleStringified ??= ruleNode.toString();
 					const lines = ruleStringified.slice(i).split('\n');
 					let comment = lines[0] ?? '';
 

--- a/lib/rules/no-invalid-double-slash-comments/index.mjs
+++ b/lib/rules/no-invalid-double-slash-comments/index.mjs
@@ -1,3 +1,4 @@
+import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -33,7 +34,7 @@ const rule = (primary) => {
 		});
 
 		root.walkRules((ruleNode) => {
-			const selectors = (ruleNode.raws?.selector?.raw ?? ruleNode.selector).split(',');
+			const selectors = getRuleSelector(ruleNode).split(',');
 
 			let ruleStringified;
 			let index = 0;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/issues/7904

> Is there anything in the PR that needs further explanation?

I also noticed that rules were eagerly serialized, this is quite expensive.

This change:

```
;node benchmark-rule.mjs no-invalid-double-slash-comments 'true'                               
Warnings: 0
Mean: 95.35613458823532 ms
Deviation: 9.862092026552252 ms
```

Main:

```
;node benchmark-rule.mjs no-invalid-double-slash-comments 'true'
Warnings: 0
Mean: 118.80464825 ms
Deviation: 23.471924727353816 ms
```
