### PR TITLE
Added `media-feature-name-no-vendor-prefix` support for computing `EditInfo`

### DIFF
--- a/.changeset/plain-mice-allow.md
+++ b/.changeset/plain-mice-allow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added `media-feature-name-no-vendor-prefix` support for computing `EditInfo`

--- a/lib/rules/media-feature-name-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/media-feature-name-no-vendor-prefix/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -25,6 +26,10 @@ testRule({
 		{
 			code: '@media (-webkit-min-device-pixel-ratio: 1) {}',
 			fixed: '@media (min-device-pixel-ratio: 1) {}',
+			fix: {
+				range: [8, 16],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 9,
@@ -32,6 +37,10 @@ testRule({
 		{
 			code: '@media (-wEbKiT-mIn-DeViCe-PiXeL-rAtIo: 1) {}',
 			fixed: '@media (mIn-DeViCe-PiXeL-rAtIo: 1) {}',
+			fix: {
+				range: [8, 16],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 9,
@@ -39,6 +48,10 @@ testRule({
 		{
 			code: '@media (-WEBKIT-MIN-DEVICE-PIXEL-RATIO: 1) {}',
 			fixed: '@media (MIN-DEVICE-PIXEL-RATIO: 1) {}',
+			fix: {
+				range: [8, 16],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 9,
@@ -46,6 +59,10 @@ testRule({
 		{
 			code: '@media (min--moz-device-pixel-ratio: 1) {}',
 			fixed: '@media (min-device-pixel-ratio: 1) {}',
+			fix: {
+				range: [12, 17],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 9,
@@ -53,6 +70,10 @@ testRule({
 		{
 			code: '@media ( max--moz-device-pixel-ratio: 1) {}',
 			fixed: '@media ( max-device-pixel-ratio: 1) {}',
+			fix: {
+				range: [13, 18],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 10,
@@ -60,6 +81,10 @@ testRule({
 		{
 			code: '@media (/* a comment */MIN--moz-device-pixel-ratio: 1) {}',
 			fixed: '@media (/* a comment */MIN-device-pixel-ratio: 1) {}',
+			fix: {
+				range: [27, 32],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 24,
@@ -67,6 +92,10 @@ testRule({
 		{
 			code: '@media\n\t(min--moz-device-pixel-ratio: 1) {}',
 			fixed: '@media\n\t(min-device-pixel-ratio: 1) {}',
+			fix: {
+				range: [13, 18],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 2,
 			column: 3,
@@ -74,6 +103,10 @@ testRule({
 		{
 			code: '@media   (-o-max-device-pixel-ratio: 1/1) {}',
 			fixed: '@media   (max-device-pixel-ratio: 1/1) {}',
+			fix: {
+				range: [10, 13],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 11,
@@ -81,6 +114,10 @@ testRule({
 		{
 			code: '@media (-o-device-pixel-ratio > 1) {}',
 			fixed: '@media (device-pixel-ratio > 1) {}',
+			fix: {
+				range: [8, 11],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 9,
@@ -90,6 +127,10 @@ testRule({
 		{
 			code: '@media (0 < -webkit-device-pixel-ratio < 2) {}',
 			fixed: '@media (0 < device-pixel-ratio < 2) {}',
+			fix: {
+				range: [12, 20],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 13,
@@ -102,6 +143,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.rejected,
+					fix: {
+						range: [8, 16],
+						text: '',
+					},
 					line: 1,
 					column: 9,
 					endLine: 1,
@@ -109,6 +154,7 @@ testRule({
 				},
 				{
 					message: messages.rejected,
+					fix: undefined,
 					line: 1,
 					column: 49,
 					endLine: 1,

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.cjs
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.cjs
@@ -64,7 +64,10 @@ const rule = (primary) => {
 					word: match,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: atRule,
+					},
 				});
 			}
 		});

--- a/lib/rules/media-feature-name-no-vendor-prefix/index.mjs
+++ b/lib/rules/media-feature-name-no-vendor-prefix/index.mjs
@@ -60,7 +60,10 @@ const rule = (primary) => {
 					word: match,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: atRule,
+					},
 				});
 			}
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
