### PR TITLE
Fix `at-rule-(dis)allowed-list`, `at-rule-no-vendor-prefix`, `at-rule-property-required-list` message argument

### DIFF
--- a/.changeset/perfect-pots-destroy.md
+++ b/.changeset/perfect-pots-destroy.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Changed: `at-rule-(dis)allowed-list`, `at-rule-no-vendor-prefix`, `at-rule-property-required-list` message argument

--- a/.changeset/perfect-pots-destroy.md
+++ b/.changeset/perfect-pots-destroy.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": minor
+"stylelint": patch
 ---
 
-Changed: `at-rule-(dis)allowed-list`, `at-rule-no-vendor-prefix`, `at-rule-property-required-list` message argument
+Fixed: `at-rule-(dis)allowed-list`, `at-rule-no-vendor-prefix`, `at-rule-property-required-list` message argument

--- a/lib/rules/at-rule-allowed-list/__tests__/index.mjs
+++ b/lib/rules/at-rule-allowed-list/__tests__/index.mjs
@@ -71,7 +71,7 @@ testRule({
 			column: 7,
 			endLine: 2,
 			endColumn: 13,
-			message: messages.rejected('mixin'),
+			message: messages.rejected('@mixin'),
 			description: '@rule not from an allowed list; independent rule.',
 		},
 	],
@@ -126,7 +126,7 @@ testRule({
 			code: `
       @mixin name ($p) {}
     `,
-			message: messages.rejected('mixin'),
+			message: messages.rejected('@mixin'),
 			line: 2,
 			column: 7,
 			endLine: 2,
@@ -135,7 +135,7 @@ testRule({
 		},
 		{
 			code: "@import 'path/to/file.css';",
-			message: messages.rejected('import'),
+			message: messages.rejected('@import'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -144,7 +144,7 @@ testRule({
 		},
 		{
 			code: '@media screen and (max-witdh: 1000px) {}',
-			message: messages.rejected('media'),
+			message: messages.rejected('@media'),
 			line: 1,
 			column: 1,
 			endLine: 1,

--- a/lib/rules/at-rule-allowed-list/index.cjs
+++ b/lib/rules/at-rule-allowed-list/index.cjs
@@ -12,7 +12,7 @@ const vendor = require('../../utils/vendor.cjs');
 const ruleName = 'at-rule-allowed-list';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (name) => `Unexpected at-rule "${name}"`,
+	rejected: (atRule) => `Unexpected at-rule "${atRule}"`,
 });
 
 const meta = {
@@ -44,13 +44,15 @@ const rule = (primary) => {
 				return;
 			}
 
+			const atName = `@${name}`;
+
 			report({
 				message: messages.rejected,
-				messageArgs: [name],
+				messageArgs: [atName],
 				node: atRule,
 				result,
 				ruleName,
-				word: `@${name}`,
+				word: atName,
 			});
 		});
 	};

--- a/lib/rules/at-rule-allowed-list/index.mjs
+++ b/lib/rules/at-rule-allowed-list/index.mjs
@@ -8,7 +8,7 @@ import vendor from '../../utils/vendor.mjs';
 const ruleName = 'at-rule-allowed-list';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (name) => `Unexpected at-rule "${name}"`,
+	rejected: (atRule) => `Unexpected at-rule "${atRule}"`,
 });
 
 const meta = {
@@ -40,13 +40,15 @@ const rule = (primary) => {
 				return;
 			}
 
+			const atName = `@${name}`;
+
 			report({
 				message: messages.rejected,
-				messageArgs: [name],
+				messageArgs: [atName],
 				node: atRule,
 				result,
 				ruleName,
-				word: `@${name}`,
+				word: atName,
 			});
 		});
 	};

--- a/lib/rules/at-rule-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/at-rule-disallowed-list/__tests__/index.mjs
@@ -20,7 +20,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { @extend %placeholder; }',
-			message: messages.rejected('extend'),
+			message: messages.rejected('@extend'),
 			line: 1,
 			column: 5,
 			endLine: 1,
