### PR TITLE
Fix `selector-pseudo-element-no-unknown` false positives for `::details-content`

### DIFF
--- a/.changeset/stupid-seals-clap.md
+++ b/.changeset/stupid-seals-clap.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Adds `::details-content` pseudo element

--- a/.changeset/stupid-seals-clap.md
+++ b/.changeset/stupid-seals-clap.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": minor
+"stylelint": patch
 ---
 
-Adds `::details-content` pseudo element
+Fixed: `selector-pseudo-element-no-unknown` for `::details-content`

--- a/.changeset/stupid-seals-clap.md
+++ b/.changeset/stupid-seals-clap.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `selector-pseudo-element-no-unknown` false positive for `::details-content`
+Fixed: `selector-pseudo-element-no-unknown` false positives for `::details-content`

--- a/.changeset/stupid-seals-clap.md
+++ b/.changeset/stupid-seals-clap.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `selector-pseudo-element-no-unknown` for `::details-content`
+Fixed: `selector-pseudo-element-no-unknown` false positive for `::details-content`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -190,6 +190,7 @@ const pseudoElements = uniteSets(
 		'backdrop',
 		'content',
 		'cue',
+		'details-content',
 		'file-selector-button',
 		'grammar-error',
 		'highlight',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -187,6 +187,7 @@ export const pseudoElements = uniteSets(
 		'backdrop',
 		'content',
 		'cue',
+		'details-content',
 		'file-selector-button',
 		'grammar-error',
 		'highlight',


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8175

> Is there anything in the PR that needs further explanation?

`::details-content` is a new pseudo element, specced [here](https://drafts.csswg.org/css-pseudo/#details-content-pseudo). See [this](https://developer.chrome.com/blog/styling-details#the_details-content_pseudo) chrome blog post for more details.
