### PR TITLE
Refactor `color-hex-alpha` and `no-irregular-whitespace` to use consistent `ruleMessage` keys

### DIFF
--- a/lib/rules/color-hex-alpha/__tests__/index.mjs
+++ b/lib/rules/color-hex-alpha/__tests__/index.mjs
@@ -59,7 +59,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { color: #ffff; }',
-			message: messages.unexpected('#ffff'),
+			message: messages.rejected('#ffff'),
 			line: 1,
 			column: 12,
 			endLine: 1,

--- a/lib/rules/color-hex-alpha/index.cjs
+++ b/lib/rules/color-hex-alpha/index.cjs
@@ -15,7 +15,7 @@ const ruleName = 'color-hex-alpha';
 
 const messages = ruleMessages(ruleName, {
 	expected: (hex) => `Expected alpha channel in "${hex}"`,
-	unexpected: (hex) => `Unexpected alpha channel in "${hex}"`,
+	rejected: (hex) => `Unexpected alpha channel in "${hex}"`,
 });
 
 const meta = {
@@ -52,7 +52,7 @@ const rule = (primary) => {
 				const endIndex = index + value.length;
 
 				report({
-					message: primary === 'never' ? messages.unexpected : messages.expected,
+					message: primary === 'never' ? messages.rejected : messages.expected,
 					messageArgs: [value],
 					node: decl,
 					index,

--- a/lib/rules/color-hex-alpha/index.mjs
+++ b/lib/rules/color-hex-alpha/index.mjs
@@ -12,7 +12,7 @@ const ruleName = 'color-hex-alpha';
 
 const messages = ruleMessages(ruleName, {
 	expected: (hex) => `Expected alpha channel in "${hex}"`,
-	unexpected: (hex) => `Unexpected alpha channel in "${hex}"`,
+	rejected: (hex) => `Unexpected alpha channel in "${hex}"`,
 });
 
 const meta = {
@@ -49,7 +49,7 @@ const rule = (primary) => {
 				const endIndex = index + value.length;
 
 				report({
-					message: primary === 'never' ? messages.unexpected : messages.expected,
+					message: primary === 'never' ? messages.rejected : messages.expected,
 					messageArgs: [value],
 					node: decl,
 					index,

--- a/lib/rules/no-irregular-whitespace/__tests__/index.mjs
+++ b/lib/rules/no-irregular-whitespace/__tests__/index.mjs
@@ -89,7 +89,7 @@ testRule({
 		{
 			code: '@ charset "utf-8"',
 			description: 'irregular whitespace in at-charset css rule',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 2,
 			endLine: 1,
@@ -98,7 +98,7 @@ testRule({
 		{
 			code: '@charset  "utf-8"',
 			description: 'irregular whitespace after at-charset css rule',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 9,
 			endLine: 1,
@@ -107,7 +107,7 @@ testRule({
 		{
 			code: '.firstClass .secondClass { color: pink; }',
 			description: 'irregular whitespace in selector',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -116,7 +116,7 @@ testRule({
 		{
 			code: '.firstClass .secondClass  { color: pink; }',
 			description: 'irregular whitespace after selector',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 26,
 			endLine: 1,
@@ -125,7 +125,7 @@ testRule({
 		{
 			code: 'margin: 1rem 2rem;',
 			description: 'irregular whitespace in declaration value',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 13,
 			endLine: 1,
@@ -134,7 +134,7 @@ testRule({
 		{
 			code: 'margin: 1rem 2rem ;',
 			description: 'irregular whitespace after value',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 18,
 			endLine: 1,
@@ -143,7 +143,7 @@ testRule({
 		{
 			code: '$variable : 5rem;',
 			description: 'irregular whitespace in variable name',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 10,
 			endLine: 1,
@@ -152,7 +152,7 @@ testRule({
 		{
 			code: '@media screen {\f}',
 			description: 'irregular whitespace in the after of an at rule',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 16,
 			endLine: 1,
@@ -161,7 +161,7 @@ testRule({
 		{
 			code: '.a {\f}',
 			description: 'irregular whitespace in the after of a rule',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 5,
 			endLine: 1,
@@ -170,7 +170,7 @@ testRule({
 		{
 			code: '.a {\f\f}',
 			description: 'irregular whitespace in the after of a rule',
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 5,
 			endLine: 1,
@@ -180,7 +180,7 @@ testRule({
 		...IRREGULAR_WHITESPACES.map((ws) => ({
 			code: `a[title="irregular${ws}whitespace"] { color: pink; }`,
 			description: `irregular whitespace in attribute selector: ${characterToUnicodeString(ws)}`,
-			message: messages.unexpected,
+			message: messages.rejected,
 			line: 1,
 			column: 19,
 			endLine: 1,
@@ -197,21 +197,21 @@ testRule({
 			`,
 			warnings: [
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 2,
 					column: 1,
 					endLine: 2,
 					endColumn: 2,
 				},
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 3,
 					column: 2,
 					endLine: 3,
 					endColumn: 3,
 				},
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 5,
 					column: 1,
 					endLine: 5,
@@ -230,21 +230,21 @@ testRule({
 			`,
 			warnings: [
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 2,
 					column: 1,
 					endLine: 2,
 					endColumn: 2,
 				},
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 4,
 					column: 1,
 					endLine: 4,
 					endColumn: 2,
 				},
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 5,
 					column: 5,
 					endLine: 5,
@@ -265,28 +265,28 @@ testRule({
 			`,
 			warnings: [
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 3,
 					column: 9,
 					endLine: 3,
 					endColumn: 10,
 				},
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 4,
 					column: 2,
 					endLine: 4,
 					endColumn: 3,
 				},
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 5,
 					column: 5,
 					endLine: 5,
 					endColumn: 6,
 				},
 				{
-					message: messages.unexpected,
+					message: messages.rejected,
 					line: 7,
 					column: 10,
 					endLine: 7,

--- a/lib/rules/no-irregular-whitespace/index.cjs
+++ b/lib/rules/no-irregular-whitespace/index.cjs
@@ -13,7 +13,7 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'no-irregular-whitespace';
 
 const messages = ruleMessages(ruleName, {
-	unexpected: 'Unexpected irregular whitespace',
+	rejected: 'Unexpected irregular whitespace',
 });
 
 const meta = {
@@ -90,7 +90,7 @@ const rule = (primary) => {
 				report({
 					ruleName,
 					result,
-					message: messages.unexpected,
+					message: messages.rejected,
 					node,
 					index: startIndex + index,
 					endIndex: startIndex + index + length,

--- a/lib/rules/no-irregular-whitespace/index.mjs
+++ b/lib/rules/no-irregular-whitespace/index.mjs
@@ -19,7 +19,7 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'no-irregular-whitespace';
 
 const messages = ruleMessages(ruleName, {
-	unexpected: 'Unexpected irregular whitespace',
+	rejected: 'Unexpected irregular whitespace',
 });
 
 const meta = {
@@ -96,7 +96,7 @@ const rule = (primary) => {
 				report({
 					ruleName,
 					result,
-					message: messages.unexpected,
+					message: messages.rejected,
 					node,
 					index: startIndex + index,
 					endIndex: startIndex + index + length,


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

I am planning to send a PR that will add the possibility to add the types of the core rule's `messages`.
i.e.
```ts
	type CoreRule<
		P extends Primary,
		S extends Secondary = CommonOptions,
		M extends RuleMessages = Messages
	> = Rule<P, S, M>;
```
This will permit to document the order and names of the arguments.
e.g.
- distinguish between `(property: string, keyword: string) => string` and `(keyword: string, property: string) => string`
- hypothetical documentation generation
- autocompletion for configurations

This preliminary PR is to prepare the codebase for that change.
i.e. these rules are the only ones that produce errors for
```ts
	type Messages = {
		[key in `expected${string}` | `rejected${string}`]: RuleMessage;
	};
```