### PR TITLE
Add replaced text

### DIFF
--- a/lib/formatters/__tests__/verboseFormatter.test.mjs
+++ b/lib/formatters/__tests__/verboseFormatter.test.mjs
@@ -225,8 +225,8 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'block-no-empty': [{ fixed: false }],
-								'color-hex-length': [{ fixed: true }],
+								'block-no-empty': [],
+								'color-hex-length': [{}],
 							},
 						},
 					},
@@ -254,7 +254,7 @@ describe('verboseFormatter', () => {
 		test('no warnings and plural', () => {
 			const position = { line: 0, column: 0 };
 			const range = { start: position, end: position };
-			const fixerData = { range, fixed: true };
+			const fixerData = { range };
 			const results = [
 				{
 					source: 'path/to/file.css',
@@ -291,7 +291,7 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'color-hex-length': [{ fixed: true }, { fixed: true }],
+								'color-hex-length': [{}, {}],
 							},
 						},
 					},
@@ -303,7 +303,7 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'function-name-case': [{ fixed: true }, { fixed: false }],
+								'function-name-case': [{}],
 							},
 						},
 					},

--- a/lib/formatters/verboseFormatter.cjs
+++ b/lib/formatters/verboseFormatter.cjs
@@ -171,7 +171,7 @@ function getFixedRules(results) {
 		const entries = Object.entries(fixersData);
 
 		for (const [ruleName, fixerData] of entries) {
-			const count = fixerData.filter(({ fixed }) => fixed).length;
+			const count = fixerData.length;
 
 			if (count) rules.set(ruleName, (rules.get(ruleName) ?? 0) + count);
 		}

--- a/lib/formatters/verboseFormatter.mjs
+++ b/lib/formatters/verboseFormatter.mjs
@@ -167,7 +167,7 @@ function getFixedRules(results) {
 		const entries = Object.entries(fixersData);
 
 		for (const [ruleName, fixerData] of entries) {
-			const count = fixerData.filter(({ fixed }) => fixed).length;
+			const count = fixerData.length;
 
 			if (count) rules.set(ruleName, (rules.get(ruleName) ?? 0) + count);
 		}

--- a/lib/lintSource.cjs
+++ b/lib/lintSource.cjs
@@ -98,6 +98,7 @@ async function lintSource(stylelint, options = {}) {
 			customUrls: {},
 			ruleMetadata: {},
 			fixersData: {},
+			fixedNodes: new WeakSet(),
 			disabledRanges: {},
 		},
 	});
@@ -123,6 +124,7 @@ function createEmptyStylelintPostcssResult() {
 		customUrls: {},
 		ruleMetadata: {},
 		fixersData: {},
+		fixedNodes: new WeakSet(),
 		disabledRanges: {},
 		ignored: true,
 		stylelintError: false,

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -96,6 +96,7 @@ export default async function lintSource(stylelint, options = {}) {
 			customUrls: {},
 			ruleMetadata: {},
 			fixersData: {},
+			fixedNodes: new WeakSet(),
 			disabledRanges: {},
 		},
 	});
