### PR TITLE
Add regex support to `ignoreAtRules` option of `at-rule-empty-line-before`

### DIFF
--- a/.changeset/red-clouds-sit.md
+++ b/.changeset/red-clouds-sit.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `ignoreAtRules:[]` regex support in `at-rule-empty-line-before`

--- a/.changeset/red-clouds-sit.md
+++ b/.changeset/red-clouds-sit.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `ignoreAtRules:[]` regex support in `at-rule-empty-line-before`
+Added: regex support to `ignoreAtRules` option of `at-rule-empty-line-before`

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -399,7 +399,7 @@ The following patterns are _not_ considered problems:
 @media print {}
 ```
 
-### `ignoreAtRules: ["array", "of", "at-rules"]`
+### `ignoreAtRules: ["/regex/", /regex/, "string"]`
 
 Ignore specified at-rules.
 
@@ -408,7 +408,7 @@ For example, with `"always"`.
 Given:
 
 ```json
-["namespace"]
+["namespace", "/^--my-/"]
 ```
 
 The following patterns are _not_ considered problems:
@@ -417,4 +417,10 @@ The following patterns are _not_ considered problems:
 ```css
 @import "foo.css";
 @namespace svg url('http://www.w3.org/2000/svg');
+```
+
+<!-- prettier-ignore -->
+```css
+a {}
+@my-at-rule {}
 ```

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -408,7 +408,7 @@ For example, with `"always"`.
 Given:
 
 ```json
-["namespace", "/^--my-/"]
+["namespace", "/^my-/"]
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.mjs
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.mjs
@@ -756,6 +756,20 @@ testRule({
 
 testRule({
 	ruleName,
+	config: ['always', { ignoreAtRules: /^--my-/ }],
+
+	accept: [
+		{
+			code: `
+			a {}
+			@--my-at-rule {}
+		`,
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: ['always', { ignoreAtRules: '/el/' }],
 	fix: true,
 

--- a/lib/rules/at-rule-empty-line-before/index.cjs
+++ b/lib/rules/at-rule-empty-line-before/index.cjs
@@ -2,6 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
+const validateTypes = require('../../utils/validateTypes.cjs');
 const fixEmptyLinesBefore = require('../../utils/fixEmptyLinesBefore.cjs');
 const getPreviousNonSharedLineCommentNode = require('../../utils/getPreviousNonSharedLineCommentNode.cjs');
 const hasEmptyLine = require('../../utils/hasEmptyLine.cjs');
@@ -12,7 +13,6 @@ const isBlocklessAtRuleAfterSameNameBlocklessAtRule = require('../../utils/isBlo
 const isFirstNested = require('../../utils/isFirstNested.cjs');
 const isFirstNodeOfRoot = require('../../utils/isFirstNodeOfRoot.cjs');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule.cjs');
-const validateTypes = require('../../utils/validateTypes.cjs');
 const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -57,7 +57,7 @@ const rule = (primary, secondaryOptions, context) => {
 						'blockless-after-same-name-blockless',
 						'blockless-after-blockless',
 					],
-					ignoreAtRules: [validateTypes.isString],
+					ignoreAtRules: [validateTypes.isString, validateTypes.isRegExp],
 				},
 				optional: true,
 			},

--- a/lib/rules/at-rule-empty-line-before/index.mjs
+++ b/lib/rules/at-rule-empty-line-before/index.mjs
@@ -1,3 +1,4 @@
+import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import fixEmptyLinesBefore from '../../utils/fixEmptyLinesBefore.mjs';
 import getPreviousNonSharedLineCommentNode from '../../utils/getPreviousNonSharedLineCommentNode.mjs';
 import hasEmptyLine from '../../utils/hasEmptyLine.mjs';
@@ -8,7 +9,6 @@ import isBlocklessAtRuleAfterSameNameBlocklessAtRule from '../../utils/isBlockle
 import isFirstNested from '../../utils/isFirstNested.mjs';
 import isFirstNodeOfRoot from '../../utils/isFirstNodeOfRoot.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
-import { isString } from '../../utils/validateTypes.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -53,7 +53,7 @@ const rule = (primary, secondaryOptions, context) => {
 						'blockless-after-same-name-blockless',
 						'blockless-after-blockless',
 					],
-					ignoreAtRules: [isString],
+					ignoreAtRules: [isString, isRegExp],
 				},
 				optional: true,
 			},

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -316,7 +316,7 @@ declare namespace stylelint {
 					| 'blockless-after-same-name-blockless'
 					| 'blockless-after-blockless'
 				>;
-				ignoreAtRules: OneOrMany<string>;
+				ignoreAtRules: OneOrMany<StringOrRegex>;
 			}
 		>;
 		'at-rule-no-deprecated': CoreRule<true, { ignoreAtRules: OneOrMany<StringOrRegex> }>;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8377

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
