### PR TITLE
Fix `selector-class-pattern` false positives when using the column combinator

### DIFF
--- a/.changeset/nine-ducks-deny.md
+++ b/.changeset/nine-ducks-deny.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-class-pattern` false positives when using the column combinator

--- a/lib/rules/selector-class-pattern/__tests__/index.mjs
+++ b/lib/rules/selector-class-pattern/__tests__/index.mjs
@@ -319,6 +319,10 @@ testRule({
 			code: '.A { &>.B {} }',
 			message: messages.expected('.A', /^B+$/),
 		},
+		{
+			code: '.A { &||.B {} }',
+			message: messages.expected('.A', /^B+$/),
+		},
 	],
 });
 

--- a/lib/rules/selector-class-pattern/index.cjs
+++ b/lib/rules/selector-class-pattern/index.cjs
@@ -126,32 +126,31 @@ const rule = (primary, secondaryOptions) => {
  */
 function hasInterpolatingAmpersand(selector) {
 	for (const [i, char] of Array.from(selector).entries()) {
-		if (char !== '&') {
-			continue;
-		}
+		if (char !== '&') continue;
 
-		const prevChar = selector.charAt(i - 1);
-
-		if (prevChar && !isCombinator(prevChar)) {
-			return true;
-		}
-
-		const nextChar = selector.charAt(i + 1);
-
-		if (nextChar && !isCombinator(nextChar)) {
-			return true;
-		}
+		if (!hasAdjacentCombinator(selector, i)) return true;
 	}
 
 	return false;
 }
 
 /**
- * @param {string} x
- * @returns {boolean}
+ * @param {string} selector
+ * @param {number} index
  */
-function isCombinator(x) {
-	return /[\s+>~]/.test(x);
+function hasAdjacentCombinator(selector, index) {
+	const prevChar = selector.charAt(index - 1);
+	const fn = (/** @type {string} */ character) => /[\s+>~]/.test(character);
+
+	if (prevChar && fn(prevChar)) return true;
+
+	if (prevChar === '|' && selector.charAt(index - 2) === '|') return true;
+
+	const nextChar = selector.at(index + 1);
+
+	if (nextChar && fn(nextChar)) return true;
+
+	if (nextChar === '|' && selector.at(index + 2) === '|') return true;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/selector-class-pattern/index.mjs
+++ b/lib/rules/selector-class-pattern/index.mjs
@@ -123,32 +123,31 @@ const rule = (primary, secondaryOptions) => {
  */
 function hasInterpolatingAmpersand(selector) {
 	for (const [i, char] of Array.from(selector).entries()) {
-		if (char !== '&') {
-			continue;
-		}
+		if (char !== '&') continue;
 
-		const prevChar = selector.charAt(i - 1);
-
-		if (prevChar && !isCombinator(prevChar)) {
-			return true;
-		}
-
-		const nextChar = selector.charAt(i + 1);
-
-		if (nextChar && !isCombinator(nextChar)) {
-			return true;
-		}
+		if (!hasAdjacentCombinator(selector, i)) return true;
 	}
 
 	return false;
 }
 
 /**
- * @param {string} x
- * @returns {boolean}
+ * @param {string} selector
+ * @param {number} index
  */
-function isCombinator(x) {
-	return /[\s+>~]/.test(x);
+function hasAdjacentCombinator(selector, index) {
+	const prevChar = selector.charAt(index - 1);
+	const fn = (/** @type {string} */ character) => /[\s+>~]/.test(character);
+
+	if (prevChar && fn(prevChar)) return true;
+
+	if (prevChar === '|' && selector.charAt(index - 2) === '|') return true;
+
+	const nextChar = selector.at(index + 1);
+
+	if (nextChar && fn(nextChar)) return true;
+
+	if (nextChar === '|' && selector.at(index + 2) === '|') return true;
 }
 
 rule.ruleName = ruleName;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

1.
This is not supported by any browser yet but we do have precedents.
e.g. `:blank`, [`no-unknown-custom-media` rule](https://stylelint.io/user-guide/rules/no-unknown-custom-media)

2.
[demo](https://stylelint.io/demo/#N4Igxg9gJgpiBcIB0BBABMNAyA1EgQhgL5pEA6AdpahtgD50HGkgA0IAZgJYA2MAcgEMAtnEQwAHiIAOfJGADOCtuAgVuAcwQhglNGjIgATgFc+Cw-Ax79BkAph8wAFwhGAtGB6Cl76YOdnGCMqBDQAbUMAegA9fBwAEijDVlpDIxgFCB4ANwFMoKgAZUcYFzcLMOdTGFIAXRtyCiIVSHUuDQAxN2EA7QArLIoVWGllRF0KfUMFZwBPPh4uCmdLO28g2ZSbGfnF5edPNU13WcEKKEEjKDXDDYLDShaiIA)

3.
https://developer.mozilla.org/en-US/docs/Web/CSS/Column_combinator
Fyrd/caniuse#1058
Fyrd/caniuse#2369

4.
cf https://github.com/stylelint/stylelint/commit/5323f0a5e2f3ce6a05d23d0a2b9d919679521fbe#diff-3ff2a8966a90824e5659b4db8b336a644d195a28e773a17ccbf0e7e314c8b7a8R79

5.
Since it doesn't have a dedicated issue, I would prefer if it required at least two approvals for it to be merged.