### PR TITLE
Add `at-rule-empty-line-before` support for computing `EditInfo`

### DIFF
--- a/.changeset/metal-impalas-divide.md
+++ b/.changeset/metal-impalas-divide.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `at-rule-empty-line-before` support for computing `EditInfo`.
+Added: `at-rule-empty-line-before` support for computing `EditInfo`

--- a/.changeset/metal-impalas-divide.md
+++ b/.changeset/metal-impalas-divide.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `at-rule-empty-line-before` support for computing `EditInfo`.

--- a/lib/rules/at-rule-empty-line-before/__tests__/index.mjs
+++ b/lib/rules/at-rule-empty-line-before/__tests__/index.mjs
@@ -53,51 +53,61 @@ const sharedAlwaysTests = {
 			code: 'a {} @media {}',
 			fixed: 'a {}\n\n @media {}',
 			message: messages.expected,
+			fix: { range: [3, 4], text: '}\n\n' },
 		},
 		{
 			code: 'a {} @mEdIa {}',
 			fixed: 'a {}\n\n @mEdIa {}',
 			message: messages.expected,
+			fix: { range: [3, 4], text: '}\n\n' },
 		},
 		{
 			code: 'a {} @MEDIA {}',
 			fixed: 'a {}\n\n @MEDIA {}',
 			message: messages.expected,
+			fix: { range: [3, 4], text: '}\n\n' },
 		},
 		{
 			code: '@keyframes foo {} @media {}',
 			fixed: '@keyframes foo {}\n\n @media {}',
 			message: messages.expected,
+			fix: { range: [16, 17], text: '}\n\n' },
 		},
 		{
 			code: '@-webkit-keyframes foo {} @media {}',
 			fixed: '@-webkit-keyframes foo {}\n\n @media {}',
 			message: messages.expected,
+			fix: { range: [24, 25], text: '}\n\n' },
 		},
 		{
 			code: '@-webkit-keyframes foo {} @-webkit-keyframes bar {}',
 			fixed: '@-webkit-keyframes foo {}\n\n @-webkit-keyframes bar {}',
 			message: messages.expected,
+			fix: { range: [24, 25], text: '}\n\n' },
 		},
 		{
 			code: 'a {}\n@media {}',
 			fixed: 'a {}\n\n@media {}',
 			message: messages.expected,
+			fix: { range: [4, 5], text: '\n\n' },
 		},
 		{
 			code: 'a {}\r\n@media {}',
 			fixed: 'a {}\r\n\r\n@media {}',
 			message: messages.expected,
+			fix: { range: [5, 6], text: '\n\r\n' },
 		},
 		{
 			code: 'a {}\n\n/* comment */\n@media {}',
 			fixed: 'a {}\n\n/* comment */\n\n@media {}',
 			message: messages.expected,
+			fix: { range: [19, 20], text: '\n\n' },
 		},
 		{
 			code: 'a {}\r\n\r\n/* comment */\r\n@media {}',
 			fixed: 'a {}\r\n\r\n/* comment */\r\n\r\n@media {}',
 			message: messages.expected,
+			fix: { range: [22, 23], text: '\n\r\n' },
 		},
 	],
 };
@@ -131,21 +141,25 @@ const sharedNeverTests = {
 			code: 'a {}\n\n@media {}',
 			fixed: 'a {}\n@media {}',
 			message: messages.rejected,
+			fix: { range: [5, 6], text: '' },
 		},
 		{
 			code: 'a {}\r\n\r\n@media {}',
 			fixed: 'a {}\r\n@media {}',
 			message: messages.rejected,
+			fix: { range: [6, 8], text: '' },
 		},
 		{
 			code: '@keyframes foo {}\n/* comment */\n\n@media {}',
 			fixed: '@keyframes foo {}\n/* comment */\n@media {}',
 			message: messages.rejected,
+			fix: { range: [32, 33], text: '' },
 		},
 		{
 			code: '@keyframes foo {}\r\n/* comment */\r\n\r\n@media {}',
 			fixed: '@keyframes foo {}\r\n/* comment */\r\n@media {}',
 			message: messages.rejected,
+			fix: { range: [34, 36], text: '' },
 		},
 	],
 };
