### PR TITLE
Add support for `string` to `ignoreLonghands` option of `declaration-block-no-redundant-longhand-properties`

### DIFF
--- a/.changeset/clever-cycles-share.md
+++ b/.changeset/clever-cycles-share.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: support for `string` to `ignoreLonghands` option of `declaration-block-no-redundant-longhand-properties`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -175,7 +175,7 @@ a {
 
 ## Optional secondary options
 
-### `ignoreLonghands`: `["array", "of", "properties"]|"property"`
+### `ignoreLonghands: ["array", "of", "properties"]`
 
 Given:
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -175,7 +175,7 @@ a {
 
 ## Optional secondary options
 
-### `ignoreLonghands: ["string"]`
+### `ignoreLonghands`: `["array", "of", "properties"]|"property"`
 
 Given:
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -895,14 +895,24 @@ testRule({
 	config: [
 		true,
 		{
-			ignoreLonghands: [
-				'background-size',
-				'background-origin',
-				'background-clip',
-				'text-decoration-thickness',
-			],
+			ignoreLonghands: ['background-size', 'background-origin', 'background-clip'],
 		},
 	],
+	fix: true,
+
+	reject: [
+		{
+			code: 'a { background-repeat: repeat; background-attachment: scroll; background-position: 0% 0%; background-color: transparent; background-image: none; background-size: contain; background-origin: border-box; background-clip: text; }',
+			fixed:
+				'a { background: none 0% 0% repeat scroll transparent; background-size: contain; background-origin: border-box; background-clip: text; }',
+			message: messages.expected('background'),
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [true, { ignoreLonghands: 'text-decoration-thickness' }],
 	fix: true,
 
 	reject: [
@@ -918,12 +928,6 @@ testRule({
 				'a { text-decoration: underline solid purple; text-decoration-thickness: 1px; text-decoration-width: 1px; }',
 			description: 'ignore text-decoration-width by default',
 			message: messages.expected('text-decoration'),
-		},
-		{
-			code: 'a { background-repeat: repeat; background-attachment: scroll; background-position: 0% 0%; background-color: transparent; background-image: none; background-size: contain; background-origin: border-box; background-clip: text; }',
-			fixed:
-				'a { background: none 0% 0% repeat scroll transparent; background-size: contain; background-origin: border-box; background-clip: text; }',
-			message: messages.expected('background'),
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -241,8 +241,7 @@ const rule = (primary, secondaryOptions) => {
 
 		/** @type {Map<string, import('stylelint').ShorthandProperties[]>} */
 		const longhandToShorthands = new Map();
-		/** @type {string[]} */
-		const ignoreLonghands = secondaryOptions?.ignoreLonghands ?? [];
+		const ignoreLonghands = [secondaryOptions?.ignoreLonghands ?? []].flat();
 
 		for (const [shorthand, longhandProps] of properties.longhandSubPropertiesOfShorthandProperties.entries()) {
 			if (optionsMatches(secondaryOptions, 'ignoreShorthands', shorthand)) {

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -238,8 +238,7 @@ const rule = (primary, secondaryOptions) => {
 
 		/** @type {Map<string, import('stylelint').ShorthandProperties[]>} */
 		const longhandToShorthands = new Map();
-		/** @type {string[]} */
-		const ignoreLonghands = secondaryOptions?.ignoreLonghands ?? [];
+		const ignoreLonghands = [secondaryOptions?.ignoreLonghands ?? []].flat();
 
 		for (const [shorthand, longhandProps] of longhandSubPropertiesOfShorthandProperties.entries()) {
 			if (optionsMatches(secondaryOptions, 'ignoreShorthands', shorthand)) {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -371,7 +371,7 @@ declare namespace stylelint {
 			true,
 			{
 				ignoreShorthands: OneOrMany<StringOrRegex>;
-				ignoreLonghands: string[];
+				ignoreLonghands: OneOrMany<string>;
 			}
 		>;
 		'declaration-block-no-shorthand-property-overrides': CoreRule<true>;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

see exceptions section of https://github.com/stylelint/stylelint/pull/7967#issue-2489168630

> Is there anything in the PR that needs further explanation?

```diff
-                               ignoreLonghands: string[];
+                               ignoreLonghands: OneOrMany<string>;
```