### PR TITLE
Add `at-rule-no-deprecated` support for computing `EditInfo`

### DIFF
--- a/.changeset/heavy-seas-drop.md
+++ b/.changeset/heavy-seas-drop.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `at-rule-no-deprecated` support computing `EditInfo`.

--- a/.changeset/heavy-seas-drop.md
+++ b/.changeset/heavy-seas-drop.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `at-rule-no-deprecated` support computing `EditInfo`.
+Added: `at-rule-no-deprecated` support for computing `EditInfo`

--- a/lib/rules/at-rule-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/at-rule-no-deprecated/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -48,6 +49,10 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 10,
+			fix: {
+				range: [4, 10],
+				text: '',
+			},
 		},
 		{
 			code: 'a { @NEST .foo & {} }',
@@ -57,6 +62,10 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 10,
+			fix: {
+				range: [4, 10],
+				text: '',
+			},
 		},
 		{
 			code: 'a { @apply foo; }',
@@ -78,6 +87,10 @@ testRule({
 					column: 5,
 					endLine: 1,
 					endColumn: 10,
+					fix: {
+						range: [4, 10],
+						text: '',
+					},
 				},
 				{
 					message: rule.messages.rejected('@nest'),
@@ -85,6 +98,7 @@ testRule({
 					column: 19,
 					endLine: 1,
 					endColumn: 24,
+					fix: undefined,
 				},
 			],
 		},

--- a/lib/rules/at-rule-no-deprecated/index.cjs
+++ b/lib/rules/at-rule-no-deprecated/index.cjs
@@ -73,7 +73,10 @@ const rule = (primary, secondaryOptions) => {
 				result,
 				index: 0,
 				endIndex: atName.length,
-				fix,
+				fix: {
+					apply: fix,
+					node: atRule.parent,
+				},
 			});
 		});
 	};

--- a/lib/rules/at-rule-no-deprecated/index.mjs
+++ b/lib/rules/at-rule-no-deprecated/index.mjs
@@ -70,7 +70,10 @@ const rule = (primary, secondaryOptions) => {
 				result,
 				index: 0,
 				endIndex: atName.length,
-				fix,
+				fix: {
+					apply: fix,
+					node: atRule.parent,
+				},
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
