### PR TITLE
Added `rule-empty-line-before` support for computing `EditInfo`

### DIFF
--- a/.changeset/green-trains-invite.md
+++ b/.changeset/green-trains-invite.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `rule-empty-line-before` support for computing `EditInfo`

--- a/lib/rules/rule-empty-line-before/__tests__/index.mjs
+++ b/lib/rules/rule-empty-line-before/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -42,21 +43,37 @@ testRule({
 		{
 			code: 'b {} a {}',
 			fixed: 'b {}\n\n a {}',
+			fix: {
+				range: [3, 4],
+				text: '}\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'b {}\na {}',
 			fixed: 'b {}\n\na {}',
+			fix: {
+				range: [4, 5],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'b {}\n\n/* comment here*/\na {}',
 			fixed: 'b {}\n\n/* comment here*/\n\na {}',
+			fix: {
+				range: [23, 24],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'b {}\r\n\r\n/* comment here*/\r\na {}',
 			fixed: 'b {}\r\n\r\n/* comment here*/\r\n\r\na {}',
+			fix: {
+				range: [26, 27],
+				text: '\n\r\n',
+			},
 			description: 'CRLF',
 			message: messages.expected,
 		},
@@ -69,11 +86,16 @@ testRule({
 					message: messages.expected,
 					line: 1,
 					column: 10,
+					fix: {
+						range: [7, 8],
+						text: '{\n\n',
+					},
 				},
 				{
 					message: messages.expected,
 					line: 4,
 					column: 1,
+					fix: undefined,
 				},
 			],
 		},
@@ -84,6 +106,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignore: ['after-comment'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -106,6 +129,10 @@ testRule({
 		{
 			code: 'b {} a {}',
 			fixed: 'b {}\n\n a {}',
+			fix: {
+				range: [3, 4],
+				text: '}\n\n',
+			},
 			message: messages.expected,
 		},
 		{
@@ -116,6 +143,10 @@ testRule({
 					message: messages.expected,
 					line: 1,
 					column: 10,
+					fix: {
+						range: [7, 8],
+						text: '{\n\n',
+					},
 				},
 				{
 					message: messages.expected,
@@ -131,6 +162,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignore: ['first-nested'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -145,6 +177,10 @@ testRule({
 		{
 			code: '@media {\n b {}\n c {}\n}',
 			fixed: '@media {\n b {}\n\n c {}\n}',
+			fix: {
+				range: [14, 15],
+				text: '\n\n',
+			},
 			message: messages.expected,
 			line: 3,
 			column: 2,
@@ -156,6 +192,7 @@ testRule({
 	ruleName,
 	config: ['always', { ignore: ['inside-block'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -170,6 +207,10 @@ testRule({
 		{
 			code: 'b {} a {}',
 			fixed: 'b {}\n\n a {}',
+			fix: {
+				range: [3, 4],
+				text: '}\n\n',
+			},
 			message: messages.expected,
 		},
 	],
@@ -179,6 +220,7 @@ testRule({
 	ruleName,
 	config: ['always', { except: ['after-rule'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -206,21 +248,37 @@ testRule({
 		{
 			code: 'a {}\n\nb {}',
 			fixed: 'a {}\nb {}',
+			fix: {
+				range: [5, 6],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '$var: pink;\nb {}',
 			fixed: '$var: pink;\n\nb {}',
+			fix: {
+				range: [11, 12],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '@media {}\na{}',
 			fixed: '@media {}\n\na{}',
+			fix: {
+				range: [9, 10],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '@media {\n\na{}\n\nb{}}',
 			fixed: '@media {\n\na{}\nb{}}',
+			fix: {
+				range: [14, 15],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 	],
@@ -230,6 +288,7 @@ testRule({
 	ruleName,
 	config: ['always', { except: ['after-single-line-comment'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -251,22 +310,38 @@ testRule({
 		{
 			code: '/**\n * comment\n*/\na {}',
 			fixed: '/**\n * comment\n*/\n\na {}',
+			fix: {
+				range: [17, 18],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '/* comment */\n\na {}',
 			fixed: '/* comment */\na {}',
+			fix: {
+				range: [14, 15],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media { /* comment */\na {} }',
 			fixed: '@media { /* comment */\n\na {} }',
+			fix: {
+				range: [22, 23],
+				text: '\n\n',
+			},
 			message: messages.expected,
 			description: 'nested shared-line comment',
 		},
 		{
 			code: 'a {} /* comment */\nb {}',
 			fixed: 'a {} /* comment */\n\nb {}',
+			fix: {
+				range: [18, 19],
+				text: '\n\n',
+			},
 			message: messages.expected,
 			description: 'shared-line comment',
 		},
@@ -277,6 +352,7 @@ testRule({
 	ruleName,
 	config: ['always', { except: ['first-nested'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -316,48 +392,84 @@ testRule({
 		{
 			code: 'b {} a {}',
 			fixed: 'b {}\n\n a {}',
+			fix: {
+				range: [3, 4],
+				text: '}\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '@media {\n\n  a {}\n}',
 			fixed: '@media {\n  a {}\n}',
+			fix: {
+				range: [9, 10],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media { /* comment */\n\n  a {}\n}',
 			fixed: '@media { /* comment */\n  a {}\n}',
+			fix: {
+				range: [23, 24],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media { /* comment */\n\n  a {}\n}',
 			fixed: '@media { /* comment */\n  a {}\n}',
+			fix: {
+				range: [23, 24],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media {\n\n  a {}\n\n  b{}\n}',
 			fixed: '@media {\n  a {}\n\n  b{}\n}',
+			fix: {
+				range: [9, 10],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media {\r\n\r\n  a {}\r\n\r\n  b{}\r\n}',
 			fixed: '@media {\r\n  a {}\r\n\r\n  b{}\r\n}',
+			fix: {
+				range: [10, 12],
+				text: '',
+			},
 			description: 'CRLF',
 			message: messages.rejected,
 		},
 		{
 			code: '@media {\n  b {} a {} }',
 			fixed: '@media {\n  b {}\n\n a {} }',
+			fix: {
+				range: [14, 15],
+				text: '}\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '@media {\r\n  b {} a {} }',
 			fixed: '@media {\r\n  b {}\r\n\r\n a {} }',
+			fix: {
+				range: [15, 16],
+				text: '}\r\n\r\n',
+			},
 			description: 'CRLF',
 			message: messages.expected,
 		},
 		{
 			code: '@media {\n  b {}\n  a {}\n\n}',
 			fixed: '@media {\n  b {}\n\n  a {}\n\n}',
+			fix: {
+				range: [15, 16],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 	],
@@ -379,6 +491,7 @@ testRule({
 	ruleName,
 	config: ['always', { except: ['inside-block-and-after-rule'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -407,31 +520,55 @@ testRule({
 		{
 			code: 'a {} b {}',
 			fixed: 'a {}\n\n b {}',
+			fix: {
+				range: [3, 4],
+				text: '}\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'a {}\nb {}',
 			fixed: 'a {}\n\nb {}',
+			fix: {
+				range: [4, 5],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'a {\n color: pink; b {color: red; }\n c {color: blue; }\n}',
 			fixed: 'a {\n color: pink;\n\n b {color: red; }\n c {color: blue; }\n}',
+			fix: {
+				range: [16, 17],
+				text: ';\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'a {\n color: pink;\n b {color: red; }\n c {color: blue; }\n}',
 			fixed: 'a {\n color: pink;\n\n b {color: red; }\n c {color: blue; }\n}',
+			fix: {
+				range: [17, 18],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'a {\n color: pink;\n\n b {color: red; }\n\n c {color: blue; }\n}',
 			fixed: 'a {\n color: pink;\n\n b {color: red; }\n c {color: blue; }\n}',
+			fix: {
+				range: [37, 38],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'a {\n @media {\n\n   b {}\n }\n c {}\n d {}\n}',
 			fixed: 'a {\n @media {\n\n   b {}\n }\n\n c {}\n d {}\n}',
+			fix: {
+				range: [25, 26],
+				text: '\n\n',
+			},
 			description: 'media rule',
 			message: messages.expected,
 		},
@@ -439,12 +576,20 @@ testRule({
 			code: 'a {\r\n color: pink;\r\n b {\r\ncolor: red; \r\n}\r\n c {\r\ncolor: blue; \r\n}\r\n}',
 			fixed:
 				'a {\r\n color: pink;\r\n\r\n b {\r\ncolor: red; \r\n}\r\n c {\r\ncolor: blue; \r\n}\r\n}',
+			fix: {
+				range: [19, 20],
+				text: '\n\r\n',
+			},
 			description: 'CRLF',
 			message: messages.expected,
 		},
 		{
 			code: '.foo {\r\n text-align: center;\r\n.bar {\r\nfont-style: italic;\r\n}\r\n}',
 			fixed: '.foo {\r\n text-align: center;\r\n\r\n.bar {\r\nfont-style: italic;\r\n}\r\n}',
+			fix: {
+				range: [29, 30],
+				text: '\n\r\n',
+			},
 			description: 'selector after declaration',
 			message: messages.expected,
 		},
@@ -455,6 +600,7 @@ testRule({
 	ruleName,
 	config: ['always', { except: ['inside-block'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -465,6 +611,10 @@ testRule({
 		{
 			code: '.foo {\r\n text-align: center;\r\n\r\n.bar {\r\nfont-style: italic;\r\n}\r\n}',
 			fixed: '.foo {\r\n text-align: center;\r\n.bar {\r\nfont-style: italic;\r\n}\r\n}',
+			fix: {
+				range: [30, 32],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 	],
@@ -474,6 +624,7 @@ testRule({
 	ruleName,
 	config: ['never'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -496,38 +647,66 @@ testRule({
 		{
 			code: 'b {}\n\na {}',
 			fixed: 'b {}\na {}',
+			fix: {
+				range: [5, 6],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\t\n\n\ta {}',
 			fixed: 'b {}\t\n\ta {}',
+			fix: {
+				range: [6, 7],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\t\r\n\r\n\ta {}',
 			fixed: 'b {}\t\r\n\ta {}',
+			fix: {
+				range: [7, 9],
+				text: '',
+			},
 			description: 'CRLF',
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\n  \t\na {}',
 			fixed: 'b {}\na {}',
+			fix: {
+				range: [5, 9],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\r\n  \t\r\na {}',
 			fixed: 'b {}\r\na {}',
+			fix: {
+				range: [6, 11],
+				text: '',
+			},
 			description: 'CRLF',
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\n\n/* comment here*/\n\na {}',
 			fixed: 'b {}\n\n/* comment here*/\na {}',
+			fix: {
+				range: [24, 25],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media {\n\na {} }',
 			fixed: '@media {\na {} }',
+			fix: {
+				range: [9, 10],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 	],
@@ -537,6 +716,7 @@ testRule({
 	ruleName,
 	config: ['never', { except: ['after-rule'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -564,21 +744,37 @@ testRule({
 		{
 			code: 'a {}\nb {}',
 			fixed: 'a {}\n\nb {}',
+			fix: {
+				range: [4, 5],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '$var: pink;\n\nb {}',
 			fixed: '$var: pink;\nb {}',
+			fix: {
+				range: [12, 13],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media {}\n\na{}',
 			fixed: '@media {}\na{}',
+			fix: {
+				range: [10, 11],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media {\na{}\nb{}}',
 			fixed: '@media {\na{}\n\nb{}}',
+			fix: {
+				range: [12, 13],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 	],
@@ -588,6 +784,7 @@ testRule({
 	ruleName,
 	config: ['never', { except: ['after-single-line-comment'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -606,22 +803,38 @@ testRule({
 		{
 			code: '/**\n * comment\n*/\n\na {}',
 			fixed: '/**\n * comment\n*/\na {}',
+			fix: {
+				range: [18, 19],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '/* comment */\na {}',
 			fixed: '/* comment */\n\na {}',
+			fix: {
+				range: [13, 14],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '@media { /* comment */\n\na {} }',
 			fixed: '@media { /* comment */\na {} }',
+			fix: {
+				range: [23, 24],
+				text: '',
+			},
 			message: messages.rejected,
 			description: 'nested shared-line comment',
 		},
 		{
 			code: 'a {} /* comment */\n\nb {}',
 			fixed: 'a {} /* comment */\nb {}',
+			fix: {
+				range: [19, 20],
+				text: '',
+			},
 			message: messages.rejected,
 			description: 'shared-line comment',
 		},
@@ -632,6 +845,7 @@ testRule({
 	ruleName,
 	config: ['never', { ignore: ['after-comment'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -650,6 +864,10 @@ testRule({
 		{
 			code: 'b {}\n\na {}',
 			fixed: 'b {}\na {}',
+			fix: {
+				range: [5, 6],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 	],
@@ -659,6 +877,7 @@ testRule({
 	ruleName,
 	config: ['always-multi-line'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -692,27 +911,47 @@ testRule({
 		{
 			code: 'b {} a\n{}',
 			fixed: 'b {}\n\n a\n{}',
+			fix: {
+				range: [3, 4],
+				text: '}\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'b\n{}\na\n{}',
 			fixed: 'b\n{}\n\na\n{}',
+			fix: {
+				range: [4, 5],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: 'b\r\n{}\r\na\r\n{}',
 			fixed: 'b\r\n{}\r\n\r\na\r\n{}',
+			fix: {
+				range: [6, 7],
+				text: '\n\r\n',
+			},
 			description: 'CRLF',
 			message: messages.expected,
 		},
 		{
 			code: 'b {}\n\n/* comment here*/\na\n{}',
 			fixed: 'b {}\n\n/* comment here*/\n\na\n{}',
+			fix: {
+				range: [23, 24],
+				text: '\n\n',
+			},
 			message: messages.expected,
 		},
 		{
 			code: '@media { a\n{} }',
 			fixed: '@media {\n\n a\n{} }',
+			fix: {
+				range: [7, 8],
+				text: '{\n\n',
+			},
 			message: messages.expected,
 		},
 	],
@@ -722,6 +961,7 @@ testRule({
 	ruleName,
 	config: ['never-multi-line'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -741,49 +981,85 @@ testRule({
 		{
 			code: 'b {}\n\na\n{}',
 			fixed: 'b {}\na\n{}',
+			fix: {
+				range: [5, 6],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\t\n\n\ta\n{}',
 			fixed: 'b {}\t\n\ta\n{}',
+			fix: {
+				range: [6, 7],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\t\r\n\r\n\ta\r\n{}',
 			fixed: 'b {}\t\r\n\ta\r\n{}',
+			fix: {
+				range: [7, 9],
+				text: '',
+			},
 			description: 'CRLF',
 			message: messages.rejected,
 		},
 		{
 			code: 'b\n{}\n  \t\na\n{}',
 			fixed: 'b\n{}\na\n{}',
+			fix: {
+				range: [5, 9],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'b\r\n{}\r\n  \t\r\na\r\n{}',
 			fixed: 'b\r\n{}\r\na\r\n{}',
+			fix: {
+				range: [7, 12],
+				text: '',
+			},
 			description: 'CRLF',
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\n\n/* comment here*/\n\na\n{}',
 			fixed: 'b {}\n\n/* comment here*/\na\n{}',
+			fix: {
+				range: [24, 25],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: 'b {}\r\n\r\n/* comment here*/\r\n\r\na\r\n{}',
 			fixed: 'b {}\r\n\r\n/* comment here*/\r\na\r\n{}',
+			fix: {
+				range: [27, 29],
+				text: '',
+			},
 			description: 'CRLF',
 			message: messages.rejected,
 		},
 		{
 			code: '@media\n{\n\na\n{} }',
 			fixed: '@media\n{\na\n{} }',
+			fix: {
+				range: [9, 10],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 		{
 			code: '@media\r\n{\r\n\r\na\r\n{} }',
 			fixed: '@media\r\n{\r\na\r\n{} }',
+			fix: {
+				range: [11, 13],
+				text: '',
+			},
 			message: messages.rejected,
 		},
 	],

--- a/lib/rules/rule-empty-line-before/index.cjs
+++ b/lib/rules/rule-empty-line-before/index.cjs
@@ -134,7 +134,10 @@ const rule = (primary, secondaryOptions, context) => {
 				node: ruleNode,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: ruleNode.parent,
+				},
 			});
 		});
 	};

--- a/lib/rules/rule-empty-line-before/index.mjs
+++ b/lib/rules/rule-empty-line-before/index.mjs
@@ -130,7 +130,10 @@ const rule = (primary, secondaryOptions, context) => {
 				node: ruleNode,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: ruleNode.parent,
+				},
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
