### PR TITLE
Add permissions to pkg.pr.new comment workflow

### DIFF
--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -23,6 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+      - name: Install Packages
+        run: npm ci
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pkg.pr.new-comment.yml
+++ b/.github/workflows/pkg.pr.new-comment.yml
@@ -6,6 +6,10 @@ name: Update pkg.pr.new comment
 # does not have the permission to comment on the pull request,
 # so the workflow is split.
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   workflow_run:
     workflows: [Publish to pkg.pr.new]
@@ -19,12 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: npm
-      - name: Install Packages
-        run: npm ci
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #8352

> Is there anything in the PR that needs further explanation?

This PR is follow-up to #8353, and #8401. 

This PR fixes the workflow of `pkg.pr.new-comment` to allow commenting on pull requests.

`pkg.pr.new-comment` tries to comment a link to the Demo site in the pull request, but it fails with 403 😓 

https://github.com/stylelint/stylelint/actions/runs/13448325443/job/37578178501

