### PR TITLE
Change `PublicApi['rules']` type

### DIFF
--- a/types/stylelint/index.d.mts
+++ b/types/stylelint/index.d.mts
@@ -1,6 +1,5 @@
 export {
 	default,
-	BuiltInRules,
 	Config,
 	ConfigRuleSettings,
 	CosmiconfigResult,
@@ -16,7 +15,6 @@ export {
 	DisabledWarning,
 	Formatter,
 	FormatterType,
-	Formatters,
 	GetLintSourceOptions,
 	GetPostcssOptions,
 	InternalApi,
@@ -39,7 +37,6 @@ export {
 	RuleMeta,
 	RuleOptions,
 	RuleOptionsPossible,
-	RuleSeverity,
 	Severity,
 	ShorthandProperties,
 	StylelintPostcssResult,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -278,10 +278,6 @@ declare namespace stylelint {
 		meta?: RuleMeta;
 	};
 
-	type BuiltInRules = {
-		readonly [name in keyof CoreRules]: Promise<Rule>;
-	};
-
 	type StringOrRegex = string | RegExp;
 	type StringsOrRegexes = Array<StringOrRegex>;
 	type OneOrMoreStrings = string | string[];
@@ -1014,7 +1010,7 @@ declare namespace stylelint {
 		/**
 		 * Available rules.
 		 */
-		rules: BuiltInRules;
+		rules: { readonly [name in keyof CoreRules]: Promise<CoreRules[name]> };
 
 		/**
 		 * Result report formatters by name.


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

see https://github.com/stylelint/stylelint/pull/7954#discussion_r1731601791 and https://github.com/stylelint/stylelint/pull/7954#discussion_r1731266595

> Is there anything in the PR that needs further explanation?

`index.d.mts` exposed too many types.