### PR TITLE
Pin third party actions on CI

### DIFF
--- a/.github/workflows/preparing-github-release.yml
+++ b/.github/workflows/preparing-github-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Prepare release
-        uses: stylelint/changelog-to-github-release-action@main
+        uses: stylelint/changelog-to-github-release-action@944dfc1b76b778a9d57df65c88e5be7558e05d90 # 0.3.0
         with:
           tag: ${{ github.ref_name }}
           draft: true

--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -46,7 +46,7 @@ jobs:
           echo "new-version=${new_version}" >> "$GITHUB_OUTPUT"
 
       - name: Create release pull request
-        uses: changesets/action@v1
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           commit: Prepare ${{ steps.get-changeset-status.outputs.new-version }}
           title: Prepare ${{ steps.get-changeset-status.outputs.new-version }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,7 +51,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           files: ./.coverage/lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

This fixes the code scanning alerts:
- https://github.com/stylelint/stylelint/security/code-scanning/79
- https://github.com/stylelint/stylelint/security/code-scanning/80
- https://github.com/stylelint/stylelint/security/code-scanning/81

> Is there anything in the PR that needs further explanation?

Note that this PR doesn't update all actions; only for third-party actions, e.g. not `actions/*`.

This pinning technique generally mitigates risks for supply chain attacks, and GitHub officially suggests:
https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
