### PR TITLE
Fix `declaration-property-value-keyword-no-deprecated` false positives for `border-color`

### DIFF
--- a/.changeset/lovely-monkeys-yell.md
+++ b/.changeset/lovely-monkeys-yell.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-property-value-keyword-no-deprecated` false positives for `border-color`

--- a/lib/reference/properties.cjs
+++ b/lib/reference/properties.cjs
@@ -621,7 +621,6 @@ const singleValueColorProperties = new Set([
 	'border-block-end-color',
 	'border-block-start-color',
 	'border-bottom-color',
-	'border-color',
 	'border-inline-color',
 	'border-inline-end-color',
 	'border-inline-start-color',

--- a/lib/reference/properties.mjs
+++ b/lib/reference/properties.mjs
@@ -617,7 +617,6 @@ export const singleValueColorProperties = new Set([
 	'border-block-end-color',
 	'border-block-start-color',
 	'border-bottom-color',
-	'border-color',
 	'border-inline-color',
 	'border-inline-end-color',
 	'border-inline-start-color',

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
@@ -7,7 +7,7 @@ testRule({
 	fix: true,
 	accept: [
 		{
-			code: 'a { color: red; }',
+			code: 'a { border-color: background; }',
 		},
 	],
 

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
@@ -7,7 +7,11 @@ testRule({
 	fix: true,
 	accept: [
 		{
-			code: 'a { border-color: background; }',
+			code: 'a { color: red; }',
+		},
+		{
+			code: 'a { scrollbar-color: red Background; border-color: green yellow blue WindowFrame; }',
+			description: 'properties that accept multiple keywords are not yet supported',
 		},
 	],
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#8327

> Is there anything in the PR that needs further explanation?

1.
`border-color` is not a single value color property.
i.e. it accepts 1, 2, 3 and 4
This was missed during the review of #8223.

2.
[shorthand properties are not supported](https://github.com/stylelint/stylelint/pull/8223#issue-2758167186)