### PR TITLE
Added `length-zero-no-unit` support for computing `EditInfo`.

### DIFF
--- a/.changeset/sad-sloths-sell.md
+++ b/.changeset/sad-sloths-sell.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `length-zero-no-unit` support for computing `EditInfo`

--- a/lib/rules/length-zero-no-unit/__tests__/index.mjs
+++ b/lib/rules/length-zero-no-unit/__tests__/index.mjs
@@ -7,6 +7,8 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
+
 	accept: [
 		{
 			code: 'a { top: 0; }',
@@ -288,6 +290,10 @@ testRule({
 		{
 			code: 'a { top: 0px; }',
 			fixed: 'a { top: 0; }',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -298,6 +304,10 @@ testRule({
 		{
 			code: 'a { top: 0px /* comment */; }',
 			fixed: 'a { top: 0 /* comment */; }',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -308,6 +318,10 @@ testRule({
 		{
 			code: 'a { tOp: 0px; }',
 			fixed: 'a { tOp: 0; }',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -318,6 +332,10 @@ testRule({
 		{
 			code: 'a { TOP: 0px; }',
 			fixed: 'a { TOP: 0; }',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -328,6 +346,10 @@ testRule({
 		{
 			code: 'a { top: 0pX; }',
 			fixed: 'a { top: 0; }',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -338,6 +360,10 @@ testRule({
 		{
 			code: 'a { top: 0PX; }',
 			fixed: 'a { top: 0; }',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -348,6 +374,10 @@ testRule({
 		{
 			code: 'a { top: 0.000px; }',
 			fixed: 'a { top: 0.000; }',
+			fix: {
+				range: [14, 16],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -358,6 +388,10 @@ testRule({
 		{
 			code: 'a { padding: 0px 1px 2px 3px; }',
 			fixed: 'a { padding: 0 1px 2px 3px; }',
+			fix: {
+				range: [14, 16],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -368,6 +402,10 @@ testRule({
 		{
 			code: 'a { padding: 1px 0vmax 2px 3px; }',
 			fixed: 'a { padding: 1px 0 2px 3px; }',
+			fix: {
+				range: [18, 22],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -378,6 +416,10 @@ testRule({
 		{
 			code: 'a { padding: 1px 2px 0rem 3px; }',
 			fixed: 'a { padding: 1px 2px 0 3px; }',
+			fix: {
+				range: [22, 25],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -388,6 +430,10 @@ testRule({
 		{
 			code: 'a { padding: 1px 2px 3px 0em; }',
 			fixed: 'a { padding: 1px 2px 3px 0; }',
+			fix: {
+				range: [26, 28],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -399,10 +445,13 @@ testRule({
 			description: 'ignore calc, and inner functions',
 			code: 'padding: calc(var(--foo, 0in) + 10px) 0px;',
 			fixed: 'padding: calc(var(--foo, 0in) + 10px) 0;',
-
 			warnings: [
 				{
 					message: messages.rejected,
+					fix: {
+						range: [39, 41],
+						text: '',
+					},
 					line: 1,
 					column: 40,
 					endLine: 1,
@@ -414,10 +463,13 @@ testRule({
 			description: 'ignore calc. has another zero units',
 			code: 'a { padding: calc(1in + 0in * 2)) 0in calc(0px) 0px; }',
 			fixed: 'a { padding: calc(1in + 0in * 2)) 0 calc(0px) 0; }',
-
 			warnings: [
 				{
 					message: messages.rejected,
+					fix: {
+						range: [35, 37],
+						text: '',
+					},
 					line: 1,
 					column: 36,
 					endLine: 1,
@@ -425,6 +477,7 @@ testRule({
 				},
 				{
 					message: messages.rejected,
+					fix: undefined,
 					line: 1,
 					column: 50,
 					endLine: 1,
@@ -436,10 +489,13 @@ testRule({
 			description: 'ignore min, max, clamp. has another zero units',
 			code: 'padding: min(1vw, 0in) max(1vw, 0px) clamp(0em, 1vw, 10px) 0px;',
 			fixed: 'padding: min(1vw, 0in) max(1vw, 0px) clamp(0em, 1vw, 10px) 0;',
-
 			warnings: [
 				{
 					message: messages.rejected,
+					fix: {
+						range: [60, 62],
+						text: '',
+					},
 					line: 1,
 					column: 61,
 					endLine: 1,
@@ -450,6 +506,10 @@ testRule({
 		{
 			code: '@media (min-width: 0px) {}',
 			fixed: '@media (min-width: 0) {}',
+			fix: {
+				range: [20, 22],
+				text: '',
+			},
 
 			description: 'simple media feature',
 			message: messages.rejected,
@@ -461,6 +521,10 @@ testRule({
 		{
 			code: '@media (min-width: 0px /* comment */) {}',
 			fixed: '@media (min-width: 0 /* comment */) {}',
+			fix: {
+				range: [20, 22],
+				text: '',
+			},
 
 			description: 'simple media feature with comment',
 			message: messages.rejected,
@@ -472,6 +536,10 @@ testRule({
 		{
 			code: '@media screen and (min-width: 0px) {}',
 			fixed: '@media screen and (min-width: 0) {}',
+			fix: {
+				range: [31, 33],
+				text: '',
+			},
 
 			description: 'more complicated media feature',
 			message: messages.rejected,
@@ -483,6 +551,10 @@ testRule({
 		{
 			code: 'a { transform: translate(0px); }',
 			fixed: 'a { transform: translate(0); }',
+			fix: {
+				range: [26, 28],
+				text: '',
+			},
 
 			description: 'transform function',
 			message: messages.rejected,
@@ -494,6 +566,10 @@ testRule({
 		{
 			code: 'a { margin: 0q; }',
 			fixed: 'a { margin: 0; }',
+			fix: {
+				range: [13, 14],
+				text: '',
+			},
 
 			description: 'work with q unit',
 			message: messages.rejected,
@@ -505,6 +581,10 @@ testRule({
 		{
 			code: 'a { margin:0px; }',
 			fixed: 'a { margin:0; }',
+			fix: {
+				range: [12, 14],
+				text: '',
+			},
 
 			description: 'no space after colon',
 			message: messages.rejected,
@@ -516,6 +596,10 @@ testRule({
 		{
 			code: 'a { margin:\n0px; }',
 			fixed: 'a { margin:\n0; }',
+			fix: {
+				range: [13, 15],
+				text: '',
+			},
 
 			description: 'newline after colon',
 			message: messages.rejected,
@@ -527,6 +611,10 @@ testRule({
 		{
 			code: 'a { margin:\r\n0px; }',
 			fixed: 'a { margin:\r\n0; }',
+			fix: {
+				range: [14, 16],
+				text: '',
+			},
 
 			description: 'CRLF after colon',
 			message: messages.rejected,
@@ -538,6 +626,10 @@ testRule({
 		{
 			code: 'a { margin:\t0px; }',
 			fixed: 'a { margin:\t0; }',
+			fix: {
+				range: [13, 15],
+				text: '',
+			},
 
 			description: 'tab after colon',
 			message: messages.rejected,
@@ -549,6 +641,10 @@ testRule({
 		{
 			code: 'a { margin :0px; }',
 			fixed: 'a { margin :0; }',
+			fix: {
+				range: [13, 15],
+				text: '',
+			},
 
 			description: 'space before colon',
 			message: messages.rejected,
@@ -560,6 +656,10 @@ testRule({
 		{
 			code: 'a { margin : 0px; }',
 			fixed: 'a { margin : 0; }',
+			fix: {
+				range: [14, 16],
+				text: '',
+			},
 
 			description: 'space before and after colon',
 			message: messages.rejected,
@@ -571,6 +671,10 @@ testRule({
 		{
 			code: 'a { --x: 0px; }',
 			fixed: 'a { --x: 0; }',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -581,6 +685,10 @@ testRule({
 		{
 			code: 'a { grid-template-columns: 0px 0fr 1fr };',
 			fixed: 'a { grid-template-columns: 0 0fr 1fr };',
+			fix: {
+				range: [28, 30],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -591,6 +699,10 @@ testRule({
 		{
 			code: 'a { grid-template-colUMns: 0px  0fr 1fr };',
 			fixed: 'a { grid-template-colUMns: 0  0fr 1fr };',
+			fix: {
+				range: [28, 30],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -601,6 +713,10 @@ testRule({
 		{
 			code: 'a { grid-template-rows: 40px 4fr 0px; };',
 			fixed: 'a { grid-template-rows: 40px 4fr 0; };',
+			fix: {
+				range: [34, 36],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -611,6 +727,10 @@ testRule({
 		{
 			code: 'a { grid-auto-columns: 0px };',
 			fixed: 'a { grid-auto-columns: 0 };',
+			fix: {
+				range: [24, 26],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -621,6 +741,10 @@ testRule({
 		{
 			code: 'a { grid-template-columns: repeat(2, 50px 0px) 100px; };',
 			fixed: 'a { grid-template-columns: repeat(2, 50px 0) 100px; };',
+			fix: {
+				range: [43, 45],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -631,6 +755,10 @@ testRule({
 		{
 			code: 'a { font: normal normal 400 0px / 0px cursive; }',
 			fixed: 'a { font: normal normal 400 0 / 0px cursive; }',
+			fix: {
+				range: [29, 31],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -641,6 +769,10 @@ testRule({
 		{
 			code: 'a { font: normal normal 400 0px /0px cursive; }',
 			fixed: 'a { font: normal normal 400 0 /0px cursive; }',
+			fix: {
+				range: [29, 31],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -651,6 +783,10 @@ testRule({
 		{
 			code: 'a { font: normal normal 400 0px/0px cursive; }',
 			fixed: 'a { font: normal normal 400 0/0px cursive; }',
+			fix: {
+				range: [29, 31],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -661,6 +797,10 @@ testRule({
 		{
 			code: 'a { font: normal normal 400 0px/ 0px cursive; }',
 			fixed: 'a { font: normal normal 400 0/ 0px cursive; }',
+			fix: {
+				range: [29, 31],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -671,6 +811,10 @@ testRule({
 		{
 			code: 'a { margin: var(--foo, 0px); }',
 			fixed: 'a { margin: var(--foo, 0); }',
+			fix: {
+				range: [24, 26],
+				text: '',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 25,
@@ -680,6 +824,10 @@ testRule({
 		{
 			code: 'a { right: .0rem; }',
 			fixed: 'a { right: 0; }',
+			fix: {
+				range: [11, 16],
+				text: '0',
+			},
 			message: messages.rejected,
 			line: 1,
 			column: 14,
@@ -700,6 +848,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.rejected,
+					fix: {
+						range: [27, 30],
+						text: '',
+					},
 					line: 2,
 					column: 24,
 					endLine: 2,
@@ -707,6 +859,7 @@ testRule({
 				},
 				{
 					message: messages.rejected,
+					fix: undefined,
 					line: 2,
 					column: 29,
 					endLine: 2,
@@ -735,6 +888,7 @@ testRule({
 	ruleName,
 	config: [true, { ignoreFunctions: ['var', /^--/] }],
 	fix: true,
+	computeEditInfo: true,
 	accept: [
 		{
 			code: 'a { top: var(--foo, 0px); }',
@@ -747,6 +901,10 @@ testRule({
 		{
 			code: 'a { margin: var(--foo, 0px) 0px --bar(0px); }',
 			fixed: 'a { margin: var(--foo, 0px) 0 --bar(0px); }',
+			fix: {
+				range: [29, 31],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -761,6 +919,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 	customSyntax: 'postcss-scss',
 
 	accept: [
@@ -773,6 +932,10 @@ testRule({
 		{
 			code: '@include border-left-radius($input-top-left-radius: 0px);',
 			fixed: '@include border-left-radius($input-top-left-radius: 0);',
+			fix: {
+				range: [53, 55],
+				text: '',
+			},
 
 			message: messages.rejected,
 			line: 1,
@@ -798,6 +961,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 	customSyntax: 'postcss-less',
 	accept: [
 		{

--- a/lib/rules/length-zero-no-unit/index.cjs
+++ b/lib/rules/length-zero-no-unit/index.cjs
@@ -109,7 +109,10 @@ const rule = (primary, secondaryOptions) => {
 				node,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node,
+				},
 			});
 		}
 

--- a/lib/rules/length-zero-no-unit/index.mjs
+++ b/lib/rules/length-zero-no-unit/index.mjs
@@ -106,7 +106,10 @@ const rule = (primary, secondaryOptions) => {
 				node,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node,
+				},
 			});
 		}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
