### PR TITLE
Add support for `string | RegExp` to `ignoreValues` option of `value-no-vendor-prefix`

### DIFF
--- a/.changeset/fair-crews-think.md
+++ b/.changeset/fair-crews-think.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: support for `string | RegExp` to `ignoreValues` option of `value-no-vendor-prefix`

--- a/lib/rules/value-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/value-no-vendor-prefix/__tests__/index.mjs
@@ -204,6 +204,17 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [true, { ignoreValues: /^-moz-hangul$/ }],
+
+	accept: [
+		{
+			code: 'a { list-style-type: -moz-hangul; }',
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: [true, { ignoreValues: ['grab', 'hangul', '/^-webkit-linear-/', /^-moz-all$/] }],
 	fix: true,
 

--- a/lib/rules/value-no-vendor-prefix/index.cjs
+++ b/lib/rules/value-no-vendor-prefix/index.cjs
@@ -26,10 +26,7 @@ const meta = {
 	fixable: true,
 };
 
-/** @typedef {import('stylelint').CoreRules[ruleName]} Rule */
-/** @typedef {Parameters<Rule>[1]['ignoreValues']} IgnoreValues */
-
-/** @type {Rule} */
+/** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -50,17 +47,21 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		/**
-		 * @type {{ raw: IgnoreValues, unprefixed: IgnoreValues }}
+		 * @typedef {string | RegExp} IgnoreValue
+		 * @type {{ raw: IgnoreValue[], unprefixed: IgnoreValue[] }}
 		 * @todo use Object.groupBy once Node v20 support is dropped
 		 */
 		const groups = { raw: [], unprefixed: [] };
-
-		secondaryOptions?.ignoreValues?.forEach((value) => {
+		const ignoreValues = secondaryOptions?.ignoreValues;
+		const fillGroups = (/** @type {IgnoreValue} */ value) => {
 			const useRawValue = validateTypes.isRegExp(value) || (value.startsWith('/') && value.match(/\/i?$/));
 			const group = useRawValue ? 'raw' : 'unprefixed';
 
 			groups[group].push(value);
-		});
+		};
+
+		if (validateTypes.isString(ignoreValues) || validateTypes.isRegExp(ignoreValues)) fillGroups(ignoreValues);
+		else if (Array.isArray(ignoreValues)) ignoreValues.forEach(fillGroups);
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/lib/rules/value-no-vendor-prefix/index.cjs
+++ b/lib/rules/value-no-vendor-prefix/index.cjs
@@ -52,16 +52,13 @@ const rule = (primary, secondaryOptions) => {
 		 * @todo use Object.groupBy once Node v20 support is dropped
 		 */
 		const groups = { raw: [], unprefixed: [] };
-		const ignoreValues = secondaryOptions?.ignoreValues;
-		const fillGroups = (/** @type {IgnoreValue} */ value) => {
+
+		[secondaryOptions?.ignoreValues ?? []].flat().forEach((value) => {
 			const useRawValue = validateTypes.isRegExp(value) || (value.startsWith('/') && value.match(/\/i?$/));
 			const group = useRawValue ? 'raw' : 'unprefixed';
 
 			groups[group].push(value);
-		};
-
-		if (validateTypes.isString(ignoreValues) || validateTypes.isRegExp(ignoreValues)) fillGroups(ignoreValues);
-		else if (Array.isArray(ignoreValues)) ignoreValues.forEach(fillGroups);
+		});
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/lib/rules/value-no-vendor-prefix/index.mjs
+++ b/lib/rules/value-no-vendor-prefix/index.mjs
@@ -24,10 +24,7 @@ const meta = {
 	fixable: true,
 };
 
-/** @typedef {import('stylelint').CoreRules[ruleName]} Rule */
-/** @typedef {Parameters<Rule>[1]['ignoreValues']} IgnoreValues */
-
-/** @type {Rule} */
+/** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
 		const validOptions = validateOptions(
@@ -48,17 +45,21 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		/**
-		 * @type {{ raw: IgnoreValues, unprefixed: IgnoreValues }}
+		 * @typedef {string | RegExp} IgnoreValue
+		 * @type {{ raw: IgnoreValue[], unprefixed: IgnoreValue[] }}
 		 * @todo use Object.groupBy once Node v20 support is dropped
 		 */
 		const groups = { raw: [], unprefixed: [] };
-
-		secondaryOptions?.ignoreValues?.forEach((value) => {
+		const ignoreValues = secondaryOptions?.ignoreValues;
+		const fillGroups = (/** @type {IgnoreValue} */ value) => {
 			const useRawValue = isRegExp(value) || (value.startsWith('/') && value.match(/\/i?$/));
 			const group = useRawValue ? 'raw' : 'unprefixed';
 
 			groups[group].push(value);
-		});
+		};
+
+		if (isString(ignoreValues) || isRegExp(ignoreValues)) fillGroups(ignoreValues);
+		else if (Array.isArray(ignoreValues)) ignoreValues.forEach(fillGroups);
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/lib/rules/value-no-vendor-prefix/index.mjs
+++ b/lib/rules/value-no-vendor-prefix/index.mjs
@@ -50,16 +50,13 @@ const rule = (primary, secondaryOptions) => {
 		 * @todo use Object.groupBy once Node v20 support is dropped
 		 */
 		const groups = { raw: [], unprefixed: [] };
-		const ignoreValues = secondaryOptions?.ignoreValues;
-		const fillGroups = (/** @type {IgnoreValue} */ value) => {
+
+		[secondaryOptions?.ignoreValues ?? []].flat().forEach((value) => {
 			const useRawValue = isRegExp(value) || (value.startsWith('/') && value.match(/\/i?$/));
 			const group = useRawValue ? 'raw' : 'unprefixed';
 
 			groups[group].push(value);
-		};
-
-		if (isString(ignoreValues) || isRegExp(ignoreValues)) fillGroups(ignoreValues);
-		else if (Array.isArray(ignoreValues)) ignoreValues.forEach(fillGroups);
+		});
 
 		root.walkDecls((decl) => {
 			const { value } = decl;

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -624,7 +624,7 @@ declare namespace stylelint {
 				camelCaseSvgKeywords: boolean;
 			}
 		>;
-		'value-no-vendor-prefix': CoreRule<true, { ignoreValues: Array<StringOrRegex> }>;
+		'value-no-vendor-prefix': CoreRule<true, { ignoreValues: OneOrMany<StringOrRegex> }>;
 	};
 
 	/** @internal */


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

see exceptions section of https://github.com/stylelint/stylelint/pull/7967#issue-2489168630

> Is there anything in the PR that needs further explanation?

```diff
-               'value-no-vendor-prefix': CoreRule<true, { ignoreValues: Array<StringOrRegex> }>;
+               'value-no-vendor-prefix': CoreRule<true, { ignoreValues: OneOrMany<StringOrRegex> }>;
```