### PR TITLE
Change deprecation warning to link to `https://stylelint.io/awesome-stylelint#formatters`

### DIFF
--- a/.changeset/thick-seas-fail.md
+++ b/.changeset/thick-seas-fail.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Changed: deprecation warning to suggest `@csstools/stylelint-formatter-github`

--- a/.changeset/thick-seas-fail.md
+++ b/.changeset/thick-seas-fail.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Changed: deprecation warning to suggest `@csstools/stylelint-formatter-github`
+Changed: deprecation warning to link to `https://stylelint.io/awesome-stylelint#formatters`

--- a/lib/__tests__/cli-deprecation.test.mjs
+++ b/lib/__tests__/cli-deprecation.test.mjs
@@ -16,8 +16,7 @@ it('flags.formatter=github should issue a deprecation warning', async () => {
 		'"github" formatter is deprecated.',
 		{
 			code: 'stylelint:004',
-			detail:
-				'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
+			detail: 'See https://stylelint.io/awesome-stylelint#formatters for alternative formatters.',
 			type: 'DeprecationWarning',
 		},
 	];

--- a/lib/__tests__/cli-deprecation.test.mjs
+++ b/lib/__tests__/cli-deprecation.test.mjs
@@ -16,7 +16,7 @@ it('flags.formatter=github should issue a deprecation warning', async () => {
 		'"github" formatter is deprecated.',
 		{
 			code: 'stylelint:004',
-			detail: 'Please use "stylelint-actions-formatters" instead.',
+			detail: 'Please use "@csstools/stylelint-formatter-github" instead.',
 			type: 'DeprecationWarning',
 		},
 	];

--- a/lib/__tests__/cli-deprecation.test.mjs
+++ b/lib/__tests__/cli-deprecation.test.mjs
@@ -16,7 +16,8 @@ it('flags.formatter=github should issue a deprecation warning', async () => {
 		'"github" formatter is deprecated.',
 		{
 			code: 'stylelint:004',
-			detail: 'Please use "@csstools/stylelint-formatter-github" instead.',
+			detail:
+				'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
 			type: 'DeprecationWarning',
 		},
 	];

--- a/lib/__tests__/standalone-deprecations.test.mjs
+++ b/lib/__tests__/standalone-deprecations.test.mjs
@@ -86,7 +86,7 @@ describe('standalone with the `output` property deprecation', () => {
 
 		expect(mock).toHaveBeenCalledWith('"github" formatter is deprecated.', {
 			code: 'stylelint:004',
-			detail: 'Please use "stylelint-actions-formatters" instead.',
+			detail: 'Please use "@csstools/stylelint-formatter-github" instead.',
 			type: 'DeprecationWarning',
 		});
 

--- a/lib/__tests__/standalone-deprecations.test.mjs
+++ b/lib/__tests__/standalone-deprecations.test.mjs
@@ -86,8 +86,7 @@ describe('standalone with the `output` property deprecation', () => {
 
 		expect(mock).toHaveBeenCalledWith('"github" formatter is deprecated.', {
 			code: 'stylelint:004',
-			detail:
-				'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
+			detail: 'See https://stylelint.io/awesome-stylelint#formatters for alternative formatters.',
 			type: 'DeprecationWarning',
 		});
 

--- a/lib/__tests__/standalone-deprecations.test.mjs
+++ b/lib/__tests__/standalone-deprecations.test.mjs
@@ -86,7 +86,8 @@ describe('standalone with the `output` property deprecation', () => {
 
 		expect(mock).toHaveBeenCalledWith('"github" formatter is deprecated.', {
 			code: 'stylelint:004',
-			detail: 'Please use "@csstools/stylelint-formatter-github" instead.',
+			detail:
+				'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
 			type: 'DeprecationWarning',
 		});
 

--- a/lib/formatters/githubFormatter.cjs
+++ b/lib/formatters/githubFormatter.cjs
@@ -9,7 +9,7 @@ const preprocessWarnings = require('./preprocessWarnings.cjs');
  *
  * @type {import('stylelint').Formatter}
  *
- * @deprecated use "stylelint-actions-formatters" instead
+ * @deprecated use "@csstools/stylelint-formatter-github" instead
  */
 function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';

--- a/lib/formatters/githubFormatter.cjs
+++ b/lib/formatters/githubFormatter.cjs
@@ -9,7 +9,7 @@ const preprocessWarnings = require('./preprocessWarnings.cjs');
  *
  * @type {import('stylelint').Formatter}
  *
- * @deprecated See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.
+ * @deprecated See https://stylelint.io/awesome-stylelint#formatters for alternative formatters.
  */
 function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';

--- a/lib/formatters/githubFormatter.cjs
+++ b/lib/formatters/githubFormatter.cjs
@@ -9,7 +9,7 @@ const preprocessWarnings = require('./preprocessWarnings.cjs');
  *
  * @type {import('stylelint').Formatter}
  *
- * @deprecated use "@csstools/stylelint-formatter-github" instead
+ * @deprecated See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.
  */
 function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';

--- a/lib/formatters/githubFormatter.mjs
+++ b/lib/formatters/githubFormatter.mjs
@@ -5,7 +5,7 @@ import preprocessWarnings from './preprocessWarnings.mjs';
  *
  * @type {import('stylelint').Formatter}
  *
- * @deprecated use "stylelint-actions-formatters" instead
+ * @deprecated use "@csstools/stylelint-formatter-github" instead
  */
 export default function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';

--- a/lib/formatters/githubFormatter.mjs
+++ b/lib/formatters/githubFormatter.mjs
@@ -5,7 +5,7 @@ import preprocessWarnings from './preprocessWarnings.mjs';
  *
  * @type {import('stylelint').Formatter}
  *
- * @deprecated See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.
+ * @deprecated See https://stylelint.io/awesome-stylelint#formatters for alternative formatters.
  */
 export default function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';

--- a/lib/formatters/githubFormatter.mjs
+++ b/lib/formatters/githubFormatter.mjs
@@ -5,7 +5,7 @@ import preprocessWarnings from './preprocessWarnings.mjs';
  *
  * @type {import('stylelint').Formatter}
  *
- * @deprecated use "@csstools/stylelint-formatter-github" instead
+ * @deprecated See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.
  */
 export default function githubFormatter(results, returnValue) {
 	const title = 'Stylelint problem';

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -113,7 +113,7 @@ async function standalone({
 		emitDeprecationWarning(
 			'"github" formatter is deprecated.',
 			'GITHUB_FORMATTER',
-			'Please use "stylelint-actions-formatters" instead.',
+			'Please use "@csstools/stylelint-formatter-github" instead.',
 		);
 	}
 

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -113,7 +113,7 @@ async function standalone({
 		emitDeprecationWarning(
 			'"github" formatter is deprecated.',
 			'GITHUB_FORMATTER',
-			'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
+			'See https://stylelint.io/awesome-stylelint#formatters for alternative formatters.',
 		);
 	}
 

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -113,7 +113,7 @@ async function standalone({
 		emitDeprecationWarning(
 			'"github" formatter is deprecated.',
 			'GITHUB_FORMATTER',
-			'Please use "@csstools/stylelint-formatter-github" instead.',
+			'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
 		);
 	}
 

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -111,7 +111,7 @@ export default async function standalone({
 		emitDeprecationWarning(
 			'"github" formatter is deprecated.',
 			'GITHUB_FORMATTER',
-			'Please use "stylelint-actions-formatters" instead.',
+			'Please use "@csstools/stylelint-formatter-github" instead.',
 		);
 	}
 

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -111,7 +111,7 @@ export default async function standalone({
 		emitDeprecationWarning(
 			'"github" formatter is deprecated.',
 			'GITHUB_FORMATTER',
-			'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
+			'See https://stylelint.io/awesome-stylelint#formatters for alternative formatters.',
 		);
 	}
 

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -111,7 +111,7 @@ export default async function standalone({
 		emitDeprecationWarning(
 			'"github" formatter is deprecated.',
 			'GITHUB_FORMATTER',
-			'Please use "@csstools/stylelint-formatter-github" instead.',
+			'See https://github.com/stylelint/awesome-stylelint/blob/main/README.md#formatters for alternative formatters.',
 		);
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8111 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
