### PR TITLE
Add `function-calc-no-unspaced-operator` support for computing `EditInfo`.

### DIFF
--- a/.changeset/yummy-signs-cross.md
+++ b/.changeset/yummy-signs-cross.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `function-calc-no-unspaced-operator` support for computing `EditInfo`.

--- a/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -263,40 +264,110 @@ testRule({
 			fixed: 'a { top: calc(2px + 1px); }',
 			description: 'no space before or after operator',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
-				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 19,
+					fix: { range: [17, 18], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 19,
+					fix: undefined,
+				},
 			],
 		},
 		{
 			code: 'a { top: calc-size(any, 2px+1px); }',
 			fixed: 'a { top: calc-size(any, 2px + 1px); }',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, column: 28, endLine: 1, endColumn: 29 },
-				{ message: messages.expectedBefore('+'), line: 1, column: 28, endLine: 1, endColumn: 29 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 28,
+					endLine: 1,
+					endColumn: 29,
+					fix: { range: [27, 28], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 28,
+					endLine: 1,
+					endColumn: 29,
+					fix: undefined,
+				},
 			],
 		},
 		{
 			code: 'a { transform: rotate(acos(2+1)); }',
 			fixed: 'a { transform: rotate(acos(2 + 1)); }',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
-				{ message: messages.expectedBefore('+'), line: 1, column: 29, endLine: 1, endColumn: 30 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 29,
+					endLine: 1,
+					endColumn: 30,
+					fix: { range: [28, 29], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 29,
+					endLine: 1,
+					endColumn: 30,
+					fix: undefined,
+				},
 			],
 		},
 		{
 			code: 'a { scale: rem(10+2, 1.7); }',
 			fixed: 'a { scale: rem(10 + 2, 1.7); }',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
-				{ message: messages.expectedBefore('+'), line: 1, column: 18, endLine: 1, endColumn: 19 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 19,
+					fix: { range: [17, 18], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 18,
+					endLine: 1,
+					endColumn: 19,
+					fix: undefined,
+				},
 			],
 		},
 		{
 			code: 'a { rotate: rem(10turn, 2turn+1turn); }',
 			fixed: 'a { rotate: rem(10turn, 2turn + 1turn); }',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
-				{ message: messages.expectedBefore('+'), line: 1, column: 30, endLine: 1, endColumn: 31 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					column: 30,
+					endLine: 1,
+					endColumn: 31,
+					fix: { range: [29, 30], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					column: 30,
+					endLine: 1,
+					endColumn: 31,
+					fix: undefined,
+				},
 			],
 		},
 		{
@@ -308,6 +379,10 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [19, 20],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { top: calc(1px +  -1px); }',
@@ -318,6 +393,10 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [20, 21],
+				text: '',
+			},
 		},
 		{
 			code: 'a { top: calc(1px+ 2px); }',
@@ -327,6 +406,10 @@ testRule({
 			column: 18,
 			endLine: 1,
 			endColumn: 19,
+			fix: {
+				range: [16, 17],
+				text: 'x ',
+			},
 		},
 		{
 			code: 'a { top: cAlC(1px+ 2px); }',
@@ -336,6 +419,10 @@ testRule({
 			column: 18,
 			endLine: 1,
 			endColumn: 19,
+			fix: {
+				range: [16, 17],
+				text: 'x ',
+			},
 		},
 		{
 			code: 'a { top: CALC(1px+ 2px); }',
@@ -345,6 +432,10 @@ testRule({
 			column: 18,
 			endLine: 1,
 			endColumn: 19,
+			fix: {
+				range: [16, 17],
+				text: 'x ',
+			},
 		},
 		{
 			code: 'a { top: calc(1px  + 2px); }',
@@ -354,6 +445,10 @@ testRule({
 			column: 20,
 			endLine: 1,
 			endColumn: 21,
+			fix: {
+				range: [18, 19],
+				text: '',
+			},
 		},
 		{
 			code: 'a { top: calc(1px\t+ 2px); }',
@@ -363,6 +458,10 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [17, 18],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { top: calc(1px +  2px); }',
@@ -372,6 +471,10 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [20, 21],
+				text: '',
+			},
 		},
 		{
 			code: 'a { top: calc(1px +\t2px); }',
@@ -381,6 +484,10 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [19, 20],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { top: calc(1px- 2px); }',
@@ -390,6 +497,10 @@ testRule({
 			column: 18,
 			endLine: 1,
 			endColumn: 19,
+			fix: {
+				range: [16, 17],
+				text: 'x ',
+			},
 		},
 		{
 			code: 'a { top: calc(1px +2px); }',
@@ -399,6 +510,10 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [18, 19],
+				text: '+ ',
+			},
 		},
 		{
 			code: 'a { top: calc(1px -2px); }',
@@ -408,6 +523,10 @@ testRule({
 			column: 19,
 			endLine: 1,
 			endColumn: 20,
+			fix: {
+				range: [18, 19],
+				text: '- ',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px +\t-1px); }',
@@ -418,6 +537,10 @@ testRule({
 			column: 28,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [28, 29],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px +  -1px); }',
@@ -428,6 +551,10 @@ testRule({
 			column: 28,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [29, 30],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px+ 2px); }',
@@ -437,6 +564,10 @@ testRule({
 			column: 27,
 			endLine: 1,
 			endColumn: 28,
+			fix: {
+				range: [25, 26],
+				text: 'x ',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px  + 2px); }',
@@ -446,6 +577,10 @@ testRule({
 			column: 29,
 			endLine: 1,
 			endColumn: 30,
+			fix: {
+				range: [27, 28],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px\t+ 2px); }',
@@ -455,6 +590,10 @@ testRule({
 			column: 28,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [26, 27],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px +  2px); }',
@@ -464,6 +603,10 @@ testRule({
 			column: 28,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [29, 30],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px +\t2px); }',
@@ -473,6 +616,10 @@ testRule({
 			column: 28,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [28, 29],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px- 2px); }',
@@ -482,6 +629,10 @@ testRule({
 			column: 27,
 			endLine: 1,
 			endColumn: 28,
+			fix: {
+				range: [25, 26],
+				text: 'x ',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px +2px); }',
@@ -491,6 +642,10 @@ testRule({
 			column: 28,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [27, 28],
+				text: '+ ',
+			},
 		},
 		{
 			code: 'a { padding: 10px calc(1px -2px); }',
@@ -500,6 +655,10 @@ testRule({
 			column: 28,
 			endLine: 1,
 			endColumn: 29,
+			fix: {
+				range: [27, 28],
+				text: '- ',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem\t + 1em); }',
@@ -510,6 +669,10 @@ testRule({
 			column: 25,
 			endLine: 1,
 			endColumn: 26,
+			fix: {
+				range: [22, 23],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem  \t+ 1em); }',
@@ -520,6 +683,10 @@ testRule({
 			column: 26,
 			endLine: 1,
 			endColumn: 27,
+			fix: {
+				range: [23, 25],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem\t\f\r\t+ 1em); }',
@@ -530,6 +697,10 @@ testRule({
 			column: 27,
 			endLine: 1,
 			endColumn: 28,
+			fix: {
+				range: [22, 26],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem +  \t1em); }',
@@ -540,6 +711,10 @@ testRule({
 			column: 24,
 			endLine: 1,
 			endColumn: 25,
+			fix: {
+				range: [25, 27],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem +\t \t1em); }',
@@ -550,6 +725,10 @@ testRule({
 			column: 24,
 			endLine: 1,
 			endColumn: 25,
+			fix: {
+				range: [24, 27],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem +\t\r\f\t1em); }',
@@ -560,6 +739,10 @@ testRule({
 			column: 24,
 			endLine: 1,
 			endColumn: 25,
+			fix: {
+				range: [24, 28],
+				text: ' ',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem +\t \t\f\n\f\t1em); }',
@@ -570,6 +753,10 @@ testRule({
 			column: 24,
 			endLine: 1,
 			endColumn: 25,
+			fix: {
+				range: [24, 28],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: calc(1rem +  \t\r\n  1em); }',
@@ -580,6 +767,10 @@ testRule({
 			column: 24,
 			endLine: 1,
 			endColumn: 25,
+			fix: {
+				range: [24, 27],
+				text: '',
+			},
 		},
 		{
 			code: 'a { padding: calc(1px +-2px); }',
@@ -589,37 +780,139 @@ testRule({
 			column: 23,
 			endLine: 1,
 			endColumn: 24,
+			fix: {
+				range: [22, 23],
+				text: '+ ',
+			},
 		},
 		{
 			code: 'a { padding: calc(1px+2px+3px); }',
 			fixed: 'a { padding: calc(1px + 2px + 3px); }',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 22,
+					endColumn: 23,
+					fix: { range: [21, 22], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 22,
+					endColumn: 23,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 26,
+					endColumn: 27,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 26,
+					endColumn: 27,
+					fix: undefined,
+				},
 			],
 		},
 		{
 			code: 'a { padding: calc(1px+2px-3px); }',
 			fixed: 'a { padding: calc(1px + 2px - 3px); }',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 22,
+					endColumn: 23,
+					fix: { range: [21, 22], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 22,
+					endColumn: 23,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedAfter('-'),
+					line: 1,
+					endLine: 1,
+					column: 26,
+					endColumn: 27,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 26,
+					endColumn: 27,
+					fix: undefined,
+				},
 			],
 		},
 		{
 			code: 'a { padding: calc(1px+2px-3px-4px); }',
 			fixed: 'a { padding: calc(1px + 2px - 3px - 4px); }',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 26, endColumn: 27 },
-				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 30, endColumn: 31 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 22,
+					endColumn: 23,
+					fix: { range: [21, 22], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 22,
+					endColumn: 23,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedAfter('-'),
+					line: 1,
+					endLine: 1,
+					column: 26,
+					endColumn: 27,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 26,
+					endColumn: 27,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedAfter('-'),
+					line: 1,
+					endLine: 1,
+					column: 30,
+					endColumn: 31,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 30,
+					endColumn: 31,
+					fix: undefined,
+				},
 			],
 		},
 		{
@@ -657,8 +950,22 @@ testRule({
 			fixed: 'a { font-size: clamp(1rem, 2.5vw, 1rem + 1rem); }',
 			description: 'multiple argument functions',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 39, endColumn: 40 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 39,
+					endColumn: 40,
+					fix: { range: [38, 39], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 39,
+					endColumn: 40,
+					fix: undefined,
+				},
 			],
 		},
 		{
@@ -666,9 +973,30 @@ testRule({
 			fixed: 'a { top: clamp(1px + 2px, 3px - 4px, none); }',
 			description: 'multiple argument functions',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
-				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 29, endColumn: 30 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 20,
+					endColumn: 21,
+					fix: { range: [19, 20], text: '+ ' },
+				},
+				{
+					message: messages.expectedAfter('-'),
+					line: 1,
+					endLine: 1,
+					column: 29,
+					endColumn: 30,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 29,
+					endColumn: 30,
+					fix: undefined,
+				},
 			],
 		},
 		{
@@ -676,8 +1004,22 @@ testRule({
 			fixed: 'a { width: min(25vw + 25vw); }',
 			description: 'multiple argument functions',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 20, endColumn: 21 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 20,
+					endColumn: 21,
+					fix: { range: [19, 20], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 20,
+					endColumn: 21,
+					fix: undefined,
+				},
 			],
 		},
 		{
@@ -685,8 +1027,22 @@ testRule({
 			fixed: 'a { padding: calc(1px + 2px) calc(3px + 4px); }',
 			description: 'nested math expression',
 			warnings: [
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 22, endColumn: 23 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 37, endColumn: 38 },
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 22,
+					endColumn: 23,
+					fix: { range: [20, 21], text: 'x ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 37,
+					endColumn: 38,
+					fix: undefined,
+				},
 			],
 		},
 		{
@@ -695,14 +1051,70 @@ testRule({
 				'a { top: rgb(from red calc(r + 1) calc(g - +2) calc(clamp(10px + 2px, g + 2, none))); }',
 			description: 'nested math expression',
 			warnings: [
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 29, endColumn: 30 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
-				{ message: messages.expectedAfter('-'), line: 1, endLine: 1, column: 39, endColumn: 40 },
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 59, endColumn: 60 },
-				{ message: messages.expectedAfter('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
-				{ message: messages.expectedBefore('+'), line: 1, endLine: 1, column: 66, endColumn: 67 },
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 29,
+					endColumn: 30,
+					fix: { range: [28, 29], text: '+ ' },
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 29,
+					endColumn: 30,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 39,
+					endColumn: 40,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedAfter('-'),
+					line: 1,
+					endLine: 1,
+					column: 39,
+					endColumn: 40,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 59,
+					endColumn: 60,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 59,
+					endColumn: 60,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedAfter('+'),
+					line: 1,
+					endLine: 1,
+					column: 66,
+					endColumn: 67,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('+'),
+					line: 1,
+					endLine: 1,
+					column: 66,
+					endColumn: 67,
+					fix: undefined,
+				},
 			],
 		},
 		{
@@ -710,9 +1122,30 @@ testRule({
 			fixed: 'a { padding: calc(1\\23  - 2px) calc(1\\23 a - 2px) calc(1\\23g - 2px); }',
 			description: 'escape sequences as units',
 			warnings: [
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 24, endColumn: 25 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 42, endColumn: 43 },
-				{ message: messages.expectedBefore('-'), line: 1, endLine: 1, column: 59, endColumn: 60 },
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 24,
+					endColumn: 25,
+					fix: { range: [22, 23], text: '  ' },
+				},
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 42,
+					endColumn: 43,
+					fix: undefined,
+				},
+				{
+					message: messages.expectedBefore('-'),
+					line: 1,
+					endLine: 1,
+					column: 59,
+					endColumn: 60,
+					fix: undefined,
+				},
 			],
 		},
 	],

--- a/lib/rules/function-calc-no-unspaced-operator/index.cjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.cjs
@@ -54,7 +54,16 @@ const rule = (primary) => {
 			const endIndex = index + operator.length;
 			const messageArgs = [operator];
 
-			report({ message, messageArgs, node, index, endIndex, result, ruleName, fix });
+			report({
+				message,
+				messageArgs,
+				node,
+				index,
+				endIndex,
+				result,
+				ruleName,
+				fix: { apply: fix, node },
+			});
 		}
 
 		root.walkDecls((decl) => {

--- a/lib/rules/function-calc-no-unspaced-operator/index.mjs
+++ b/lib/rules/function-calc-no-unspaced-operator/index.mjs
@@ -76,7 +76,16 @@ const rule = (primary) => {
 			const endIndex = index + operator.length;
 			const messageArgs = [operator];
 
-			report({ message, messageArgs, node, index, endIndex, result, ruleName, fix });
+			report({
+				message,
+				messageArgs,
+				node,
+				index,
+				endIndex,
+				result,
+				ruleName,
+				fix: { apply: fix, node },
+			});
 		}
 
 		root.walkDecls((decl) => {


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
