### PR TITLE
Added `value-no-vendor-prefix` support for computing `EditInfo`

### DIFF
--- a/.changeset/fast-forks-look.md
+++ b/.changeset/fast-forks-look.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `value-no-vendor-prefix` support for computing `EditInfo`

--- a/lib/rules/value-no-vendor-prefix/__tests__/index.mjs
+++ b/lib/rules/value-no-vendor-prefix/__tests__/index.mjs
@@ -5,6 +5,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -37,6 +38,10 @@ testRule({
 		{
 			code: 'a { white-space: -pre-wrap; }',
 			description: 'ignores non-vendor prefixed values',
+			fix: {
+				range: [111, 222],
+				text: 'any',
+			},
 		},
 		{
 			code: 'a { background-color: -apple-wireless-playback-target-active; }',
@@ -56,6 +61,10 @@ testRule({
 		{
 			code: '.foo { display: -webkit-flex; }',
 			fixed: '.foo { display: flex; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-webkit-flex'),
 			line: 1,
 			column: 17,
@@ -65,6 +74,10 @@ testRule({
 		{
 			code: '.foo { display: -wEbKiT-fLeX; }',
 			fixed: '.foo { display: fLeX; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-wEbKiT-fLeX'),
 			line: 1,
 			column: 17,
@@ -74,6 +87,10 @@ testRule({
 		{
 			code: '.foo { display: -WEBKIT-FLEX; }',
 			fixed: '.foo { display: FLEX; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-WEBKIT-FLEX'),
 			line: 1,
 			column: 17,
@@ -83,6 +100,10 @@ testRule({
 		{
 			code: '.foo { dIsPlAy: -webkit-flex; }',
 			fixed: '.foo { dIsPlAy: flex; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-webkit-flex'),
 			line: 1,
 			column: 17,
@@ -92,6 +113,10 @@ testRule({
 		{
 			code: '.foo { DISPLAY: -webkit-flex; }',
 			fixed: '.foo { DISPLAY: flex; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-webkit-flex'),
 			line: 1,
 			column: 17,
@@ -101,6 +126,10 @@ testRule({
 		{
 			code: '.foo { color: pink; display: -webkit-flex; }',
 			fixed: '.foo { color: pink; display: flex; }',
+			fix: {
+				range: [29, 37],
+				text: '',
+			},
 			message: messages.rejected('-webkit-flex'),
 			line: 1,
 			column: 30,
@@ -110,6 +139,10 @@ testRule({
 		{
 			code: '.foo { image-rendering: -o-crisp-edges; }',
 			fixed: '.foo { image-rendering: crisp-edges; }',
+			fix: {
+				range: [24, 27],
+				text: '',
+			},
 			message: messages.rejected('-o-crisp-edges'),
 			line: 1,
 			column: 25,
@@ -119,6 +152,10 @@ testRule({
 		{
 			code: '.foo { background: -webkit-linear-gradient(bottom, #000, #fff); }',
 			fixed: '.foo { background: linear-gradient(bottom, #000, #fff); }',
+			fix: {
+				range: [19, 27],
+				text: '',
+			},
 			message: messages.rejected('-webkit-linear-gradient'),
 			line: 1,
 			column: 20,
@@ -128,6 +165,10 @@ testRule({
 		{
 			code: '.foo { max-width: -moz-max-content; }',
 			fixed: '.foo { max-width: max-content; }',
+			fix: {
+				range: [18, 23],
+				text: '',
+			},
 			message: messages.rejected('-moz-max-content'),
 			line: 1,
 			column: 19,
@@ -137,6 +178,10 @@ testRule({
 		{
 			code: '.foo { speak: -xv-digits; }',
 			fixed: '.foo { speak: digits; }',
+			fix: {
+				range: [14, 18],
+				text: '',
+			},
 			message: messages.rejected('-xv-digits'),
 			line: 1,
 			column: 15,
@@ -146,6 +191,10 @@ testRule({
 		{
 			code: '.foo { white-space: -o-pre-wrap; }',
 			fixed: '.foo { white-space: pre-wrap; }',
+			fix: {
+				range: [20, 23],
+				text: '',
+			},
 			message: messages.rejected('-o-pre-wrap'),
 			line: 1,
 			column: 21,
@@ -155,6 +204,10 @@ testRule({
 		{
 			code: '.foo { -webkit-user-select: -moz-all; }',
 			fixed: '.foo { -webkit-user-select: all; }',
+			fix: {
+				range: [28, 33],
+				text: '',
+			},
 			message: messages.rejected('-moz-all'),
 			line: 1,
 			column: 29,
@@ -217,6 +270,7 @@ testRule({
 	ruleName,
 	config: [true, { ignoreValues: ['grab', 'hangul', '/^-webkit-linear-/', /^-moz-all$/] }],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -237,6 +291,10 @@ testRule({
 		{
 			code: '.foo { display: -webkit-flex; }',
 			fixed: '.foo { display: flex; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-webkit-flex'),
 			line: 1,
 			column: 17,
@@ -246,6 +304,10 @@ testRule({
 		{
 			code: '.foo { display: -wEbKiT-fLeX; }',
 			fixed: '.foo { display: fLeX; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-wEbKiT-fLeX'),
 			line: 1,
 			column: 17,
@@ -255,6 +317,10 @@ testRule({
 		{
 			code: '.foo { display: -WEBKIT-FLEX; }',
 			fixed: '.foo { display: FLEX; }',
+			fix: {
+				range: [16, 24],
+				text: '',
+			},
 			message: messages.rejected('-WEBKIT-FLEX'),
 			line: 1,
 			column: 17,
@@ -264,6 +330,10 @@ testRule({
 		{
 			code: '.foo { list-style-type: -moz-hangul-consonant; }',
 			fixed: '.foo { list-style-type: hangul-consonant; }',
+			fix: {
+				range: [24, 29],
+				text: '',
+			},
 			message: messages.rejected('-moz-hangul-consonant'),
 			line: 1,
 			column: 25,

--- a/lib/rules/value-no-vendor-prefix/index.cjs
+++ b/lib/rules/value-no-vendor-prefix/index.cjs
@@ -102,7 +102,10 @@ const rule = (primary, secondaryOptions) => {
 					endIndex: index + node.value.length,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});

--- a/lib/rules/value-no-vendor-prefix/index.mjs
+++ b/lib/rules/value-no-vendor-prefix/index.mjs
@@ -100,7 +100,10 @@ const rule = (primary, secondaryOptions) => {
 					endIndex: index + node.value.length,
 					result,
 					ruleName,
-					fix,
+					fix: {
+						apply: fix,
+						node: decl,
+					},
 				});
 			});
 		});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
