### PR TITLE
Fix `selector-no-qualifying-type` reported ranges

### DIFF
--- a/.changeset/stupid-walls-glow.md
+++ b/.changeset/stupid-walls-glow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-no-qualifying-type` reported ranges

--- a/lib/rules/selector-no-qualifying-type/__tests__/index.mjs
+++ b/lib/rules/selector-no-qualifying-type/__tests__/index.mjs
@@ -255,6 +255,16 @@ testRule({
 			code: 'html { --custom-property-set: {} }',
 			description: 'custom property set in selector',
 		},
+		{
+			code: stripIndent`
+				/* stylelint-disable-next-line selector-no-qualifying-type */
+				div#thing, /* stylelint-disable-next-line selector-no-qualifying-type */
+				div#thing,
+				/* stylelint-disable-next-line selector-no-qualifying-type */
+				div#thing
+				{}
+			`,
+		},
 	],
 
 	reject: [
@@ -363,6 +373,22 @@ testRule({
 			endColumn: 10,
 		},
 		{
+			code: 'div:hover#thing { }',
+			message: messages.rejected('div:hover#thing'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 16,
+		},
+		{
+			code: 'div:hover#thing a { }',
+			message: messages.rejected('div:hover#thing'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 16,
+		},
+		{
 			code: 'a:hover div#thing { }',
 			message: messages.rejected('div#thing'),
 			line: 1,
@@ -409,6 +435,14 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 8,
+		},
+		{
+			code: 'ul.list.list--modifier, a { }',
+			message: messages.rejected('ul.list.list--modifier'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 23,
 		},
 		{
 			code: 'a, ul.list { }',
@@ -641,6 +675,39 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 16,
+		},
+		{
+			code: stripIndent`
+				/* a comment */
+				div#thing, /* a comment */
+				div#thing,
+				/* a comment */
+				div#thing
+				{}
+			`,
+			warnings: [
+				{
+					message: messages.rejected('div#thing'),
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 10,
+				},
+				{
+					message: messages.rejected('div#thing'),
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 10,
+				},
+				{
+					message: messages.rejected('div#thing'),
+					line: 5,
+					column: 1,
+					endLine: 5,
+					endColumn: 10,
+				},
+			],
 		},
 	],
 });
@@ -2181,7 +2248,7 @@ testRule({
 			line: 1,
 			column: 5,
 			endLine: 1,
-			endColumn: 20,
+			endColumn: 17,
 		},
 		{
 			code: 'a { &.class {} }',
@@ -2189,7 +2256,7 @@ testRule({
 			line: 1,
 			column: 5,
 			endLine: 1,
-			endColumn: 15,
+			endColumn: 12,
 		},
 		{
 			code: 'a { &#id {} }',
@@ -2197,7 +2264,7 @@ testRule({
 			line: 1,
 			column: 5,
 			endLine: 1,
-			endColumn: 12,
+			endColumn: 9,
 		},
 		{
 			code: 'div a { &[attribute] {} }',
@@ -2205,7 +2272,7 @@ testRule({
 			line: 1,
 			column: 9,
 			endLine: 1,
-			endColumn: 24,
+			endColumn: 21,
 		},
 		{
 			code: 'div a { &.class {} }',
@@ -2213,7 +2280,7 @@ testRule({
 			line: 1,
 			column: 9,
 			endLine: 1,
-			endColumn: 19,
+			endColumn: 16,
 		},
 		{
 			code: 'div a { &#id {} }',
@@ -2221,7 +2288,7 @@ testRule({
 			line: 1,
 			column: 9,
 			endLine: 1,
-			endColumn: 16,
+			endColumn: 13,
 		},
 		{
 			code: 'div { & > a { &[attribute] {} } }',
@@ -2229,7 +2296,7 @@ testRule({
 			line: 1,
 			column: 15,
 			endLine: 1,
-			endColumn: 30,
+			endColumn: 27,
 		},
 		{
 			code: 'div { & > a { &.class {} } }',
@@ -2237,7 +2304,7 @@ testRule({
 			line: 1,
 			column: 15,
 			endLine: 1,
-			endColumn: 25,
+			endColumn: 22,
 		},
 		{
 			code: 'div { & > a { &#id {} } }',
@@ -2245,7 +2312,7 @@ testRule({
 			line: 1,
 			column: 15,
 			endLine: 1,
-			endColumn: 22,
+			endColumn: 19,
 		},
 	],
 });
@@ -2309,7 +2376,7 @@ testRule({
 			line: 1,
 			column: 5,
 			endLine: 1,
-			endColumn: 20,
+			endColumn: 17,
 		},
 		{
 			code: 'a { &.class {} }',
@@ -2317,7 +2384,7 @@ testRule({
 			line: 1,
 			column: 5,
 			endLine: 1,
-			endColumn: 15,
+			endColumn: 12,
 		},
 		{
 			code: 'a { &#id {} }',
@@ -2325,7 +2392,7 @@ testRule({
 			line: 1,
 			column: 5,
 			endLine: 1,
-			endColumn: 12,
+			endColumn: 9,
 		},
 		{
 			code: 'div a { &[attribute] {} }',
@@ -2333,7 +2400,7 @@ testRule({
 			line: 1,
 			column: 9,
 			endLine: 1,
-			endColumn: 24,
+			endColumn: 21,
 		},
 		{
 			code: 'div a { &.class {} }',
@@ -2341,7 +2408,7 @@ testRule({
 			line: 1,
 			column: 9,
 			endLine: 1,
-			endColumn: 19,
+			endColumn: 16,
 		},
 		{
 			code: 'div a { &#id {} }',
@@ -2349,7 +2416,7 @@ testRule({
 			line: 1,
 			column: 9,
 			endLine: 1,
-			endColumn: 16,
+			endColumn: 13,
 		},
 		{
 			code: 'div { & > a { &[attribute] {} } }',
@@ -2357,7 +2424,7 @@ testRule({
 			line: 1,
 			column: 15,
 			endLine: 1,
-			endColumn: 30,
+			endColumn: 27,
 		},
 		{
 			code: 'div { & > a { &.class {} } }',
@@ -2365,7 +2432,7 @@ testRule({
 			line: 1,
 			column: 15,
 			endLine: 1,
-			endColumn: 25,
+			endColumn: 22,
 		},
 		{
 			code: 'div { & > a { &#id {} } }',
@@ -2373,7 +2440,7 @@ testRule({
 			line: 1,
 			column: 15,
 			endLine: 1,
-			endColumn: 22,
+			endColumn: 19,
 		},
 		{
 			code: stripIndent`

