### PR TITLE
Fix `FileCache` false negatives when only contents have changed

### DIFF
--- a/lib/__tests__/standalone-cache.test.mjs
+++ b/lib/__tests__/standalone-cache.test.mjs
@@ -412,6 +412,22 @@ describe('standalone cache uses cacheStrategy', () => {
 		expect(resultsCached.some((file) => isChanged(file, newFileDest))).toBe(true);
 	});
 
+	it('cacheStrategy is "content" and the file is modified', async () => {
+		const cacheStrategy = 'content';
+
+		await copyFile(validFile, newFileDest);
+
+		const { results } = await standalone(getConfig({ cacheStrategy }));
+
+		expect(results.some((file) => isChanged(file, newFileDest))).toBe(true);
+
+		await copyFile(syntaxErrorFile, newFileDest);
+
+		const { results: resultsCached } = await standalone(getConfig({ cacheStrategy }));
+
+		expect(resultsCached.some((file) => isChanged(file, newFileDest))).toBe(true);
+	});
+
 	it('cacheStrategy is "content" and only the timestamps are different', async () => {
 		const cacheStrategy = 'content';
 

--- a/lib/__tests__/standalone-cache.test.mjs
+++ b/lib/__tests__/standalone-cache.test.mjs
@@ -412,7 +412,7 @@ describe('standalone cache uses cacheStrategy', () => {
 		expect(resultsCached.some((file) => isChanged(file, newFileDest))).toBe(true);
 	});
 
-	it('cacheStrategy is "content"', async () => {
+	it('cacheStrategy is "content" and only the timestamps are different', async () => {
 		const cacheStrategy = 'content';
 
 		await copyFile(validFile, newFileDest);
@@ -420,10 +420,31 @@ describe('standalone cache uses cacheStrategy', () => {
 
 		expect(results.some((file) => isChanged(file, newFileDest))).toBe(true);
 
-		// No content change, but file metadata id changed
+		// No content change, but file metadata is changed
 		await utimes(newFileDest, new Date(), new Date());
 		const { results: resultsCached } = await standalone(getConfig({ cacheStrategy }));
 
 		expect(resultsCached.some((file) => isChanged(file, newFileDest))).toBe(false);
+	});
+
+	it('cacheStrategy is "content" and only the content is different', async () => {
+		const cacheStrategy = 'content';
+
+		const now = new Date();
+
+		await copyFile(validFile, newFileDest);
+		await utimes(newFileDest, now, now);
+
+		const { results } = await standalone(getConfig({ cacheStrategy }));
+
+		expect(results.some((file) => isChanged(file, newFileDest))).toBe(true);
+
+		// No file metadata change, but content is changed
+		await copyFile(syntaxErrorFile, newFileDest);
+		await utimes(newFileDest, now, now);
+
+		const { results: resultsCached } = await standalone(getConfig({ cacheStrategy }));
+
+		expect(resultsCached.some((file) => isChanged(file, newFileDest))).toBe(true);
 	});
 });

--- a/lib/utils/FileCache.cjs
+++ b/lib/utils/FileCache.cjs
@@ -57,6 +57,7 @@ class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 
+		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
 		/** @type {{ hashOfConfig?: string; }} */
@@ -67,7 +68,7 @@ class FileCache {
 		let changed = false;
 
 		if (this._useCheckSum) {
-			changed = configChanged || this.#hasFileCheckSumChanged(descriptor.key, descriptor.meta.hash);
+			changed = configChanged || !metaCache?.hash || metaCache?.hash !== descriptor.meta.hash;
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}
@@ -83,25 +84,6 @@ class FileCache {
 		}
 
 		return changed;
-	}
-
-	/**
-	 * @param {string} key
-	 * @param {string | undefined} fileHash
-	 * @returns {boolean}
-	 */
-	#hasFileCheckSumChanged(key, fileHash) {
-		if (!fileHash) {
-			return true;
-		}
-
-		const metaCache = this._fileCache.cache.getKey(key);
-
-		if (fileHash !== metaCache?.hash) {
-			return true;
-		}
-
-		return false;
 	}
 
 	reconcile() {

--- a/lib/utils/FileCache.cjs
+++ b/lib/utils/FileCache.cjs
@@ -57,6 +57,7 @@ class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 
+		/** @type {import('file-entry-cache').FileDescriptorMeta | undefined} */
 		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
@@ -65,10 +66,10 @@ class FileCache {
 
 		const configChanged = metadata.hashOfConfig !== this._hashOfConfig;
 
-		let changed = false;
+		let changed;
 
 		if (this._useCheckSum) {
-			changed = configChanged || !metaCache?.hash || metaCache?.hash !== descriptor.meta.hash;
+			changed = configChanged || !metaCache?.hash || metaCache.hash !== descriptor.meta.hash;
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -68,7 +68,7 @@ export default class FileCache {
 
 		const configChanged = metadata.hashOfConfig !== this._hashOfConfig;
 
-		let changed = false;
+		let changed;
 
 		if (this._useCheckSum) {
 			changed = configChanged || !metaCache?.hash || metaCache?.hash !== descriptor.meta.hash;

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -59,6 +59,7 @@ export default class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 
+		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 
 		/** @type {{ hashOfConfig?: string; }} */
@@ -69,7 +70,7 @@ export default class FileCache {
 		let changed = false;
 
 		if (this._useCheckSum) {
-			changed = configChanged || this.#hasFileCheckSumChanged(descriptor.key, descriptor.meta.hash);
+			changed = configChanged || !metaCache?.hash || metaCache?.hash !== descriptor.meta.hash;
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}
@@ -85,25 +86,6 @@ export default class FileCache {
 		}
 
 		return changed;
-	}
-
-	/**
-	 * @param {string} key
-	 * @param {string | undefined} fileHash
-	 * @returns {boolean}
-	 */
-	#hasFileCheckSumChanged(key, fileHash) {
-		if (!fileHash) {
-			return true;
-		}
-
-		const metaCache = this._fileCache.cache.getKey(key);
-
-		if (fileHash !== metaCache?.hash) {
-			return true;
-		}
-
-		return false;
 	}
 
 	reconcile() {

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -71,7 +71,7 @@ export default class FileCache {
 		let changed;
 
 		if (this._useCheckSum) {
-			changed = configChanged || !metaCache?.hash || metaCache?.hash !== descriptor.meta.hash;
+			changed = configChanged || !metaCache?.hash || metaCache.hash !== descriptor.meta.hash;
 		} else {
 			changed = configChanged || Boolean(descriptor.changed);
 		}

--- a/lib/utils/FileCache.mjs
+++ b/lib/utils/FileCache.mjs
@@ -59,6 +59,7 @@ export default class FileCache {
 		// Get file descriptor compares current metadata against cached
 		// one and stores the result to "changed" prop.w
 
+		/** @type {import('file-entry-cache').FileDescriptorMeta | undefined} */
 		const metaCache = this._fileCache.cache.getKey(this._fileCache.createFileKey(absoluteFilepath));
 		const descriptor = this._fileCache.getFileDescriptor(absoluteFilepath);
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See https://github.com/stylelint/stylelint/pull/8256

> Is there anything in the PR that needs further explanation?

It seems we made a small mistake in https://github.com/stylelint/stylelint/pull/8262 and that we didn't have sufficient test coverage.

`this._fileCache.getFileDescriptor(absoluteFilepath);` also writes the new content hash to `this._fileCache.cache` even though it is a getter method.

Any reads from the cache to compare the file hash after already calling `getFileDescriptor` would return the new hash, not the previous one.

So to compare content hashes we need to first read from the cache and only after call `getFileDescriptor`.