### PR TITLE
Fix `font-family-no-missing-generic-family-keyword` false positives for `font-family` descriptor in `@font-palette-values`

### DIFF
--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
@@ -54,7 +54,7 @@ testRule({
 			code: "@font-palette-values --foo { font-family: bar; }",
 		},
 		{
-			code: "@FONT-PALETTE-VALUES -foo { font-family: bar; }",
+			code: "@FONT-PALETTE-VALUES --foo { font-family: bar; }",
 		},
 		{
 			code: 'a { font: inherit; }',

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
@@ -51,6 +51,12 @@ testRule({
 			code: '@FONT-FACE { font-family: Gentium; }',
 		},
 		{
+			code: "@font-palette-values --foo { font-family: bar; }",
+		},
+		{
+			code: "@FONT-PALETTE-VALUES -foo { font-family: bar; }",
+		},
+		{
 			code: 'a { font: inherit; }',
 		},
 		{

--- a/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/__tests__/index.mjs
@@ -51,10 +51,10 @@ testRule({
 			code: '@FONT-FACE { font-family: Gentium; }',
 		},
 		{
-			code: "@font-palette-values --foo { font-family: bar; }",
+			code: '@font-palette-values --foo { font-family: bar; }',
 		},
 		{
-			code: "@FONT-PALETTE-VALUES --foo { font-family: bar; }",
+			code: '@FONT-PALETTE-VALUES --foo { font-family: bar; }',
 		},
 		{
 			code: 'a { font: inherit; }',

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
@@ -63,10 +63,14 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
-			// Ignore @font-face
+			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;
 
 			if (parent && typeGuards.isAtRule(parent) && parent.name.toLowerCase() === 'font-face') {
+				return;
+			}
+
+			if (parent && typeGuards.isAtRule(parent) && parent.name.toLowerCase() === 'font-palette-values') {
 				return;
 			}
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
@@ -62,12 +62,12 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		root.walkDecls(/^font(-family)?$/i, (decl) => {
-			// Ignore @font-face and @font-palette-values
-			const parent = decl.parent;
-			const rules = ['font-face', 'font-palette-values'];
+		const ignoredAtRules = new Set(['font-face', 'font-palette-values']);
 
-			if (parent && typeGuards.isAtRule(parent) && rules.includes(parent.name.toLowerCase())) {
+		root.walkDecls(/^font(-family)?$/i, (decl) => {
+			const parent = decl.parent;
+
+			if (parent && typeGuards.isAtRule(parent) && ignoredAtRules.has(parent.name.toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
@@ -65,12 +65,8 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
 			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;
-
-			if (parent && typeGuards.isAtRule(parent) && parent.name.toLowerCase() === 'font-face') {
-				return;
-			}
-
-			if (parent && typeGuards.isAtRule(parent) && parent.name.toLowerCase() === 'font-palette-values') {
+			const rules = ['font-face', 'font-palette-values'];
+			if (parent && typeGuards.isAtRule(parent) && rules.includes(parent.name.toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.cjs
@@ -66,6 +66,7 @@ const rule = (primary, secondaryOptions) => {
 			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;
 			const rules = ['font-face', 'font-palette-values'];
+
 			if (parent && typeGuards.isAtRule(parent) && rules.includes(parent.name.toLowerCase())) {
 				return;
 			}

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -64,7 +64,7 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
 			const parent = decl.parent;
 
-			if (parent && isAtRule(parent) && rules.includes(parent.name.toLowerCase())) {
+			if (parent && isAtRule(parent) && ignoredAtRules.has(parent.name.toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -59,6 +59,8 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
+		const ignoredAtRules = new Set(['font-face', 'font-palette-values']);
+
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
 			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -62,6 +62,7 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
 			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;
+			const rules = ['font-face', 'font-palette-values'];
 
 			if (parent && isAtRule(parent) && rules.includes(parent.name.toLowerCase())) {
 				return;

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -63,7 +63,6 @@ const rule = (primary, secondaryOptions) => {
 
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
 			const parent = decl.parent;
-			const rules = ['font-face', 'font-palette-values'];
 
 			if (parent && isAtRule(parent) && rules.includes(parent.name.toLowerCase())) {
 				return;

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -63,11 +63,7 @@ const rule = (primary, secondaryOptions) => {
 			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;
 
-			if (parent && isAtRule(parent) && parent.name.toLowerCase() === 'font-face') {
-				return;
-			}
-
-			if (parent && isAtRule(parent) && parent.name.toLowerCase() === 'font-palette-values') {
+			if (parent && isAtRule(parent) && rules.includes(parent.name.toLowerCase())) {
 				return;
 			}
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -62,7 +62,6 @@ const rule = (primary, secondaryOptions) => {
 		const ignoredAtRules = new Set(['font-face', 'font-palette-values']);
 
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
-			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;
 			const rules = ['font-face', 'font-palette-values'];
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/index.mjs
@@ -60,10 +60,14 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		root.walkDecls(/^font(-family)?$/i, (decl) => {
-			// Ignore @font-face
+			// Ignore @font-face and @font-palette-values
 			const parent = decl.parent;
 
 			if (parent && isAtRule(parent) && parent.name.toLowerCase() === 'font-face') {
+				return;
+			}
+
+			if (parent && isAtRule(parent) && parent.name.toLowerCase() === 'font-palette-values') {
 				return;
 			}
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #8139

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
