### PR TITLE
Fix `declaration-property-value-keyword-no-deprecated` false positives for non-standard syntax values

### DIFF
--- a/.changeset/violet-shirts-dream.md
+++ b/.changeset/violet-shirts-dream.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `declaration-property-value-keyword-no-deprecated` false positives in styled component interpolations
+Fixed: `declaration-property-value-keyword-no-deprecated` false positives for non-standard syntax values

--- a/.changeset/violet-shirts-dream.md
+++ b/.changeset/violet-shirts-dream.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-property-value-keyword-no-deprecated` false positives in styled component interpolations

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
@@ -83,3 +83,23 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	customSyntax: 'postcss-scss',
+	config: true,
+	accept: [
+		{
+			code: `
+				$prefix: info;
+				a { background-color: $prefix + background; }
+			`,
+		},
+		{
+			code: `
+				$postfix: text;
+				a { background-color: menu + $postfix; }
+			`,
+		},
+	],
+});

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
@@ -7,6 +7,7 @@ const validateTypes = require('../../utils/validateTypes.cjs');
 const nodeFieldIndices = require('../../utils/nodeFieldIndices.cjs');
 const getDeclarationValue = require('../../utils/getDeclarationValue.cjs');
 const isStandardSyntaxDeclaration = require('../../utils/isStandardSyntaxDeclaration.cjs');
+const isStandardSyntaxValue = require('../../utils/isStandardSyntaxValue.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -126,6 +127,8 @@ const rule = (primary, secondaryOptions) => {
 			const { prop, value } = decl;
 
 			if (optionsMatches(secondaryOptions, 'ignoreKeywords', value)) return;
+
+			if (!isStandardSyntaxValue(value)) return;
 
 			const keywords = PROPERTY_NAME_TO_KEYWORDS.get(prop.toLowerCase());
 

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
@@ -128,13 +128,18 @@ const rule = (primary, secondaryOptions) => {
 
 			if (optionsMatches(secondaryOptions, 'ignoreKeywords', value)) return;
 
-			if (!isStandardSyntaxValue(value)) return;
-
 			const keywords = PROPERTY_NAME_TO_KEYWORDS.get(prop.toLowerCase());
 
 			if (!keywords) return;
 
 			const parsedValue = valueParser(getDeclarationValue(decl));
+			let isStandardKeyword = true;
+
+			parsedValue.walk(({ type, value: keyword }) => {
+				if (type === 'word' && !isStandardSyntaxValue(keyword)) isStandardKeyword = false;
+			});
+
+			if (!isStandardKeyword) return;
 
 			parsedValue.walk((node) => {
 				if (node.type !== 'word') return;

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
@@ -4,6 +4,7 @@ import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
+import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -123,6 +124,8 @@ const rule = (primary, secondaryOptions) => {
 			const { prop, value } = decl;
 
 			if (optionsMatches(secondaryOptions, 'ignoreKeywords', value)) return;
+
+			if (!isStandardSyntaxValue(value)) return;
 
 			const keywords = PROPERTY_NAME_TO_KEYWORDS.get(prop.toLowerCase());
 

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
@@ -125,13 +125,18 @@ const rule = (primary, secondaryOptions) => {
 
 			if (optionsMatches(secondaryOptions, 'ignoreKeywords', value)) return;
 
-			if (!isStandardSyntaxValue(value)) return;
-
 			const keywords = PROPERTY_NAME_TO_KEYWORDS.get(prop.toLowerCase());
 
 			if (!keywords) return;
 
 			const parsedValue = valueParser(getDeclarationValue(decl));
+			let isStandardKeyword = true;
+
+			parsedValue.walk(({ type, value: keyword }) => {
+				if (type === 'word' && !isStandardSyntaxValue(keyword)) isStandardKeyword = false;
+			});
+
+			if (!isStandardKeyword) return;
 
 			parsedValue.walk((node) => {
 				if (node.type !== 'word') return;

--- a/lib/utils/isStandardSyntaxValue.cjs
+++ b/lib/utils/isStandardSyntaxValue.cjs
@@ -19,6 +19,7 @@ function isStandardSyntaxValue(value) {
 	}
 
 	// SCSS variable (example $variable)
+	// styled component interpolation (example ${foo => foo.bar})
 	if (normalizedValue.startsWith('$')) {
 		return false;
 	}

--- a/lib/utils/isStandardSyntaxValue.mjs
+++ b/lib/utils/isStandardSyntaxValue.mjs
@@ -15,6 +15,7 @@ export default function isStandardSyntaxValue(value) {
 	}
 
 	// SCSS variable (example $variable)
+	// styled component interpolation (example ${foo => foo.bar})
 	if (normalizedValue.startsWith('$')) {
 		return false;
 	}


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #8327

> Is there anything in the PR that needs further explanation?

`${foo(({ background }) => background.bar)}` cannot be tested in the `accept` array because it gives a `CssSyntaxError` without `postcss-styled-syntax` which shan't be added as a dependency.
i.e. no `customSyntax: 'postcss-styled-syntax',` testRule
see discussion in #6556

ref: https://styled-components.com/docs/advanced#tagged-template-literals