### PR TITLE
Fix `function-calc-no-unspaced-operator` false negatives for `calc-size`

### DIFF
--- a/.changeset/flat-tomatoes-kick.md
+++ b/.changeset/flat-tomatoes-kick.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `function-no-unknown` false positives for `calc-size`
+Fixed: `function-calc-no-unspaced-operator` false negatives for `calc-size`

--- a/.changeset/flat-tomatoes-kick.md
+++ b/.changeset/flat-tomatoes-kick.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: Support `calc-size` function

--- a/.changeset/flat-tomatoes-kick.md
+++ b/.changeset/flat-tomatoes-kick.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": minor
+"stylelint": patch
 ---
 
-Added: Support `calc-size` function
+Fixed: `function-no-unknown` false positives for `calc-size`

--- a/lib/reference/functions.cjs
+++ b/lib/reference/functions.cjs
@@ -36,7 +36,6 @@ const singleArgumentMathFunctions = new Set([
 	'asin',
 	'atan',
 	'calc',
-	'calc-size',
 	'cos',
 	'exp',
 	'sign',
@@ -48,6 +47,7 @@ const singleArgumentMathFunctions = new Set([
 const mathFunctions = new Set([
 	...singleArgumentMathFunctions,
 	'atan2',
+	'calc-size',
 	'clamp',
 	'hypot',
 	'log',

--- a/lib/reference/functions.cjs
+++ b/lib/reference/functions.cjs
@@ -36,6 +36,7 @@ const singleArgumentMathFunctions = new Set([
 	'asin',
 	'atan',
 	'calc',
+	'calc-size',
 	'cos',
 	'exp',
 	'sign',

--- a/lib/reference/functions.mjs
+++ b/lib/reference/functions.mjs
@@ -32,7 +32,6 @@ const singleArgumentMathFunctions = new Set([
 	'asin',
 	'atan',
 	'calc',
-	'calc-size',
 	'cos',
 	'exp',
 	'sign',
@@ -44,6 +43,7 @@ const singleArgumentMathFunctions = new Set([
 export const mathFunctions = new Set([
 	...singleArgumentMathFunctions,
 	'atan2',
+	'calc-size',
 	'clamp',
 	'hypot',
 	'log',

--- a/lib/reference/functions.mjs
+++ b/lib/reference/functions.mjs
@@ -32,6 +32,7 @@ const singleArgumentMathFunctions = new Set([
 	'asin',
 	'atan',
 	'calc',
+	'calc-size',
 	'cos',
 	'exp',
 	'sign',

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -268,6 +268,14 @@ testRule({
 			],
 		},
 		{
+			code: 'a { top: calc-size(any, 2px+1px); }',
+			fixed: 'a { top: calc-size(any, 2px + 1px); }',
+			warnings: [
+				{ message: messages.expectedAfter('+'), line: 1, column: 28, endLine: 1, endColumn: 29 },
+				{ message: messages.expectedBefore('+'), line: 1, column: 28, endLine: 1, endColumn: 29 },
+			],
+		},
+		{
 			code: 'a { transform: rotate(acos(2+1)); }',
 			fixed: 'a { transform: rotate(acos(2 + 1)); }',
 			warnings: [

--- a/lib/rules/function-no-unknown/__tests__/index.mjs
+++ b/lib/rules/function-no-unknown/__tests__/index.mjs
@@ -28,6 +28,9 @@ testRule({
 			code: 'a { height: calc(10px*(5*(10 - 5))); }',
 		},
 		{
+			code: 'a { height: calc-size(auto); }',
+		},
+		{
 			code: 'a { top: anchor(bottom); }',
 		},
 		{

--- a/lib/rules/function-no-unknown/__tests__/index.mjs
+++ b/lib/rules/function-no-unknown/__tests__/index.mjs
@@ -28,9 +28,6 @@ testRule({
 			code: 'a { height: calc(10px*(5*(10 - 5))); }',
 		},
 		{
-			code: 'a { height: calc-size(auto); }',
-		},
-		{
 			code: 'a { top: anchor(bottom); }',
 		},
 		{

--- a/lib/utils/__tests__/isMathFunction.test.mjs
+++ b/lib/utils/__tests__/isMathFunction.test.mjs
@@ -10,6 +10,10 @@ describe('isMathFunction', () => {
 		expect(isMathFunction(valueParser('cALc(10% + 10px)').nodes[0])).toBe(true);
 	});
 
+	it('matches calc-size', () => {
+		expect(isMathFunction(valueParser('calc-size(auto)').nodes[0])).toBe(true);
+	});
+
 	it('does not match var', () => {
 		expect(isMathFunction(valueParser('var(--foo, 1px)').nodes[0])).toBe(false);
 	});

--- a/lib/utils/__tests__/isMathFunction.test.mjs
+++ b/lib/utils/__tests__/isMathFunction.test.mjs
@@ -11,7 +11,7 @@ describe('isMathFunction', () => {
 	});
 
 	it('matches calc-size', () => {
-		expect(isMathFunction(valueParser('calc-size(auto)').nodes[0])).toBe(true);
+		expect(isMathFunction(valueParser('calc-size(any, 0px)').nodes[0])).toBe(true);
 	});
 
 	it('does not match var', () => {


### PR DESCRIPTION
Added new CSS function `calc-size`.

> Which issue, if any, is this issue related to?

N/A.

> Is there anything in the PR that needs further explanation?

Read more:
https://chromestatus.com/feature/5196713071738880
https://blog.webdevsimplified.com/2024-07/css-calc-size/
https://caniuse.com/?search=calc-size