### PR TITLE
Fix `at-rule-property-required-list` message for inclusion of properties and descriptors

### DIFF
--- a/.changeset/curvy-buses-rhyme.md
+++ b/.changeset/curvy-buses-rhyme.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `at-rule-property-required-list` message for inclusion of properties and descriptors

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -1,6 +1,6 @@
 # at-rule-property-required-list
 
-Specify a list of required descriptors (previously labelled as properties) for an at-rule.
+Specify a list of required properties (or descriptors) for an at-rule.
 
 <!-- prettier-ignore -->
 ```css
@@ -13,7 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "at-rule-name": ["array", "of", "descriptors"]|"descriptor" }`
+`object`: `{ "at-rule-name": ["array", "of", "properties or descriptors", "properties"]|"property or descriptor" }`
 
 Given:
 

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -13,7 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "at-rule-name": ["array", "of", "properties or descriptors", "properties"]|"property or descriptor" }`
+`object`: `{ "at-rule-name": ["array", "of", "properties or descriptors"]|"property or descriptor" }`
 
 Given:
 

--- a/lib/rules/at-rule-property-required-list/index.cjs
+++ b/lib/rules/at-rule-property-required-list/index.cjs
@@ -15,7 +15,8 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'at-rule-property-required-list';
 
 const messages = ruleMessages(ruleName, {
-	expected: (atRule, descriptor) => `Expected descriptor "${descriptor}" for at-rule "${atRule}"`,
+	expected: (atRule, property) =>
+		`Expected property (or descriptor) "${property}" for at-rule "${atRule}"`,
 });
 
 const meta = {

--- a/lib/rules/at-rule-property-required-list/index.mjs
+++ b/lib/rules/at-rule-property-required-list/index.mjs
@@ -11,7 +11,8 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'at-rule-property-required-list';
 
 const messages = ruleMessages(ruleName, {
-	expected: (atRule, descriptor) => `Expected descriptor "${descriptor}" for at-rule "${atRule}"`,
+	expected: (atRule, property) =>
+		`Expected property (or descriptor) "${property}" for at-rule "${atRule}"`,
 });
 
 const meta = {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/8185

> Is there anything in the PR that needs further explanation?

People can use this rule to require properties for nested at-rule. 

```css
a {
  @media (min-width: 10px } {
    color: red;
  }
}
```

[Demo](https://stylelint.io/demo/#N4Igxg9gJgpiBcICGACYAdAdilABAtjFAJaoAUA7sVAC4AWKAfCgIwAMADgB4CUaWOHJAA2EAE7wUYogG4BKAL5YFIADQgAZsWEwAckkIIQMLgY46AdGADO1teAiYtAcyMZsKdMa40YmKNZekgDa8jhe1jQAnjrCxJg0ALSQTsTOiZFI-khiUF7yALqq8l5iAK46gQj8HuHISeU6iRxiEBwwYtGJ0gCOZcTSUIlxkUE1goJehCRIY6EgJNbmSFFeBWGK8kqYKuopLgBi4vhINEYAVtaO9rAcdojudZExMHEJY17CpzCjaiUgz1i8SS+zSGRoWSgOTy1U+31+yhACiAA).

As a generic rule that applies to properties and descriptors, we can tweak the wording from https://github.com/stylelint/stylelint/pull/8185.


