### PR TITLE
Add `color-function-notation` support for computing `EditInfo`

### DIFF
--- a/.changeset/rude-phones-sit.md
+++ b/.changeset/rude-phones-sit.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `color-function-notation` support for computing `EditInfo`

--- a/lib/rules/color-function-notation/__tests__/index.mjs
+++ b/lib/rules/color-function-notation/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: ['modern'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -79,6 +80,10 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 24,
+			fix: {
+				range: [16, 20],
+				text: ' 0',
+			},
 		},
 		{
 			code: 'a { color: rgba(0, 0, 0, 0) }',
@@ -88,6 +93,10 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 28,
+			fix: {
+				range: [14, 24],
+				text: '(0 0 0 /',
+			},
 		},
 		{
 			code: 'a { color: rgba(0, 0, 0, 50%) }',
@@ -97,6 +106,10 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 30,
+			fix: {
+				range: [14, 24],
+				text: '(0 0 0 /',
+			},
 		},
 		{
 			code: 'a { color: rgba(0 , 0 , 0 , 50%) }',
@@ -106,6 +119,10 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 33,
+			fix: {
+				range: [14, 27],
+				text: '(0 0 0 /',
+			},
 		},
 		{
 			code: 'a { color: rgba(0,0,0,50%) }',
@@ -115,6 +132,10 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 27,
+			fix: {
+				range: [14, 22],
+				text: '(0 0 0 / ',
+			},
 		},
 		{
 			code: 'a { color: rgba(var(--r, 20), var(--g), var(--b), 0.6); }',
@@ -124,6 +145,10 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 55,
+			fix: {
+				range: [14, 49],
+				text: '(var(--r, 20) var(--g) var(--b) /',
+			},
 		},
 		{
 			code: stripIndent`
@@ -147,6 +172,10 @@ testRule({
 			column: 9,
 			endLine: 5,
 			endColumn: 3,
+			fix: {
+				range: [15, 54],
+				text: stripIndent`(\n\t\tcalc(var(--hue) + 30)\n\t\t28% 50% /`,
+			},
 		},
 		{
 			code: stripIndent`
@@ -172,6 +201,10 @@ testRule({
 			column: 9,
 			endLine: 6,
 			endColumn: 3,
+			fix: {
+				range: [15, 54],
+				text: stripIndent`(\n\t\tcalc(var(--hue) + 30)\n\t\t28% 50% /`,
+			},
 		},
 		{
 			code: stripIndent`
@@ -197,6 +230,10 @@ testRule({
 			column: 9,
 			endLine: 6,
 			endColumn: 3,
+			fix: {
+				range: [15, 56],
+				text: `(\n\t\tcalc(var(--hue) + 30)\n\t\t28%\n\t\t50% /`,
+			},
 		},
 		{
 			code: stripIndent`
@@ -220,6 +257,10 @@ testRule({
 			column: 9,
 			endLine: 5,
 			endColumn: 3,
+			fix: {
+				range: [15, 82],
+				text: '(\n\t\tcalc(var(--hue) + 30) /* comment */\n\t\t28% 50% /* comment */ /',
+			},
 		},
 		{
 			code: stripIndent`
@@ -245,6 +286,10 @@ testRule({
 			column: 9,
 			endLine: 6,
 			endColumn: 3,
+			fix: {
+				range: [15, 85],
+				text: '(\n\t\tcalc(var(--hue) + 30) /* comment */\n\t\t28% 50% /* comment */\n\t\t/',
+			},
 		},
 		{
 			code: stripIndent`
@@ -266,8 +311,22 @@ testRule({
 				}
 			`,
 			warnings: [
-				{ message: messages.expected('modern'), line: 4, column: 3, endLine: 4, endColumn: 23 },
-				{ message: messages.expected('modern'), line: 5, column: 3, endLine: 5, endColumn: 21 },
+				{
+					message: messages.expected('modern'),
+					line: 4,
+					column: 3,
+					endLine: 4,
+					endColumn: 23,
+					fix: { range: [57, 71], text: '(30 75 115 /' },
+				},
+				{
+					message: messages.expected('modern'),
+					line: 5,
+					column: 3,
+					endLine: 5,
+					endColumn: 21,
+					fix: undefined,
+				},
 			],
 		},
 	],
@@ -402,6 +461,7 @@ testRule({
 	customSyntax: 'postcss-scss',
 	config: ['modern'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -450,6 +510,10 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 17,
+			fix: {
+				range: [9, 13],
+				text: ' 0',
+			},
 		},
 		{
 			code: '$a: rgb(0, 0, 0, 0);',
@@ -459,6 +523,10 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [9, 16],
+				text: ' 0 0 /',
+			},
 		},
 	],
 });

--- a/lib/rules/color-function-notation/index.cjs
+++ b/lib/rules/color-function-notation/index.cjs
@@ -120,7 +120,10 @@ const rule = (primary, secondaryOptions) => {
 					endIndex,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});

--- a/lib/rules/color-function-notation/index.mjs
+++ b/lib/rules/color-function-notation/index.mjs
@@ -117,7 +117,10 @@ const rule = (primary, secondaryOptions) => {
 					endIndex,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
