### PR TITLE
Refactor to prevent unexpected mutation of shared objects

### DIFF
--- a/lib/reference/atKeywords.cjs
+++ b/lib/reference/atKeywords.cjs
@@ -6,7 +6,10 @@ const uniteSets = require('../utils/uniteSets.cjs');
 
 const deprecatedAtKeywords = new Set(['apply', 'document', 'nest', 'viewport']);
 
-// https://www.w3.org/TR/css-nesting-1/#conditionals
+/**
+ * @see https://www.w3.org/TR/css-nesting-1/#conditionals
+ * @type {ReadonlySet<string>}
+ */
 const nestingSupportedAtKeywords = new Set([
 	'container',
 	'layer',
@@ -16,7 +19,10 @@ const nestingSupportedAtKeywords = new Set([
 	'supports',
 ]);
 
-// https://www.w3.org/TR/css-page-3/#syntax-page-selector
+/**
+ * @see https://www.w3.org/TR/css-page-3/#syntax-page-selector
+ * @type {ReadonlySet<string>}
+ */
 const pageMarginAtKeywords = new Set([
 	'top-left-corner',
 	'top-left',
@@ -36,7 +42,10 @@ const pageMarginAtKeywords = new Set([
 	'right-bottom',
 ]);
 
-// https://www.w3.org/TR/css-fonts-4/#font-feature-values-font-feature-value-type
+/**
+ * @see https://www.w3.org/TR/css-fonts-4/#font-feature-values-font-feature-value-type
+ * @type {ReadonlySet<string>}
+ */
 const fontFeatureValueTypes = new Set([
 	'annotation',
 	'character-variant',
@@ -47,7 +56,10 @@ const fontFeatureValueTypes = new Set([
 	'swash',
 ]);
 
-// https://developer.mozilla.org/en/docs/Web/CSS/At-rule
+/**
+ * @see https://developer.mozilla.org/en/docs/Web/CSS/At-rule
+ * @type {ReadonlySet<string>}
+ */
 const atKeywords = uniteSets(
 	deprecatedAtKeywords,
 	nestingSupportedAtKeywords,

--- a/lib/reference/atKeywords.cjs
+++ b/lib/reference/atKeywords.cjs
@@ -4,6 +4,7 @@
 
 const uniteSets = require('../utils/uniteSets.cjs');
 
+/** @type {ReadonlySet<string>} */
 const deprecatedAtKeywords = new Set(['apply', 'document', 'nest', 'viewport']);
 
 /**

--- a/lib/reference/atKeywords.mjs
+++ b/lib/reference/atKeywords.mjs
@@ -2,7 +2,10 @@ import uniteSets from '../utils/uniteSets.mjs';
 
 export const deprecatedAtKeywords = new Set(['apply', 'document', 'nest', 'viewport']);
 
-// https://www.w3.org/TR/css-nesting-1/#conditionals
+/**
+ * @see https://www.w3.org/TR/css-nesting-1/#conditionals
+ * @type {ReadonlySet<string>}
+ */
 export const nestingSupportedAtKeywords = new Set([
 	'container',
 	'layer',
@@ -12,7 +15,10 @@ export const nestingSupportedAtKeywords = new Set([
 	'supports',
 ]);
 
-// https://www.w3.org/TR/css-page-3/#syntax-page-selector
+/**
+ * @see https://www.w3.org/TR/css-page-3/#syntax-page-selector
+ * @type {ReadonlySet<string>}
+ */
 export const pageMarginAtKeywords = new Set([
 	'top-left-corner',
 	'top-left',
@@ -32,7 +38,10 @@ export const pageMarginAtKeywords = new Set([
 	'right-bottom',
 ]);
 
-// https://www.w3.org/TR/css-fonts-4/#font-feature-values-font-feature-value-type
+/**
+ * @see https://www.w3.org/TR/css-fonts-4/#font-feature-values-font-feature-value-type
+ * @type {ReadonlySet<string>}
+ */
 const fontFeatureValueTypes = new Set([
 	'annotation',
 	'character-variant',
@@ -43,7 +52,10 @@ const fontFeatureValueTypes = new Set([
 	'swash',
 ]);
 
-// https://developer.mozilla.org/en/docs/Web/CSS/At-rule
+/**
+ * @see https://developer.mozilla.org/en/docs/Web/CSS/At-rule
+ * @type {ReadonlySet<string>}
+ */
 export const atKeywords = uniteSets(
 	deprecatedAtKeywords,
 	nestingSupportedAtKeywords,

--- a/lib/reference/atKeywords.mjs
+++ b/lib/reference/atKeywords.mjs
@@ -1,5 +1,6 @@
 import uniteSets from '../utils/uniteSets.mjs';
 
+/** @type {ReadonlySet<string>} */
 export const deprecatedAtKeywords = new Set(['apply', 'document', 'nest', 'viewport']);
 
 /**

--- a/lib/reference/functions.cjs
+++ b/lib/reference/functions.cjs
@@ -2,6 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
+/** @type {ReadonlySet<string>} */
 const camelCaseFunctions = new Set([
 	'translateX',
 	'translateY',
@@ -16,6 +17,7 @@ const camelCaseFunctions = new Set([
 	'skewY',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const colorFunctions = new Set([
 	'color',
 	'color-mix',
@@ -30,6 +32,7 @@ const colorFunctions = new Set([
 	'rgba',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const singleArgumentMathFunctions = new Set([
 	'abs',
 	'acos',
@@ -44,6 +47,7 @@ const singleArgumentMathFunctions = new Set([
 	'tan',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const mathFunctions = new Set([
 	...singleArgumentMathFunctions,
 	'atan2',

--- a/lib/reference/functions.mjs
+++ b/lib/reference/functions.mjs
@@ -1,3 +1,4 @@
+/** @type {ReadonlySet<string>} */
 export const camelCaseFunctions = new Set([
 	'translateX',
 	'translateY',
@@ -12,6 +13,7 @@ export const camelCaseFunctions = new Set([
 	'skewY',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const colorFunctions = new Set([
 	'color',
 	'color-mix',
@@ -26,6 +28,7 @@ export const colorFunctions = new Set([
 	'rgba',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const singleArgumentMathFunctions = new Set([
 	'abs',
 	'acos',
@@ -40,6 +43,7 @@ const singleArgumentMathFunctions = new Set([
 	'tan',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const mathFunctions = new Set([
 	...singleArgumentMathFunctions,
 	'atan2',

--- a/lib/reference/keywords.cjs
+++ b/lib/reference/keywords.cjs
@@ -4,8 +4,10 @@
 
 const uniteSets = require('../utils/uniteSets.cjs');
 
+/** @type {ReadonlySet<string>} */
 const basicKeywords = new Set(['initial', 'inherit', 'revert', 'revert-layer', 'unset']);
 
+/** @type {ReadonlySet<string>} */
 const systemFontKeywords = uniteSets(basicKeywords, [
 	'caption',
 	'icon',
@@ -15,6 +17,7 @@ const systemFontKeywords = uniteSets(basicKeywords, [
 	'status-bar',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const fontFamilyKeywords = uniteSets(basicKeywords, [
 	'serif',
 	'sans-serif',
@@ -31,6 +34,7 @@ const fontFamilyKeywords = uniteSets(basicKeywords, [
 	'fangsong',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const appleSystemFonts = new Set([
 	'-apple-system',
 	'-apple-system-headline',
@@ -52,6 +56,7 @@ const appleSystemFonts = new Set([
 	'-apple-system-title4',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const mozillaSystemFonts = new Set([
 	'-moz-button',
 	'-moz-desktop',
@@ -66,6 +71,7 @@ const mozillaSystemFonts = new Set([
 	'-moz-workspace',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const webkitSystemFonts = new Set([
 	'-webkit-body',
 	'-webkit-control',
@@ -75,21 +81,26 @@ const webkitSystemFonts = new Set([
 	'-webkit-standard',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const prefixedSystemFonts = uniteSets(
 	appleSystemFonts,
 	mozillaSystemFonts,
 	webkitSystemFonts,
 );
 
+/** @type {ReadonlySet<string>} */
 const fontWeightRelativeKeywords = new Set(['bolder', 'lighter']);
 
+/** @type {ReadonlySet<string>} */
 const fontWeightAbsoluteKeywords = new Set(['normal', 'bold']);
 
+/** @type {ReadonlySet<string>} */
 const fontWeightNonNumericKeywords = uniteSets(
 	fontWeightRelativeKeywords,
 	fontWeightAbsoluteKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 const fontWeightNumericKeywords = new Set([
 	'100',
 	'200',
@@ -102,16 +113,20 @@ const fontWeightNumericKeywords = new Set([
 	'900',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const fontWeightKeywords = uniteSets(
 	basicKeywords,
 	fontWeightNonNumericKeywords,
 	fontWeightNumericKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 const fontStyleKeywords = uniteSets(basicKeywords, ['normal', 'italic', 'oblique']);
 
+/** @type {ReadonlySet<string>} */
 const fontVariantCSS2Keywords = uniteSets(basicKeywords, ['normal', 'none', 'small-caps']);
 
+/** @type {ReadonlySet<string>} */
 const fontStretchKeywords = uniteSets(basicKeywords, [
 	'semi-condensed',
 	'condensed',
@@ -123,6 +138,7 @@ const fontStretchKeywords = uniteSets(basicKeywords, [
 	'ultra-expanded',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const fontSizeKeywords = uniteSets(basicKeywords, [
 	'xx-small',
 	'x-small',
@@ -139,8 +155,10 @@ const fontSizeKeywords = uniteSets(basicKeywords, [
 	'-webkit-xxx-large',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);
 
+/** @type {ReadonlySet<string>} */
 const fontShorthandKeywords = uniteSets(
 	basicKeywords,
 	fontStyleKeywords,
@@ -152,8 +170,10 @@ const fontShorthandKeywords = uniteSets(
 	fontFamilyKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 const animationNameKeywords = uniteSets(basicKeywords, ['none']);
 
+/** @type {ReadonlySet<string>} */
 const animationTimingFunctionKeywords = uniteSets(basicKeywords, [
 	'linear',
 	'ease',
@@ -166,8 +186,10 @@ const animationTimingFunctionKeywords = uniteSets(basicKeywords, [
 	'cubic-bezier',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const animationIterationCountKeywords = new Set(['infinite']);
 
+/** @type {ReadonlySet<string>} */
 const animationDirectionKeywords = uniteSets(basicKeywords, [
 	'normal',
 	'reverse',
@@ -175,11 +197,16 @@ const animationDirectionKeywords = uniteSets(basicKeywords, [
 	'alternate-reverse',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const animationFillModeKeywords = new Set(['none', 'forwards', 'backwards', 'both']);
 
+/** @type {ReadonlySet<string>} */
 const animationPlayStateKeywords = uniteSets(basicKeywords, ['running', 'paused']);
 
-// cf. https://developer.mozilla.org/docs/Web/CSS/animation
+/**
+ * @see https://developer.mozilla.org/docs/Web/CSS/animation
+ * @type {ReadonlySet<string>}
+ */
 const animationShorthandKeywords = uniteSets(
 	basicKeywords,
 	animationNameKeywords,
@@ -190,18 +217,28 @@ const animationShorthandKeywords = uniteSets(
 	animationPlayStateKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 const gridRowKeywords = uniteSets(basicKeywords, ['auto', 'span']);
 
+/** @type {ReadonlySet<string>} */
 const gridColumnKeywords = uniteSets(basicKeywords, ['auto', 'span']);
 
+/** @type {ReadonlySet<string>} */
 const gridAreaKeywords = uniteSets(basicKeywords, ['auto', 'span']);
 
-// https://developer.mozilla.org/docs/Web/CSS/counter-increment
+/**
+ * @see https://developer.mozilla.org/docs/Web/CSS/counter-increment
+ * @type {ReadonlySet<string>}
+ */
 const counterIncrementKeywords = uniteSets(basicKeywords, ['none']);
 
+/** @type {ReadonlySet<string>} */
 const counterResetKeywords = uniteSets(basicKeywords, ['none']);
 
-// https://developer.mozilla.org/docs/Web/CSS/list-style-type
+/**
+ * @see https://developer.mozilla.org/docs/Web/CSS/list-style-type
+ * @type {ReadonlySet<string>}
+ */
 const listStyleTypeKeywords = uniteSets(basicKeywords, [
 	'none',
 	'disc',
@@ -301,10 +338,13 @@ const listStyleTypeKeywords = uniteSets(basicKeywords, [
 	'octal',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const listStylePositionKeywords = uniteSets(basicKeywords, ['inside', 'outside']);
 
+/** @type {ReadonlySet<string>} */
 const listStyleImageKeywords = uniteSets(basicKeywords, ['none']);
 
+/** @type {ReadonlySet<string>} */
 const listStyleShorthandKeywords = uniteSets(
 	basicKeywords,
 	listStyleTypeKeywords,
@@ -312,6 +352,7 @@ const listStyleShorthandKeywords = uniteSets(
 	listStyleImageKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 const camelCaseKeywords = new Set([
 	'optimizeSpeed',
 	'optimizeQuality',
@@ -326,9 +367,13 @@ const camelCaseKeywords = new Set([
 	'linearRGB',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const keyframeSelectorKeywords = new Set(['from', 'to']);
 
-// https://drafts.csswg.org/scroll-animations-1/#view-progress-timelines
+/**
+ * @see https://drafts.csswg.org/scroll-animations-1/#view-progress-timelines
+ * @type {ReadonlySet<string>}
+ */
 const namedTimelineRangeKeywords = new Set([
 	'contain',
 	'cover',
@@ -338,7 +383,10 @@ const namedTimelineRangeKeywords = new Set([
 	'exit-crossing',
 ]);
 
-// https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#color_keywords
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#color_keywords
+ * @type {ReadonlySet<string>}
+ */
 const prefixedSystemColorKeywords = new Set([
 	'-moz-buttondefault',
 	'-moz-buttonhoverface',
@@ -381,6 +429,7 @@ const prefixedSystemColorKeywords = new Set([
 	'-ms-hotlight',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const deprecatedSystemColorKeywords = new Set([
 	'activeborder',
 	'activecaption',
@@ -407,6 +456,7 @@ const deprecatedSystemColorKeywords = new Set([
 	'windowtext',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const systemColorsKeywords = uniteSets(
 	prefixedSystemColorKeywords,
 	deprecatedSystemColorKeywords,
@@ -434,8 +484,11 @@ const systemColorsKeywords = uniteSets(
 	],
 );
 
+/**
+ * @see https://www.w3.org/TR/css-color-4/#named-colors
+ * @type {ReadonlySet<string>}
+ */
 const namedColorsKeywords = new Set([
-	// https://www.w3.org/TR/css-color-4/#named-colors
 	'aliceblue',
 	'antiquewhite',
 	'aqua',

--- a/lib/reference/keywords.mjs
+++ b/lib/reference/keywords.mjs
@@ -1,7 +1,9 @@
 import uniteSets from '../utils/uniteSets.mjs';
 
+/** @type {ReadonlySet<string>} */
 export const basicKeywords = new Set(['initial', 'inherit', 'revert', 'revert-layer', 'unset']);
 
+/** @type {ReadonlySet<string>} */
 export const systemFontKeywords = uniteSets(basicKeywords, [
 	'caption',
 	'icon',
@@ -11,6 +13,7 @@ export const systemFontKeywords = uniteSets(basicKeywords, [
 	'status-bar',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const fontFamilyKeywords = uniteSets(basicKeywords, [
 	'serif',
 	'sans-serif',
@@ -27,6 +30,7 @@ export const fontFamilyKeywords = uniteSets(basicKeywords, [
 	'fangsong',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const appleSystemFonts = new Set([
 	'-apple-system',
 	'-apple-system-headline',
@@ -48,6 +52,7 @@ const appleSystemFonts = new Set([
 	'-apple-system-title4',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const mozillaSystemFonts = new Set([
 	'-moz-button',
 	'-moz-desktop',
@@ -62,6 +67,7 @@ const mozillaSystemFonts = new Set([
 	'-moz-workspace',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const webkitSystemFonts = new Set([
 	'-webkit-body',
 	'-webkit-control',
@@ -71,21 +77,26 @@ const webkitSystemFonts = new Set([
 	'-webkit-standard',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const prefixedSystemFonts = uniteSets(
 	appleSystemFonts,
 	mozillaSystemFonts,
 	webkitSystemFonts,
 );
 
+/** @type {ReadonlySet<string>} */
 export const fontWeightRelativeKeywords = new Set(['bolder', 'lighter']);
 
+/** @type {ReadonlySet<string>} */
 export const fontWeightAbsoluteKeywords = new Set(['normal', 'bold']);
 
+/** @type {ReadonlySet<string>} */
 export const fontWeightNonNumericKeywords = uniteSets(
 	fontWeightRelativeKeywords,
 	fontWeightAbsoluteKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 const fontWeightNumericKeywords = new Set([
 	'100',
 	'200',
@@ -98,16 +109,20 @@ const fontWeightNumericKeywords = new Set([
 	'900',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const fontWeightKeywords = uniteSets(
 	basicKeywords,
 	fontWeightNonNumericKeywords,
 	fontWeightNumericKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 const fontStyleKeywords = uniteSets(basicKeywords, ['normal', 'italic', 'oblique']);
 
+/** @type {ReadonlySet<string>} */
 const fontVariantCSS2Keywords = uniteSets(basicKeywords, ['normal', 'none', 'small-caps']);
 
+/** @type {ReadonlySet<string>} */
 const fontStretchKeywords = uniteSets(basicKeywords, [
 	'semi-condensed',
 	'condensed',
@@ -119,6 +134,7 @@ const fontStretchKeywords = uniteSets(basicKeywords, [
 	'ultra-expanded',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const fontSizeKeywords = uniteSets(basicKeywords, [
 	'xx-small',
 	'x-small',
@@ -135,8 +151,10 @@ export const fontSizeKeywords = uniteSets(basicKeywords, [
 	'-webkit-xxx-large',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const lineHeightKeywords = uniteSets(basicKeywords, ['normal']);
 
+/** @type {ReadonlySet<string>} */
 export const fontShorthandKeywords = uniteSets(
 	basicKeywords,
 	fontStyleKeywords,
@@ -148,8 +166,10 @@ export const fontShorthandKeywords = uniteSets(
 	fontFamilyKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 export const animationNameKeywords = uniteSets(basicKeywords, ['none']);
 
+/** @type {ReadonlySet<string>} */
 const animationTimingFunctionKeywords = uniteSets(basicKeywords, [
 	'linear',
 	'ease',
@@ -162,8 +182,10 @@ const animationTimingFunctionKeywords = uniteSets(basicKeywords, [
 	'cubic-bezier',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const animationIterationCountKeywords = new Set(['infinite']);
 
+/** @type {ReadonlySet<string>} */
 const animationDirectionKeywords = uniteSets(basicKeywords, [
 	'normal',
 	'reverse',
@@ -171,11 +193,16 @@ const animationDirectionKeywords = uniteSets(basicKeywords, [
 	'alternate-reverse',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const animationFillModeKeywords = new Set(['none', 'forwards', 'backwards', 'both']);
 
+/** @type {ReadonlySet<string>} */
 const animationPlayStateKeywords = uniteSets(basicKeywords, ['running', 'paused']);
 
-// cf. https://developer.mozilla.org/docs/Web/CSS/animation
+/**
+ * @see https://developer.mozilla.org/docs/Web/CSS/animation
+ * @type {ReadonlySet<string>}
+ */
 export const animationShorthandKeywords = uniteSets(
 	basicKeywords,
 	animationNameKeywords,
@@ -186,18 +213,28 @@ export const animationShorthandKeywords = uniteSets(
 	animationPlayStateKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 export const gridRowKeywords = uniteSets(basicKeywords, ['auto', 'span']);
 
+/** @type {ReadonlySet<string>} */
 export const gridColumnKeywords = uniteSets(basicKeywords, ['auto', 'span']);
 
+/** @type {ReadonlySet<string>} */
 export const gridAreaKeywords = uniteSets(basicKeywords, ['auto', 'span']);
 
-// https://developer.mozilla.org/docs/Web/CSS/counter-increment
+/**
+ * @see https://developer.mozilla.org/docs/Web/CSS/counter-increment
+ * @type {ReadonlySet<string>}
+ */
 export const counterIncrementKeywords = uniteSets(basicKeywords, ['none']);
 
+/** @type {ReadonlySet<string>} */
 export const counterResetKeywords = uniteSets(basicKeywords, ['none']);
 
-// https://developer.mozilla.org/docs/Web/CSS/list-style-type
+/**
+ * @see https://developer.mozilla.org/docs/Web/CSS/list-style-type
+ * @type {ReadonlySet<string>}
+ */
 export const listStyleTypeKeywords = uniteSets(basicKeywords, [
 	'none',
 	'disc',
@@ -297,10 +334,13 @@ export const listStyleTypeKeywords = uniteSets(basicKeywords, [
 	'octal',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const listStylePositionKeywords = uniteSets(basicKeywords, ['inside', 'outside']);
 
+/** @type {ReadonlySet<string>} */
 export const listStyleImageKeywords = uniteSets(basicKeywords, ['none']);
 
+/** @type {ReadonlySet<string>} */
 export const listStyleShorthandKeywords = uniteSets(
 	basicKeywords,
 	listStyleTypeKeywords,
@@ -308,6 +348,7 @@ export const listStyleShorthandKeywords = uniteSets(
 	listStyleImageKeywords,
 );
 
+/** @type {ReadonlySet<string>} */
 export const camelCaseKeywords = new Set([
 	'optimizeSpeed',
 	'optimizeQuality',
@@ -322,9 +363,13 @@ export const camelCaseKeywords = new Set([
 	'linearRGB',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const keyframeSelectorKeywords = new Set(['from', 'to']);
 
-// https://drafts.csswg.org/scroll-animations-1/#view-progress-timelines
+/**
+ * @see https://drafts.csswg.org/scroll-animations-1/#view-progress-timelines
+ * @type {ReadonlySet<string>}
+ */
 export const namedTimelineRangeKeywords = new Set([
 	'contain',
 	'cover',
@@ -334,7 +379,10 @@ export const namedTimelineRangeKeywords = new Set([
 	'exit-crossing',
 ]);
 
-// https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#color_keywords
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#color_keywords
+ * @type {ReadonlySet<string>}
+ */
 const prefixedSystemColorKeywords = new Set([
 	'-moz-buttondefault',
 	'-moz-buttonhoverface',
@@ -377,6 +425,7 @@ const prefixedSystemColorKeywords = new Set([
 	'-ms-hotlight',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const deprecatedSystemColorKeywords = new Set([
 	'activeborder',
 	'activecaption',
@@ -403,6 +452,7 @@ export const deprecatedSystemColorKeywords = new Set([
 	'windowtext',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const systemColorsKeywords = uniteSets(
 	prefixedSystemColorKeywords,
 	deprecatedSystemColorKeywords,
@@ -430,8 +480,11 @@ export const systemColorsKeywords = uniteSets(
 	],
 );
 
+/**
+ * @see https://www.w3.org/TR/css-color-4/#named-colors
+ * @type {ReadonlySet<string>}
+ */
 export const namedColorsKeywords = new Set([
-	// https://www.w3.org/TR/css-color-4/#named-colors
 	'aliceblue',
 	'antiquewhite',
 	'aqua',

--- a/lib/reference/mediaFeatures.cjs
+++ b/lib/reference/mediaFeatures.cjs
@@ -4,12 +4,14 @@
 
 const uniteSets = require('../utils/uniteSets.cjs');
 
+/** @type {ReadonlySet<string>} */
 const deprecatedMediaFeatureNames = new Set([
 	'device-aspect-ratio',
 	'device-height',
 	'device-width',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const rangeTypeMediaFeatureNames = uniteSets(deprecatedMediaFeatureNames, [
 	'aspect-ratio',
 	'color',
@@ -22,12 +24,14 @@ const rangeTypeMediaFeatureNames = uniteSets(deprecatedMediaFeatureNames, [
 	'width',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const rangeTypeMediaFeatureNamesWithMinMaxPrefix = new Set(
 	[...rangeTypeMediaFeatureNames].flatMap((name) => {
 		return [`min-${name}`, `max-${name}`];
 	}),
 );
 
+/** @type {ReadonlySet<string>} */
 const discreteTypeMediaFeatureNames = new Set([
 	'any-hover',
 	'any-pointer',
@@ -57,6 +61,7 @@ const discreteTypeMediaFeatureNames = new Set([
 	'video-dynamic-range',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const mediaFeatureNames = uniteSets(
 	deprecatedMediaFeatureNames,
 	rangeTypeMediaFeatureNames,
@@ -64,6 +69,7 @@ const mediaFeatureNames = uniteSets(
 	discreteTypeMediaFeatureNames,
 );
 
+/** @type {ReadonlyMap<string, ReadonlySet<string>>} */
 const mediaFeatureNameAllowedValueKeywords = new Map([
 	['any-hover', new Set(['none', 'hover'])],
 	['any-pointer', new Set(['none', 'coarse', 'fine'])],
@@ -95,6 +101,7 @@ const mediaFeatureNameAllowedValueKeywords = new Map([
 	['video-dynamic-range', new Set(['standard', 'high'])],
 ]);
 
+/** @type {ReadonlyMap<string, ReadonlySet<string>>} */
 const mediaFeatureNameAllowedValueTypes = new Map([
 	['aspect-ratio', new Set(['ratio'])],
 	['color', new Set(['integer'])],

--- a/lib/reference/mediaFeatures.mjs
+++ b/lib/reference/mediaFeatures.mjs
@@ -1,11 +1,13 @@
 import uniteSets from '../utils/uniteSets.mjs';
 
+/** @type {ReadonlySet<string>} */
 const deprecatedMediaFeatureNames = new Set([
 	'device-aspect-ratio',
 	'device-height',
 	'device-width',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const rangeTypeMediaFeatureNames = uniteSets(deprecatedMediaFeatureNames, [
 	'aspect-ratio',
 	'color',
@@ -18,12 +20,14 @@ export const rangeTypeMediaFeatureNames = uniteSets(deprecatedMediaFeatureNames,
 	'width',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const rangeTypeMediaFeatureNamesWithMinMaxPrefix = new Set(
 	[...rangeTypeMediaFeatureNames].flatMap((name) => {
 		return [`min-${name}`, `max-${name}`];
 	}),
 );
 
+/** @type {ReadonlySet<string>} */
 const discreteTypeMediaFeatureNames = new Set([
 	'any-hover',
 	'any-pointer',
@@ -53,6 +57,7 @@ const discreteTypeMediaFeatureNames = new Set([
 	'video-dynamic-range',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const mediaFeatureNames = uniteSets(
 	deprecatedMediaFeatureNames,
 	rangeTypeMediaFeatureNames,
@@ -60,6 +65,7 @@ export const mediaFeatureNames = uniteSets(
 	discreteTypeMediaFeatureNames,
 );
 
+/** @type {ReadonlyMap<string, ReadonlySet<string>>} */
 export const mediaFeatureNameAllowedValueKeywords = new Map([
 	['any-hover', new Set(['none', 'hover'])],
 	['any-pointer', new Set(['none', 'coarse', 'fine'])],
@@ -91,6 +97,7 @@ export const mediaFeatureNameAllowedValueKeywords = new Map([
 	['video-dynamic-range', new Set(['standard', 'high'])],
 ]);
 
+/** @type {ReadonlyMap<string, ReadonlySet<string>>} */
 export const mediaFeatureNameAllowedValueTypes = new Map([
 	['aspect-ratio', new Set(['ratio'])],
 	['color', new Set(['integer'])],

--- a/lib/reference/prefixes.cjs
+++ b/lib/reference/prefixes.cjs
@@ -2,9 +2,13 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-// used by value-no-vendor-prefix and selector-no-vendor-prefix
-// i.e. this list is deliberately not exhaustive
-// cf https://www.w3.org/TR/CSS22/syndata.html#vendor-keyword-history
+/**
+ * used by value-no-vendor-prefix and selector-no-vendor-prefix
+ * i.e. this list is deliberately not exhaustive
+ *
+ * @see https://www.w3.org/TR/CSS22/syndata.html#vendor-keyword-history
+ * @type {ReadonlySet<string>}
+ */
 const prefixes = new Set([
 	'-webkit-',
 	'-moz-',

--- a/lib/reference/prefixes.mjs
+++ b/lib/reference/prefixes.mjs
@@ -1,6 +1,10 @@
-// used by value-no-vendor-prefix and selector-no-vendor-prefix
-// i.e. this list is deliberately not exhaustive
-// cf https://www.w3.org/TR/CSS22/syndata.html#vendor-keyword-history
+/**
+ * used by value-no-vendor-prefix and selector-no-vendor-prefix
+ * i.e. this list is deliberately not exhaustive
+ *
+ * @see https://www.w3.org/TR/CSS22/syndata.html#vendor-keyword-history
+ * @type {ReadonlySet<string>}
+ */
 export const prefixes = new Set([
 	'-webkit-',
 	'-moz-',

--- a/lib/reference/properties.cjs
+++ b/lib/reference/properties.cjs
@@ -2,6 +2,7 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
+/** @type {ReadonlySet<string>} */
 const acceptCustomIdentsProperties = new Set([
 	'animation',
 	'animation-name',
@@ -15,6 +16,7 @@ const acceptCustomIdentsProperties = new Set([
 	'list-style-type',
 ]);
 
+/** @type {ReadonlyMap<string, ReadonlySet<string>>} */
 const shorthandToResetToInitialProperty = new Map([
 	[
 		'border',
@@ -614,6 +616,7 @@ const longhandSubPropertiesOfShorthandProperties = new Map([
 	],
 ]);
 
+/** @type {ReadonlySet<string>} */
 const singleValueColorProperties = new Set([
 	'accent-color',
 	'background-color',
@@ -639,6 +642,7 @@ const singleValueColorProperties = new Set([
 	'stop-color',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const longhandTimeProperties = new Set([
 	'transition-duration',
 	'transition-delay',
@@ -646,8 +650,10 @@ const longhandTimeProperties = new Set([
 	'animation-delay',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const shorthandTimeProperties = new Set(['transition', 'animation']);
 
+/** @type {ReadonlySet<string>} */
 const pageContextProperties = new Set([
 	'direction',
 	'background-color',
@@ -717,6 +723,7 @@ const pageContextProperties = new Set([
 	'max-width',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const marginContextProperties = new Set([
 	'direction',
 	'unicode-bidi',

--- a/lib/reference/properties.mjs
+++ b/lib/reference/properties.mjs
@@ -1,3 +1,4 @@
+/** @type {ReadonlySet<string>} */
 export const acceptCustomIdentsProperties = new Set([
 	'animation',
 	'animation-name',
@@ -11,6 +12,7 @@ export const acceptCustomIdentsProperties = new Set([
 	'list-style-type',
 ]);
 
+/** @type {ReadonlyMap<string, ReadonlySet<string>>} */
 export const shorthandToResetToInitialProperty = new Map([
 	[
 		'border',
@@ -610,6 +612,7 @@ export const longhandSubPropertiesOfShorthandProperties = new Map([
 	],
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const singleValueColorProperties = new Set([
 	'accent-color',
 	'background-color',
@@ -635,6 +638,7 @@ export const singleValueColorProperties = new Set([
 	'stop-color',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const longhandTimeProperties = new Set([
 	'transition-duration',
 	'transition-delay',
@@ -642,8 +646,10 @@ export const longhandTimeProperties = new Set([
 	'animation-delay',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const shorthandTimeProperties = new Set(['transition', 'animation']);
 
+/** @type {ReadonlySet<string>} */
 export const pageContextProperties = new Set([
 	'direction',
 	'background-color',
@@ -713,6 +719,7 @@ export const pageContextProperties = new Set([
 	'max-width',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const marginContextProperties = new Set([
 	'direction',
 	'unicode-bidi',

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -5,6 +5,7 @@
 const htmlTags = require('html-tags');
 const uniteSets = require('../utils/uniteSets.cjs');
 
+/** @type {ReadonlySet<string>} */
 const deprecatedHtmlTypeSelectors = new Set([
 	'acronym',
 	'applet',
@@ -39,9 +40,10 @@ const deprecatedHtmlTypeSelectors = new Set([
 ]);
 
 // typecasting htmlTags to be more generic; see https://github.com/stylelint/stylelint/pull/6013 for discussion
-/** @type {Set<string>} */
+/** @type {ReadonlySet<string>} */
 const standardHtmlTypeSelectors = new Set(htmlTags);
 
+/** @type {ReadonlySet<string>} */
 const experimentalHtmlTypeSelectors = new Set([
 	'fencedframe',
 	'listbox',
@@ -50,12 +52,14 @@ const experimentalHtmlTypeSelectors = new Set([
 	'selectlist',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const htmlTypeSelectors = uniteSets(
 	deprecatedHtmlTypeSelectors,
 	standardHtmlTypeSelectors,
 	experimentalHtmlTypeSelectors,
 );
 
+/** @type {ReadonlySet<string>} */
 const deprecatedSvgTypeSelectors = new Set([
 	'altGlyph',
 	'altGlyphDef',
@@ -76,6 +80,7 @@ const deprecatedSvgTypeSelectors = new Set([
 	'vkern',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const mixedCaseSvgTypeSelectors = new Set([
 	'altGlyph',
 	'altGlyphDef',
@@ -117,7 +122,11 @@ const mixedCaseSvgTypeSelectors = new Set([
 	'textPath',
 ]);
 
-// These are the ones that can have single-colon notation
+/**
+ * These are the ones that can have single-colon notation
+ *
+ * @type {ReadonlySet<string>}
+ */
 const levelOneAndTwoPseudoElements = new Set([
 	'before',
 	'after',
@@ -125,8 +134,10 @@ const levelOneAndTwoPseudoElements = new Set([
 	'first-letter',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const shadowTreePseudoElements = new Set(['part']);
 
+/** @type {ReadonlySet<string>} */
 const webkitScrollbarPseudoElements = new Set([
 	'-webkit-resizer',
 	'-webkit-scrollbar',
@@ -137,6 +148,7 @@ const webkitScrollbarPseudoElements = new Set([
 	'-webkit-scrollbar-track-piece',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const vendorSpecificPseudoElements = uniteSets(webkitScrollbarPseudoElements, [
 	'-moz-focus-inner',
 	'-moz-focus-outer',
@@ -206,8 +218,10 @@ const vendorSpecificPseudoElements = uniteSets(webkitScrollbarPseudoElements, [
 	'-webkit-validation-bubble-text-block',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const deprecatedPseudoElements = new Set(['shadow']);
 
+/** @type {ReadonlySet<string>} */
 const pseudoElements = uniteSets(
 	levelOneAndTwoPseudoElements,
 	vendorSpecificPseudoElements,
@@ -237,6 +251,7 @@ const pseudoElements = uniteSets(
 	],
 );
 
+/** @type {ReadonlySet<string>} */
 const aNPlusBNotationPseudoClasses = new Set([
 	'nth-column',
 	'nth-last-column',
@@ -244,8 +259,10 @@ const aNPlusBNotationPseudoClasses = new Set([
 	'nth-of-type',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const aNPlusBOfSNotationPseudoClasses = new Set(['nth-child', 'nth-last-child']);
 
+/** @type {ReadonlySet<string>} */
 const atRulePagePseudoClasses = new Set([
 	'first',
 	'right',
@@ -256,10 +273,13 @@ const atRulePagePseudoClasses = new Set([
 	'nth',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const linguisticPseudoClasses = new Set(['dir', 'lang']);
 
+/** @type {ReadonlySet<string>} */
 const logicalCombinationsPseudoClasses = new Set(['has', 'is', 'matches', 'not', 'where']);
 
+/** @type {ReadonlySet<string>} */
 const deprecatedPseudoClasses = new Set([
 	'contains',
 	'drop',
@@ -271,6 +291,7 @@ const deprecatedPseudoClasses = new Set([
 	'user-error',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const vendorSpecificPseudoClasses = new Set([
 	'-khtml-drag',
 	'-moz-any',
@@ -311,7 +332,10 @@ const vendorSpecificPseudoClasses = new Set([
 	'-webkit-full-screen-ancestor',
 ]);
 
-// https://webkit.org/blog/363/styling-scrollbars/
+/**
+ * @see https://webkit.org/blog/363/styling-scrollbars/
+ * @type {ReadonlySet<string>}
+ */
 const webkitScrollbarPseudoClasses = new Set([
 	'horizontal',
 	'vertical',
@@ -326,7 +350,10 @@ const webkitScrollbarPseudoClasses = new Set([
 	'window-inactive',
 ]);
 
-// https://www.w3.org/TR/selectors-4/#resource-pseudos
+/**
+ * @see https://www.w3.org/TR/selectors-4/#resource-pseudos
+ * @type {ReadonlySet<string>}
+ */
 const resourceStatePseudoClasses = new Set([
 	'buffering',
 	'muted',
@@ -337,6 +364,7 @@ const resourceStatePseudoClasses = new Set([
 	'volume-locked',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const pseudoClasses = uniteSets(
 	aNPlusBNotationPseudoClasses,
 	linguisticPseudoClasses,

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -2,6 +2,7 @@ import htmlTags from 'html-tags';
 
 import uniteSets from '../utils/uniteSets.mjs';
 
+/** @type {ReadonlySet<string>} */
 const deprecatedHtmlTypeSelectors = new Set([
 	'acronym',
 	'applet',
@@ -36,9 +37,10 @@ const deprecatedHtmlTypeSelectors = new Set([
 ]);
 
 // typecasting htmlTags to be more generic; see https://github.com/stylelint/stylelint/pull/6013 for discussion
-/** @type {Set<string>} */
+/** @type {ReadonlySet<string>} */
 const standardHtmlTypeSelectors = new Set(htmlTags);
 
+/** @type {ReadonlySet<string>} */
 const experimentalHtmlTypeSelectors = new Set([
 	'fencedframe',
 	'listbox',
@@ -47,12 +49,14 @@ const experimentalHtmlTypeSelectors = new Set([
 	'selectlist',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const htmlTypeSelectors = uniteSets(
 	deprecatedHtmlTypeSelectors,
 	standardHtmlTypeSelectors,
 	experimentalHtmlTypeSelectors,
 );
 
+/** @type {ReadonlySet<string>} */
 export const deprecatedSvgTypeSelectors = new Set([
 	'altGlyph',
 	'altGlyphDef',
@@ -73,6 +77,7 @@ export const deprecatedSvgTypeSelectors = new Set([
 	'vkern',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const mixedCaseSvgTypeSelectors = new Set([
 	'altGlyph',
 	'altGlyphDef',
@@ -114,7 +119,11 @@ export const mixedCaseSvgTypeSelectors = new Set([
 	'textPath',
 ]);
 
-// These are the ones that can have single-colon notation
+/**
+ * These are the ones that can have single-colon notation
+ *
+ * @type {ReadonlySet<string>}
+ */
 export const levelOneAndTwoPseudoElements = new Set([
 	'before',
 	'after',
@@ -122,8 +131,10 @@ export const levelOneAndTwoPseudoElements = new Set([
 	'first-letter',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const shadowTreePseudoElements = new Set(['part']);
 
+/** @type {ReadonlySet<string>} */
 export const webkitScrollbarPseudoElements = new Set([
 	'-webkit-resizer',
 	'-webkit-scrollbar',
@@ -134,6 +145,7 @@ export const webkitScrollbarPseudoElements = new Set([
 	'-webkit-scrollbar-track-piece',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const vendorSpecificPseudoElements = uniteSets(webkitScrollbarPseudoElements, [
 	'-moz-focus-inner',
 	'-moz-focus-outer',
@@ -203,8 +215,10 @@ const vendorSpecificPseudoElements = uniteSets(webkitScrollbarPseudoElements, [
 	'-webkit-validation-bubble-text-block',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const deprecatedPseudoElements = new Set(['shadow']);
 
+/** @type {ReadonlySet<string>} */
 export const pseudoElements = uniteSets(
 	levelOneAndTwoPseudoElements,
 	vendorSpecificPseudoElements,
@@ -234,6 +248,7 @@ export const pseudoElements = uniteSets(
 	],
 );
 
+/** @type {ReadonlySet<string>} */
 export const aNPlusBNotationPseudoClasses = new Set([
 	'nth-column',
 	'nth-last-column',
@@ -241,8 +256,10 @@ export const aNPlusBNotationPseudoClasses = new Set([
 	'nth-of-type',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const aNPlusBOfSNotationPseudoClasses = new Set(['nth-child', 'nth-last-child']);
 
+/** @type {ReadonlySet<string>} */
 export const atRulePagePseudoClasses = new Set([
 	'first',
 	'right',
@@ -253,10 +270,13 @@ export const atRulePagePseudoClasses = new Set([
 	'nth',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const linguisticPseudoClasses = new Set(['dir', 'lang']);
 
+/** @type {ReadonlySet<string>} */
 export const logicalCombinationsPseudoClasses = new Set(['has', 'is', 'matches', 'not', 'where']);
 
+/** @type {ReadonlySet<string>} */
 export const deprecatedPseudoClasses = new Set([
 	'contains',
 	'drop',
@@ -268,6 +288,7 @@ export const deprecatedPseudoClasses = new Set([
 	'user-error',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const vendorSpecificPseudoClasses = new Set([
 	'-khtml-drag',
 	'-moz-any',
@@ -308,7 +329,10 @@ const vendorSpecificPseudoClasses = new Set([
 	'-webkit-full-screen-ancestor',
 ]);
 
-// https://webkit.org/blog/363/styling-scrollbars/
+/**
+ * @see https://webkit.org/blog/363/styling-scrollbars/
+ * @type {ReadonlySet<string>}
+ */
 export const webkitScrollbarPseudoClasses = new Set([
 	'horizontal',
 	'vertical',
@@ -323,7 +347,10 @@ export const webkitScrollbarPseudoClasses = new Set([
 	'window-inactive',
 ]);
 
-// https://www.w3.org/TR/selectors-4/#resource-pseudos
+/**
+ * @see https://www.w3.org/TR/selectors-4/#resource-pseudos
+ * @type {ReadonlySet<string>}
+ */
 const resourceStatePseudoClasses = new Set([
 	'buffering',
 	'muted',
@@ -334,6 +361,7 @@ const resourceStatePseudoClasses = new Set([
 	'volume-locked',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const pseudoClasses = uniteSets(
 	aNPlusBNotationPseudoClasses,
 	linguisticPseudoClasses,

--- a/lib/reference/units.cjs
+++ b/lib/reference/units.cjs
@@ -4,6 +4,7 @@
 
 const uniteSets = require('../utils/uniteSets.cjs');
 
+/** @type {ReadonlySet<string>} */
 const lengthUnits = new Set([
 	// Font-relative length units
 	'cap',
@@ -64,8 +65,10 @@ const lengthUnits = new Set([
 	'cqmax',
 ]);
 
+/** @type {ReadonlySet<string>} */
 const resolutionUnits = new Set(['dpi', 'dpcm', 'dppx', 'x']);
 
+/** @type {ReadonlySet<string>} */
 const units = uniteSets(lengthUnits, resolutionUnits, [
 	// Relative length units
 	'%',

--- a/lib/reference/units.mjs
+++ b/lib/reference/units.mjs
@@ -1,5 +1,6 @@
 import uniteSets from '../utils/uniteSets.mjs';
 
+/** @type {ReadonlySet<string>} */
 export const lengthUnits = new Set([
 	// Font-relative length units
 	'cap',
@@ -60,8 +61,10 @@ export const lengthUnits = new Set([
 	'cqmax',
 ]);
 
+/** @type {ReadonlySet<string>} */
 export const resolutionUnits = new Set(['dpi', 'dpcm', 'dppx', 'x']);
 
+/** @type {ReadonlySet<string>} */
 export const units = uniteSets(lengthUnits, resolutionUnits, [
 	// Relative length units
 	'%',

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.cjs
@@ -54,7 +54,7 @@ const DEPRECATED_COLORS = {
 	inactivecaptiontext: 'GrayText',
 };
 
-/** @type {Array<[singleValueColorProperties[keyof singleValueColorProperties], Record<string, string>]>} */
+/** @type {ReadonlyArray<[string, Record<string, string>]>} */
 const COLOR_PROPERTIES = [...properties.singleValueColorProperties.values()].map((value) => [
 	value,
 	DEPRECATED_COLORS,

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/index.mjs
@@ -51,7 +51,7 @@ const DEPRECATED_COLORS = {
 	inactivecaptiontext: 'GrayText',
 };
 
-/** @type {Array<[singleValueColorProperties[keyof singleValueColorProperties], Record<string, string>]>} */
+/** @type {ReadonlyArray<[string, Record<string, string>]>} */
 const COLOR_PROPERTIES = [...singleValueColorProperties.values()].map((value) => [
 	value,
 	DEPRECATED_COLORS,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

TypeScript's `Readonly*` types can prevent a mistake like this:

```js
lib/reference/units.mjs:67:17 - error TS2339: Property 'add' does not exist on type 'ReadonlySet<string>'.

67 resolutionUnits.add('foo');
                   ~~~
```
