### PR TITLE
Fix `selector-pseudo-element-no-unknown` false positives for `::scroll-marker` and `::scroll-marker-group`

### DIFF
--- a/.changeset/spotty-dancers-divide.md
+++ b/.changeset/spotty-dancers-divide.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-element-no-unknown` false positives for `::scroll-marker` and `::scroll-marker-group`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -195,6 +195,8 @@ const pseudoElements = uniteSets(
 		'highlight',
 		'marker',
 		'placeholder',
+		'scroll-marker',
+		'scroll-marker-group',
 		'selection',
 		'shadow',
 		'slotted',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -192,6 +192,8 @@ export const pseudoElements = uniteSets(
 		'highlight',
 		'marker',
 		'placeholder',
+		'scroll-marker',
+		'scroll-marker-group',
 		'selection',
 		'shadow',
 		'slotted',

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
@@ -109,6 +109,9 @@ testRule({
 			code: 'a::part(shadow-part) { }',
 		},
 		{
+			code: '::scroll-marker, ::scroll-marker-group { }',
+		},
+		{
 			code: stripIndent`
 				/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
 				a::pseudo, /* stylelint-disable-next-line selector-pseudo-element-no-unknown */


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

- ["Layout support for ::column::scroll-marker"](https://issues.chromium.org/issues/365680822#comment11)
- https://issues.chromium.org/issues/332396355
- [explainer](https://github.com/flackr/carousel/tree/main/scroll-marker)
- [`::scroll-marker-group`](https://drafts.csswg.org/css-overflow-5/#scroll-marker-group-pseudo)
- [`::scroll-marker`](https://drafts.csswg.org/css-overflow-5/#scroll-marker-pseudo)

`::column` will be added separately