### PR TITLE
Fix `max-nesting-depth` ignore option for '&' and pseudo-classes

### DIFF
--- a/lib/rules/max-nesting-depth/__tests__/index.mjs
+++ b/lib/rules/max-nesting-depth/__tests__/index.mjs
@@ -361,6 +361,73 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [1, { ignoreRules: ['&'], ignore: ['pseudo-classes'] }],
+
+	accept: [
+		{
+			code: stripIndent`
+			a {
+				color: red;
+				& {
+					color: blue;
+				}
+				b {
+					color: gray;
+					& {
+						color: white;
+					}
+					&:hover {
+						color: orange;
+					}
+					&,
+					&:hover {
+						color: purple;
+					}
+				}
+			}
+		`,
+			description: 'Ensures "&" selectors and pseudo-classes are correctly ignored',
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [1, { ignoreRules: ['&'] }],
+
+	reject: [
+		{
+			code: stripIndent`
+					a {
+						color: red;
+						& {
+							color: blue;
+						}
+						b {
+							color: gray;
+							& {
+								color: white;
+							}
+							&,
+							&:hover {
+								color: purple;
+							}
+						}
+					}
+				`,
+			message: messages.expected(1),
+			line: 11,
+			column: 3,
+			endLine: 14,
+			endColumn: 4,
+			description:
+				'"&" included in ignoreRules with comma-separated selectors mixed with pseudo-classes.',
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: [
 		1,
 		{

--- a/lib/rules/max-nesting-depth/index.cjs
+++ b/lib/rules/max-nesting-depth/index.cjs
@@ -127,7 +127,11 @@ const rule = (primary, secondaryOptions) => {
 			const normalized = parser().processSync(selector, { lossless: false });
 			const selectors = normalized.split(',');
 
-			return selectors.every((sel) => extractPseudoRule(sel));
+			const filteredSelectors = selectors.filter(
+				(sel) => !optionsMatches(secondaryOptions, 'ignoreRules', sel),
+			);
+
+			return filteredSelectors.every((sel) => extractPseudoRule(sel));
 		}
 
 		/**

--- a/lib/rules/max-nesting-depth/index.mjs
+++ b/lib/rules/max-nesting-depth/index.mjs
@@ -124,7 +124,11 @@ const rule = (primary, secondaryOptions) => {
 			const normalized = parser().processSync(selector, { lossless: false });
 			const selectors = normalized.split(',');
 
-			return selectors.every((sel) => extractPseudoRule(sel));
+			const filteredSelectors = selectors.filter(
+				(sel) => !optionsMatches(secondaryOptions, 'ignoreRules', sel),
+			);
+
+			return filteredSelectors.every((sel) => extractPseudoRule(sel));
 		}
 
 		/**


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/7873

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
