### PR TITLE
Document use of `isStandardSyntax*` utils

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -110,10 +110,10 @@ There are significant benefits to using these parsers instead of regular express
 
 Stylelint has [utility functions](https://github.com/stylelint/stylelint/tree/main/lib/utils) that are used in existing rules and might prove useful to you, as well. Please look through those so that you know what's available. (And if you have a new function that you think might prove generally helpful, let's add it to the list!).
 
-Use the:
+Always use the:
 
 - `validateOptions()` utility to warn users about invalid options
-- `isStandardSyntax*` utilities to ignore non-standard syntax
+- `isStandardSyntax*` utilities before checking a node or string to ignore non-standard syntax
 
 ### Add options
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

This PR tweaks the documentation to imply that the `isStandardSyntax*` utils should always be used.
