### PR TITLE
Bump prettier from 3.0.0 to 3.4.2

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -341,7 +341,7 @@ const rule = (primary, secondaryOptions) => {
 										);
 									});
 								}
-						  }
+							}
 						: undefined;
 
 					report({

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -338,7 +338,7 @@ const rule = (primary, secondaryOptions) => {
 										);
 									});
 								}
-						  }
+							}
 						: undefined;
 
 					report({

--- a/lib/rules/selector-max-specificity/index.cjs
+++ b/lib/rules/selector-max-specificity/index.cjs
@@ -98,7 +98,7 @@ const rule = (primary, secondaryOptions) => {
 						default:
 						// Other node types are not ignorable.
 					}
-			  }
+				}
 			: undefined;
 
 		const [a, b, c] = primary.split(',').map((s) => Number.parseFloat(s));

--- a/lib/rules/selector-max-specificity/index.mjs
+++ b/lib/rules/selector-max-specificity/index.mjs
@@ -95,7 +95,7 @@ const rule = (primary, secondaryOptions) => {
 						default:
 						// Other node types are not ignorable.
 					}
-			  }
+				}
 			: undefined;
 
 		const [a, b, c] = primary.split(',').map((s) => Number.parseFloat(s));

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -170,9 +170,9 @@ async function standalone({
 		if (autofix && postcssResult && !postcssResult.stylelint.ignored) {
 			returnValue.code = postcssResult.opts
 				? // If we're fixing, the output should be the fixed code
-				  postcssResult.root.toString(postcssResult.opts.syntax)
+					postcssResult.root.toString(postcssResult.opts.syntax)
 				: // If the writing of the fix is disabled, the input code is returned as-is
-				  code;
+					code;
 			returnValue._output = returnValue.code; // TODO: Deprecated. Remove in the next major version.
 		}
 

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -168,9 +168,9 @@ export default async function standalone({
 		if (autofix && postcssResult && !postcssResult.stylelint.ignored) {
 			returnValue.code = postcssResult.opts
 				? // If we're fixing, the output should be the fixed code
-				  postcssResult.root.toString(postcssResult.opts.syntax)
+					postcssResult.root.toString(postcssResult.opts.syntax)
 				: // If the writing of the fix is disabled, the input code is returned as-is
-				  code;
+					code;
 			returnValue._output = returnValue.code; // TODO: Deprecated. Remove in the next major version.
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "postcss-less": "^6.0.0",
         "postcss-sass": "^0.5.0",
         "postcss-scss": "^4.0.9",
+        "prettier": "^3.4.2",
         "remark-cli": "^12.0.1",
         "rollup": "^4.28.0",
         "sugarss": "^4.0.1",
@@ -14182,11 +14183,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "postcss-less": "^6.0.0",
     "postcss-sass": "^0.5.0",
     "postcss-scss": "^4.0.9",
+    "prettier": "^3.4.2",
     "remark-cli": "^12.0.1",
     "rollup": "^4.28.0",
     "sugarss": "^4.0.1",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Here is an official blog post for the latest version 3.4 of Prettier:
https://prettier.io/blog/2024/11/26/3.4.0

In addition, this change explicitly adds `prettier` to `package.json` because `prettier` is installed as a peer dependency of `@stylelint/prettier-config` and so it is not updated unless `@stylelint/prettier-config` is updated.

```sh-session
$ NODE_OPTIONS=--no-warnings npm v @stylelint/prettier-config peerDependencies
{ prettier: '>=3.0.0' }
```

