### PR TITLE
Added `lightness-notation` support for computing `EditInfo`

### DIFF
--- a/.changeset/great-dots-shine.md
+++ b/.changeset/great-dots-shine.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `lightness-notation` support for computing `EditInfo`

--- a/lib/rules/lightness-notation/__tests__/index.mjs
+++ b/lib/rules/lightness-notation/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: ['percentage'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -58,6 +59,10 @@ testRule({
 		{
 			code: 'a { color: oklch(0.7 0.1 241) }',
 			fixed: 'a { color: oklch(70% 0.1 241) }',
+			fix: {
+				range: [17, 20],
+				text: '70%',
+			},
 			message: messages.expected('0.7', '70%'),
 			line: 1,
 			column: 18,
@@ -67,6 +72,10 @@ testRule({
 		{
 			code: 'a { color: lch(70 0.1 241) }',
 			fixed: 'a { color: lch(70% 0.1 241) }',
+			fix: {
+				range: [16, 17],
+				text: '0%',
+			},
 			message: messages.expected('70', '70%'),
 			line: 1,
 			column: 16,
@@ -76,6 +85,10 @@ testRule({
 		{
 			code: 'a { color: oklab(0.7 0.1 241) }',
 			fixed: 'a { color: oklab(70% 0.1 241) }',
+			fix: {
+				range: [17, 20],
+				text: '70%',
+			},
 			message: messages.expected('0.7', '70%'),
 			line: 1,
 			column: 18,
@@ -85,6 +98,10 @@ testRule({
 		{
 			code: 'a { color: lab(70 0.1 241) }',
 			fixed: 'a { color: lab(70% 0.1 241) }',
+			fix: {
+				range: [16, 17],
+				text: '0%',
+			},
 			message: messages.expected('70', '70%'),
 			line: 1,
 			column: 16,
@@ -94,6 +111,10 @@ testRule({
 		{
 			code: 'a { color: lch(56.29 19.86 200) }',
 			fixed: 'a { color: lch(56.29% 19.86 200) }',
+			fix: {
+				range: [19, 20],
+				text: '9%',
+			},
 			message: messages.expected('56.29', '56.29%'),
 			line: 1,
 			column: 16,
@@ -103,6 +124,10 @@ testRule({
 		{
 			code: 'a { color: oklch(0.5629 0.1 241) }',
 			fixed: 'a { color: oklch(56.29% 0.1 241) }',
+			fix: {
+				range: [17, 23],
+				text: '56.29%',
+			},
 			message: messages.expected('0.5629', '56.29%'),
 			line: 1,
 			column: 18,
@@ -112,6 +137,10 @@ testRule({
 		{
 			code: 'a { color: lch(56.29 19.86 200/ 100%) }',
 			fixed: 'a { color: lch(56.29% 19.86 200/ 100%) }',
+			fix: {
+				range: [19, 20],
+				text: '9%',
+			},
 			message: messages.expected('56.29', '56.29%'),
 			line: 1,
 			column: 16,
@@ -121,6 +150,10 @@ testRule({
 		{
 			code: 'a { color: oklch(/*comment*/0.5629 0.1 241) }',
 			fixed: 'a { color: oklch(/*comment*/56.29% 0.1 241) }',
+			fix: {
+				range: [28, 34],
+				text: '56.29%',
+			},
 			message: messages.expected('0.5629', '56.29%'),
 			line: 1,
 			column: 29,
@@ -130,6 +163,10 @@ testRule({
 		{
 			code: 'a { color: lch(52.9 0.1 241/*comment*/) }',
 			fixed: 'a { color: lch(52.9% 0.1 241/*comment*/) }',
+			fix: {
+				range: [18, 19],
+				text: '9%',
+			},
 			message: messages.expected('52.9', '52.9%'),
 			line: 1,
 			column: 16,
@@ -158,6 +195,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('29.2345', '29.2345%'),
+					fix: {
+						range: [64, 65],
+						text: '5%',
+					},
 					line: 4,
 					column: 7,
 					endLine: 4,
@@ -165,6 +206,7 @@ testRule({
 				},
 				{
 					message: messages.expected('56.29', '56.29%'),
+					fix: undefined,
 					line: 5,
 					column: 7,
 					endLine: 5,
@@ -179,6 +221,7 @@ testRule({
 	ruleName,
 	config: ['number'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -225,6 +268,10 @@ testRule({
 		{
 			code: 'a { color: oklch(70% 0.1 241) }',
 			fixed: 'a { color: oklch(0.7 0.1 241) }',
+			fix: {
+				range: [17, 20],
+				text: '0.7',
+			},
 			message: messages.expected('70%', '0.7'),
 			line: 1,
 			column: 18,
@@ -234,6 +281,10 @@ testRule({
 		{
 			code: 'a { color: lch(70% 0.1 241) }',
 			fixed: 'a { color: lch(70 0.1 241) }',
+			fix: {
+				range: [17, 18],
+				text: '',
+			},
 			message: messages.expected('70%', '70'),
 			line: 1,
 			column: 16,
@@ -243,6 +294,10 @@ testRule({
 		{
 			code: 'a { color: oklab(70% 0.1 241) }',
 			fixed: 'a { color: oklab(0.7 0.1 241) }',
+			fix: {
+				range: [17, 20],
+				text: '0.7',
+			},
 			message: messages.expected('70%', '0.7'),
 			line: 1,
 			column: 18,
@@ -252,6 +307,10 @@ testRule({
 		{
 			code: 'a { color: lab(70% 0.1 241) }',
 			fixed: 'a { color: lab(70 0.1 241) }',
+			fix: {
+				range: [17, 18],
+				text: '',
+			},
 			message: messages.expected('70%', '70'),
 			line: 1,
 			column: 16,
@@ -261,6 +320,10 @@ testRule({
 		{
 			code: 'a { color: lch(56.29% 19.86 200) }',
 			fixed: 'a { color: lch(56.29 19.86 200) }',
+			fix: {
+				range: [20, 21],
+				text: '',
+			},
 			message: messages.expected('56.29%', '56.29'),
 			line: 1,
 			column: 16,
@@ -270,6 +333,10 @@ testRule({
 		{
 			code: 'a { color: oklch(56.29% 0.1 241) }',
 			fixed: 'a { color: oklch(0.5629 0.1 241) }',
+			fix: {
+				range: [17, 23],
+				text: '0.5629',
+			},
 			message: messages.expected('56.29%', '0.5629'),
 			line: 1,
 			column: 18,
@@ -279,6 +346,10 @@ testRule({
 		{
 			code: 'a { color: lch(56.29% 19.86 200/ 100%) }',
 			fixed: 'a { color: lch(56.29 19.86 200/ 100%) }',
+			fix: {
+				range: [20, 21],
+				text: '',
+			},
 			message: messages.expected('56.29%', '56.29'),
 			line: 1,
 			column: 16,
@@ -288,6 +359,10 @@ testRule({
 		{
 			code: 'a { color: oklch(/*comment*/56.29% 0.1 241) }',
 			fixed: 'a { color: oklch(/*comment*/0.5629 0.1 241) }',
+			fix: {
+				range: [28, 34],
+				text: '0.5629',
+			},
 			message: messages.expected('56.29%', '0.5629'),
 			line: 1,
 			column: 29,
@@ -297,6 +372,10 @@ testRule({
 		{
 			code: 'a { color: lch(52.9% 0.1 241/*comment*/) }',
 			fixed: 'a { color: lch(52.9 0.1 241/*comment*/) }',
+			fix: {
+				range: [19, 20],
+				text: '',
+			},
 			message: messages.expected('52.9%', '52.9'),
 			line: 1,
 			column: 16,
@@ -325,6 +404,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('29.2345%', '29.2345'),
+					fix: {
+						range: [65, 66],
+						text: '',
+					},
 					line: 4,
 					column: 7,
 					endLine: 4,
@@ -332,6 +415,7 @@ testRule({
 				},
 				{
 					message: messages.expected('56.29%', '56.29'),
+					fix: undefined,
 					line: 5,
 					column: 7,
 					endLine: 5,

--- a/lib/rules/lightness-notation/index.cjs
+++ b/lib/rules/lightness-notation/index.cjs
@@ -91,7 +91,10 @@ const rule = (primary) => {
 					endIndex: valueIndex + lightness.sourceEndIndex,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});

--- a/lib/rules/lightness-notation/index.mjs
+++ b/lib/rules/lightness-notation/index.mjs
@@ -88,7 +88,10 @@ const rule = (primary) => {
 					endIndex: valueIndex + lightness.sourceEndIndex,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
