### PR TITLE
Add `declaration-property-value-keyword-no-deprecated` support for computing `EditInfo`.

### DIFF
--- a/.changeset/rotten-pumas-post.md
+++ b/.changeset/rotten-pumas-post.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `declaration-property-value-keyword-no-deprecated` support for computing `EditInfo`.

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/__tests__/index.mjs
@@ -5,6 +5,8 @@ testRule({
 	ruleName,
 	config: true,
 	fix: true,
+	computeEditInfo: true,
+
 	accept: [
 		{
 			code: 'a { color: red; }',
@@ -20,6 +22,10 @@ testRule({
 			column: 17,
 			endLine: 1,
 			endColumn: 28,
+			fix: {
+				range: [16, 27],
+				text: 'auto',
+			},
 		},
 		{
 			code: 'a { color: InactiveCaptionText; }',
@@ -29,6 +35,10 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 31,
+			fix: {
+				range: [11, 26],
+				text: 'Gray',
+			},
 		},
 		{
 			code: 'a { zOom: /*qux*/reset/*baz*/; }',
@@ -38,6 +48,10 @@ testRule({
 			column: 18,
 			endLine: 1,
 			endColumn: 23,
+			fix: {
+				range: [17, 22],
+				text: '1',
+			},
 		},
 		{
 			code: 'a { overflow-x: overlay; }',
@@ -47,6 +61,10 @@ testRule({
 			column: 17,
 			endLine: 1,
 			endColumn: 24,
+			fix: {
+				range: [16, 23],
+				text: 'auto',
+			},
 		},
 		{
 			code: 'a { border-color: green yellow WindowFrame blue; }',
@@ -56,6 +74,10 @@ testRule({
 			column: 32,
 			endLine: 1,
 			endColumn: 43,
+			fix: {
+				range: [31, 42],
+				text: 'ButtonBorder',
+			},
 		},
 		{
 			code: 'a { scrollbar-color: red Background; }',
@@ -65,6 +87,10 @@ testRule({
 			column: 26,
 			endLine: 1,
 			endColumn: 36,
+			fix: {
+				range: [25, 35],
+				text: 'canvas',
+			},
 		},
 		{
 			code: 'a { overflow: overlay; }',
@@ -74,6 +100,10 @@ testRule({
 			column: 15,
 			endLine: 1,
 			endColumn: 22,
+			fix: {
+				range: [14, 21],
+				text: 'auto',
+			},
 		},
 		{
 			code: 'a { overflow: hidden overlay; }',
@@ -83,6 +113,10 @@ testRule({
 			column: 22,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [21, 28],
+				text: 'auto',
+			},
 		},
 		{
 			code: 'a { overflow: hidden /* comment */ overlay; }',
@@ -92,6 +126,10 @@ testRule({
 			column: 36,
 			endLine: 1,
 			endColumn: 43,
+			fix: {
+				range: [35, 42],
+				text: 'auto',
+			},
 		},
 		{
 			code: 'a { text-decoration-line: /* foo */blink/* bar */; }',

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
@@ -183,7 +183,10 @@ const rule = (primary, secondaryOptions) => {
 					ruleName,
 					index,
 					endIndex,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
@@ -180,7 +180,10 @@ const rule = (primary, secondaryOptions) => {
 					ruleName,
 					index,
 					endIndex,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
