### PR TITLE
Document `!important` caveat in `no-descending-specificity`

### DIFF
--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -33,11 +33,19 @@ This rule resolves nested selectors before calculating the specificity of the se
 
 ## Limitations
 
+This rule has the following limitations:
+
+- does not have access to HTML or DOM structure
+- does not consider `!important`
+- does not consider individual properties
+
+This can lead to valid linting errors appearing to be invalid at first glance.
+
+It may be possible to restructure your CSS to remove the error, otherwise it is recommended that you disable the rule for that line and leave a comment saying why the error should be ignored. Note that disabling the rule will cause additional valid errors from being reported.
+
 ### DOM structure
 
 The linter can only check the CSS to check for specificity order. It does not have access to the HTML or DOM in order to interpret the use of the CSS.
-
-This can lead to valid linting errors appearing to be invalid at first glance.
 
 For example the following will cause an error:
 
@@ -52,13 +60,9 @@ This is a correct error because the `a:hover` on line 2 has a higher specificity
 
 This may lead to confusion because "the two selectors will never match the same `a` in the DOM". However, since the linter does not have access to the DOM it can not evaluate this, and therefore correctly reports the error about descending specificity.
 
-It may be possible to restructure your CSS to remove the error, otherwise it is recommended that you disable the rule for that line and leave a comment saying why the error should be ignored. Note that disabling the rule will cause additional valid errors from being reported.
-
 ### `!important`
 
 The linter only checks selectors and doesn't take `!important` into account.
-
-This can lead to valid linting errors appearing to be invalid at first glance.
 
 For example the following will cause an error:
 
@@ -72,13 +76,9 @@ This is a correct error because the `a:hover` on line 1 has a higher specificity
 
 This may lead to confusion because the declaration with `!important` will apply regardless of position. However, the linter only evaluates selectors, and therefore correctly reports the error about descending specificity.
 
-It may be possible to restructure your CSS to remove the error, otherwise it is recommended that you disable the rule for that line and leave a comment saying why the error should be ignored.
-
 ### Different properties
 
 The linter only checks selectors and doesn't take individual properties into account.
-
-This can lead to valid linting errors appearing to be invalid at first glance.
 
 For example the following will cause an error:
 
@@ -91,8 +91,6 @@ a { left: 10px; }
 This is a correct error because the `a:hover` on line 1 has a higher specificity than the `a` on line 2.
 
 This may lead to confusion because both rules contain different declarations and there isn't any conflict between either. However, the linter only evaluates selectors, and therefore correctly reports the error about descending specificity.
-
-It may be possible to restructure your CSS to remove the error, otherwise it is recommended that you disable the rule for that line and leave a comment saying why the error should be ignored.
 
 ## Options
 

--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -31,7 +31,9 @@ This rule only compares rules that are within the same media context. So `a {top
 
 This rule resolves nested selectors before calculating the specificity of the selectors.
 
-## DOM Limitations
+## Limitations
+
+### DOM structure
 
 The linter can only check the CSS to check for specificity order. It does not have access to the HTML or DOM in order to interpret the use of the CSS.
 
@@ -51,6 +53,46 @@ This is a correct error because the `a:hover` on line 2 has a higher specificity
 This may lead to confusion because "the two selectors will never match the same `a` in the DOM". However, since the linter does not have access to the DOM it can not evaluate this, and therefore correctly reports the error about descending specificity.
 
 It may be possible to restructure your CSS to remove the error, otherwise it is recommended that you disable the rule for that line and leave a comment saying why the error should be ignored. Note that disabling the rule will cause additional valid errors from being reported.
+
+### `!important`
+
+The linter only checks selectors and doesn't take `!important` into account.
+
+This can lead to valid linting errors appearing to be invalid at first glance.
+
+For example the following will cause an error:
+
+<!-- prettier-ignore -->
+```css
+a:hover { top: 10px; }
+a { top: 10px; !important; }
+```
+
+This is a correct error because the `a:hover` on line 1 has a higher specificity than the `a` on line 2.
+
+This may lead to confusion because the declaration with `!important` will apply regardless of position. However, the linter only evaluates selectors, and therefore correctly reports the error about descending specificity.
+
+It may be possible to restructure your CSS to remove the error, otherwise it is recommended that you disable the rule for that line and leave a comment saying why the error should be ignored.
+
+### Different properties
+
+The linter only checks selectors and doesn't take individual properties into account.
+
+This can lead to valid linting errors appearing to be invalid at first glance.
+
+For example the following will cause an error:
+
+<!-- prettier-ignore -->
+```css
+a:hover { top: 10px; }
+a { left: 10px; }
+```
+
+This is a correct error because the `a:hover` on line 1 has a higher specificity than the `a` on line 2.
+
+This may lead to confusion because both rules contain different declarations and there isn't any conflict between either. However, the linter only evaluates selectors, and therefore correctly reports the error about descending specificity.
+
+It may be possible to restructure your CSS to remove the error, otherwise it is recommended that you disable the rule for that line and leave a comment saying why the error should be ignored.
 
 ## Options
 

--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -65,7 +65,7 @@ For example the following will cause an error:
 <!-- prettier-ignore -->
 ```css
 a:hover { top: 10px; }
-a { top: 10px; !important; }
+a { top: 10px !important; }
 ```
 
 This is a correct error because the `a:hover` on line 1 has a higher specificity than the `a` on line 2.

--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -33,11 +33,11 @@ This rule resolves nested selectors before calculating the specificity of the se
 
 ## Limitations
 
-This rule has the following limitations:
+This rule doesn't:
 
-- does not have access to HTML or DOM structure
-- does not consider `!important`
-- does not consider individual properties
+- have access to HTML or DOM structure
+- consider `!important`
+- consider individual properties
 
 This can lead to valid linting errors appearing to be invalid at first glance.
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/3052

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
