### PR TITLE
Fix `atrule-*` false positives and negatives for `@charset` rule

### DIFF
--- a/.changeset/gold-suns-notice.md
+++ b/.changeset/gold-suns-notice.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `atrule-*` false positives and negatives for `@charset` rule

--- a/lib/reference/atKeywords.cjs
+++ b/lib/reference/atKeywords.cjs
@@ -52,7 +52,6 @@ const atKeywords = uniteSets(
 	fontFeatureValueTypes,
 	[
 		'apply',
-		'charset',
 		'counter-style',
 		'custom-media',
 		'custom-selector',

--- a/lib/reference/atKeywords.mjs
+++ b/lib/reference/atKeywords.mjs
@@ -48,7 +48,6 @@ export const atKeywords = uniteSets(
 	fontFeatureValueTypes,
 	[
 		'apply',
-		'charset',
 		'counter-style',
 		'custom-media',
 		'custom-selector',

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of allowed at-rules.
  * At-rules like this */
 ```
 
+This rule ignores the `@charset` rule.
+
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
 ## Options

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of disallowed at-rules.
  * At-rules like this */
 ```
 
+This rule ignores the `@charset` rule.
+
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
 ## Options

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -14,7 +14,8 @@ a {}
 This rule ignores:
 
 - at-rules that are the very first node in the source
-- `@import` in Less.
+- the `@charset` rule
+- `@import` in Less
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
@@ -90,8 +91,6 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-@charset "UTF-8";
-
 @import url(x.css);
 @import url(y.css);
 
@@ -163,18 +162,18 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-@charset "UTF-8";
-
 @import url(x.css);
 @import url(y.css);
+
+@namespace svg url('http://www.w3.org/2000/svg');
 ```
 
 <!-- prettier-ignore -->
 ```css
-@charset "UTF-8";
-
 @import url(x.css); /* comment */
 @import url(y.css);
+
+@namespace svg url('http://www.w3.org/2000/svg');
 ```
 
 <!-- prettier-ignore -->
@@ -357,10 +356,10 @@ The following patterns are _not_ considered problems:
 <!-- prettier-ignore -->
 ```css
 
-@charset "UTF-8";
-
 @import url(x.css);
 @import url(y.css);
+
+@namespace svg url('http://www.w3.org/2000/svg');
 ```
 
 <!-- prettier-ignore -->
@@ -409,13 +408,13 @@ For example, with `"always"`.
 Given:
 
 ```json
-["import"]
+["namespace"]
 ```
 
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-@charset "UTF-8";
-@import {}
+@import "foo.css";
+@namespace svg url('http://www.w3.org/2000/svg');
 ```

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -28,16 +28,6 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-@charset "UTF-8";
-```
-
-<!-- prettier-ignore -->
-```css
-@CHARSET "UTF-8";
-```
-
-<!-- prettier-ignore -->
-```css
 @media (max-width: 960px) {}
 ```
 

--- a/lib/rules/at-rule-no-unknown/__tests__/index.mjs
+++ b/lib/rules/at-rule-no-unknown/__tests__/index.mjs
@@ -7,25 +7,24 @@ testRule({
 
 	accept: [
 		{
+			code: "@charset 'UTF-8';",
+			description: 'ignore @charset as not an at-rule',
+		},
+		{
+			code: "@CHARSET 'UTF-8';",
+			description: 'ignore capitalised @charset as not an at-rule',
+		},
+		{
 			code: '@position-try --foo {}',
 		},
 		{
 			code: '@starting-style { opacity: 0; }',
 		},
 		{
-			code: "@charset 'UTF-8';",
-		},
-		{
 			code: '@container (min-width: 700px)',
 		},
 		{
 			code: '@CONTAINER (min-width: 500px)',
-		},
-		{
-			code: "@CHARSET 'UTF-8';",
-		},
-		{
-			code: "@charset 'iso-8859-15'",
 		},
 		{
 			code: '@import url("fineprint.css") print;',

--- a/lib/rules/no-irregular-whitespace/__tests__/index.mjs
+++ b/lib/rules/no-irregular-whitespace/__tests__/index.mjs
@@ -88,7 +88,7 @@ testRule({
 	reject: [
 		{
 			code: '@ charset "utf-8"',
-			description: 'irregular whitespace in at-rule',
+			description: 'irregular whitespace in at-charset css rule',
 			message: messages.unexpected,
 			line: 1,
 			column: 2,
@@ -97,7 +97,7 @@ testRule({
 		},
 		{
 			code: '@charset  "utf-8"',
-			description: 'irregular whitespace after at-rule',
+			description: 'irregular whitespace after at-charset css rule',
 			message: messages.unexpected,
 			line: 1,
 			column: 9,

--- a/lib/rules/string-no-newline/__tests__/index.mjs
+++ b/lib/rules/string-no-newline/__tests__/index.mjs
@@ -72,13 +72,13 @@ testRule({
 			endColumn: 13,
 		},
 		{
-			code: "@charset 'utf-8\n';",
+			code: "@import 'foo\n.css';",
 			description: 'atRule CRLF',
 			message: messages.rejected,
 			line: 1,
-			column: 10,
+			column: 9,
 			endLine: 1,
-			endColumn: 16,
+			endColumn: 13,
 		},
 	],
 });

--- a/lib/utils/__tests__/isStandardSyntaxAtRule.test.mjs
+++ b/lib/utils/__tests__/isStandardSyntaxAtRule.test.mjs
@@ -6,26 +6,18 @@ import postcssScss from 'postcss-scss';
 
 describe('isStandardSyntaxAtRule', () => {
 	it('non nested at-rules without quotes', () => {
-		expect(isStandardSyntaxAtRule(atRule('@charset UTF-8;'))).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@import url(foo.css)'))).toBeTruthy();
 	});
 
 	it("non nested at-rules with `'` quotes", () => {
-		expect(isStandardSyntaxAtRule(atRule("@charset 'UTF-8';"))).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule("@import 'foo.css';"))).toBeTruthy();
 	});
 
 	it('non nested at-rules with `"` quotes', () => {
-		expect(isStandardSyntaxAtRule(atRule('@charset "UTF-8";'))).toBeTruthy();
+		expect(isStandardSyntaxAtRule(atRule('@import "foo.css";'))).toBeTruthy();
 	});
 
