### PR TITLE
Refactor to normalize report locations before use

### DIFF
--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -6,7 +6,7 @@ const validateTypes = require('./validateTypes.cjs');
 const constants = require('../constants.cjs');
 const nodeRangeBy = require('./nodeRangeBy.cjs');
 
-/** @import { DisabledRangeObject, Problem, Range, RuleMessage, StylelintPostcssResult, Utils, WarningOptions } from 'stylelint' */
+/** @import { DisabledRangeObject, Problem, ProblemWithNormalizedPositions, Range, RuleMessage, StylelintPostcssResult, Utils, WarningOptions } from 'stylelint' */
 
 /**
  * Report a problem.
@@ -46,7 +46,9 @@ function report(problem) {
 		);
 	}
 
-	if (!normalizeReportSourceLocation(problem)) {
+	normalizeReportSourceLocation(problem);
+
+	if (!isProblemWithNormalizedPositions(problem)) {
 		throw new Error(
 			`The "${ruleName}" rule failed to pass either a node or a line number to the \`report()\` function.`,
 		);
@@ -109,8 +111,8 @@ function report(problem) {
 }
 
 /**
- * @param {import('stylelint').Problem} problem
- * @return {problem is import('stylelint').ProblemWithNormalizedPositions}
+ * @param {Problem} problem
+ * @return {void}
  */
 function normalizeReportSourceLocation(problem) {
 	// Use the given node to calculate the start and end positions.
@@ -123,10 +125,10 @@ function normalizeReportSourceLocation(problem) {
 		}
 	}
 
