### PR TITLE
Added `selector-not-notation` support for computing `EditInfo`

### DIFF
--- a/.changeset/wicked-mammals-attack.md
+++ b/.changeset/wicked-mammals-attack.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `selector-not-notation` support for computing `EditInfo`

--- a/lib/rules/selector-not-notation/__tests__/index.mjs
+++ b/lib/rules/selector-not-notation/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: ['simple'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -73,6 +74,10 @@ testRule({
 		{
 			code: ':not(a, div) {}',
 			fixed: ':not(a):not(div) {}',
+			fix: {
+				range: [6, 8],
+				text: '):not(',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 1,
@@ -82,6 +87,10 @@ testRule({
 		{
 			code: 'p, :not(a, div) {}',
 			fixed: 'p, :not(a):not(div) {}',
+			fix: {
+				range: [9, 11],
+				text: '):not(',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 4,
@@ -89,9 +98,12 @@ testRule({
 			endColumn: 16,
 		},
 		{
-			code: `p, img:not(a
-, div) {}`,
+			code: `p, img:not(a\n, div) {}`,
 			fixed: 'p, img:not(a):not(div) {}',
+			fix: {
+				range: [12, 15],
+				text: '):not(',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 7,
@@ -101,6 +113,10 @@ testRule({
 		{
 			code: ':not(.bar, .baz, .foo) {}',
 			fixed: ':not(.bar):not(.baz):not(.foo) {}',
+			fix: {
+				range: [9, 17],
+				text: '):not(.baz):not(',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 1,
@@ -110,6 +126,10 @@ testRule({
 		{
 			code: ':not(.bar, .baz, .foo) .qux {}',
 			fixed: ':not(.bar):not(.baz):not(.foo) .qux {}',
+			fix: {
+				range: [9, 17],
+				text: '):not(.baz):not(',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 1,
@@ -119,6 +139,10 @@ testRule({
 		{
 			code: ':not(.bar, .baz) .qux :not(.foo) {}',
 			fixed: ':not(.bar):not(.baz) .qux :not(.foo) {}',
+			fix: {
+				range: [9, 11],
+				text: '):not(',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 1,
@@ -128,6 +152,10 @@ testRule({
 		{
 			code: ':not(.foo) .qux :not(.bar, .baz) {}',
 			fixed: ':not(.foo) .qux :not(.bar):not(.baz) {}',
+			fix: {
+				range: [25, 27],
+				text: '):not(',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 17,
@@ -137,6 +165,10 @@ testRule({
 		{
 			code: ':not(a ,) {}',
 			fixed: ':not(a) {}',
+			fix: {
+				range: [6, 8],
+				text: '',
+			},
 			message: messages.expected('simple'),
 			line: 1,
 			column: 1,
@@ -172,6 +204,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('simple'),
+					fix: {
+						range: [22, 24],
+						text: '):not(',
+					},
 					line: 2,
 					column: 1,
 					endLine: 2,
@@ -179,6 +215,7 @@ testRule({
 				},
 				{
 					message: messages.expected('simple'),
+					fix: undefined,
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -186,6 +223,7 @@ testRule({
 				},
 				{
 					message: messages.expected('simple'),
+					fix: undefined,
 					line: 5,
 					column: 1,
 					endLine: 5,
@@ -200,6 +238,7 @@ testRule({
 	ruleName,
 	config: ['complex'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -220,6 +259,10 @@ testRule({
 		{
 			code: ':not( .foo ,:hover ):not(a,div) {}',
 			fixed: ':not(.foo, :hover, a, div) {}',
+			fix: {
+				range: [5, 27],
+				text: '.foo, :hover, a, ',
+			},
 			message: messages.expected('complex'),
 			line: 1,
 			column: 21,

--- a/lib/rules/selector-not-notation/index.cjs
+++ b/lib/rules/selector-not-notation/index.cjs
@@ -122,7 +122,10 @@ const rule = (primary) => {
 					ruleName,
 					index,
 					endIndex,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});

--- a/lib/rules/selector-not-notation/index.mjs
+++ b/lib/rules/selector-not-notation/index.mjs
@@ -118,7 +118,10 @@ const rule = (primary) => {
 					ruleName,
 					index,
 					endIndex,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
