### PR TITLE
Add `hue-degree-notation` support for computing `EditInfo`.

### DIFF
--- a/.changeset/funny-hounds-care.md
+++ b/.changeset/funny-hounds-care.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `hue-degree-notation` support for computing `EditInfo`

--- a/lib/rules/hue-degree-notation/__tests__/index.mjs
+++ b/lib/rules/hue-degree-notation/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: ['angle'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -67,6 +68,10 @@ testRule({
 		{
 			code: 'a { color: hsl(120 60% 70%) }',
 			fixed: 'a { color: hsl(120deg 60% 70%) }',
+			fix: {
+				range: [17, 18],
+				text: '0deg',
+			},
 			message: messages.expected('120', '120deg'),
 			line: 1,
 			column: 16,
@@ -76,6 +81,10 @@ testRule({
 		{
 			code: 'a { color: HSL(120 60% 70% / 10%) }',
 			fixed: 'a { color: HSL(120deg 60% 70% / 10%) }',
+			fix: {
+				range: [17, 18],
+				text: '0deg',
+			},
 			message: messages.expected('120', '120deg'),
 			line: 1,
 			column: 16,
@@ -85,6 +94,10 @@ testRule({
 		{
 			code: 'a { color: hwb(180 0% 0%) }',
 			fixed: 'a { color: hwb(180deg 0% 0%) }',
+			fix: {
+				range: [17, 18],
+				text: '0deg',
+			},
 			message: messages.expected('180', '180deg'),
 			line: 1,
 			column: 16,
@@ -94,6 +107,10 @@ testRule({
 		{
 			code: 'a { color: lch(56.29% 19.86 10) }',
 			fixed: 'a { color: lch(56.29% 19.86 10deg) }',
+			fix: {
+				range: [29, 30],
+				text: '0deg',
+			},
 			message: messages.expected('10', '10deg'),
 			line: 1,
 			column: 29,
@@ -103,6 +120,10 @@ testRule({
 		{
 			code: 'a { color: oklch(56.29% 19.86 10) }',
 			fixed: 'a { color: oklch(56.29% 19.86 10deg) }',
+			fix: {
+				range: [31, 32],
+				text: '0deg',
+			},
 			message: messages.expected('10', '10deg'),
 			line: 1,
 			column: 31,
@@ -112,6 +133,10 @@ testRule({
 		{
 			code: 'a { color: hsl(/*comment*/120 60% 70%) }',
 			fixed: 'a { color: hsl(/*comment*/120deg 60% 70%) }',
+			fix: {
+				range: [28, 29],
+				text: '0deg',
+			},
 			message: messages.expected('120', '120deg'),
 			line: 1,
 			column: 27,
@@ -144,6 +169,10 @@ testRule({
 					column: 7,
 					endLine: 4,
 					endColumn: 10,
+					fix: {
+						range: [60, 61],
+						text: '0deg',
+					},
 				},
 				{
 					message: messages.expected('236.62', '236.62deg'),
@@ -161,6 +190,7 @@ testRule({
 	ruleName,
 	config: ['number'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -178,6 +208,10 @@ testRule({
 		{
 			code: 'a { color: hsl(120deg 60% 70%) }',
 			fixed: 'a { color: hsl(120 60% 70%) }',
+			fix: {
+				range: [18, 21],
+				text: '',
+			},
 			message: messages.expected('120deg', '120'),
 			line: 1,
 			column: 16,
@@ -187,6 +221,10 @@ testRule({
 		{
 			code: 'a { color: HSL(120deg 60% 70% / 10%) }',
 			fixed: 'a { color: HSL(120 60% 70% / 10%) }',
+			fix: {
+				range: [18, 21],
+				text: '',
+			},
 			message: messages.expected('120deg', '120'),
 			line: 1,
 			column: 16,
@@ -196,6 +234,10 @@ testRule({
 		{
 			code: 'a { color: HSLA(120DEG, 60%, 70%, 10%) }',
 			fixed: 'a { color: HSLA(120, 60%, 70%, 10%) }',
+			fix: {
+				range: [19, 22],
+				text: '',
+			},
 			message: messages.expected('120DEG', '120'),
 			line: 1,
 			column: 17,
@@ -205,6 +247,10 @@ testRule({
 		{
 			code: 'a { color: lch(56.29% 19.86 10deg) }',
 			fixed: 'a { color: lch(56.29% 19.86 10) }',
+			fix: {
+				range: [30, 33],
+				text: '',
+			},
 			message: messages.expected('10deg', '10'),
 			line: 1,
 			column: 29,
@@ -214,6 +260,10 @@ testRule({
 		{
 			code: 'a { color: oklch(56.29% 19.86 10deg) }',
 			fixed: 'a { color: oklch(56.29% 19.86 10) }',
+			fix: {
+				range: [32, 35],
+				text: '',
+			},
 			message: messages.expected('10deg', '10'),
 			line: 1,
 			column: 31,
@@ -246,6 +296,10 @@ testRule({
 					column: 7,
 					endLine: 4,
 					endColumn: 13,
+					fix: {
+						range: [61, 64],
+						text: '',
+					},
 				},
 				{
 					message: messages.expected('236.62deg', '236.62'),
@@ -264,6 +318,7 @@ testRule({
 	customSyntax: 'postcss-scss',
 	config: ['angle'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -278,6 +333,10 @@ testRule({
 		{
 			code: '$a: hsl(0 0 0);',
 			fixed: '$a: hsl(0deg 0 0);',
+			fix: {
+				range: [8, 9],
+				text: '0deg',
+			},
 			message: messages.expected('0', '0deg'),
 			line: 1,
 			column: 9,
@@ -292,6 +351,7 @@ testRule({
 	customSyntax: 'postcss-scss',
 	config: ['number'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -306,6 +366,10 @@ testRule({
 		{
 			code: '$a: hsl(0deg 0 0);',
 			fixed: '$a: hsl(0 0 0);',
+			fix: {
+				range: [9, 12],
+				text: '',
+			},
 			message: messages.expected('0deg', '0'),
 			line: 1,
 			column: 9,

--- a/lib/rules/hue-degree-notation/index.cjs
+++ b/lib/rules/hue-degree-notation/index.cjs
@@ -86,7 +86,10 @@ const rule = (primary) => {
 					endIndex: valueIndex + hue.sourceEndIndex,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});

--- a/lib/rules/hue-degree-notation/index.mjs
+++ b/lib/rules/hue-degree-notation/index.mjs
@@ -83,7 +83,10 @@ const rule = (primary) => {
 					endIndex: valueIndex + hue.sourceEndIndex,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
