### PR TITLE
Add `property-no-unknown` support for `languageOptions`

### DIFF
--- a/.changeset/honest-fans-drive.md
+++ b/.changeset/honest-fans-drive.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `property-no-unknown` support for `languageOptions`

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -301,6 +301,7 @@ The following rules are configured via the `languageOptions` property:
 - [`at-rule-descriptor-value-no-unknown`](../../lib/rules/at-rule-descriptor-value-no-unknown/README.md)
 - [`at-rule-prelude-no-invalid`](../../lib/rules/at-rule-prelude-no-invalid/README.md)
 - [`declaration-property-value-no-unknown`](../../lib/rules/declaration-property-value-no-unknown/README.md)
+- [`property-no-unknown`](../../lib/rules/property-no-unknown/README.md)
 
 #### `AtRules`
 

--- a/lib/__tests__/fixtures/config-language-options.json
+++ b/lib/__tests__/fixtures/config-language-options.json
@@ -20,6 +20,7 @@
 		"at-rule-descriptor-no-unknown": true,
 		"at-rule-descriptor-value-no-unknown": true,
 		"at-rule-prelude-no-invalid": true,
-		"declaration-property-value-no-unknown": true
+		"declaration-property-value-no-unknown": true,
+		"property-no-unknown": true
 	}
 }

--- a/lib/__tests__/languageOptions.test.mjs
+++ b/lib/__tests__/languageOptions.test.mjs
@@ -163,13 +163,19 @@ describe('standalone with languageOptions', () => {
 
 		it('does not trigger warning for valid extended property type', async () => {
 			const data = await standalone({
-				code: 'a { top: --foo(10px); }',
+				code: stripIndent`
+					a {
+						top: var(--foo);
+						bar: red;
+					}
+				`,
 				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
 
 			expect(report).not.toContain('declaration-property-value-no-unknown');
+			expect(report).not.toContain('property-no-unknown');
 
 			expect(results).toHaveLength(1);
 			expect(results[0].warnings).toHaveLength(0);
@@ -193,6 +199,26 @@ describe('standalone with languageOptions', () => {
 			expect(warning.rule).toBe('declaration-property-value-no-unknown');
 			expect(warning.text).toContain('Unexpected unknown value');
 			expect(warning.text).toContain('top');
+		});
+
+		it('triggers warning for unknown property', async () => {
+			const data = await standalone({
+				code: 'a { foo: 10px; }',
+				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+			});
+
+			const { report, results } = data;
+
+			expect(report).toContain('property-no-unknown');
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+
+			const warning = results[0].warnings[0];
+
+			expect(warning.rule).toBe('property-no-unknown');
+			expect(warning.text).toContain('Unexpected unknown property');
+			expect(warning.text).toContain('foo');
 		});
 	});
 

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -20,6 +20,8 @@ Use option `checkPrefixed` described below to turn on checking of vendor-prefixe
 
 The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
+For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) section.
+
 ## Options
 
 ### `true`

--- a/lib/rules/property-no-unknown/index.cjs
+++ b/lib/rules/property-no-unknown/index.cjs
@@ -53,6 +53,9 @@ const rule = (primary, secondaryOptions) => {
 
 		const shouldCheckPrefixed = secondaryOptions && secondaryOptions.checkPrefixed;
 
+		const languageProperties = result.stylelint.config?.languageOptions?.syntax?.properties || {};
+		const configuredPropertyNames = new Set(Object.keys(languageProperties));
+
 		root.walkDecls(checkStatement);
 
 		/**
@@ -78,6 +81,10 @@ const rule = (primary, secondaryOptions) => {
 			}
 
 			if (!shouldCheckPrefixed && vendor.prefix(prop)) {
+				return;
+			}
+
+			if (configuredPropertyNames.has(prop)) {
 				return;
 			}
 

--- a/lib/rules/property-no-unknown/index.mjs
+++ b/lib/rules/property-no-unknown/index.mjs
@@ -50,6 +50,9 @@ const rule = (primary, secondaryOptions) => {
 
 		const shouldCheckPrefixed = secondaryOptions && secondaryOptions.checkPrefixed;
 
+		const languageProperties = result.stylelint.config?.languageOptions?.syntax?.properties || {};
+		const configuredPropertyNames = new Set(Object.keys(languageProperties));
+
 		root.walkDecls(checkStatement);
 
 		/**
@@ -75,6 +78,10 @@ const rule = (primary, secondaryOptions) => {
 			}
 
 			if (!shouldCheckPrefixed && vendor.prefix(prop)) {
+				return;
+			}
+
+			if (configuredPropertyNames.has(prop)) {
 				return;
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8454 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.

Related: https://github.com/stylelint/stylelint/pull/8475
