### PR TITLE
Test invalid options for all rules

### DIFF
--- a/lib/rules/__tests__/index.test.mjs
+++ b/lib/rules/__tests__/index.test.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 
+import postcss from 'postcss';
+
 import rules from '../index.mjs';
 
 const require = createRequire(import.meta.url);
@@ -72,6 +74,28 @@ describe('custom message option', () => {
 			expect(doc).toContain('`message` secondary option');
 		},
 	);
+});
+
+describe('invalid options', () => {
+	test.each(ruleNames)('"%s" should handle invalid options', async (name) => {
+		const rule = await rules[name];
+		const primaryOption = false;
+		const secondaryOptions = {};
+		const context = {};
+		const root = postcss.root();
+		const warn = import.meta.jest.fn();
+		const result = {
+			stylelint: { config: { validate: true } },
+			warn,
+		};
+
+		await rule(primaryOption, secondaryOptions, context)(root, result);
+
+		expect(warn).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ stylelintType: 'invalidOption' }),
+		);
+	});
 });
 
 // eslint-disable-next-line jest/no-disabled-tests -- To prevent a failure when adding a new rule to the sharable config. See #7045.

--- a/lib/rules/__tests__/index.test.mjs
+++ b/lib/rules/__tests__/index.test.mjs
@@ -83,18 +83,15 @@ describe('invalid options', () => {
 		const secondaryOptions = {};
 		const context = {};
 		const root = postcss.root();
-		const warn = import.meta.jest.fn();
-		const result = {
+		const result = Object.assign(root.toResult(), {
 			stylelint: { config: { validate: true } },
-			warn,
-		};
+		});
 
 		await rule(primaryOption, secondaryOptions, context)(root, result);
 
-		expect(warn).toHaveBeenCalledWith(
-			expect.any(String),
-			expect.objectContaining({ stylelintType: 'invalidOption' }),
-		);
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0]).toHaveProperty('text', expect.stringContaining(`rule "${name}"`));
+		expect(result.messages[0]).toHaveProperty('stylelintType', 'invalidOption');
 	});
 });
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This increases the test coverage when invalid options are passed to all the rules.

```js
if (!validOptions) {
	return; //<- This line is now covered.
}
```

See the coverage on Codecov: https://app.codecov.io/gh/stylelint/stylelint/pull/8270