### PR TITLE
Added `keyframe-selector-notation` support for computing `EditInfo`

### DIFF
--- a/.changeset/tasty-buttons-hang.md
+++ b/.changeset/tasty-buttons-hang.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `keyframe-selector-notation` support for computing `EditInfo`

--- a/lib/rules/keyframe-selector-notation/__tests__/index.mjs
+++ b/lib/rules/keyframe-selector-notation/__tests__/index.mjs
@@ -39,6 +39,7 @@ testRule({
 	ruleName,
 	config: ['keyword'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -77,6 +78,10 @@ testRule({
 		{
 			code: '@keyframes foo { 0% {} }',
 			fixed: '@keyframes foo { from {} }',
+			fix: {
+				range: [17, 19],
+				text: 'from',
+			},
 			message: messages.expected('0%', 'from'),
 			line: 1,
 			column: 18,
@@ -86,6 +91,10 @@ testRule({
 		{
 			code: '@keyframes foo { 100% {} }',
 			fixed: '@keyframes foo { to {} }',
+			fix: {
+				range: [17, 21],
+				text: 'to',
+			},
 			message: messages.expected('100%', 'to'),
 			line: 1,
 			column: 18,
@@ -98,6 +107,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('0%', 'from'),
+					fix: {
+						range: [17, 19],
+						text: 'from',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -105,6 +118,10 @@ testRule({
 				},
 				{
 					message: messages.expected('100%', 'to'),
+					fix: {
+						range: [23, 27],
+						text: 'to',
+					},
 					line: 1,
 					column: 24,
 					endLine: 1,
@@ -118,6 +135,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('0%', 'from'),
+					fix: {
+						range: [17, 19],
+						text: 'from',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -125,6 +146,7 @@ testRule({
 				},
 				{
 					message: messages.expected('0%', 'from'),
+					fix: undefined,
 					line: 1,
 					column: 22,
 					endLine: 1,
@@ -138,6 +160,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('100%', 'to'),
+					fix: {
+						range: [17, 21],
+						text: 'to',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -145,6 +171,7 @@ testRule({
 				},
 				{
 					message: messages.expected('0%', 'from'),
+					fix: undefined,
 					line: 1,
 					column: 24,
 					endLine: 1,
@@ -159,6 +186,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('0%', 'from'),
+					fix: {
+						range: [17, 19],
+						text: 'from',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -166,6 +197,10 @@ testRule({
 				},
 				{
 					message: messages.expected('0%', 'from'),
+					fix: {
+						range: [23, 25],
+						text: 'from',
+					},
 					line: 1,
 					column: 24,
 					endLine: 1,
@@ -187,6 +222,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('0%', 'from'),
+					fix: {
+						range: [17, 19],
+						text: 'from',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -194,6 +233,10 @@ testRule({
 				},
 				{
 					message: messages.expected('100%', 'to'),
+					fix: {
+						range: [30, 34],
+						text: 'to',
+					},
 					line: 1,
 					column: 31,
 					endLine: 1,
@@ -208,6 +251,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('0%', 'from'),
+					fix: {
+						range: [17, 19],
+						text: 'from',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -215,6 +262,7 @@ testRule({
 				},
 				{
 					message: messages.expected('100%', 'to'),
+					fix: undefined,
 					line: 1,
 					column: 22,
 					endLine: 1,
@@ -229,6 +277,7 @@ testRule({
 	ruleName,
 	config: ['percentage'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -267,6 +316,10 @@ testRule({
 		{
 			code: '@keyframes foo { from {} }',
 			fixed: '@keyframes foo { 0% {} }',
+			fix: {
+				range: [17, 21],
+				text: '0%',
+			},
 			message: messages.expected('from', '0%'),
 			line: 1,
 			column: 18,
@@ -276,6 +329,10 @@ testRule({
 		{
 			code: '@keyframes foo { to {} }',
 			fixed: '@keyframes foo { 100% {} }',
+			fix: {
+				range: [17, 19],
+				text: '100%',
+			},
 			message: messages.expected('to', '100%'),
 			line: 1,
 			column: 18,
@@ -288,6 +345,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('from', '0%'),
+					fix: {
+						range: [17, 21],
+						text: '0%',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -295,6 +356,10 @@ testRule({
 				},
 				{
 					message: messages.expected('to', '100%'),
+					fix: {
+						range: [25, 27],
+						text: '100%',
+					},
 					line: 1,
 					column: 26,
 					endLine: 1,
@@ -309,6 +374,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('from', '0%'),
+					fix: {
+						range: [17, 21],
+						text: '0%',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -316,6 +385,10 @@ testRule({
 				},
 				{
 					message: messages.expected('from', '0%'),
+					fix: {
+						range: [25, 29],
+						text: '0%',
+					},
 					line: 1,
 					column: 26,
 					endLine: 1,
@@ -323,6 +396,10 @@ testRule({
 				},
 				{
 					message: messages.expected('to', '100%'),
+					fix: {
+						range: [33, 35],
+						text: '100%',
+					},
 					line: 1,
 					column: 34,
 					endLine: 1,
@@ -337,6 +414,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('from', '0%'),
+					fix: {
+						range: [17, 21],
+						text: '0%',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -344,6 +425,10 @@ testRule({
 				},
 				{
 					message: messages.expected('to', '100%'),
+					fix: {
+						range: [32, 34],
+						text: '100%',
+					},
 					line: 1,
 					column: 33,
 					endLine: 1,
@@ -358,6 +443,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('from', '0%'),
+					fix: {
+						range: [17, 21],
+						text: '0%',
+					},
 					line: 1,
 					column: 18,
 					endLine: 1,
@@ -365,6 +454,7 @@ testRule({
 				},
 				{
 					message: messages.expected('to', '100%'),
+					fix: undefined,
 					line: 1,
 					column: 24,
 					endLine: 1,
@@ -396,6 +486,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('from', '0%'),
+					fix: {
+						range: [35, 39],
+						text: '0%',
+					},
 					line: 3,
 					column: 2,
 					endLine: 3,
@@ -403,6 +497,7 @@ testRule({
 				},
 				{
 					message: messages.expected('from', '0%'),
+					fix: undefined,
 					line: 4,
 					column: 2,
 					endLine: 4,
@@ -410,6 +505,7 @@ testRule({
 				},
 				{
 					message: messages.expected('from', '0%'),
+					fix: undefined,
 					line: 6,
 					column: 2,
 					endLine: 6,
@@ -424,6 +520,7 @@ testRule({
 	ruleName,
 	config: ['percentage-unless-within-keyword-only-block'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -454,11 +551,19 @@ testRule({
 		{
 			code: '@keyframes foo { from {} 100% {} }',
 			fixed: '@keyframes foo { 0% {} 100% {} }',
+			fix: {
+				range: [17, 21],
+				text: '0%',
+			},
 			message: messages.expected('from', '0%'),
 		},
 		{
 			code: '@keyframes foo { 0% {} to {} }',
 			fixed: '@keyframes foo { 0% {} 100% {} }',
+			fix: {
+				range: [23, 25],
+				text: '100%',
+			},
 			message: messages.expected('to', '100%'),
 		},
 		{
@@ -467,6 +572,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('from', '0%'),
+					fix: {
+						range: [17, 21],
+						text: '0%',
+					},
 				},
 				{
 					message: messages.expected('to', '100%'),
@@ -476,16 +585,28 @@ testRule({
 		{
 			code: '@keyframes foo { from,100% {} }',
 			fixed: '@keyframes foo { 0%,100% {} }',
+			fix: {
+				range: [17, 21],
+				text: '0%',
+			},
 			message: messages.expected('from', '0%'),
 		},
 		{
 			code: '@keyframes foo { 0%,to {} }',
 			fixed: '@keyframes foo { 0%,100% {} }',
+			fix: {
+				range: [20, 22],
+				text: '100%',
+			},
 			message: messages.expected('to', '100%'),
 		},
 		{
 			code: '@keyframes foo { 0%,TO {} }',
 			fixed: '@keyframes foo { 0%,100% {} }',
+			fix: {
+				range: [20, 22],
+				text: '100%',
+			},
 			message: messages.expected('TO', '100%'),
 		},
 	],

--- a/lib/rules/keyframe-selector-notation/index.cjs
+++ b/lib/rules/keyframe-selector-notation/index.cjs
@@ -96,6 +96,11 @@ const rule = (primary) => {
 
 					const fixedSelector = fixFunc(normalizedSelector);
 
+					const fix = () => {
+						keyframeSelector.value = fixedSelector;
+						keyframeRule.selector = selectors.toString();
+					};
+
 					report({
 						message: messages.expected,
 						messageArgs: [keyframeSelector.value, fixedSelector],
@@ -104,9 +109,9 @@ const rule = (primary) => {
 						ruleName,
 						index: keyframeSelector.sourceIndex,
 						endIndex: keyframeSelector.sourceIndex + normalizedSelector.length,
-						fix: () => {
-							keyframeSelector.value = fixedSelector;
-							keyframeRule.selector = selectors.toString();
+						fix: {
+							apply: fix,
+							node: keyframeRule,
 						},
 					});
 				});

--- a/lib/rules/keyframe-selector-notation/index.mjs
+++ b/lib/rules/keyframe-selector-notation/index.mjs
@@ -93,6 +93,11 @@ const rule = (primary) => {
 
 					const fixedSelector = fixFunc(normalizedSelector);
 
+					const fix = () => {
+						keyframeSelector.value = fixedSelector;
+						keyframeRule.selector = selectors.toString();
+					};
+
 					report({
 						message: messages.expected,
 						messageArgs: [keyframeSelector.value, fixedSelector],
@@ -101,9 +106,9 @@ const rule = (primary) => {
 						ruleName,
 						index: keyframeSelector.sourceIndex,
 						endIndex: keyframeSelector.sourceIndex + normalizedSelector.length,
-						fix: () => {
-							keyframeSelector.value = fixedSelector;
-							keyframeRule.selector = selectors.toString();
+						fix: {
+							apply: fix,
+							node: keyframeRule,
 						},
 					});
 				});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
