### PR TITLE
Fix `RuleContext['fix']` type

### DIFF
--- a/.changeset/lucky-garlics-compare.md
+++ b/.changeset/lucky-garlics-compare.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `RuleContext['fix']` type

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -231,7 +231,7 @@ declare namespace stylelint {
 	 */
 	export type RuleContext = {
 		configurationComment?: string | undefined;
-		fix?: boolean | FixMode;
+		fix?: boolean | undefined;
 		newline?: string | undefined;
 	};
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#8308
doesn't c l o s e it (a new enhancement issue must be created)

> Is there anything in the PR that needs further explanation?

1.
guilty commit: 0f92394
We failed to detect the problem during the review.

2.
So that it doesn't happen again here are some suggestions:

- improve `type-test.ts`
- review the errors reported by `stylelint-ecosystem-tester` more carefully during the pre-release phase
- increase the number of approvals needed when the number of `mjs` files reach a certain threshold—e.g. 3 approvals

These are just suggestions—i.e. overcompensating can be bad too—maybe it was simply an oversight and it can't be helped.