### PR TITLE
`function-allowed-list` allows a function if a fallback is provided

### DIFF
--- a/lib/rules/function-allowed-list/README.md
+++ b/lib/rules/function-allowed-list/README.md
@@ -73,3 +73,11 @@ a {
     -moz-linear-gradient(45deg, blue, red);
 }
 ```
+
+<!-- prettier-ignore -->
+```css
+a {
+  color: darkseagreen;
+  color: hsla(170, 50%, 45%, 1);
+}
+```

--- a/lib/rules/function-allowed-list/__tests__/index.mjs
+++ b/lib/rules/function-allowed-list/__tests__/index.mjs
@@ -209,3 +209,42 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+
+	config: ['max'],
+
+	accept: [
+		{
+			description: 'should allow function if fallback is provided',
+			code: 'a { width: 1px; width: min(1px, 2px); }',
+		},
+		{
+			description: 'should allow function if fallback is provided (comment between rules)',
+			code: 'a { width: 1px; /* comment */ width: min(1px, 2px); }',
+		},
+	],
+
+	reject: [
+		{
+			description: 'should not allow function if fallback is not provided',
+			code: 'a { width: min(1px, 2px); }',
+			message: messages.rejected('min'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 15,
+		},
+		{
+			description:
+				'should not allow function if fallback is not provided (prop is in another rule)',
+			code: 'b { width: 1px; } a { width: min(1px, 2px); }',
+			message: messages.rejected('min'),
+			line: 1,
+			column: 30,
+			endLine: 1,
+			endColumn: 33,
+		},
+	],
+});

--- a/lib/rules/function-allowed-list/index.cjs
+++ b/lib/rules/function-allowed-list/index.cjs
@@ -22,6 +22,20 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/function-allowed-list',
 };
 
+/**
+ * @param {import('postcss').Declaration} decl
+ * @returns {import('postcss').Declaration | void}
+ */
+function getPrevDeclaration(decl) {
+	let prev = decl.prev();
+
+	while (prev && prev.type !== 'decl') {
+		prev = prev.prev();
+	}
+
+	return prev;
+}
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -45,6 +59,12 @@ const rule = (primary) => {
 				}
 
 				if (matchesStringOrRegExp(vendor.unprefixed(node.value), primary)) {
+					return;
+				}
+
+				const prevDecl = getPrevDeclaration(decl);
+
+				if (prevDecl?.prop === decl.prop) {
 					return;
 				}
 

--- a/lib/rules/function-allowed-list/index.mjs
+++ b/lib/rules/function-allowed-list/index.mjs
@@ -19,6 +19,20 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/function-allowed-list',
 };
 
+/**
+ * @param {import('postcss').Declaration} decl
+ * @returns {import('postcss').Declaration | void}
+ */
+function getPrevDeclaration(decl) {
+	let prev = decl.prev();
+
+	while (prev && prev.type !== 'decl') {
+		prev = prev.prev();
+	}
+
+	return prev;
+}
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -42,6 +56,12 @@ const rule = (primary) => {
 				}
 
 				if (matchesStringOrRegExp(vendor.unprefixed(node.value), primary)) {
+					return;
+				}
+
+				const prevDecl = getPrevDeclaration(decl);
+
+				if (prevDecl?.prop === decl.prop) {
 					return;
 				}
 


### PR DESCRIPTION
#### Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8291 .

#### Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

#### Summary of Changes

This PR enhances the functionality of the `function-allowed-list` rule to support the use of restricted functions when valid fallbacks are provided. For example:

```css
  width: 200px; /* Fallback for older browsers */
  width: min(50%, 300px); /* Advanced functionality for modern browsers */
```

Previously, such usage was disallowed, even with a proper fallback. This update ensures that developers can leverage modern CSS features responsibly while maintaining compatibility with older browsers. 