### PR TITLE
Fix `at-rule-property-required-list` message to use "descriptor" for accuracy

### DIFF
--- a/.changeset/blue-carrots-share.md
+++ b/.changeset/blue-carrots-share.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `at-rule-property-required-list` message to use "descriptor" for accuracy

--- a/lib/rules/at-rule-property-required-list/index.cjs
+++ b/lib/rules/at-rule-property-required-list/index.cjs
@@ -10,10 +10,12 @@ const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateObjectWithArrayProps = require('../../utils/validateObjectWithArrayProps.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
 
+// NOTE: We should have named this rule as `at-rule-descriptor-required-list` instead.
+// See https://github.com/stylelint/stylelint/pull/8185
 const ruleName = 'at-rule-property-required-list';
 
 const messages = ruleMessages(ruleName, {
-	expected: (atRule, property) => `Expected property "${property}" for at-rule "${atRule}"`,
+	expected: (atRule, descriptor) => `Expected descriptor "${descriptor}" for at-rule "${atRule}"`,
 });
 
 const meta = {

--- a/lib/rules/at-rule-property-required-list/index.mjs
+++ b/lib/rules/at-rule-property-required-list/index.mjs
@@ -6,10 +6,12 @@ import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateObjectWithArrayProps from '../../utils/validateObjectWithArrayProps.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
 
+// NOTE: We should have named this rule as `at-rule-descriptor-required-list` instead.
+// See https://github.com/stylelint/stylelint/pull/8185
 const ruleName = 'at-rule-property-required-list';
 
 const messages = ruleMessages(ruleName, {
-	expected: (atRule, property) => `Expected property "${property}" for at-rule "${atRule}"`,
+	expected: (atRule, descriptor) => `Expected descriptor "${descriptor}" for at-rule "${atRule}"`,
 });
 
 const meta = {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up PR #8185
See also <https://github.com/stylelint/stylelint/issues/8148#issuecomment-2531031990>

> Is there anything in the PR that needs further explanation?

Note that it doesn't rename local variables to minimize code diffs and keep git-blame easy.
