### PR TITLE
Added `selector-no-vendor-prefix` support for `EditInfo`

### DIFF
--- a/.changeset/big-doodles-follow.md
+++ b/.changeset/big-doodles-follow.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `selector-no-vendor-prefix` support for `EditInfo`

--- a/lib/rules/selector-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/selector-no-vendor-prefix/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -59,6 +60,10 @@ testRule({
 		{
 			code: ':-webkit-full-screen a {}',
 			fixed: ':full-screen a {}',
+			fix: {
+				range: [1, 9],
+				text: '',
+			},
 			message: messages.rejected(':-webkit-full-screen'),
 			line: 1,
 			column: 1,
@@ -68,6 +73,10 @@ testRule({
 		{
 			code: ':-wEbKiT-fUlL-sCrEeN a {}',
 			fixed: ':fUlL-sCrEeN a {}',
+			fix: {
+				range: [1, 9],
+				text: '',
+			},
 			message: messages.rejected(':-wEbKiT-fUlL-sCrEeN'),
 			line: 1,
 			column: 1,
@@ -77,6 +86,10 @@ testRule({
 		{
 			code: ':-WEBKIT-FULL-SCREEN a {}',
 			fixed: ':FULL-SCREEN a {}',
+			fix: {
+				range: [1, 9],
+				text: '',
+			},
 			message: messages.rejected(':-WEBKIT-FULL-SCREEN'),
 			line: 1,
 			column: 1,
@@ -86,6 +99,10 @@ testRule({
 		{
 			code: 'body, :-ms-fullscreen a {}',
 			fixed: 'body, :fullscreen a {}',
+			fix: {
+				range: [7, 11],
+				text: '',
+			},
 			message: messages.rejected(':-ms-fullscreen'),
 			line: 1,
 			column: 7,
@@ -95,6 +112,10 @@ testRule({
 		{
 			code: 'input::-moz-placeholder, input::placeholder { color: pink; }',
 			fixed: 'input::placeholder, input::placeholder { color: pink; }',
+			fix: {
+				range: [7, 12],
+				text: '',
+			},
 			message: messages.rejected('::-moz-placeholder'),
 			line: 1,
 			column: 6,
@@ -104,6 +125,10 @@ testRule({
 		{
 			code: 'input::-moz-placeholder { color: pink; }',
 			fixed: 'input::placeholder { color: pink; }',
+			fix: {
+				range: [7, 12],
+				text: '',
+			},
 			message: messages.rejected('::-moz-placeholder'),
 			line: 1,
 			column: 6,
@@ -113,6 +138,10 @@ testRule({
 		{
 			code: 'input::-webkit-input-placeholder { color: pink; }',
 			fixed: 'input::input-placeholder { color: pink; }',
+			fix: {
+				range: [7, 15],
+				text: '',
+			},
 			message: messages.rejected('::-webkit-input-placeholder'),
 			line: 1,
 			column: 6,
@@ -122,6 +151,10 @@ testRule({
 		{
 			code: 'input::-ms-clear + input::-moz-placeholder {}',
 			fixed: 'input::-ms-clear + input::placeholder {}',
+			fix: {
+				range: [26, 31],
+				text: '',
+			},
 			message: messages.rejected('::-moz-placeholder'),
 			line: 1,
 			column: 25,
@@ -176,6 +209,7 @@ testRule({
 	ruleName,
 	config: [true, { ignoreSelectors: ['::-webkit-input-placeholder', '/-moz-.*/', /-screen$/] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -193,6 +227,10 @@ testRule({
 		{
 			code: 'input::-ms-input-placeholder { color: pink; }',
 			fixed: 'input::input-placeholder { color: pink; }',
+			fix: {
+				range: [7, 11],
+				text: '',
+			},
 			message: messages.rejected('::-ms-input-placeholder'),
 		},
 	],

--- a/lib/rules/selector-no-vendor-prefix/index.cjs
+++ b/lib/rules/selector-no-vendor-prefix/index.cjs
@@ -82,7 +82,10 @@ const rule = (primary, secondaryOptions) => {
 					node: ruleNode,
 					index,
 					endIndex,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});

--- a/lib/rules/selector-no-vendor-prefix/index.mjs
+++ b/lib/rules/selector-no-vendor-prefix/index.mjs
@@ -78,7 +78,10 @@ const rule = (primary, secondaryOptions) => {
 					node: ruleNode,
 					index,
 					endIndex,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
