### PR TITLE
Fix `selector-{type,pseudo-class}-no-unknown` and `selector-type-case` false positives for deprecated selectors

### DIFF
--- a/.changeset/dull-pears-burn.md
+++ b/.changeset/dull-pears-burn.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-type-no-unknown` false positives for `shadow`, `hatch` and `hatchpath`

--- a/.changeset/little-bobcats-punch.md
+++ b/.changeset/little-bobcats-punch.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for deprecated pseudo-classes

--- a/.changeset/shy-zebras-wave.md
+++ b/.changeset/shy-zebras-wave.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-type-case` false positives for `hatchPath`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -29,6 +29,7 @@ const deprecatedHtmlTypeSelectors = new Set([
 	'noframes',
 	'plaintext',
 	'param',
+	'shadow',
 	'spacer',
 	'strike',
 	'tt',
@@ -52,6 +53,26 @@ const htmlTypeSelectors = uniteSets(
 	standardHtmlTypeSelectors,
 	experimentalHtmlTypeSelectors,
 );
+
+const deprecatedSvgTypeSelectors = new Set([
+	'altGlyph',
+	'altGlyphDef',
+	'altGlyphItem',
+	'cursor',
+	'font',
+	'font-face',
+	'font-face-format',
+	'font-face-name',
+	'font-face-src',
+	'font-face-uri',
+	'glyph',
+	'glyphRef',
+	'hatchPath',
+	'hkern',
+	'missing-glyph',
+	'tref',
+	'vkern',
+]);
 
 const mixedCaseSvgTypeSelectors = new Set([
 	'altGlyph',
@@ -88,6 +109,7 @@ const mixedCaseSvgTypeSelectors = new Set([
 	'feTurbulence',
 	'foreignObject',
 	'glyphRef',
+	'hatchPath',
 	'linearGradient',
 	'radialGradient',
 	'textPath',
@@ -182,10 +204,13 @@ const vendorSpecificPseudoElements = uniteSets(webkitScrollbarPseudoElements, [
 	'-webkit-validation-bubble-text-block',
 ]);
 
+const deprecatedPseudoElements = new Set(['shadow']);
+
 const pseudoElements = uniteSets(
 	levelOneAndTwoPseudoElements,
 	vendorSpecificPseudoElements,
 	shadowTreePseudoElements,
+	deprecatedPseudoElements,
 	[
 		'backdrop',
 		'content',
@@ -199,7 +224,6 @@ const pseudoElements = uniteSets(
 		'scroll-marker',
 		'scroll-marker-group',
 		'selection',
-		'shadow',
 		'slotted',
 		'spelling-error',
 		'target-text',
@@ -233,6 +257,15 @@ const atRulePagePseudoClasses = new Set([
 const linguisticPseudoClasses = new Set(['dir', 'lang']);
 
 const logicalCombinationsPseudoClasses = new Set(['has', 'is', 'matches', 'not', 'where']);
+
+const deprecatedPseudoClasses = new Set([
+	'popup-open',
+	'top-layer',
+	'focus-ring',
+	'user-error',
+	'matches',
+	'contains',
+]);
 
 const vendorSpecificPseudoClasses = new Set([
 	'-khtml-drag',
@@ -307,6 +340,7 @@ const pseudoClasses = uniteSets(
 	aNPlusBOfSNotationPseudoClasses,
 	resourceStatePseudoClasses,
 	vendorSpecificPseudoClasses,
+	deprecatedPseudoClasses,
 	[
 		'active',
 		'active-view-transition',
@@ -371,6 +405,9 @@ const pseudoClasses = uniteSets(
 exports.aNPlusBNotationPseudoClasses = aNPlusBNotationPseudoClasses;
 exports.aNPlusBOfSNotationPseudoClasses = aNPlusBOfSNotationPseudoClasses;
 exports.atRulePagePseudoClasses = atRulePagePseudoClasses;
+exports.deprecatedPseudoClasses = deprecatedPseudoClasses;
+exports.deprecatedPseudoElements = deprecatedPseudoElements;
+exports.deprecatedSvgTypeSelectors = deprecatedSvgTypeSelectors;
 exports.htmlTypeSelectors = htmlTypeSelectors;
 exports.levelOneAndTwoPseudoElements = levelOneAndTwoPseudoElements;
 exports.linguisticPseudoClasses = linguisticPseudoClasses;

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -259,12 +259,13 @@ const linguisticPseudoClasses = new Set(['dir', 'lang']);
 const logicalCombinationsPseudoClasses = new Set(['has', 'is', 'matches', 'not', 'where']);
 
 const deprecatedPseudoClasses = new Set([
+	'contains',
+	'drop',
+	'focus-ring',
+	'matches',
 	'popup-open',
 	'top-layer',
-	'focus-ring',
 	'user-error',
-	'matches',
-	'contains',
 ]);
 
 const vendorSpecificPseudoClasses = new Set([

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -256,12 +256,13 @@ export const linguisticPseudoClasses = new Set(['dir', 'lang']);
 export const logicalCombinationsPseudoClasses = new Set(['has', 'is', 'matches', 'not', 'where']);
 
 export const deprecatedPseudoClasses = new Set([
+	'contains',
+	'drop',
+	'focus-ring',
+	'matches',
 	'popup-open',
 	'top-layer',
-	'focus-ring',
 	'user-error',
-	'matches',
-	'contains',
 ]);
 
 const vendorSpecificPseudoClasses = new Set([

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -26,6 +26,7 @@ const deprecatedHtmlTypeSelectors = new Set([
 	'noframes',
 	'plaintext',
 	'param',
+	'shadow',
 	'spacer',
 	'strike',
 	'tt',
@@ -49,6 +50,26 @@ export const htmlTypeSelectors = uniteSets(
 	standardHtmlTypeSelectors,
 	experimentalHtmlTypeSelectors,
 );
+
+export const deprecatedSvgTypeSelectors = new Set([
+	'altGlyph',
+	'altGlyphDef',
+	'altGlyphItem',
+	'cursor',
+	'font',
+	'font-face',
+	'font-face-format',
+	'font-face-name',
+	'font-face-src',
+	'font-face-uri',
+	'glyph',
+	'glyphRef',
+	'hatchPath',
+	'hkern',
+	'missing-glyph',
+	'tref',
+	'vkern',
+]);
 
 export const mixedCaseSvgTypeSelectors = new Set([
 	'altGlyph',
@@ -85,6 +106,7 @@ export const mixedCaseSvgTypeSelectors = new Set([
 	'feTurbulence',
 	'foreignObject',
 	'glyphRef',
+	'hatchPath',
 	'linearGradient',
 	'radialGradient',
 	'textPath',
@@ -179,10 +201,13 @@ const vendorSpecificPseudoElements = uniteSets(webkitScrollbarPseudoElements, [
 	'-webkit-validation-bubble-text-block',
 ]);
 
+export const deprecatedPseudoElements = new Set(['shadow']);
+
 export const pseudoElements = uniteSets(
 	levelOneAndTwoPseudoElements,
 	vendorSpecificPseudoElements,
 	shadowTreePseudoElements,
+	deprecatedPseudoElements,
 	[
 		'backdrop',
 		'content',
@@ -196,7 +221,6 @@ export const pseudoElements = uniteSets(
 		'scroll-marker',
 		'scroll-marker-group',
 		'selection',
-		'shadow',
 		'slotted',
 		'spelling-error',
 		'target-text',
@@ -230,6 +254,15 @@ export const atRulePagePseudoClasses = new Set([
 export const linguisticPseudoClasses = new Set(['dir', 'lang']);
 
 export const logicalCombinationsPseudoClasses = new Set(['has', 'is', 'matches', 'not', 'where']);
+
+export const deprecatedPseudoClasses = new Set([
+	'popup-open',
+	'top-layer',
+	'focus-ring',
+	'user-error',
+	'matches',
+	'contains',
+]);
 
 const vendorSpecificPseudoClasses = new Set([
 	'-khtml-drag',
@@ -304,6 +337,7 @@ export const pseudoClasses = uniteSets(
 	aNPlusBOfSNotationPseudoClasses,
 	resourceStatePseudoClasses,
 	vendorSpecificPseudoClasses,
+	deprecatedPseudoClasses,
 	[
 		'active',
 		'active-view-transition',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -138,6 +138,10 @@ testRule({
 			description: 'explicit :open test',
 		},
 		{
+			code: ':user-error {}',
+			description: 'deprecated pseudo-class',
+		},
+		{
 			code: ':active-view-transition, :active-view-transition-type() {}',
 		},
 		{

--- a/lib/rules/selector-type-no-unknown/index.cjs
+++ b/lib/rules/selector-type-no-unknown/index.cjs
@@ -103,11 +103,12 @@ const rule = (primary, secondaryOptions) => {
 
 				const tagName = tagNode.value;
 				const tagNameLowerCase = tagName.toLowerCase();
+				// SVG tags are case-sensitive
+				const svgTypeSelectors = [...svgTags, 'hatch', 'hatchpath', 'hatchPath'];
 
 				if (
 					selectors.htmlTypeSelectors.has(tagNameLowerCase) ||
-					// SVG tags are case-sensitive
-					svgTags.includes(tagName) ||
+					svgTypeSelectors.includes(tagName) ||
 					mathMLTags.includes(tagNameLowerCase)
 				) {
 					return;

--- a/lib/rules/selector-type-no-unknown/index.mjs
+++ b/lib/rules/selector-type-no-unknown/index.mjs
@@ -100,11 +100,12 @@ const rule = (primary, secondaryOptions) => {
 
 				const tagName = tagNode.value;
 				const tagNameLowerCase = tagName.toLowerCase();
+				// SVG tags are case-sensitive
+				const svgTypeSelectors = [...svgTags, 'hatch', 'hatchpath', 'hatchPath'];
 
 				if (
 					htmlTypeSelectors.has(tagNameLowerCase) ||
-					// SVG tags are case-sensitive
-					svgTags.includes(tagName) ||
+					svgTypeSelectors.includes(tagName) ||
 					mathMLTags.includes(tagNameLowerCase)
 				) {
 					return;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#8225

> Resources

- pseudo-classes
  - [`:top-layer`](https://issues.chromium.org/issues/40860536)
  - [`:popup-open`](https://issues.chromium.org/issues/40218886#comment39)
  - [`:focus-ring`](https://web.archive.org/web/20171209101655/https://drafts.csswg.org/selectors-4/)
  - [`:matches`](https://caniuse.com/css-matches-pseudo)
  - [`:drop`](https://drafts.csswg.org/selectors-4/#changes-2018-02)
    - [GTK](https://github.com/GNOME/gtk/commit/158dbbc88f2c2735c417d27bbc96dbecd7a67656) 
  - [`:user-error`](https://drafts.csswg.org/selectors-4/#changes-2013)
  - [`:contains`](https://www.w3.org/TR/2001/CR-css3-selectors-20011113/#content-selectors)
    - [sizzle](https://github.com/jquery/sizzle/wiki#additions)
    - [Beautiful Soup](https://facelessuser.github.io/soupsieve/selectors/pseudo-classes/#:-soup-contains)
- SVG elements
  - [Scripting and Interactivity chapter](https://svgwg.org/svg2-draft/single-page.html#changes-interact)
  - [Text chapter](https://svgwg.org/svg2-draft/single-page.html#changes-text)
  - [Fonts chapter](https://svgwg.org/svg2-draft/single-page.html#changes-fonts)
- `shadow` element
  - [biome](https://github.com/biomejs/biome/blob/main/crates/biome_css_analyze/src/keywords.rs#L5581)
  - [bugzilla.mozilla.org](https://bugzilla.mozilla.org/show_bug.cgi?id=887538)
  - [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/29)
  - [w3c.github.io](https://web.archive.org/web/20150429040731/http://w3c.github.io/webcomponents/spec/shadow/#the-shadow-element)

> Is there anything in the PR that needs further explanation?

Since Mozilla never went ahead with https://bugzilla.mozilla.org/show_bug.cgi?id=371323 back in 2007 I chose not to include `:nth-column` and `:nth-last-column`. They were supported by [`sel`](https://github.com/amccollum/sel) though.
We can discuss whether we should add these 2 and `:active-drop-target`, `:valid-drop-target`, `:invalid-drop-target`, `:nth-match` and `:nth-last-match` in #8225.
i.e. this PR goal is not to be exhaustive 