### PR TITLE
Refactor to allow node for `isConfigurationComment()` private utility

### DIFF
--- a/lib/rules/block-no-empty/index.cjs
+++ b/lib/rules/block-no-empty/index.cjs
@@ -94,7 +94,7 @@ const rule = (primary, secondaryOptions, context) => {
 				if (typeGuards.isComment(child)) {
 					if (ignoreComments) return false;
 
-					if (configurationComment.isConfigurationComment(child.text, context.configurationComment)) return false;
+					if (configurationComment.isConfigurationComment(child, context.configurationComment)) return false;
 				}
 
 				return true;

--- a/lib/rules/block-no-empty/index.mjs
+++ b/lib/rules/block-no-empty/index.mjs
@@ -90,7 +90,7 @@ const rule = (primary, secondaryOptions, context) => {
 				if (isComment(child)) {
 					if (ignoreComments) return false;
 
-					if (isConfigurationComment(child.text, context.configurationComment)) return false;
+					if (isConfigurationComment(child, context.configurationComment)) return false;
 				}
 
 				return true;

--- a/lib/rules/comment-empty-line-before/index.cjs
+++ b/lib/rules/comment-empty-line-before/index.cjs
@@ -61,7 +61,7 @@ const rule = (primary, secondaryOptions, context) => {
 
 			// Optionally ignore stylelint commands
 			if (
-				configurationComment.isConfigurationComment(comment.text, context.configurationComment) &&
+				configurationComment.isConfigurationComment(comment, context.configurationComment) &&
 				optionsMatches(secondaryOptions, 'ignore', 'stylelint-commands')
 			) {
 				return;

--- a/lib/rules/comment-empty-line-before/index.mjs
+++ b/lib/rules/comment-empty-line-before/index.mjs
@@ -57,7 +57,7 @@ const rule = (primary, secondaryOptions, context) => {
 
 			// Optionally ignore stylelint commands
 			if (
-				isConfigurationComment(comment.text, context.configurationComment) &&
+				isConfigurationComment(comment, context.configurationComment) &&
 				optionsMatches(secondaryOptions, 'ignore', 'stylelint-commands')
 			) {
 				return;

--- a/lib/rules/no-empty-source/index.cjs
+++ b/lib/rules/no-empty-source/index.cjs
@@ -2,7 +2,6 @@
 // please instead edit the ESM counterpart and rebuild with Rollup (npm run build).
 'use strict';
 
-const typeGuards = require('../../utils/typeGuards.cjs');
 const configurationComment = require('../../utils/configurationComment.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
@@ -34,8 +33,7 @@ const rule = (primary, _secondaryOptions, context) => {
 		const hasNotableChild =
 			Boolean(rootString.trim()) &&
 			root.nodes.some((child) => {
-				if (typeGuards.isComment(child) && configurationComment.isConfigurationComment(child.text, context.configurationComment))
-					return false;
+				if (configurationComment.isConfigurationComment(child, context.configurationComment)) return false;
 
 				return true;
 			});

--- a/lib/rules/no-empty-source/index.mjs
+++ b/lib/rules/no-empty-source/index.mjs
@@ -1,4 +1,3 @@
-import { isComment } from '../../utils/typeGuards.mjs';
 import { isConfigurationComment } from '../../utils/configurationComment.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -30,8 +29,7 @@ const rule = (primary, _secondaryOptions, context) => {
 		const hasNotableChild =
 			Boolean(rootString.trim()) &&
 			root.nodes.some((child) => {
-				if (isComment(child) && isConfigurationComment(child.text, context.configurationComment))
-					return false;
+				if (isConfigurationComment(child, context.configurationComment)) return false;
 
 				return true;
 			});

--- a/lib/utils/__tests__/configurationComment.test.mjs
+++ b/lib/utils/__tests__/configurationComment.test.mjs
@@ -1,3 +1,5 @@
+import postcss from 'postcss';
+
 import { extractConfigurationComment, isConfigurationComment } from '../configurationComment.mjs';
 
 test('extractConfigurationComment', () => {
@@ -31,4 +33,15 @@ test('isConfigurationComment', () => {
 
 	expect(isConfigurationComment('stylelint-disable', 'stylelint-2')).toBe(false);
 	expect(isConfigurationComment('stylelint-2-disable', 'stylelint-2')).toBe(true);
+});
+
+test('isConfigurationComment for Comment node', () => {
+	const commentNode = (text) => postcss.comment({ text });
+
+	expect(isConfigurationComment(commentNode('stylelint-disable'))).toBe(true);
+	expect(isConfigurationComment(commentNode('foo'))).toBe(false);
+	expect(isConfigurationComment(commentNode('stylelint-2-disable'), 'stylelint-2')).toBe(true);
+
+	// Non-comment node
+	expect(isConfigurationComment(postcss.atRule())).toBe(false);
 });

--- a/lib/utils/configurationComment.cjs
+++ b/lib/utils/configurationComment.cjs
@@ -3,6 +3,7 @@
 'use strict';
 
 const validateTypes = require('./validateTypes.cjs');
+const typeGuards = require('./typeGuards.cjs');
 
 const DISABLE_COMMAND = '-disable';
 const DISABLE_LINE_COMMAND = '-disable-line';
@@ -18,8 +19,6 @@ const ALL_COMMANDS = new Set([
 
 const DEFAULT_CONFIGURATION_COMMENT = 'stylelint';
 
-/** @typedef {import('postcss').Comment} Comment */
-
 /**
  * Extract a command from a given comment.
  *
@@ -31,6 +30,8 @@ function extractConfigurationComment(
 	commentText,
 	configurationComment = DEFAULT_CONFIGURATION_COMMENT,
 ) {
+	if (!commentText) return commentText;
+
 	const [command] = commentText.split(/\s/, 1);
 
 	validateTypes.assertString(command);
@@ -41,14 +42,22 @@ function extractConfigurationComment(
 /**
  * Tests if the given comment is a Stylelint command.
  *
- * @param {string} commentText
+ * @param {string | import('postcss').Node} textOrNode
  * @param {string} [configurationComment]
  * @returns {boolean}
  */
 function isConfigurationComment(
-	commentText,
+	textOrNode,
 	configurationComment = DEFAULT_CONFIGURATION_COMMENT,
 ) {
+	const commentText = validateTypes.isString(textOrNode)
+		? textOrNode
+		: typeGuards.isComment(textOrNode)
+			? textOrNode.text
+			: undefined;
+
+	if (!commentText) return false;
+
 	const command = extractConfigurationComment(commentText, configurationComment);
 
 	return command !== undefined && ALL_COMMANDS.has(command);

--- a/lib/utils/configurationComment.mjs
+++ b/lib/utils/configurationComment.mjs
@@ -1,4 +1,5 @@
-import { assertString } from './validateTypes.mjs';
+import { assertString, isString } from './validateTypes.mjs';
+import { isComment } from './typeGuards.mjs';
 
 export const DISABLE_COMMAND = '-disable';
 export const DISABLE_LINE_COMMAND = '-disable-line';
@@ -14,8 +15,6 @@ const ALL_COMMANDS = new Set([
 
 export const DEFAULT_CONFIGURATION_COMMENT = 'stylelint';
 
-/** @typedef {import('postcss').Comment} Comment */
-
 /**
  * Extract a command from a given comment.
  *
@@ -27,6 +26,8 @@ export function extractConfigurationComment(
 	commentText,
 	configurationComment = DEFAULT_CONFIGURATION_COMMENT,
 ) {
+	if (!commentText) return commentText;
+
 	const [command] = commentText.split(/\s/, 1);
 
 	assertString(command);
@@ -37,14 +38,22 @@ export function extractConfigurationComment(
 /**
  * Tests if the given comment is a Stylelint command.
  *
- * @param {string} commentText
+ * @param {string | import('postcss').Node} textOrNode
  * @param {string} [configurationComment]
  * @returns {boolean}
  */
 export function isConfigurationComment(
-	commentText,
+	textOrNode,
 	configurationComment = DEFAULT_CONFIGURATION_COMMENT,
 ) {
+	const commentText = isString(textOrNode)
+		? textOrNode
+		: isComment(textOrNode)
+			? textOrNode.text
+			: undefined;
+
+	if (!commentText) return false;
+
 	const command = extractConfigurationComment(commentText, configurationComment);
 
 	return command !== undefined && ALL_COMMANDS.has(command);


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This allows a PostCSS node as an argument for the `isConfigurationComment()` private utility.
It can simplify the caller code because of no need for type guards, such as `isComment()`.

```js
// Before
isComment(node) && isConfigurationComment(node.text);

// After
isConfigurationComment(node);
```
