### PR TITLE
Fix `declaration-property-value-no-unknown` false positive for `stroke-opacity`

### DIFF
--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
@@ -75,6 +75,9 @@ testRule({
 			code: 'a { anchor-name: --bar, --qux; }',
 		},
 		{
+			code: 'a { stroke-opacity: 50%; }',
+		},
+		{
 			code: stripIndent`
 				a { font-weight: bolder; }
 				@font-face { font-weight: 100 200; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
         "css-functions-list": "^3.2.3",
-        "css-tree": "^3.0.0",
+        "css-tree": "^3.0.1",
         "debug": "^4.3.7",
         "fast-glob": "^3.3.2",
         "fastest-levenshtein": "^1.0.16",
@@ -4682,11 +4682,12 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.0.0.tgz",
-      "integrity": "sha512-o88DVQ6GzsABn1+6+zo2ct801dBO5OASVyxbbvA2W20ue2puSh/VOuqUj90eUeMSX/xqGqBmOKiRQN7tJOuBXw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.0.1.tgz",
+      "integrity": "sha512-8Fxxv+tGhORlshCdCwnNJytvlvq46sOLSYEx2ZIGurahWvMucSRnyjPA3AmrMq4VPRYbHVpWj5VkiVasrM2H4Q==",
+      "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.10.0",
+        "mdn-data": "2.12.1",
         "source-map-js": "^1.0.1"
       },
       "engines": {
@@ -11698,9 +11699,10 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.10.0.tgz",
-      "integrity": "sha512-qq7C3EtK3yJXMwz1zAab65pjl+UhohqMOctTgcqjLOWABqmwj+me02LSsCuEUxnst9X1lCBpoE0WArGKgdGDzw=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.1.tgz",
+      "integrity": "sha512-rsfnCbOHjqrhWxwt5/wtSLzpoKTzW7OXdT5lLOIH1OTYhWu9rRJveGq0sKvDZODABH7RX+uoR+DYcpFnq4Tf6Q==",
+      "license": "CC0-1.0"
     },
     "node_modules/memorystream": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "colord": "^2.9.3",
     "cosmiconfig": "^9.0.0",
     "css-functions-list": "^3.2.3",
-    "css-tree": "^3.0.0",
+    "css-tree": "^3.0.1",
     "debug": "^4.3.7",
     "fast-glob": "^3.3.2",
     "fastest-levenshtein": "^1.0.16",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8080

> Is there anything in the PR that needs further explanation?

The changes reflect a fix for the issue in csstree.
https://github.com/csstree/csstree/issues/299