-	it("non nested at-rules with `'` quotes and without space after name", () => {
-		expect(isStandardSyntaxAtRule(atRule("@charset'UTF-8';"))).toBeTruthy();
-	});
-
-	it('non nested at-rules with `"` quotes and without space after name', () => {
-		expect(isStandardSyntaxAtRule(atRule('@charset"UTF-8";'))).toBeTruthy();
-	});
-
-	it('non nested at-rules with function and without space after name', () => {
+	it('non nested at-rules with function and ident', () => {
 		expect(isStandardSyntaxAtRule(atRule('@import url("fineprint.css") print;'))).toBeTruthy();
 	});
 
@@ -43,6 +35,10 @@ describe('isStandardSyntaxAtRule', () => {
 
 	it('nested at-rules without space after name', () => {
 		expect(isStandardSyntaxAtRule(atRule('@media(min-width: 100px) {};'))).toBeTruthy();
+	});
+
+	it('at-charset css rule', () => {
+		expect(isStandardSyntaxAtRule(atRule('@charset UTF-8;'))).toBeFalsy();
 	});
 
 	// eslint-disable-next-line jest/no-disabled-tests -- see AleshaOleg/postcss-sass#56

--- a/lib/utils/isStandardSyntaxAtRule.cjs
+++ b/lib/utils/isStandardSyntaxAtRule.cjs
@@ -9,6 +9,11 @@
  * @returns {boolean} If `true`, the declaration is standard
  */
 function isStandardSyntaxAtRule(atRule) {
+	// Ignore `@charset` css rule (is parsed as at-rule)
+	if (atRule.name === 'charset') {
+		return false;
+	}
+
 	// Ignore scss `@content` inside mixins
 	if (!atRule.nodes && atRule.params === '') {
 		return false;

--- a/lib/utils/isStandardSyntaxAtRule.cjs
+++ b/lib/utils/isStandardSyntaxAtRule.cjs
@@ -10,7 +10,7 @@
  */
 function isStandardSyntaxAtRule(atRule) {
 	// Ignore `@charset` css rule (is parsed as at-rule)
-	if (atRule.name === 'charset') {
+	if (atRule.name.toLowerCase() === 'charset') {
 		return false;
 	}
 

--- a/lib/utils/isStandardSyntaxAtRule.mjs
+++ b/lib/utils/isStandardSyntaxAtRule.mjs
@@ -5,6 +5,11 @@
  * @returns {boolean} If `true`, the declaration is standard
  */
 export default function isStandardSyntaxAtRule(atRule) {
+	// Ignore `@charset` css rule (is parsed as at-rule)
+	if (atRule.name === 'charset') {
+		return false;
+	}
+
 	// Ignore scss `@content` inside mixins
 	if (!atRule.nodes && atRule.params === '') {
 		return false;

--- a/lib/utils/isStandardSyntaxAtRule.mjs
+++ b/lib/utils/isStandardSyntaxAtRule.mjs
@@ -6,7 +6,7 @@
  */
 export default function isStandardSyntaxAtRule(atRule) {
 	// Ignore `@charset` css rule (is parsed as at-rule)
-	if (atRule.name === 'charset') {
+	if (atRule.name.toLowerCase() === 'charset') {
 		return false;
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/7492#issuecomment-1907995564
Ref https://github.com/stylelint/stylelint/pull/8214#pullrequestreview-2518665122

> Is there anything in the PR that needs further explanation?

Fixes `@charset` being treated as an at-rule in our examples and tests.

It felt like an appropriate time to address this as we're adding new rules to shore up our capabilities around at-rules.
