### PR TITLE
Enable tokenless upload for Codecov

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,7 +51,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./.coverage/lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   build:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to #8127

> Is there anything in the PR that needs further explanation?

Since this project's source code and its Codecov pages are completely open, we should not need any tokens for coverage data.
I think the tokenless upload is valuable to reduce our maintenance work for tokens.

In addition to this code change, there are the following manual tasks by admins:
- [x] Enable the tokenless upload on the Codecov's organization settings
- [ ] Remove the `CODECOV_TOKEN` secret from this GitHub repository

See also:
- https://github.com/codecov/codecov-action/releases/tag/v5.0.0
- https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token
