### PR TITLE
Fix `value-no-vendor-prefix` false negatives for vendor-prefixed `center`

### DIFF
--- a/.changeset/clean-scissors-eat.md
+++ b/.changeset/clean-scissors-eat.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `value-no-vendor-prefix` false negatives for vendor-prefixed `center`

--- a/lib/rules/value-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/value-no-vendor-prefix/__tests__/index.mjs
@@ -50,6 +50,10 @@ testRule({
 			code: 'a { list-style-type: -moz-ethiopic-halehame; }',
 			description: '-moz-: ignores unfixable',
 		},
+		{
+			code: 'a { user-select: -moz-text; }',
+			description: 'cannot be overridden by -moz-user-select: all; elements in the parent chain',
+		},
 	],
 
 	reject: [

--- a/lib/utils/isAutoprefixable.cjs
+++ b/lib/utils/isAutoprefixable.cjs
@@ -219,8 +219,10 @@ const PROPERTIES = new Set([
  * @see https://github.com/stylelint/stylelint/pull/5312/files#r636018013
  */
 const PROPERTY_VALUES = new Set([
+	'-khtml-center',
 	'-moz-all',
 	'-moz-calc',
+	'-moz-center',
 	'-moz-crisp-edges',
 	'-moz-element',
 	'-moz-fit-content',
@@ -253,6 +255,7 @@ const PROPERTY_VALUES = new Set([
 	'-o-repeating-linear-gradient',
 	'-o-repeating-radial-gradient',
 	'-webkit-calc',
+	'-webkit-center',
 	'-webkit-cross-fade',
 	'-webkit-filter',
 	'-webkit-fit-content',

--- a/lib/utils/isAutoprefixable.mjs
+++ b/lib/utils/isAutoprefixable.mjs
@@ -215,8 +215,10 @@ const PROPERTIES = new Set([
  * @see https://github.com/stylelint/stylelint/pull/5312/files#r636018013
  */
 const PROPERTY_VALUES = new Set([
+	'-khtml-center',
 	'-moz-all',
 	'-moz-calc',
+	'-moz-center',
 	'-moz-crisp-edges',
 	'-moz-element',
 	'-moz-fit-content',
@@ -249,6 +251,7 @@ const PROPERTY_VALUES = new Set([
 	'-o-repeating-linear-gradient',
 	'-o-repeating-radial-gradient',
 	'-webkit-calc',
+	'-webkit-center',
 	'-webkit-cross-fade',
 	'-webkit-filter',
 	'-webkit-fit-content',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

https://bugzilla.mozilla.org/show_bug.cgi?id=1181130#c10
https://developer.mozilla.org/en-US/docs/Web/CSS/text-align
