### PR TITLE
Document `at-rule-property-required-list`  difference between properties and descriptors

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -155,7 +155,7 @@ Allow, disallow or require things with these `allowed-list`, `disallowed-list`, 
 | [`at-rule-allowed-list`](../../lib/rules/at-rule-allowed-list/README.md)<br/>Specify a list of allowed at-rules. | | |
 | [`at-rule-disallowed-list`](../../lib/rules/at-rule-disallowed-list/README.md)<br/>Specify a list of disallowed at-rules. | | |
 | [`at-rule-no-vendor-prefix`](../../lib/rules/at-rule-no-vendor-prefix/README.md)<br/>Disallow vendor prefixes for at-rules. | ✅ | 🔧 |
-| [`at-rule-property-required-list`](../../lib/rules/at-rule-property-required-list/README.md)<br/>Specify a list of required properties for an at-rule. | | |
+| [`at-rule-property-required-list`](../../lib/rules/at-rule-property-required-list/README.md)<br/>Specify a list of required descriptors for an at-rule. | | |
 <!-- prettier-ignore-end -->
 
 #### Color

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -1,19 +1,19 @@
 # at-rule-property-required-list
 
-Specify a list of required properties for an at-rule.
+Specify a list of required descriptors (previously labelled properties) for an at-rule.
 
 <!-- prettier-ignore -->
 ```css
     @font-face { font-display: swap; font-family: 'foo'; }
 /**  ↑           ↑                   ↑
- *  At-rule and required property names */
+ *  At-rule and required descriptor names */
 ```
 
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
 ## Options
 
-`object`: `{ "at-rule-name": ["array", "of", "properties"]|"property" }`
+`object`: `{ "at-rule-name": ["array", "of", "descriptors"]|"descriptor" }`
 
 Given:
 

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -1,6 +1,6 @@
 # at-rule-property-required-list
 
-Specify a list of required descriptors (previously labelled properties) for an at-rule.
+Specify a list of required descriptors (previously labelled as properties) for an at-rule.
 
 <!-- prettier-ignore -->
 ```css


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This change was produced by the discussion on <https://github.com/stylelint/stylelint/issues/8148#issuecomment-2531031990>.

> Is there anything in the PR that needs further explanation?

We probably should have named the `at-rule-property-required-list` as `at-rule-descriptor-required-list` because declarations in at-rules are semantically descriptors rather than properties.

See also <https://drafts.csswg.org/css-syntax/#declaration>.
