### PR TITLE
Fix `declaration-property-value-keyword-no-deprecated` false positives for styled components interpolated functions

### DIFF
--- a/.changeset/long-onions-know.md
+++ b/.changeset/long-onions-know.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-property-value-keyword-no-deprecated` false positives for styled components interpolated functions

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
@@ -162,6 +162,12 @@ testRule({
 		},
 		{
 			code: `
+				$prefix: info;
+				a { background-color: /* a */ $prefix /* b */ + /* c */ background /* d */; }
+			`,
+		},
+		{
+			code: `
 				$postfix: text;
 				a { background-color: menu + $postfix; }
 			`,

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
@@ -138,13 +138,15 @@ const rule = (primary, secondaryOptions) => {
 			if (!keywords) return;
 
 			const parsedValue = valueParser(getDeclarationValue(decl));
-			let isStandardKeyword = true;
+			let isStandardValue = true;
 
-			parsedValue.walk(({ type, value: keyword }) => {
-				if (type === 'word' && !isStandardSyntaxValue(keyword)) isStandardKeyword = false;
+			parsedValue.walk((node) => {
+				if (node.type === 'comment') return;
+
+				if (!isStandardSyntaxValue(node.value)) isStandardValue = false;
 			});
 
-			if (!isStandardKeyword) return;
+			if (!isStandardValue) return;
 
 			parsedValue.walk((node) => {
 				if (node.type !== 'word') return;

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
@@ -135,13 +135,15 @@ const rule = (primary, secondaryOptions) => {
 			if (!keywords) return;
 
 			const parsedValue = valueParser(getDeclarationValue(decl));
-			let isStandardKeyword = true;
+			let isStandardValue = true;
 
-			parsedValue.walk(({ type, value: keyword }) => {
-				if (type === 'word' && !isStandardSyntaxValue(keyword)) isStandardKeyword = false;
+			parsedValue.walk((node) => {
+				if (node.type === 'comment') return;
+
+				if (!isStandardSyntaxValue(node.value)) isStandardValue = false;
 			});
 
-			if (!isStandardKeyword) return;
+			if (!isStandardValue) return;
 
 			parsedValue.walk((node) => {
 				if (node.type !== 'word') return;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

follow-up of #8329
see https://github.com/stylelint/stylelint/issues/8327#issuecomment-2650992504

> Is there anything in the PR that needs further explanation?

To test you have to

1.
```sh
npm i -D postcss-styled-syntax
```

reminder: we don't support these syntaxes officially but if the fix is trivial we do make exceptions

2.
add
```js
testRule({
	ruleName,
	customSyntax: 'postcss-styled-syntax',
	config: true,
	accept: [
		{
			code: `
				export const s = styled.a\`
					background-color: \${palette(({ background }) => background.primary)};
				\`;
			`,
		},
	],
});
```
to `declaration-property-value-keyword-no-deprecated/__tests__/index.mjs`