### PR TITLE
Fix `no-empty-source` false positives for non-standard syntaxes

### DIFF
--- a/.changeset/smart-groups-lie.md
+++ b/.changeset/smart-groups-lie.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `no-empty-source` false positives for non-standard syntaxes

--- a/lib/__tests__/fixtures/postcss-naive-css-in-js.cjs
+++ b/lib/__tests__/fixtures/postcss-naive-css-in-js.cjs
@@ -1,4 +1,5 @@
 const postcss = require('postcss');
+const safeParse = require('postcss-safe-parser');
 
 /**
  * @type {postcss.Parser<postcss.Document>}
@@ -14,7 +15,19 @@ function parse(css) {
 
 	// E.g. "css` color: red; `;"
 	for (const match of source.matchAll(/\bcss`([^`]+)`;/g)) {
-		document.append(postcss.parse(match[1]));
+		let parsedNode;
+
+		try {
+			parsedNode = postcss.parse(match[1]);
+		} catch (error) {
+			if (error.name === 'CssSyntaxError') {
+				parsedNode = safeParse(match[1]);
+			} else {
+				throw error;
+			}
+		}
+
+		document.append(parsedNode);
 	}
 
 	return document;

--- a/lib/rules/no-empty-source/__tests__/index.mjs
+++ b/lib/rules/no-empty-source/__tests__/index.mjs
@@ -1,3 +1,5 @@
+import naiveCssInJs from '../../../__tests__/fixtures/postcss-naive-css-in-js.cjs';
+
 import rule from '../index.mjs';
 const { messages, ruleName } = rule;
 
@@ -144,6 +146,19 @@ testRule({
 			column: 1,
 			endLine: 2,
 			endColumn: 2,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: [true],
+	customSyntax: naiveCssInJs,
+
+	accept: [
+		{
+			code: 'css` $var `;',
+			description: 'contains only non-standard syntax',
 		},
 	],
 });

--- a/lib/rules/no-empty-source/index.cjs
+++ b/lib/rules/no-empty-source/index.cjs
@@ -31,14 +31,22 @@ const rule = (primary, _secondaryOptions, context) => {
 		// i.e. root.source.input.css remains unchanged after a fix
 		const rootString = context.fix ? root.toString() : (root.source && root.source.input.css) || '';
 
-		const hasNotableChild =
+		let hasNotableChild =
 			Boolean(rootString.trim()) &&
 			root.nodes.some((child) => {
-				if (typeGuards.isComment(child) && configurationComment.isConfigurationComment(child.text, context.configurationComment))
+				if (typeGuards.isComment(child) && configurationComment.isConfigurationComment(child.text, context.configurationComment)) {
 					return false;
+				}
 
 				return true;
 			});
+
+		if (!hasNotableChild) {
+			// Assume a case when a non-standard syntax is used, such as JSX. See #8547.
+			if (root.nodes.length === 0 && Boolean(root.raws.after?.trim())) {
+				hasNotableChild = true;
+			}
+		}
 
 		if (hasNotableChild) {
 			return;

--- a/lib/rules/no-empty-source/index.mjs
+++ b/lib/rules/no-empty-source/index.mjs
@@ -27,14 +27,22 @@ const rule = (primary, _secondaryOptions, context) => {
 		// i.e. root.source.input.css remains unchanged after a fix
 		const rootString = context.fix ? root.toString() : (root.source && root.source.input.css) || '';
 
-		const hasNotableChild =
+		let hasNotableChild =
 			Boolean(rootString.trim()) &&
 			root.nodes.some((child) => {
-				if (isComment(child) && isConfigurationComment(child.text, context.configurationComment))
+				if (isComment(child) && isConfigurationComment(child.text, context.configurationComment)) {
 					return false;
+				}
 
 				return true;
 			});
+
+		if (!hasNotableChild) {
+			// Assume a case when a non-standard syntax is used, such as JSX. See #8547.
+			if (root.nodes.length === 0 && Boolean(root.raws.after?.trim())) {
+				hasNotableChild = true;
+			}
+		}
 
 		if (hasNotableChild) {
 			return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8547

> Is there anything in the PR that needs further explanation?

This fixes false positives for the `no-empty-source` rule in a non-standard syntax.

For example, [`postcss-styled-syntax`](https://github.com/hudochenkov/postcss-styled-syntax) produces the following AST.
Like this case, even if `root.nodes` is empty, we should consider that `root` contains a notable child.

```js
styled.a` ${VAR} `;
/*=>
Root {
  raws: {
    styledSyntaxRangeStart: 9,
    styledSyntaxRangeEnd: 17,
    isRuleLike: true,
    styledSyntaxIsComponent: true,
    after: ' ${VAR} ',
    codeBefore: 'styled.a`',
    codeAfter: '`;\n'
  },
  type: 'root',
  nodes: [],
}
*/
```

