### PR TITLE
Document links to rules correctly with remark plugin

### DIFF
--- a/docs/user-guide/customize.md
+++ b/docs/user-guide/customize.md
@@ -15,7 +15,7 @@ There's a lot you can do. For example, if you only want to allow:
 - `px` for borders
 - `rem` for paddings and gaps
 
-You can use the [`unit-allowed-list`](../../lib/rules/unit-allowed-list) and [`declaration-property-unit-allowed-list`](../../lib/rules/declaration-property-unit-allowed-list) rules:
+You can use the [`unit-allowed-list`](../../lib/rules/unit-allowed-list/README.md) and [`declaration-property-unit-allowed-list`](../../lib/rules/declaration-property-unit-allowed-list/README.md) rules:
 
 ```diff json
 {
@@ -30,7 +30,7 @@ You can use the [`unit-allowed-list`](../../lib/rules/unit-allowed-list) and [`d
 }
 ```
 
-Or you can enforce the `hsl()` color notation using the [`color-named`](../../lib/rules/color-named), [`color-no-hex`](../../lib/rules/color-no-hex),[`function-disallowed-list`](../../lib/rules/function-disallowed-list) rules:
+Or you can enforce the `hsl()` color notation using the [`color-named`](../../lib/rules/color-named/README.md), [`color-no-hex`](../../lib/rules/color-no-hex/README.md),[`function-disallowed-list`](../../lib/rules/function-disallowed-list/README.md) rules:
 
 ```diff json
 {

--- a/lib/rules/at-rule-descriptor-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-no-unknown/README.md
@@ -17,7 +17,7 @@ You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syn
 
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
-This rule checks descriptors within at-rules. To check properties, you can use the [property-no-unknown](../property-no-unknown/README.md) rule.
+This rule checks descriptors within at-rules. To check properties, you can use the [`property-no-unknown`](../property-no-unknown/README.md) rule.
 
 Prior art:
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
   "prettier": "@stylelint/prettier-config",
   "remarkConfig": {
     "plugins": [
-      "@stylelint/remark-preset"
+      "@stylelint/remark-preset",
+      "./scripts/remark-plugins/lint-link-to-rule.mjs"
     ]
   },
   "jest": {

--- a/scripts/remark-plugins/lint-link-to-rule.mjs
+++ b/scripts/remark-plugins/lint-link-to-rule.mjs
@@ -1,0 +1,43 @@
+import path from 'node:path';
+
+/* eslint-disable n/no-extraneous-import */
+import { SKIP, visitParents } from 'unist-util-visit-parents';
+import { lintRule } from 'unified-lint-rule';
+/* eslint-enable n/no-extraneous-import */
+
+/**
+ * Check if rule document links are valid.
+ */
+export default lintRule('stylelint:link-to-rule', (tree, file) => {
+	visitParents(tree, 'link', (link, ancestors) => {
+		if (link.url.startsWith('http')) return SKIP;
+
+		const absolutePath = path.join(file.cwd, file.path, link.url);
+
+		if (!absolutePath.includes('/rules/')) return SKIP;
+
+		if (/\.m?js$/.test(absolutePath)) return SKIP;
+
+		const report = (message) => {
+			file.message(message, { ancestors, place: link.position });
+		};
+
+		if (!absolutePath.endsWith('README.md')) {
+			report(`Expected "${link.url}" link to end with "README.md"`);
+		}
+
+		const [content] = link.children;
+
+		if (!content) return SKIP;
+
+		const ruleName = content.value;
+
+		if (content.type !== 'inlineCode') {
+			report(`Expected "${link.url}" link to have an inline code like "\`${ruleName}\`"`);
+		}
+
+		if (!(absolutePath.includes(`/${ruleName}/`) || absolutePath.endsWith(`/${ruleName}`))) {
+			report(`Expected "${link.url}" link to include "${ruleName}"`);
+		}
+	});
+});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None. This only affects the documentation.

> Is there anything in the PR that needs further explanation?

This aims to check all links to rule documents in Markdown files using a new custom remark-lint plugin.

Conditions:

- The links must end with `README.md`.
  - ❌ `[...](../lib/rules/unit-allowed-list)`
  - ✅ `[...](../lib/rules/unit-allowed-list/README.md)`
- The links must have an inline code instead of just a text.
  - ❌ `[unit-allowed-list](...)`
  - ✅ ``[`unit-allowed-list`](...)``
- The links must include a correct rule name.
  - ❌ ``[`unit-disallowed-list`](../lib/rules/unit-allowed-list/README.md)``
  - ✅ ``[`unit-allowed-list`](../lib/rules/unit-allowed-list/README.md)``

Result:

```sh-session
docs/user-guide/customize.md
18:17-18:73   warning Expected "../../lib/rules/unit-allowed-list" link to end with "README.md"                            link-to-rule stylelint
18:78-18:176  warning Expected "../../lib/rules/declaration-property-unit-allowed-list" link to end with "README.md"       link-to-rule stylelint
33:57-33:101  warning Expected "../../lib/rules/color-named" link to end with "README.md"                                  link-to-rule stylelint
33:103-33:149 warning Expected "../../lib/rules/color-no-hex" link to end with "README.md"                                 link-to-rule stylelint
33:150-33:220 warning Expected "../../lib/rules/function-disallowed-list" link to end with "README.md"                     link-to-rule stylelint

lib/rules/at-rule-descriptor-no-unknown/README.md
20:84-20:139  warning Expected "../property-no-unknown/README.md" link to have an inline code like "`property-no-unknown`" link-to-rule stylelint

⚠ 6 warnings
```

See also the remark-lint results on CI:
https://github.com/stylelint/stylelint/actions/runs/12536474461/job/34959526249#step:6:31