### PR TITLE
Fix `.cjs` files clean up

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,19 +5,20 @@ import { rmSync } from 'node:fs';
 
 import fg from 'fast-glob';
 
+const testFileGlobs = ['!**/__tests__/**', '!lib/testUtils/**'];
+
+// clean up
+for (const cjs of fg.globSync(['lib/**/*.cjs', ...testFileGlobs])) {
+	rmSync(cjs);
+}
+
 const inputFiles = fg.globSync([
 	'lib/**/*.mjs',
-	'!**/__tests__/**',
-	'!lib/testUtils/**',
+	...testFileGlobs,
 
 	// NOTE: We cannot support CommonJS for `cli.mjs` since the `meow` dependency is pure ESM.
 	'!lib/cli.mjs',
 ]);
-
-// clean up
-for (const input of inputFiles) {
-	rmSync(input.replace('.mjs', '.cjs'), { force: true });
-}
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url));
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

We found this issue in <https://github.com/stylelint/stylelint/pull/7918#issuecomment-2283016175>.

> Is there anything in the PR that needs further explanation?

This change eliminates *all* `.cjs` files before the build to prevent us from forgetting to delete unused `.cjs` files.

Verification:

```shell
# Add `.mjs`/`.cjs` files for a module
echo "export default 'foo';" > lib/foo.mjs
npm run build
git add lib/foo.*
git commit -m 'add lib/foo module'

# Remove the module files
rm lib/foo.mjs
npm run build
npm run build-check
```

Then, we see the following message:

```
You must commit the following files:
lib/foo.cjs
lib/foo.mjs
```
