### PR TITLE
Added `selector-type-case` support for computing `EditInfo`

### DIFF
--- a/.changeset/stale-paws-lie.md
+++ b/.changeset/stale-paws-lie.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `selector-type-case` support for computing `EditInfo`

--- a/lib/rules/selector-type-case/__tests__/index.mjs
+++ b/lib/rules/selector-type-case/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: ['lower'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -122,11 +123,19 @@ testRule({
 		{
 			code: 'A {}',
 			fixed: 'a {}',
+			fix: {
+				range: [0, 1],
+				text: 'a',
+			},
 			message: messages.expected('A', 'a'),
 		},
 		{
 			code: 'DIV::before {}',
 			fixed: 'div::before {}',
+			fix: {
+				range: [0, 3],
+				text: 'div',
+			},
 			message: messages.expected('DIV', 'div'),
 			line: 1,
 			column: 1,
@@ -136,31 +145,55 @@ testRule({
 		{
 			code: 'a B {}',
 			fixed: 'a b {}',
+			fix: {
+				range: [2, 3],
+				text: 'b',
+			},
 			message: messages.expected('B', 'b'),
 		},
 		{
 			code: 'a { & B {}}',
 			fixed: 'a { & b {}}',
+			fix: {
+				range: [6, 7],
+				text: 'b',
+			},
 			message: messages.expected('B', 'b'),
 		},
 		{
 			code: 'A:nth-child(even) {}',
 			fixed: 'a:nth-child(even) {}',
+			fix: {
+				range: [0, 1],
+				text: 'a',
+			},
 			message: messages.expected('A', 'a'),
 		},
 		{
 			code: 'A:nth-child(-n) {}',
 			fixed: 'a:nth-child(-n) {}',
+			fix: {
+				range: [0, 1],
+				text: 'a',
+			},
 			message: messages.expected('A', 'a'),
 		},
 		{
 			code: 'A { &:nth-child(3n + 1) {} }',
 			fixed: 'a { &:nth-child(3n + 1) {} }',
+			fix: {
+				range: [0, 1],
+				text: 'a',
+			},
 			message: messages.expected('A', 'a'),
 		},
 		{
 			code: 'a /*comments */\n B {}',
 			fixed: 'a /*comments */\n b {}',
+			fix: {
+				range: [17, 18],
+				text: 'b',
+			},
 			message: messages.expected('B', 'b'),
 		},
 		{
@@ -183,6 +216,10 @@ testRule({
 			warnings: [
 				{
 					message: messages.expected('A', 'a'),
+					fix: {
+						range: [16, 17],
+						text: 'a',
+					},
 					line: 2,
 					column: 1,
 					endLine: 2,
@@ -190,6 +227,7 @@ testRule({
 				},
 				{
 					message: messages.expected('A', 'a'),
+					fix: undefined,
 					line: 3,
 					column: 1,
 					endLine: 3,
@@ -197,6 +235,7 @@ testRule({
 				},
 				{
 					message: messages.expected('A', 'a'),
+					fix: undefined,
 					line: 5,
 					column: 1,
 					endLine: 5,
@@ -211,6 +250,7 @@ testRule({
 	ruleName,
 	config: ['upper'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -290,11 +330,19 @@ testRule({
 		{
 			code: 'a {}',
 			fixed: 'A {}',
+			fix: {
+				range: [0, 1],
+				text: 'A',
+			},
 			message: messages.expected('a', 'A'),
 		},
 		{
 			code: 'div::before {}',
 			fixed: 'DIV::before {}',
+			fix: {
+				range: [0, 3],
+				text: 'DIV',
+			},
 			message: messages.expected('div', 'DIV'),
 			line: 1,
 			column: 1,
@@ -304,36 +352,64 @@ testRule({
 		{
 			code: 'a B {}',
 			fixed: 'A B {}',
+			fix: {
+				range: [0, 1],
+				text: 'A',
+			},
 			message: messages.expected('a', 'A'),
 		},
 		{
 			code: 'a { & B {}}',
 			fixed: 'A { & B {}}',
+			fix: {
+				range: [0, 1],
+				text: 'A',
+			},
 			message: messages.expected('a', 'A'),
 		},
 		{
 			code: 'a:nth-child(even) {}',
 			fixed: 'A:nth-child(even) {}',
+			fix: {
+				range: [0, 1],
+				text: 'A',
+			},
 			message: messages.expected('a', 'A'),
 		},
 		{
 			code: 'a:nth-child(-n) {}',
 			fixed: 'A:nth-child(-n) {}',
+			fix: {
+				range: [0, 1],
+				text: 'A',
+			},
 			message: messages.expected('a', 'A'),
 		},
 		{
 			code: 'a { &:nth-child(3n + 1) {} }',
 			fixed: 'A { &:nth-child(3n + 1) {} }',
+			fix: {
+				range: [0, 1],
+				text: 'A',
+			},
 			message: messages.expected('a', 'A'),
 		},
 		{
 			code: 'A, /*comments */\n b {}',
 			fixed: 'A, /*comments */\n B {}',
+			fix: {
+				range: [18, 19],
+				text: 'B',
+			},
 			message: messages.expected('b', 'B'),
 		},
 		{
 			code: 'A /*comments */\n b {}',
 			fixed: 'A /*comments */\n B {}',
+			fix: {
+				range: [17, 18],
+				text: 'B',
+			},
 			message: messages.expected('b', 'B'),
 		},
 	],
@@ -365,6 +441,7 @@ testRule({
 testRule({
 	ruleName,
 	config: ['lower', { ignoreTypes: ['$childClass', '/(p|P)arent.*/', /foo$/i] }],
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -382,6 +459,10 @@ testRule({
 		{
 			code: 'DIV::before {}',
 			fixed: 'div::before {}',
+			fix: {
+				range: [0, 3],
+				text: 'div',
+			},
 			message: messages.expected('DIV', 'div'),
 		},
 	],

--- a/lib/rules/selector-type-case/index.cjs
+++ b/lib/rules/selector-type-case/index.cjs
@@ -106,7 +106,10 @@ const rule = (primary, secondaryOptions) => {
 					endIndex,
 					ruleName,
 					result,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});

--- a/lib/rules/selector-type-case/index.mjs
+++ b/lib/rules/selector-type-case/index.mjs
@@ -102,7 +102,10 @@ const rule = (primary, secondaryOptions) => {
 					endIndex,
 					ruleName,
 					result,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
