### PR TITLE
Add `at-rule-no-unknown` support for `languageOptions`

### DIFF
--- a/.changeset/old-symbols-kneel.md
+++ b/.changeset/old-symbols-kneel.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `at-rule-no-unknown` support for `languageOptions`

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -299,6 +299,7 @@ The following rules are configured via the `languageOptions` property:
 
 - [`at-rule-descriptor-no-unknown`](../../lib/rules/at-rule-descriptor-no-unknown/README.md)
 - [`at-rule-descriptor-value-no-unknown`](../../lib/rules/at-rule-descriptor-value-no-unknown/README.md)
+- [`at-rule-no-unknown`](../../lib/rules/at-rule-no-unknown/README.md)
 - [`at-rule-prelude-no-invalid`](../../lib/rules/at-rule-prelude-no-invalid/README.md)
 - [`declaration-property-value-no-unknown`](../../lib/rules/declaration-property-value-no-unknown/README.md)
 

--- a/lib/__tests__/fixtures/config-language-options.json
+++ b/lib/__tests__/fixtures/config-language-options.json
@@ -19,6 +19,7 @@
 	"rules": {
 		"at-rule-descriptor-no-unknown": true,
 		"at-rule-descriptor-value-no-unknown": true,
+		"at-rule-no-unknown": true,
 		"at-rule-prelude-no-invalid": true,
 		"declaration-property-value-no-unknown": true
 	}

--- a/lib/__tests__/languageOptions.test.mjs
+++ b/lib/__tests__/languageOptions.test.mjs
@@ -21,12 +21,33 @@ describe('standalone with languageOptions', () => {
 
 			const { report, results } = data;
 
+			expect(report).not.toContain('at-rule-no-unknown');
 			expect(report).not.toContain('at-rule-descriptor-no-unknown');
 			expect(report).not.toContain('at-rule-descriptor-value-no-unknown');
 			expect(report).not.toContain('at-rule-prelude-no-invalid');
 
 			expect(results).toHaveLength(1);
 			expect(results[0].warnings).toHaveLength(0);
+		});
+
+		it('triggers warning for unknown at-rule', async () => {
+			const data = await standalone({
+				code: '@foo { foo: bar; }',
+				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+			});
+
+			const { report, results } = data;
+
+			expect(report).toContain('at-rule-no-unknown');
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+
+			const warning = results[0].warnings[0];
+
+			expect(warning.rule).toBe('at-rule-no-unknown');
+			expect(warning.text).toContain('Unexpected unknown at-rule');
+			expect(warning.text).toContain('foo');
 		});
 
 		it('triggers warning for unknown descriptor in custom at-rule', async () => {

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -13,6 +13,8 @@ This rule considers at-rules defined in the CSS Specifications, up to and includ
 
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
+For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) section.
+
 ## Options
 
 ### `true`

--- a/lib/rules/at-rule-no-unknown/index.cjs
+++ b/lib/rules/at-rule-no-unknown/index.cjs
@@ -41,6 +41,9 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
+		const languageAtRules = result.stylelint.config?.languageOptions?.syntax?.atRules || {};
+		const configuredAtRuleNames = new Set(Object.keys(languageAtRules));
+
 		root.walkAtRules((atRule) => {
 			if (!isStandardSyntaxAtRule(atRule)) {
 				return;
@@ -48,10 +51,7 @@ const rule = (primary, secondaryOptions) => {
 
 			const name = atRule.name;
 
-			const languageAtRules = result.stylelint.config?.languageOptions?.syntax?.atRules || {};
-			const atRuleNames = new Set(Object.keys(languageAtRules));
-
-			if (atRuleNames.has(name)) {
+			if (configuredAtRuleNames.has(name)) {
 				return;
 			}
 

--- a/lib/rules/at-rule-no-unknown/index.cjs
+++ b/lib/rules/at-rule-no-unknown/index.cjs
@@ -48,6 +48,13 @@ const rule = (primary, secondaryOptions) => {
 
 			const name = atRule.name;
 
+			const languageAtRules = result.stylelint.config?.languageOptions?.syntax?.atRules || {};
+			const atRuleNames = new Set(Object.keys(languageAtRules));
+
+			if (atRuleNames.has(name)) {
+				return;
+			}
+
 			// Return early if at-rule is to be ignored
 			if (optionsMatches(secondaryOptions, 'ignoreAtRules', atRule.name)) {
 				return;

--- a/lib/rules/at-rule-no-unknown/index.mjs
+++ b/lib/rules/at-rule-no-unknown/index.mjs
@@ -44,6 +44,13 @@ const rule = (primary, secondaryOptions) => {
 
 			const name = atRule.name;
 
+			const languageAtRules = result.stylelint.config?.languageOptions?.syntax?.atRules || {};
+			const atRuleNames = new Set(Object.keys(languageAtRules));
+
+			if (atRuleNames.has(name)) {
+				return;
+			}
+
 			// Return early if at-rule is to be ignored
 			if (optionsMatches(secondaryOptions, 'ignoreAtRules', atRule.name)) {
 				return;

--- a/lib/rules/at-rule-no-unknown/index.mjs
+++ b/lib/rules/at-rule-no-unknown/index.mjs
@@ -37,6 +37,9 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
+		const languageAtRules = result.stylelint.config?.languageOptions?.syntax?.atRules || {};
+		const configuredAtRuleNames = new Set(Object.keys(languageAtRules));
+
 		root.walkAtRules((atRule) => {
 			if (!isStandardSyntaxAtRule(atRule)) {
 				return;
@@ -44,10 +47,7 @@ const rule = (primary, secondaryOptions) => {
 
 			const name = atRule.name;
 
-			const languageAtRules = result.stylelint.config?.languageOptions?.syntax?.atRules || {};
-			const atRuleNames = new Set(Object.keys(languageAtRules));
-
-			if (atRuleNames.has(name)) {
+			if (configuredAtRuleNames.has(name)) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8453 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

This is slightly off-topic, but I created an issue because tests currently only support `standalone`. 
It would be better if `languageOptions` could be configured per rule.

https://github.com/stylelint/jest-preset-stylelint/issues/143

