### PR TITLE
Fix code block in Markdown documents

### DIFF
--- a/docs/developer-guide/formatters.md
+++ b/docs/developer-guide/formatters.md
@@ -13,7 +13,7 @@ export default function formatter(results, returnValue) {
 
 Where the first argument (`results`) is an array of Stylelint result objects (type `Array<StylelintResult>`) in the form:
 
-```js
+```jsonc
 // A Stylelint result object
 {
   "source": "path/to/file.css", // The filepath or PostCSS identifier like <input css 1>
@@ -49,7 +49,7 @@ Where the first argument (`results`) is an array of Stylelint result objects (ty
 
 And the second argument (`returnValue`) is an object (type `LinterResult`) with one or more of the following keys:
 
-```js
+```jsonc
 {
   "errored": false, // `true` if there were any warnings with "error" severity
   "maxWarningsExceeded": {
@@ -60,7 +60,7 @@ And the second argument (`returnValue`) is an object (type `LinterResult`) with 
   "ruleMetadata": {
     "block-no-empty": {
       "url": "https://stylelint.io/user-guide/rules/block-no-empty"
-    },
+    }
     // other rules...
   }
 }

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -232,7 +232,7 @@ function rule(primary, secondary) {
 If `context.fix` is `true`, then change `root` using PostCSS API and return early before `report()` is called.
 
 ```js
-function rule(primary, secondary) {
+function rule(primary, secondary, context) {
   return (root, result) => {
     if (context.fix) {
       // Apply fixes using PostCSS API

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -232,12 +232,16 @@ function rule(primary, secondary) {
 If `context.fix` is `true`, then change `root` using PostCSS API and return early before `report()` is called.
 
 ```js
-if (context.fix) {
-  // Apply fixes using PostCSS API
-  return; // Return and don't report a problem
-}
+function rule(primary, secondary) {
+  return (root, result) => {
+    if (context.fix) {
+      // Apply fixes using PostCSS API
+      return; // Return and don't report a problem
+    }
 
-report(/* .. */);
+    report(/* .. */);
+  };
+}
 ```
 
 ### Write the README

--- a/docs/migration-guide/to-14.md
+++ b/docs/migration-guide/to-14.md
@@ -31,11 +31,11 @@ npm install --save-dev stylelint-config-standard-scss
 
 Then, update your [configuration object](../user-guide/configure.md) to use it:
 
-```json
+```jsonc
 {
   "extends": ["stylelint-config-standard-scss"],
   "rules": {
-    ..
+    // ..
   }
 }
 ```
@@ -59,11 +59,11 @@ npm install --save-dev sugarss
 
 Then, update your configuration object to use it:
 
-```json
+```jsonc
 {
   "customSyntax": "sugarss",
   "rules": {
-    ..
+    // ..
   }
 }
 ```

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -149,24 +149,33 @@ Alternately, you can write a [custom formatter](../developer-guide/formatters.md
 
 Experimental feature: some rules support message arguments. For example, when configuring the `color-no-hex` rule, the hex color can be used in the message string:
 
-`.stylelintrc.js`:
+Via JavaScript:
 
 ```js
-{
-  'color-no-hex': [true, {
-    message: (hex) => `Don't use hex colors like "${hex}"`,
-  }]
-}
+export default {
+  rules: {
+    "color-no-hex": [
+      true,
+      {
+        message: (hex) => `Don't use hex colors like "${hex}"`
+      }
+    ]
+  }
+};
 ```
 
-`.stylelintrc.json`:
+Via JSON:
 
-<!-- prettier-ignore -->
 ```json
 {
-  "color-no-hex": [true, {
-    "message": "Don't use hex colors like \"%s\""
-  }]
+  "rules": {
+    "color-no-hex": [
+      true,
+      {
+        "message": "Don't use hex colors like \"%s\""
+      }
+    ]
+  }
 }
 ```
 
@@ -178,10 +187,11 @@ You can use the `url` secondary option to provide a custom link to external docs
 
 For example:
 
-<!-- prettier-ignore -->
 ```json
 {
-  "color-no-hex": [true, {"url": "https://example.org/your-custom-doc"}]
+  "rules": {
+    "color-no-hex": [true, { "url": "https://example.org/your-custom-doc" }]
+  }
 }
 ```
 
@@ -235,18 +245,18 @@ This function must return `"error"`, `"warning"`, or `null`. When it would retur
 For example, given:
 
 ```js
-{
-	rules: {
-		'selector-disallowed-list': [
-			['a > .foo', '/\\[data-.+]/'],
-			{
-				severity: (selector) => {
-					return selector.includes('a > .foo') ? 'error' : 'warning';
-				},
-			},
-		],
-	},
-}
+export default {
+  rules: {
+    "selector-disallowed-list": [
+      ["a > .foo", "/\\[data-.+]/"],
+      {
+        severity: (selector) => {
+          return selector.includes("a > .foo") ? "error" : "warning";
+        }
+      }
+    ]
+  }
+};
 ```
 
 The following pattern is reported as an error:

--- a/lib/rules/declaration-property-max-values/README.md
+++ b/lib/rules/declaration-property-max-values/README.md
@@ -15,8 +15,8 @@ Given:
 ```json
 {
   "border": 2,
-  "/^margin/": 1,
-},
+  "/^margin/": 1
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/no-empty-source/README.md
+++ b/lib/rules/no-empty-source/README.md
@@ -4,33 +4,14 @@ Disallow empty sources.
 
 <!-- prettier-ignore -->
 ```css
-  ···\n\t
-/**     ↑
- *  This empty source */
+
 ```
 
-A source containing only whitespace is considered empty.
+A source containing only whitespace, i.e., spaces, tabs, or newlines, is considered empty.
 
 ## Options
 
 ### `true`
-
-The following patterns are considered problems:
-
-<!-- prettier-ignore -->
-```css
-
-```
-
-<!-- prettier-ignore -->
-```css
-\t\t
-```
-
-<!-- prettier-ignore -->
-```css
-\n
-```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/no-empty-source/README.md
+++ b/lib/rules/no-empty-source/README.md
@@ -7,7 +7,7 @@ Disallow empty sources.
 
 ```
 
-A source containing only whitespace, i.e., spaces, tabs, or newlines, is considered empty.
+A source containing only whitespace, e.g., spaces, tabs, or newlines, is considered empty.
 
 ## Options
 

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -4,7 +4,7 @@ Specify a list of disallowed selectors.
 
 <!-- prettier-ignore -->
 ```css
-    .foo > .bar
+    .foo > .bar {}
 /** ↑
  * This is selector */
 ```

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -74,7 +74,7 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-[type="text"][disabled]
+[type="text"][disabled] {}
 ```
 
 <!-- prettier-ignore -->

--- a/lib/rules/selector-nested-pattern/README.md
+++ b/lib/rules/selector-nested-pattern/README.md
@@ -6,8 +6,7 @@ Specify a pattern for the selectors of rules nested within rules.
 ```css
     a {
       color: orange;
-      &:hover { color: pink; }
-    } ↑
+      &:hover { color: pink; } }
 /**   ↑
  * This nested selector */
 ```

--- a/lib/rules/string-no-newline/README.md
+++ b/lib/rules/string-no-newline/README.md
@@ -6,9 +6,8 @@ Disallow invalid newlines within strings.
 ```css
 a {
   content: "first
-    second";     ↑
-}                ↑
-/**              ↑
+    second"; }/* ↑
+ *               ↑
  * The newline here */
 ```
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Summary:
- Fix syntax errors (thanks to [`remark-lint-code-block-syntax`](https://www.npmjs.com/package/remark-lint-code-block-syntax))
- Make code examples more consistent in `user-guide/configure.md`

To verify syntax, temporarily update `package.json` and run `npm i && npm run lint:md`:

```diff
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
   },
   "remarkConfig": {
     "plugins": [
-      "@stylelint/remark-preset"
+      "@stylelint/remark-preset",
+      "remark-lint-code-block-syntax"
     ]
   },
   "jest": {
@@ -239,6 +240,7 @@
     "postcss-sass": "^0.5.0",
     "postcss-scss": "^4.0.9",
     "remark-cli": "^12.0.1",
+    "remark-lint-code-block-syntax": "^0.10.0",
     "rollup": "^4.21.2",
     "sugarss": "^4.0.1",
     "typescript": "^5.5.4"
```

Or run only the commands:

```shell
npm i -D remark-lint-code-block-syntax
npm pkg set 'remarkConfig.plugins[1]=remark-lint-code-block-syntax'
npm run lint:md
```

However, we have to accept the following errors for now:

```
lib/rules/no-empty-source/README.md
6:1-10:4  warning Invalid CSS: <css input>:1:3: Unknown word code-block-syntax remark-lint
26:1-28:4 warning Invalid CSS: <css input>:1:1: Unknown word code-block-syntax remark-lint
31:1-33:4 warning Invalid CSS: <css input>:1:1: Unknown word code-block-syntax remark-lint
```
