### PR TITLE
Document best practices for position arguments in `utils.report()`

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -54,7 +54,8 @@ const ruleFunction = (primary, secondaryOptions, context) => {
         ruleName,
         message: messages.rejected(selector),
         node: ruleNode,
-        word: selector
+        index: 0,
+        endIndex: selector.length
       });
     });
   };

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -54,8 +54,7 @@ const ruleFunction = (primary, secondaryOptions, context) => {
         ruleName,
         message: messages.rejected(selector),
         node: ruleNode,
-        index: 0,
-        endIndex: selector.length
+        word: selector
       });
     });
   };

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -152,9 +152,9 @@ root.walkRules((ruleNode) => {
 
 Using `word` is the slowest approach to finding a location within a node, especially on nodes with many children, e.g. at-rules.
 
-When using offsets and positions, you can use the `nodeFieldIndices` utilities, e.g. `declarationValueIndex`, to get the index of part of a node. These utilities account for the `raw` fields in the PostCSS AST.
+When using offsets and positions, you can use the `nodeFieldIndices` utilities, e.g. `declarationValueIndex()`, to get the index of part of a node. These utilities account for the `raw` fields in the PostCSS AST.
 
-In the following example of using `index`, `endIndex` and the `declarationValueIndex` utility, the location spans the value of the declaration:
+In the following example of using `index`, `endIndex` and the `declarationValueIndex()` utility, the location spans the value of the declaration:
 
 ```js
 root.walkDecls((declNode) => {

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -178,7 +178,7 @@ This approach also works well when using construct-specific parsers:
 
 ```js
 root.walkDecls((declNode) => {
-  const { prop, value as declValue } = declNode;
+  const { prop, value: declValue } = declNode;
 
   valueParser(declValue).walk(({ value, sourceIndex }) => {
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -212,6 +212,8 @@ function rule(primary, secondary) {
       ruleName,
       message,
       node,
+      index,
+      endIndex,
 +     fix
     });
   };

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -123,7 +123,7 @@ When using `report()`, you can specify the location of a problem in various ways
 - only `node` - implicitly span the entire range of the given node
 - `word` - the first instance of a word in the serialized given node
 - `index` and `endIndex` offsets - an index range within the given node
-- `start` and `end` positions - a position range within the given node
+- `start` and `end` positions - a [range](https://postcss.org/api/#range) within the given node
 
 Each approach has pros and cons concerning:
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -130,9 +130,9 @@ Each approach has pros and cons concerning:
 - convenience - ease of use
 - narrowness - how well a location matches the issue
 - correctness - chance of bugs or incorrect locations
-- performance - the cost of calcuating the location
+- performance - the cost of calculating the location
 
-For example, it's often convenient to use only `node` or use `word` but that comes at the expense of narrownesst and correctness.
+For example, using only `node` or `word` is often convenient, but comes at the expense of narrowness and correctness.
 
 In the following example of using `word`, the location is the selector within the rule:
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8261

> Is there anything in the PR that needs further explanation?

If someone has time, it may be worth adding a small section to the "writing rules" about the `report()` function to give examples of how `node`, `index` and `endIndex` are likely used.
