### PR TITLE
Fix `selector-anb-no-unmatchable` reported ranges and message

### DIFF
--- a/.changeset/funny-pets-cover.md
+++ b/.changeset/funny-pets-cover.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `selector-anb-no-unmatchable` reported ranges
+Fixed: `selector-anb-no-unmatchable` reported ranges and message

--- a/.changeset/funny-pets-cover.md
+++ b/.changeset/funny-pets-cover.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-anb-no-unmatchable` reported ranges

--- a/lib/rules/selector-anb-no-unmatchable/__tests__/index.mjs
+++ b/lib/rules/selector-anb-no-unmatchable/__tests__/index.mjs
@@ -1,3 +1,5 @@
+import { stripIndent } from 'common-tags';
+
 import rule from '../index.mjs';
 const { messages, ruleName } = rule;
 
@@ -43,6 +45,16 @@ testRule({
 			code: 'a:nth-child(3n + - 6) {}',
 			description: 'CSSTree parse error not flagged',
 		},
+		{
+			code: stripIndent`
+				/* stylelint-disable-next-line selector-anb-no-unmatchable */
+				a:nth-child(0), /* stylelint-disable-next-line selector-anb-no-unmatchable */
+				b:nth-child(0),
+				/* stylelint-disable-next-line selector-anb-no-unmatchable */
+				c:nth-child(0)
+				{}
+			`,
+		},
 	],
 
 	reject: [
@@ -50,105 +62,146 @@ testRule({
 			code: 'a:nth-child(0) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 16,
+			endColumn: 15,
 		},
 		{
 			code: 'a:nth-child(0n) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 17,
+			endColumn: 16,
 		},
 		{
 			code: 'a:nth-child(+0n) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 18,
+			endColumn: 17,
 		},
 		{
 			code: 'a:nth-child(-0n) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 18,
+			endColumn: 17,
 		},
 		{
 			code: 'a:nth-child(0n+0) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 19,
+			endColumn: 18,
 		},
 		{
 			code: 'a:nth-child(0n + 0) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 21,
+			endColumn: 20,
 		},
 		{
 			code: 'a:nth-child(0n-0) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 19,
+			endColumn: 18,
 		},
 		{
 			code: 'a:nth-child(-0n-0) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 20,
+			endColumn: 19,
 		},
 		{
 			code: 'a:nth-child(0 of a) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 21,
+			endColumn: 20,
 		},
 		{
 			code: 'a:nth-child(0), a:nth-child(1) {}',
 			message: messages.rejected(':nth-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 16,
+			endColumn: 15,
 		},
 		{
 			code: 'a:nth-last-child(0) {}',
 			message: messages.rejected(':nth-last-child'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 21,
+			endColumn: 20,
 		},
 		{
 			code: 'a:nth-of-type(0) {}',
 			message: messages.rejected(':nth-of-type'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 18,
+			endColumn: 17,
 		},
 		{
 			code: 'a:nth-last-of-type(0) {}',
 			message: messages.rejected(':nth-last-of-type'),
 			line: 1,
-			column: 3,
+			column: 2,
 			endLine: 1,
-			endColumn: 23,
+			endColumn: 22,
+		},
+		{
+			code: stripIndent`
+				/* a comment */
+				a:nth-child(0), /* a comment */
+				b:nth-child(0),
+				/* a comment */
+				c:nth-child(0),
+				/* a comment */ d:nth-child(0)
+				{}
+			`,
+			warnings: [
+				{
+					message: messages.rejected(':nth-child'),
+					line: 2,
+					column: 2,
+					endLine: 2,
+					endColumn: 15,
+				},
+				{
+					message: messages.rejected(':nth-child'),
+					line: 3,
+					column: 2,
+					endLine: 3,
+					endColumn: 15,
+				},
+				{
+					message: messages.rejected(':nth-child'),
+					line: 5,
+					column: 2,
+					endLine: 5,
+					endColumn: 15,
+				},
+				{
+					message: messages.rejected(':nth-child'),
+					line: 6,
+					column: 18,
+					endLine: 6,
+					endColumn: 31,
+				},
+			],
 		},
 	],
 });

--- a/lib/rules/selector-anb-no-unmatchable/__tests__/index.mjs
+++ b/lib/rules/selector-anb-no-unmatchable/__tests__/index.mjs
@@ -60,7 +60,7 @@ testRule({
 	reject: [
 		{
 			code: 'a:nth-child(0) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -68,7 +68,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(0n) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(0n)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -76,7 +76,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(+0n) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(+0n)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -84,7 +84,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(-0n) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(-0n)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -92,7 +92,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(0n+0) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(0n+0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -100,7 +100,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(0n + 0) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(0n + 0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -108,7 +108,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(0n-0) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(0n-0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -116,7 +116,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(-0n-0) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(-0n-0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -124,7 +124,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(0 of a) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(0 of a)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -132,7 +132,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-child(0), a:nth-child(1) {}',
-			message: messages.rejected(':nth-child'),
+			message: messages.rejected(':nth-child(0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -140,7 +140,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-last-child(0) {}',
-			message: messages.rejected(':nth-last-child'),
+			message: messages.rejected(':nth-last-child(0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -148,7 +148,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-of-type(0) {}',
-			message: messages.rejected(':nth-of-type'),
+			message: messages.rejected(':nth-of-type(0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -156,7 +156,7 @@ testRule({
 		},
 		{
 			code: 'a:nth-last-of-type(0) {}',
-			message: messages.rejected(':nth-last-of-type'),
+			message: messages.rejected(':nth-last-of-type(0)'),
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -169,36 +169,44 @@ testRule({
 				b:nth-child(0),
 				/* a comment */
 				c:nth-child(0),
-				/* a comment */ d:nth-child(0)
+				d:nth-child(0 /* a comment */ of a),
+				/* a comment */ e:nth-child(0)
 				{}
 			`,
 			warnings: [
 				{
-					message: messages.rejected(':nth-child'),
+					message: messages.rejected(':nth-child(0)'),
 					line: 2,
 					column: 2,
 					endLine: 2,
 					endColumn: 15,
 				},
 				{
-					message: messages.rejected(':nth-child'),
+					message: messages.rejected(':nth-child(0)'),
 					line: 3,
 					column: 2,
 					endLine: 3,
 					endColumn: 15,
 				},
 				{
-					message: messages.rejected(':nth-child'),
+					message: messages.rejected(':nth-child(0)'),
 					line: 5,
 					column: 2,
 					endLine: 5,
 					endColumn: 15,
 				},
 				{
-					message: messages.rejected(':nth-child'),
+					message: messages.rejected(':nth-child(0 /* a comment */ of a)'),
 					line: 6,
-					column: 18,
+					column: 2,
 					endLine: 6,
+					endColumn: 36,
+				},
+				{
+					message: messages.rejected(':nth-child(0)'),
+					line: 7,
+					column: 18,
+					endLine: 7,
 					endColumn: 31,
 				},
 			],

