### PR TITLE
Refactor `FileCache` to support `file-entry-cache` version 10

### DIFF
--- a/lib/__tests__/standalone-cache.test.mjs
+++ b/lib/__tests__/standalone-cache.test.mjs
@@ -405,10 +405,7 @@ describe('standalone cache uses cacheStrategy', () => {
 
 		// No content change, but file metadata id changed
 		// Note: needs a time offset for fast test machines
-		const time = new Date();
-
-		time.setSeconds(time.getSeconds() + 10);
-		await utimes(newFileDest, time, time);
+		await utimes(newFileDest, Date.now(), Date.now() + 1000);
 
 		const { results: resultsCached } = await standalone(getConfig({ cacheStrategy }));
 

--- a/lib/__tests__/standalone-cache.test.mjs
+++ b/lib/__tests__/standalone-cache.test.mjs
@@ -405,7 +405,7 @@ describe('standalone cache uses cacheStrategy', () => {
 
 		// No content change, but file metadata id changed
 		// Note: needs a time offset for fast test machines
-		await utimes(newFileDest, Date.now() / 1000, Date.now() / 1000 + 1000);
+		await utimes(newFileDest, Date.now() / 1000, Date.now() / 1000 + 1);
 
 		const { results: resultsCached } = await standalone(getConfig({ cacheStrategy }));
 

--- a/lib/__tests__/standalone-cache.test.mjs
+++ b/lib/__tests__/standalone-cache.test.mjs
@@ -404,7 +404,12 @@ describe('standalone cache uses cacheStrategy', () => {
 		expect(results.some((file) => isChanged(file, newFileDest))).toBe(true);
 
 		// No content change, but file metadata id changed
-		await utimes(newFileDest, new Date(), new Date());
+		// Note: needs a time offset for fast test machines
+		const time = new Date();
+
+		time.setSeconds(time.getSeconds() + 10);
+		await utimes(newFileDest, time, time);
+
 		const { results: resultsCached } = await standalone(getConfig({ cacheStrategy }));
 
 		expect(resultsCached.some((file) => isChanged(file, newFileDest))).toBe(true);

--- a/lib/__tests__/standalone-cache.test.mjs
+++ b/lib/__tests__/standalone-cache.test.mjs
@@ -405,7 +405,7 @@ describe('standalone cache uses cacheStrategy', () => {
 
 		// No content change, but file metadata id changed
 		// Note: needs a time offset for fast test machines
-		await utimes(newFileDest, Date.now(), Date.now() + 1000);
+		await utimes(newFileDest, Date.now() / 1000, Date.now() / 1000 + 1000);
 
 		const { results: resultsCached } = await standalone(getConfig({ cacheStrategy }));
 

--- a/lib/utils/FileCache.cjs
+++ b/lib/utils/FileCache.cjs
@@ -8,7 +8,6 @@ const node_path = require('node:path');
 const createDebug = require('debug');
 const fileEntryCache = require('file-entry-cache');
 const constants = require('../constants.cjs');
-const validateTypes = require('./validateTypes.cjs');
 const getCacheFile = require('./getCacheFile.cjs');
 const hash = require('./hash.cjs');
 
@@ -58,21 +57,17 @@ class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 
-		const fileCheckSumChanged = this._useCheckSum
-			? this.hasFileCheckSumChanged(absoluteFilepath)
-			: false;
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
-		descriptor.meta.data ??= {};
+		/** @type {{ hashOfConfig?: string; }} */
+		const metadata = (descriptor.meta.data ??= {});
 
-		validateTypes.assert(validateTypes.isPlainObject(descriptor.meta.data));
-
-		const configChanged = descriptor.meta.data.hashOfConfig !== this._hashOfConfig;
+		const configChanged = metadata.hashOfConfig !== this._hashOfConfig;
 
 		let changed = false;
 
 		if (this._useCheckSum) {
-			changed = configChanged || fileCheckSumChanged;
+			changed = configChanged || this.#hasFileCheckSumChanged(descriptor.key, descriptor.meta.hash);
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}
@@ -83,27 +78,26 @@ class FileCache {
 
 		// Mutate file descriptor object and store config hash to each file.
 		// Running lint with different config should invalidate the cache.
-		if (descriptor.meta.data.hashOfConfig !== this._hashOfConfig) {
-			descriptor.meta.data.hashOfConfig = this._hashOfConfig;
+		if (metadata.hashOfConfig !== this._hashOfConfig) {
+			metadata.hashOfConfig = this._hashOfConfig;
 		}
 
 		return changed;
 	}
 
 	/**
-	 * @param {string} absoluteFilepath
+	 * @param {string} key
+	 * @param {string | undefined} fileHash
 	 * @returns {boolean}
 	 */
-	hasFileCheckSumChanged(absoluteFilepath) {
-		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
-
-		if (!metaCache?.hash) {
+	#hasFileCheckSumChanged(key, fileHash) {
+		if (!fileHash) {
 			return true;
 		}
 
-		const buffer = node_fs.readFileSync(absoluteFilepath);
+		const metaCache = this._fileCache.cache.getKey(key);
 
-		if (this._fileCache.getHash(buffer) !== metaCache.hash) {
+		if (fileHash !== metaCache?.hash) {
 			return true;
 		}
 

--- a/lib/utils/FileCache.cjs
+++ b/lib/utils/FileCache.cjs
@@ -57,6 +57,10 @@ class FileCache {
 	hasFileChanged(absoluteFilepath) {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
+
+		const fileCheckSumChanged = this._useCheckSum
+			? this.hasFileCheckSumChanged(absoluteFilepath)
+			: false;
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
 		descriptor.meta.data ??= {};
@@ -68,7 +72,7 @@ class FileCache {
 		let changed = false;
 
 		if (this._useCheckSum) {
-			changed = configChanged || this.hasFileCheckSumChanged(absoluteFilepath);
+			changed = configChanged || fileCheckSumChanged;
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}

--- a/lib/utils/FileCache.cjs
+++ b/lib/utils/FileCache.cjs
@@ -8,6 +8,7 @@ const node_path = require('node:path');
 const createDebug = require('debug');
 const fileEntryCache = require('file-entry-cache');
 const constants = require('../constants.cjs');
+const validateTypes = require('./validateTypes.cjs');
 const getCacheFile = require('./getCacheFile.cjs');
 const hash = require('./hash.cjs');
 
@@ -15,8 +16,6 @@ var _documentCurrentScript = typeof document !== 'undefined' ? document.currentS
 const debug = createDebug('stylelint:file-cache');
 
 const pkg = JSON.parse(node_fs.readFileSync(new URL('../../package.json', (typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.tagName.toUpperCase() === 'SCRIPT' && _documentCurrentScript.src || new URL('lib/utils/FileCache.cjs', document.baseURI).href))), 'utf8'));
-
-/** @typedef {import('file-entry-cache').FileDescriptor["meta"] & { hashOfConfig?: string }} CacheMetadata */
 
 class FileCache {
 	constructor(
@@ -34,8 +33,9 @@ class FileCache {
 		const useCheckSum = cacheStrategy === constants.CACHE_STRATEGY_CONTENT;
 
 		debug(`Cache file is created at ${cacheFile}`);
-		this._fileCache = fileEntryCache.create(cacheFile, undefined, useCheckSum);
+		this._fileCache = fileEntryCache.createFromFile(cacheFile, useCheckSum, undefined);
 		this._hashOfConfig = '';
+		this._useCheckSum = useCheckSum;
 	}
 
 	/**
@@ -58,9 +58,20 @@ class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
-		/** @type {CacheMetadata} */
-		const meta = descriptor.meta || {};
-		const changed = descriptor.changed || meta.hashOfConfig !== this._hashOfConfig;
+
+		descriptor.meta.data ??= {};
+
+		validateTypes.assert(validateTypes.isPlainObject(descriptor.meta.data));
+
+		const configChanged = descriptor.meta.data.hashOfConfig !== this._hashOfConfig;
+
+		let changed = false;
+
+		if (this._useCheckSum) {
+			changed = configChanged || this.hasFileCheckSumChanged(absoluteFilepath);
+		} else {
+			changed = configChanged || Boolean(descriptor.changed);
+		}
 
 		if (!changed) {
 			debug(`Skip linting ${absoluteFilepath}. File hasn't changed.`);
@@ -68,11 +79,31 @@ class FileCache {
 
 		// Mutate file descriptor object and store config hash to each file.
 		// Running lint with different config should invalidate the cache.
-		if (meta.hashOfConfig !== this._hashOfConfig) {
-			meta.hashOfConfig = this._hashOfConfig;
+		if (descriptor.meta.data.hashOfConfig !== this._hashOfConfig) {
+			descriptor.meta.data.hashOfConfig = this._hashOfConfig;
 		}
 
 		return changed;
+	}
+
+	/**
+	 * @param {string} absoluteFilepath
+	 * @returns {boolean}
+	 */
+	hasFileCheckSumChanged(absoluteFilepath) {
+		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
+
+		if (!metaCache?.hash) {
+			return true;
+		}
+
+		const buffer = node_fs.readFileSync(absoluteFilepath);
+
+		if (this._fileCache.getHash(buffer) !== metaCache.hash) {
+			return true;
+		}
+
+		return false;
 	}
 
 	reconcile() {

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -59,6 +59,10 @@ export default class FileCache {
 	hasFileChanged(absoluteFilepath) {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
+
+		const fileCheckSumChanged = this._useCheckSum
+			? this.hasFileCheckSumChanged(absoluteFilepath)
+			: false;
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
 		descriptor.meta.data ??= {};
@@ -70,7 +74,7 @@ export default class FileCache {
 		let changed = false;
 
 		if (this._useCheckSum) {
-			changed = configChanged || this.hasFileCheckSumChanged(absoluteFilepath);
+			changed = configChanged || fileCheckSumChanged;
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -73,7 +73,7 @@ export default class FileCache {
 		let changed = false;
 
 		if (this._useCheckSum) {
-			changed = configChanged || fileCheckSumChanged;
+			changed = configChanged || this.#hasFileCheckSumChanged(descriptor.key, descriptor.meta.hash);
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -65,9 +65,8 @@ export default class FileCache {
 			: false;
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
-		descriptor.meta.data ??= {};
-
-		assert(isPlainObject(descriptor.meta.data));
+		/** @type {{ hashOfConfig?: string; }} */
+		const metadata = descriptor.meta.data ??= {};
 
 		const configChanged = descriptor.meta.data.hashOfConfig !== this._hashOfConfig;
 

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -11,14 +11,13 @@ import {
 	DEFAULT_CACHE_LOCATION,
 	DEFAULT_CACHE_STRATEGY,
 } from '../constants.mjs';
+import { assert, isPlainObject } from './validateTypes.mjs';
 import getCacheFile from './getCacheFile.mjs';
 import hash from './hash.mjs';
 
 const debug = createDebug('stylelint:file-cache');
 
 const pkg = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
-
-/** @typedef {import('file-entry-cache').FileDescriptor["meta"] & { hashOfConfig?: string }} CacheMetadata */
 
 export default class FileCache {
 	constructor(
@@ -36,8 +35,9 @@ export default class FileCache {
 		const useCheckSum = cacheStrategy === CACHE_STRATEGY_CONTENT;
 
 		debug(`Cache file is created at ${cacheFile}`);
-		this._fileCache = fileEntryCache.create(cacheFile, undefined, useCheckSum);
+		this._fileCache = fileEntryCache.createFromFile(cacheFile, useCheckSum, undefined);
 		this._hashOfConfig = '';
+		this._useCheckSum = useCheckSum;
 	}
 
 	/**
@@ -60,9 +60,20 @@ export default class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
-		/** @type {CacheMetadata} */
-		const meta = descriptor.meta || {};
-		const changed = descriptor.changed || meta.hashOfConfig !== this._hashOfConfig;
+
+		descriptor.meta.data ??= {};
+
+		assert(isPlainObject(descriptor.meta.data));
+
+		const configChanged = descriptor.meta.data.hashOfConfig !== this._hashOfConfig;
+
+		let changed = false;
+
+		if (this._useCheckSum) {
+			changed = configChanged || this.hasFileCheckSumChanged(absoluteFilepath);
+		} else {
+			changed = configChanged || Boolean(descriptor.changed);
+		}
 
 		if (!changed) {
 			debug(`Skip linting ${absoluteFilepath}. File hasn't changed.`);
@@ -70,11 +81,31 @@ export default class FileCache {
 
 		// Mutate file descriptor object and store config hash to each file.
 		// Running lint with different config should invalidate the cache.
-		if (meta.hashOfConfig !== this._hashOfConfig) {
-			meta.hashOfConfig = this._hashOfConfig;
+		if (descriptor.meta.data.hashOfConfig !== this._hashOfConfig) {
+			descriptor.meta.data.hashOfConfig = this._hashOfConfig;
 		}
 
 		return changed;
+	}
+
+	/**
+	 * @param {string} absoluteFilepath
+	 * @returns {boolean}
+	 */
+	hasFileCheckSumChanged(absoluteFilepath) {
+		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
+
+		if (!metaCache?.hash) {
+			return true;
+		}
+
+		const buffer = readFileSync(absoluteFilepath);
+
+		if (this._fileCache.getHash(buffer) !== metaCache.hash) {
+			return true;
+		}
+
+		return false;
 	}
 
 	reconcile() {

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -95,7 +95,7 @@ export default class FileCache {
 	 * @param {string} absoluteFilepath
 	 * @returns {boolean}
 	 */
-	hasFileCheckSumChanged(absoluteFilepath) {
+	#hasFileCheckSumChanged(absoluteFilepath) {
 		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
 
 		if (!metaCache?.hash) {

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -11,7 +11,6 @@ import {
 	DEFAULT_CACHE_LOCATION,
 	DEFAULT_CACHE_STRATEGY,
 } from '../constants.mjs';
-import { assert, isPlainObject } from './validateTypes.mjs';
 import getCacheFile from './getCacheFile.mjs';
 import hash from './hash.mjs';
 
@@ -60,15 +59,12 @@ export default class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 
-		const fileCheckSumChanged = this._useCheckSum
-			? this.hasFileCheckSumChanged(absoluteFilepath)
-			: false;
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
 		/** @type {{ hashOfConfig?: string; }} */
-		const metadata = descriptor.meta.data ??= {};
+		const metadata = (descriptor.meta.data ??= {});
 
-		const configChanged = descriptor.meta.data.hashOfConfig !== this._hashOfConfig;
+		const configChanged = metadata.hashOfConfig !== this._hashOfConfig;
 
 		let changed = false;
 
@@ -84,27 +80,26 @@ export default class FileCache {
 
 		// Mutate file descriptor object and store config hash to each file.
 		// Running lint with different config should invalidate the cache.
-		if (descriptor.meta.data.hashOfConfig !== this._hashOfConfig) {
-			descriptor.meta.data.hashOfConfig = this._hashOfConfig;
+		if (metadata.hashOfConfig !== this._hashOfConfig) {
+			metadata.hashOfConfig = this._hashOfConfig;
 		}
 
 		return changed;
 	}
 
 	/**
-	 * @param {string} absoluteFilepath
+	 * @param {string} key
+	 * @param {string | undefined} fileHash
 	 * @returns {boolean}
 	 */
-	#hasFileCheckSumChanged(absoluteFilepath) {
-		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
-
-		if (!metaCache?.hash) {
+	#hasFileCheckSumChanged(key, fileHash) {
+		if (!fileHash) {
 			return true;
 		}
 
-		const buffer = readFileSync(absoluteFilepath);
+		const metaCache = this._fileCache.cache.getKey(key);
 
-		if (this._fileCache.getHash(buffer) !== metaCache.hash) {
+		if (fileHash !== metaCache?.hash) {
 			return true;
 		}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/pull/8256

> Is there anything in the PR that needs further explanation?

The latest version of `file-entry-cache` considers any file with either a changed check sum or changed meta data as changed. This is different from the previous version.

As I understood the current code and tests we want to skip linting files that still have the same content, even when a timestamp or other metadata has changed.

In support of that I added a `hasFileCheckSumChanged` method to `FileCache` and updated `hasFileChanged` to restore the old behavior.
