### PR TITLE
Document `shorthand-property-no-redundant-values` README description without grammatical error

### DIFF
--- a/lib/rules/shorthand-property-no-redundant-values/README.md
+++ b/lib/rules/shorthand-property-no-redundant-values/README.md
@@ -11,7 +11,7 @@ a { margin: 1px 1px 1px 1px; }
 
 You can use [shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties) to set multiple values at once. For example, you can use the `margin` property to set the `margin-top`, `margin-right`, `margin-bottom`, and `margin-left` properties at once.
 
-For some shorthand properties, e.g. those related to the [edges of a box](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box), you can safely omitted some values.
+For some shorthand properties, e.g. those related to the [edges of a box](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box), you can safely omit some values.
 
 This rule checks the following shorthand properties:
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None -> documentation fix

> Is there anything in the PR that needs further explanation?

No
