### PR TITLE
Refactor `selector-not-notation` to have unambiguous position arguments

### DIFF
--- a/lib/rules/selector-not-notation/index.cjs
+++ b/lib/rules/selector-not-notation/index.cjs
@@ -90,7 +90,9 @@ const rule = (primary) => {
 			selectorRoot.walkPseudos((pseudo) => {
 				if (!isNot(pseudo)) return;
 
-				const range = getRange(pseudo, ruleNode);
+				const index = pseudo.sourceIndex;
+				const endIndex = index + pseudo.toString().trim().length;
+
 				let fix;
 
 				if (primary === 'complex') {
@@ -118,8 +120,8 @@ const rule = (primary) => {
 					node: ruleNode,
 					result,
 					ruleName,
-					line: range.start.line,
-					...range,
+					index,
+					endIndex,
 					fix,
 				});
 			});
@@ -211,22 +213,6 @@ function fixComplex(previousNot, ruleNode, selectorRoot) {
 	}
 
 	ruleNode.selector = selectorRoot.toString();
-}
-
-/**
- * @param {Pseudo} pseudo
- * @param {Rule} ruleNode
- * @returns {Range}
- */
-function getRange(pseudo, ruleNode) {
-	validateTypes.assert(ruleNode.source?.start && pseudo.source?.start && pseudo.source?.end);
-	const startline = ruleNode.source.start.line + pseudo.source.start.line - 1;
-	const endline = ruleNode.source.start.line + pseudo.source.end.line - 1;
-
-	return {
-		start: { line: startline, column: pseudo.source.start.column },
-		end: { line: endline, column: pseudo.source.end.column + 1 },
-	};
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/selector-not-notation/index.mjs
+++ b/lib/rules/selector-not-notation/index.mjs
@@ -86,7 +86,9 @@ const rule = (primary) => {
 			selectorRoot.walkPseudos((pseudo) => {
 				if (!isNot(pseudo)) return;
 
-				const range = getRange(pseudo, ruleNode);
+				const index = pseudo.sourceIndex;
+				const endIndex = index + pseudo.toString().trim().length;
+
 				let fix;
 
 				if (primary === 'complex') {
@@ -114,8 +116,8 @@ const rule = (primary) => {
 					node: ruleNode,
 					result,
 					ruleName,
-					line: range.start.line,
-					...range,
+					index,
+					endIndex,
 					fix,
 				});
 			});
@@ -207,22 +209,6 @@ function fixComplex(previousNot, ruleNode, selectorRoot) {
 	}
 
 	ruleNode.selector = selectorRoot.toString();
-}
-
-/**
- * @param {Pseudo} pseudo
- * @param {Rule} ruleNode
- * @returns {Range}
- */
-function getRange(pseudo, ruleNode) {
-	assert(ruleNode.source?.start && pseudo.source?.start && pseudo.source?.end);
-	const startline = ruleNode.source.start.line + pseudo.source.start.line - 1;
-	const endline = ruleNode.source.start.line + pseudo.source.end.line - 1;
-
-	return {
-		start: { line: startline, column: pseudo.source.start.column },
-		end: { line: endline, column: pseudo.source.end.column + 1 },
-	};
 }
 
 rule.ruleName = ruleName;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/issues/8243

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
