### PR TITLE
Document alumni in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ We recommend using a pretty printer like Prettier alongside Stylelint. Linters a
 
 Stylelint is maintained by volunteers. Without the code contributions from [all these fantastic people](https://github.com/stylelint/stylelint/graphs/contributors), Stylelint would not exist. [Become a contributor](CONTRIBUTING.md).
 
+### Alumni
+
+We'd like to thank all past members for their invaluable contributions, including two of Stylelint's co-creators [@davidtheclark](https://github.com/davidtheclark) and [@MoOx](https://github.com/MoOx).
+
 ### Sponsors
 
 <object data="https://opencollective.com/stylelint/sponsors.svg?width=420&button=false" type="image/svg+xml">


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

I want to respect and be thankful for them, but there is no proper place for us to do that now.

For example, the Rust team mentions its alumni in this document:
https://www.rust-lang.org/governance/teams/leadership-council
