### PR TITLE
Fix `custom-property-no-missing-var-function` false positives for `view-transition-name`

### DIFF
--- a/.changeset/strange-nails-give.md
+++ b/.changeset/strange-nails-give.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Added: `view-transition-name` to the ignored properties by `custom-property-no-missing-var-function`

--- a/.changeset/strange-nails-give.md
+++ b/.changeset/strange-nails-give.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Added: `view-transition-name` to the ignored properties by `custom-property-no-missing-var-function`
+Fixed: `custom-property-no-missing-var-function` false positives for `view-transition-name`

--- a/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/__tests__/index.mjs
@@ -56,6 +56,9 @@ testRule({
 			code: '@property --foo {} a { transition: --foo; }',
 			description: 'ignore a property that can receive a custom-ident',
 		},
+		{
+			code: '@property --foo {} a { view-transition-name: --foo; }',
+		},
 	],
 
 	reject: [

--- a/lib/rules/custom-property-no-missing-var-function/index.cjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.cjs
@@ -18,10 +18,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
 
+// Properties that can receive a custom-ident
 const IGNORED_PROPERTIES = new Set([
-	// In alphabetical order
-
-	// Properties that can receive a custom-ident
 	'animation',
 	'animation-name',
 	'counter-increment',
@@ -37,6 +35,7 @@ const IGNORED_PROPERTIES = new Set([
 	'list-style-type',
 	'transition',
 	'transition-property',
+	'view-transition-name',
 	'will-change',
 ]);
 

--- a/lib/rules/custom-property-no-missing-var-function/index.mjs
+++ b/lib/rules/custom-property-no-missing-var-function/index.mjs
@@ -15,10 +15,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/custom-property-no-missing-var-function',
 };
 
+// Properties that can receive a custom-ident
 const IGNORED_PROPERTIES = new Set([
-	// In alphabetical order
-
-	// Properties that can receive a custom-ident
 	'animation',
 	'animation-name',
 	'counter-increment',
@@ -34,6 +32,7 @@ const IGNORED_PROPERTIES = new Set([
 	'list-style-type',
 	'transition',
 	'transition-property',
+	'view-transition-name',
 	'will-change',
 ]);
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

https://github.com/stylelint/stylelint/issues/7911#issuecomment-2278017759

> Is there anything in the PR that needs further explanation?

N/A