### PR TITLE
Add `import-notation` support for computing `EditInfo`.

### DIFF
--- a/.changeset/grumpy-teeth-send.md
+++ b/.changeset/grumpy-teeth-send.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `import-notation` support for computing `EditInfo`.

--- a/lib/rules/import-notation/__tests__/index.mjs
+++ b/lib/rules/import-notation/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: ['url'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -46,6 +47,10 @@ testRule({
 		{
 			code: '@import "foo.css";',
 			fixed: '@import url("foo.css");',
+			fix: {
+				range: [8, 17],
+				text: 'url("foo.css")',
+			},
 			message: messages.expected('"foo.css"', 'url("foo.css")'),
 			line: 1,
 			column: 9,
@@ -55,6 +60,10 @@ testRule({
 		{
 			code: "@import 'foo.css';",
 			fixed: "@import url('foo.css');",
+			fix: {
+				range: [8, 17],
+				text: "url('foo.css')",
+			},
 			message: messages.expected("'foo.css'", "url('foo.css')"),
 			line: 1,
 			column: 9,
@@ -64,6 +73,10 @@ testRule({
 		{
 			code: "@import 'foo.css' print;",
 			fixed: "@import url('foo.css') print;",
+			fix: {
+				range: [8, 17],
+				text: "url('foo.css')",
+			},
 			message: messages.expected("'foo.css'", "url('foo.css')"),
 			line: 1,
 			column: 9,
@@ -73,6 +86,10 @@ testRule({
 		{
 			code: "@import 'foo.css' supports(display: flex) screen and (max-width: 400px);",
 			fixed: "@import url('foo.css') supports(display: flex) screen and (max-width: 400px);",
+			fix: {
+				range: [8, 17],
+				text: "url('foo.css')",
+			},
 			message: messages.expected("'foo.css'", "url('foo.css')"),
 			line: 1,
 			column: 9,
@@ -86,6 +103,7 @@ testRule({
 	ruleName,
 	config: ['string'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -111,6 +129,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 23,
+			fix: {
+				range: [8, 22],
+				text: '"foo.css"',
+			},
 		},
 		{
 			code: '@import uRl("foo.css");',
@@ -120,6 +142,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 23,
+			fix: {
+				range: [8, 22],
+				text: '"foo.css"',
+			},
 		},
 		{
 			code: '@import URL("foo.css");',
@@ -129,6 +155,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 23,
+			fix: {
+				range: [8, 22],
+				text: '"foo.css"',
+			},
 		},
 		{
 			code: '@import url( "foo.css" );',
@@ -138,6 +168,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 25,
+			fix: {
+				range: [8, 24],
+				text: '"foo.css"',
+			},
 		},
 		{
 			code: "@import url('foo.css');",
@@ -147,6 +181,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 23,
+			fix: {
+				range: [8, 22],
+				text: "'foo.css'",
+			},
 		},
 		{
 			code: "@import url( 'foo.css' );",
@@ -156,6 +194,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 25,
+			fix: {
+				range: [8, 24],
+				text: "'foo.css'",
+			},
 		},
 		{
 			code: '@import url(foo.css);',
@@ -165,6 +207,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 21,
+			fix: {
+				range: [8, 20],
+				text: '"foo.css"',
+			},
 		},
 		{
 			code: '@import url(foo.css) print;',
@@ -174,6 +220,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 21,
+			fix: {
+				range: [8, 20],
+				text: '"foo.css"',
+			},
 		},
 		{
 			code: "@import url('foo.css') supports(display: flex) screen and (max-width: 400px);",
@@ -183,6 +233,10 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 23,
+			fix: {
+				range: [8, 22],
+				text: "'foo.css'",
+			},
 		},
 	],
 });

--- a/lib/rules/import-notation/index.cjs
+++ b/lib/rules/import-notation/index.cjs
@@ -69,7 +69,7 @@ const rule = (primary) => {
 					const message = messages.expected;
 					const messageArgs = [urlFunctionFull, quotedUrlFunctionFirstArgument];
 
-					report({ ...problem, message, messageArgs, fix });
+					report({ ...problem, message, messageArgs, fix: { apply: fix, node: problem.node } });
 
 					return;
 				}
@@ -87,7 +87,7 @@ const rule = (primary) => {
 					const message = messages.expected;
 					const messageArgs = [quotedNodeValue, urlFunctionFull];
 
-					report({ ...problem, message, messageArgs, fix });
+					report({ ...problem, message, messageArgs, fix: { apply: fix, node: problem.node } });
 
 					return;
 				}

--- a/lib/rules/import-notation/index.mjs
+++ b/lib/rules/import-notation/index.mjs
@@ -66,7 +66,7 @@ const rule = (primary) => {
 					const message = messages.expected;
 					const messageArgs = [urlFunctionFull, quotedUrlFunctionFirstArgument];
 
-					report({ ...problem, message, messageArgs, fix });
+					report({ ...problem, message, messageArgs, fix: { apply: fix, node: problem.node } });
 
 					return;
 				}
@@ -84,7 +84,7 @@ const rule = (primary) => {
 					const message = messages.expected;
 					const messageArgs = [quotedNodeValue, urlFunctionFull];
 
-					report({ ...problem, message, messageArgs, fix });
+					report({ ...problem, message, messageArgs, fix: { apply: fix, node: problem.node } });
 
 					return;
 				}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
