### PR TITLE
Refactor `utils.report` to not restore mutated nodes in `computeEditInfo`

### DIFF
--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -262,9 +262,6 @@ function computeEditInfo({ fix, line, result: { stylelint }, ruleName }) {
 		return;
 	}
 
-	// Record the current state of the node that will be fixed
-	const fixedNodeClone = node.clone();
-
 	// Apply the fix
 	apply();
 
@@ -274,13 +271,10 @@ function computeEditInfo({ fix, line, result: { stylelint }, ruleName }) {
 		text: node.toString(),
 	});
 
-	// Restore the previous state of the fixed node
-	node.replaceWith(fixedNodeClone);
-
 	// Mark the fixed range as mutated
 	rangesOfComputedEditInfos.push(fixData.range);
 
-	return { ...fixData };
+	return fixData;
 }
 
 /**

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -270,9 +270,6 @@ function computeEditInfo({ fix, line, result: { stylelint }, ruleName }) {
 		return;
 	}
 
-	// Record the current state of the node that will be fixed
-	const fixedNodeClone = node.clone();
-
 	// Apply the fix
 	apply();
 
@@ -282,13 +279,10 @@ function computeEditInfo({ fix, line, result: { stylelint }, ruleName }) {
 		text: node.toString(),
 	});
 
-	// Restore the previous state of the fixed node
-	node.replaceWith(fixedNodeClone);
-
 	// Mark the fixed range as mutated
 	rangesOfComputedEditInfos.push(fixData.range);
 
-	return { ...fixData };
+	return fixData;
 }
 
 /**


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8364

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
