### PR TITLE
Add `selector-pseudo-class-disallowed-list` support for `@page`

### DIFF
--- a/.changeset/dirty-fishes-approve.md
+++ b/.changeset/dirty-fishes-approve.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for `:-moz-only-whitespace`

--- a/.changeset/fresh-seahorses-grab.md
+++ b/.changeset/fresh-seahorses-grab.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `@page` support to `selector-pseudo-class-disallowed-list`
+Added: `selector-pseudo-class-disallowed-list` now checks `@page` at-rules and supports `@page` pseudo-classes

--- a/.changeset/fresh-seahorses-grab.md
+++ b/.changeset/fresh-seahorses-grab.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `@page` support to `selector-pseudo-class-disallowed-list`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -240,6 +240,7 @@ const vendorSpecificPseudoClasses = new Set([
 	'-moz-meter-optimum',
 	'-moz-meter-sub-optimum',
 	'-moz-meter-sub-sub-optimum',
+	'-moz-only-whitespace',
 	'-moz-placeholder',
 	'-moz-submit-invalid',
 	'-moz-suppressed',
@@ -296,6 +297,10 @@ const pseudoClasses = uniteSets(
 		'active-view-transition-type',
 		'any-link',
 		'autofill',
+		/*
+			introduced the 10/05/2016 by 8c808d0
+			as of 2024 it is still not supported by any browser
+		*/
 		'blank',
 		'checked',
 		'current',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -237,6 +237,7 @@ const vendorSpecificPseudoClasses = new Set([
 	'-moz-meter-optimum',
 	'-moz-meter-sub-optimum',
 	'-moz-meter-sub-sub-optimum',
+	'-moz-only-whitespace',
 	'-moz-placeholder',
 	'-moz-submit-invalid',
 	'-moz-suppressed',
@@ -293,6 +294,10 @@ export const pseudoClasses = uniteSets(
 		'active-view-transition-type',
 		'any-link',
 		'autofill',
+		/*
+			introduced the 10/05/2016 by 8c808d0
+			as of 2024 it is still not supported by any browser
+		*/
 		'blank',
 		'checked',
 		'current',

--- a/lib/rules/selector-pseudo-class-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-disallowed-list/__tests__/index.mjs
@@ -209,6 +209,36 @@ testRule({
 
 testRule({
 	ruleName,
+	config: ['first'],
+
+	accept: [
+		{
+			code: '@page :blank {}',
+		},
+	],
+
+	reject: [
+		{
+			code: '@page :first {}',
+			message: messages.rejected(':first'),
+			line: 1,
+			column: 7,
+			endLine: 1,
+			endColumn: 13,
+		},
+		{
+			code: '@page  qux:first {}',
+			message: messages.rejected(':first'),
+			line: 1,
+			column: 11,
+			endLine: 1,
+			endColumn: 17,
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: [/(not|matches|has)/],
 
 	accept: [

--- a/lib/rules/selector-pseudo-class-disallowed-list/index.cjs
+++ b/lib/rules/selector-pseudo-class-disallowed-list/index.cjs
@@ -3,7 +3,9 @@
 'use strict';
 
 const validateTypes = require('../../utils/validateTypes.cjs');
+const getAtRuleParams = require('../../utils/getAtRuleParams.cjs');
 const getRuleSelector = require('../../utils/getRuleSelector.cjs');
+const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
 const matchesStringOrRegExp = require('../../utils/matchesStringOrRegExp.cjs');
 const parseSelector = require('../../utils/parseSelector.cjs');
@@ -22,6 +24,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-pseudo-class-disallowed-list',
 };
 
+/** @import {AtRule, Rule} from 'postcss' */
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -30,51 +34,69 @@ const rule = (primary) => {
 			possible: [validateTypes.isString, validateTypes.isRegExp],
 		});
 
-		if (!validOptions) {
-			return;
-		}
+		if (!validOptions) return;
 
-		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
-
-			if (!ruleNode.selector.includes(':')) {
-				return;
-			}
-
-			parseSelector(getRuleSelector(ruleNode), result, ruleNode)?.walkPseudos((pseudoNode) => {
-				const value = pseudoNode.value;
-				const index = pseudoNode.sourceIndex;
-				const endIndex = index + pseudoNode.value.length;
-
+		/**
+		 * @param {string} selector
+		 * @param {AtRule | Rule} node
+		 * @param {number} offset
+		 */
+		function check(selector, node, offset = 0) {
+			parseSelector(selector, result, node)?.walkPseudos(({ value, sourceIndex }) => {
 				// Ignore pseudo-elements
-				if (value.slice(0, 2) === '::') {
-					return;
-				}
+				if (value.slice(0, 2) === '::') return;
 
 				const name = value.slice(1);
 
-				if (!matchesStringOrRegExp(vendor.unprefixed(name), primary)) {
-					return;
-				}
+				if (!matchesStringOrRegExp(vendor.unprefixed(name), primary)) return;
+
+				const index = offset + sourceIndex;
 
 				report({
 					message: messages.rejected,
 					messageArgs: [value],
-					node: ruleNode,
+					node,
 					result,
 					ruleName,
 					index,
-					endIndex,
+					endIndex: index + value.length,
 				});
 			});
+		}
+
+		root.walk((node) => {
+			switch (node.type) {
+				case 'atrule': {
+					if (node.name !== 'page') return;
+
+					if (!isStandardSyntaxAtRule(node)) return;
+
+					const params = getAtRuleParams(node);
+
+					if (!params.includes(':')) return;
+
+					const offset = `@page${node.raws.afterName ?? ''}`.length;
+
+					check(params, node, offset);
+					break;
+				}
+				case 'rule': {
+					if (!isStandardSyntaxRule(node)) return;
+
+					const selector = getRuleSelector(node);
+
+					if (!selector.includes(':')) return;
+
+					check(selector, node);
+					break;
+				}
+				default:
+			}
 		});
 	};
 };
 
 rule.primaryOptionArray = true;
-
 rule.ruleName = ruleName;
 rule.messages = messages;
 rule.meta = meta;

--- a/lib/rules/selector-pseudo-class-disallowed-list/index.mjs
+++ b/lib/rules/selector-pseudo-class-disallowed-list/index.mjs
@@ -1,5 +1,7 @@
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
+import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import matchesStringOrRegExp from '../../utils/matchesStringOrRegExp.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
@@ -18,6 +20,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-pseudo-class-disallowed-list',
 };
 
+/** @import {AtRule, Rule} from 'postcss' */
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -26,51 +30,69 @@ const rule = (primary) => {
 			possible: [isString, isRegExp],
 		});
 
-		if (!validOptions) {
-			return;
-		}
+		if (!validOptions) return;
 
-		root.walkRules((ruleNode) => {
-			if (!isStandardSyntaxRule(ruleNode)) {
-				return;
-			}
-
-			if (!ruleNode.selector.includes(':')) {
-				return;
-			}
-
-			parseSelector(getRuleSelector(ruleNode), result, ruleNode)?.walkPseudos((pseudoNode) => {
-				const value = pseudoNode.value;
-				const index = pseudoNode.sourceIndex;
-				const endIndex = index + pseudoNode.value.length;
-
+		/**
+		 * @param {string} selector
+		 * @param {AtRule | Rule} node
+		 * @param {number} offset
+		 */
+		function check(selector, node, offset = 0) {
+			parseSelector(selector, result, node)?.walkPseudos(({ value, sourceIndex }) => {
 				// Ignore pseudo-elements
-				if (value.slice(0, 2) === '::') {
-					return;
-				}
+				if (value.slice(0, 2) === '::') return;
 
 				const name = value.slice(1);
 
-				if (!matchesStringOrRegExp(vendor.unprefixed(name), primary)) {
-					return;
-				}
+				if (!matchesStringOrRegExp(vendor.unprefixed(name), primary)) return;
+
+				const index = offset + sourceIndex;
 
 				report({
 					message: messages.rejected,
 					messageArgs: [value],
-					node: ruleNode,
+					node,
 					result,
 					ruleName,
 					index,
-					endIndex,
+					endIndex: index + value.length,
 				});
 			});
+		}
+
+		root.walk((node) => {
+			switch (node.type) {
+				case 'atrule': {
+					if (node.name !== 'page') return;
+
+					if (!isStandardSyntaxAtRule(node)) return;
+
+					const params = getAtRuleParams(node);
+
+					if (!params.includes(':')) return;
+
+					const offset = `@page${node.raws.afterName ?? ''}`.length;
+
+					check(params, node, offset);
+					break;
+				}
+				case 'rule': {
+					if (!isStandardSyntaxRule(node)) return;
+
+					const selector = getRuleSelector(node);
+
+					if (!selector.includes(':')) return;
+
+					check(selector, node);
+					break;
+				}
+				default:
+			}
 		});
 	};
 };
 
 rule.primaryOptionArray = true;
-
 rule.ruleName = ruleName;
 rule.messages = messages;
 rule.meta = meta;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#1871

> Is there anything in the PR that needs further explanation?

1. `:blank` references

https://developer.mozilla.org/en-US/docs/Web/CSS/:blank
https://caniuse.com/mdn-css_selectors_-moz-only-whitespace
https://drafts.csswg.org/selectors-4/#blank-pseudo
web-platform-tests/interop#595
https://www.npmjs.com/package/css-blank-pseudo

2. I tried using a combination of `walkAtRules` and `walkRules` instead of `walk`, the performance hit was negligible.
