### PR TITLE
Fix `declaration-property-value-no-unknown` false positives

### DIFF
--- a/.changeset/famous-glasses-trade.md
+++ b/.changeset/famous-glasses-trade.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-property-value-no-unknown` false positives

--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
@@ -358,7 +358,7 @@ testRule({
 			code: 'a { text-box-trim: none; }',
 		},
 		{
-			code: 'a { text-spacing-trim: space-first }',
+			code: 'a { text-spacing-trim: space-first; }',
 		},
 		{
 			code: 'a { text-wrap-style: stable; }',

--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
@@ -57,6 +57,18 @@ testRule({
 			code: 'a { font-size: max(1rem, 3rem); }',
 		},
 		{
+			code: 'a { word-break: auto-phrase; }',
+		},
+		{
+			code: 'a { field-sizing: content; }',
+		},
+		{
+			code: 'a { overflow: overlay; }',
+		},
+		{
+			code: 'a { width: min-intrinsic; }',
+		},
+		{
 			code: stripIndent`
 				a { font-weight: bolder; }
 				@font-face { font-weight: 100 200; }
@@ -135,6 +147,14 @@ testRule({
 	],
 
 	reject: [
+		{
+			code: 'a { text-box-edge: text ex; }',
+			message: messages.rejected('text-box-edge', 'ex'),
+			line: 1,
+			column: 25,
+			endLine: 1,
+			endColumn: 27,
+		},
 		{
 			code: 'a { top: unknown; }',
 			message: messages.rejected('top', 'unknown'),
@@ -327,6 +347,21 @@ testRule({
 	accept: [
 		{
 			code: 'a { size: 10px; }',
+		},
+		{
+			code: 'a { text-box-edge: ideographic-ink; }',
+		},
+		{
+			code: 'a { text-box-edge: ex text; }',
+		},
+		{
+			code: 'a { text-box-trim: none; }',
+		},
+		{
+			code: 'a { text-spacing-trim: space-first }',
+		},
+		{
+			code: 'a { text-wrap-style: stable; }',
 		},
 	],
 

--- a/lib/rules/declaration-property-value-no-unknown/index.cjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.cjs
@@ -69,7 +69,7 @@ const rule = (primary, secondaryOptions) => {
 			width: '| min-intrinsic | -moz-min-content | -moz-available | -webkit-fill-available', // csstree/csstree#242
 			'field-sizing': 'content | fixed',
 			'text-box-edge':
-				'[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
+				'auto | [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
 			'text-box-trim': 'none | trim-start | trim-end | trim-both',
 			'text-spacing-trim': 'normal | space-all | space-first | trim-start',
 			'text-wrap-style': 'auto | balance | pretty | stable',

--- a/lib/rules/declaration-property-value-no-unknown/index.cjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.cjs
@@ -30,7 +30,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown',
 };
 
-const SYNTAX_PROPERTY = /^syntax$/i;
+const SYNTAX_DESCRIPTOR = /^syntax$/i;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
@@ -65,10 +65,19 @@ const rule = (primary, secondaryOptions) => {
 		};
 
 		const propertiesSyntax = {
-			// Take a shallow clone as this object will be appended to.
-			...(secondaryOptions?.propertiesSyntax ?? {}),
+			overflow: '| overlay', // csstree/csstree#248
+			width: '| min-intrinsic | -moz-min-content | -moz-available | -webkit-fill-available', // csstree/csstree#242
+			'field-sizing': 'content | fixed',
+			'text-box-edge':
+				'[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
+			'text-box-trim': 'none | trim-start | trim-end | trim-both',
+			'text-spacing-trim': 'normal | space-all | space-first | trim-start',
+			'text-wrap-style': 'auto | balance | pretty | stable',
+			'word-break': '| auto-phrase',
+			...secondaryOptions?.propertiesSyntax,
 		};
-		const typesSyntax = secondaryOptions?.typesSyntax ?? {};
+		// TODO csstree/csstree#244
+		const typesSyntax = { ...secondaryOptions?.typesSyntax };
 
 		/** @type {Map<string, string>} */
 		const typedCustomPropertyNames = new Map();
@@ -79,7 +88,7 @@ const rule = (primary, secondaryOptions) => {
 			if (!propName || !atRule.nodes || !isCustomProperty(propName)) return;
 
 			for (const node of atRule.nodes) {
-				if (typeGuards.isDeclaration(node) && SYNTAX_PROPERTY.test(node.prop)) {
+				if (typeGuards.isDeclaration(node) && SYNTAX_DESCRIPTOR.test(node.prop)) {
 					const value = node.value.trim();
 					const unquoted = cssTree.string.decode(value);
 
@@ -114,8 +123,8 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls((decl) => {
 			const { prop, value, parent } = decl;
 
+			// csstree/csstree#243
 			// NOTE: CSSTree's `fork()` doesn't support `-moz-initial`, but it may be possible in the future.
-			// See https://github.com/stylelint/stylelint/pull/6511#issuecomment-1412921062
 			if (/^-moz-initial$/i.test(value)) return;
 
 			if (!isStandardSyntaxDeclaration(decl)) return;
@@ -128,7 +137,7 @@ const rule = (primary, secondaryOptions) => {
 
 			if (isPropIgnored(prop, value)) return;
 
-			// https://github.com/mdn/data/pull/674
+			// mdn/data#674
 			// `initial-value` has an incorrect syntax definition.
 			// In reality everything is valid.
 			if (
@@ -198,9 +207,6 @@ const rule = (primary, secondaryOptions) => {
  *
  * @see csstree/csstree#164 min, max, clamp
  * @see csstree/csstree#245 env
- * @see https://github.com/stylelint/stylelint/pull/6511#issuecomment-1412921062
- * @see https://github.com/stylelint/stylelint/issues/6635#issuecomment-1425787649
- *
  * @param {import('css-tree').CssNode} cssTreeNode
  * @returns {boolean}
  */

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -27,7 +27,7 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown',
 };
 
-const SYNTAX_PROPERTY = /^syntax$/i;
+const SYNTAX_DESCRIPTOR = /^syntax$/i;
 
 /** @type {import('stylelint').Rule} */
 const rule = (primary, secondaryOptions) => {
@@ -62,10 +62,19 @@ const rule = (primary, secondaryOptions) => {
 		};
 
 		const propertiesSyntax = {
-			// Take a shallow clone as this object will be appended to.
-			...(secondaryOptions?.propertiesSyntax ?? {}),
+			overflow: '| overlay', // csstree/csstree#248
+			width: '| min-intrinsic | -moz-min-content | -moz-available | -webkit-fill-available', // csstree/csstree#242
+			'field-sizing': 'content | fixed',
+			'text-box-edge':
+				'[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
+			'text-box-trim': 'none | trim-start | trim-end | trim-both',
+			'text-spacing-trim': 'normal | space-all | space-first | trim-start',
+			'text-wrap-style': 'auto | balance | pretty | stable',
+			'word-break': '| auto-phrase',
+			...secondaryOptions?.propertiesSyntax,
 		};
-		const typesSyntax = secondaryOptions?.typesSyntax ?? {};
+		// TODO csstree/csstree#244
+		const typesSyntax = { ...secondaryOptions?.typesSyntax };
 
 		/** @type {Map<string, string>} */
 		const typedCustomPropertyNames = new Map();
@@ -76,7 +85,7 @@ const rule = (primary, secondaryOptions) => {
 			if (!propName || !atRule.nodes || !isCustomProperty(propName)) return;
 
 			for (const node of atRule.nodes) {
-				if (isDeclaration(node) && SYNTAX_PROPERTY.test(node.prop)) {
+				if (isDeclaration(node) && SYNTAX_DESCRIPTOR.test(node.prop)) {
 					const value = node.value.trim();
 					const unquoted = string.decode(value);
 
@@ -111,8 +120,8 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls((decl) => {
 			const { prop, value, parent } = decl;
 
+			// csstree/csstree#243
 			// NOTE: CSSTree's `fork()` doesn't support `-moz-initial`, but it may be possible in the future.
-			// See https://github.com/stylelint/stylelint/pull/6511#issuecomment-1412921062
 			if (/^-moz-initial$/i.test(value)) return;
 
 			if (!isStandardSyntaxDeclaration(decl)) return;
@@ -125,7 +134,7 @@ const rule = (primary, secondaryOptions) => {
 
 			if (isPropIgnored(prop, value)) return;
 
-			// https://github.com/mdn/data/pull/674
+			// mdn/data#674
 			// `initial-value` has an incorrect syntax definition.
 			// In reality everything is valid.
 			if (
@@ -195,9 +204,6 @@ const rule = (primary, secondaryOptions) => {
  *
  * @see csstree/csstree#164 min, max, clamp
  * @see csstree/csstree#245 env
- * @see https://github.com/stylelint/stylelint/pull/6511#issuecomment-1412921062
- * @see https://github.com/stylelint/stylelint/issues/6635#issuecomment-1425787649
- *
  * @param {import('css-tree').CssNode} cssTreeNode
  * @returns {boolean}
  */

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -66,7 +66,7 @@ const rule = (primary, secondaryOptions) => {
 			width: '| min-intrinsic | -moz-min-content | -moz-available | -webkit-fill-available', // csstree/csstree#242
 			'field-sizing': 'content | fixed',
 			'text-box-edge':
-				'[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
+				'auto | [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
 			'text-box-trim': 'none | trim-start | trim-end | trim-both',
 			'text-spacing-trim': 'normal | space-all | space-first | trim-start',
 			'text-wrap-style': 'auto | balance | pretty | stable',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #6667
Closes #7939

> Is there anything in the PR that needs further explanation?

[I warned about the very situation we are in](https://github.com/stylelint/stylelint/pull/6511#issuecomment-1407586913) when we were adding this rule.
I was getting impatient so I went ahead and fixed some false positives.
If `css-tree` eventually catches up, we will remove the default extension.
I only added properties that have at least some browser support.
i.e. not block-step-insert, block-step-size, line-fit-edge, text-autospace, text-group-align, etc.

https://caniuse.com/css-text-box-trim
https://caniuse.com/mdn-css_properties_text-spacing-trim
https://caniuse.com/mdn-css_properties_text-wrap-style
https://caniuse.com/mdn-css_properties_field-sizing
https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax

The last version of `css-tree` was released in 2022, which predates these PRs:

- csstree/csstree#242
- csstree/csstree#248
