### PR TITLE
Add `--[no-]validate` flag and `validate` option

### DIFF
--- a/.changeset/yellow-chairs-laugh.md
+++ b/.changeset/yellow-chairs-laugh.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `validate` option to Node.js API and `--validate` CLI flag

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -126,7 +126,7 @@ Accept stdin input even if it is empty.
 
 ### `--validate, --no-validate`
 
-Force enable/disable the validation of the rules' options.
+Force enable/disable the validation of the rules' options. [More info](options.md#validate).
 
 ### `--version, -v`
 

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -124,6 +124,10 @@ A filename to assign the input. [More info](options.md#codefilename).
 
 Accept stdin input even if it is empty.
 
+### `--validate, --no-validate`
+
+Force enable/disable the validation of the rules' options.
+
 ### `--version, -v`
 
 Show the currently installed version of Stylelint.

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -212,6 +212,12 @@ CLI flags: `--report-needless-disables, --rd`
 
 Report `stylelint-disable` comments that don't actually match any lints that need to be disabled.
 
+## `validate`
+
+CLI flags: [`--validate, --no-validate`](cli.md#--validate---no-validate)
+
+Force enable/disable the validation of the rules' options.
+
 ## `codeFilename`
 
 CLI flag: `--stdin-filename`

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -214,9 +214,18 @@ Report `stylelint-disable` comments that don't actually match any lints that nee
 
 ## `validate`
 
-CLI flags: [`--validate, --no-validate`](cli.md#--validate---no-validate)
+CLI flags: `--validate, --no-validate`
 
-Force enable/disable the validation of the rules' options.
+Force enable/disable the validation of the rules' options. Default: `true`.
+For example, your CI might be faster by skipping the validation if [`rules`](configure.md#rules) didn't change.
+e.g.
+
+```js
+export default {
+  // …
+  validate: process.env["CI"] !== "true"
+};
+```
 
 ## `codeFilename`
 

--- a/lib/__tests__/__snapshots__/cli.test.mjs.snap
+++ b/lib/__tests__/__snapshots__/cli.test.mjs.snap
@@ -133,6 +133,10 @@ exports[`CLI --help 1`] = `
 
       Force enabling/disabling of color.
 
+    --[no-]validate
+
+      Force enable/disable the validation of the rules' options.
+
     --report-needless-disables, --rd
 
       Also report errors for "stylelint-disable" comments that are not blocking

--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -48,6 +48,7 @@ describe('buildCLI', () => {
 			reportInvalidScopeDisables: false,
 			reportNeedlessDisables: false,
 			stdin: false,
+			validate: true,
 			version: false,
 		});
 	});
@@ -104,6 +105,11 @@ describe('buildCLI', () => {
 
 	it('flags.fix', () => {
 		expect(buildCLI(['--fix']).flags.fix).toBe(true);
+	});
+
+	it('flags.validate', () => {
+		expect(buildCLI(['--validate']).flags.validate).toBe(true);
+		expect(buildCLI(['--no-validate']).flags.validate).toBe(false);
 	});
 
 	it('flags.formatter', () => {

--- a/lib/__tests__/standalone.test.mjs
+++ b/lib/__tests__/standalone.test.mjs
@@ -128,6 +128,24 @@ describe('standalone with files and cwd', () => {
 	});
 });
 
+test('absence of option validation', async () => {
+	const {
+		results: [result],
+	} = await standalone({
+		files: 'empty-block.css',
+		cwd: fixturesPath,
+		config: {
+			rules: {
+				'block-no-empty': '',
+			},
+		},
+		validate: false,
+	});
+
+	expect(result.errored).toBe(true);
+	expect(result.invalidOptionWarnings).toHaveLength(0);
+});
+
 it('standalone with input css', async () => {
 	const { report, results } = await standalone({
 		code: 'a {}',

--- a/lib/__tests__/standalone.test.mjs
+++ b/lib/__tests__/standalone.test.mjs
@@ -148,50 +148,52 @@ it('standalone without input css and file(s) should throw error', async () => {
 	await expect(() => standalone({ config: configBlockNoEmpty })).rejects.toThrow(expectedError);
 });
 
-it('standalone with nonexistent-file throws an error', async () => {
-	const files = `${fixturesPath}/nonexistent-file.css`;
-	const expectedError = new NoFilesFoundError(files);
+describe('standalone with nonexistent-file', () => {
+	it('throws an error', async () => {
+		const files = `${fixturesPath}/nonexistent-file.css`;
+		const expectedError = new NoFilesFoundError(files);
 
-	await expect(
-		standalone({
-			files,
+		await expect(
+			standalone({
+				files,
+				config: configBlockNoEmpty,
+			}),
+		).rejects.toThrow(expectedError);
+	});
+
+	it('allowEmptyInput enabled quietly exits', async () => {
+		const { results, errored, report } = await standalone({
+			files: `${fixturesPath}/nonexistent-file.css`,
 			config: configBlockNoEmpty,
-		}),
-	).rejects.toThrow(expectedError);
-});
+			allowEmptyInput: true,
+		});
 
-it('standalone with nonexistent-file and allowEmptyInput enabled quietly exits', async () => {
-	const { results, errored, report } = await standalone({
-		files: `${fixturesPath}/nonexistent-file.css`,
-		config: configBlockNoEmpty,
-		allowEmptyInput: true,
+		expect(results).toHaveLength(0);
+		expect(errored).toBe(false);
+		expect(report).toBe('[]');
 	});
 
-	expect(results).toHaveLength(0);
-	expect(errored).toBe(false);
-	expect(report).toBe('[]');
-});
+	it('allowEmptyInput enabled (in config) quietly exits', async () => {
+		const { results, errored, report } = await standalone({
+			files: `${fixturesPath}/nonexistent-file.css`,
+			config: { ...configBlockNoEmpty, allowEmptyInput: true },
+		});
 
-it('standalone with nonexistent-file and allowEmptyInput enabled (in config) quietly exits', async () => {
-	const { results, errored, report } = await standalone({
-		files: `${fixturesPath}/nonexistent-file.css`,
-		config: { ...configBlockNoEmpty, allowEmptyInput: true },
+		expect(results).toHaveLength(0);
+		expect(errored).toBe(false);
+		expect(report).toBe('[]');
 	});
 
-	expect(results).toHaveLength(0);
-	expect(errored).toBe(false);
-	expect(report).toBe('[]');
-});
+	it('allowEmptyInput enabled (in config file) quietly exits', async () => {
+		const { results, errored, report } = await standalone({
+			files: `${fixturesPath}/nonexistent-file.css`,
+			configFile: `${fixturesPath}/config-allow-empty-input.json`,
+		});
 
-it('standalone with nonexistent-file and allowEmptyInput enabled (in config file) quietly exits', async () => {
-	const { results, errored, report } = await standalone({
-		files: `${fixturesPath}/nonexistent-file.css`,
-		configFile: `${fixturesPath}/config-allow-empty-input.json`,
+		expect(results).toHaveLength(0);
+		expect(errored).toBe(false);
+		expect(report).toBe('[]');
 	});
-
-	expect(results).toHaveLength(0);
-	expect(errored).toBe(false);
-	expect(report).toBe('[]');
 });
 
 it('standalone ignoring passed "allowEmptyInput: false" option', async () => {

--- a/lib/augmentConfig.cjs
+++ b/lib/augmentConfig.cjs
@@ -525,6 +525,10 @@ function addOptions(stylelint, config) {
 		augmentedConfig.fix = stylelint._options.fix;
 	}
 
+	if (stylelint._options.validate) {
+		augmentedConfig.validate = stylelint._options.validate;
+	}
+
 	return augmentedConfig;
 }
 

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -523,5 +523,9 @@ function addOptions(stylelint, config) {
 		augmentedConfig.fix = stylelint._options.fix;
 	}
 
+	if (stylelint._options.validate) {
+		augmentedConfig.validate = stylelint._options.validate;
+	}
+
 	return augmentedConfig;
 }

--- a/lib/cli.mjs
+++ b/lib/cli.mjs
@@ -156,6 +156,10 @@ const helpText = `
 
         Force enabling/disabling of color.
 
+      --[no-]validate
+
+        Force enable/disable the validation of the rules' options.
+
       --report-needless-disables, --rd
 
         Also report errors for "stylelint-disable" comments that are not blocking
@@ -299,6 +303,10 @@ const flags = {
 	stdinFilename: {
 		type: 'string',
 	},
+	validate: {
+		type: 'boolean',
+		default: true,
+	},
 	version: {
 		shortFlag: 'v',
 		type: 'boolean',
@@ -349,6 +357,7 @@ export default async function main(argv) {
 		reportNeedlessDisables,
 		stdin,
 		stdinFilename,
+		validate,
 		version,
 	} = cli.flags;
 
@@ -456,6 +465,10 @@ export default async function main(argv) {
 
 	if (isBoolean(fix)) {
 		options.fix = fix;
+	}
+
+	if (isBoolean(validate)) {
+		options.validate = validate;
 	}
 
 	if (isBoolean(reportNeedlessDisables)) {

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -59,6 +59,7 @@ async function standalone({
 	reportDescriptionlessDisables,
 	reportInvalidScopeDisables,
 	reportNeedlessDisables,
+	validate = true,
 }) {
 	const startTime = Date.now();
 
@@ -116,6 +117,7 @@ async function standalone({
 		fix,
 		quiet,
 		quietDeprecationWarnings,
+		validate,
 	});
 
 	if (!files) {

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -57,6 +57,7 @@ export default async function standalone({
 	reportDescriptionlessDisables,
 	reportInvalidScopeDisables,
 	reportNeedlessDisables,
+	validate = true,
 }) {
 	const startTime = Date.now();
 
@@ -114,6 +115,7 @@ export default async function standalone({
 		fix,
 		quiet,
 		quietDeprecationWarnings,
+		validate,
 	});
 
 	if (!files) {

--- a/lib/utils/__tests__/validateOptions.test.mjs
+++ b/lib/utils/__tests__/validateOptions.test.mjs
@@ -5,7 +5,7 @@ import { jest } from '@jest/globals';
 function mockResult() {
 	return {
 		warn: jest.fn(),
-		stylelint: {},
+		stylelint: { config: { validate: true } },
 	};
 }
 

--- a/lib/utils/validateOptions.cjs
+++ b/lib/utils/validateOptions.cjs
@@ -19,6 +19,10 @@ const REPORT_OPTIONS = new Set([
  * @type {import('stylelint').Utils['validateOptions']}
  */
 function validateOptions(result, ruleName, ...optionDescriptions) {
+	const mustValidate = result.stylelint.config?.validate;
+
+	if (!mustValidate) return true;
+
 	let noErrors = true;
 
 	for (const optionDescription of optionDescriptions) {

--- a/lib/utils/validateOptions.mjs
+++ b/lib/utils/validateOptions.mjs
@@ -15,6 +15,10 @@ const REPORT_OPTIONS = new Set([
  * @type {import('stylelint').Utils['validateOptions']}
  */
 export default function validateOptions(result, ruleName, ...optionDescriptions) {
+	const mustValidate = result.stylelint.config?.validate;
+
+	if (!mustValidate) return true;
+
 	let noErrors = true;
 
 	for (const optionDescription of optionDescriptions) {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -123,6 +123,7 @@ declare namespace stylelint {
 		allowEmptyInput?: boolean;
 		cache?: boolean;
 		fix?: boolean;
+		validate?: boolean;
 	};
 
 	/** @internal */
@@ -674,6 +675,7 @@ declare namespace stylelint {
 		allowEmptyInput?: boolean;
 		quiet?: boolean;
 		quietDeprecationWarnings?: boolean;
+		validate?: boolean;
 	};
 
 	/**


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

It was inspired by:

> […by it's very nature Stylelint runs should gravitate towards becoming a `noop`.](https://github.com/stylelint/stylelint/issues/6869#issue-1729397616)

> Is there anything in the PR that needs further explanation?

1.

Most of the time your config is valid. Hence we ought to provide a way to turn `validateOptions` into a noop.
i.e. if you know what you are doing then skipping the validation of the options should be possible
e.g. faster CI, vscode extension

The default is `true`.
i.e. it's not a disruptive change

2.

My very basic/crude perf test compared `main` and `flag-option-validate` using time and [bulma](https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css):

```console
$ time ./bin/stylelint.mjs bulma.min.css -f compact
```

```json
{
  "extends": [
    "stylelint-config-standard"
  ],
  "validate": false
}
```
After removing the lower and upper outliers, I was getting between 50 and 500 ms of gains on my old macbook air.
Thorough testing is not needed because the outcome should be obvious.

3.

Caching is another alternative.
The flag/option is easier to introduce.
i.e. overloading `cache` is riskier

4.

only review the second commit