--- a/lib/rules/selector-anb-no-unmatchable/index.cjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.cjs
@@ -6,6 +6,7 @@ const cssTree = require('css-tree');
 const selectors = require('../../reference/selectors.cjs');
 const getRuleSelector = require('../../utils/getRuleSelector.cjs');
 const hasANPlusBNotationPseudoClasses = require('../../utils/hasANPlusBNotationPseudoClasses.cjs');
+const validateTypes = require('../../utils/validateTypes.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -49,10 +50,11 @@ const rule = (primary) => {
 
 			if (!isStandardSyntaxRule(ruleNode)) return;
 
+			const ruleSelector = getRuleSelector(ruleNode);
 			let cssTreeSelectors;
 
 			try {
-				cssTreeSelectors = cssTree.parse(getRuleSelector(ruleNode), {
+				cssTreeSelectors = cssTree.parse(ruleSelector, {
 					context: 'selectorList',
 					positions: true,
 				});
@@ -91,13 +93,20 @@ const rule = (primary) => {
 							return;
 						}
 
+						const index = pseudoClassSelector.loc?.start.offset;
+						const endIndex = pseudoClassSelector.loc?.end.offset;
+
 						if (isUnmatchableNth(child.nth)) {
 							report({
 								message: messages.rejected,
-								messageArgs: [`:${pseudoClassSelector.name}`],
+								messageArgs: [
+									validateTypes.isNumber(index) && validateTypes.isNumber(endIndex)
+										? ruleSelector.slice(index, endIndex)
+										: cssTree.generate(pseudoClassSelector),
+								],
 								node: ruleNode,
-								index: pseudoClassSelector.loc?.start.offset,
-								endIndex: pseudoClassSelector.loc?.end.offset,
+								index,
+								endIndex,
 								result,
 								ruleName,
 							});

--- a/lib/rules/selector-anb-no-unmatchable/index.cjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.cjs
@@ -4,9 +4,9 @@
 
 const cssTree = require('css-tree');
 const selectors = require('../../reference/selectors.cjs');
+const validateTypes = require('../../utils/validateTypes.cjs');
 const getRuleSelector = require('../../utils/getRuleSelector.cjs');
 const hasANPlusBNotationPseudoClasses = require('../../utils/hasANPlusBNotationPseudoClasses.cjs');
-const validateTypes = require('../../utils/validateTypes.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -93,17 +93,16 @@ const rule = (primary) => {
 							return;
 						}
 
-						const index = pseudoClassSelector.loc?.start.offset;
-						const endIndex = pseudoClassSelector.loc?.end.offset;
+						// `loc` is expected to be present when calling `parse()` with `{ positions: true }`
+						validateTypes.assert(pseudoClassSelector.loc);
+
+						const index = pseudoClassSelector.loc.start.offset;
+						const endIndex = pseudoClassSelector.loc.end.offset;
 
 						if (isUnmatchableNth(child.nth)) {
 							report({
 								message: messages.rejected,
-								messageArgs: [
-									validateTypes.isNumber(index) && validateTypes.isNumber(endIndex)
-										? ruleSelector.slice(index, endIndex)
-										: cssTree.generate(pseudoClassSelector),
-								],
+								messageArgs: [ruleSelector.slice(index, endIndex)],
 								node: ruleNode,
 								index,
 								endIndex,

--- a/lib/rules/selector-anb-no-unmatchable/index.cjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.cjs
@@ -4,6 +4,7 @@
 
 const cssTree = require('css-tree');
 const selectors = require('../../reference/selectors.cjs');
+const getRuleSelector = require('../../utils/getRuleSelector.cjs');
 const hasANPlusBNotationPseudoClasses = require('../../utils/hasANPlusBNotationPseudoClasses.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
 const report = require('../../utils/report.cjs');
@@ -48,15 +49,20 @@ const rule = (primary) => {
 
 			if (!isStandardSyntaxRule(ruleNode)) return;
 
-			ruleNode.selectors.forEach((selector) => {
-				let cssTreeSelector;
+			let cssTreeSelectors;
 
-				try {
-					cssTreeSelector = cssTree.parse(selector, { context: 'selector', positions: true });
-				} catch (e) {
-					return;
-				}
+			try {
+				cssTreeSelectors = cssTree.parse(getRuleSelector(ruleNode), {
+					context: 'selectorList',
+					positions: true,
+				});
+			} catch (e) {
+				return;
+			}
 
+			if (!cssTreeSelectors || cssTreeSelectors.type !== 'SelectorList') return;
+
+			cssTreeSelectors.children.forEach((cssTreeSelector) => {
 				checkSelector(cssTreeSelector);
 			});
 
@@ -90,8 +96,8 @@ const rule = (primary) => {
 								message: messages.rejected,
 								messageArgs: [`:${pseudoClassSelector.name}`],
 								node: ruleNode,
-								index: pseudoClassSelector.loc?.start.column,
-								endIndex: pseudoClassSelector.loc?.end.column,
+								index: pseudoClassSelector.loc?.start.offset,
+								endIndex: pseudoClassSelector.loc?.end.offset,
 								result,
 								ruleName,
 							});

--- a/lib/rules/selector-anb-no-unmatchable/index.cjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.cjs
@@ -60,7 +60,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			if (!cssTreeSelectors || cssTreeSelectors.type !== 'SelectorList') return;
+			if (cssTreeSelectors.type !== 'SelectorList') return;
 
 			cssTreeSelectors.children.forEach((cssTreeSelector) => {
 				checkSelector(cssTreeSelector);

--- a/lib/rules/selector-anb-no-unmatchable/index.mjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.mjs
@@ -1,4 +1,4 @@
-import { parse } from 'css-tree';
+import { generate, parse } from 'css-tree';
 
 import {
 	aNPlusBNotationPseudoClasses,
@@ -6,6 +6,7 @@ import {
 } from '../../reference/selectors.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import hasANPlusBNotationPseudoClasses from '../../utils/hasANPlusBNotationPseudoClasses.mjs';
+import { isNumber } from '../../utils/validateTypes.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -49,10 +50,11 @@ const rule = (primary) => {
 
 			if (!isStandardSyntaxRule(ruleNode)) return;
 
+			const ruleSelector = getRuleSelector(ruleNode);
 			let cssTreeSelectors;
 
 			try {
-				cssTreeSelectors = parse(getRuleSelector(ruleNode), {
+				cssTreeSelectors = parse(ruleSelector, {
 					context: 'selectorList',
 					positions: true,
 				});
@@ -91,13 +93,20 @@ const rule = (primary) => {
 							return;
 						}
 
+						const index = pseudoClassSelector.loc?.start.offset;
+						const endIndex = pseudoClassSelector.loc?.end.offset;
+
 						if (isUnmatchableNth(child.nth)) {
 							report({
 								message: messages.rejected,
-								messageArgs: [`:${pseudoClassSelector.name}`],
+								messageArgs: [
+									isNumber(index) && isNumber(endIndex)
+										? ruleSelector.slice(index, endIndex)
+										: generate(pseudoClassSelector),
+								],
 								node: ruleNode,
-								index: pseudoClassSelector.loc?.start.offset,
-								endIndex: pseudoClassSelector.loc?.end.offset,
+								index,
+								endIndex,
 								result,
 								ruleName,
 							});

--- a/lib/rules/selector-anb-no-unmatchable/index.mjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.mjs
@@ -1,12 +1,12 @@
-import { generate, parse } from 'css-tree';
+import { parse } from 'css-tree';
 
 import {
 	aNPlusBNotationPseudoClasses,
 	aNPlusBOfSNotationPseudoClasses,
 } from '../../reference/selectors.mjs';
+import { assert } from '../../utils/validateTypes.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import hasANPlusBNotationPseudoClasses from '../../utils/hasANPlusBNotationPseudoClasses.mjs';
-import { isNumber } from '../../utils/validateTypes.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -93,17 +93,16 @@ const rule = (primary) => {
 							return;
 						}
 
-						const index = pseudoClassSelector.loc?.start.offset;
-						const endIndex = pseudoClassSelector.loc?.end.offset;
+						// `loc` is expected to be present when calling `parse()` with `{ positions: true }`
+						assert(pseudoClassSelector.loc);
+
+						const index = pseudoClassSelector.loc.start.offset;
+						const endIndex = pseudoClassSelector.loc.end.offset;
 
 						if (isUnmatchableNth(child.nth)) {
 							report({
 								message: messages.rejected,
-								messageArgs: [
-									isNumber(index) && isNumber(endIndex)
-										? ruleSelector.slice(index, endIndex)
-										: generate(pseudoClassSelector),
-								],
+								messageArgs: [ruleSelector.slice(index, endIndex)],
 								node: ruleNode,
 								index,
 								endIndex,

--- a/lib/rules/selector-anb-no-unmatchable/index.mjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.mjs
@@ -60,7 +60,7 @@ const rule = (primary) => {
 				return;
 			}
 
-			if (!cssTreeSelectors || cssTreeSelectors.type !== 'SelectorList') return;
+			if (cssTreeSelectors.type !== 'SelectorList') return;
 
 			cssTreeSelectors.children.forEach((cssTreeSelector) => {
 				checkSelector(cssTreeSelector);

--- a/lib/rules/selector-anb-no-unmatchable/index.mjs
+++ b/lib/rules/selector-anb-no-unmatchable/index.mjs
@@ -4,6 +4,7 @@ import {
 	aNPlusBNotationPseudoClasses,
 	aNPlusBOfSNotationPseudoClasses,
 } from '../../reference/selectors.mjs';
+import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import hasANPlusBNotationPseudoClasses from '../../utils/hasANPlusBNotationPseudoClasses.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import report from '../../utils/report.mjs';
@@ -48,15 +49,20 @@ const rule = (primary) => {
 
 			if (!isStandardSyntaxRule(ruleNode)) return;
 
-			ruleNode.selectors.forEach((selector) => {
-				let cssTreeSelector;
+			let cssTreeSelectors;
 
-				try {
-					cssTreeSelector = parse(selector, { context: 'selector', positions: true });
-				} catch (e) {
-					return;
-				}
+			try {
+				cssTreeSelectors = parse(getRuleSelector(ruleNode), {
+					context: 'selectorList',
+					positions: true,
+				});
+			} catch (e) {
+				return;
+			}
 
+			if (!cssTreeSelectors || cssTreeSelectors.type !== 'SelectorList') return;
+
+			cssTreeSelectors.children.forEach((cssTreeSelector) => {
 				checkSelector(cssTreeSelector);
 			});
 
@@ -90,8 +96,8 @@ const rule = (primary) => {
 								message: messages.rejected,
 								messageArgs: [`:${pseudoClassSelector.name}`],
 								node: ruleNode,
-								index: pseudoClassSelector.loc?.start.column,
-								endIndex: pseudoClassSelector.loc?.end.column,
+								index: pseudoClassSelector.loc?.start.offset,
+								endIndex: pseudoClassSelector.loc?.end.offset,
 								result,
 								ruleName,
 							});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/issues/7904

> Is there anything in the PR that needs further explanation?

The reported ranges for this rule were incorrect in various ways :)
Most impactful was the use of `column` instead of `offset` leading to cases like these: https://stylelint.io/demo/#N4Igxg9gJgpiBcICG8B2AXAFgWjJglgDZQAUADAJQA0AOqgEZpa4HHnV1hM55GmXA6NdJEIQATvAAE4mFADcdAL4gqIAGZEYAOSQBbOIhgAPfQAdCMAHRgAzrdXgIqTQHMEIQailSaIE+gwqFC2ftIA2nQ+Pn626ACeloT4GLjObthxSMFI4lB+UVIAusqOkC74rgBiEnpI6B4AVrbOjrBmDoheMSBxiTDJGGG+IIT1MHF+tN4jfUkp6GkVrpno2VC5+QgjY4GTIKVKQA

<img width="742" alt="Screenshot of Stylelint errors for this rule showing that all errors are reported as if happening on the first line, while an error actually occurred on each of three lines" src="https://github.com/user-attachments/assets/ff228291-3f79-4599-8e02-1e2b0f0db367">

