### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` autofix for `grid-column`/`grid-row`

### DIFF
--- a/.changeset/heavy-dryers-promise.md
+++ b/.changeset/heavy-dryers-promise.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` autofix for `grid-column`/`grid-row`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -722,11 +722,11 @@ testRule({
 		},
 		{
 			code: stripIndent`
-        a {
-          grid-column: line-outer-left / line-outer-right;
-          grid-row: line-inner-top / line-inner-bottom;
-        }
-      `,
+				a {
+					grid-column: line-outer-left / line-outer-right;
+					grid-row: line-inner-top / line-inner-bottom;
+				}
+			`,
 			skip: true,
 			description: 'TODO: explicit grid-area test',
 			message: messages.expected('grid-area'),

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -721,6 +721,17 @@ testRule({
 			],
 		},
 		{
+			code: stripIndent`
+        a {
+          grid-column: line-outer-left / line-outer-right;
+          grid-row: line-inner-top / line-inner-bottom;
+        }
+      `,
+			skip: true,
+			description: 'TODO: explicit grid-area test',
+			message: messages.expected('grid-area'),
+		},
+		{
 			code: 'a { border-top-left-radius: 1em; border-top-right-radius: 2em; border-bottom-right-radius: 3em; border-bottom-left-radius: 4em; }',
 			fixed: 'a { border-radius: 1em 2em 3em 4em; }',
 			description: 'explicit border-radius test',

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -707,7 +707,7 @@ testRule({
 					grid-column: 3 / 4;
 				}
 			`,
-			description: 'explicit grid-area test',
+			description: 'combination of grid-row and grid-column test',
 			warnings: [
 				{ column: 2, endColumn: 14, endLine: 3, line: 3, message: messages.expected('grid-row') },
 				{ column: 2, endColumn: 17, endLine: 5, line: 5, message: messages.expected('grid-area') },

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -693,6 +693,34 @@ testRule({
 			message: messages.expected('grid-row'),
 		},
 		{
+			code: stripIndent`
+				a {
+					grid-row-start: 1;
+					grid-row-end: 2;
+					grid-column-start: 3;
+					grid-column-end: 4;
+				}
+			`,
+			fixed: stripIndent`
+				a {
+					grid-row: 1 / 2;
+					grid-column: 3 / 4;
+				}
+			`,
+			description: 'explicit grid-area test',
+			warnings: [
+				{ column: 2, endColumn: 14, endLine: 3, line: 3, message: messages.expected('grid-row') },
+				{ column: 2, endColumn: 17, endLine: 5, line: 5, message: messages.expected('grid-area') },
+				{
+					column: 2,
+					endColumn: 17,
+					endLine: 5,
+					line: 5,
+					message: messages.expected('grid-column'),
+				},
+			],
+		},
+		{
 			code: 'a { border-top-left-radius: 1em; border-top-right-radius: 2em; border-bottom-right-radius: 3em; border-bottom-left-radius: 4em; }',
 			fixed: 'a { border-radius: 1em 2em 3em 4em; }',
 			description: 'explicit border-radius test',

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -190,6 +190,9 @@ const haveConflicts = [
 	'border-right',
 	'border-bottom',
 	'border-left',
+	'grid-area',
+	'grid-column',
+	'grid-row',
 ];
 
 /**

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -190,7 +190,6 @@ const haveConflicts = [
 	'border-right',
 	'border-bottom',
 	'border-left',
-	'grid-area',
 	'grid-column',
 	'grid-row',
 ];

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -187,6 +187,9 @@ const haveConflicts = [
 	'border-right',
 	'border-bottom',
 	'border-left',
+	'grid-area',
+	'grid-column',
+	'grid-row',
 ];
 
 /**

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -187,7 +187,6 @@ const haveConflicts = [
 	'border-right',
 	'border-bottom',
 	'border-left',
-	'grid-area',
 	'grid-column',
 	'grid-row',
 ];


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7933

> Is there anything in the PR that needs further explanation?

This follows the approach from a previous PR that fixed similar longhand property issues.
ref: https://github.com/stylelint/stylelint/pull/7626