--- a/lib/rules/selector-no-qualifying-type/index.cjs
+++ b/lib/rules/selector-no-qualifying-type/index.cjs
@@ -2,13 +2,13 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-const resolvedNestedSelector = require('postcss-resolve-nested-selector');
+const selectorParser = require('postcss-selector-parser');
+const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelectorsForRule.cjs');
+const getStrippedSelectorSource = require('../../utils/getStrippedSelectorSource.cjs');
 const isKeyframeRule = require('../../utils/isKeyframeRule.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
-const isStandardSyntaxSelector = require('../../utils/isStandardSyntaxSelector.cjs');
 const isStandardSyntaxTypeSelector = require('../../utils/isStandardSyntaxTypeSelector.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
-const parseSelector = require('../../utils/parseSelector.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -23,36 +23,39 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-no-qualifying-type',
 };
 
-const selectorCharacters = ['#', '.', '['];
+const HAS_ID_CLASS_ATTRIBUTE_PREFIXES = /[#.[]/;
+
+/** @import { Tag, Node, Selector, Container } from 'postcss-selector-parser' */
 
 /**
- * @param {string} value
- * @returns {boolean}
- */
-function isSelectorCharacters(value) {
-	return selectorCharacters.some((char) => value.includes(char));
-}
-
-/**
- * @param {import('postcss-selector-parser').Tag} node
- * @returns {Array<import('postcss-selector-parser').Node>}
+ * @param {Tag} node
+ * @returns {Array<Node>}
  */
 function getRightNodes(node) {
+	/** @type {Array<Node>} */
 	const result = [];
 
-	/** @type {import('postcss-selector-parser').Node | undefined} */
+	/** @type {Node | undefined} */
 	let rightNode = node;
 
 	while ((rightNode = rightNode.next())) {
-		if (rightNode.type === 'combinator') {
+		if (selectorParser.isCombinator(rightNode) || selectorParser.isPseudoElement(rightNode)) {
 			break;
 		}
 
-		if (rightNode.type !== 'id' && rightNode.type !== 'class' && rightNode.type !== 'attribute') {
-			continue;
+		result.push(rightNode);
+	}
+
+	while ((rightNode = result.at(-1))) {
+		if (
+			selectorParser.isIdentifier(rightNode) ||
+			selectorParser.isClassName(rightNode) ||
+			selectorParser.isAttribute(rightNode)
+		) {
+			break;
 		}
 
-		result.push(rightNode);
+		result.splice(-1, 1);
 	}
 
 	return result;
@@ -94,15 +97,17 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			if (!isSelectorCharacters(ruleNode.selector)) {
+			if (!HAS_ID_CLASS_ATTRIBUTE_PREFIXES.test(ruleNode.selector)) {
 				return;
 			}
 
 			/**
-			 * @param {import('postcss-selector-parser').Root} selectorAST
+			 * @param {Container<string | undefined>} resolvedSelectorNode
+			 * @param {Selector} selectorNode
+			 * @param {boolean} nested
 			 */
-			function checkSelector(selectorAST) {
-				selectorAST.walkTags((tagNode) => {
+			function checkSelector(resolvedSelectorNode, selectorNode, nested) {
+				resolvedSelectorNode.walkTags((tagNode) => {
 					if (!isStandardSyntaxTypeSelector(tagNode)) return;
 
 					const selectorParent = tagNode.parent;
@@ -111,45 +116,46 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
-					const selectorNodes = getRightNodes(tagNode);
+					const rightNodes = getRightNodes(tagNode);
 
-					for (const selectorNode of selectorNodes) {
+					for (const rightNode of rightNodes) {
 						if (
-							(selectorNode.type === 'id' && !ignoreId) ||
-							(selectorNode.type === 'class' && !ignoreClass) ||
-							(selectorNode.type === 'attribute' && !ignoreAttribute)
+							(rightNode.type === 'id' && !ignoreId) ||
+							(rightNode.type === 'class' && !ignoreClass) ||
+							(rightNode.type === 'attribute' && !ignoreAttribute)
 						) {
-							const selector = [tagNode, ...selectorNodes].join('').trimStart();
+							let index = 0;
+							let endIndex = 0;
+							const selector = [tagNode, ...rightNodes].join('').trim();
 
-							complain(selector);
+							if (nested) {
+								({ index, endIndex } = getStrippedSelectorSource(selectorNode));
+							} else {
+								index = tagNode.sourceIndex ?? 0;
+								endIndex = index + selector.length;
+							}
+
+							report({
+								ruleName,
+								result,
+								node: ruleNode,
+								message: messages.rejected,
+								messageArgs: [selector],
+								index,
+								endIndex,
+							});
+
+							break;
 						}
 					}
 				});
 			}
 
-			for (const resolvedSelector of resolvedNestedSelector(ruleNode.selector, ruleNode)) {
-				if (!isStandardSyntaxSelector(resolvedSelector)) {
-					continue;
-				}
-
-				const selectorRoot = parseSelector(resolvedSelector, result, ruleNode);
-
-				if (selectorRoot) checkSelector(selectorRoot);
-			}
-
-			/**
-			 * @param {string} selector
-			 */
-			function complain(selector) {
-				report({
-					ruleName,
-					result,
-					node: ruleNode,
-					message: messages.rejected,
-					messageArgs: [selector],
-					word: selector,
-				});
-			}
+			flattenNestedSelectorsForRule(ruleNode, result).forEach(
+				({ selector, resolvedSelectors, nested }) => {
+					checkSelector(resolvedSelectors, selector, nested);
+				},
+			);
 		});
 	};
 };

--- a/lib/rules/selector-no-qualifying-type/index.mjs
+++ b/lib/rules/selector-no-qualifying-type/index.mjs
@@ -1,11 +1,11 @@
-import resolvedNestedSelector from 'postcss-resolve-nested-selector';
+import selectorParser from 'postcss-selector-parser';
 
+import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsForRule.mjs';
+import getStrippedSelectorSource from '../../utils/getStrippedSelectorSource.mjs';
 import isKeyframeRule from '../../utils/isKeyframeRule.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
-import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import isStandardSyntaxTypeSelector from '../../utils/isStandardSyntaxTypeSelector.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
-import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -20,36 +20,39 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-no-qualifying-type',
 };
 
-const selectorCharacters = ['#', '.', '['];
+const HAS_ID_CLASS_ATTRIBUTE_PREFIXES = /[#.[]/;
+
+/** @import { Tag, Node, Selector, Container } from 'postcss-selector-parser' */
 
 /**
- * @param {string} value
- * @returns {boolean}
- */
-function isSelectorCharacters(value) {
-	return selectorCharacters.some((char) => value.includes(char));
-}
-
-/**
- * @param {import('postcss-selector-parser').Tag} node
- * @returns {Array<import('postcss-selector-parser').Node>}
+ * @param {Tag} node
+ * @returns {Array<Node>}
  */
 function getRightNodes(node) {
+	/** @type {Array<Node>} */
 	const result = [];
 
-	/** @type {import('postcss-selector-parser').Node | undefined} */
+	/** @type {Node | undefined} */
 	let rightNode = node;
 
 	while ((rightNode = rightNode.next())) {
-		if (rightNode.type === 'combinator') {
+		if (selectorParser.isCombinator(rightNode) || selectorParser.isPseudoElement(rightNode)) {
 			break;
 		}
 
-		if (rightNode.type !== 'id' && rightNode.type !== 'class' && rightNode.type !== 'attribute') {
-			continue;
+		result.push(rightNode);
+	}
+
+	while ((rightNode = result.at(-1))) {
+		if (
+			selectorParser.isIdentifier(rightNode) ||
+			selectorParser.isClassName(rightNode) ||
+			selectorParser.isAttribute(rightNode)
+		) {
+			break;
 		}
 
-		result.push(rightNode);
+		result.splice(-1, 1);
 	}
 
 	return result;
@@ -91,15 +94,17 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			if (!isSelectorCharacters(ruleNode.selector)) {
+			if (!HAS_ID_CLASS_ATTRIBUTE_PREFIXES.test(ruleNode.selector)) {
 				return;
 			}
 
 			/**
-			 * @param {import('postcss-selector-parser').Root} selectorAST
+			 * @param {Container<string | undefined>} resolvedSelectorNode
+			 * @param {Selector} selectorNode
+			 * @param {boolean} nested
 			 */
-			function checkSelector(selectorAST) {
-				selectorAST.walkTags((tagNode) => {
+			function checkSelector(resolvedSelectorNode, selectorNode, nested) {
+				resolvedSelectorNode.walkTags((tagNode) => {
 					if (!isStandardSyntaxTypeSelector(tagNode)) return;
 
 					const selectorParent = tagNode.parent;
@@ -108,45 +113,46 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
-					const selectorNodes = getRightNodes(tagNode);
+					const rightNodes = getRightNodes(tagNode);
 
-					for (const selectorNode of selectorNodes) {
+					for (const rightNode of rightNodes) {
 						if (
-							(selectorNode.type === 'id' && !ignoreId) ||
-							(selectorNode.type === 'class' && !ignoreClass) ||
-							(selectorNode.type === 'attribute' && !ignoreAttribute)
+							(rightNode.type === 'id' && !ignoreId) ||
+							(rightNode.type === 'class' && !ignoreClass) ||
+							(rightNode.type === 'attribute' && !ignoreAttribute)
 						) {
-							const selector = [tagNode, ...selectorNodes].join('').trimStart();
+							let index = 0;
+							let endIndex = 0;
+							const selector = [tagNode, ...rightNodes].join('').trim();
 
-							complain(selector);
+							if (nested) {
+								({ index, endIndex } = getStrippedSelectorSource(selectorNode));
+							} else {
+								index = tagNode.sourceIndex ?? 0;
+								endIndex = index + selector.length;
+							}
+
+							report({
+								ruleName,
+								result,
+								node: ruleNode,
+								message: messages.rejected,
+								messageArgs: [selector],
+								index,
+								endIndex,
+							});
+
+							break;
 						}
 					}
 				});
 			}
 
-			for (const resolvedSelector of resolvedNestedSelector(ruleNode.selector, ruleNode)) {
-				if (!isStandardSyntaxSelector(resolvedSelector)) {
-					continue;
-				}
-
-				const selectorRoot = parseSelector(resolvedSelector, result, ruleNode);
-
-				if (selectorRoot) checkSelector(selectorRoot);
-			}
-
-			/**
-			 * @param {string} selector
-			 */
-			function complain(selector) {
-				report({
-					ruleName,
-					result,
-					node: ruleNode,
-					message: messages.rejected,
-					messageArgs: [selector],
-					word: selector,
-				});
-			}
+			flattenNestedSelectorsForRule(ruleNode, result).forEach(
+				({ selector, resolvedSelectors, nested }) => {
+					checkSelector(resolvedSelectors, selector, nested);
+				},
+			);
 		});
 	};
 };

--- a/lib/utils/flattenNestedSelectorsForRule.cjs
+++ b/lib/utils/flattenNestedSelectorsForRule.cjs
@@ -8,13 +8,19 @@ const getRuleSelector = require('./getRuleSelector.cjs');
 const isStandardSyntaxSelector = require('./isStandardSyntaxSelector.cjs');
 const parseSelector = require('./parseSelector.cjs');
 
+/** @import { Selector, Root } from 'postcss-selector-parser' */
+/** @import { Rule } from 'postcss' */
+/** @import { PostcssResult } from 'stylelint' */
+
 /**
- * @typedef {import('postcss-selector-parser').Selector} Selector
- * @typedef {import('postcss-selector-parser').Root} Root
+ * Flatten the selectors of the current rule against it's parent rules and at-rules.
+ *
+ * The selectors for the current rule are assumed to be standard CSS selectors.
+ *
  * @typedef {{selector: Selector, resolvedSelectors: Root, nested: boolean}} FlattenedSelector
  *
- * @param {import('postcss').Rule} rule
- * @param {import('stylelint').PostcssResult} result
+ * @param {Rule} rule
+ * @param {PostcssResult} result
  * @returns {Array<FlattenedSelector>}
  */
 function flattenNestedSelectorsForRule(rule, result) {

--- a/lib/utils/flattenNestedSelectorsForRule.cjs
+++ b/lib/utils/flattenNestedSelectorsForRule.cjs
@@ -3,6 +3,7 @@
 'use strict';
 
 const resolveNestedSelector = require('postcss-resolve-nested-selector');
+const selectorParser = require('postcss-selector-parser');
 const getRuleSelector = require('./getRuleSelector.cjs');
 const isStandardSyntaxSelector = require('./isStandardSyntaxSelector.cjs');
 const parseSelector = require('./parseSelector.cjs');
@@ -10,20 +11,37 @@ const parseSelector = require('./parseSelector.cjs');
 /**
  * @typedef {import('postcss-selector-parser').Selector} Selector
  * @typedef {import('postcss-selector-parser').Root} Root
+ * @typedef {{selector: Selector, resolvedSelectors: Root, nested: boolean}} FlattenedSelector
  *
  * @param {import('postcss').Rule} rule
  * @param {import('stylelint').PostcssResult} result
- * @returns {Array<{selector: Selector, resolvedSelectors: Root}>}
+ * @returns {Array<FlattenedSelector>}
  */
 function flattenNestedSelectorsForRule(rule, result) {
 	const ownAST = parseSelector(getRuleSelector(rule), result, rule);
 
 	if (!ownAST) return [];
 
+	/** @type {Array<FlattenedSelector>} */
 	const flattenedSelectors = [];
 
 	for (const selectorAST of ownAST.nodes) {
-		const resolvedSelectors = resolveNestedSelector(selectorAST.toString(), rule);
+		const selector = selectorAST.toString();
+
+		const resolvedSelectors = resolveNestedSelector(selector, rule);
+
+		if (resolvedSelectors.length === 1 && resolvedSelectors[0] === selector) {
+			flattenedSelectors.push({
+				selector: selectorAST,
+				resolvedSelectors: selectorParser.root({
+					value: '',
+					nodes: [selectorAST],
+				}),
+				nested: false,
+			});
+
+			continue;
+		}
 
 		for (const resolvedSelector of resolvedSelectors) {
 			if (!isStandardSyntaxSelector(resolvedSelector)) return [];
@@ -37,6 +55,7 @@ function flattenNestedSelectorsForRule(rule, result) {
 			flattenedSelectors.push({
 				selector: selectorAST,
 				resolvedSelectors: resolvedRoot,
+				nested: true,
 			});
 		}
 	}

--- a/lib/utils/flattenNestedSelectorsForRule.mjs
+++ b/lib/utils/flattenNestedSelectorsForRule.mjs
@@ -5,13 +5,19 @@ import getRuleSelector from './getRuleSelector.mjs';
 import isStandardSyntaxSelector from './isStandardSyntaxSelector.mjs';
 import parseSelector from './parseSelector.mjs';
 
+/** @import { Selector, Root } from 'postcss-selector-parser' */
+/** @import { Rule } from 'postcss' */
+/** @import { PostcssResult } from 'stylelint' */
+
 /**
- * @typedef {import('postcss-selector-parser').Selector} Selector
- * @typedef {import('postcss-selector-parser').Root} Root
+ * Flatten the selectors of the current rule against it's parent rules and at-rules.
+ *
+ * The selectors for the current rule are assumed to be standard CSS selectors.
+ *
  * @typedef {{selector: Selector, resolvedSelectors: Root, nested: boolean}} FlattenedSelector
  *
- * @param {import('postcss').Rule} rule
- * @param {import('stylelint').PostcssResult} result
+ * @param {Rule} rule
+ * @param {PostcssResult} result
  * @returns {Array<FlattenedSelector>}
  */
 export default function flattenNestedSelectorsForRule(rule, result) {

--- a/lib/utils/flattenNestedSelectorsForRule.mjs
+++ b/lib/utils/flattenNestedSelectorsForRule.mjs
@@ -1,4 +1,5 @@
 import resolveNestedSelector from 'postcss-resolve-nested-selector';
+import selectorParser from 'postcss-selector-parser';
 
 import getRuleSelector from './getRuleSelector.mjs';
 import isStandardSyntaxSelector from './isStandardSyntaxSelector.mjs';
@@ -7,20 +8,37 @@ import parseSelector from './parseSelector.mjs';
 /**
  * @typedef {import('postcss-selector-parser').Selector} Selector
  * @typedef {import('postcss-selector-parser').Root} Root
+ * @typedef {{selector: Selector, resolvedSelectors: Root, nested: boolean}} FlattenedSelector
  *
  * @param {import('postcss').Rule} rule
  * @param {import('stylelint').PostcssResult} result
- * @returns {Array<{selector: Selector, resolvedSelectors: Root}>}
+ * @returns {Array<FlattenedSelector>}
  */
 export default function flattenNestedSelectorsForRule(rule, result) {
 	const ownAST = parseSelector(getRuleSelector(rule), result, rule);
 
 	if (!ownAST) return [];
 
+	/** @type {Array<FlattenedSelector>} */
 	const flattenedSelectors = [];
 
 	for (const selectorAST of ownAST.nodes) {
-		const resolvedSelectors = resolveNestedSelector(selectorAST.toString(), rule);
+		const selector = selectorAST.toString();
+
+		const resolvedSelectors = resolveNestedSelector(selector, rule);
+
+		if (resolvedSelectors.length === 1 && resolvedSelectors[0] === selector) {
+			flattenedSelectors.push({
+				selector: selectorAST,
+				resolvedSelectors: selectorParser.root({
+					value: '',
+					nodes: [selectorAST],
+				}),
+				nested: false,
+			});
+
+			continue;
+		}
 
 		for (const resolvedSelector of resolvedSelectors) {
 			if (!isStandardSyntaxSelector(resolvedSelector)) return [];
@@ -34,6 +52,7 @@ export default function flattenNestedSelectorsForRule(rule, result) {
 			flattenedSelectors.push({
 				selector: selectorAST,
 				resolvedSelectors: resolvedRoot,
+				nested: true,
 			});
 		}
 	}

--- a/system-tests/002/__snapshots__/fs.test.mjs.snap
+++ b/system-tests/002/__snapshots__/fs.test.mjs.snap
@@ -32,8 +32,8 @@ exports[`fs - invalid twbs buttons and their config 1`] = `
         },
         {
           "column": 3,
-          "endColumn": 4,
-          "endLine": 125,
+          "endColumn": 15,
+          "endLine": 123,
           "line": 123,
           "rule": "selector-no-qualifying-type",
           "severity": "error",
@@ -70,8 +70,8 @@ exports[`fs - invalid twbs buttons and their config 1`] = `
         },
         {
           "column": 3,
-          "endColumn": 4,
-          "endLine": 125,
+          "endColumn": 15,
+          "endLine": 123,
           "line": 123,
           "rule": "selector-no-qualifying-type",
           "severity": "error",
@@ -112,8 +112,8 @@ exports[`fs - invalid twbs buttons and their config 1`] = `
         },
         {
           "column": 3,
-          "endColumn": 4,
-          "endLine": 125,
+          "endColumn": 15,
+          "endLine": 123,
           "line": 123,
           "rule": "selector-no-qualifying-type",
           "severity": "error",

--- a/system-tests/002/__snapshots__/no-fs.test.mjs.snap
+++ b/system-tests/002/__snapshots__/no-fs.test.mjs.snap
@@ -32,8 +32,8 @@ exports[`no-fs - invalid twbs buttons and their config 1`] = `
         },
         {
           "column": 3,
-          "endColumn": 4,
-          "endLine": 125,
+          "endColumn": 15,
+          "endLine": 123,
           "line": 123,
           "rule": "selector-no-qualifying-type",
           "severity": "error",
@@ -70,8 +70,8 @@ exports[`no-fs - invalid twbs buttons and their config 1`] = `
         },
         {
           "column": 3,
-          "endColumn": 4,
-          "endLine": 125,
+          "endColumn": 15,
+          "endLine": 123,
           "line": 123,
           "rule": "selector-no-qualifying-type",
           "severity": "error",
@@ -112,8 +112,8 @@ exports[`no-fs - invalid twbs buttons and their config 1`] = `
         },
         {
           "column": 3,
-          "endColumn": 4,
-          "endLine": 125,
+          "endColumn": 15,
+          "endLine": 123,
           "line": 123,
           "rule": "selector-no-qualifying-type",
           "severity": "error",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See:
- https://github.com/stylelint/stylelint/issues/7904
- https://github.com/stylelint/stylelint/issues/6234

> Is there anything in the PR that needs further explanation?

This was the last one in this series and I was still unhappy with the reduced precision of reported ranges for regular, not-nested, selectors.

For all nested selectors it becomes impossible to know if the problematic part of the selector appears exactly in the same form in source or if it was artificially constructed when resolving the nested selector. So it also becomes impossible to have a report range for a part of a selector.

However this restriction only exists for nested selectors.

I've added a boolean flag to `flattenNestedSelectorsForRule` so that we have better report ranges for regular selectors.