@@ -121,6 +122,7 @@ function createEmptyStylelintPostcssResult() {
 		customUrls: {},
 		ruleMetadata: {},
 		fixersData: {},
+		fixedNodes: new WeakSet(),
 		disabledRanges: {},
 		ignored: true,
 		stylelintError: false,

--- a/lib/rules/media-feature-range-notation/index.cjs
+++ b/lib/rules/media-feature-range-notation/index.cjs
@@ -90,6 +90,8 @@ const rule = (primary) => {
 						if (expectedMediaQueryList === atRule.params) return;
 
 						atRule.params = expectedMediaQueryList;
+
+						return atRule;
 					};
 
 					const hasFix =

--- a/lib/rules/media-feature-range-notation/index.mjs
+++ b/lib/rules/media-feature-range-notation/index.mjs
@@ -94,6 +94,8 @@ const rule = (primary) => {
 						if (expectedMediaQueryList === atRule.params) return;
 
 						atRule.params = expectedMediaQueryList;
+
+						return atRule;
 					};
 
 					const hasFix =

--- a/lib/utils/__tests__/checkAgainstRule.test.mjs
+++ b/lib/utils/__tests__/checkAgainstRule.test.mjs
@@ -12,6 +12,7 @@ const resultStylelint = (props) => ({
 	customUrls: {},
 	disabledRanges: {},
 	fixersData: {},
+	fixedNodes: new WeakSet(),
 	...props,
 });
 

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -11,6 +11,7 @@ const resultStylelint = (props) => ({
 	customUrls: {},
 	disabledRanges: {},
 	fixersData: {},
+	fixedNodes: new WeakSet(),
 	...props,
 });
 
@@ -413,7 +414,6 @@ describe('with fix callback', () => {
 
 		const fixerData = fixersData.foo[0];
 
-		expect(fixerData.fixed).toBe(true);
 		expect(fixerData.range).toBeUndefined();
 	});
 
@@ -442,10 +442,7 @@ describe('with fix callback', () => {
 		expect(v.result.warn).toHaveBeenCalledTimes(1);
 		expect(v.fix).toHaveBeenCalledTimes(0);
 
-		const fixerData = fixersData.foo[0];
-
-		expect(fixerData.fixed).toBe(false);
-		expect(fixerData.range).toBeUndefined();
+		expect(fixersData.foo).toBeUndefined();
 	});
 
 	test('failing due to non-fixable metadata', () => {
@@ -486,9 +483,8 @@ test('with fix callback missing', () => {
 	report(v);
 	expect(v.result.warn).toHaveBeenCalledTimes(1);
 
-	const fixerData = fixersData.foo[1];
+	const fixerData = fixersData.foo[0];
 
-	expect(fixerData.fixed).toBe(false);
 	expect(fixerData.range).toBeUndefined();
 });
 

--- a/lib/utils/checkAgainstRule.cjs
+++ b/lib/utils/checkAgainstRule.cjs
@@ -49,6 +49,7 @@ async function checkAgainstRule(options, callback) {
 		customUrls: {},
 		ruleMetadata: {},
 		fixersData: {},
+		fixedNodes: new WeakSet(),
 		disabledRanges: {},
 	};
 

--- a/lib/utils/checkAgainstRule.mjs
+++ b/lib/utils/checkAgainstRule.mjs
@@ -46,6 +46,7 @@ export default async function checkAgainstRule(options, callback) {
 		customUrls: {},
 		ruleMetadata: {},
 		fixersData: {},
+		fixedNodes: new WeakSet(),
 		disabledRanges: {},
 	};
 

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -4,8 +4,10 @@
 
 const validateTypes = require('./validateTypes.cjs');
 const constants = require('../constants.cjs');
+const typeGuards = require('./typeGuards.cjs');
 
 /** @import { DisabledRangeObject, Problem, Range, RuleMessage, StylelintPostcssResult, Utils, WarningOptions } from 'stylelint' */
+/** @import { Node as PostcssNode } from 'postcss' */
 
 /**
  * Report a problem.
@@ -163,24 +165,47 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 }
 
 /** @param {Problem & { line: number }} problem */
-function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
-	const { disabledRanges, config = {}, fixersData } = stylelint;
+function isFixApplied({ node, fix, line, result: { stylelint }, ruleName }) {
+	const { disabledRanges, config = {}, fixersData, fixedNodes } = stylelint;
 
-	if (!validateTypes.isFunction(fix)) {
-		addFixData({ fixersData, ruleName, fixed: false });
-
-		return false;
-	}
+	if (!validateTypes.isFunction(fix)) return false;
 
 	const shouldFix = Boolean(config.fix && !config.rules?.[ruleName][1]?.disableFix);
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	addFixData({ fixersData, ruleName, fixed: mayFix });
-
 	if (!mayFix) return false;
 
-	fix();
+	const fixedNode = fix();
+
+	if (
+		Boolean(config.recordReplacementText) &&
+		fixedNode &&
+		fixedNode.source?.start &&
+		fixedNode.source?.end
+	) {
+		// When recording replacement text we want to ensure that there is no overlap with any other fix.
+		// We only record the first fix for each node.
+		if (fixedNodes.has(node)) return true;
+
+		addFixData({
+			fixersData,
+			ruleName,
+			...reduceFixRange(fixedNode, {
+				range: {
+					start: fixedNode.source.start,
+					end: fixedNode.source.end,
+				},
+				text: fixedNode.toString(),
+			}),
+		});
+
+		addFixedNode(fixedNodes, fixedNode);
+	} else {
+		addFixData({ fixersData, ruleName });
+
+		addFixedNode(fixedNodes, node);
+	}
 
 	return true;
 }
@@ -190,13 +215,85 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
  * @param {Range} [o.range]
- * @param {boolean} o.fixed
+ * @param {string} [o.text]
  * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range, fixed }) {
+function addFixData({ fixersData, ruleName, range, text }) {
 	const ruleFixers = (fixersData[ruleName] ??= []);
 
-	ruleFixers.push({ range, fixed });
+	ruleFixers.push({ range, text });
+}
+
+/**
+ * @param {WeakSet<PostcssNode>} fixedNodes
+ * @param {PostcssNode} node
+ */
+function addFixedNode(fixedNodes, node) {
+	fixedNodes.add(node);
+
+	if (typeGuards.isContainer(node)) {
+		node.walk((childNode) => {
+			fixedNodes.add(childNode);
+		});
+	}
+}
+
+/**
+ * @param {PostcssNode} node
+ * @param {{range: Range, text: string}} fixData
+ * @returns {{range: Range, text: string}}
+ */
+function reduceFixRange(node, fixData) {
+	if (!validateTypes.isNumber(node.source?.start?.offset) || !validateTypes.isNumber(node.source?.end?.offset)) {
+		return fixData;
+	}
+
+	const stringRepresentation = node.source.input.css.slice(
+		node.source?.start?.offset,
+		node.source?.end?.offset,
+	);
+
+	let replacementStartOffset = 0;
+	let startOffset = node.source?.start?.offset;
+
+	for (let i = 0; i < stringRepresentation.length; i++) {
+		const a = stringRepresentation[i];
+		const b = fixData.text[i];
+
+		if (a !== b) break;
+
+		startOffset++;
+		replacementStartOffset++;
+	}
+
+	const start = node.positionInside(startOffset);
+
+	start.offset = startOffset;
+
+	let replacementEndOffset = fixData.text.length;
+	let endOffset = node.source?.end?.offset;
+
+	for (let i = stringRepresentation.length - 1; i >= 0; i--) {
+		const a = stringRepresentation[i];
+		const b = fixData.text[i];
+
+		if (a !== b) break;
+
+		endOffset--;
+		replacementEndOffset--;
+	}
+
+	const end = node.positionInside(endOffset);
+
+	end.offset = endOffset;
+
+	return {
+		text: fixData.text.slice(replacementStartOffset, replacementEndOffset),
+		range: {
+			start,
+			end,
+		},
+	};
 }
 
 module.exports = report;

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -6,8 +6,10 @@ import {
 	SEVERITY_ERROR,
 	SEVERITY_WARNING,
 } from '../constants.mjs';
+import { isContainer } from './typeGuards.mjs';
 
 /** @import { DisabledRangeObject, Problem, Range, RuleMessage, StylelintPostcssResult, Utils, WarningOptions } from 'stylelint' */
+/** @import { Node as PostcssNode } from 'postcss' */
 
 /**
  * Report a problem.
@@ -165,24 +167,47 @@ function isDisabled(ruleName, startLine, disabledRanges) {
 }
 
 /** @param {Problem & { line: number }} problem */
-function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
-	const { disabledRanges, config = {}, fixersData } = stylelint;
+function isFixApplied({ node, fix, line, result: { stylelint }, ruleName }) {
+	const { disabledRanges, config = {}, fixersData, fixedNodes } = stylelint;
 
-	if (!isFn(fix)) {
-		addFixData({ fixersData, ruleName, fixed: false });
-
-		return false;
-	}
+	if (!isFn(fix)) return false;
 
 	const shouldFix = Boolean(config.fix && !config.rules?.[ruleName][1]?.disableFix);
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	addFixData({ fixersData, ruleName, fixed: mayFix });
-
 	if (!mayFix) return false;
 
-	fix();
+	const fixedNode = fix();
+
+	if (
+		Boolean(config.recordReplacementText) &&
+		fixedNode &&
+		fixedNode.source?.start &&
+		fixedNode.source?.end
+	) {
+		// When recording replacement text we want to ensure that there is no overlap with any other fix.
+		// We only record the first fix for each node.
+		if (fixedNodes.has(node)) return true;
+
+		addFixData({
+			fixersData,
+			ruleName,
+			...reduceFixRange(fixedNode, {
+				range: {
+					start: fixedNode.source.start,
+					end: fixedNode.source.end,
+				},
+				text: fixedNode.toString(),
+			}),
+		});
+
+		addFixedNode(fixedNodes, fixedNode);
+	} else {
+		addFixData({ fixersData, ruleName });
+
+		addFixedNode(fixedNodes, node);
+	}
 
 	return true;
 }
@@ -192,11 +217,83 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
  * @param {Range} [o.range]
- * @param {boolean} o.fixed
+ * @param {string} [o.text]
  * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range, fixed }) {
+function addFixData({ fixersData, ruleName, range, text }) {
 	const ruleFixers = (fixersData[ruleName] ??= []);
 
-	ruleFixers.push({ range, fixed });
+	ruleFixers.push({ range, text });
+}
+
+/**
+ * @param {WeakSet<PostcssNode>} fixedNodes
+ * @param {PostcssNode} node
+ */
+function addFixedNode(fixedNodes, node) {
+	fixedNodes.add(node);
+
+	if (isContainer(node)) {
+		node.walk((childNode) => {
+			fixedNodes.add(childNode);
+		});
+	}
+}
+
+/**
+ * @param {PostcssNode} node
+ * @param {{range: Range, text: string}} fixData
+ * @returns {{range: Range, text: string}}
+ */
+function reduceFixRange(node, fixData) {
+	if (!isNumber(node.source?.start?.offset) || !isNumber(node.source?.end?.offset)) {
+		return fixData;
+	}
+
+	const stringRepresentation = node.source.input.css.slice(
+		node.source?.start?.offset,
+		node.source?.end?.offset,
+	);
+
+	let replacementStartOffset = 0;
+	let startOffset = node.source?.start?.offset;
+
+	for (let i = 0; i < stringRepresentation.length; i++) {
+		const a = stringRepresentation[i];
+		const b = fixData.text[i];
+
+		if (a !== b) break;
+
+		startOffset++;
+		replacementStartOffset++;
+	}
+
+	const start = node.positionInside(startOffset);
+
+	start.offset = startOffset;
+
+	let replacementEndOffset = fixData.text.length;
+	let endOffset = node.source?.end?.offset;
+
+	for (let i = stringRepresentation.length - 1; i >= 0; i--) {
+		const a = stringRepresentation[i];
+		const b = fixData.text[i];
+
+		if (a !== b) break;
+
+		endOffset--;
+		replacementEndOffset--;
+	}
+
+	const end = node.positionInside(endOffset);
+
+	end.offset = endOffset;
+
+	return {
+		text: fixData.text.slice(replacementStartOffset, replacementEndOffset),
+		range: {
+			start,
+			end,
+		},
+	};
 }

--- a/lib/utils/typeGuards.cjs
+++ b/lib/utils/typeGuards.cjs
@@ -7,6 +7,14 @@
 
 /**
  * @param {Node} node
+ * @returns {node is import('postcss').Container}
+ */
+function isContainer(node) {
+	return isRoot(node) || isRule(node) || isAtRule(node) || isDocument(node);
+}
+
+/**
+ * @param {Node} node
  * @returns {node is import('postcss').Root}
  */
 function isRoot(node) {
@@ -96,6 +104,7 @@ function hasSource(node) {
 exports.hasSource = hasSource;
 exports.isAtRule = isAtRule;
 exports.isComment = isComment;
+exports.isContainer = isContainer;
 exports.isDeclaration = isDeclaration;
 exports.isDocument = isDocument;
 exports.isRoot = isRoot;

--- a/lib/utils/typeGuards.mjs
+++ b/lib/utils/typeGuards.mjs
@@ -3,6 +3,14 @@
 
 /**
  * @param {Node} node
+ * @returns {node is import('postcss').Container}
+ */
+export function isContainer(node) {
+	return isRoot(node) || isRule(node) || isAtRule(node) || isDocument(node);
+}
+
+/**
+ * @param {Node} node
  * @returns {node is import('postcss').Root}
  */
 export function isRoot(node) {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -112,6 +112,7 @@ declare namespace stylelint {
 		allowEmptyInput?: boolean;
 		cache?: boolean;
 		fix?: boolean;
+		recordReplacementText?: boolean;
 		validate?: boolean;
 	};
 
@@ -149,6 +150,7 @@ declare namespace stylelint {
 		customUrls: { [ruleName: string]: string };
 		ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
 		fixersData: { [ruleName: string]: Array<FixerData> };
+		fixedNodes: WeakSet<PostCSS.Node>;
 		quiet?: boolean;
 		disabledRanges: DisabledRangeObject;
 		disabledWarnings?: DisabledWarning[];
@@ -255,7 +257,7 @@ declare namespace stylelint {
 
 	type FixerData = {
 		range?: Range;
-		fixed: boolean;
+		text?: string;
 	};
 
 	/**
@@ -851,7 +853,7 @@ declare namespace stylelint {
 		 * Optional severity override for the problem.
 		 */
 		severity?: RuleSeverity;
-		fix?: () => void | undefined | never;
+		fix?: () => PostCSS.Node | void | undefined | never;
 	};
 
 	/** @internal */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/7192

> Is there anything in the PR that needs further explanation?

This is only a very rough proposal at this time.

After working on several issues related to the reported ranges I gained some new insights and saw a way forwards for https://github.com/stylelint/stylelint/issues/7192.

In all my previous ideas I was working from the perspective of rule authors with the main questions/hurdles being:
- how to compute replacement text
- how to handle escaping
- how to handle replacements spanning multiple nodes
- how to avoid having another complex callback, next to the existing `fix()` callback, that works roughly the same but still slightly different

In this proposal I am ignoring all those issues 😅 
They simply don't exist for rule authors.

Instead we ask rule authors to return a single `PostCSS.Node` that encompasses all nodes they altered in a fix callback. In most cases this will be the node they altered. In extreme cases this might be the root node.

From this node we do all needed computations for rule authors:
- are there conflicts with previous fixes?
- what is the minimal range and replacement text?

To avoid conflicts I have used a simpler `Set` approach that keeps track of altered nodes, but it should instead be done by checking for overlapping ranges. For a draft the current approach is good enough.

The compromise in this approach is that any area in a source file can only have one corresponding fix per Stylelint run. If multiple overlapping fixes need to be applied, then end users will need to run their flows multiple times. Each time fixing all issues before starting a next run.

I have no idea if this current approach works as the test framework doesn't support this new data. But I kinda like this direction for its apparent simplicity.