-	if (!validateTypes.isNumber(problem.line) && validateTypes.isNumber(problem.start?.line)) {
+	if (!problem.line && problem.start?.line) {
 		// Fallback the line to the line of the start position
 		problem.line = problem.start.line;
-	} else if (!problem.start && validateTypes.isNumber(problem.line)) {
+	} else if (!problem.start && problem.line) {
 		// Fallback the start position to the line
 		problem.start = {
 			line: problem.line,
@@ -134,14 +136,22 @@ function normalizeReportSourceLocation(problem) {
 		};
 	}
 
+	// `index` and `endIndex` must not be used directly
 	delete problem.index;
 	delete problem.endIndex;
+}
 
-	if (problem.start && validateTypes.isNumber(problem.line)) {
-		return true;
-	}
-
-	return false;
+/**
+ * @param {Problem} problem
+ * @return {problem is ProblemWithNormalizedPositions}
+ */
+function isProblemWithNormalizedPositions(problem) {
+	return Boolean(
+		problem.start?.line &&
+			problem.line &&
+			typeof problem.index === 'undefined' &&
+			typeof problem.endIndex === 'undefined',
+	);
 }
 
 /**
@@ -193,7 +203,7 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 	return false;
 }
 
-/** @param {Problem & { line: number }} problem */
+/** @param {ProblemWithNormalizedPositions & { line: number }} problem */
 function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = stylelint;
 

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -23,7 +23,7 @@ const nodeRangeBy = require('./nodeRangeBy.cjs');
  * @type {Utils['report']}
  */
 function report(problem) {
-	const { node, index, endIndex, line, start, end, result, ruleName, word, fix, ...rest } = problem;
+	const { node, result, ruleName, word, fix, ...rest } = problem;
 	const {
 		disabledRanges,
 		quiet,
@@ -46,28 +46,24 @@ function report(problem) {
 		);
 	}
 
-	const range = nodeRangeBy(node, { index, endIndex });
-
-	// If a line is not passed, use the node.rangeBy method to get the
-	// line number that the complaint pertains to
-	const startLine = line ?? range?.start?.line;
-
-	if (!startLine) {
+	if (!normalizeReportSourceLocation(problem)) {
 		throw new Error(
 			`The "${ruleName}" rule failed to pass either a node or a line number to the \`report()\` function.`,
 		);
 	}
 
-	if (isFixApplied({ ...problem, line: startLine })) return;
+	const { start, end, line } = problem;
 
-	if (isDisabled(ruleName, startLine, disabledRanges)) {
+	if (isFixApplied({ ...problem, line })) return;
+
+	if (isDisabled(ruleName, line, disabledRanges)) {
 		// Collect disabled warnings
 		// Used to report `needlessDisables` in subsequent processing.
 		const disabledWarnings = (result.stylelint.disabledWarnings ||= []);
 
 		disabledWarnings.push({
 			rule: ruleName,
-			line: startLine,
+			line,
 		});
 
 		if (!ignoreDisables) return;
@@ -93,24 +89,10 @@ function report(problem) {
 
 	if (start) {
 		warningProperties.start = start;
-	} else if (range?.start) {
-		warningProperties.start = range.start;
-	} else if (validateTypes.isNumber(startLine)) {
-		warningProperties.start = {
-			line: startLine,
-			column: 1, // use the start of the line when `node` is undefined
-		};
 	}
 
 	if (end) {
 		warningProperties.end = end;
-	} else if (range?.end) {
-		warningProperties.end = range.end;
-	} else if (validateTypes.isNumber(startLine)) {
-		warningProperties.end = {
-			line: startLine,
-			column: 2, // the start of the line + 1 when `node` is undefined
-		};
 	}
 
 	if (word) {
@@ -124,6 +106,42 @@ function report(problem) {
 	const warningMessage = buildWarningMessage(message, messageArgs);
 
 	result.warn(warningMessage, warningProperties);
+}
+
+/**
+ * @param {import('stylelint').Problem} problem
+ * @return {problem is import('stylelint').ProblemWithNormalizedPositions}
+ */
+function normalizeReportSourceLocation(problem) {
+	// Use the given node to calculate the start and end positions.
+	if (problem.node && (!problem.start || !problem.end)) {
+		const range = nodeRangeBy(problem.node, { index: problem.index, endIndex: problem.endIndex });
+
+		if (range) {
+			problem.start ??= range.start;
+			problem.end ??= range.end;
+		}
+	}
+
+	if (!validateTypes.isNumber(problem.line) && validateTypes.isNumber(problem.start?.line)) {
+		// Fallback the line to the line of the start position
+		problem.line = problem.start.line;
+	} else if (!problem.start && validateTypes.isNumber(problem.line)) {
+		// Fallback the start position to the line
+		problem.start = {
+			line: problem.line,
+			column: 1,
+		};
+	}
+
+	delete problem.index;
+	delete problem.endIndex;
+
+	if (problem.start && validateTypes.isNumber(problem.line)) {
+		return true;
+	}
+
+	return false;
 }
 
 /**

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -46,7 +46,7 @@ function report(problem) {
 		);
 	}
 
-	normalizeProblemSourceLocation(problem);
+	normalizeProblemSourcePositions(problem);
 
 	if (!isProblemWithNormalizedPositions(problem)) {
 		throw new Error(
@@ -114,7 +114,7 @@ function report(problem) {
  * @param {Problem} problem
  * @return {void}
  */
-function normalizeProblemSourceLocation(problem) {
+function normalizeProblemSourcePositions(problem) {
 	// Use the given node to calculate the start and end positions.
 	if (problem.node && (!problem.start || !problem.end)) {
 		const range = nodeRangeBy(problem.node, { index: problem.index, endIndex: problem.endIndex });

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -46,7 +46,7 @@ function report(problem) {
 		);
 	}
 
-	normalizeReportSourceLocation(problem);
+	normalizeProblemSourceLocation(problem);
 
 	if (!isProblemWithNormalizedPositions(problem)) {
 		throw new Error(
@@ -114,7 +114,7 @@ function report(problem) {
  * @param {Problem} problem
  * @return {void}
  */
-function normalizeReportSourceLocation(problem) {
+function normalizeProblemSourceLocation(problem) {
 	// Use the given node to calculate the start and end positions.
 	if (problem.node && (!problem.start || !problem.end)) {
 		const range = nodeRangeBy(problem.node, { index: problem.index, endIndex: problem.endIndex });

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -203,7 +203,7 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 	return false;
 }
 
-/** @param {ProblemWithNormalizedPositions & { line: number }} problem */
+/** @param {ProblemWithNormalizedPositions} problem */
 function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = stylelint;
 

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -206,7 +206,7 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 	return false;
 }
 
-/** @param {ProblemWithNormalizedPositions & { line: number }} problem */
+/** @param {ProblemWithNormalizedPositions} problem */
 function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = stylelint;
 

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -1,4 +1,4 @@
-import { isFunction as isFn, isNumber, isString } from '../utils/validateTypes.mjs';
+import { isFunction as isFn, isString } from '../utils/validateTypes.mjs';
 
 import {
 	DEFAULT_SEVERITY,
@@ -9,7 +9,7 @@ import {
 
 import nodeRangeBy from './nodeRangeBy.mjs';
 
-/** @import { DisabledRangeObject, Problem, Range, RuleMessage, StylelintPostcssResult, Utils, WarningOptions } from 'stylelint' */
+/** @import { DisabledRangeObject, Problem, ProblemWithNormalizedPositions, Range, RuleMessage, StylelintPostcssResult, Utils, WarningOptions } from 'stylelint' */
 
 /**
  * Report a problem.
@@ -49,7 +49,9 @@ export default function report(problem) {
 		);
 	}
 
-	if (!normalizeReportSourceLocation(problem)) {
+	normalizeReportSourceLocation(problem);
+
+	if (!isProblemWithNormalizedPositions(problem)) {
 		throw new Error(
 			`The "${ruleName}" rule failed to pass either a node or a line number to the \`report()\` function.`,
 		);
@@ -112,8 +114,8 @@ export default function report(problem) {
 }
 
 /**
- * @param {import('stylelint').Problem} problem
- * @return {problem is import('stylelint').ProblemWithNormalizedPositions}
+ * @param {Problem} problem
+ * @return {void}
  */
 function normalizeReportSourceLocation(problem) {
 	// Use the given node to calculate the start and end positions.
@@ -126,10 +128,10 @@ function normalizeReportSourceLocation(problem) {
 		}
 	}
 
-	if (!isNumber(problem.line) && isNumber(problem.start?.line)) {
+	if (!problem.line && problem.start?.line) {
 		// Fallback the line to the line of the start position
 		problem.line = problem.start.line;
-	} else if (!problem.start && isNumber(problem.line)) {
+	} else if (!problem.start && problem.line) {
 		// Fallback the start position to the line
 		problem.start = {
 			line: problem.line,
@@ -137,14 +139,22 @@ function normalizeReportSourceLocation(problem) {
 		};
 	}
 
+	// `index` and `endIndex` must not be used directly
 	delete problem.index;
 	delete problem.endIndex;
+}
 
-	if (problem.start && isNumber(problem.line)) {
-		return true;
-	}
-
-	return false;
+/**
+ * @param {Problem} problem
+ * @return {problem is ProblemWithNormalizedPositions}
+ */
+function isProblemWithNormalizedPositions(problem) {
+	return Boolean(
+		problem.start?.line &&
+			problem.line &&
+			typeof problem.index === 'undefined' &&
+			typeof problem.endIndex === 'undefined',
+	);
 }
 
 /**
@@ -196,7 +206,7 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 	return false;
 }
 
-/** @param {Problem & { line: number }} problem */
+/** @param {ProblemWithNormalizedPositions & { line: number }} problem */
 function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = stylelint;
 

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -26,7 +26,7 @@ import nodeRangeBy from './nodeRangeBy.mjs';
  * @type {Utils['report']}
  */
 export default function report(problem) {
-	const { node, index, endIndex, line, start, end, result, ruleName, word, fix, ...rest } = problem;
+	const { node, result, ruleName, word, fix, ...rest } = problem;
 	const {
 		disabledRanges,
 		quiet,
@@ -49,28 +49,24 @@ export default function report(problem) {
 		);
 	}
 
-	const range = nodeRangeBy(node, { index, endIndex });
-
-	// If a line is not passed, use the node.rangeBy method to get the
-	// line number that the complaint pertains to
-	const startLine = line ?? range?.start?.line;
-
-	if (!startLine) {
+	if (!normalizeReportSourceLocation(problem)) {
 		throw new Error(
 			`The "${ruleName}" rule failed to pass either a node or a line number to the \`report()\` function.`,
 		);
 	}
 
-	if (isFixApplied({ ...problem, line: startLine })) return;
+	const { start, end, line } = problem;
 
-	if (isDisabled(ruleName, startLine, disabledRanges)) {
+	if (isFixApplied({ ...problem, line })) return;
+
+	if (isDisabled(ruleName, line, disabledRanges)) {
 		// Collect disabled warnings
 		// Used to report `needlessDisables` in subsequent processing.
 		const disabledWarnings = (result.stylelint.disabledWarnings ||= []);
 
 		disabledWarnings.push({
 			rule: ruleName,
-			line: startLine,
+			line,
 		});
 
 		if (!ignoreDisables) return;
@@ -96,24 +92,10 @@ export default function report(problem) {
 
 	if (start) {
 		warningProperties.start = start;
-	} else if (range?.start) {
-		warningProperties.start = range.start;
-	} else if (isNumber(startLine)) {
-		warningProperties.start = {
-			line: startLine,
-			column: 1, // use the start of the line when `node` is undefined
-		};
 	}
 
 	if (end) {
 		warningProperties.end = end;
-	} else if (range?.end) {
-		warningProperties.end = range.end;
-	} else if (isNumber(startLine)) {
-		warningProperties.end = {
-			line: startLine,
-			column: 2, // the start of the line + 1 when `node` is undefined
-		};
 	}
 
 	if (word) {
@@ -127,6 +109,42 @@ export default function report(problem) {
 	const warningMessage = buildWarningMessage(message, messageArgs);
 
 	result.warn(warningMessage, warningProperties);
+}
+
+/**
+ * @param {import('stylelint').Problem} problem
+ * @return {problem is import('stylelint').ProblemWithNormalizedPositions}
+ */
+function normalizeReportSourceLocation(problem) {
+	// Use the given node to calculate the start and end positions.
+	if (problem.node && (!problem.start || !problem.end)) {
+		const range = nodeRangeBy(problem.node, { index: problem.index, endIndex: problem.endIndex });
+
+		if (range) {
+			problem.start ??= range.start;
+			problem.end ??= range.end;
+		}
+	}
+
+	if (!isNumber(problem.line) && isNumber(problem.start?.line)) {
+		// Fallback the line to the line of the start position
+		problem.line = problem.start.line;
+	} else if (!problem.start && isNumber(problem.line)) {
+		// Fallback the start position to the line
+		problem.start = {
+			line: problem.line,
+			column: 1,
+		};
+	}
+
+	delete problem.index;
+	delete problem.endIndex;
+
+	if (problem.start && isNumber(problem.line)) {
+		return true;
+	}
+
+	return false;
 }
 
 /**

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -49,7 +49,7 @@ export default function report(problem) {
 		);
 	}
 
-	normalizeProblemSourceLocation(problem);
+	normalizeProblemSourcePositions(problem);
 
 	if (!isProblemWithNormalizedPositions(problem)) {
 		throw new Error(
@@ -117,7 +117,7 @@ export default function report(problem) {
  * @param {Problem} problem
  * @return {void}
  */
-function normalizeProblemSourceLocation(problem) {
+function normalizeProblemSourcePositions(problem) {
 	// Use the given node to calculate the start and end positions.
 	if (problem.node && (!problem.start || !problem.end)) {
 		const range = nodeRangeBy(problem.node, { index: problem.index, endIndex: problem.endIndex });

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -49,7 +49,7 @@ export default function report(problem) {
 		);
 	}
 
-	normalizeReportSourceLocation(problem);
+	normalizeProblemSourceLocation(problem);
 
 	if (!isProblemWithNormalizedPositions(problem)) {
 		throw new Error(
@@ -117,7 +117,7 @@ export default function report(problem) {
  * @param {Problem} problem
  * @return {void}
  */
-function normalizeReportSourceLocation(problem) {
+function normalizeProblemSourceLocation(problem) {
 	// Use the given node to calculate the start and end positions.
 	if (problem.node && (!problem.start || !problem.end)) {
 		const range = nodeRangeBy(problem.node, { index: problem.index, endIndex: problem.endIndex });

--- a/types/stylelint/index.d.mts
+++ b/types/stylelint/index.d.mts
@@ -27,6 +27,7 @@ export {
 	PostcssResult,
 	Processor,
 	Problem,
+	ProblemWithNormalizedPositions,
 	PublicApi,
 	Range,
 	Rule,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -851,13 +851,8 @@ declare namespace stylelint {
 	};
 
 	/** @internal */
-	export type ProblemWithNormalizedPositions = Problem & {
-		line: number;
-		start: Position;
-		end: Position;
-		index: undefined;
-		endIndex: undefined;
-	};
+	export type ProblemWithNormalizedPositions = Omit<Problem, 'index' | 'endIndex'> &
+                                                 Required<Pick<Problem, 'line' | 'start' | 'end'>>;
 
 	/** @internal */
 	export type ShorthandProperties =

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -851,6 +851,15 @@ declare namespace stylelint {
 	};
 
 	/** @internal */
+	export type ProblemWithNormalizedPositions = Problem & {
+		line: number;
+		start: Position;
+		end: Position;
+		index: undefined;
+		endIndex: undefined;
+	};
+
+	/** @internal */
 	export type ShorthandProperties =
 		| 'animation'
 		| 'background'

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -852,7 +852,7 @@ declare namespace stylelint {
 
 	/** @internal */
 	export type ProblemWithNormalizedPositions = Omit<Problem, 'index' | 'endIndex'> &
-                                                 Required<Pick<Problem, 'line' | 'start' | 'end'>>;
+		Required<Pick<Problem, 'line' | 'start' | 'end'>>;
 
 	/** @internal */
 	export type ShorthandProperties =

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -852,7 +852,7 @@ declare namespace stylelint {
 
 	/** @internal */
 	export type ProblemWithNormalizedPositions = Omit<Problem, 'index' | 'endIndex'> &
-		Required<Pick<Problem, 'line' | 'start' | 'end'>>;
+		Required<Pick<Problem, 'line' | 'start'>>;
 
 	/** @internal */
 	export type ShorthandProperties =


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/pull/8086

> Is there anything in the PR that needs further explanation?

I am unsure if this is the right direction and I didn't want to complicate review of #8086 by suddenly introducing new things. So happy to close this without merging if this is not something we want.

While working on #8086 and getting feedback in review I wondered if maybe we are lacking a step in `report()`.

Instead of ad-hoc calculations of position values it might be better to have a dedicated normalization step.

Calling `normalizeReportSourceLocation(problem)` would ensure that `problem` has position values of an expected shape.

Individual functions and call sites wouldn't need to each make the determination to look at `line`, `index`, `start`, ...

By grouping everything related to this it is also (slightly) simpler to reason about the possible outcomes.