### PR TITLE
Refactor to remove `fixed` from `FixerData`

### DIFF
--- a/lib/formatters/__tests__/verboseFormatter.test.mjs
+++ b/lib/formatters/__tests__/verboseFormatter.test.mjs
@@ -225,8 +225,8 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'block-no-empty': [{ fixed: false }],
-								'color-hex-length': [{ fixed: true }],
+								'block-no-empty': [],
+								'color-hex-length': [{}],
 							},
 						},
 					},
@@ -254,7 +254,7 @@ describe('verboseFormatter', () => {
 		test('no warnings and plural', () => {
 			const position = { line: 0, column: 0 };
 			const range = { start: position, end: position };
-			const fixerData = { range, fixed: true };
+			const fixerData = { range };
 			const results = [
 				{
 					source: 'path/to/file.css',
@@ -291,7 +291,7 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'color-hex-length': [{ fixed: true }, { fixed: true }],
+								'color-hex-length': [{}, {}],
 							},
 						},
 					},
@@ -303,7 +303,7 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'function-name-case': [{ fixed: true }, { fixed: false }],
+								'function-name-case': [{}],
 							},
 						},
 					},

--- a/lib/formatters/verboseFormatter.cjs
+++ b/lib/formatters/verboseFormatter.cjs
@@ -171,7 +171,7 @@ function getFixedRules(results) {
 		const entries = Object.entries(fixersData);
 
 		for (const [ruleName, fixerData] of entries) {
-			const count = fixerData.filter(({ fixed }) => fixed).length;
+			const count = fixerData.length;
 
 			if (count) rules.set(ruleName, (rules.get(ruleName) ?? 0) + count);
 		}

--- a/lib/formatters/verboseFormatter.mjs
+++ b/lib/formatters/verboseFormatter.mjs
@@ -167,7 +167,7 @@ function getFixedRules(results) {
 		const entries = Object.entries(fixersData);
 
 		for (const [ruleName, fixerData] of entries) {
-			const count = fixerData.filter(({ fixed }) => fixed).length;
+			const count = fixerData.length;
 
 			if (count) rules.set(ruleName, (rules.get(ruleName) ?? 0) + count);
 		}

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -425,7 +425,6 @@ describe('with fix callback', () => {
 
 		const fixerData = fixersData.foo[0];
 
-		expect(fixerData.fixed).toBe(true);
 		expect(fixerData.range).toBeUndefined();
 	});
 
@@ -454,10 +453,7 @@ describe('with fix callback', () => {
 		expect(v.result.warn).toHaveBeenCalledTimes(1);
 		expect(v.fix).toHaveBeenCalledTimes(0);
 
-		const fixerData = fixersData.foo[0];
-
-		expect(fixerData.fixed).toBe(false);
-		expect(fixerData.range).toBeUndefined();
+		expect(fixersData.foo).toBeUndefined();
 	});
 
 	test('failing due to non-fixable metadata', () => {
@@ -501,8 +497,7 @@ test('with fix callback missing', () => {
 
 	const fixerData = fixersData.foo[1];
 
-	expect(fixerData.fixed).toBe(false);
-	expect(fixerData.range).toBeUndefined();
+	expect(fixerData).toBeUndefined();
 });
 
 test('with custom message', () => {

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -210,8 +210,6 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = stylelint;
 
 	if (!validateTypes.isFunction(fix)) {
-		addFixData({ fixersData, ruleName, fixed: false });
-
 		return false;
 	}
 
@@ -219,11 +217,11 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	addFixData({ fixersData, ruleName, fixed: mayFix });
-
 	if (!mayFix) return false;
 
 	fix();
+
+	addFixData({ fixersData, ruleName });
 
 	return true;
 }
@@ -233,13 +231,12 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
  * @param {Range} [o.range]
- * @param {boolean} o.fixed
  * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range, fixed }) {
+function addFixData({ fixersData, ruleName, range }) {
 	const ruleFixers = (fixersData[ruleName] ??= []);
 
-	ruleFixers.push({ range, fixed });
+	ruleFixers.push({ range });
 }
 
 /**

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -218,8 +218,6 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const { disabledRanges, config = {}, fixersData } = stylelint;
 
 	if (!isFn(fix)) {
-		addFixData({ fixersData, ruleName, fixed: false });
-
 		return false;
 	}
 
@@ -227,11 +225,11 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 	const mayFix =
 		shouldFix && (config.ignoreDisables || !isDisabled(ruleName, line, disabledRanges));
 
-	addFixData({ fixersData, ruleName, fixed: mayFix });
-
 	if (!mayFix) return false;
 
 	fix();
+
+	addFixData({ fixersData, ruleName });
 
 	return true;
 }
@@ -241,13 +239,12 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
  * @param {Range} [o.range]
- * @param {boolean} o.fixed
  * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range, fixed }) {
+function addFixData({ fixersData, ruleName, range }) {
 	const ruleFixers = (fixersData[ruleName] ??= []);
 
-	ruleFixers.push({ range, fixed });
+	ruleFixers.push({ range });
 }
 
 /**

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -257,7 +257,6 @@ declare namespace stylelint {
 
 	type FixerData = {
 		range?: Range;
-		fixed: boolean;
 	};
 
 	/**


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8233

> Is there anything in the PR that needs further explanation?

`fixersData` is not part of our public API and the verbose formatter still produces the same reports as before.
