### PR TITLE
Fix `selector-max-compound-selectors` reported ranges

### DIFF
--- a/.changeset/silent-bats-tap.md
+++ b/.changeset/silent-bats-tap.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-max-compound-selectors` reported ranges

--- a/lib/rules/selector-max-compound-selectors/__tests__/index.mjs
+++ b/lib/rules/selector-max-compound-selectors/__tests__/index.mjs
@@ -1,3 +1,5 @@
+import { stripIndent } from 'common-tags';
+
 import rule from '../index.mjs';
 const { messages, ruleName } = rule;
 
@@ -53,6 +55,16 @@ testRule({
 			code: 'html { --custom-property-set: {} }',
 			description: 'custom property set in selector',
 		},
+		{
+			code: stripIndent`
+				/* stylelint-disable-next-line selector-max-compound-selectors */
+				a b c, /* stylelint-disable-next-line selector-max-compound-selectors */
+				a b c,
+				/* stylelint-disable-next-line selector-max-compound-selectors */
+				a b c
+				{}
+			`,
+		},
 	],
 
 	reject: [
@@ -87,6 +99,39 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 10,
+		},
+		{
+			code: stripIndent`
+				/* a comment */
+				a b c, /* a comment */
+				a b c,
+				/* a comment */
+				a b c
+				{}
+			`,
+			warnings: [
+				{
+					message: messages.expected('a b c', 2),
+					line: 2,
+					column: 1,
+					endLine: 2,
+					endColumn: 6,
+				},
+				{
+					message: messages.expected('a b c', 2),
+					line: 3,
+					column: 1,
+					endLine: 3,
+					endColumn: 6,
+				},
+				{
+					message: messages.expected('a b c', 2),
+					line: 5,
+					column: 1,
+					endLine: 5,
+					endColumn: 6,
+				},
+			],
 		},
 	],
 });

--- a/lib/rules/selector-max-compound-selectors/index.cjs
+++ b/lib/rules/selector-max-compound-selectors/index.cjs
@@ -5,7 +5,7 @@
 const selectorParser = require('postcss-selector-parser');
 const validateTypes = require('../../utils/validateTypes.cjs');
 const flattenNestedSelectorsForRule = require('../../utils/flattenNestedSelectorsForRule.cjs');
-const getSelectorSourceIndex = require('../../utils/getSelectorSourceIndex.cjs');
+const getStrippedSelectorSource = require('../../utils/getStrippedSelectorSource.cjs');
 const isContextFunctionalPseudoClass = require('../../utils/isContextFunctionalPseudoClass.cjs');
 const isNonNegativeInteger = require('../../utils/isNonNegativeInteger.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
@@ -95,8 +95,7 @@ const rule = (primary, secondaryOptions) => {
 			const compoundCount = combinatorCount + 1;
 
 			if (compoundCount > primary) {
-				const index = getSelectorSourceIndex(selectorNode);
-				const selectorStr = selectorNode.toString().trim();
+				const { index, endIndex, selector: selectorStr } = getStrippedSelectorSource(selectorNode);
 
 				report({
 					ruleName,
@@ -105,7 +104,7 @@ const rule = (primary, secondaryOptions) => {
 					message: messages.expected,
 					messageArgs: [selectorStr, primary],
 					index,
-					endIndex: index + selectorStr.length,
+					endIndex,
 				});
 			}
 		}

--- a/lib/rules/selector-max-compound-selectors/index.mjs
+++ b/lib/rules/selector-max-compound-selectors/index.mjs
@@ -3,7 +3,7 @@ const { isCombinator, isPseudo, isRoot, isSelector } = selectorParser;
 
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import flattenNestedSelectorsForRule from '../../utils/flattenNestedSelectorsForRule.mjs';
-import getSelectorSourceIndex from '../../utils/getSelectorSourceIndex.mjs';
+import getStrippedSelectorSource from '../../utils/getStrippedSelectorSource.mjs';
 import isContextFunctionalPseudoClass from '../../utils/isContextFunctionalPseudoClass.mjs';
 import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
@@ -91,8 +91,7 @@ const rule = (primary, secondaryOptions) => {
 			const compoundCount = combinatorCount + 1;
 
 			if (compoundCount > primary) {
-				const index = getSelectorSourceIndex(selectorNode);
-				const selectorStr = selectorNode.toString().trim();
+				const { index, endIndex, selector: selectorStr } = getStrippedSelectorSource(selectorNode);
 
 				report({
 					ruleName,
@@ -101,7 +100,7 @@ const rule = (primary, secondaryOptions) => {
 					message: messages.expected,
 					messageArgs: [selectorStr, primary],
 					index,
-					endIndex: index + selectorStr.length,
+					endIndex,
 				});
 			}
 		}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/issues/7904

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
