### PR TITLE
Document css-wide keywords and `languageOptions` in writing rules

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -55,6 +55,7 @@ You should:
 You should ask yourself how does your rule handle:
 
 - variables (e.g. `var(--custom-property)`)?
+- CSS-wide keywords (e.g. `initial`)?
 - CSS strings (e.g. `content: "anything goes";`)?
 - CSS comments (e.g. `/* anything goes */`)?
 - empty functions (e.g. `var()`)?
@@ -296,6 +297,30 @@ function rule(primary, secondary) {
       node,
 +     fix
     });
+  };
+}
+```
+
+### Add `languageOptions` support
+
+Depending on the rule, it may need to support the [`languageOptions`](../user-guide/configure.md#languageoptions) configuration property.
+
+For example:
+
+```diff js
+import { basicKeywords } from '../../reference/keywords.mjs';
+
+function rule(primary, secondary) {
+  return (root, result) => {
+    /* .. */
+
+    if (!validOptions) return;
+
++   const languageCssWideKeywords = result.stylelint.config?.languageOptions?.syntax?.cssWideKeywords ?? [];
+
++   languageCssWideKeywords.forEach(basicKeywords.add, basicKeywords);
+
+    /* .. */
   };
 }
 ```

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -318,7 +318,7 @@ function rule(primary, secondary) {
 
 +   const languageCssWideKeywords = result.stylelint.config?.languageOptions?.syntax?.cssWideKeywords ?? [];
 
-+   languageCssWideKeywords.forEach(basicKeywords.add, basicKeywords);
++   const cssWideKeywords = new Set([...basicKeywords, ...languageCssWideKeywords]);
 
     /* .. */
   };


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

These came up in https://github.com/stylelint/stylelint/pull/8498
