### PR TITLE
Document `declaration-property-unit-allowed-list` full configs

### DIFF
--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "units"] }
 ```
 
-You can also specify a single unit instead of arrays of them.
+You can also specify a single unit instead of an array of them.
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -13,7 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "units"]|"unit" }`
+```json
+{ "unprefixed-property-name": ["array", "of", "units"] }
+```
+
+You can also specify a single unit instead of arrays of them.
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
@@ -21,9 +25,11 @@ Given:
 
 ```json
 {
-  "font-size": ["em", "px"],
-  "/^animation/": "s",
-  "line-height": []
+  "declaration-property-unit-allowed-list": {
+    "font-size": ["em", "px"],
+    "/^animation/": "s",
+    "line-height": []
+  }
 }
 ```
 
@@ -95,15 +101,17 @@ Ignore units that are inside a function.
 For example, given:
 
 ```json
-[
-  {
-    "/^border/": ["px"],
-    "/^background/": ["%"]
-  },
-  {
-    "ignore": ["inside-function"]
-  }
-]
+{
+  "declaration-property-unit-allowed-list": [
+    {
+      "/^border/": ["px"],
+      "/^background/": ["%"]
+    },
+    {
+      "ignore": ["inside-function"]
+    }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Part of #4808 and #3372

> Is there anything in the PR that needs further explanation?

In addition to #4808, this PR aims to help the discussion in #3372. My points are:

- A typical valid JSON defining a schema is enough, e.g., not using an invalid syntax like `|` for union types.
- If necessary, supplement a schema with additional descriptions.
- Good examples are provided to help users understand how to use a rule.
