### PR TITLE
Add `at-rule-no-vendor-prefix` support for computing `EditInfo`

### DIFF
--- a/.changeset/sixty-boats-dream.md
+++ b/.changeset/sixty-boats-dream.md
@@ -2,4 +2,4 @@
 "stylelint": minor
 ---
 
-Added: `at-rule-no-vendor-prefix` support computing `EditInfo`.
+Added: `at-rule-no-vendor-prefix` support for computing `EditInfo`

--- a/.changeset/sixty-boats-dream.md
+++ b/.changeset/sixty-boats-dream.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `at-rule-no-vendor-prefix` support computing `EditInfo`.

--- a/lib/rules/at-rule-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/at-rule-no-vendor-prefix/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -24,6 +25,10 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 19,
+			fix: {
+				range: [1, 9],
+				text: '',
+			},
 		},
 		{
 			code: '@-wEbKiT-kEyFrAmEs { 0% { top: 0; } }',
@@ -33,6 +38,10 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 19,
+			fix: {
+				range: [1, 9],
+				text: '',
+			},
 		},
 		{
 			code: '@-WEBKIT-KEYFRAMES { 0% { top: 0; } }',
@@ -42,6 +51,10 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 19,
+			fix: {
+				range: [1, 9],
+				text: '',
+			},
 		},
 		{
 			code: '@-moz-keyframes { 0% { top: 0; } }',
@@ -51,6 +64,10 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 16,
+			fix: {
+				range: [1, 6],
+				text: '',
+			},
 		},
 		{
 			code: '@-ms-viewport { orientation: landscape; }',
@@ -60,6 +77,10 @@ testRule({
 			column: 1,
 			endLine: 1,
 			endColumn: 14,
+			fix: {
+				range: [1, 5],
+				text: '',
+			},
 		},
 	],
 });

--- a/lib/rules/at-rule-no-vendor-prefix/index.cjs
+++ b/lib/rules/at-rule-no-vendor-prefix/index.cjs
@@ -56,7 +56,10 @@ const rule = (primary) => {
 				word: atName,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: atRule,
+				},
 			});
 		});
 	};

--- a/lib/rules/at-rule-no-vendor-prefix/index.mjs
+++ b/lib/rules/at-rule-no-vendor-prefix/index.mjs
@@ -52,7 +52,10 @@ const rule = (primary) => {
 				word: atName,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: atRule,
+				},
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
