### PR TITLE
Document how to handle emitted deprecation warnings

### DIFF
--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -396,7 +396,7 @@ When publishing such configurations, use the `stylelint-config` keyword within y
 
 We sometimes introduce deprecation warnings that impact plugin authors. You can individually quiet these in your plugin by handling the `emitWarning` event.
 
-For example, to quiet the deprecationg warning for `context.fix`:
+For example, to quiet the deprecation warning for `context.fix`:
 
 ```diff js
 const ruleName = "plugin/foo-bar-qux";

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -402,7 +402,9 @@ For example, to quiet the deprecation warning for `context.fix`:
 const ruleName = "plugin/foo-bar-qux";
 
 + const original = process.emitWarning;
-+ process.emitWarning = function (message, options) {
++ process.emitWarning = function emitWarning(warning, type, code, ctor) {
++   const options = arguments[1];
++ 
 +  if (
 +    options &&
 +    typeof options === "object" &&

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -133,22 +133,23 @@ We sometimes introduce deprecation warnings that impact plugin authors. You can 
 
 For example, to quiet the deprecationg warning for `context.fix`:
 
-```js
-const ruleName = "foo-bar-qux";
-const original = process.emitWarning;
-process.emitWarning = function (message, options) {
-  if (
-    options &&
-    typeof options === "object" &&
-    options.type === "DeprecationWarning" &&
-    options.code === "stylelint:005" &&
-    options.detail.includes(ruleName)
-  ) {
-    return;
-  }
+```diff js
+const ruleName = "plugin/foo-bar-qux";
 
-  original.apply(process, arguments);
-};
++ const original = process.emitWarning;
++ process.emitWarning = function (message, options) {
++  if (
++    options &&
++    typeof options === "object" &&
++    options.type === "DeprecationWarning" &&
++    options.code === "stylelint:005" &&
++    options.detail.includes(ruleName)
++  ) {
++    return;
++  }
++
++  original.apply(process, arguments);
++ };
 ```
 
 > [!WARNING]

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -140,7 +140,8 @@ process.emitWarning = function (message, options) {
     options &&
     typeof options === "object" &&
     options.type === "DeprecationWarning" &&
-    options.code === "stylelint:005"
+    options.code === "stylelint:005" &&
+    options.detail.includes(ruleName)
   ) {
     return;
   }

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -134,6 +134,7 @@ We sometimes introduce deprecation warnings that impact plugin authors. You can 
 For example, to quiet the deprecationg warning for `context.fix`:
 
 ```js
+const ruleName = "foo-bar-qux";
 const original = process.emitWarning;
 process.emitWarning = function (message, options) {
   if (

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -137,9 +137,8 @@ For example, to quiet the deprecationg warning for `context.fix`:
 const original = process.emitWarning;
 process.emitWarning = function (message, options) {
   if (
-    message &&
     options?.type === "DeprecationWarning" &&
-    options.code === "stylelint:005"
+    options?.code === "stylelint:005"
   )
     return;
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -143,7 +143,7 @@ process.emitWarning = function (message, options) {
     return;
   }
 
-  original.call(process, message, options);
+  original.apply(process, arguments);
 };
 ```
 

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -404,7 +404,7 @@ const ruleName = "plugin/foo-bar-qux";
 + const original = process.emitWarning;
 + process.emitWarning = function emitWarning(warning, type, code, ctor) {
 +   const options = arguments[1];
-+ 
++
 +  if (
 +    options &&
 +    typeof options === "object" &&

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -127,34 +127,6 @@ const ruleFunction = (primary, secondaryOptions) => {
 };
 ```
 
-## Quiet deprecation warnings
-
-We sometimes introduce deprecation warnings that impact plugin authors. You can individually quiet these in your plugin by handling the `emitWarning` event.
-
-For example, to quiet the deprecationg warning for `context.fix`:
-
-```diff js
-const ruleName = "plugin/foo-bar-qux";
-
-+ const original = process.emitWarning;
-+ process.emitWarning = function (message, options) {
-+  if (
-+    options &&
-+    typeof options === "object" &&
-+    options.type === "DeprecationWarning" &&
-+    options.code === "stylelint:005" &&
-+    options.detail.includes(ruleName)
-+  ) {
-+    return;
-+  }
-+
-+  original.apply(process, arguments);
-+ };
-```
-
-> [!WARNING]
-> Note that this monkey patch might have side effects.
-
 ## Testing
 
 You can use either:
@@ -419,3 +391,31 @@ When publishing such configurations, use the `stylelint-config` keyword within y
   "keywords": ["stylelint", "stylelint-config"]
 }
 ```
+
+## Quiet deprecation warnings
+
+We sometimes introduce deprecation warnings that impact plugin authors. You can individually quiet these in your plugin by handling the `emitWarning` event.
+
+For example, to quiet the deprecationg warning for `context.fix`:
+
+```diff js
+const ruleName = "plugin/foo-bar-qux";
+
++ const original = process.emitWarning;
++ process.emitWarning = function (message, options) {
++  if (
++    options &&
++    typeof options === "object" &&
++    options.type === "DeprecationWarning" &&
++    options.code === "stylelint:005" &&
++    options.detail.includes(ruleName)
++  ) {
++    return;
++  }
++
++  original.apply(process, arguments);
++ };
+```
+
+> [!WARNING]
+> Note that this monkey patch might have side effects.

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -137,8 +137,10 @@ For example, to quiet the deprecationg warning for `context.fix`:
 const original = process.emitWarning;
 process.emitWarning = function (message, options) {
   if (
-    options?.type === "DeprecationWarning" &&
-    options?.code === "stylelint:005"
+    options &&
+    typeof options === "object" &&
+    options.type === "DeprecationWarning" &&
+    options.code === "stylelint:005"
   ) {
     return;
   }

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -127,6 +127,26 @@ const ruleFunction = (primary, secondaryOptions) => {
 };
 ```
 
+## Quiet deprecation warnings
+
+We sometimes introduce deprecation warnings that impact plugin authors. You can individually quiet these in your plugin by handling the `emitWarning` event.
+
+For example, to quiet the deprecationg warning for `context.fix`:
+
+```js
+const original = process.emitWarning;
+process.emitWarning = function (message, options) {
+  if (
+    message &&
+    options?.type === "DeprecationWarning" &&
+    options.code === "stylelint:005"
+  )
+    return;
+
+  original.call(process, message, options);
+};
+```
+
 ## Testing
 
 You can use either:

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -139,8 +139,9 @@ process.emitWarning = function (message, options) {
   if (
     options?.type === "DeprecationWarning" &&
     options?.code === "stylelint:005"
-  )
+  ) {
     return;
+  }
 
   original.call(process, message, options);
 };

--- a/docs/developer-guide/plugins.md
+++ b/docs/developer-guide/plugins.md
@@ -150,6 +150,9 @@ process.emitWarning = function (message, options) {
 };
 ```
 
+> [!WARNING]
+> Note that this monkey patch might have side effects.
+
 ## Testing
 
 You can use either:

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -262,6 +262,8 @@ Ignore deprecation warnings.
 > [!TIP]
 > For Node.js 20.11.0+, you can disable individual deprecation warnings using the Node.js [`--disable-warning`](https://nodejs.org/api/cli.html#--disable-warningcode-or-type) mechanism, e.g.:
 >
-> `NODE_OPTIONS='--disable-warning=stylelint:005' npx stylelint "**/*.css"`
+> ```shell
+> NODE_OPTIONS='--disable-warning=stylelint:005' npx stylelint "**/*.css"
+> ```
 
 [1]: ../user-guide/ignore-code.md#parts-of-a-file

--- a/docs/user-guide/options.md
+++ b/docs/user-guide/options.md
@@ -259,4 +259,9 @@ CLI flag: `--quiet-deprecation-warnings`
 
 Ignore deprecation warnings.
 
+> [!TIP]
+> For Node.js 20.11.0+, you can disable individual deprecation warnings using the Node.js [`--disable-warning`](https://nodejs.org/api/cli.html#--disable-warningcode-or-type) mechanism, e.g.:
+>
+> `NODE_OPTIONS='--disable-warning=stylelint:005' npx stylelint "**/*.css"`
+
 [1]: ../user-guide/ignore-code.md#parts-of-a-file


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8249 

> Is there anything in the PR that needs further explanation?

I'd also like to add something for plugin authors that describes https://github.com/stylelint/stylelint/issues/8249#issuecomment-2564755567, i.e. handling warning events, but I could only silence all warnings in a plugin using:

```js
process.removeAllListeners("warning");
```

I thought I'd be able to silence individual warnings using:

```js
process.on("warning", (warning) => {
  if (warning.code === "stylelint:005") return;
});
```

But that didn't work. Am I missing something?