@@ -155,6 +169,7 @@ testRule(
 		ruleName,
 		config: ['always'],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -169,6 +184,7 @@ testRule(
 		ruleName,
 		config: ['always', { except: ['blockless-after-blockless'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -193,11 +209,13 @@ testRule(
 				code: "@keyframes foo {}\n@import 'x.css'",
 				fixed: "@keyframes foo {}\n\n@import 'x.css'",
 				message: messages.expected,
+				fix: { range: [17, 18], text: '\n\n' },
 			},
 			{
 				code: "@import 'x.css';\n\n@import 'y.css'",
 				fixed: "@import 'x.css';\n@import 'y.css'",
 				message: messages.rejected,
+				fix: { range: [17, 18], text: '' },
 			},
 		],
 	}),
@@ -207,6 +225,7 @@ testRule({
 	ruleName,
 	config: ['always', { except: ['blockless-after-blockless'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -226,11 +245,13 @@ testRule({
 			code: "@keyframes foo {}\n@import 'x.css'",
 			fixed: "@keyframes foo {}\n\n@import 'x.css'",
 			message: messages.expected,
+			fix: { range: [17, 18], text: '\n\n' },
 		},
 		{
 			code: "@import 'x.css';\n\n@import 'y.css'",
 			fixed: "@import 'x.css';\n@import 'y.css'",
 			message: messages.rejected,
+			fix: { range: [17, 18], text: '' },
 		},
 	],
 });
@@ -239,6 +260,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignore: ['blockless-after-blockless'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -253,11 +275,13 @@ testRule({
 			message: messages.expected,
 			line: 1,
 			column: 18,
+			fix: { range: [15, 16], text: ';\n\n' },
 		},
 		{
 			code: "@import 'test'; @include mixin(1) { @content; };",
 			fixed: "@import 'test';\n\n @include mixin(1) { @content; };",
 			message: messages.expected,
+			fix: { range: [14, 15], text: ';\n\n' },
 		},
 	],
 });
@@ -266,6 +290,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignore: ['after-comment'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -285,6 +310,7 @@ testRule({
 			code: 'a {} @media {}',
 			fixed: 'a {}\n\n @media {}',
 			message: messages.expected,
+			fix: { range: [3, 4], text: '}\n\n' },
 		},
 		{
 			code: 'bar {} /* foo */\n@media {}',
@@ -293,6 +319,7 @@ testRule({
 			line: 2,
 			column: 1,
 			description: 'after shared-line comment',
+			fix: { range: [16, 17], text: '\n\n' },
 		},
 	],
 });
@@ -301,6 +328,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignore: ['first-nested'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -318,6 +346,7 @@ testRule({
 			message: messages.expected,
 			line: 3,
 			column: 3,
+			fix: { range: [23, 24], text: '\n\n' },
 		},
 	],
 });
@@ -327,6 +356,7 @@ testRule(
 		ruleName,
 		config: ['always', { except: ['inside-block'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -342,11 +372,13 @@ testRule(
 				code: 'a {\n\n  @mixin foo;\n  color: pink;\n}',
 				fixed: 'a {\n  @mixin foo;\n  color: pink;\n}',
 				message: messages.rejected,
+				fix: { range: [4, 5], text: '' },
 			},
 			{
 				code: 'a {\n\n  color: pink;\n\n  @mixin foo;\n}',
 				fixed: 'a {\n\n  color: pink;\n  @mixin foo;\n}',
 				message: messages.rejected,
+				fix: { range: [20, 21], text: '' },
 			},
 		],
 	}),
@@ -357,6 +389,7 @@ testRule(
 		ruleName,
 		config: ['always', { except: ['first-nested'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -373,16 +406,19 @@ testRule(
 				code: 'a {\n  color: pink;\n  @mixin foo;\n}',
 				fixed: 'a {\n  color: pink;\n\n  @mixin foo;\n}',
 				message: messages.expected,
+				fix: { range: [18, 19], text: '\n\n' },
 			},
 			{
 				code: 'a {\n\n  @mixin foo;\n  color: pink;\n}',
 				fixed: 'a {\n  @mixin foo;\n  color: pink;\n}',
 				message: messages.rejected,
+				fix: { range: [4, 5], text: '' },
 			},
 			{
 				code: 'a {/* comment */\n\n  @mixin foo;\n  color: pink;\n}',
 				fixed: 'a {/* comment */\n  @mixin foo;\n  color: pink;\n}',
 				message: messages.rejected,
+				fix: { range: [17, 18], text: '' },
 			},
 		],
 	}),
@@ -393,6 +429,7 @@ testRule(
 		ruleName,
 		config: ['always', { ignore: ['inside-block'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -416,6 +453,7 @@ testRule(
 		ruleName,
 		config: ['always', { except: ['blockless-after-blockless', 'inside-block'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -446,21 +484,25 @@ testRule(
 				code: "@keyframes foo {}\n@import 'x.css'",
 				fixed: "@keyframes foo {}\n\n@import 'x.css'",
 				message: messages.expected,
+				fix: { range: [17, 18], text: '\n\n' },
 			},
 			{
 				code: "@import 'x.css';\n\n@import 'y.css'",
 				fixed: "@import 'x.css';\n@import 'y.css'",
 				message: messages.rejected,
+				fix: { range: [17, 18], text: '' },
 			},
 			{
 				code: 'a {\n\n  @mixin foo;\n  color: pink;\n}',
 				fixed: 'a {\n  @mixin foo;\n  color: pink;\n}',
 				message: messages.rejected,
+				fix: { range: [4, 5], text: '' },
 			},
 			{
 				code: 'a {\n\n  color: pink;\n\n  @mixin foo;\n}',
 				fixed: 'a {\n\n  color: pink;\n  @mixin foo;\n}',
 				message: messages.rejected,
+				fix: { range: [20, 21], text: '' },
 			},
 		],
 	}),
@@ -471,6 +513,7 @@ testRule(
 		ruleName,
 		config: ['never'],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -485,6 +528,7 @@ testRule(
 		ruleName,
 		config: ['never', { except: ['blockless-after-blockless'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -509,11 +553,13 @@ testRule(
 				code: "@keyframes foo {}\n\n@import 'x.css'",
 				fixed: "@keyframes foo {}\n@import 'x.css'",
 				message: messages.rejected,
+				fix: { range: [18, 19], text: '' },
 			},
 			{
 				code: "@import 'x.css';\n@import 'y.css'",
 				fixed: "@import 'x.css';\n\n@import 'y.css'",
 				message: messages.expected,
+				fix: { range: [16, 17], text: '\n\n' },
 			},
 		],
 	}),
@@ -524,6 +570,7 @@ testRule(
 		ruleName,
 		config: ['never', { except: ['inside-block'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -539,11 +586,13 @@ testRule(
 				code: 'a {\n  @mixin foo;\n  color: pink;\n}',
 				fixed: 'a {\n\n  @mixin foo;\n  color: pink;\n}',
 				message: messages.expected,
+				fix: { range: [3, 4], text: '\n\n' },
 			},
 			{
 				code: 'a {\n\n  color: pink;\n  @mixin foo;\n}',
 				fixed: 'a {\n\n  color: pink;\n\n  @mixin foo;\n}',
 				message: messages.expected,
+				fix: { range: [19, 20], text: '\n\n' },
 			},
 		],
 	}),
@@ -554,6 +603,7 @@ testRule(
 		ruleName,
 		config: ['never', { except: ['first-nested'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -566,11 +616,13 @@ testRule(
 				code: 'a {\n  color: pink;\n\n  @mixin foo;\n}',
 				fixed: 'a {\n  color: pink;\n  @mixin foo;\n}',
 				message: messages.rejected,
+				fix: { range: [19, 20], text: '' },
 			},
 			{
 				code: 'a {\n  @mixin foo;\n  color: pink;\n}',
 				fixed: 'a {\n\n  @mixin foo;\n  color: pink;\n}',
 				message: messages.expected,
+				fix: { range: [3, 4], text: '\n\n' },
 			},
 		],
 	}),
@@ -580,6 +632,7 @@ testRule({
 	ruleName,
 	config: ['never', { ignore: ['blockless-after-blockless'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -617,6 +670,7 @@ testRule({
 			message: messages.rejected,
 			line: 4,
 			column: 7,
+			fix: { range: [24, 25], text: '' },
 		},
 	],
 });
@@ -625,6 +679,7 @@ testRule({
 	ruleName,
 	config: ['never', { ignore: ['after-comment'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -644,12 +699,14 @@ testRule({
 			code: 'b {}\n\n@media {}',
 			fixed: 'b {}\n@media {}',
 			message: messages.rejected,
+			fix: { range: [5, 6], text: '' },
 		},
 		{
 			code: 'b {}\r\n\r\n@media {}',
 			fixed: 'b {}\r\n@media {}',
 			description: 'CRLF',
 			message: messages.rejected,
+			fix: { range: [6, 8], text: '' },
 		},
 		{
 			code: 'b {} /* comment */\n\n@media {}',
@@ -658,6 +715,7 @@ testRule({
 			message: messages.rejected,
 			line: 3,
 			column: 1,
+			fix: { range: [19, 20], text: '' },
 		},
 	],
 });
@@ -667,6 +725,7 @@ testRule(
 		ruleName,
 		config: ['never', { ignore: ['inside-block'] }],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -689,6 +748,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignoreAtRules: ['else'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -734,6 +794,7 @@ testRule({
 			message: messages.expected,
 			line: 3,
 			column: 9,
+			fix: { range: [25, 26], text: '}\n\n' },
 		},
 		{
 			code: `
@@ -750,6 +811,7 @@ testRule({
 			message: messages.expected,
 			line: 3,
 			column: 7,
+			fix: { range: [20, 21], text: '\n\n' },
 		},
 	],
 });
@@ -772,6 +834,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignoreAtRules: '/el/' }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -804,6 +867,7 @@ testRule({
 			message: messages.expected,
 			line: 5,
 			column: 7,
+			fix: { range: [43, 44], text: '\n\n' },
 		},
 	],
 });
@@ -812,6 +876,7 @@ testRule({
 	ruleName,
 	config: ['never', { ignoreAtRules: ['else'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -857,6 +922,7 @@ testRule({
 			message: messages.rejected,
 			line: 5,
 			column: 7,
+			fix: { range: [27, 28], text: '' },
 		},
 		{
 			code: `
@@ -875,6 +941,7 @@ testRule({
 			message: messages.rejected,
 			line: 5,
 			column: 7,
+			fix: { range: [27, 28], text: '' },
 		},
 	],
 });
@@ -883,6 +950,7 @@ testRule({
 	ruleName,
 	config: ['never', { ignoreAtRules: '/el/' }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -920,6 +988,7 @@ testRule({
 			message: messages.rejected,
 			line: 6,
 			column: 7,
+			fix: { range: [44, 45], text: '' },
 		},
 	],
 });
@@ -934,6 +1003,7 @@ testRule(
 			},
 		],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -978,6 +1048,7 @@ testRule(
 				message: messages.expected,
 				line: 2,
 				column: 1,
+				fix: { range: [17, 18], text: '\n\n' },
 			},
 			{
 				code: stripIndent`
@@ -1000,6 +1071,7 @@ testRule(
 				message: messages.expected,
 				line: 5,
 				column: 3,
+				fix: { range: [38, 39], text: '\n\n' },
 			},
 		],
 	}),
@@ -1015,6 +1087,7 @@ testRule(
 			},
 		],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -1059,6 +1132,7 @@ testRule(
 				message: messages.expected,
 				line: 2,
 				column: 1,
+				fix: { range: [17, 18], text: '\n\n' },
 			},
 			{
 				code: stripIndent`
@@ -1081,6 +1155,7 @@ testRule(
 				message: messages.expected,
 				line: 5,
 				column: 3,
+				fix: { range: [38, 39], text: '\n\n' },
 			},
 		],
 	}),
@@ -1096,6 +1171,7 @@ testRule(
 			},
 		],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -1132,6 +1208,7 @@ testRule(
 				message: messages.expected,
 				line: 3,
 				column: 1,
+				fix: { range: [37, 38], text: '\n\n' },
 			},
 			{
 				code: stripIndent`
@@ -1150,6 +1227,7 @@ testRule(
 				message: messages.expected,
 				line: 4,
 				column: 3,
+				fix: { range: [37, 38], text: '\n\n' },
 			},
 		],
 	}),
@@ -1164,6 +1242,7 @@ testRule({
 		},
 	],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -1200,6 +1279,7 @@ testRule({
 			message: messages.expected,
 			line: 2,
 			column: 1,
+			fix: { range: [17, 18], text: '\n\n' },
 		},
 		{
 			code: stripIndent`
@@ -1222,6 +1302,7 @@ testRule({
 			message: messages.expected,
 			line: 5,
 			column: 3,
+			fix: { range: [38, 39], text: '\n\n' },
 		},
 	],
 });
@@ -1236,6 +1317,7 @@ testRule(
 			},
 		],
 		fix: true,
+		computeEditInfo: true,
 
 		accept: [
 			{
@@ -1272,6 +1354,7 @@ testRule(
 				message: messages.expected,
 				line: 3,
 				column: 1,
+				fix: { range: [29, 30], text: '\n\n' },
 			},
 			{
 				code: stripIndent`
@@ -1290,6 +1373,7 @@ testRule(
 				message: messages.expected,
 				line: 4,
 				column: 3,
+				fix: { range: [34, 35], text: '\n\n' },
 			},
 		],
 	}),
@@ -1299,6 +1383,7 @@ testRule({
 	ruleName,
 	customSyntax: 'postcss-less',
 	config: ['always'],
+	computeEditInfo: true,
 
 	accept: [
 		{

--- a/lib/rules/at-rule-empty-line-before/index.cjs
+++ b/lib/rules/at-rule-empty-line-before/index.cjs
@@ -157,7 +157,10 @@ const rule = (primary, secondaryOptions, context) => {
 				node: atRule,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: atRule.parent,
+				},
 			});
 		});
 	};

--- a/lib/rules/at-rule-empty-line-before/index.mjs
+++ b/lib/rules/at-rule-empty-line-before/index.mjs
@@ -153,7 +153,10 @@ const rule = (primary, secondaryOptions, context) => {
 				node: atRule,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: atRule.parent,
+				},
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
