### PR TITLE
Fix `length-zero-no-unit` false positives for Sass variables

### DIFF
--- a/.changeset/wet-foxes-fail.md
+++ b/.changeset/wet-foxes-fail.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `length-zero-no-unit` false positives for Sass variables

--- a/lib/rules/length-zero-no-unit/__tests__/index.mjs
+++ b/lib/rules/length-zero-no-unit/__tests__/index.mjs
@@ -763,6 +763,12 @@ testRule({
 	fix: true,
 	customSyntax: 'postcss-scss',
 
+	accept: [
+		{
+			code: 'a { $padding-top-base-offset: 5px; $padding-top-extra-offset: 0px; }',
+			description: 'Ignore Sass variables with zero length units',
+		},
+	],
 	reject: [
 		{
 			code: '@include border-left-radius($input-top-left-radius: 0px);',
@@ -806,38 +812,17 @@ testRule({
 			code: '@detached-ruleset: { font: normal normal 400 0/0px cursive; };',
 			description: 'ignore Less detached ruleset with font',
 		},
-	],
-
-	reject: [
 		{
 			code: '@detached-ruleset: { font-size: 0px; };',
-			fixed: '@detached-ruleset: { font-size: 0; };',
-
-			message: messages.rejected,
-			line: 1,
-			column: 34,
-			endLine: 1,
-			endColumn: 36,
+			description: 'ignore Less detached ruleset with font-size',
 		},
 		{
 			code: '@detached-ruleset: { grid-template-columns: 0fr; font-size: 0px; line-height: 0px; };',
-			fixed: '@detached-ruleset: { grid-template-columns: 0fr; font-size: 0; line-height: 0px; };',
-
-			message: messages.rejected,
-			line: 1,
-			column: 62,
-			endLine: 1,
-			endColumn: 64,
+			description: 'ignore Less detached ruleset with multiple properties',
 		},
 		{
 			code: '@detached-ruleset: { font: normal normal 400 0px/0px cursive; };',
-			fixed: '@detached-ruleset: { font: normal normal 400 0/0px cursive; };',
-
-			message: messages.rejected,
-			line: 1,
-			column: 47,
-			endLine: 1,
-			endColumn: 49,
+			description: 'ignore Less detached ruleset with font',
 		},
 	],
 });

--- a/lib/rules/length-zero-no-unit/index.cjs
+++ b/lib/rules/length-zero-no-unit/index.cjs
@@ -12,6 +12,7 @@ const getDeclarationValue = require('../../utils/getDeclarationValue.cjs');
 const isCustomProperty = require('../../utils/isCustomProperty.cjs');
 const isMathFunction = require('../../utils/isMathFunction.cjs');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule.cjs');
+const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration.cjs');
 const units = require('../../reference/units.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
@@ -126,6 +127,8 @@ const rule = (primary, secondaryOptions) => {
 		/** @param {Declaration} node */
 		function checkDecl(node) {
 			const { prop } = node;
+
+			if (!isStandardSyntaxDeclaration(node)) return;
 
 			if (isLineHeight(prop)) return;
 

--- a/lib/rules/length-zero-no-unit/index.mjs
+++ b/lib/rules/length-zero-no-unit/index.mjs
@@ -9,6 +9,7 @@ import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
 import isMathFunction from '../../utils/isMathFunction.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
+import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
 import { lengthUnits } from '../../reference/units.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
@@ -123,6 +124,8 @@ const rule = (primary, secondaryOptions) => {
 		/** @param {Declaration} node */
 		function checkDecl(node) {
 			const { prop } = node;
+
+			if (!isStandardSyntaxDeclaration(node)) return;
 
 			if (isLineHeight(prop)) return;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8034

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