@@ -34,7 +34,7 @@ testRule({
         %placeholder;
       }
     `,
-			message: messages.rejected('extend'),
+			message: messages.rejected('@extend'),
 			line: 3,
 			column: 9,
 			endLine: 3,
@@ -48,7 +48,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('keyframes'),
+			message: messages.rejected('@keyframes'),
 			line: 2,
 			column: 7,
 			endLine: 2,
@@ -62,7 +62,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('Keyframes'),
+			message: messages.rejected('@Keyframes'),
 			line: 2,
 			column: 7,
 			description: '@rule from a disallowed list; independent rule; messed case.',
@@ -74,7 +74,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('-moz-keyframes'),
+			message: messages.rejected('@-moz-keyframes'),
 			line: 2,
 			column: 7,
 			description: '@rule from a disallowed list; independent rule; has vendor prefix.',
@@ -86,7 +86,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('-WEBKET-KEYFRAMES'),
+			message: messages.rejected('@-WEBKET-KEYFRAMES'),
 			line: 2,
 			column: 7,
 			description: '@rule from a disallowed list; independent rule; has vendor prefix.',
@@ -118,7 +118,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('keyframes'),
+			message: messages.rejected('@keyframes'),
 			line: 2,
 			column: 7,
 			description: '@rule from a disallowed list; independent rule.',
@@ -130,7 +130,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('Keyframes'),
+			message: messages.rejected('@Keyframes'),
 			line: 2,
 			column: 7,
 			description: '@rule from a disallowed list; independent rule; messed case.',
@@ -142,7 +142,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('-moz-keyframes'),
+			message: messages.rejected('@-moz-keyframes'),
 			line: 2,
 			column: 7,
 			description: '@rule from a disallowed list; independent rule; has vendor prefix.',
@@ -154,7 +154,7 @@ testRule({
         to { top: 20px; }
       }
     `,
-			message: messages.rejected('-WEBKET-KEYFRAMES'),
+			message: messages.rejected('@-WEBKET-KEYFRAMES'),
 			line: 2,
 			column: 7,
 			description: '@rule from a disallowed list; independent rule; has vendor prefix.',

--- a/lib/rules/at-rule-disallowed-list/index.cjs
+++ b/lib/rules/at-rule-disallowed-list/index.cjs
@@ -12,7 +12,7 @@ const vendor = require('../../utils/vendor.cjs');
 const ruleName = 'at-rule-disallowed-list';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (name) => `Unexpected at-rule "${name}"`,
+	rejected: (atRule) => `Unexpected at-rule "${atRule}"`,
 });
 
 const meta = {
@@ -44,13 +44,15 @@ const rule = (primary) => {
 				return;
 			}
 
+			const atName = `@${atRule.name}`;
+
 			report({
 				message: messages.rejected,
-				messageArgs: [name],
+				messageArgs: [atName],
 				node: atRule,
 				result,
 				ruleName,
-				word: `@${atRule.name}`,
+				word: atName,
 			});
 		});
 	};

--- a/lib/rules/at-rule-disallowed-list/index.mjs
+++ b/lib/rules/at-rule-disallowed-list/index.mjs
@@ -8,7 +8,7 @@ import vendor from '../../utils/vendor.mjs';
 const ruleName = 'at-rule-disallowed-list';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (name) => `Unexpected at-rule "${name}"`,
+	rejected: (atRule) => `Unexpected at-rule "${atRule}"`,
 });
 
 const meta = {
@@ -40,13 +40,15 @@ const rule = (primary) => {
 				return;
 			}
 
+			const atName = `@${atRule.name}`;
+
 			report({
 				message: messages.rejected,
-				messageArgs: [name],
+				messageArgs: [atName],
 				node: atRule,
 				result,
 				ruleName,
-				word: `@${atRule.name}`,
+				word: atName,
 			});
 		});
 	};

