### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for `:recto`, `:verso` and `:nth()`

### DIFF
--- a/.changeset/curly-lies-serve.md
+++ b/.changeset/curly-lies-serve.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for `:recto`, `:verso` and `:nth()`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -219,7 +219,15 @@ const aNPlusBNotationPseudoClasses = new Set([
 
 const aNPlusBOfSNotationPseudoClasses = new Set(['nth-child', 'nth-last-child']);
 
-const atRulePagePseudoClasses = new Set(['first', 'right', 'left', 'blank']);
+const atRulePagePseudoClasses = new Set([
+	'first',
+	'right',
+	'left',
+	'blank',
+	'recto',
+	'verso',
+	'nth',
+]);
 
 const linguisticPseudoClasses = new Set(['dir', 'lang']);
 

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -216,7 +216,15 @@ export const aNPlusBNotationPseudoClasses = new Set([
 
 export const aNPlusBOfSNotationPseudoClasses = new Set(['nth-child', 'nth-last-child']);
 
-export const atRulePagePseudoClasses = new Set(['first', 'right', 'left', 'blank']);
+export const atRulePagePseudoClasses = new Set([
+	'first',
+	'right',
+	'left',
+	'blank',
+	'recto',
+	'verso',
+	'nth',
+]);
 
 export const linguisticPseudoClasses = new Set(['dir', 'lang']);
 

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -75,13 +75,22 @@ testRule({
 			code: '::selection:window-inactive { }',
 		},
 		{
-			code: '@page :first { }',
+			code: '@page :first {}',
 		},
 		{
-			code: '@page :blank:left { }',
+			code: '@page :blank:left {}',
 		},
 		{
-			code: '@page foo:left { }',
+			code: '@page foo:left {}',
+		},
+		{
+			code: '@page bar:verso {}',
+		},
+		{
+			code: '@page :recto {}',
+		},
+		{
+			code: '@page :nth(2n) {}',
 		},
 		{
 			code: 'body:not(div):not(span) {}',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#2445

> Is there anything in the PR that needs further explanation?

https://www.princexml.com/doc/css-at-rules/#nested-at-rules
https://pagedjs.org/documentation/5-web-design-for-print/#pseudo-class-selectors-for-pages
https://github.com/Kozea/WeasyPrint/pull/846

https://drafts.csswg.org/css-logical/#page
https://www.w3.org/TR/css-gcpm-3/#document-page-selectors
