### PR TITLE
Added `selector-attribute-quotes` support for computing `EditInfo`

### DIFF
--- a/.changeset/chilly-mice-say.md
+++ b/.changeset/chilly-mice-say.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `selector-attribute-quotes` support for computing `EditInfo`

--- a/lib/rules/selector-attribute-quotes/__tests__/index.mjs
+++ b/lib/rules/selector-attribute-quotes/__tests__/index.mjs
@@ -7,6 +7,7 @@ testRule({
 	ruleName,
 	config: ['always'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -65,13 +66,13 @@ testRule({
 		},
 		{
 			code: stripIndent`
-				/* stylelint-disable-next-line selector-attribute-quotes */
-				a[title=flower], /* stylelint-disable-next-line selector-attribute-quotes */
-				a[class^=top],
-				/* stylelint-disable-next-line selector-attribute-quotes */
-				a[title~=text]
-				{ }
-			`,
+                /* stylelint-disable-next-line selector-attribute-quotes */
+                a[title=flower], /* stylelint-disable-next-line selector-attribute-quotes */
+                a[class^=top],
+                /* stylelint-disable-next-line selector-attribute-quotes */
+                a[title~=text]
+                { }
+            `,
 		},
 	],
 
@@ -84,6 +85,7 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 15,
+			fix: { range: [8, 14], text: '"flower"' },
 		},
 		{
 			code: 'a[ title=flower ] { }',
@@ -93,6 +95,7 @@ testRule({
 			column: 10,
 			endLine: 1,
 			endColumn: 16,
+			fix: { range: [9, 15], text: '"flower"' },
 		},
 		{
 			code: '[class^=top] { }',
@@ -102,6 +105,7 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 12,
+			fix: { range: [8, 11], text: '"top"' },
 		},
 		{
 			code: '[class ^= top] { }',
@@ -111,6 +115,7 @@ testRule({
 			column: 11,
 			endLine: 1,
 			endColumn: 14,
+			fix: { range: [10, 13], text: '"top"' },
 		},
 		{
 			code: '[frame=hsides i] { }',
@@ -120,6 +125,7 @@ testRule({
 			column: 8,
 			endLine: 1,
 			endColumn: 14,
+			fix: { range: [7, 13], text: '"hsides"' },
 		},
 		{
 			code: '[data-style=value][data-loading] { }',
@@ -129,6 +135,7 @@ testRule({
 			column: 13,
 			endLine: 1,
 			endColumn: 18,
+			fix: { range: [12, 17], text: '"value"' },
 		},
 		{
 			code: `[href=te\\'s\\"t] { }`,
@@ -138,6 +145,7 @@ testRule({
 			column: 7,
 			endLine: 1,
 			endColumn: 15,
+			fix: { range: [6, 14], text: `"te's\\"t"` },
 		},
 		{
 			code: '[href=\\"test\\"] { }',
@@ -147,6 +155,7 @@ testRule({
 			column: 7,
 			endLine: 1,
 			endColumn: 15,
+			fix: { range: [6, 13], text: '"\\"test\\"' },
 		},
 		{
 			code: "[href=\\'test\\'] { }",
@@ -156,24 +165,25 @@ testRule({
 			column: 7,
 			endLine: 1,
 			endColumn: 15,
+			fix: { range: [6, 14], text: `"'test'"` },
 		},
 		{
 			code: stripIndent`
-				/* a comment */
-				a[title=flower], /* a comment */
-				a[class^=top],
-				/* a comment */
-				a[title~=text]
-				{ }
-			`,
+                /* a comment */
+                a[title=flower], /* a comment */
+                a[class^=top],
+                /* a comment */
+                a[title~=text]
+                { }
+            `,
 			fixed: stripIndent`
-				/* a comment */
-				a[title="flower"], /* a comment */
-				a[class^="top"],
-				/* a comment */
-				a[title~="text"]
-				{ }
-			`,
+                /* a comment */
+                a[title="flower"], /* a comment */
+                a[class^="top"],
+                /* a comment */
+                a[title~="text"]
+                { }
+            `,
 			warnings: [
 				{
 					column: 9,
@@ -181,6 +191,7 @@ testRule({
 					endLine: 2,
 					line: 2,
 					message: messages.expected('flower'),
+					fix: { range: [24, 30], text: '"flower"' },
 				},
 				{
 					column: 10,
@@ -205,6 +216,7 @@ testRule({
 	ruleName,
 	config: ['never'],
 	fix: true,
+	computeEditInfo: true,
 
 	accept: [
 		{
@@ -253,6 +265,7 @@ testRule({
 			column: 10,
 			endLine: 1,
 			endColumn: 18,
+			fix: { range: [9, 17], text: '_blank' },
 		},
 		{
 			code: 'a[ target="_blank" ] { }',
@@ -262,6 +275,7 @@ testRule({
 			column: 11,
 			endLine: 1,
 			endColumn: 19,
+			fix: { range: [10, 18], text: '_blank' },
 		},
 		{
 			code: '[class|="top"] { }',
@@ -271,6 +285,7 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 14,
+			fix: { range: [8, 13], text: 'top' },
 		},
 		{
 			code: '[class |= "top"] { }',
@@ -280,6 +295,7 @@ testRule({
 			column: 11,
 			endLine: 1,
 			endColumn: 16,
+			fix: { range: [10, 15], text: 'top' },
 		},
 		{
 			code: "[title~='text'] { }",
@@ -289,6 +305,7 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 15,
+			fix: { range: [8, 14], text: 'text' },
 		},
 		{
 			code: "[data-attribute='component'] { }",
@@ -298,6 +315,7 @@ testRule({
 			column: 17,
 			endLine: 1,
 			endColumn: 28,
+			fix: { range: [16, 27], text: 'component' },
 		},
 		{
 			code: '[frame="hsides" i] { }',
@@ -307,6 +325,7 @@ testRule({
 			column: 8,
 			endLine: 1,
 			endColumn: 16,
+			fix: { range: [7, 15], text: 'hsides' },
 		},
 		{
 			code: "[frame='hsides' i] { }",
@@ -316,6 +335,7 @@ testRule({
 			column: 8,
 			endLine: 1,
 			endColumn: 16,
+			fix: { range: [7, 15], text: 'hsides' },
 		},
 		{
 			code: "[data-style='value'][data-loading] { }",
@@ -325,6 +345,7 @@ testRule({
 			column: 13,
 			endLine: 1,
 			endColumn: 20,
+			fix: { range: [12, 19], text: 'value' },
 		},
 		{
 			code: "[href='te\\'s\\'t'] { }",
@@ -334,6 +355,7 @@ testRule({
 			column: 7,
 			endLine: 1,
 			endColumn: 17,
+			fix: { range: [6, 16], text: "te\\'s\\'t" },
 		},
 		{
 			code: '[href="te\\"s\\"t"] { }',
@@ -343,6 +365,7 @@ testRule({
 			column: 7,
 			endLine: 1,
 			endColumn: 17,
+			fix: { range: [6, 16], text: 'te\\"s\\"t' },
 		},
 		{
 			code: 'a[target="_blank"], /* comment */ a { }',
@@ -352,6 +375,7 @@ testRule({
 			column: 10,
 			endLine: 1,
 			endColumn: 18,
+			fix: { range: [9, 17], text: '_blank' },
 		},
 	],
 });

--- a/lib/rules/selector-attribute-quotes/index.cjs
+++ b/lib/rules/selector-attribute-quotes/index.cjs
@@ -73,7 +73,10 @@ const rule = (primary) => {
 					result,
 					ruleName,
 					node: ruleNode,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			};
 

--- a/lib/rules/selector-attribute-quotes/index.mjs
+++ b/lib/rules/selector-attribute-quotes/index.mjs
@@ -69,7 +69,10 @@ const rule = (primary) => {
 					result,
 					ruleName,
 					node: ruleNode,
-					fix,
+					fix: {
+						apply: fix,
+						node: ruleNode,
+					},
 				});
 			};
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See: https://github.com/stylelint/stylelint/issues/8362

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
