### PR TITLE
Bump css-tree from 2.3.1 to 3.0.0

### DIFF
--- a/.changeset/many-baboons-care.md
+++ b/.changeset/many-baboons-care.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `declaration-property-value-no-unknown` false positives via [`css-tree` 3.0.0](https://github.com/csstree/csstree/blob/v3.0.0/CHANGELOG.md#300-september-11-2024)

--- a/.changeset/many-baboons-care.md
+++ b/.changeset/many-baboons-care.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Fixed: `declaration-property-value-no-unknown` false positives via [`css-tree` 3.0.0](https://github.com/csstree/csstree/blob/v3.0.0/CHANGELOG.md#300-september-11-2024)
+Fixed: `declaration-property-value-no-unknown` false negatives/positives via [`css-tree@3.0.0`](https://github.com/csstree/csstree/releases/tag/v3.0.0)

--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
@@ -60,28 +60,16 @@ testRule({
 			code: 'a { word-break: auto-phrase; }',
 		},
 		{
-			code: 'a { field-sizing: content; }',
-		},
-		{
-			code: 'a  { text-wrap: wrap; }',
-		},
-		{
-			code: 'a  { text-wrap-mode: nowrap; }',
-		},
-		{
 			code: 'a { overflow: overlay; }',
 		},
 		{
 			code: 'a { width: min-intrinsic; }',
 		},
 		{
-			code: 'a { view-timeline-name: --foo; }',
-		},
-		{
 			code: 'a { view-timeline: --bar x; }',
 		},
 		{
-			code: 'a { view-transition-name: qux-baz; }',
+			code: 'a { view-timeline: --qux inline 1px 2px; }',
 		},
 		{
 			code: 'a { anchor-name: --bar, --qux; }',
@@ -172,6 +160,62 @@ testRule({
 			column: 25,
 			endLine: 1,
 			endColumn: 27,
+		},
+		{
+			code: 'a { text-box-trim: foo; }',
+			message: messages.rejected('text-box-trim', 'foo'),
+			line: 1,
+			column: 20,
+			endLine: 1,
+			endColumn: 23,
+		},
+		{
+			code: 'a { text-spacing-trim: bar; }',
+			message: messages.rejected('text-spacing-trim', 'bar'),
+			line: 1,
+			column: 24,
+			endLine: 1,
+			endColumn: 27,
+		},
+		{
+			code: 'a { text-wrap: foo; }',
+			message: messages.rejected('text-wrap', 'foo'),
+			line: 1,
+			column: 16,
+			endLine: 1,
+			endColumn: 19,
+		},
+		{
+			code: 'a { view-timeline-name: foo; }',
+			message: messages.rejected('view-timeline-name', 'foo'),
+			line: 1,
+			column: 25,
+			endLine: 1,
+			endColumn: 28,
+		},
+		{
+			code: 'a { view-transition-name:; }',
+			message: messages.rejected('view-transition-name', ''),
+			line: 1,
+			column: 26,
+			endLine: 1,
+			endColumn: 27,
+		},
+		{
+			code: 'a { anchor-name: foo; }',
+			message: messages.rejected('anchor-name', 'foo'),
+			line: 1,
+			column: 18,
+			endLine: 1,
+			endColumn: 21,
+		},
+		{
+			code: 'a { field-sizing: bar; }',
+			message: messages.rejected('field-sizing', 'bar'),
+			line: 1,
+			column: 19,
+			endLine: 1,
+			endColumn: 22,
 		},
 		{
 			code: 'a { top: unknown; }',
@@ -365,21 +409,6 @@ testRule({
 	accept: [
 		{
 			code: 'a { size: 10px; }',
-		},
-		{
-			code: 'a { text-box-edge: ideographic-ink; }',
-		},
-		{
-			code: 'a { text-box-edge: ex text; }',
-		},
-		{
-			code: 'a { text-box-trim: none; }',
-		},
-		{
-			code: 'a { text-spacing-trim: space-first; }',
-		},
-		{
-			code: 'a { text-wrap-style: stable; }',
 		},
 	],
 

--- a/lib/rules/declaration-property-value-no-unknown/index.cjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.cjs
@@ -141,18 +141,6 @@ const rule = (primary, secondaryOptions) => {
 
 			if (isPropIgnored(prop, value)) return;
 
-			// mdn/data#674
-			// `initial-value` has an incorrect syntax definition.
-			// In reality everything is valid.
-			if (
-				/^initial-value$/i.test(prop) &&
-				decl.parent &&
-				typeGuards.isAtRule(decl.parent) &&
-				/^property$/i.test(decl.parent.name)
-			) {
-				return;
-			}
-
 			/** @type {import('css-tree').CssNode} */
 			let cssTreeValueNode;
 

--- a/lib/rules/declaration-property-value-no-unknown/index.cjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.cjs
@@ -69,27 +69,11 @@ const rule = (primary, secondaryOptions) => {
 
 		/** @type {SecondaryOptions['propertiesSyntax']} */
 		const propertiesSyntax = {
-			overflow: '| overlay', // csstree/csstree#248
-			width: '| min-intrinsic | -moz-min-content | -moz-available | -webkit-fill-available', // csstree/csstree#242
-			'anchor-name': 'none | <custom-property-name>#',
-			'field-sizing': 'content | fixed',
 			'text-box-edge':
 				'auto | [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
 			'text-box-trim': 'none | trim-start | trim-end | trim-both',
-			'text-spacing-trim': 'normal | space-all | space-first | trim-start',
-			'text-wrap-mode': 'wrap | nowrap',
-			'text-wrap-style': 'auto | balance | pretty | stable',
-			'text-wrap': "<'text-wrap-mode'> || <'text-wrap-style'>",
-			'view-timeline-axis': '[ block | inline | x | y ]#',
-			'view-timeline-inset': '[ [ auto | <length-percentage> ]{1,2} ]#',
-			'view-timeline-name': '[ none | <custom-property-name> ]#',
 			'view-timeline':
 				"[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
-			// <custom-ident> represents any valid CSS identifier that would not be misinterpreted as a pre-defined keyword in that property’s value definition
-			// i.e. reserved keywords don't have to be excluded explicitly
-			// w3c/csswg-drafts#9895
-			'view-transition-name': 'none | <custom-ident>',
-			'word-break': '| auto-phrase',
 			...secondaryOptions?.propertiesSyntax,
 		};
 

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -138,18 +138,6 @@ const rule = (primary, secondaryOptions) => {
 
 			if (isPropIgnored(prop, value)) return;
 
-			// mdn/data#674
-			// `initial-value` has an incorrect syntax definition.
-			// In reality everything is valid.
-			if (
-				/^initial-value$/i.test(prop) &&
-				decl.parent &&
-				isAtRule(decl.parent) &&
-				/^property$/i.test(decl.parent.name)
-			) {
-				return;
-			}
-
 			/** @type {import('css-tree').CssNode} */
 			let cssTreeValueNode;
 

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -66,27 +66,11 @@ const rule = (primary, secondaryOptions) => {
 
 		/** @type {SecondaryOptions['propertiesSyntax']} */
 		const propertiesSyntax = {
-			overflow: '| overlay', // csstree/csstree#248
-			width: '| min-intrinsic | -moz-min-content | -moz-available | -webkit-fill-available', // csstree/csstree#242
-			'anchor-name': 'none | <custom-property-name>#',
-			'field-sizing': 'content | fixed',
 			'text-box-edge':
 				'auto | [ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?',
 			'text-box-trim': 'none | trim-start | trim-end | trim-both',
-			'text-spacing-trim': 'normal | space-all | space-first | trim-start',
-			'text-wrap-mode': 'wrap | nowrap',
-			'text-wrap-style': 'auto | balance | pretty | stable',
-			'text-wrap': "<'text-wrap-mode'> || <'text-wrap-style'>",
-			'view-timeline-axis': '[ block | inline | x | y ]#',
-			'view-timeline-inset': '[ [ auto | <length-percentage> ]{1,2} ]#',
-			'view-timeline-name': '[ none | <custom-property-name> ]#',
 			'view-timeline':
 				"[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
-			// <custom-ident> represents any valid CSS identifier that would not be misinterpreted as a pre-defined keyword in that property’s value definition
-			// i.e. reserved keywords don't have to be excluded explicitly
-			// w3c/csswg-drafts#9895
-			'view-transition-name': 'none | <custom-ident>',
-			'word-break': '| auto-phrase',
 			...secondaryOptions?.propertiesSyntax,
 		};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
         "css-functions-list": "^3.2.2",
-        "css-tree": "^2.3.1",
+        "css-tree": "^3.0.0",
         "debug": "^4.3.7",
         "fast-glob": "^3.3.2",
         "fastest-levenshtein": "^1.0.16",
@@ -4547,11 +4547,11 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.0.0.tgz",
+      "integrity": "sha512-o88DVQ6GzsABn1+6+zo2ct801dBO5OASVyxbbvA2W20ue2puSh/VOuqUj90eUeMSX/xqGqBmOKiRQN7tJOuBXw==",
       "dependencies": {
-        "mdn-data": "2.0.30",
+        "mdn-data": "2.10.0",
         "source-map-js": "^1.0.1"
       },
       "engines": {
@@ -11467,9 +11467,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.10.0.tgz",
+      "integrity": "sha512-qq7C3EtK3yJXMwz1zAab65pjl+UhohqMOctTgcqjLOWABqmwj+me02LSsCuEUxnst9X1lCBpoE0WArGKgdGDzw=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "colord": "^2.9.3",
     "cosmiconfig": "^9.0.0",
     "css-functions-list": "^3.2.2",
-    "css-tree": "^2.3.1",
+    "css-tree": "^3.0.0",
     "debug": "^4.3.7",
     "fast-glob": "^3.3.2",
     "fastest-levenshtein": "^1.0.16",


### PR DESCRIPTION
Close #7995

- [Release notes](https://github.com/csstree/csstree/releases/tag/v3.0.0)
- [Commits](https://github.com/csstree/csstree/compare/v2.3.1...v3.0.0)

> Is there anything in the PR that needs further explanation?

Unknown properties are ignored by `declaration-property-value-no-unknown`.
i.e. most regressions will be picked up by `reject`, not `accept`

It doesn't c l o s e #7964 because `position-try-options` is still unknown. 