### PR TITLE
Fix `ignore.default is not a function`

### DIFF
--- a/.changeset/pink-panthers-fix.md
+++ b/.changeset/pink-panthers-fix.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `ignore.default is not a function`

--- a/lib/utils/getFileIgnorer.cjs
+++ b/lib/utils/getFileIgnorer.cjs
@@ -14,7 +14,6 @@ const constants = require('../constants.cjs');
  * @returns {import('ignore').Ignore}
  */
 function getFileIgnorer({ ignorePath, ignorePattern, cwd }) {
-	/* @ts-expect-error */
 	const ignorer = ignore();
 	const ignorePaths = [ignorePath || []].flat();
 

--- a/lib/utils/getFileIgnorer.cjs
+++ b/lib/utils/getFileIgnorer.cjs
@@ -14,7 +14,8 @@ const constants = require('../constants.cjs');
  * @returns {import('ignore').Ignore}
  */
 function getFileIgnorer({ ignorePath, ignorePattern, cwd }) {
-	const ignorer = ignore.default();
+	/* @ts-expect-error */
+	const ignorer = ignore();
 	const ignorePaths = [ignorePath || []].flat();
 
 	if (ignorePaths.length === 0) {

--- a/lib/utils/getFileIgnorer.mjs
+++ b/lib/utils/getFileIgnorer.mjs
@@ -11,7 +11,6 @@ import { DEFAULT_IGNORE_FILENAME } from '../constants.mjs';
  * @returns {import('ignore').Ignore}
  */
 export default function getFileIgnorer({ ignorePath, ignorePattern, cwd }) {
-	/* @ts-expect-error */
 	const ignorer = ignore();
 	const ignorePaths = [ignorePath || []].flat();
 

--- a/lib/utils/getFileIgnorer.mjs
+++ b/lib/utils/getFileIgnorer.mjs
@@ -11,7 +11,8 @@ import { DEFAULT_IGNORE_FILENAME } from '../constants.mjs';
  * @returns {import('ignore').Ignore}
  */
 export default function getFileIgnorer({ ignorePath, ignorePattern, cwd }) {
-	const ignorer = ignore.default();
+	/* @ts-expect-error */
+	const ignorer = ignore();
 	const ignorePaths = [ignorePath || []].flat();
 
 	if (ignorePaths.length === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^3.3.1",
-        "ignore": "^7.0.0",
+        "ignore": "^7.0.1",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.35.0",
@@ -7088,9 +7088,10 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.0.tgz",
-      "integrity": "sha512-lcX8PNQygAa22u/0BysEY8VhaFRzlOkvdlKczDPnJvrkJD1EuqzEky5VYYKM2iySIuaVIDv9N190DfSreSLw2A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.1.tgz",
+      "integrity": "sha512-D1gVletsbVOoiXF963rgZnfobGAbq7Lb+dz3fcBmlOmZg6hHkpbycLqL8PLNB8f4GVv6dOVYwhPL/r7hwiH0Fw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "globby": "^11.1.0",
     "globjoin": "^0.1.4",
     "html-tags": "^3.3.1",
-    "ignore": "^7.0.0",
+    "ignore": "^7.0.1",
     "imurmurhash": "^0.1.4",
     "is-plain-object": "^5.0.0",
     "known-css-properties": "^0.35.0",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8304

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
