### PR TITLE
Added `shorthand-property-no-redundant-values` support for computing `EditInfo`

### DIFF
--- a/.changeset/six-ties-cry.md
+++ b/.changeset/six-ties-cry.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `shorthand-property-no-redundant-values` support for computing `EditInfo`

--- a/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 	accept: [
 		{
 			code: 'a { margin: 1px; }',
@@ -119,6 +120,10 @@ testRule({
 		{
 			code: 'a { overflow: scroll scroll; }',
 			fixed: 'a { overflow: scroll; }',
+			fix: {
+				range: [20, 27],
+				text: '',
+			},
 			message: messages.expected('scroll scroll', 'scroll'),
 			line: 1,
 			column: 15,
@@ -128,6 +133,10 @@ testRule({
 		{
 			code: 'a { gap: 1rem 1rem; }',
 			fixed: 'a { gap: 1rem; }',
+			fix: {
+				range: [13, 18],
+				text: '',
+			},
 			message: messages.expected('1rem 1rem', '1rem'),
 			line: 1,
 			column: 10,
@@ -137,6 +146,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 1px; }',
 			fixed: 'a { margin: 1px; }',
+			fix: {
+				range: [15, 19],
+				text: '',
+			},
 			message: messages.expected('1px 1px', '1px'),
 			line: 1,
 			column: 13,
@@ -146,6 +159,10 @@ testRule({
 		{
 			code: 'a { margin: 1Px 1pX; }',
 			fixed: 'a { margin: 1Px; }',
+			fix: {
+				range: [15, 19],
+				text: '',
+			},
 			message: messages.expected('1Px 1pX', '1Px'),
 			line: 1,
 			column: 13,
@@ -153,6 +170,10 @@ testRule({
 		{
 			code: 'a { margin: 1PX 1PX; }',
 			fixed: 'a { margin: 1PX; }',
+			fix: {
+				range: [15, 19],
+				text: '',
+			},
 			message: messages.expected('1PX 1PX', '1PX'),
 			line: 1,
 			column: 13,
@@ -160,6 +181,10 @@ testRule({
 		{
 			code: 'a { mArGiN: 1px 1px; }',
 			fixed: 'a { mArGiN: 1px; }',
+			fix: {
+				range: [15, 19],
+				text: '',
+			},
 			message: messages.expected('1px 1px', '1px'),
 			line: 1,
 			column: 13,
@@ -167,6 +192,10 @@ testRule({
 		{
 			code: 'a { MARGIN: 1px 1px; }',
 			fixed: 'a { MARGIN: 1px; }',
+			fix: {
+				range: [15, 19],
+				text: '',
+			},
 			message: messages.expected('1px 1px', '1px'),
 			line: 1,
 			column: 13,
@@ -174,6 +203,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 1px 1px; }',
 			fixed: 'a { margin: 1px; }',
+			fix: {
+				range: [15, 23],
+				text: '',
+			},
 			message: messages.expected('1px 1px 1px', '1px'),
 			line: 1,
 			column: 13,
@@ -181,6 +214,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 2px 1px; }',
 			fixed: 'a { margin: 1px 2px; }',
+			fix: {
+				range: [19, 23],
+				text: '',
+			},
 			message: messages.expected('1px 2px 1px', '1px 2px'),
 			line: 1,
 			column: 13,
@@ -188,6 +225,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 2pX 1px; }',
 			fixed: 'a { margin: 1px 2pX; }',
+			fix: {
+				range: [19, 23],
+				text: '',
+			},
 			message: messages.expected('1px 2pX 1px', '1px 2pX'),
 			line: 1,
 			column: 13,
@@ -195,6 +236,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 2PX 1px; }',
 			fixed: 'a { margin: 1px 2PX; }',
+			fix: {
+				range: [19, 23],
+				text: '',
+			},
 			message: messages.expected('1px 2PX 1px', '1px 2PX'),
 			line: 1,
 			column: 13,
@@ -202,6 +247,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 1px 1px 1px; }',
 			fixed: 'a { margin: 1px; }',
+			fix: {
+				range: [15, 27],
+				text: '',
+			},
 			message: messages.expected('1px 1px 1px 1px', '1px'),
 			line: 1,
 			column: 13,
@@ -209,6 +258,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 2px 1px 2px; }',
 			fixed: 'a { margin: 1px 2px; }',
+			fix: {
+				range: [19, 27],
+				text: '',
+			},
 			message: messages.expected('1px 2px 1px 2px', '1px 2px'),
 			line: 1,
 			column: 13,
@@ -216,6 +269,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 2px 2px 2px; }',
 			fixed: 'a { margin: 1px 2px 2px; }',
+			fix: {
+				range: [23, 27],
+				text: '',
+			},
 			message: messages.expected('1px 2px 2px 2px', '1px 2px 2px'),
 			line: 1,
 			column: 13,
@@ -223,6 +280,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 2px 3px 2px; }',
 			fixed: 'a { margin: 1px 2px 3px; }',
+			fix: {
+				range: [23, 27],
+				text: '',
+			},
 			message: messages.expected('1px 2px 3px 2px', '1px 2px 3px'),
 			line: 1,
 			column: 13,
@@ -230,6 +291,10 @@ testRule({
 		{
 			code: 'a { margin: 1px  1px   1px    1px; }',
 			fixed: 'a { margin: 1px; }',
+			fix: {
+				range: [15, 33],
+				text: '',
+			},
 			message: messages.expected('1px  1px   1px    1px', '1px'),
 			line: 1,
 			column: 13,
@@ -239,6 +304,10 @@ testRule({
 		{
 			code: 'a { margin: 100% 100% 100% 100%; }',
 			fixed: 'a { margin: 100%; }',
+			fix: {
+				range: [16, 31],
+				text: '',
+			},
 			message: messages.expected('100% 100% 100% 100%', '100%'),
 			line: 1,
 			column: 13,
@@ -246,6 +315,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 1px !important; }',
 			fixed: 'a { margin: 1px !important; }',
+			fix: {
+				range: [16, 20],
+				text: '',
+			},
 			message: messages.expected('1px 1px', '1px'),
 			line: 1,
 			column: 13,
@@ -255,6 +328,10 @@ testRule({
 		{
 			code: 'a { margin: 1px 1px 1px 1px !important; }',
 			fixed: 'a { margin: 1px !important; }',
+			fix: {
+				range: [16, 28],
+				text: '',
+			},
 			message: messages.expected('1px 1px 1px 1px', '1px'),
 			line: 1,
 			column: 13,
@@ -264,6 +341,10 @@ testRule({
 		{
 			code: 'a { padding: 1px 1px 1px 1px; }',
 			fixed: 'a { padding: 1px; }',
+			fix: {
+				range: [16, 28],
+				text: '',
+			},
 			message: messages.expected('1px 1px 1px 1px', '1px'),
 			line: 1,
 			column: 14,
@@ -271,6 +352,10 @@ testRule({
 		{
 			code: 'a { border-color: transparent transparent transparent transparent; }',
 			fixed: 'a { border-color: transparent; }',
+			fix: {
+				range: [29, 65],
+				text: '',
+			},
 			message: messages.expected('transparent transparent transparent transparent', 'transparent'),
 			line: 1,
 			column: 19,
@@ -278,6 +363,10 @@ testRule({
 		{
 			code: 'a { border-color: transparent tRaNsPaReNt TRANSPARENT transparent; }',
 			fixed: 'a { border-color: transparent; }',
+			fix: {
+				range: [29, 65],
+				text: '',
+			},
 			message: messages.expected('transparent tRaNsPaReNt TRANSPARENT transparent', 'transparent'),
 			line: 1,
 			column: 19,
@@ -285,6 +374,10 @@ testRule({
 		{
 			code: 'a { border-color: tRaNsPaReNt TRANSPARENT TRANSPARENT transparent; }',
 			fixed: 'a { border-color: tRaNsPaReNt; }',
+			fix: {
+				range: [29, 65],
+				text: '',
+			},
 			message: messages.expected('tRaNsPaReNt TRANSPARENT TRANSPARENT transparent', 'tRaNsPaReNt'),
 			line: 1,
 			column: 19,
@@ -292,6 +385,10 @@ testRule({
 		{
 			code: 'a { border-color: tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt; }',
 			fixed: 'a { border-color: tRaNsPaReNt; }',
+			fix: {
+				range: [29, 65],
+				text: '',
+			},
 			message: messages.expected('tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt tRaNsPaReNt', 'tRaNsPaReNt'),
 			line: 1,
 			column: 19,
@@ -299,6 +396,10 @@ testRule({
 		{
 			code: 'a { border-color: TRANSPARENT TRANSPARENT TRANSPARENT TRANSPARENT; }',
 			fixed: 'a { border-color: TRANSPARENT; }',
+			fix: {
+				range: [29, 65],
+				text: '',
+			},
 			message: messages.expected('TRANSPARENT TRANSPARENT TRANSPARENT TRANSPARENT', 'TRANSPARENT'),
 			line: 1,
 			column: 19,
@@ -306,6 +407,10 @@ testRule({
 		{
 			code: 'a { border-color: inherit inherit inherit inherit; }',
 			fixed: 'a { border-color: inherit; }',
+			fix: {
+				range: [25, 49],
+				text: '',
+			},
 			message: messages.expected('inherit inherit inherit inherit', 'inherit'),
 			line: 1,
 			column: 19,
@@ -313,6 +418,10 @@ testRule({
 		{
 			code: 'a { border-color: #fff #fff #fff #fff; }',
 			fixed: 'a { border-color: #fff; }',
+			fix: {
+				range: [22, 37],
+				text: '',
+			},
 			message: messages.expected('#fff #fff #fff #fff', '#fff'),
 			line: 1,
 			column: 19,
@@ -320,6 +429,10 @@ testRule({
 		{
 			code: 'a { border-radius: 1px 1px 1px 1px; }',
 			fixed: 'a { border-radius: 1px; }',
+			fix: {
+				range: [22, 34],
+				text: '',
+			},
 			message: messages.expected('1px 1px 1px 1px', '1px'),
 			line: 1,
 			column: 20,
@@ -327,6 +440,10 @@ testRule({
 		{
 			code: 'a { -webkit-border-radius: 1px 1px 1px 1px; }',
 			fixed: 'a { -webkit-border-radius: 1px; }',
+			fix: {
+				range: [30, 42],
+				text: '',
+			},
 			message: messages.expected('1px 1px 1px 1px', '1px'),
 			line: 1,
 			column: 28,
@@ -334,6 +451,10 @@ testRule({
 		{
 			code: 'a { border-style: solid solid solid solid; }',
 			fixed: 'a { border-style: solid; }',
+			fix: {
+				range: [23, 41],
+				text: '',
+			},
 			message: messages.expected('solid solid solid solid', 'solid'),
 			line: 1,
 			column: 19,
@@ -341,6 +462,10 @@ testRule({
 		{
 			code: 'a { border-width: 1px 1px 1px 1px; }',
 			fixed: 'a { border-width: 1px; }',
+			fix: {
+				range: [21, 33],
+				text: '',
+			},
 			message: messages.expected('1px 1px 1px 1px', '1px'),
 			line: 1,
 			column: 19,
@@ -348,6 +473,10 @@ testRule({
 		{
 			code: 'a { border-width: thin thin thin thin; }',
 			fixed: 'a { border-width: thin; }',
+			fix: {
+				range: [22, 37],
+				text: '',
+			},
 			message: messages.expected('thin thin thin thin', 'thin'),
 			line: 1,
 			column: 19,
@@ -355,6 +484,10 @@ testRule({
 		{
 			code: 'a { margin: 1em 0 2em 0; }',
 			fixed: 'a { margin: 1em 0 2em; }',
+			fix: {
+				range: [21, 23],
+				text: '',
+			},
 			message: messages.expected('1em 0 2em 0', '1em 0 2em'),
 			line: 1,
 			column: 13,
@@ -362,6 +495,10 @@ testRule({
 		{
 			code: 'a { margin: -1px -1px -1px -1px; }',
 			fixed: 'a { margin: -1px; }',
+			fix: {
+				range: [16, 31],
+				text: '',
+			},
 			message: messages.expected('-1px -1px -1px -1px', '-1px'),
 			line: 1,
 			column: 13,
@@ -369,6 +506,10 @@ testRule({
 		{
 			code: 'a { margin: -1px -1px -1px; }',
 			fixed: 'a { margin: -1px; }',
+			fix: {
+				range: [16, 26],
+				text: '',
+			},
 			message: messages.expected('-1px -1px -1px', '-1px'),
 			line: 1,
 			column: 13,
@@ -376,6 +517,10 @@ testRule({
 		{
 			code: 'a { margin: 0 -1px 0 -1px; }',
 			fixed: 'a { margin: 0 -1px; }',
+			fix: {
+				range: [18, 25],
+				text: '',
+			},
 			message: messages.expected('0 -1px 0 -1px', '0 -1px'),
 			line: 1,
 			column: 13,
@@ -383,6 +528,10 @@ testRule({
 		{
 			code: 'a { margin: -1em 0 2em 0; }',
 			fixed: 'a { margin: -1em 0 2em; }',
+			fix: {
+				range: [22, 24],
+				text: '',
+			},
 			message: messages.expected('-1em 0 2em 0', '-1em 0 2em'),
 			line: 1,
 			column: 13,
@@ -390,6 +539,10 @@ testRule({
 		{
 			code: 'a { inset: 0 0 0 0; }',
 			fixed: 'a { inset: 0; }',
+			fix: {
+				range: [12, 18],
+				text: '',
+			},
 			message: messages.expected('0 0 0 0', '0'),
 			line: 1,
 			column: 12,
@@ -397,6 +550,10 @@ testRule({
 		{
 			code: 'a { inset: 1px 0 1px 0; }',
 			fixed: 'a { inset: 1px 0; }',
+			fix: {
+				range: [16, 22],
+				text: '',
+			},
 			message: messages.expected('1px 0 1px 0', '1px 0'),
 			line: 1,
 			column: 12,
@@ -404,6 +561,10 @@ testRule({
 		{
 			code: 'a { margin: calc(1px + 1px) calc(1px + 1px); }',
 			fixed: 'a { margin: calc(1px + 1px); }',
+			fix: {
+				range: [27, 43],
+				text: '',
+			},
 			message: messages.expected('calc(1px + 1px) calc(1px + 1px)', 'calc(1px + 1px)'),
 			line: 1,
 			column: 13,
@@ -413,6 +574,10 @@ testRule({
 		{
 			code: 'a { margin: some-function(1px + 1px) some-function(1px + 1px); }',
 			fixed: 'a { margin: some-function(1px + 1px); }',
+			fix: {
+				range: [36, 61],
+				text: '',
+			},
 			message: messages.expected(
 				'some-function(1px + 1px) some-function(1px + 1px)',
 				'some-function(1px + 1px)',

--- a/lib/rules/shorthand-property-no-redundant-values/index.cjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.cjs
@@ -186,7 +186,10 @@ const rule = (primary) => {
 				endIndex,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: decl,
+				},
 			});
 		});
 	};

--- a/lib/rules/shorthand-property-no-redundant-values/index.mjs
+++ b/lib/rules/shorthand-property-no-redundant-values/index.mjs
@@ -184,7 +184,10 @@ const rule = (primary) => {
 				endIndex,
 				result,
 				ruleName,
-				fix,
+				fix: {
+					apply: fix,
+					node: decl,
+				},
 			});
 		});
 	};


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
