### PR TITLE
Added `property-no-vendor-prefix` support for computing `EditInfo`

### DIFF
--- a/.changeset/sweet-ants-post.md
+++ b/.changeset/sweet-ants-post.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `property-no-vendor-prefix` support for computing `EditInfo`

--- a/lib/rules/property-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/property-no-vendor-prefix/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -51,6 +52,10 @@ testRule({
 		{
 			code: 'a { -webkit-background-size: 1px 2px; }',
 			fixed: 'a { background-size: 1px 2px; }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			description: 'webkit: unprefixing with 2 values (single background)',
 			message: messages.rejected('-webkit-background-size'),
 			line: 1,
@@ -61,6 +66,10 @@ testRule({
 		{
 			code: 'a { -webkit-background-size: 1px 2px, 2px 1px; }',
 			fixed: 'a { background-size: 1px 2px, 2px 1px; }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			description: 'webkit: unprefixing with 2 values (multiple backgrounds)',
 			message: messages.rejected('-webkit-background-size'),
 			line: 1,
@@ -71,6 +80,10 @@ testRule({
 		{
 			code: 'a { -webkit-background-size: inherit; }',
 			fixed: 'a { background-size: inherit; }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-webkit-background-size'),
 			line: 1,
 			column: 5,
@@ -80,6 +93,10 @@ testRule({
 		{
 			code: 'a { -webkit-background-size: initial; }',
 			fixed: 'a { background-size: initial; }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-webkit-background-size'),
 			line: 1,
 			column: 5,
@@ -89,6 +106,10 @@ testRule({
 		{
 			code: 'a { -webkit-background-size: auto; }',
 			fixed: 'a { background-size: auto; }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-webkit-background-size'),
 			line: 1,
 			column: 5,
@@ -98,6 +119,10 @@ testRule({
 		{
 			code: 'a { -moz-background-size: contain; }',
 			fixed: 'a { background-size: contain; }',
+			fix: {
+				range: [4, 9],
+				text: '',
+			},
 			message: messages.rejected('-moz-background-size'),
 			line: 1,
 			column: 5,
@@ -107,6 +132,10 @@ testRule({
 		{
 			code: 'a { -o-background-size: cover; }',
 			fixed: 'a { background-size: cover; }',
+			fix: {
+				range: [4, 7],
+				text: '',
+			},
 			message: messages.rejected('-o-background-size'),
 			line: 1,
 			column: 5,
@@ -116,6 +145,10 @@ testRule({
 		{
 			code: 'a { -webkit-transform: scale(1); }',
 			fixed: 'a { transform: scale(1); }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-webkit-transform'),
 			line: 1,
 			column: 5,
@@ -125,6 +158,10 @@ testRule({
 		{
 			code: 'a { -wEbKiT-tRaNsFoRm: scale(1); }',
 			fixed: 'a { tRaNsFoRm: scale(1); }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-wEbKiT-tRaNsFoRm'),
 			line: 1,
 			column: 5,
@@ -134,6 +171,10 @@ testRule({
 		{
 			code: 'a { -WEBKIT-TRANSFORM: scale(1); }',
 			fixed: 'a { TRANSFORM: scale(1); }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-WEBKIT-TRANSFORM'),
 			line: 1,
 			column: 5,
@@ -143,6 +184,10 @@ testRule({
 		{
 			code: 'a { -webkit-transform: scale(1); transform: scale(1); }',
 			fixed: 'a { transform: scale(1); transform: scale(1); }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-webkit-transform'),
 			line: 1,
 			column: 5,
@@ -152,6 +197,10 @@ testRule({
 		{
 			code: 'a { transform: scale(1); -webkit-transform: scale(1); }',
 			fixed: 'a { transform: scale(1); transform: scale(1); }',
+			fix: {
+				range: [25, 33],
+				text: '',
+			},
 			message: messages.rejected('-webkit-transform'),
 			line: 1,
 			column: 26,
@@ -161,6 +210,10 @@ testRule({
 		{
 			code: 'a { -moz-transition: all 3s; }',
 			fixed: 'a { transition: all 3s; }',
+			fix: {
+				range: [4, 9],
+				text: '',
+			},
 			message: messages.rejected('-moz-transition'),
 			line: 1,
 			column: 5,
@@ -170,6 +223,10 @@ testRule({
 		{
 			code: 'a { -moz-columns: 2; }',
 			fixed: 'a { columns: 2; }',
+			fix: {
+				range: [4, 9],
+				text: '',
+			},
 			message: messages.rejected('-moz-columns'),
 			line: 1,
 			column: 5,
@@ -179,6 +236,10 @@ testRule({
 		{
 			code: 'a { -o-columns: 2; }',
 			fixed: 'a { columns: 2; }',
+			fix: {
+				range: [4, 7],
+				text: '',
+			},
 			description: 'mistaken prefix',
 			message: messages.rejected('-o-columns'),
 			line: 1,
@@ -193,6 +254,7 @@ testRule({
 	ruleName,
 	config: [true, { ignoreProperties: ['transform', 'columns', '/^animation-/i'] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -215,6 +277,10 @@ testRule({
 		{
 			code: 'a { -webkit-border-radius: 10px; }',
 			fixed: 'a { border-radius: 10px; }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-webkit-border-radius'),
 			line: 1,
 			column: 5,
@@ -224,6 +290,10 @@ testRule({
 		{
 			code: 'a { -moz-background-size: cover; }',
 			fixed: 'a { background-size: cover; }',
+			fix: {
+				range: [4, 9],
+				text: '',
+			},
 			message: messages.rejected('-moz-background-size'),
 			line: 1,
 			column: 5,
@@ -233,6 +303,10 @@ testRule({
 		{
 			code: 'a { -WEBKIT-tranSFoRM: translateY(-50%); }',
 			fixed: 'a { tranSFoRM: translateY(-50%); }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-WEBKIT-tranSFoRM'),
 			line: 1,
 			column: 5,
@@ -246,6 +320,7 @@ testRule({
 	ruleName,
 	config: [true, { ignoreProperties: [/^animation-/i] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -256,6 +331,10 @@ testRule({
 		{
 			code: 'a { -webkit-border-radius: 10px; }',
 			fixed: 'a { border-radius: 10px; }',
+			fix: {
+				range: [4, 12],
+				text: '',
+			},
 			message: messages.rejected('-webkit-border-radius'),
 			line: 1,
 			column: 5,

--- a/lib/rules/property-no-vendor-prefix/index.cjs
+++ b/lib/rules/property-no-vendor-prefix/index.cjs
@@ -94,7 +94,10 @@ const rule = (primary, secondaryOptions) => {
 				node: decl,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: decl,
+				},
 			});
 		});
 	};

--- a/lib/rules/property-no-vendor-prefix/index.mjs
+++ b/lib/rules/property-no-vendor-prefix/index.mjs
@@ -90,7 +90,10 @@ const rule = (primary, secondaryOptions) => {
 				node: decl,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: decl,
+				},
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
