### PR TITLE
Refactor to remove direct dependencies on PostCSS internals

### DIFF
--- a/lib/getPostcssResult.cjs
+++ b/lib/getPostcssResult.cjs
@@ -3,7 +3,6 @@
 'use strict';
 
 const promises = require('node:fs/promises');
-const LazyResult = require('postcss/lib/lazy-result');
 const postcss = require('postcss');
 const dynamicImport = require('./utils/dynamicImport.cjs');
 const getModulePath = require('./utils/getModulePath.cjs');
@@ -48,7 +47,7 @@ async function getPostcssResult(stylelint, { customSyntax, filePath, code } = {}
 		throw new Error('code or filePath required');
 	}
 
-	const postcssResult = await new LazyResult(postcssProcessor, getCode, postcssOptions);
+	const postcssResult = await postcssProcessor.process(getCode, postcssOptions).async();
 
 	if (filePath) {
 		stylelint._postcssResultCache.set(filePath, postcssResult);

--- a/lib/getPostcssResult.mjs
+++ b/lib/getPostcssResult.mjs
@@ -1,6 +1,5 @@
 import { readFile } from 'node:fs/promises';
 
-import LazyResult from 'postcss/lib/lazy-result';
 import postcss from 'postcss';
 
 import dynamicImport from './utils/dynamicImport.mjs';
@@ -46,7 +45,7 @@ export default async function getPostcssResult(stylelint, { customSyntax, filePa
 		throw new Error('code or filePath required');
 	}
 
-	const postcssResult = await new LazyResult(postcssProcessor, getCode, postcssOptions);
+	const postcssResult = await postcssProcessor.process(getCode, postcssOptions).async();
 
 	if (filePath) {
 		stylelint._postcssResultCache.set(filePath, postcssResult);

--- a/lib/lintSource.cjs
+++ b/lib/lintSource.cjs
@@ -49,11 +49,7 @@ async function lintSource(stylelint, options = {}) {
 	});
 
 	if (isIgnored) {
-		return options.existingPostcssResult
-			? Object.assign(options.existingPostcssResult, {
-					stylelint: createEmptyStylelintPostcssResult(),
-			  })
-			: createEmptyPostcssResult(inputFilePath);
+		return createEmptyPostcssResult(inputFilePath, options.existingPostcssResult);
 	}
 
 	const configSearchPath = stylelint._options.configFile || inputFilePath;
@@ -82,11 +78,7 @@ async function lintSource(stylelint, options = {}) {
 		stylelint._fileCache.calcHashOfConfig(config);
 
 		if (options.filePath && !stylelint._fileCache.hasFileChanged(options.filePath)) {
-			return existingPostcssResult
-				? Object.assign(existingPostcssResult, {
-						stylelint: createEmptyStylelintPostcssResult(),
-				  })
-				: createEmptyPostcssResult(inputFilePath);
+			return createEmptyPostcssResult(inputFilePath, existingPostcssResult);
 		}
 	}
 
@@ -139,14 +131,12 @@ function createEmptyStylelintPostcssResult() {
 }
 
 /**
- * @param {string} [filePath]
+ * @param {string | undefined} filePath
+ * @param {Options['existingPostcssResult']} existingPostcssResult
  * @returns {PostcssResult}
  */
-function createEmptyPostcssResult(filePath) {
-	const result = postcss().process('', { from: filePath }).sync();
-
-	return /** @type {PostcssResult} */ ({
-		...result,
+function createEmptyPostcssResult(filePath, existingPostcssResult) {
+	return Object.assign(existingPostcssResult ?? postcss().process('', { from: filePath }).sync(), {
 		stylelint: createEmptyStylelintPostcssResult(),
 	});
 }

--- a/lib/lintSource.cjs
+++ b/lib/lintSource.cjs
@@ -3,6 +3,7 @@
 'use strict';
 
 const path = require('node:path');
+const postcss = require('postcss');
 const descriptionlessDisables = require('./descriptionlessDisables.cjs');
 const getConfigForFile = require('./getConfigForFile.cjs');
 const getPostcssResult = require('./getPostcssResult.cjs');
@@ -142,17 +143,12 @@ function createEmptyStylelintPostcssResult() {
  * @returns {PostcssResult}
  */
 function createEmptyPostcssResult(filePath) {
-	return {
-		root: {
-			source: {
-				input: { file: filePath },
-			},
-		},
-		messages: [],
-		opts: undefined,
+	const result = postcss().process('', { from: filePath }).sync();
+
+	return /** @type {PostcssResult} */ ({
+		...result,
 		stylelint: createEmptyStylelintPostcssResult(),
-		warn: () => {},
-	};
+	});
 }
 
 module.exports = lintSource;

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -47,11 +47,7 @@ export default async function lintSource(stylelint, options = {}) {
 	});
 
 	if (isIgnored) {
-		return options.existingPostcssResult
-			? Object.assign(options.existingPostcssResult, {
-					stylelint: createEmptyStylelintPostcssResult(),
-			  })
-			: createEmptyPostcssResult(inputFilePath);
+		return createEmptyPostcssResult(inputFilePath, options.existingPostcssResult);
 	}
 
 	const configSearchPath = stylelint._options.configFile || inputFilePath;
@@ -80,11 +76,7 @@ export default async function lintSource(stylelint, options = {}) {
 		stylelint._fileCache.calcHashOfConfig(config);
 
 		if (options.filePath && !stylelint._fileCache.hasFileChanged(options.filePath)) {
-			return existingPostcssResult
-				? Object.assign(existingPostcssResult, {
-						stylelint: createEmptyStylelintPostcssResult(),
-				  })
-				: createEmptyPostcssResult(inputFilePath);
+			return createEmptyPostcssResult(inputFilePath, existingPostcssResult);
 		}
 	}
 
@@ -137,14 +129,12 @@ function createEmptyStylelintPostcssResult() {
 }
 
 /**
- * @param {string} [filePath]
+ * @param {string | undefined} filePath
+ * @param {Options['existingPostcssResult']} existingPostcssResult
  * @returns {PostcssResult}
  */
-function createEmptyPostcssResult(filePath) {
-	const result = postcss().process('', { from: filePath }).sync();
-
-	return /** @type {PostcssResult} */ ({
-		...result,
+function createEmptyPostcssResult(filePath, existingPostcssResult) {
+	return Object.assign(existingPostcssResult ?? postcss().process('', { from: filePath }).sync(), {
 		stylelint: createEmptyStylelintPostcssResult(),
 	});
 }

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -1,5 +1,7 @@
 import { isAbsolute } from 'node:path';
 
+import postcss from 'postcss';
+
 import descriptionlessDisables from './descriptionlessDisables.mjs';
 import getConfigForFile from './getConfigForFile.mjs';
 import getPostcssResult from './getPostcssResult.mjs';
@@ -139,15 +141,10 @@ function createEmptyStylelintPostcssResult() {
  * @returns {PostcssResult}
  */
 function createEmptyPostcssResult(filePath) {
-	return {
-		root: {
-			source: {
-				input: { file: filePath },
-			},
-		},
-		messages: [],
-		opts: undefined,
+	const result = postcss().process('', { from: filePath }).sync();
+
+	return /** @type {PostcssResult} */ ({
+		...result,
 		stylelint: createEmptyStylelintPostcssResult(),
-		warn: () => {},
-	};
+	});
 }

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -34,20 +34,6 @@ type FileCache = {
 	removeEntry: (absoluteFilepath: string) => void;
 };
 
-type EmptyResult = {
-	root: {
-		nodes?: undefined;
-		source: {
-			lang?: undefined;
-			input: {
-				file?: string;
-			};
-		};
-	};
-	messages: PostCSS.Message[];
-	opts: undefined;
-};
-
 // Note: With strict function types enabled, function signatures are checked contravariantly.
 // This means that it would not be possible for rule authors to narrow the message function
 // parameters to e.g. just `string`. Declaring the type for rule message functions through
@@ -182,7 +168,7 @@ declare namespace stylelint {
 	};
 
 	/** @internal */
-	export type PostcssResult = (PostCSS.Result | EmptyResult) & {
+	export type PostcssResult = PostCSS.Result & {
 		stylelint: StylelintPostcssResult;
 		warn(message: string, options?: WarningOptions): void;
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/8086/files#r1818082556

> Is there anything in the PR that needs further explanation?

This refactors using only PostCSS public API to reduce our custom code.
https://postcss.org/api/

PostCSS's `Processor#process` returns an object of `LazyResult` or `NoWorkResult`:
https://github.com/postcss/postcss/blob/8.4.47/lib/processor.js#L44-L55
