### PR TITLE
Fix `font-family-name-quotes` false positives for vendor-prefixed font-size values

### DIFF
--- a/.changeset/witty-needles-flow.md
+++ b/.changeset/witty-needles-flow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `font-family-name-quotes` false positives due to vendor-prefixed font-size values

--- a/lib/reference/keywords.cjs
+++ b/lib/reference/keywords.cjs
@@ -132,6 +132,8 @@ const fontSizeKeywords = uniteSets(basicKeywords, [
 	'larger',
 	'smaller',
 	'math',
+	'-konq-xxx-large',
+	'-webkit-xxx-large',
 ]);
 
 const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);

--- a/lib/reference/keywords.mjs
+++ b/lib/reference/keywords.mjs
@@ -128,6 +128,8 @@ export const fontSizeKeywords = uniteSets(basicKeywords, [
 	'larger',
 	'smaller',
 	'math',
+	'-konq-xxx-large',
+	'-webkit-xxx-large',
 ]);
 
 const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);

--- a/lib/rules/font-family-name-quotes/__tests__/index.mjs
+++ b/lib/rules/font-family-name-quotes/__tests__/index.mjs
@@ -86,6 +86,9 @@ testRule({
 			code: 'a { font: italic 300 16px/30px "Arial", serif; }',
 		},
 		{
+			code: 'a { font: -webkit-xxx-large "Arial"; }',
+		},
+		{
 			code: 'a { font-family: "\u1100"; }',
 		},
 		{


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

follow-up of https://github.com/stylelint/stylelint/pull/7823/files#diff-55ac48e2b42df1382f80e3eb95f6e4aeb8ae0764fd62398512da7a9d3597c0c0R127

> Is there anything in the PR that needs further explanation?

https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/StandardCSSProperties.html#//apple_ref/doc/uid/TP30001266-font-size
w3c/csswg-drafts#3907
https://github.com/KDE/kdelibs/commit/4feea2dd7aa1b6a604ce1fd382853afcbe0b692c
[demo](https://stylelint.io/demo/#N4Igxg9gJgpiBcICGACYAdAdugLgMwkx3hQA9yBaAGyQCcBzGFdEAQVoEskqWAaFAM5JMAigJic8Abiy4CREhQDuMAEYBrDjgrlS1Oo2ZtO3PoOGjxkmdnyFiKCusIBHHZRoMmLdlx4h+IRExCQ5pLABfLACQPA4qGAA5JABbOEQYUlSABwSAOjABARjITDj6BBAMTBQjWgBXBIEWEmra2pZ5bTxU+IBPCkxUmAoXeogcGGaEI24lJD7Reswm0XUYPqUIWigWLFqozAiSwnKAMW2UpBxKgCsBQhjYbOLENqMBHD6Eqg4iFqMNEmnz4+w+Xx+f20pXKYhwwigdF2MxYQKmOD2RxAESAA)
