### PR TITLE
Fix pkg.pr.new-comment workflow

### DIFF
--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -19,6 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+      - name: Install Packages
+        run: npm ci
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #8352

> Is there anything in the PR that needs further explanation?

This PR is follow-up to #8353. 

This PR fixes the workflow of `pkg.pr.new-comment` to allow the automatic comment posting script to work.
The automatic comment posting script requires `lz-string`, but since `npm ci` was not run, `lz-string` was not found and it failed 😓 

https://github.com/stylelint/stylelint/actions/runs/13360990127/job/37310591018

