### PR TITLE
Refactor to replace `strip-ansi` with `stripVTControlCharacters` from `node:util`

### DIFF
--- a/lib/__tests__/cli.test.mjs
+++ b/lib/__tests__/cli.test.mjs
@@ -4,9 +4,9 @@ import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import process from 'node:process';
+import { stripVTControlCharacters } from 'node:util';
 
 import { jest } from '@jest/globals';
-import stripAnsi from 'strip-ansi';
 import { stripIndent } from 'common-tags';
 
 import {
@@ -390,7 +390,7 @@ describe('CLI', () => {
 		expect(output).toBeInstanceOf(Array);
 		expect(output[0]).toHaveProperty('source', expect.stringContaining('empty-block.css'));
 
-		expect(stripAnsi(process.stderr.write.mock.calls[1][0])).toContain(
+		expect(stripVTControlCharacters(process.stderr.write.mock.calls[1][0])).toContain(
 			'Max warnings exceeded: 1 found. 0 allowed',
 		);
 	});
@@ -502,7 +502,7 @@ describe('CLI', () => {
 
 		expect(process.stdout.write).not.toHaveBeenCalled();
 		expect(process.stderr.write).toHaveBeenCalledTimes(1);
-		expect(stripAnsi(process.stderr.write.mock.calls[0][0])).toContain(
+		expect(stripVTControlCharacters(process.stderr.write.mock.calls[0][0])).toContain(
 			'Invalid option "--globby-options". The value "wrong" is not valid JSON object.',
 		);
 	});

--- a/lib/__tests__/standalone-formatter.test.mjs
+++ b/lib/__tests__/standalone-formatter.test.mjs
@@ -1,5 +1,3 @@
-import stripAnsi from 'strip-ansi';
-
 import customFormatter from './fixtures/custom-formatter.mjs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -9,6 +7,7 @@ import readJSONFile from '../testUtils/readJSONFile.mjs';
 import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import standalone from '../standalone.mjs';
 import stringFormatter from '../formatters/stringFormatter.mjs';
+import { stripVTControlCharacters } from 'node:util';
 
 const configBlockNoEmpty = readJSONFile(
 	new URL('./fixtures/config-block-no-empty.json', import.meta.url),
@@ -24,7 +23,7 @@ it('standalone with input css and alternate formatter specified by keyword', asy
 		formatter: 'string',
 	});
 
-	const strippedOutput = stripAnsi(report);
+	const strippedOutput = stripVTControlCharacters(report);
 
 	expect(strippedOutput).toContain('1:3');
 	expect(strippedOutput).toContain('block-no-empty');
@@ -37,7 +36,7 @@ it('standalone with input css and alternate formatter function', async () => {
 		formatter: stringFormatter,
 	});
 
-	const strippedOutput = stripAnsi(report);
+	const strippedOutput = stripVTControlCharacters(report);
 
 	expect(strippedOutput).toContain('1:3');
 	expect(strippedOutput).toContain('block-no-empty');
@@ -78,7 +77,7 @@ it('standalone with formatter specified in configuration', async () => {
 		config: configWithFormatter,
 	});
 
-	const strippedOutput = stripAnsi(report);
+	const strippedOutput = stripVTControlCharacters(report);
 
 	expect(strippedOutput).toContain('1:3');
 	expect(strippedOutput).toContain('block-no-empty');
@@ -96,7 +95,7 @@ it('standalone with formatter argument overriding configuration formatter', asyn
 		formatter: 'string',
 	});
 
-	const strippedOutput = stripAnsi(report);
+	const strippedOutput = stripVTControlCharacters(report);
 
 	expect(strippedOutput).toContain('1:3');
 	expect(strippedOutput).toContain('block-no-empty');

--- a/lib/formatters/__tests__/stringFormatter.test.mjs
+++ b/lib/formatters/__tests__/stringFormatter.test.mjs
@@ -1,6 +1,6 @@
 import process from 'node:process';
+import { stripVTControlCharacters } from 'node:util';
 
-import stripAnsi from 'strip-ansi';
 import { stripIndent } from 'common-tags';
 
 import { getCleanFormatterOutput } from '../../testUtils/getCleanOutput.mjs';
@@ -76,7 +76,7 @@ path/to/file.css
 		];
 
 		const errorSymbol = isUnicodeSupported() ? '✖' : '×';
-		const output = stripAnsi(stringFormatter(results, { ruleMetadata: {} })).trim();
+		const output = stripVTControlCharacters(stringFormatter(results, { ruleMetadata: {} })).trim();
 
 		expect(output).toBe(stripIndent`
 path/to/file.css

--- a/lib/testUtils/getCleanOutput.mjs
+++ b/lib/testUtils/getCleanOutput.mjs
@@ -1,4 +1,4 @@
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
 
 const symbolConversions = new Map();
 
@@ -12,7 +12,7 @@ symbolConversions.set('✖', '×');
  * @returns {string}
  */
 export default function getCleanOutput(output) {
-	let cleanOutput = stripAnsi(output).trim();
+	let cleanOutput = stripVTControlCharacters(output).trim();
 
 	for (const [nix, win] of symbolConversions.entries()) {
 		cleanOutput = cleanOutput.replace(new RegExp(nix, 'g'), win);

--- a/lib/writeOutputFile.cjs
+++ b/lib/writeOutputFile.cjs
@@ -4,7 +4,7 @@
 
 const node_path = require('node:path');
 const promises = require('node:fs/promises');
-const stripAnsi = require('strip-ansi');
+const node_util = require('node:util');
 const writeFileAtomic = require('write-file-atomic');
 
 /**
@@ -15,7 +15,7 @@ const writeFileAtomic = require('write-file-atomic');
 async function writeOutputFile(content, filePath) {
 	await promises.mkdir(node_path.dirname(filePath), { recursive: true });
 
-	await writeFileAtomic(node_path.normalize(filePath), stripAnsi(content));
+	await writeFileAtomic(node_path.normalize(filePath), node_util.stripVTControlCharacters(content));
 }
 
 module.exports = writeOutputFile;

--- a/lib/writeOutputFile.mjs
+++ b/lib/writeOutputFile.mjs
@@ -1,6 +1,6 @@
 import { dirname, normalize } from 'node:path';
 import { mkdir } from 'node:fs/promises';
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters } from 'node:util';
 import writeFileAtomic from 'write-file-atomic';
 
 /**
@@ -11,5 +11,5 @@ import writeFileAtomic from 'write-file-atomic';
 export default async function writeOutputFile(content, filePath) {
 	await mkdir(dirname(filePath), { recursive: true });
 
-	await writeFileAtomic(normalize(filePath), stripAnsi(content));
+	await writeFileAtomic(normalize(filePath), stripVTControlCharacters(content));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
-        "strip-ansi": "^7.1.0",
         "supports-hyperlinks": "^3.1.0",
         "svg-tags": "^1.0.0",
         "table": "^6.8.2",
@@ -15932,6 +15931,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -15959,6 +15959,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
     "postcss-value-parser": "^4.2.0",
     "resolve-from": "^5.0.0",
     "string-width": "^4.2.3",
-    "strip-ansi": "^7.1.0",
     "supports-hyperlinks": "^3.1.0",
     "svg-tags": "^1.0.0",
     "table": "^6.8.2",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

- Closes #8016 

> Is there anything in the PR that needs further explanation?

This pull request replaces all instances of `strip-ansi` in all file(s) with `util.stripVTControlCharacters`.

The utility is available since Node 16.11, so there shouldn't be any compatibility issues as the latest version of `stylelint` requires Node 18.12 at minimum.