### PR TITLE
Fix incorrect `config` option for Node.js API with `extends` and `overrides`

### DIFF
--- a/.changeset/lemon-dots-learn.md
+++ b/.changeset/lemon-dots-learn.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: incorrect `config` option for Node.js API with `extends` and `overrides`

--- a/lib/__tests__/overrides.test.mjs
+++ b/lib/__tests__/overrides.test.mjs
@@ -127,6 +127,21 @@ describe('single input file. all overrides are matching', () => {
 		expect(linted.results[0].warnings[1].rule).toBe('color-named');
 	});
 
+	it('override with extends in config property', async () => {
+		const { results } = await standalone({
+			files: [path.join(fixturesPath, 'style.css')],
+			config: {
+				extends: path.join(fixturesPath, 'extends-in-overrides.json'),
+				rules: {},
+			},
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0].warnings).toHaveLength(2);
+		expect(results[0].warnings[0].rule).toBe('block-no-empty');
+		expect(results[0].warnings[1].rule).toBe('color-named');
+	});
+
 	it('priority to apply overrides: apply overrides extends', async () => {
 		const linted = await standalone({
 			files: [path.join(fixturesPath, 'precision.css')],

--- a/lib/getConfigForFile.cjs
+++ b/lib/getConfigForFile.cjs
@@ -27,23 +27,25 @@ async function getConfigForFile(
 	const optionsConfig = stylelint._options.config;
 	const cwd = stylelint._options.cwd;
 
-	if (optionsConfig !== undefined) {
-		const cached = stylelint._specifiedConfigCache.get(optionsConfig);
+	if (optionsConfig) {
+		const filePathAsCacheKey = filePath ?? '';
+		/** @type {Map<string, StylelintCosmiconfigResult>} */
+		const cachedForFiles = stylelint._specifiedConfigCache.get(optionsConfig) ?? new Map();
+		const cached = cachedForFiles.get(filePathAsCacheKey);
 
-		// If config has overrides the resulting config might be different for some files.
-		// Cache results only if resulted config is the same for all linted files.
-		if (cached && !optionsConfig.overrides) {
+		if (cached) {
 			return cached;
 		}
 
-		const augmentedResult = augmentConfig.augmentConfigFull(stylelint, filePath, {
+		const augmentedResult = await augmentConfig.augmentConfigFull(stylelint, filePath, {
 			config: optionsConfig,
 			// Add the extra path part so that we can get the directory without being
 			// confused
 			filepath: path.join(cwd, 'argument-config'),
 		});
 
-		stylelint._specifiedConfigCache.set(optionsConfig, augmentedResult);
+		cachedForFiles.set(filePathAsCacheKey, augmentedResult);
+		stylelint._specifiedConfigCache.set(optionsConfig, cachedForFiles);
 
 		return augmentedResult;
 	}

--- a/lib/getConfigForFile.mjs
+++ b/lib/getConfigForFile.mjs
@@ -25,23 +25,25 @@ export default async function getConfigForFile(
 	const optionsConfig = stylelint._options.config;
 	const cwd = stylelint._options.cwd;
 
-	if (optionsConfig !== undefined) {
-		const cached = stylelint._specifiedConfigCache.get(optionsConfig);
+	if (optionsConfig) {
+		const filePathAsCacheKey = filePath ?? '';
+		/** @type {Map<string, StylelintCosmiconfigResult>} */
+		const cachedForFiles = stylelint._specifiedConfigCache.get(optionsConfig) ?? new Map();
+		const cached = cachedForFiles.get(filePathAsCacheKey);
 
-		// If config has overrides the resulting config might be different for some files.
-		// Cache results only if resulted config is the same for all linted files.
-		if (cached && !optionsConfig.overrides) {
+		if (cached) {
 			return cached;
 		}
 
-		const augmentedResult = augmentConfigFull(stylelint, filePath, {
+		const augmentedResult = await augmentConfigFull(stylelint, filePath, {
 			config: optionsConfig,
 			// Add the extra path part so that we can get the directory without being
 			// confused
 			filepath: join(cwd, 'argument-config'),
 		});
 
-		stylelint._specifiedConfigCache.set(optionsConfig, augmentedResult);
+		cachedForFiles.set(filePathAsCacheKey, augmentedResult);
+		stylelint._specifiedConfigCache.set(optionsConfig, cachedForFiles);
 
 		return augmentedResult;
 	}

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1015,7 +1015,7 @@ declare namespace stylelint {
 	export type InternalApi = {
 		_options: LinterOptions & { cwd: string };
 		_extendExplorer: ReturnType<typeof cosmiconfig>;
-		_specifiedConfigCache: Map<Config, Promise<CosmiconfigResult>>;
+		_specifiedConfigCache: Map<Config, Map<string, CosmiconfigResult>>;
 		_postcssResultCache: Map<string, PostCSS.Result>;
 		_fileCache: FileCache;
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8014
(This bug was introduced in #7826)

> Is there anything in the PR that needs further explanation?

The bug's root cause is present in caching in the `getConfigForFile()` function. The current logic depends on the `overrides` property like this:

https://github.com/stylelint/stylelint/blob/baf7c0e4448e6e1b1d472b53df8a3dd35291449a/lib/getConfigForFile.mjs#L31-L35

But, in the case that `overrides` is only in nested config files, `optionsConfig.overrides` is falsy, and then an incorrect cached config is returned unexpectedly, for example:

```js
standalone({
  config: {
    extends: './with-overrides.js',
    rules: {},
  },
});
```

```js
// with-overrides.js
export default {
  overrides: [ 
    { 
      files: ["*.css"],
      rules: {
        'block-no-empty': true,
      },
    },
  ],
};
```

So, this PR uses `optionsConfig` and `filePath` for caching keys, instead of `optionsConfig.overrides`. For that purpose, we have to change the structure of the cache data like this:

```diff
- Map<Config, Promise<CosmiconfigResult>>
+ Map<Config, Map<string, CosmiconfigResult>>
```

