### PR TITLE
Added `selector-pseudo-element-colon-notation` support for `EditInfo`

### DIFF
--- a/.changeset/chatty-bushes-remain.md
+++ b/.changeset/chatty-bushes-remain.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `selector-pseudo-element-colon-notation` support for `EditInfo`

--- a/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-element-colon-notation/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: ['single'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -77,6 +78,10 @@ testRule({
 		{
 			code: 'a::before { color: pink; }',
 			fixed: 'a:before { color: pink; }',
+			fix: {
+				range: [2, 3],
+				text: '',
+			},
 			message: messages.expected('single'),
 			line: 1,
 			column: 2,
@@ -86,6 +91,10 @@ testRule({
 		{
 			code: 'a::bEfOrE { color: pink; }',
 			fixed: 'a:bEfOrE { color: pink; }',
+			fix: {
+				range: [2, 3],
+				text: '',
+			},
 			message: messages.expected('single'),
 			line: 1,
 			column: 2,
@@ -95,6 +104,10 @@ testRule({
 		{
 			code: 'a::BEFORE { color: pink; }',
 			fixed: 'a:BEFORE { color: pink; }',
+			fix: {
+				range: [2, 3],
+				text: '',
+			},
 			message: messages.expected('single'),
 			line: 1,
 			column: 2,
@@ -104,6 +117,10 @@ testRule({
 		{
 			code: 'a::after { color: pink; }',
 			fixed: 'a:after { color: pink; }',
+			fix: {
+				range: [2, 3],
+				text: '',
+			},
 			message: messages.expected('single'),
 			line: 1,
 			column: 2,
@@ -113,6 +130,10 @@ testRule({
 		{
 			code: 'a::first-line { color: pink; }',
 			fixed: 'a:first-line { color: pink; }',
+			fix: {
+				range: [2, 3],
+				text: '',
+			},
 			message: messages.expected('single'),
 			line: 1,
 			column: 2,
@@ -122,6 +143,10 @@ testRule({
 		{
 			code: 'a::first-letter { color: pink; }',
 			fixed: 'a:first-letter { color: pink; }',
+			fix: {
+				range: [2, 3],
+				text: '',
+			},
 			message: messages.expected('single'),
 			line: 1,
 			column: 2,
@@ -131,6 +156,10 @@ testRule({
 		{
 			code: 'a\\:before-none::before { color: pink; }',
 			fixed: 'a\\:before-none:before { color: pink; }',
+			fix: {
+				range: [15, 16],
+				text: '',
+			},
 			message: messages.expected('single'),
 			line: 1,
 			column: 15,
@@ -143,6 +172,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('single'),
+					fix: {
+						range: [2, 3],
+						text: '',
+					},
 					line: 1,
 					column: 2,
 					endLine: 1,
@@ -184,6 +217,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('single'),
+					fix: {
+						range: [18, 19],
+						text: '',
+					},
 					line: 2,
 					column: 2,
 					endLine: 2,
@@ -212,6 +249,7 @@ testRule({
 	ruleName,
 	config: ['double'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -253,6 +291,10 @@ testRule({
 		{
 			code: 'a:before { color: pink; }',
 			fixed: 'a::before { color: pink; }',
+			fix: {
+				range: [1, 2],
+				text: '::',
+			},
 			message: messages.expected('double'),
 			line: 1,
 			column: 2,
@@ -262,6 +304,10 @@ testRule({
 		{
 			code: 'a:after { color: pink; }',
 			fixed: 'a::after { color: pink; }',
+			fix: {
+				range: [1, 2],
+				text: '::',
+			},
 			message: messages.expected('double'),
 			line: 1,
 			column: 2,
@@ -271,6 +317,10 @@ testRule({
 		{
 			code: 'a:first-line { color: pink; }',
 			fixed: 'a::first-line { color: pink; }',
+			fix: {
+				range: [1, 2],
+				text: '::',
+			},
 			message: messages.expected('double'),
 			line: 1,
 			column: 2,
@@ -280,6 +330,10 @@ testRule({
 		{
 			code: 'a:first-letter { color: pink; }',
 			fixed: 'a::first-letter { color: pink; }',
+			fix: {
+				range: [1, 2],
+				text: '::',
+			},
 			message: messages.expected('double'),
 			line: 1,
 			column: 2,
@@ -292,6 +346,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('double'),
+					fix: {
+						range: [1, 2],
+						text: '::',
+					},
 					line: 1,
 					column: 2,
 					endLine: 1,

--- a/lib/rules/selector-pseudo-element-colon-notation/index.cjs
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.cjs
@@ -85,7 +85,10 @@ const rule = (primary) => {
 					endIndex: pseudo.sourceIndex + (isDouble ? 2 : 1),
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});

--- a/lib/rules/selector-pseudo-element-colon-notation/index.mjs
+++ b/lib/rules/selector-pseudo-element-colon-notation/index.mjs
@@ -81,7 +81,10 @@ const rule = (primary) => {
 					endIndex: pseudo.sourceIndex + (isDouble ? 2 : 1),
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
