### PR TITLE
Fix `benchmark-rule` script to resolve `TypeError`

### DIFF
--- a/.changeset/twenty-dragons-accept.md
+++ b/.changeset/twenty-dragons-accept.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `benchmark-rule` script to resolve `TypeError`

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -337,7 +337,7 @@ result.warn(
 You can run a benchmark on any given rule with any valid config using:
 
 ```shell
-npm run benchmark-rule -- ruleName ruleOptions [ruleContext]
+npm run benchmark-rule -- ruleName ruleOptions [config]
 ```
 
 If the `ruleOptions` argument is anything other than a string or a boolean, it must be valid JSON wrapped in quotation marks.
@@ -350,7 +350,7 @@ npm run benchmark-rule -- value-keyword-case lower
 npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'
 ```
 
-If the `ruleContext` argument is specified, the same procedure would apply:
+If the `config` argument is specified, the same procedure would apply:
 
 ```shell
 npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -30,12 +30,12 @@ function printHelp() {
 
 if (!ruleName || !ruleOptions) {
 	printHelp();
-	exit(-1);
+	exit(1);
 }
 
 if (!stylelint.rules[ruleName]) {
 	console.error(`Unknown rule: ${ruleName}`);
-	exit(-1);
+	exit(1);
 }
 
 const CSS_URL = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.css';

--- a/scripts/benchmark-rule.mjs
+++ b/scripts/benchmark-rule.mjs
@@ -3,19 +3,17 @@ import { argv, exit } from 'node:process';
 
 import Benchmark from 'benchmark';
 import picocolors from 'picocolors';
-import postcss from 'postcss';
 
-import normalizeRuleSettings from '../lib/normalizeRuleSettings.mjs';
-import rules from '../lib/rules/index.mjs';
+import stylelint from '../lib/index.mjs';
 
-const { bold, yellow } = picocolors;
+const { bold, red, yellow } = picocolors;
 
-const [, , ruleName, ruleOptions, ruleContext] = argv;
+const [, , ruleName, ruleOptions, config] = argv;
 
 function printHelp() {
 	const script = 'node benchmark-rule.mjs';
 
-	console.log(`Usage: ${script} <ruleName> <ruleOptions> [ruleContext]`);
+	console.log(`Usage: ${script} <ruleName> <ruleOptions> [config]`);
 	console.log('');
 	console.log('Examples:');
 	console.log('  # With a primary option');
@@ -24,14 +22,19 @@ function printHelp() {
 	console.log('  # With secondary options (JSON format)');
 	console.log(`  ${script} value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'`);
 	console.log('');
-	console.log('  # With a context');
+	console.log('  # With a config');
 	console.log(
 		`  ${script} value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'`,
 	);
 }
 
-if (!ruleName || !(ruleName in rules) || !ruleOptions) {
+if (!ruleName || !ruleOptions) {
 	printHelp();
+	exit(-1);
+}
+
+if (!stylelint.rules[ruleName]) {
+	console.error(`Unknown rule: ${ruleName}`);
 	exit(-1);
 }
 
@@ -58,14 +61,14 @@ if (
 }
 
 /* eslint-enable eqeqeq */
-const ruleSettings = normalizeRuleSettings(parsedOptions);
 
-const [primary, secondary] = ruleSettings;
-const context = ruleContext ? JSON.parse(ruleContext) : {};
-
-const rule = (await rules[ruleName])(primary, secondary, context);
-
-const processor = postcss().use(rule);
+const lintConfig = {
+	rules: { [ruleName]: parsedOptions },
+	cache: false,
+	formatter: () => '',
+	...(config ? JSON.parse(config) : {}),
+};
+const lint = (code) => stylelint.lint({ code, config: lintConfig });
 
 // eslint-disable-next-line n/no-unsupported-features/node-builtins -- This script is only for development. We can tolerate it.
 fetch(CSS_URL)
@@ -83,22 +86,25 @@ fetch(CSS_URL)
 		const bench = new Benchmark('rule test', {
 			defer: true,
 			setup: () => {
-				lazyResult = processor.process(css, { from: undefined });
+				lazyResult = lint(css);
 			},
 			onCycle: () => {
-				lazyResult = processor.process(css, { from: undefined });
+				lazyResult = lint(css);
 			},
 			fn: (deferred) => {
 				lazyResult
 					.then((result) => {
 						if (firstTime) {
 							firstTime = false;
-							result.messages
-								.filter((m) => m.stylelintType === 'invalidOption')
-								.forEach((m) => {
-									console.log(bold(yellow(`>> ${m.text}`)));
+							result.results.forEach(({ parseErrors, invalidOptionWarnings, warnings }) => {
+								parseErrors.forEach(({ text }) => {
+									console.error(bold(red(`>> ${text}`)));
 								});
-							console.log(`${bold('Warnings')}: ${result.warnings().length}`);
+								invalidOptionWarnings.forEach(({ text }) => {
+									console.warn(bold(yellow(`>> ${text}`)));
+								});
+								console.log(`${bold('Warnings')}: ${warnings.length}`);
+							});
 						}
 
 						deferred.resolve();


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #8044
Related to #8085

> Is there anything in the PR that needs further explanation?

This fixes the following `TypeError` by using the Stylelint Public API, instead of PostCSS and Stylelint internals.

```
TypeError: Cannot read properties of undefined (reading 'config')
    at validateOptions (file:///Users/masafumi/git/stylelint/stylelint/lib/utils/validateOptions.mjs:19:40)
```

> [!WARNING]
> This makes the benchmark script slower (about 2x slower in my machine), while the script will be less fragile.

In addition, this converts the script's third argument from a rule context to a lint config because the `context.fix` property is now deprecated.

### My local benchmarks

```sh-session
$ node --run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'
Warnings: 280
Mean: 437.2615783125 ms
Deviation: 31.228799920667353 ms
```

```sh-session
$ node --run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix":true}'
Warnings: 0
Mean: 492.96302766666673 ms
Deviation: 34.28542103536553 ms
```