### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for `:open`

### DIFF
--- a/.changeset/tiny-lobsters-float.md
+++ b/.changeset/tiny-lobsters-float.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `selector-pseudo-class-no-unknown` false positive for `:open`
+Fixed: `selector-pseudo-class-no-unknown` false positives for `:open`

--- a/.changeset/tiny-lobsters-float.md
+++ b/.changeset/tiny-lobsters-float.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positive for `:open`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -338,6 +338,7 @@ const pseudoClasses = uniteSets(
 		'modal',
 		'only-child',
 		'only-of-type',
+		'open',
 		'optional',
 		'out-of-range',
 		'past',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -335,6 +335,7 @@ export const pseudoClasses = uniteSets(
 		'modal',
 		'only-child',
 		'only-of-type',
+		'open',
 		'optional',
 		'out-of-range',
 		'past',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -134,6 +134,10 @@ testRule({
 			description: 'explicit :popover-open test',
 		},
 		{
+			code: ':open {}',
+			description: 'explicit :open test',
+		},
+		{
 			code: ':active-view-transition, :active-view-transition-type() {}',
 		},
 		{


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8183

> Is there anything in the PR that needs further explanation?

See issue for more details on this new pseudo class. See https://groups.google.com/a/chromium.org/g/blink-dev/c/Pdo4oOXYKcA for the Chromium intent to ship for this.
