### PR TITLE
Document preferred config file format

### DIFF
--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -2,7 +2,7 @@
 
 Stylelint expects a configuration object.
 
-Starting from the current working directory, Stylelint searches upwards until it finds a `stylelint.config.{js,mjs}` file that exports one. Or, you can use the [`--config`](cli.md#--config--c) or [`configFile`](options.md#configfile) option to short-circuit the search.
+Starting from the current working directory, Stylelint searches upwards until it finds a `stylelint.config.js` (or `stylelint.config.mjs`, `stylelint.config.cjs`) file that exports one. Or, you can use the [`--config`](cli.md#--config--c) or [`configFile`](options.md#configfile) option to short-circuit the search.
 
 > [!NOTE]
 > Stylelint currently supports other configuration formats, but we may remove these in the future:

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -2,19 +2,9 @@
 
 Stylelint expects a configuration object.
 
-Starting from the current working directory, Stylelint searches upwards until it finds a `stylelint.config.js` (or `stylelint.config.mjs`, `stylelint.config.cjs`) file that exports one. Or, you can use the [`--config`](cli.md#--config--c) or [`configFile`](options.md#configfile) option to short-circuit the search.
+Starting from the current working directory, Stylelint searches upwards until it finds a `stylelint.config.js` file that exports one. You can use the [`--config`](cli.md#--config--c) or [`configFile`](options.md#configfile) options to short-circuit the search.
 
-> [!NOTE]
-> Stylelint currently supports other configuration formats, but we may remove these in the future:
->
-> - `.stylelintrc` file in JSON or YAML format.
-> - `.stylelintrc.json` file or `stylelint` property in `package.json`
-> - `.stylelintrc.yml` or `.stylelintrc.yaml` file
-> - `.stylelintrc.js` file using `export default` or `module.exports`
-> - `.stylelintrc.mjs` file using `export default`
-> - `stylelint.config.cjs` or `.stylelintrc.cjs` file using `module.exports`
->
-> For `.js` files, the module system depends on your [default module system configuration](https://nodejs.org/api/packages.html#determining-module-system) for Node.js (e.g., `"type": "module"` in `package.json`).
+The style of export depends on your [default module system configuration](https://nodejs.org/api/packages.html#determining-module-system) for Node.js, e.g., `"type": "module"` in your `package.json` file. You can use the `stylelint.config.mjs` or `stylelint.config.cjs` filename to be explicit.
 
 Example `stylelint.config.mjs` file:
 
@@ -26,6 +16,17 @@ export default {
   }
 };
 ```
+
+> [!NOTE]
+> Stylelint currently supports other configuration locations and formats, but we may remove these in the future:
+>
+> - `.stylelintrc.js` file using `export default` or `module.exports`
+> - `.stylelintrc.mjs` file using `export default`
+> - `.stylelintrc.cjs` file using `module.exports`
+> - `.stylelintrc` file in YAML or JSON format.
+> - `.stylelintrc.yml` or `.stylelintrc.yaml` file
+> - `.stylelintrc.json` file
+> - `stylelint` property in `package.json`
 
 The configuration object has the following properties:
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -23,7 +23,7 @@ export default {
 > - `.stylelintrc.js` file using `export default` or `module.exports`
 > - `.stylelintrc.mjs` file using `export default`
 > - `.stylelintrc.cjs` file using `module.exports`
-> - `.stylelintrc` file in YAML or JSON format.
+> - `.stylelintrc` file in YAML or JSON format
 > - `.stylelintrc.yml` or `.stylelintrc.yaml` file
 > - `.stylelintrc.json` file
 > - `stylelint` property in `package.json`

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -9,7 +9,7 @@ The style of export depends on your [default module system configuration](https:
 Example `stylelint.config.mjs` file:
 
 ```js
-/** @import { Config } from 'stylelint' */
+/** @type {import('stylelint').Config} */
 export default {
   rules: {
     "block-no-empty": true

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -6,7 +6,7 @@ Starting from the current working directory, Stylelint searches upwards until it
 
 The style of export depends on your [default module system configuration](https://nodejs.org/api/packages.html#determining-module-system) for Node.js, e.g., `"type": "module"` in your `package.json` file. You can use the `stylelint.config.mjs` or `stylelint.config.cjs` filename to be explicit.
 
-Example `stylelint.config.mjs` file:
+Example `stylelint.config.js` file:
 
 ```js
 /** @type {import('stylelint').Config} */

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -19,7 +19,7 @@ Starting from the current working directory, Stylelint searches upwards until it
 Example `stylelint.config.mjs` file:
 
 ```js
-/** @type {import('stylelint').Config} */
+/** @import { Config } from 'stylelint' */
 export default {
   rules: {
     "block-no-empty": true

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -1,17 +1,22 @@
 # Configuring
 
-Stylelint expects a configuration object, and looks for one in a:
+Stylelint expects a configuration object.
 
-- `stylelint.config.js` or `.stylelintrc.js` file
-  - Which module system to use depends on your [default module system configuration](https://nodejs.org/api/packages.html#determining-module-system) for Node.js (e.g., `"type": "module"` in `package.json`).
-- `stylelint.config.mjs` or `.stylelintrc.mjs` file using `export default` (ES module)
-- `stylelint.config.cjs` or `.stylelintrc.cjs` file using `module.exports` (CommonJS)
-- `.stylelintrc.json`, `.stylelintrc.yml`, or `.stylelintrc.yaml` file
-- `.stylelintrc` file in JSON or YAML format
-  - We recommend adding an extension (e.g., `.json`) to help your editor provide syntax checking and highlighting.
-- `stylelint` property in `package.json`
+Starting from the current working directory, Stylelint searches upwards until it finds a `stylelint.config.{js,mjs}` file that exports one. Or, you can use the [`--config`](cli.md#--config--c) or [`configFile`](options.md#configfile) option to short-circuit the search.
 
-ES module example:
+> [!NOTE]
+> Stylelint currently supports other configuration formats, but we may remove these in the future:
+>
+> - `.stylelintrc` file in JSON or YAML format.
+> - `.stylelintrc.json` file or `stylelint` property in `package.json`
+> - `.stylelintrc.yml` or `.stylelintrc.yaml` file
+> - `.stylelintrc.js` file using `export default` or `module.exports`
+> - `.stylelintrc.mjs` file using `export default`
+> - `stylelint.config.cjs` or `.stylelintrc.cjs` file using `module.exports`
+>
+> For `.js` files, the module system depends on your [default module system configuration](https://nodejs.org/api/packages.html#determining-module-system) for Node.js (e.g., `"type": "module"` in `package.json`).
+
+Example `stylelint.config.mjs` file:
 
 ```js
 /** @type {import('stylelint').Config} */
@@ -21,32 +26,6 @@ export default {
   }
 };
 ```
-
-> [!NOTE]
-> The `@type` JSDoc annotation enables Typescript to autocomplete and type-check.
-
-CommonJS example:
-
-```js
-/** @type {import('stylelint').Config} */
-module.exports = {
-  rules: {
-    "block-no-empty": true
-  }
-};
-```
-
-JSON example:
-
-```json
-{
-  "rules": {
-    "block-no-empty": true
-  }
-}
-```
-
-Starting from the current working directory, Stylelint stops searching when one of these is found. Alternatively, you can use the [`--config`](cli.md#--config--c) or [`configFile`](options.md#configfile) option to short-circuit the search.
 
 The configuration object has the following properties:
 

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -92,7 +92,7 @@ If you want to lint more than one language or container, you can use the [`overr
 For example, to lint CSS files and the CSS within Lit Elements you can update your configuration to:
 
 ```js
-/** @type {import('stylelint').Config} */
+/** @import { Config } from 'stylelint' */
 export default {
   extends: ["stylelint-config-standard"],
   overrides: [

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -38,7 +38,7 @@ For example, to lint SCSS you can extend the [SCSS community config](https://www
 npm install --save-dev stylelint stylelint-config-standard-scss
 ```
 
-2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
+2\. Create a `stylelint.config.js` configuration file in the root of your project with the following content:
 
 ```js
 /** @type {import('stylelint').Config} */

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -38,12 +38,13 @@ For example, to lint SCSS you can extend the [SCSS community config](https://www
 npm install --save-dev stylelint stylelint-config-standard-scss
 ```
 
-2\. Create a `.stylelintrc.json` configuration file in the root of your project with the following content:
+2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
 
-```json
-{
-  "extends": "stylelint-config-standard-scss"
-}
+```js
+/** @type {import('stylelint').Config} */
+export default {
+  extends: ["stylelint-config-standard"]
+};
 ```
 
 3\. Run Stylelint on all the SCSS files in your project:
@@ -66,13 +67,14 @@ For example, to lint CSS inside of [Lit elements](https://lit.dev/).
 npm install --save-dev stylelint stylelint-config-standard postcss-lit
 ```
 
-2\. Create a `.stylelintrc.json` configuration file in the root of your project with the following content:
+2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
 
-```json
-{
-  "extends": "stylelint-config-standard",
-  "customSyntax": "postcss-lit"
-}
+```js
+/** @type {import('stylelint').Config} */
+export default {
+  extends: "stylelint-config-standard",
+  customSyntax: "postcss-lit"
+};
 ```
 
 3\. Run Stylelint on all the JavaScript files in your project:
@@ -89,16 +91,17 @@ If you want to lint more than one language or container, you can use the [`overr
 
 For example, to lint CSS files and the CSS within Lit Elements you can update your configuration to:
 
-```json
-{
-  "extends": ["stylelint-config-standard"],
-  "overrides": [
+```js
+/** @type {import('stylelint').Config} */
+export default {
+  extends: ["stylelint-config-standard"],
+  overrides: [
     {
-      "files": ["*.js"],
-      "customSyntax": "postcss-lit"
+      files: ["*.js"],
+      customSyntax: "postcss-lit"
     }
   ]
-}
+};
 ```
 
 And then run Stylelint on both your CSS and JavaScript files:

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -41,7 +41,7 @@ npm install --save-dev stylelint stylelint-config-standard-scss
 2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
 
 ```js
-/** @import { Config } from 'stylelint' */
+/** @type {import('stylelint').Config} */
 export default {
   extends: ["stylelint-config-standard"]
 };
@@ -70,7 +70,7 @@ npm install --save-dev stylelint stylelint-config-standard postcss-lit
 2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
 
 ```js
-/** @import { Config } from 'stylelint' */
+/** @type {import('stylelint').Config} */
 export default {
   extends: "stylelint-config-standard",
   customSyntax: "postcss-lit"
@@ -92,7 +92,7 @@ If you want to lint more than one language or container, you can use the [`overr
 For example, to lint CSS files and the CSS within Lit Elements you can update your configuration to:
 
 ```js
-/** @import { Config } from 'stylelint' */
+/** @type {import('stylelint').Config} */
 export default {
   extends: ["stylelint-config-standard"],
   overrides: [

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -67,7 +67,7 @@ For example, to lint CSS inside of [Lit elements](https://lit.dev/).
 npm install --save-dev stylelint stylelint-config-standard postcss-lit
 ```
 
-2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
+2\. Create a `stylelint.config.js` configuration file in the root of your project with the following content:
 
 ```js
 /** @type {import('stylelint').Config} */

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -41,7 +41,7 @@ npm install --save-dev stylelint stylelint-config-standard-scss
 2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
 
 ```js
-/** @type {import('stylelint').Config} */
+/** @import { Config } from 'stylelint' */
 export default {
   extends: ["stylelint-config-standard"]
 };
@@ -70,7 +70,7 @@ npm install --save-dev stylelint stylelint-config-standard postcss-lit
 2\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
 
 ```js
-/** @type {import('stylelint').Config} */
+/** @import { Config } from 'stylelint' */
 export default {
   extends: "stylelint-config-standard",
   customSyntax: "postcss-lit"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

It's a documentation fix that relates to https://github.com/stylelint/create-stylelint/pull/92#issuecomment-2564129562

> Is there anything in the PR that needs further explanation?

A while back, we:

- updated many of our examples to use ESM
- decided to only implement things that would be compatible with a flat config

This PR brings the _getting started_ and _configuring_ docs in line with that by recommending people use a `stylelint.config.{js,mjs}` file.
