### PR TITLE
Add `declaration-block-no-duplicate-properties` support for computing `EditInfo`

### DIFF
--- a/.changeset/nine-needles-grow.md
+++ b/.changeset/nine-needles-grow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `declaration-block-no-duplicate-properties` support for computing `EditInfo`

--- a/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/__tests__/index.mjs
@@ -253,6 +253,66 @@ testRule({
 
 testRule({
 	ruleName,
+	config: [true],
+	computeEditInfo: true,
+
+	accept: [],
+
+	reject: [
+		{
+			code: 'a { color: pink; color: orange }',
+			message: messages.rejected('color'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
+			fix: { range: [11, 24], text: '' },
+		},
+		{
+			code: 'a { COlOr: pink; coLOR: pink; color: pink }',
+			description: 'multiple duplicates - same',
+			warnings: [
+				{
+					message: messages.rejected('COlOr'),
+					line: 1,
+					column: 5,
+					endLine: 1,
+					endColumn: 10,
+					fix: { range: [4, 17], text: '' },
+				},
+				{
+					message: messages.rejected('coLOR'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 23,
+					fix: undefined,
+				},
+			],
+		},
+		{
+			code: 'a { color: pink; background: orange; color: orange }',
+			message: messages.rejected('color'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 10,
+			fix: { range: [4, 17], text: '' },
+		},
+		{
+			code: 'a { color: pink; background: orange; background: pink; }',
+			message: messages.rejected('background'),
+			line: 1,
+			column: 18,
+			endLine: 1,
+			endColumn: 28,
+			fix: { range: [29, 49], text: '' },
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: [true, { ignore: ['consecutive-duplicates'] }],
 	fix: true,
 
@@ -296,6 +356,27 @@ testRule({
 			code: 'p { font-size: 16px !important; font-weight: 400; font-size: 1rem; }',
 			fixed: 'p { font-size: 16px !important; font-weight: 400; }',
 			message: messages.rejected('font-size'),
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [true, { ignore: ['consecutive-duplicates'] }],
+	computeEditInfo: true,
+
+	accept: [],
+
+	reject: [
+		{
+			code: 'p { font-size: 16px; font-weight: 400; font-size: 1rem; }',
+			message: messages.rejected('font-size'),
+			fix: { range: [9, 26], text: '' },
+		},
+		{
+			code: 'p { font-size: 16px !important; font-weight: 400; font-size: 1rem; }',
+			message: messages.rejected('font-size'),
+			fix: { range: [50, 67], text: '' },
 		},
 	],
 });
@@ -487,6 +568,26 @@ testRule({
 			column: 29,
 			endLine: 1,
 			endColumn: 34,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [true, { ignore: ['consecutive-duplicates-with-different-values'] }],
+	computeEditInfo: true,
+
+	accept: [],
+
+	reject: [
+		{
+			code: 'p { font-size: 16px; font-size: 16px !important; font-weight: 400; }',
+			message: messages.rejected('font-size'),
+			line: 1,
+			column: 5,
+			endLine: 1,
+			endColumn: 14,
+			fix: { range: [19, 36], text: '' },
 		},
 	],
 });

--- a/lib/rules/declaration-block-no-duplicate-properties/index.cjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.cjs
@@ -225,7 +225,10 @@ const rule = (primary, secondaryOptions) => {
 						result,
 						ruleName,
 						word,
-						fix: fixer(node),
+						fix: {
+							apply: fixer(node),
+							node: node.parent,
+						},
 					});
 				};
 
@@ -260,7 +263,10 @@ const rule = (primary, secondaryOptions) => {
 						result,
 						ruleName,
 						word: duplicateDecl.prop,
-						fix: fixer(duplicateDecl),
+						fix: {
+							apply: fixer(duplicateDecl),
+							node: duplicateDecl.parent,
+						},
 					});
 				}
 

--- a/lib/rules/declaration-block-no-duplicate-properties/index.mjs
+++ b/lib/rules/declaration-block-no-duplicate-properties/index.mjs
@@ -222,7 +222,10 @@ const rule = (primary, secondaryOptions) => {
 						result,
 						ruleName,
 						word,
-						fix: fixer(node),
+						fix: {
+							apply: fixer(node),
+							node: node.parent,
+						},
 					});
 				};
 
@@ -257,7 +260,10 @@ const rule = (primary, secondaryOptions) => {
 						result,
 						ruleName,
 						word: duplicateDecl.prop,
-						fix: fixer(duplicateDecl),
+						fix: {
+							apply: fixer(duplicateDecl),
+							node: duplicateDecl.parent,
+						},
 					});
 				}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

This is the first PR in a series.

This rule didn't have any tests without `fix: true` in the test config.
I opted to only add a few new tests as the fixer itself has good coverage.

The needed change is simpler if a rule has existing tests without `fix: true`.
In such a case we could add `computeEditInfo: true` to the test config and add the `fix` expects.