### PR TITLE
Refactor to add `WarningOptions.StylelintWarningType` union type

### DIFF
--- a/lib/formatters/__tests__/compactFormatter.test.mjs
+++ b/lib/formatters/__tests__/compactFormatter.test.mjs
@@ -123,8 +123,8 @@ describe('compactFormatter', () => {
 					{
 						line: 1,
 						column: 1,
-						stylelintType: 'foo-error',
-						text: 'Cannot parse foo',
+						stylelintType: 'parseError',
+						text: 'Cannot parse selector',
 					},
 				],
 				warnings: [
@@ -146,7 +146,7 @@ describe('compactFormatter', () => {
 
 		const output = getCleanFormatterOutput(results, compactFormatter);
 
-		expect(output).toBe(`path/to/file.css: line 1, col 1, error - Cannot parse foo (foo-error)
+		expect(output).toBe(`path/to/file.css: line 1, col 1, error - Cannot parse selector (parseError)
 path/to/file.css: line 2, col 1, error - Anonymous error
 path/to/file.css: line 3, col 2, error - Unexpected foo`);
 	});

--- a/lib/formatters/__tests__/githubFormatter.test.mjs
+++ b/lib/formatters/__tests__/githubFormatter.test.mjs
@@ -51,8 +51,8 @@ describe('githubFormatter', () => {
 					{
 						line: 20,
 						column: 1,
-						stylelintType: 'foo-error',
-						text: 'Cannot parse foo',
+						stylelintType: 'ParseError',
+						text: 'Cannot parse selector',
 					},
 				],
 			},
@@ -67,7 +67,7 @@ describe('githubFormatter', () => {
 		expect(githubFormatter(results, returnValue))
 			.toBe(`::error file=path/to/file.css,line=1,col=2,endLine=1,endColumn=5,title=Stylelint problem::Unexpected "foo" (foo) - https://stylelint.io/rules/foo
 ::warning file=a.css,line=10,col=20,title=Stylelint problem::Unexpected "bar" (bar) [maybe fixable, deprecated] - https://stylelint.io/rules/bar
-::error file=a.css,line=20,col=1,title=Stylelint problem::Cannot parse foo (foo-error)
+::error file=a.css,line=20,col=1,title=Stylelint problem::Cannot parse selector (ParseError)
 ::error file=a.css,line=20,col=3,title=Stylelint problem::Anonymous error
 `);
 	});

--- a/lib/formatters/__tests__/githubFormatter.test.mjs
+++ b/lib/formatters/__tests__/githubFormatter.test.mjs
@@ -51,7 +51,7 @@ describe('githubFormatter', () => {
 					{
 						line: 20,
 						column: 1,
-						stylelintType: 'ParseError',
+						stylelintType: 'parseError',
 						text: 'Cannot parse selector',
 					},
 				],
@@ -67,7 +67,7 @@ describe('githubFormatter', () => {
 		expect(githubFormatter(results, returnValue))
 			.toBe(`::error file=path/to/file.css,line=1,col=2,endLine=1,endColumn=5,title=Stylelint problem::Unexpected "foo" (foo) - https://stylelint.io/rules/foo
 ::warning file=a.css,line=10,col=20,title=Stylelint problem::Unexpected "bar" (bar) [maybe fixable, deprecated] - https://stylelint.io/rules/bar
-::error file=a.css,line=20,col=1,title=Stylelint problem::Cannot parse selector (ParseError)
+::error file=a.css,line=20,col=1,title=Stylelint problem::Cannot parse selector (parseError)
 ::error file=a.css,line=20,col=3,title=Stylelint problem::Anonymous error
 `);
 	});

--- a/lib/formatters/__tests__/stringFormatter.test.mjs
+++ b/lib/formatters/__tests__/stringFormatter.test.mjs
@@ -612,8 +612,8 @@ path/to/file.css
 					{
 						line: 1,
 						column: 1,
-						stylelintType: 'foo-error',
-						text: 'Cannot parse foo',
+						stylelintType: 'ParseError',
+						text: 'Cannot parse selector',
 					},
 				],
 				warnings: [
@@ -637,9 +637,9 @@ path/to/file.css
 
 		expect(output).toBe(stripIndent`
 path/to/file.css
-  1:1  ×  Cannot parse foo  foo-error
+  1:1  ×  Cannot parse selector  ParseError
   2:1  ×  Anonymous error
-  3:1  ×  Disallow bar      no-bar
+  3:1  ×  Disallow bar           no-bar
 
 × 3 problems (3 errors, 0 warnings)`);
 	});

--- a/lib/formatters/__tests__/stringFormatter.test.mjs
+++ b/lib/formatters/__tests__/stringFormatter.test.mjs
@@ -612,7 +612,7 @@ path/to/file.css
 					{
 						line: 1,
 						column: 1,
-						stylelintType: 'ParseError',
+						stylelintType: 'parseError',
 						text: 'Cannot parse selector',
 					},
 				],
@@ -637,7 +637,7 @@ path/to/file.css
 
 		expect(output).toBe(stripIndent`
 path/to/file.css
-  1:1  ×  Cannot parse selector  ParseError
+  1:1  ×  Cannot parse selector  parseError
   2:1  ×  Anonymous error
   3:1  ×  Disallow bar           no-bar
 

--- a/lib/formatters/__tests__/tapFormatter.test.mjs
+++ b/lib/formatters/__tests__/tapFormatter.test.mjs
@@ -236,8 +236,8 @@ ok 1 - ${results[0].source} # SKIP ignored
 					{
 						line: 1,
 						column: 1,
-						stylelintType: 'foo-error',
-						text: 'Cannot parse foo',
+						stylelintType: 'parseError',
+						text: 'Cannot parse selector',
 					},
 				],
 			},
@@ -249,8 +249,8 @@ ok 1 - ${results[0].source} # SKIP ignored
 1..1
 not ok 1 - path/to/file.css
   ---
-  foo-error:
-    - message: "Cannot parse foo (foo-error)"
+  parseError:
+    - message: "Cannot parse selector (parseError)"
       severity: error
       line: 1
       column: 1

--- a/lib/formatters/__tests__/unixFormatter.test.mjs
+++ b/lib/formatters/__tests__/unixFormatter.test.mjs
@@ -143,7 +143,7 @@ path/to/file.css:1:1: Unexpected very very very very very very very very very ve
 					{
 						line: 1,
 						column: 1,
-						stylelintType: 'ParseError',
+						stylelintType: 'parseError',
 						text: 'Cannot parse selector',
 					},
 				],
@@ -160,7 +160,7 @@ path/to/file.css:1:1: Unexpected very very very very very very very very very ve
 		const output = getCleanFormatterOutput(results, unixFormatter);
 
 		expect(output).toBe(stripIndent`
-path/to/file.css:1:1: Cannot parse selector (ParseError) [error]
+path/to/file.css:1:1: Cannot parse selector (parseError) [error]
 path/to/file.css:2:1: Anonymous error [error]
 
 2 problems (2 errors, 0 warnings)`);

--- a/lib/formatters/__tests__/unixFormatter.test.mjs
+++ b/lib/formatters/__tests__/unixFormatter.test.mjs
@@ -143,8 +143,8 @@ path/to/file.css:1:1: Unexpected very very very very very very very very very ve
 					{
 						line: 1,
 						column: 1,
-						stylelintType: 'foo-error',
-						text: 'Cannot parse foo',
+						stylelintType: 'ParseError',
+						text: 'Cannot parse selector',
 					},
 				],
 				warnings: [
@@ -160,7 +160,7 @@ path/to/file.css:1:1: Unexpected very very very very very very very very very ve
 		const output = getCleanFormatterOutput(results, unixFormatter);
 
 		expect(output).toBe(stripIndent`
-path/to/file.css:1:1: Cannot parse foo (foo-error) [error]
+path/to/file.css:1:1: Cannot parse selector (ParseError) [error]
 path/to/file.css:2:1: Anonymous error [error]
 
 2 problems (2 errors, 0 warnings)`);

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -168,9 +168,11 @@ declare namespace stylelint {
 		config?: Config;
 	};
 
+	type StylelintType = 'deprecation' | 'invalidOption' | 'parseError';
+
 	/** @internal */
 	export type WarningOptions = PostCSS.WarningOptions & {
-		stylelintType?: string;
+		stylelintType?: StylelintType;
 		severity?: Severity;
 		url?: string;
 		rule?: string;
@@ -512,7 +514,7 @@ declare namespace stylelint {
 		severity: Severity;
 		text: string;
 		url?: string;
-		stylelintType?: string;
+		stylelintType?: StylelintType;
 	};
 
 	/**
@@ -527,7 +529,7 @@ declare namespace stylelint {
 		invalidOptionWarnings: {
 			text: string;
 		}[];
-		parseErrors: (PostCSS.Warning & { stylelintType: string })[];
+		parseErrors: (PostCSS.Warning & { stylelintType: Extract<StylelintType, 'parseError'> })[];
 		errored?: boolean;
 		warnings: Warning[];
 		ignored?: boolean;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -168,11 +168,11 @@ declare namespace stylelint {
 		config?: Config;
 	};
 
-	type StylelintType = 'deprecation' | 'invalidOption' | 'parseError';
+	type StylelintWarningType = 'deprecation' | 'invalidOption' | 'parseError';
 
 	/** @internal */
 	export type WarningOptions = PostCSS.WarningOptions & {
-		stylelintType?: StylelintType;
+		stylelintType?: StylelintWarningType;
 		severity?: Severity;
 		url?: string;
 		rule?: string;
@@ -514,7 +514,7 @@ declare namespace stylelint {
 		severity: Severity;
 		text: string;
 		url?: string;
-		stylelintType?: StylelintType;
+		stylelintType?: StylelintWarningType;
 	};
 
 	/**
@@ -529,7 +529,9 @@ declare namespace stylelint {
 		invalidOptionWarnings: {
 			text: string;
 		}[];
-		parseErrors: (PostCSS.Warning & { stylelintType: Extract<StylelintType, 'parseError'> })[];
+		parseErrors: (PostCSS.Warning & {
+			stylelintType: Extract<StylelintWarningType, 'parseError'>;
+		})[];
 		errored?: boolean;
 		warnings: Warning[];
 		ignored?: boolean;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

slightly related to #7845

> Is there anything in the PR that needs further explanation?


1. There are 2 places where we set `stylelintType` to `'parseError'`:

https://github.com/stylelint/stylelint/blob/860acdccb666ee3429d8509e596ce81708448b3f/lib/utils/transformSelector.mjs#L13

https://github.com/stylelint/stylelint/blob/860acdccb666ee3429d8509e596ce81708448b3f/lib/utils/parseSelector.mjs#L22

I chose the first one for the formatter tests.
i.e. the second one would have 2 parentheses

https://github.com/stylelint/stylelint/blob/860acdccb666ee3429d8509e596ce81708448b3f/lib/formatters/preprocessWarnings.mjs#L39

The tests wouldn't fail without these changes; I just thought it would be more accurate.

2. `Result.Message`'s index signature is `any` so you won't get any auto-suggestions in your IDE.
3. I didn't update this comment:
 https://github.com/stylelint/stylelint/blob/860acdccb666ee3429d8509e596ce81708448b3f/lib/createPartialStylelintResult.mjs#L61-L62