--- a/lib/rules/at-rule-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/at-rule-no-vendor-prefix/__tests__/index.mjs
@@ -19,7 +19,7 @@ testRule({
 		{
 			code: '@-webkit-keyframes { 0% { top: 0; } }',
 			fixed: '@keyframes { 0% { top: 0; } }',
-			message: messages.rejected('-webkit-keyframes'),
+			message: messages.rejected('@-webkit-keyframes'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -28,7 +28,7 @@ testRule({
 		{
 			code: '@-wEbKiT-kEyFrAmEs { 0% { top: 0; } }',
 			fixed: '@kEyFrAmEs { 0% { top: 0; } }',
-			message: messages.rejected('-wEbKiT-kEyFrAmEs'),
+			message: messages.rejected('@-wEbKiT-kEyFrAmEs'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -37,7 +37,7 @@ testRule({
 		{
 			code: '@-WEBKIT-KEYFRAMES { 0% { top: 0; } }',
 			fixed: '@KEYFRAMES { 0% { top: 0; } }',
-			message: messages.rejected('-WEBKIT-KEYFRAMES'),
+			message: messages.rejected('@-WEBKIT-KEYFRAMES'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -46,7 +46,7 @@ testRule({
 		{
 			code: '@-moz-keyframes { 0% { top: 0; } }',
 			fixed: '@keyframes { 0% { top: 0; } }',
-			message: messages.rejected('-moz-keyframes'),
+			message: messages.rejected('@-moz-keyframes'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -55,7 +55,7 @@ testRule({
 		{
 			code: '@-ms-viewport { orientation: landscape; }',
 			fixed: '@viewport { orientation: landscape; }',
-			message: messages.rejected('-ms-viewport'),
+			message: messages.rejected('@-ms-viewport'),
 			line: 1,
 			column: 1,
 			endLine: 1,

--- a/lib/rules/at-rule-no-vendor-prefix/index.cjs
+++ b/lib/rules/at-rule-no-vendor-prefix/index.cjs
@@ -11,7 +11,7 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'at-rule-no-vendor-prefix';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (p) => `Unexpected vendor-prefixed at-rule "@${p}"`,
+	rejected: (atRule) => `Unexpected vendor-prefixed at-rule "${atRule}"`,
 });
 
 const meta = {
@@ -47,11 +47,13 @@ const rule = (primary) => {
 				atRule.name = isAutoprefixable.unprefix(atRule.name);
 			};
 
+			const atName = `@${name}`;
+
 			report({
 				message: messages.rejected,
-				messageArgs: [name],
+				messageArgs: [atName],
 				node: atRule,
-				word: `@${name}`,
+				word: atName,
 				result,
 				ruleName,
 				fix,

--- a/lib/rules/at-rule-no-vendor-prefix/index.mjs
+++ b/lib/rules/at-rule-no-vendor-prefix/index.mjs
@@ -7,7 +7,7 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'at-rule-no-vendor-prefix';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (p) => `Unexpected vendor-prefixed at-rule "@${p}"`,
+	rejected: (atRule) => `Unexpected vendor-prefixed at-rule "${atRule}"`,
 });
 
 const meta = {
@@ -43,11 +43,13 @@ const rule = (primary) => {
 				atRule.name = isAutoprefixable.unprefix(atRule.name);
 			};
 
+			const atName = `@${name}`;
+
 			report({
 				message: messages.rejected,
-				messageArgs: [name],
+				messageArgs: [atName],
 				node: atRule,
-				word: `@${name}`,
+				word: atName,
 				result,
 				ruleName,
 				fix,

--- a/lib/rules/at-rule-property-required-list/__tests__/index.mjs
+++ b/lib/rules/at-rule-property-required-list/__tests__/index.mjs
@@ -39,7 +39,7 @@ testRule({
 		{
 			code: '@font-face { font-display: auto; }',
 			description: '@font-face with missing property',
-			message: messages.expected('font-face', 'font-family'),
+			message: messages.expected('@font-face', 'font-family'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -48,7 +48,7 @@ testRule({
 		{
 			code: '@FONT-FACE { FONT-DISPLAY: AUTO; }',
 			description: '@font-face with missing property (case-sensitive)',
-			message: messages.expected('font-face', 'font-family'),
+			message: messages.expected('@FONT-FACE', 'font-family'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -57,7 +57,7 @@ testRule({
 		{
 			code: "@font-face { font-family: 'Arvo'; font-weight: normal }",
 			description: '@font-face with missing property',
-			message: messages.expected('font-face', 'font-display'),
+			message: messages.expected('@font-face', 'font-display'),
 			line: 1,
 			column: 1,
 			endLine: 1,
@@ -66,7 +66,7 @@ testRule({
 		{
 			code: '@page { padding: 0.5cm }',
 			description: '@page with missing property',
-			message: messages.expected('page', 'margin'),
+			message: messages.expected('@page', 'margin'),
 			line: 1,
 			column: 1,
 			endLine: 1,

--- a/lib/rules/at-rule-property-required-list/index.cjs
+++ b/lib/rules/at-rule-property-required-list/index.cjs
@@ -75,11 +75,13 @@ const rule = (primary) => {
 			for (const requiredProp of propList) {
 				if (currentPropList.has(requiredProp)) continue;
 
+				const atName = `@${atRule.name}`;
+
 				report({
 					message: messages.expected,
-					messageArgs: [atRuleName, requiredProp],
+					messageArgs: [atName, requiredProp],
 					node: atRule,
-					word: `@${atRule.name}`,
+					word: atName,
 					result,
 					ruleName,
 				});

--- a/lib/rules/at-rule-property-required-list/index.mjs
+++ b/lib/rules/at-rule-property-required-list/index.mjs
@@ -71,11 +71,13 @@ const rule = (primary) => {
 			for (const requiredProp of propList) {
 				if (currentPropList.has(requiredProp)) continue;
 
+				const atName = `@${atRule.name}`;
+
 				report({
 					message: messages.expected,
-					messageArgs: [atRuleName, requiredProp],
+					messageArgs: [atName, requiredProp],
 					node: atRule,
-					word: `@${atRule.name}`,
+					word: atName,
 					result,
 					ruleName,
 				});

--- a/lib/rules/custom-property-pattern/index.cjs
+++ b/lib/rules/custom-property-pattern/index.cjs
@@ -15,7 +15,7 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'custom-property-pattern';
 
 const messages = ruleMessages(ruleName, {
-	expected: (propName, pattern) => `Expected "${propName}" to match pattern "${pattern}"`,
+	expected: (property, pattern) => `Expected "${property}" to match pattern "${pattern}"`,
 });
 
 const meta = {

--- a/lib/rules/custom-property-pattern/index.mjs
+++ b/lib/rules/custom-property-pattern/index.mjs
@@ -12,7 +12,7 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'custom-property-pattern';
 
 const messages = ruleMessages(ruleName, {
-	expected: (propName, pattern) => `Expected "${propName}" to match pattern "${pattern}"`,
+	expected: (property, pattern) => `Expected "${property}" to match pattern "${pattern}"`,
 });
 
 const meta = {

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -17,7 +17,7 @@ const vendor = require('../../utils/vendor.cjs');
 const ruleName = 'declaration-block-no-redundant-longhand-properties';
 
 const messages = ruleMessages(ruleName, {
-	expected: (props) => `Expected shorthand property "${props}"`,
+	expected: (property) => `Expected shorthand property "${property}"`,
 });
 
 const meta = {

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -14,7 +14,7 @@ import vendor from '../../utils/vendor.mjs';
 const ruleName = 'declaration-block-no-redundant-longhand-properties';
 
 const messages = ruleMessages(ruleName, {
-	expected: (props) => `Expected shorthand property "${props}"`,
+	expected: (property) => `Expected shorthand property "${property}"`,
 });
 
 const meta = {

--- a/lib/rules/no-unknown-custom-media/__tests__/index.mjs
+++ b/lib/rules/no-unknown-custom-media/__tests__/index.mjs
@@ -43,7 +43,7 @@ testRule({
 	reject: [
 		{
 			code: '@custom-media --foo (max-width: 30em); @media screen and (--bar) {};',
-			message: messages.expected('--bar'),
+			message: messages.rejected('--bar'),
 			line: 1,
 			column: 59,
 			endLine: 1,
@@ -51,7 +51,7 @@ testRule({
 		},
 		{
 			code: '@custom-media --foo (max-width: 30em); @media (--bar) {};',
-			message: messages.expected('--bar'),
+			message: messages.rejected('--bar'),
 			line: 1,
 			column: 48,
 			endLine: 1,
@@ -59,7 +59,7 @@ testRule({
 		},
 		{
 			code: '@media (--bar) {};',
-			message: messages.expected('--bar'),
+			message: messages.rejected('--bar'),
 			line: 1,
 			column: 9,
 			endLine: 1,
@@ -68,13 +68,13 @@ testRule({
 		{
 			code: '@media (--bar), (--baz) {};',
 			warnings: [
-				{ message: messages.expected('--bar'), line: 1, column: 9, endLine: 1, endColumn: 14 },
-				{ message: messages.expected('--baz'), line: 1, column: 18, endLine: 1, endColumn: 23 },
+				{ message: messages.rejected('--bar'), line: 1, column: 9, endLine: 1, endColumn: 14 },
+				{ message: messages.rejected('--baz'), line: 1, column: 18, endLine: 1, endColumn: 23 },
 			],
 		},
 		{
 			code: '@media (--bar), (min-width: 40rem) {};',
-			message: messages.expected('--bar'),
+			message: messages.rejected('--bar'),
 			line: 1,
 			column: 9,
 			endLine: 1,
@@ -86,7 +86,7 @@ testRule({
 				@media (--narrow-windows) {}
 				@media (--narrow-window) and (script) {}
 			`,
-			message: messages.expected('--narrow-windows'),
+			message: messages.rejected('--narrow-windows'),
 			line: 2,
 			column: 9,
 			endLine: 2,

--- a/lib/rules/no-unknown-custom-media/index.cjs
+++ b/lib/rules/no-unknown-custom-media/index.cjs
@@ -14,7 +14,7 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'no-unknown-custom-media';
 
 const messages = ruleMessages(ruleName, {
-	expected: (mediaName) => `Unexpected unknown custom media "${mediaName}"`,
+	rejected: (mediaName) => `Unexpected unknown custom media "${mediaName}"`,
 });
 
 const meta = {
@@ -58,7 +58,7 @@ const rule = (primary) => {
 					const endIndex = baseIndex + end + 1;
 
 					report({
-						message: messages.expected,
+						message: messages.rejected,
 						messageArgs: [name],
 						node: atRule,
 						index,

--- a/lib/rules/no-unknown-custom-media/index.mjs
+++ b/lib/rules/no-unknown-custom-media/index.mjs
@@ -10,7 +10,7 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'no-unknown-custom-media';
 
 const messages = ruleMessages(ruleName, {
-	expected: (mediaName) => `Unexpected unknown custom media "${mediaName}"`,
+	rejected: (mediaName) => `Unexpected unknown custom media "${mediaName}"`,
 });
 
 const meta = {
@@ -54,7 +54,7 @@ const rule = (primary) => {
 					const endIndex = baseIndex + end + 1;
 
 					report({
-						message: messages.expected,
+						message: messages.rejected,
 						messageArgs: [name],
 						node: atRule,
 						index,

--- a/lib/rules/no-unknown-custom-properties/index.cjs
+++ b/lib/rules/no-unknown-custom-properties/index.cjs
@@ -12,7 +12,7 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'no-unknown-custom-properties';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (propName) => `Unexpected unknown custom property "${propName}"`,
+	rejected: (property) => `Unexpected unknown custom property "${property}"`,
 });
 
 const meta = {

--- a/lib/rules/no-unknown-custom-properties/index.mjs
+++ b/lib/rules/no-unknown-custom-properties/index.mjs
@@ -9,7 +9,7 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'no-unknown-custom-properties';
 
 const messages = ruleMessages(ruleName, {
-	rejected: (propName) => `Unexpected unknown custom property "${propName}"`,
+	rejected: (property) => `Unexpected unknown custom property "${property}"`,
 });
 
 const meta = {


### PR DESCRIPTION
> Which PR, if any, is this related to?

follow-up of #8236 and #8252

> Is there anything in the PR that needs further explanation?

1.
`at-rule-descriptor-no-unknown`, `at-rule-no-deprecated`, `at-rule-prelude-no-invalid` and `at-rule-no-unknown` pass `'@foo'`.
`at-rule-(dis)allowed-list`, `at-rule-no-vendor-prefix`, `at-rule-property-required-list` used to pass `'foo'`.

2.
`at-rule-no-vendor-prefix` had the right message but the wrong argument.
i.e. the @ should not be added in the message itself

3.
13 rules that have a message that starts with `Unexpected unknown` use the `rejected` key for it.
`no-unknown-custom-media` used `expected`.

4.
The argument passed should respect the current style of the user's codebase.
i.e. [`"at-rule-name-case": "upper"`](https://github.com/stylelint-stylistic/stylelint-stylistic/tree/main/lib/rules/at-rule-name-case)