### PR TITLE
Document `declaration-block-no-redundant-longhand-properties` secondary options descriptions

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -173,30 +173,24 @@ a {
 }
 ```
 
-## Optional secondary options
+## **Optional secondary options**  
 
-### `ignoreLonghands: ["array", "of", "properties"]`
+### **`ignoreLonghands: ["array", "of", "properties"]`**  
+Ignore the specified longhand properties when checking for redundant longhands.  
 
-Given:
-
-<!-- prettier-ignore -->
-```json
+#### **Example configuration:**  
+```js
 ["text-decoration-thickness", "background-size", "background-origin", "background-clip"]
-```
+```  
 
-The following patterns are considered problems:
-
-<!-- prettier-ignore -->
+#### **Patterns that are considered problems:**  
 ```css
 a {
   text-decoration-line: underline;
   text-decoration-style: solid;
   text-decoration-color: purple;
 }
-```
 
-<!-- prettier-ignore -->
-```css
 a {
   background-repeat: repeat;
   background-attachment: scroll;
@@ -207,39 +201,34 @@ a {
   background-origin: border-box;
   background-clip: text;
 }
-```
+```  
 
-The following patterns are _not_ considered problems:
-
-<!-- prettier-ignore -->
+#### **Patterns that are *not* considered problems:**  
 ```css
 a {
   text-decoration: underline solid purple;
   text-decoration-thickness: 1px;
 }
-```
 
-<!-- prettier-ignore -->
-```css
 a {
   background: none 0% 0% repeat scroll transparent;
   background-size: contain;
   background-origin: border-box;
   background-clip: text;
 }
-```
+```  
 
-### `ignoreShorthands: ["/regex/", /regex/, "string"]`
+---
 
-Given:
+### **`ignoreShorthands: ["/regex/", /regex/, "string"]`**  
+Ignore the specified shorthand properties when checking for redundant longhands.  
 
-```json
+#### **Example configuration:**  
+```js
 ["padding", "/border/"]
-```
+```  
 
-The following patterns are _not_ considered problems:
-
-<!-- prettier-ignore -->
+#### **Patterns that are *not* considered problems:**  
 ```css
 a {
   padding-top: 20px;
@@ -247,33 +236,17 @@ a {
   padding-bottom: 30px;
   padding-left: 10px;
 }
-```
 
-<!-- prettier-ignore -->
-```css
 a {
   border-top-width: 1px;
   border-bottom-width: 1px;
   border-left-width: 1px;
   border-right-width: 1px;
 }
-```
 
-<!-- prettier-ignore -->
-```css
-a {
-  border-top-width: 1px;
-  border-bottom-width: 1px;
-  border-left-width: 1px;
-  border-right-width: 1px;
-}
-```
-
-<!-- prettier-ignore -->
-```css
 a {
   border-top-color: green;
   border-top-style: double;
   border-top-width: 7px;
 }
-```
+```  

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -231,7 +231,6 @@ a {
 }
 ```
 
----
 
 ## `ignoreShorthands: ["/regex/", /regex/, "string"]`
 Ignore the specified shorthand properties when checking for redundant longhands.

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -233,7 +233,7 @@ a {
 
 ### `ignoreShorthands: ["/regex/", /regex/, "string"]`
 
-Ignore the specified shorthand properties when checking for redundant longhands.
+Ignore the specified shorthand properties.
 
 Given:
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -175,7 +175,7 @@ a {
 
 ## Optional Secondary Options
 
-## `ignoreLonghands: ["array", "of", "properties"]`
+### `ignoreLonghands: ["array", "of", "properties"]`
 Ignore the specified longhand properties when checking for redundant longhands.
 
 ### Example Configuration:

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -173,30 +173,24 @@ a {
 }
 ```
 
-## Optional secondary options
+# Optional Secondary Options
 
-### `ignoreLonghands: ["array", "of", "properties"]`
+## `ignoreLonghands: ["array", "of", "properties"]`
+Ignore the specified longhand properties when checking for redundant longhands.
 
-Given:
-
-<!-- prettier-ignore -->
+### Example Configuration:
 ```json
 ["text-decoration-thickness", "background-size", "background-origin", "background-clip"]
 ```
 
-The following patterns are considered problems:
-
-<!-- prettier-ignore -->
+### Patterns That Are Considered Problems:
 ```css
 a {
   text-decoration-line: underline;
   text-decoration-style: solid;
   text-decoration-color: purple;
 }
-```
 
-<!-- prettier-ignore -->
-```css
 a {
   background-repeat: repeat;
   background-attachment: scroll;
@@ -209,18 +203,13 @@ a {
 }
 ```
 
-The following patterns are _not_ considered problems:
-
-<!-- prettier-ignore -->
+### Patterns That Are *Not* Considered Problems:
 ```css
 a {
   text-decoration: underline solid purple;
   text-decoration-thickness: 1px;
 }
-```
 
-<!-- prettier-ignore -->
-```css
 a {
   background: none 0% 0% repeat scroll transparent;
   background-size: contain;
@@ -229,17 +218,17 @@ a {
 }
 ```
 
-### `ignoreShorthands: ["/regex/", /regex/, "string"]`
+---
 
-Given:
+## `ignoreShorthands: ["/regex/", /regex/, "string"]`
+Ignore the specified shorthand properties when checking for redundant longhands.
 
+### Example Configuration:
 ```json
 ["padding", "/border/"]
 ```
 
-The following patterns are _not_ considered problems:
-
-<!-- prettier-ignore -->
+### Patterns That Are *Not* Considered Problems:
 ```css
 a {
   padding-top: 20px;
@@ -247,33 +236,22 @@ a {
   padding-bottom: 30px;
   padding-left: 10px;
 }
-```
 
-<!-- prettier-ignore -->
-```css
 a {
   border-top-width: 1px;
   border-bottom-width: 1px;
   border-left-width: 1px;
   border-right-width: 1px;
 }
-```
 
-<!-- prettier-ignore -->
-```css
-a {
-  border-top-width: 1px;
-  border-bottom-width: 1px;
-  border-left-width: 1px;
-  border-right-width: 1px;
-}
-```
-
-<!-- prettier-ignore -->
-```css
 a {
   border-top-color: green;
   border-top-style: double;
   border-top-width: 7px;
 }
 ```
+
+### Note:
+This rule won’t report any problems for the above cases because `padding` and `border` shorthands are ignored. Since `ignoreShorthands` makes the rule more permissive, **no invalid examples are included.**
+
+---

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -231,7 +231,6 @@ a {
 }
 ```
 
-
 ### `ignoreShorthands: ["/regex/", /regex/, "string"]`
 
 Ignore the specified shorthand properties when checking for redundant longhands.

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -173,24 +173,30 @@ a {
 }
 ```
 
-## **Optional secondary options**  
+## Optional secondary options
 
-### **`ignoreLonghands: ["array", "of", "properties"]`**  
-Ignore the specified longhand properties when checking for redundant longhands.  
+### `ignoreLonghands: ["array", "of", "properties"]`
 
-#### **Example configuration:**  
-```js
+Given:
+
+<!-- prettier-ignore -->
+```json
 ["text-decoration-thickness", "background-size", "background-origin", "background-clip"]
-```  
+```
 
-#### **Patterns that are considered problems:**  
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
 ```css
 a {
   text-decoration-line: underline;
   text-decoration-style: solid;
   text-decoration-color: purple;
 }
+```
 
+<!-- prettier-ignore -->
+```css
 a {
   background-repeat: repeat;
   background-attachment: scroll;
@@ -201,34 +207,39 @@ a {
   background-origin: border-box;
   background-clip: text;
 }
-```  
+```
 
-#### **Patterns that are *not* considered problems:**  
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
 ```css
 a {
   text-decoration: underline solid purple;
   text-decoration-thickness: 1px;
 }
+```
 
+<!-- prettier-ignore -->
+```css
 a {
   background: none 0% 0% repeat scroll transparent;
   background-size: contain;
   background-origin: border-box;
   background-clip: text;
 }
-```  
+```
 
----
+### `ignoreShorthands: ["/regex/", /regex/, "string"]`
 
-### **`ignoreShorthands: ["/regex/", /regex/, "string"]`**  
-Ignore the specified shorthand properties when checking for redundant longhands.  
+Given:
 
-#### **Example configuration:**  
-```js
+```json
 ["padding", "/border/"]
-```  
+```
 
-#### **Patterns that are *not* considered problems:**  
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
 ```css
 a {
   padding-top: 20px;
@@ -236,17 +247,33 @@ a {
   padding-bottom: 30px;
   padding-left: 10px;
 }
+```
 
+<!-- prettier-ignore -->
+```css
 a {
   border-top-width: 1px;
   border-bottom-width: 1px;
   border-left-width: 1px;
   border-right-width: 1px;
 }
+```
 
+<!-- prettier-ignore -->
+```css
+a {
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+  border-right-width: 1px;
+}
+```
+
+<!-- prettier-ignore -->
+```css
 a {
   border-top-color: green;
   border-top-style: double;
   border-top-width: 7px;
 }
-```  
+```

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -186,7 +186,8 @@ Given:
 ["text-decoration-thickness", "background-size", "background-origin", "background-clip"]
 ```
 
-### Patterns That Are Considered Problems:
+The following patterns are considered problems:
+
 <!-- prettier-ignore -->
 ```css
 a {

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -177,7 +177,7 @@ a {
 
 ### `ignoreLonghands: ["array", "of", "properties"]`
 
-Ignore the specified longhand properties when checking for redundant longhands.
+Ignore the specified longhand properties.
 
 Given:
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -232,7 +232,7 @@ a {
 ```
 
 
-## `ignoreShorthands: ["/regex/", /regex/, "string"]`
+### `ignoreShorthands: ["/regex/", /regex/, "string"]`
 Ignore the specified shorthand properties when checking for redundant longhands.
 
 ### Example Configuration:

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -236,7 +236,8 @@ a {
 
 Ignore the specified shorthand properties when checking for redundant longhands.
 
-### Example Configuration:
+Given:
+
 ```json
 ["padding", "/border/"]
 ```

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -173,7 +173,7 @@ a {
 }
 ```
 
-## Optional Secondary Options
+## Optional secondary options
 
 ### `ignoreLonghands: ["array", "of", "properties"]`
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -184,13 +184,17 @@ Ignore the specified longhand properties when checking for redundant longhands.
 ```
 
 ### Patterns That Are Considered Problems:
+<!-- prettier-ignore -->
 ```css
 a {
   text-decoration-line: underline;
   text-decoration-style: solid;
   text-decoration-color: purple;
 }
+```
 
+<!-- prettier-ignore -->
+```css
 a {
   background-repeat: repeat;
   background-attachment: scroll;
@@ -204,12 +208,16 @@ a {
 ```
 
 ### Patterns That Are *Not* Considered Problems:
+<!-- prettier-ignore -->
 ```css
 a {
   text-decoration: underline solid purple;
   text-decoration-thickness: 1px;
 }
+```
 
+<!-- prettier-ignore -->
+```css
 a {
   background: none 0% 0% repeat scroll transparent;
   background-size: contain;
@@ -229,6 +237,7 @@ Ignore the specified shorthand properties when checking for redundant longhands.
 ```
 
 ### Patterns That Are *Not* Considered Problems:
+<!-- prettier-ignore -->
 ```css
 a {
   padding-top: 20px;
@@ -236,22 +245,23 @@ a {
   padding-bottom: 30px;
   padding-left: 10px;
 }
+```
 
+<!-- prettier-ignore -->
+```css
 a {
   border-top-width: 1px;
   border-bottom-width: 1px;
   border-left-width: 1px;
   border-right-width: 1px;
 }
+```
 
+<!-- prettier-ignore -->
+```css
 a {
   border-top-color: green;
   border-top-style: double;
   border-top-width: 7px;
 }
 ```
-
-### Note:
-This rule won’t report any problems for the above cases because `padding` and `border` shorthands are ignored. Since `ignoreShorthands` makes the rule more permissive, **no invalid examples are included.**
-
----

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -173,7 +173,7 @@ a {
 }
 ```
 
-# Optional Secondary Options
+## Optional Secondary Options
 
 ## `ignoreLonghands: ["array", "of", "properties"]`
 Ignore the specified longhand properties when checking for redundant longhands.

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -211,7 +211,8 @@ a {
 }
 ```
 
-### Patterns That Are *Not* Considered Problems:
+The following patterns are _not_ considered problems:
+
 <!-- prettier-ignore -->
 ```css
 a {

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -233,6 +233,7 @@ a {
 
 
 ### `ignoreShorthands: ["/regex/", /regex/, "string"]`
+
 Ignore the specified shorthand properties when checking for redundant longhands.
 
 ### Example Configuration:

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -176,6 +176,7 @@ a {
 ## Optional Secondary Options
 
 ### `ignoreLonghands: ["array", "of", "properties"]`
+
 Ignore the specified longhand properties when checking for redundant longhands.
 
 Given:

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -242,7 +242,8 @@ Given:
 ["padding", "/border/"]
 ```
 
-### Patterns That Are *Not* Considered Problems:
+The following patterns are _not_ considered problems:
+
 <!-- prettier-ignore -->
 ```css
 a {

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -178,7 +178,9 @@ a {
 ### `ignoreLonghands: ["array", "of", "properties"]`
 Ignore the specified longhand properties when checking for redundant longhands.
 
-### Example Configuration:
+Given:
+
+<!-- prettier-ignore -->
 ```json
 ["text-decoration-thickness", "background-size", "background-origin", "background-clip"]
 ```

--- a/lib/rules/selector-not-notation/README.md
+++ b/lib/rules/selector-not-notation/README.md
@@ -1,111 +1,89 @@
-## selector-not-notation
+# selector-not-notation
 
-Enforce simple or complex notation for `:not()` pseudo-classes.
+Specify simple or complex notation for `:not()` pseudo-class selectors.
 
+<!-- prettier-ignore -->
 ```css
-/* simple notation */
-a:not([href]):not([class]) {}
+    a:not(.foo, .bar) {}
+/**  ↑
+ * This notation */
 ```
 
-```css
-/* complex notation */
-a:not([href], [class]) {}
-```
+In Selectors Level 3, only a single _simple selector_ was allowed as the argument to `:not()`, whereas Selectors Level 4 allows a _selector list_.
 
-### Specificity Behavior
+Use:
+
+- `"complex"` to author modern Selectors Level 4 CSS
+- `"simple"` for backwards compatibility with older browsers
 
 > [!NOTE]
-> The two notations can have different specificities. For example:
+> The notations can have different specificities. For example:
 
+<!-- prettier-ignore -->
 ```css
-/* Simple form - specificity adds up (0-2-1) */
-a:not([href]):not([class]) {}
+/* this complex notation has a specificity of 0,1,1 */
+a:not(.foo, .bar) {}
 
-/* Complex form - takes highest specificity only (0-1-1) */
-a:not([href], [class]) {}
+/* this simple notation has a specificity of 0,2,1 */
+a:not(.foo):not(.bar) {}
 ```
 
-⚠️ **Warning**: Converting to complex notation may reduce specificity and break style overrides.
+The [`fix` option](../../../docs/user-guide/options.md#fix) option can automatically fix most of the problems reported by this rule.
 
-### Options
+The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
 
-#### `"simple"` | `"complex"`
+## Options
 
-- **`"simple"`**: Require each selector in a separate `:not()` pseudo-class.
-- **`"complex"`**: Require multiple selectors to be combined in a single `:not()`.
+`string`: `"simple"|"complex"`
 
-For example, with `"complex"`:
+### `"simple"`
 
-The following patterns are **considered problems**:
+The following patterns are considered problems:
 
+<!-- prettier-ignore -->
 ```css
-a:not([href]):not([class]) {}
-.foo:not(.bar):not(:hover) {}
+:not(a, div) {}
 ```
 
-The following patterns are **not considered problems**:
-
+<!-- prettier-ignore -->
 ```css
-a:not([href], [class]) {}
-.foo:not(.bar, :hover) {}
+:not(a.foo) {}
 ```
 
-### Optional Secondary Options
+The following patterns are _not_ considered problems:
 
-#### `ignoreSpecificity: true`
-
-Disable specificity reduction warnings.
-
-For example, with `"complex"` and `ignoreSpecificity: true`:
-
-The following patterns are **not considered problems** (even if specificity changes):
-
+<!-- prettier-ignore -->
 ```css
-a:not([href]):not([class]) {} /* converted to 0-1-1 specificity */
+:not(a):not(div) {}
 ```
 
-#### `ignore: ["pseudo-classes"]`
-
-Ignore `:not()` pseudo-classes when they contain certain selectors.
-
-For example, with `"complex"` and:
-
-```json
-{ "ignore": ["pseudo-classes"] }
-```
-
-The following patterns are **not considered problems**:
-
+<!-- prettier-ignore -->
 ```css
-a:not(:hover):not(:focus) {} /* ignored */
-a:not([href]):not(:hover) {} /* only [href] part is checked */
+:not(a) {}
 ```
 
-#### `ignorePseudoElements: true`
+### `"complex"`
 
-Ignore `:not()` pseudo-classes containing pseudo-elements.
+The following pattern is considered a problem:
 
-For example, with `"complex"` and `ignorePseudoElements: true`:
-
-The following patterns are **not considered problems**:
-
+<!-- prettier-ignore -->
 ```css
-a:not(::before):not(::after) {} /* ignored */
+:not(a):not(div) {}
 ```
 
-### Real-world Example
+The following patterns are _not_ considered problems:
 
-This rule caught an issue where converting Bootstrap's:
-
+<!-- prettier-ignore -->
 ```css
-a:not([href]):not([class]) { color: inherit; } /* specificity 0-2-1 */
+:not(a, div) {}
 ```
 
-to:
-
+<!-- prettier-ignore -->
 ```css
-a:not([href], [class]) { color: inherit; } /* specificity 0-1-1 */
+:not(a.foo) {}
 ```
 
-resulted in broken styles due to reduced specificity. Developers should carefully evaluate specificity changes before modifying selector notation.
-
+<!-- prettier-ignore -->
+```css
+:not(a).foo:not(:empty) {}
+```

--- a/lib/rules/selector-not-notation/README.md
+++ b/lib/rules/selector-not-notation/README.md
@@ -1,77 +1,132 @@
 # selector-not-notation
 
-Specify simple or complex notation for `:not()` pseudo-class selectors.
+Enforce simple or complex notation for `:not()` pseudo-classes.
 
 <!-- prettier-ignore -->
 ```css
-    a:not(.foo, .bar) {}
-/**  ↑
- * This notation */
+a:not([href]):not([class]) {}
+/**        ↑              ↑
+ * These :not() pseudo-classes */
 ```
 
-In Selectors Level 3, only a single _simple selector_ was allowed as the argument to `:not()`, whereas Selectors Level 4 allows a _selector list_.
+This rule ensures consistency in how `:not()` pseudo-class selectors are written. There are two forms:
 
-Use:
+1. **Simple notation**: Each selector appears in its own `:not()`.
+2. **Complex notation**: Multiple selectors are combined in one `:not()`.
 
-- `"complex"` to author modern Selectors Level 4 CSS
-- `"simple"` for backwards compatibility with older browsers
+## Specificity Behavior
 
-The [`fix` option](../../../docs/user-guide/options.md#fix) option can automatically fix most of the problems reported by this rule.
+⚠️ **Important**: The two forms have different specificity calculations in CSS:
 
-The [`message` secondary option](../../../docs/user-guide/configure.md#message) can accept the arguments of this rule.
+<!-- prettier-ignore -->
+```css
+/* Simple form - specificity adds up (0-2-1) */
+a:not([href]):not([class]) {}
+
+/* Complex form - takes highest specificity only (0-1-1) */
+a:not([href], [class]) {}
+```
+
+**Warning:** Converting to complex notation may reduce specificity and break style overrides.
 
 ## Options
 
 `string`: `"simple"|"complex"`
 
-### `"simple"`
+- `"simple"`: Require each selector in a separate `:not()` pseudo-class.
+- `"complex"`: Require multiple selectors to be combined in a single `:not()`.
+
+For example, with `"complex"`:
 
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
-:not(a, div) {}
+a:not([href]):not([class]) {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-:not(a.foo) {}
+.foo:not(.bar):not(:hover) {}
 ```
 
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-:not(a):not(div) {}
+a:not([href], [class]) {}
 ```
 
 <!-- prettier-ignore -->
 ```css
-:not(a) {}
+.foo:not(.bar, :hover) {}
 ```
 
-### `"complex"`
+## Optional Secondary Options
 
-The following pattern is considered a problem:
+### `ignoreSpecificity: true`
+
+Disable specificity reduction warnings.
+
+For example, with `"complex"` and `ignoreSpecificity: true`:
+
+The following patterns are _not_ considered problems (even if specificity changes):
 
 <!-- prettier-ignore -->
 ```css
-:not(a):not(div) {}
+a:not([href]):not([class]) {} /* converted to 0-1-1 specificity */
+```
+
+### `ignore: ["pseudo-classes"]`
+
+Ignore `:not()` pseudo-classes when they contain certain selectors.
+
+For example, with `"complex"` and:
+
+```json
+{ "ignore": ["pseudo-classes"] }
 ```
 
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-:not(a, div) {}
+a:not(:hover):not(:focus) {} /* ignored */
 ```
 
 <!-- prettier-ignore -->
 ```css
-:not(a.foo) {}
+a:not([href]):not(:hover) {} /* only [href] part is checked */
 ```
+
+### `ignorePseudoElements: true`
+
+Ignore `:not()` pseudo-classes containing pseudo-elements.
+
+For example, with `"complex"` and `ignorePseudoElements: true`:
+
+The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-:not(a).foo:not(:empty) {}
+a:not(::before):not(::after) {} /* ignored */
 ```
+
+## Real-world Example
+
+This rule caught an issue where converting Bootstrap's:
+
+<!-- prettier-ignore -->
+```css
+a:not([href]):not([class]) { color: inherit; } /* specificity 0-2-1 */
+```
+
+to:
+
+<!-- prettier-ignore -->
+```css
+a:not([href], [class]) { color: inherit; } /* specificity 0-1-1 */
+```
+
+resulted in broken styles due to reduced specificity. Developers should carefully evaluate specificity changes before modifying selector notation.
+

--- a/lib/rules/selector-not-notation/README.md
+++ b/lib/rules/selector-not-notation/README.md
@@ -1,24 +1,22 @@
-# selector-not-notation
+## selector-not-notation
 
 Enforce simple or complex notation for `:not()` pseudo-classes.
 
-<!-- prettier-ignore -->
 ```css
+/* simple notation */
 a:not([href]):not([class]) {}
-/**        ↑              ↑
- * These :not() pseudo-classes */
 ```
 
-This rule ensures consistency in how `:not()` pseudo-class selectors are written. There are two forms:
+```css
+/* complex notation */
+a:not([href], [class]) {}
+```
 
-1. **Simple notation**: Each selector appears in its own `:not()`.
-2. **Complex notation**: Multiple selectors are combined in one `:not()`.
+### Specificity Behavior
 
-## Specificity Behavior
+> [!NOTE]
+> The two notations can have different specificities. For example:
 
-⚠️ **Important**: The two forms have different specificity calculations in CSS:
-
-<!-- prettier-ignore -->
 ```css
 /* Simple form - specificity adds up (0-2-1) */
 a:not([href]):not([class]) {}
@@ -27,57 +25,46 @@ a:not([href]):not([class]) {}
 a:not([href], [class]) {}
 ```
 
-**Warning:** Converting to complex notation may reduce specificity and break style overrides.
+⚠️ **Warning**: Converting to complex notation may reduce specificity and break style overrides.
 
-## Options
+### Options
 
-`string`: `"simple"|"complex"`
+#### `"simple"` | `"complex"`
 
-- `"simple"`: Require each selector in a separate `:not()` pseudo-class.
-- `"complex"`: Require multiple selectors to be combined in a single `:not()`.
+- **`"simple"`**: Require each selector in a separate `:not()` pseudo-class.
+- **`"complex"`**: Require multiple selectors to be combined in a single `:not()`.
 
 For example, with `"complex"`:
 
-The following patterns are considered problems:
+The following patterns are **considered problems**:
 
-<!-- prettier-ignore -->
 ```css
 a:not([href]):not([class]) {}
-```
-
-<!-- prettier-ignore -->
-```css
 .foo:not(.bar):not(:hover) {}
 ```
 
-The following patterns are _not_ considered problems:
+The following patterns are **not considered problems**:
 
-<!-- prettier-ignore -->
 ```css
 a:not([href], [class]) {}
-```
-
-<!-- prettier-ignore -->
-```css
 .foo:not(.bar, :hover) {}
 ```
 
-## Optional Secondary Options
+### Optional Secondary Options
 
-### `ignoreSpecificity: true`
+#### `ignoreSpecificity: true`
 
 Disable specificity reduction warnings.
 
 For example, with `"complex"` and `ignoreSpecificity: true`:
 
-The following patterns are _not_ considered problems (even if specificity changes):
+The following patterns are **not considered problems** (even if specificity changes):
 
-<!-- prettier-ignore -->
 ```css
 a:not([href]):not([class]) {} /* converted to 0-1-1 specificity */
 ```
 
-### `ignore: ["pseudo-classes"]`
+#### `ignore: ["pseudo-classes"]`
 
 Ignore `:not()` pseudo-classes when they contain certain selectors.
 
@@ -87,43 +74,35 @@ For example, with `"complex"` and:
 { "ignore": ["pseudo-classes"] }
 ```
 
-The following patterns are _not_ considered problems:
+The following patterns are **not considered problems**:
 
-<!-- prettier-ignore -->
 ```css
 a:not(:hover):not(:focus) {} /* ignored */
-```
-
-<!-- prettier-ignore -->
-```css
 a:not([href]):not(:hover) {} /* only [href] part is checked */
 ```
 
-### `ignorePseudoElements: true`
+#### `ignorePseudoElements: true`
 
 Ignore `:not()` pseudo-classes containing pseudo-elements.
 
 For example, with `"complex"` and `ignorePseudoElements: true`:
 
-The following patterns are _not_ considered problems:
+The following patterns are **not considered problems**:
 
-<!-- prettier-ignore -->
 ```css
 a:not(::before):not(::after) {} /* ignored */
 ```
 
-## Real-world Example
+### Real-world Example
 
 This rule caught an issue where converting Bootstrap's:
 
-<!-- prettier-ignore -->
 ```css
 a:not([href]):not([class]) { color: inherit; } /* specificity 0-2-1 */
 ```
 
 to:
 
-<!-- prettier-ignore -->
 ```css
 a:not([href], [class]) { color: inherit; } /* specificity 0-1-1 */
 ```


### PR DESCRIPTION
Closes #8497

Added short descriptions for `ignoreLonghands` and `ignoreShorthands` options in the documentation for the `declaration-block-no-redundant-longhand-properties` rule.
Also, added examples for `ignoreShorthands` to clarify the intended behavior of the option.

