### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` false negatives for ...

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.cjs
@@ -301,8 +301,12 @@ const rule = (primary, secondaryOptions) => {
 					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 
-					// TODO use toSorted in the next major that supports it
-					if (!arrayEqual(copiedPrefixedShorthandData.sort(), longhandDeclaration.sort())) {
+					if (
+						!arrayEqual(
+							copiedPrefixedShorthandData.sort((a, b) => a.localeCompare(b)),
+							longhandDeclaration.sort((a, b) => a.localeCompare(b)),
+						)
+					) {
 						continue;
 					}
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -298,8 +298,12 @@ const rule = (primary, secondaryOptions) => {
 					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
 					const copiedPrefixedShorthandData = [...prefixedShorthandData];
 
-					// TODO use toSorted in the next major that supports it
-					if (!arrayEqual(copiedPrefixedShorthandData.sort(), longhandDeclaration.sort())) {
+					if (
+						!arrayEqual(
+							copiedPrefixedShorthandData.sort((a, b) => a.localeCompare(b)),
+							longhandDeclaration.sort((a, b) => a.localeCompare(b)),
+						)
+					) {
 						continue;
 					}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8379

> Is there anything in the PR that needs further explanation?

This PR updates the sorting logic in the declaration-block-no-redundant-longhand-properties rule. Instead of using the default sort, it now uses localeCompare for both arrays, ensuring consistent order. This resolves the false negatives caused by unsorted comparisons. All tests pass.