### PR TITLE
Fix `no-empty-source` false positives for `--report-needless-disables`

### DIFF
--- a/.changeset/curvy-parrots-doubt.md
+++ b/.changeset/curvy-parrots-doubt.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `no-empty-source` false positives for `--report-needless-disables`

--- a/lib/rules/no-empty-source/__tests__/index.mjs
+++ b/lib/rules/no-empty-source/__tests__/index.mjs
@@ -21,6 +21,12 @@ testRule({
 		{
 			code: '\r\n.class {}',
 		},
+		{
+			code: '/* stylelint-disable */',
+		},
+		{
+			code: '/* stylelint-disable no-empty-source */',
+		},
 	],
 
 	reject: [
@@ -104,6 +110,15 @@ testRule({
 			column: 1,
 			endLine: 2,
 			endColumn: 4,
+		},
+		{
+			code: '/* stylelint-disable foo */',
+			description: 'unrelated configuration comment',
+			message: messages.rejected,
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 29,
 		},
 	],
 });

--- a/lib/rules/no-empty-source/index.cjs
+++ b/lib/rules/no-empty-source/index.cjs
@@ -2,6 +2,8 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
+const typeGuards = require('../../utils/typeGuards.cjs');
+const configurationComment = require('../../utils/configurationComment.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -29,7 +31,16 @@ const rule = (primary, _secondaryOptions, context) => {
 		// i.e. root.source.input.css remains unchanged after a fix
 		const rootString = context.fix ? root.toString() : (root.source && root.source.input.css) || '';
 
-		if (rootString.trim()) {
+		const hasNotableChild =
+			Boolean(rootString.trim()) &&
+			root.nodes.some((child) => {
+				if (typeGuards.isComment(child) && configurationComment.isConfigurationComment(child.text, context.configurationComment))
+					return false;
+
+				return true;
+			});
+
+		if (hasNotableChild) {
 			return;
 		}
 

--- a/lib/rules/no-empty-source/index.mjs
+++ b/lib/rules/no-empty-source/index.mjs
@@ -1,3 +1,5 @@
+import { isComment } from '../../utils/typeGuards.mjs';
+import { isConfigurationComment } from '../../utils/configurationComment.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -25,7 +27,16 @@ const rule = (primary, _secondaryOptions, context) => {
 		// i.e. root.source.input.css remains unchanged after a fix
 		const rootString = context.fix ? root.toString() : (root.source && root.source.input.css) || '';
 
-		if (rootString.trim()) {
+		const hasNotableChild =
+			Boolean(rootString.trim()) &&
+			root.nodes.some((child) => {
+				if (isComment(child) && isConfigurationComment(child.text, context.configurationComment))
+					return false;
+
+				return true;
+			});
+
+		if (hasNotableChild) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8441

> Is there anything in the PR that needs further explanation?

I found this one a bit counter intuitive :)

We resolve the reported issue by reporting more errors, not less.
By reporting an error when the source only contains configuration comments we ensure that there is an error and that `--report-needless-disables` won't report any needless disables.

When the configuration comment matches `no-empty-source` the final result will be that no errors are emitted, neither for empty files nor for needless disables.