### PR TITLE
Refactor to remove `FixerData` type

### DIFF
--- a/lib/formatters/__tests__/verboseFormatter.test.mjs
+++ b/lib/formatters/__tests__/verboseFormatter.test.mjs
@@ -225,8 +225,8 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'block-no-empty': [],
-								'color-hex-length': [{}],
+								'block-no-empty': undefined,
+								'color-hex-length': 1,
 							},
 						},
 					},
@@ -252,9 +252,6 @@ describe('verboseFormatter', () => {
 		});
 
 		test('no warnings and plural', () => {
-			const position = { line: 0, column: 0 };
-			const range = { start: position, end: position };
-			const fixerData = { range };
 			const results = [
 				{
 					source: 'path/to/file.css',
@@ -263,7 +260,7 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'color-hex-length': [fixerData, fixerData],
+								'color-hex-length': 2,
 							},
 						},
 					},
@@ -291,7 +288,7 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'color-hex-length': [{}, {}],
+								'color-hex-length': 2,
 							},
 						},
 					},
@@ -303,7 +300,7 @@ describe('verboseFormatter', () => {
 					_postcssResult: {
 						stylelint: {
 							fixersData: {
-								'function-name-case': [{}],
+								'function-name-case': 1,
 							},
 						},
 					},

--- a/lib/formatters/verboseFormatter.cjs
+++ b/lib/formatters/verboseFormatter.cjs
@@ -170,10 +170,8 @@ function getFixedRules(results) {
 		} = _postcssResult;
 		const entries = Object.entries(fixersData);
 
-		for (const [ruleName, fixerData] of entries) {
-			const count = fixerData.length;
-
-			if (count) rules.set(ruleName, (rules.get(ruleName) ?? 0) + count);
+		for (const [ruleName, count] of entries) {
+			if (count) rules.set(ruleName, count);
 		}
 	}
 

--- a/lib/formatters/verboseFormatter.mjs
+++ b/lib/formatters/verboseFormatter.mjs
@@ -166,10 +166,8 @@ function getFixedRules(results) {
 		} = _postcssResult;
 		const entries = Object.entries(fixersData);
 
-		for (const [ruleName, fixerData] of entries) {
-			const count = fixerData.length;
-
-			if (count) rules.set(ruleName, (rules.get(ruleName) ?? 0) + count);
+		for (const [ruleName, count] of entries) {
+			if (count) rules.set(ruleName, count);
 		}
 	}
 

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -422,10 +422,7 @@ describe('with fix callback', () => {
 		report(v);
 		expect(v.result.warn).toHaveBeenCalledTimes(0);
 		expect(v.fix).toHaveBeenCalledTimes(1);
-
-		const fixerData = fixersData.foo[0];
-
-		expect(fixerData.range).toBeUndefined();
+		expect(fixersData.foo).toBe(1);
 	});
 
 	test('not fixing', () => {
@@ -450,9 +447,9 @@ describe('with fix callback', () => {
 		};
 
 		report(v);
+
 		expect(v.result.warn).toHaveBeenCalledTimes(1);
 		expect(v.fix).toHaveBeenCalledTimes(0);
-
 		expect(fixersData.foo).toBeUndefined();
 	});
 
@@ -477,7 +474,7 @@ describe('with fix callback', () => {
 });
 
 test('with fix callback missing', () => {
-	const fixersData = { foo: [{}] };
+	const fixersData = {};
 	const v = {
 		ruleName: 'foo',
 		result: {
@@ -494,10 +491,7 @@ test('with fix callback missing', () => {
 
 	report(v);
 	expect(v.result.warn).toHaveBeenCalledTimes(1);
-
-	const fixerData = fixersData.foo[1];
-
-	expect(fixerData).toBeUndefined();
+	expect(fixersData.foo).toBeUndefined();
 });
 
 test('with custom message', () => {

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -221,7 +221,7 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 
 	fix();
 
-	addFixData({ fixersData, ruleName });
+	incrementFixCounter({ fixersData, ruleName });
 
 	return true;
 }
@@ -230,13 +230,10 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
  * @param {object} o
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
- * @param {Range} [o.range]
- * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range }) {
-	const ruleFixers = (fixersData[ruleName] ??= []);
-
-	ruleFixers.push({ range });
+function incrementFixCounter({ fixersData, ruleName }) {
+	fixersData[ruleName] ??= 0;
+	fixersData[ruleName]++;
 }
 
 /**

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -229,7 +229,7 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
 
 	fix();
 
-	addFixData({ fixersData, ruleName });
+	incrementFixCounter({ fixersData, ruleName });
 
 	return true;
 }
@@ -238,13 +238,10 @@ function isFixApplied({ fix, line, result: { stylelint }, ruleName }) {
  * @param {object} o
  * @param {StylelintPostcssResult['fixersData']} o.fixersData
  * @param {string} o.ruleName
- * @param {Range} [o.range]
- * @todo stylelint/stylelint#7192
  */
-function addFixData({ fixersData, ruleName, range }) {
-	const ruleFixers = (fixersData[ruleName] ??= []);
-
-	ruleFixers.push({ range });
+function incrementFixCounter({ fixersData, ruleName }) {
+	fixersData[ruleName] ??= 0;
+	fixersData[ruleName]++;
 }
 
 /**

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -149,7 +149,7 @@ declare namespace stylelint {
 		customMessages: { [ruleName: string]: RuleMessage };
 		customUrls: { [ruleName: string]: string };
 		ruleMetadata: { [ruleName: string]: Partial<RuleMeta> };
-		fixersData: { [ruleName: string]: Array<FixerData> };
+		fixersData: { [ruleName: string]: number };
 		quiet?: boolean;
 		quietDeprecationWarnings?: boolean;
 		disabledRanges: DisabledRangeObject;
@@ -253,10 +253,6 @@ declare namespace stylelint {
 	export type Range = {
 		start: Position;
 		end: Position;
-	};
-
-	type FixerData = {
-		range?: Range;
 	};
 
 	/**


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

follow-up of #8267

> Is there anything in the PR that needs further explanation?

1.
With the removal of `fixed`, it was absurd to keep `FixerData` if we were not even planning to add `range` to it.
see https://github.com/stylelint/stylelint/pull/8267#pullrequestreview-2528238317

2.
`StylelintPostcssResult['fixersData']` could be renamed in #8234 to avoid confusion with [`fixData`](https://github.com/stylelint/stylelint/pull/8234/files#diff-cba25f954347e963307879ca83b95b319e9003d9b4b51fd350d3f4110566d3a8R72).
i.e. semantic creep