### PR TITLE
Add `declaration-block-no-redundant-longhand-properties` support for computing `EditInfo`

### DIFF
--- a/.changeset/stale-coins-guess.md
+++ b/.changeset/stale-coins-guess.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `declaration-block-no-redundant-longhand-properties` support for computing `EditInfo`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -8,6 +8,7 @@ testRule({
 	ruleName,
 	config: [true],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -94,6 +95,10 @@ testRule({
 			column: 62,
 			endLine: 1,
 			endColumn: 75,
+			fix: {
+				range: [10, 77],
+				text: ': 20px 10px 30px 4',
+			},
 		},
 		{
 			code: 'a { MARGIN-LEFT: 10px; MARGIN-RIGHT: 10px; margin-top: 20px; margin-bottom: 30px; }',
@@ -103,6 +108,10 @@ testRule({
 			column: 62,
 			endLine: 1,
 			endColumn: 75,
+			fix: {
+				range: [4, 77],
+				text: 'margin: 20px 10px 30px 1',
+			},
 		},
 		{
 			code: 'a { MARGIN-LEFT: 10px; MARGIN-RIGHT: 10px; MARGIN-TOP: 20px; MARGIN-BOTTOM: 30px; }',
@@ -112,6 +121,10 @@ testRule({
 			column: 62,
 			endLine: 1,
 			endColumn: 75,
+			fix: {
+				range: [4, 77],
+				text: 'margin: 20px 10px 30px 1',
+			},
 		},
 		{
 			code: 'a { padding-left: 10px; padding-right: 10px; padding-top: 20px; padding-bottom: 30px; }',
@@ -121,6 +134,10 @@ testRule({
 			column: 65,
 			endLine: 1,
 			endColumn: 79,
+			fix: {
+				range: [11, 81],
+				text: ': 20px 10px 30px 1',
+			},
 		},
 		{
 			code: 'a { font-style: italic; font-variant: normal; font-weight: bold; font-size: .8em; font-family: Arial; line-height: 1.2; font-stretch: normal; }',
@@ -130,6 +147,10 @@ testRule({
 			column: 121,
 			endLine: 1,
 			endColumn: 133,
+			fix: {
+				range: [8, 138],
+				text: ': italic normal bold normal .8em 1.2 Ari',
+			},
 		},
 		{
 			code: 'a { border-top-width: 7px; border-top-style: double; border-top-color: green; }',
@@ -139,6 +160,10 @@ testRule({
 			column: 54,
 			endLine: 1,
 			endColumn: 70,
+			fix: {
+				range: [14, 70],
+				text: ': 7px double',
+			},
 		},
 		{
 			code: 'a { -webkit-transition-delay: 0.5s; -webkit-transition-duration: 2s; -webkit-transition-property: top; -webkit-transition-timing-function: ease; }',
@@ -148,6 +173,10 @@ testRule({
 			column: 104,
 			endLine: 1,
 			endColumn: 138,
+			fix: {
+				range: [22, 143],
+				text: ': top 2s ease 0.5s',
+			},
 		},
 		{
 			code: 'a { -WEBKIT-transition-delay: 0.5s; -webKIT-transition-duration: 2s; -webkit-TRANSITION-property: top; -webkit-transition-timing-function: ease; }',
@@ -157,6 +186,10 @@ testRule({
 			column: 104,
 			endLine: 1,
 			endColumn: 138,
+			fix: {
+				range: [5, 143],
+				text: 'webkit-transition: top 2s ease 0.5s',
+			},
 		},
 		{
 			code: stripIndent`
@@ -189,6 +222,10 @@ testRule({
 					endLine: 5,
 					endColumn: 19,
 					message: messages.expected('border-width'),
+					fix: {
+						range: [12, 100],
+						text: 'width: 1px 2px 3px',
+					},
 				},
 				{
 					line: 9,
@@ -196,34 +233,6 @@ testRule({
 					endLine: 9,
 					endColumn: 19,
 					message: messages.expected('border-color'),
-				},
-				{
-					line: 10,
-					column: 2,
-					endLine: 10,
-					endColumn: 18,
-					message: messages.expected('border-top'),
-				},
-				{
-					line: 11,
-					column: 2,
-					endLine: 11,
-					endColumn: 20,
-					message: messages.expected('border-right'),
-				},
-				{
-					line: 12,
-					column: 2,
-					endLine: 12,
-					endColumn: 21,
-					message: messages.expected('border-bottom'),
-				},
-				{
-					line: 13,
-					column: 2,
-					endLine: 13,
-					endColumn: 19,
-					message: messages.expected('border-left'),
 				},
 				{
 					line: 13,
@@ -265,6 +274,10 @@ testRule({
 					endLine: 5,
 					endColumn: 19,
 					message: messages.expected('border-width'),
+					fix: {
+						range: [12, 100],
+						text: 'width: 1px 2px 3px',
+					},
 				},
 				{
 					line: 9,
@@ -274,39 +287,11 @@ testRule({
 					message: messages.expected('border-style'),
 				},
 				{
-					line: 10,
-					column: 2,
-					endLine: 10,
-					endColumn: 18,
-					message: messages.expected('border-top'),
-				},
-				{
-					line: 11,
-					column: 2,
-					endLine: 11,
-					endColumn: 20,
-					message: messages.expected('border-right'),
-				},
-				{
-					line: 12,
-					column: 2,
-					endLine: 12,
-					endColumn: 21,
-					message: messages.expected('border-bottom'),
-				},
-				{
 					line: 13,
 					column: 2,
 					endLine: 13,
 					endColumn: 19,
 					message: messages.expected('border-color'),
-				},
-				{
-					line: 13,
-					column: 2,
-					endLine: 13,
-					endColumn: 19,
-					message: messages.expected('border-left'),
 				},
 			],
 		},
@@ -342,6 +327,10 @@ testRule({
 					endLine: 4,
 					endColumn: 18,
 					message: messages.expected('border-top'),
+					fix: {
+						range: [15, 73],
+						text: ': 1px dotted',
+					},
 				},
 				{
 					line: 7,
@@ -356,27 +345,6 @@ testRule({
 					endLine: 10,
 					endColumn: 21,
 					message: messages.expected('border-bottom'),
-				},
-				{
-					line: 11,
-					column: 2,
-					endLine: 11,
-					endColumn: 19,
-					message: messages.expected('border-width'),
-				},
-				{
-					line: 12,
-					column: 2,
-					endLine: 12,
-					endColumn: 19,
-					message: messages.expected('border-style'),
-				},
-				{
-					line: 13,
-					column: 2,
-					endLine: 13,
-					endColumn: 19,
-					message: messages.expected('border-color'),
 				},
 				{
 					line: 13,
@@ -419,6 +387,10 @@ testRule({
 					endLine: 4,
 					endColumn: 18,
 					message: messages.expected('border-top'),
+					fix: {
+						range: [15, 73],
+						text: ': 1px dotted',
+					},
 				},
 				{
 					line: 7,
@@ -433,27 +405,6 @@ testRule({
 					endLine: 10,
 					endColumn: 20,
 					message: messages.expected('border-right'),
-				},
-				{
-					line: 11,
-					column: 2,
-					endLine: 11,
-					endColumn: 19,
-					message: messages.expected('border-width'),
-				},
-				{
-					line: 12,
-					column: 2,
-					endLine: 12,
-					endColumn: 19,
-					message: messages.expected('border-style'),
-				},
-				{
-					line: 13,
-					column: 2,
-					endLine: 13,
-					endColumn: 19,
-					message: messages.expected('border-color'),
 				},
 				{
 					line: 13,
@@ -495,27 +446,10 @@ testRule({
 					endLine: 5,
 					endColumn: 19,
 					message: messages.expected('border-width'),
-				},
-				{
-					line: 7,
-					column: 2,
-					endLine: 7,
-					endColumn: 18,
-					message: messages.expected('border-top'),
-				},
-				{
-					line: 9,
-					column: 2,
-					endLine: 9,
-					endColumn: 21,
-					message: messages.expected('border-bottom'),
-				},
-				{
-					line: 11,
-					column: 2,
-					endLine: 11,
-					endColumn: 20,
-					message: messages.expected('border-right'),
+					fix: {
+						range: [12, 100],
+						text: 'width: 1px 2px 3px',
+					},
 				},
 				{
 					line: 12,
@@ -530,13 +464,6 @@ testRule({
 					endLine: 13,
 					endColumn: 19,
 					message: messages.expected('border-color'),
-				},
-				{
-					line: 13,
-					column: 2,
-					endLine: 13,
-					endColumn: 19,
-					message: messages.expected('border-left'),
 				},
 			],
 		},
@@ -572,20 +499,10 @@ testRule({
 					endLine: 4,
 					endColumn: 18,
 					message: messages.expected('border-top'),
-				},
-				{
-					line: 7,
-					column: 2,
-					endLine: 7,
-					endColumn: 19,
-					message: messages.expected('border-width'),
-				},
-				{
-					line: 10,
-					column: 2,
-					endLine: 10,
-					endColumn: 19,
-					message: messages.expected('border-style'),
+					fix: {
+						range: [15, 73],
+						text: ': 1px dotted',
+					},
 				},
 				{
 					line: 11,
@@ -600,13 +517,6 @@ testRule({
 					endLine: 12,
 					endColumn: 21,
 					message: messages.expected('border-bottom'),
-				},
-				{
-					line: 13,
-					column: 2,
-					endLine: 13,
-					endColumn: 19,
-					message: messages.expected('border-color'),
 				},
 				{
 					line: 13,
@@ -621,21 +531,37 @@ testRule({
 			code: 'a { border-top-width: 1px; border-bottom-width: 1px; border-left-width: 1px; border-right-width: 1px; }',
 			fixed: 'a { border-width: 1px 1px 1px 1px; }',
 			message: messages.expected('border-width'),
+			fix: {
+				range: [11, 96],
+				text: 'width: 1px 1px 1px',
+			},
 		},
 		{
 			code: 'a { top: 1px; right: 2px; bottom: 3px; left: 4px; }',
 			fixed: 'a { inset: 1px 2px 3px 4px; }',
 			message: messages.expected('inset'),
+			fix: {
+				range: [4, 44],
+				text: 'inset: 1px 2px 3px',
+			},
 		},
 		{
 			code: 'a { top: 1px !important; right: 2px !important; bottom: 3px !important; left: 4px !important; }',
 			fixed: 'a { inset: 1px 2px 3px 4px !important; }',
 			message: messages.expected('inset'),
+			fix: {
+				range: [4, 77],
+				text: 'inset: 1px 2px 3px',
+			},
 		},
 		{
 			code: 'a { top: 0; right: 0; bottom: 0; left: 0; }',
 			fixed: 'a { inset: 0 0 0 0; }',
 			message: messages.expected('inset'),
+			fix: {
+				range: [4, 38],
+				text: 'inset: 0 0 0',
+			},
 		},
 		{
 			code: 'a { grid-template-rows: var(--header-h) 1fr var(--footer-h); grid-template-columns: var(--toolbar-w) 1fr; grid-template-areas: "header header" "toolbar main" "footer footer"; }',
@@ -643,6 +569,10 @@ testRule({
 				'a { grid-template: "header header" var(--header-h) "toolbar main" 1fr "footer footer" var(--footer-h) / var(--toolbar-w) 1fr; }',
 			description: 'custom resolver for grid-template',
 			message: messages.expected('grid-template'),
+			fix: {
+				range: [17, 173],
+				text: ': "header header" var(--header-h) "toolbar main" 1fr "footer footer" var(--footer-h) / var(--toolbar-w) 1fr',
+			},
 		},
 		{
 			code: 'a { transition-delay: 500ms,    1s; transition-duration: 250ms,2s; transition-timing-function: ease-in-out; transition-property: transform, visibility; }',
@@ -650,6 +580,10 @@ testRule({
 			description:
 				'custom resolver for transition - multiple properties, delays, durations, timing-functions',
 			message: messages.expected('transition'),
+			fix: {
+				range: [14, 150],
+				text: ': transform 250ms ease-in-out 500ms, visibility 2s ease-in-out 1s',
+			},
 		},
 		{
 			code: 'a { transition-delay: 500ms; transition-duration: 250ms; transition-timing-function: ease-in-out; transition-property: transform, visibility; }',
@@ -658,6 +592,10 @@ testRule({
 			description:
 				'custom resolver for transition - multiple properties, single delay/duration/timing-function',
 			message: messages.expected('transition'),
+			fix: {
+				range: [14, 140],
+				text: ': transform 250ms ease-in-out 500ms, visibility 250ms ease-in-out 500ms',
+			},
 		},
 		{
 			code: 'a { transition-delay: 500ms, 1s, 1.5s; transition-duration: 250ms, 0.5s; transition-timing-function: ease-in-out; transition-property: transform, visibility, padding; }',
@@ -666,6 +604,10 @@ testRule({
 			description:
 				'custom resolver for transition - multiple properties, multiple delays/duration/timing-functions with different periods',
 			message: messages.expected('transition'),
+			fix: {
+				range: [14, 165],
+				text: ': transform 250ms ease-in-out 500ms, visibility 0.5s ease-in-out 1s, padding 250ms ease-in-out 1.5s',
+			},
 		},
 		{
 			code: 'a { transition-delay: 500ms, 1s; transition-duration: 250ms,2s; transition-timing-function: ease-in-out; transition-property: none; }',
@@ -673,6 +615,10 @@ testRule({
 			description:
 				'custom resolver for transition - transition property contains property-specific basic keyword (none), but list is of size 1',
 			message: messages.expected('transition'),
+			fix: {
+				range: [14, 130],
+				text: ': none 250ms ease-in-out 500ms',
+			},
 		},
 		{
 			code: 'a { transition-delay: ; transition-duration: 1s; transition-timing-function: ease; transition-property: top; }',
@@ -685,6 +631,10 @@ testRule({
 			fixed: '.class-name { transition: margin 10ms cubic-bezier(0, 1, 1, 1) 25ms; }',
 			description: 'autofixer should not mangle css functions with comma separated values',
 			message: messages.expected('transition'),
+			fix: {
+				range: [24, 146],
+				text: ': margin 10ms cubic-bezier(0, 1, 1, 1) 25ms',
+			},
 		},
 		{
 			code: '.class-name { transition-delay: 25ms, 50ms; transition-duration: 10ms, 20ms; transition-property: margin, padding; transition-timing-function: cubic-bezier(0, 1, 1, 1), cubic-bezier(1, 0, 0, 1); }',
@@ -692,18 +642,30 @@ testRule({
 				'.class-name { transition: margin 10ms cubic-bezier(0, 1, 1, 1) 25ms, padding 20ms cubic-bezier(1, 0, 0, 1) 50ms; }',
 			description: 'autofixer should not mangle css functions with comma separated values',
 			message: messages.expected('transition'),
+			fix: {
+				range: [24, 193],
+				text: ': margin 10ms cubic-bezier(0, 1, 1, 1) 25ms, padding 20ms cubic-bezier(1, 0, 0, 1) 50ms',
+			},
 		},
 		{
 			code: 'a { grid-column-start: 1; grid-column-end: 2; }',
 			fixed: 'a { grid-column: 1 / 2; }',
 			description: 'explicit grid-column test',
 			message: messages.expected('grid-column'),
+			fix: {
+				range: [15, 42],
+				text: ': 1 /',
+			},
 		},
 		{
 			code: 'a { grid-row-start: 1; grid-row-end: 2; }',
 			fixed: 'a { grid-row: 1 / 2; }',
 			description: 'explicit grid-row test',
 			message: messages.expected('grid-row'),
+			fix: {
+				range: [12, 36],
+				text: ': 1 /',
+			},
 		},
 		{
 			code: stripIndent`
@@ -722,8 +684,17 @@ testRule({
 			`,
 			description: 'combination of grid-row and grid-column test',
 			warnings: [
-				{ column: 2, endColumn: 14, endLine: 3, line: 3, message: messages.expected('grid-row') },
-				{ column: 2, endColumn: 17, endLine: 5, line: 5, message: messages.expected('grid-area') },
+				{
+					column: 2,
+					endColumn: 14,
+					endLine: 3,
+					line: 3,
+					message: messages.expected('grid-row'),
+					fix: {
+						range: [13, 38],
+						text: ': 1 /',
+					},
+				},
 				{
 					column: 2,
 					endColumn: 17,
@@ -743,108 +714,180 @@ testRule({
 			skip: true,
 			description: 'TODO: explicit grid-area test',
 			message: messages.expected('grid-area'),
+			fix: {
+				range: [1, 2],
+				text: '',
+			},
 		},
 		{
 			code: 'a { border-top-left-radius: 1em; border-top-right-radius: 2em; border-bottom-right-radius: 3em; border-bottom-left-radius: 4em; }',
 			fixed: 'a { border-radius: 1em 2em 3em 4em; }',
 			description: 'explicit border-radius test',
 			message: messages.expected('border-radius'),
+			fix: {
+				range: [11, 122],
+				text: 'radius: 1em 2em 3em',
+			},
 		},
 		{
 			code: 'a { border-top-width: 0px; border-right-width: 1px; border-bottom-width: 2px; border-left-width: 3px; }',
 			fixed: 'a { border-width: 0px 1px 2px 3px; }',
 			description: 'explicit border-width test',
 			message: messages.expected('border-width'),
+			fix: {
+				range: [11, 96],
+				text: 'width: 0px 1px 2px',
+			},
 		},
 		{
 			code: 'a { inset-block-start: 1px; inset-block-end: 2px; }',
 			fixed: 'a { inset-block: 1px 2px; }',
 			description: 'explicit inset-block test',
 			message: messages.expected('inset-block'),
+			fix: {
+				range: [15, 44],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { inset-inline-start: 1px; inset-inline-end: 2px; }',
 			fixed: 'a { inset-inline: 1px 2px; }',
 			description: 'explicit inset-inline test',
 			message: messages.expected('inset-inline'),
+			fix: {
+				range: [16, 46],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { margin-block-start: 1px; margin-block-end: 2px; }',
 			fixed: 'a { margin-block: 1px 2px; }',
 			description: 'explicit margin-block test',
 			message: messages.expected('margin-block'),
+			fix: {
+				range: [16, 46],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { margin-inline-start: 1px; margin-inline-end: 2px; }',
 			fixed: 'a { margin-inline: 1px 2px; }',
 			description: 'explicit margin-inline test',
 			message: messages.expected('margin-inline'),
+			fix: {
+				range: [17, 48],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { padding-block-start: 1px; padding-block-end: 2px; }',
 			fixed: 'a { padding-block: 1px 2px; }',
 			description: 'explicit padding-block test',
 			message: messages.expected('padding-block'),
+			fix: {
+				range: [17, 48],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { padding-inline-start: 1px; padding-inline-end: 2px; }',
 			fixed: 'a { padding-inline: 1px 2px; }',
 			description: 'explicit padding-inline test',
 			message: messages.expected('padding-inline'),
+			fix: {
+				range: [18, 50],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { scroll-margin-block-start: 1px; scroll-margin-block-end: 2px; }',
 			fixed: 'a { scroll-margin-block: 1px 2px; }',
 			description: 'explicit scroll-margin-block test',
 			message: messages.expected('scroll-margin-block'),
+			fix: {
+				range: [23, 60],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { scroll-margin-inline-start: 1px; scroll-margin-inline-end: 2px; }',
 			fixed: 'a { scroll-margin-inline: 1px 2px; }',
 			description: 'explicit scroll-margin-inline test',
 			message: messages.expected('scroll-margin-inline'),
+			fix: {
+				range: [24, 62],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { scroll-padding-block-start: 1px; scroll-padding-block-end: 2px; }',
 			fixed: 'a { scroll-padding-block: 1px 2px; }',
 			description: 'explicit scroll-padding-block test',
 			message: messages.expected('scroll-padding-block'),
+			fix: {
+				range: [24, 62],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { scroll-padding-inline-start: 1px; scroll-padding-inline-end: 2px; }',
 			fixed: 'a { scroll-padding-inline: 1px 2px; }',
 			description: 'explicit scroll-padding-inline test',
 			message: messages.expected('scroll-padding-inline'),
+			fix: {
+				range: [25, 64],
+				text: ': 1px',
+			},
 		},
 		{
 			code: 'a { border-block-color: blue; border-block-style: dashed; border-block-width: medium; }',
 			fixed: 'a { border-block: medium dashed blue; }',
 			description: 'explicit border-block test',
 			message: messages.expected('border-block'),
+			fix: {
+				range: [16, 84],
+				text: ': medium dashed blue',
+			},
 		},
 		{
 			code: 'a { border-inline-color: blue; border-inline-style: dashed; border-inline-width: medium; }',
 			fixed: 'a { border-inline: medium dashed blue; }',
 			description: 'explicit border-inline test',
 			message: messages.expected('border-inline'),
+			fix: {
+				range: [17, 87],
+				text: ': medium dashed blue',
+			},
 		},
 		{
 			code: 'a { font-synthesis-weight: none; font-synthesis-style: none; font-synthesis-small-caps: none; }',
 			fixed: 'a { font-synthesis: none; }',
 			description: 'font-synthesis - all none',
 			message: messages.expected('font-synthesis'),
+			fix: {
+				range: [18, 86],
+				text: '',
+			},
 		},
 		{
 			code: 'a { font-synthesis-weight: auto; font-synthesis-style: auto; font-synthesis-small-caps: auto; }',
 			fixed: 'a { font-synthesis: weight style small-caps; }',
 			description: 'font-synthesis - all auto',
 			message: messages.expected('font-synthesis'),
+			fix: {
+				range: [18, 92],
+				text: ': weight style small-caps',
+			},
 		},
 		{
 			code: 'a { font-synthesis-weight: auto; font-synthesis-style: none; font-synthesis-small-caps: auto; }',
 			fixed: 'a { font-synthesis: weight small-caps; }',
 			description: 'font-synthesis - mixed',
 			message: messages.expected('font-synthesis'),
+			fix: {
+				range: [18, 92],
+				text: ': weight small-caps',
+			},
 		},
 		{
 			code: 'a { font-synthesis-weight: aut3; font-synthesis-style: none; font-synthesis-small-caps: auto; }',
@@ -857,48 +900,80 @@ testRule({
 			fixed: 'div { overflow: hidden visible; }',
 			description: 'explicit overflow test',
 			message: messages.expected('overflow'),
+			fix: {
+				range: [14, 45],
+				text: ': hidden visible',
+			},
 		},
 		{
 			code: 'div { overscroll-behavior-y: contain; overscroll-behavior-x: auto; }',
 			fixed: 'div { overscroll-behavior: auto contain; }',
 			description: 'explicit overscroll-behavior test',
 			message: messages.expected('overscroll-behavior'),
+			fix: {
+				range: [25, 65],
+				text: ': auto contain',
+			},
 		},
 		{
 			code: 'div { column-gap: 20px; row-gap: 10px; }',
 			fixed: 'div { gap: 10px 20px; }',
 			description: 'explicit gap test',
 			message: messages.expected('gap'),
+			fix: {
+				range: [6, 34],
+				text: 'gap: 10px 2',
+			},
 		},
 		{
 			code: 'div { justify-content: center; align-content: end; }',
 			fixed: 'div { place-content: end center; }',
 			description: 'explicit place-content test',
 			message: messages.expected('place-content'),
+			fix: {
+				range: [6, 49],
+				text: 'place-content: end center',
+			},
 		},
 		{
 			code: 'div { justify-items: center; align-items: end; }',
 			fixed: 'div { place-items: end center; }',
 			description: 'explicit place-items test',
 			message: messages.expected('place-items'),
+			fix: {
+				range: [6, 45],
+				text: 'place-items: end center',
+			},
 		},
 		{
 			code: 'div { justify-self: center; align-self: end; }',
 			fixed: 'div { place-self: end center; }',
 			description: 'explicit place-self test',
 			message: messages.expected('place-self'),
+			fix: {
+				range: [6, 43],
+				text: 'place-self: end center',
+			},
 		},
 		{
 			code: 'a { scroll-margin-left: 40px; scroll-margin-right: 10px; scroll-margin-top: 20px; scroll-margin-bottom: 30px; }',
 			fixed: 'a { scroll-margin: 20px 10px 30px 40px; }',
 			description: 'explicit scroll-margin test',
 			message: messages.expected('scroll-margin'),
+			fix: {
+				range: [17, 105],
+				text: ': 20px 10px 30px 4',
+			},
 		},
 		{
 			code: 'a { scroll-padding-left: 40px; scroll-padding-right: 10px; scroll-padding-top: 20px; scroll-padding-bottom: 30px; }',
 			fixed: 'a { scroll-padding: 20px 10px 30px 40px; }',
 			description: 'explicit scroll-padding test',
 			message: messages.expected('scroll-padding'),
+			fix: {
+				range: [18, 109],
+				text: ': 20px 10px 30px 4',
+			},
 		},
 		{
 			code: 'a { grid-template-columns: repeat(3, 1fr); grid-template-rows: auto; grid-template-areas: "left center right"; }',
@@ -919,6 +994,10 @@ testRule({
 			fixed: 'a { text-decoration: underline solid purple 1px; }',
 			message: messages.expected('text-decoration'),
 			description: 'CSS Text Decoration Module Level 4',
+			fix: {
+				range: [19, 128],
+				text: ': underline solid purple 1px',
+			},
 		},
 		{
 			code: stripIndent`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -361,7 +361,10 @@ const rule = (primary, secondaryOptions) => {
 						word: decl.prop,
 						message: messages.expected,
 						messageArgs: [prefixedShorthandProperty],
-						fix,
+						fix: {
+							apply: fix,
+							node: decl.parent,
+						},
 					});
 				}
 			});

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -358,7 +358,10 @@ const rule = (primary, secondaryOptions) => {
 						word: decl.prop,
 						message: messages.expected,
 						messageArgs: [prefixedShorthandProperty],
-						fix,
+						fix: {
+							apply: fix,
+							node: decl.parent,
+						},
 					});
 				}
 			});


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
