### PR TITLE
Do not assume `stylelint` presence

### DIFF
--- a/lib/utils/validateOptions.cjs
+++ b/lib/utils/validateOptions.cjs
@@ -20,7 +20,7 @@ const REPORT_OPTIONS = new Set([
  * @type {import('stylelint').Utils['validateOptions']}
  */
 function validateOptions(result, ruleName, ...optionDescriptions) {
-	const mustValidate = result.stylelint.config?.validate;
+	const mustValidate = result.stylelint?.config?.validate;
 
 	if (!mustValidate) return true;
 

--- a/lib/utils/validateOptions.mjs
+++ b/lib/utils/validateOptions.mjs
@@ -16,7 +16,7 @@ const REPORT_OPTIONS = new Set([
  * @type {import('stylelint').Utils['validateOptions']}
  */
 export default function validateOptions(result, ruleName, ...optionDescriptions) {
-	const mustValidate = result.stylelint.config?.validate;
+	const mustValidate = result.stylelint?.config?.validate;
 
 	if (!mustValidate) return true;
 

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -64,8 +64,19 @@ const [primary, secondary] = ruleSettings;
 const context = ruleContext ? JSON.parse(ruleContext) : {};
 
 const rule = (await rules[ruleName])(primary, secondary, context);
+const fn = (root, result) => {
+	result.stylelint ||= {
+		ruleSeverities: {},
+		customMessages: {},
+		customUrls: {},
+		fixersData: {},
+		ruleMetadata: {},
+		disabledRanges: {},
+	};
 
-const processor = postcss().use(rule);
+	rule(root, result);
+};
+const processor = postcss().use(fn);
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins -- This script is only for development. We can tolerate it.
 fetch(CSS_URL)


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Related to #8044

> Is there anything in the PR that needs further explanation?

https://github.com/stylelint/stylelint/pull/7728/files#diff-cba25f954347e963307879ca83b95b319e9003d9b4b51fd350d3f4110566d3a8L21-L25
https://github.com/stylelint/stylelint/pull/8009/files#diff-a9078006ea40b10e08ed8dd13f68bb5a9585641b76e827cef5bc80216d1aa877R18

https://github.com/stylelint/stylelint/blob/b6e6a719e0e9924b60ca2b7fc1b989ab3e2f8a07/types/stylelint/index.d.ts#L186

The previous code was assuming everyone is respecting the JSDoc comments.
Since even our own script wasn't updated, it doesn't hurt to add one `?`.
