### PR TITLE
Document all rules' full configs

### DIFF
--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -89,7 +89,7 @@ Some rule options accept regular expressions (regex). If a string option surroun
 
 If allowed, the `"/regex/"` format is also available in object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.
 
-Also, rules ending with `-pattern` translates the given string without `"/"` into a regex, for example, `"^foo"` into `new RegExp("^foo")`. In this case, a regex literal in JavaScript is also available, such as `/^foo/`.
+Also, `*-pattern` rules translate the given string without `"/"` into a regex, like `"^foo"` into `new RegExp("^foo")`. In this case, you can directly specify a regex literal in JavaScript, such as `/^foo/`.
 
 You can enforce these common cases:
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -83,7 +83,7 @@ You can add any number of keys to the object. For example, you can:
 }
 ```
 
-You can also specify a single value in places where an array of multiple values is accepted. For example:
+You can also specify a single value in places where an array of multiple values is accepted. In this example, both values for `unit-allowed-list` are interpreted as equal:
 
 ```json
 {

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -83,8 +83,6 @@ You can add any number of keys to the object. For example, you can:
 }
 ```
 
-### `"/regex/"` format
-
 Some rules accept regular expressions (regex) with the `"/regex/"` format. If a string option surrounded with `"/"` is specified where allowed, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
 
 If allowed, the `"/regex/"` format is also available in object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -83,9 +83,9 @@ You can add any number of keys to the object. For example, you can:
 }
 ```
 
-### Handling regex
+### `"/regex/"` format
 
-Some rule options accept regular expressions (regex). If a string option surrounded with `"/"` is specified where allowed, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
+Some rules accept regular expressions (regex) with the `"/regex/"` format. If a string option surrounded with `"/"` is specified where allowed, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
 
 If allowed, the `"/regex/"` format is also available in object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -85,9 +85,9 @@ You can add any number of keys to the object. For example, you can:
 
 ### Handling regex
 
-Some rules and options accept a regular expression (regex). If a string is surrounded with `"/"`, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
+Some rule options accept regular expressions (regex). If a string option surrounded with `"/"` is specified where allowed, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
 
-The `"/regex/"` format is available in object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.
+If allowed, the `"/regex/"` format is also available in object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.
 
 Also, rules ending with `-pattern` translates the given string without `"/"` into a regex, for example, `"^foo"` into `new RegExp("^foo")`. In this case, a regex literal in JavaScript is also available, such as `/^foo/`.
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -94,7 +94,11 @@ You can also specify a single value in places where an array of multiple values 
 }
 ```
 
+### Handling regex
+
 Some rules and options accept a regular expression (regex). If a string is surrounded with `"/"`, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
+
+Also, rules ending with `-pattern` translates the given string without `"/"` into a regex, for example, `"^foo"` into `new RegExp("^foo")`. In this case, a regex literal in JavaScript is also available, such as `/^foo/`.
 
 You can enforce these common cases:
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -94,7 +94,7 @@ You can also specify a single value in places where an array of multiple values 
 }
 ```
 
-Some rules and options accept a regular expression (regex). If a string is surrounded with `"/"`, it's interpreted as a regex. For example, For example, `"/.+/"` matches any strings. Instead of a string surrounded with `"/"`, you can also specify a regex literal in JavaScript, such as `{ ignore: /^foo/ }`.
+Some rules and options accept a regular expression (regex). If a string is surrounded with `"/"`, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
 
 You can enforce these common cases:
 

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -83,12 +83,25 @@ You can add any number of keys to the object. For example, you can:
 }
 ```
 
-Some rules and options accept regex. You can enforce these common cases:
+You can also specify a single value in places where an array of multiple values is accepted. For example:
+
+```json
+{
+  "rules": {
+    "unit-allowed-list": "em",
+    "unit-allowed-list": ["em"]
+  }
+}
+```
+
+Some rules and options accept a regular expression (regex). If a string is surrounded with `"/"`, it's interpreted as a regex. For example, For example, `"/.+/"` matches any strings. Instead of a string surrounded with `"/"`, you can also specify a regex literal in JavaScript, such as `{ ignore: /^foo/ }`.
+
+You can enforce these common cases:
 
 <!-- prettier-ignore -->
 - kebab-case: `^([a-z][a-z0-9]*)(-[a-z0-9]+)*$`
 - lowerCamelCase: `^[a-z][a-zA-Z0-9]+$`
-- snake\_case: `^([a-z][a-z0-9]*)(_[a-z0-9]+)*$`
+- snake_case: `^([a-z][a-z0-9]*)(_[a-z0-9]+)*$`
 - UpperCamelCase: `^[A-Z][a-zA-Z0-9]+$`
 
 Or enforce a prefix using a positive lookbehind regex. For example, `(?<=foo-)` to prefix with `foo-`.

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -83,17 +83,6 @@ You can add any number of keys to the object. For example, you can:
 }
 ```
 
-You can also specify a single value in places where an array of multiple values is accepted. In this example, both values for `unit-allowed-list` are interpreted as equal:
-
-```json
-{
-  "rules": {
-    "unit-allowed-list": "em",
-    "unit-allowed-list": ["em"]
-  }
-}
-```
-
 ### Handling regex
 
 Some rules and options accept a regular expression (regex). If a string is surrounded with `"/"`, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -98,6 +98,8 @@ You can also specify a single value in places where an array of multiple values 
 
 Some rules and options accept a regular expression (regex). If a string is surrounded with `"/"`, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
 
+The `"/regex/"` format is available in object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.
+
 Also, rules ending with `-pattern` translates the given string without `"/"` into a regex, for example, `"^foo"` into `new RegExp("^foo")`. In this case, a regex literal in JavaScript is also available, such as `/^foo/`.
 
 You can enforce these common cases:

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -101,7 +101,7 @@ You can enforce these common cases:
 <!-- prettier-ignore -->
 - kebab-case: `^([a-z][a-z0-9]*)(-[a-z0-9]+)*$`
 - lowerCamelCase: `^[a-z][a-zA-Z0-9]+$`
-- snake_case: `^([a-z][a-z0-9]*)(_[a-z0-9]+)*$`
+- snake\_case: `^([a-z][a-z0-9]*)(_[a-z0-9]+)*$`
 - UpperCamelCase: `^[A-Z][a-zA-Z0-9]+$`
 
 Or enforce a prefix using a positive lookbehind regex. For example, `(?<=foo-)` to prefix with `foo-`.

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -83,11 +83,11 @@ You can add any number of keys to the object. For example, you can:
 }
 ```
 
-Some rules accept regular expressions (regex) with the `"/regex/"` format. If a string option surrounded with `"/"` is specified where allowed, it's interpreted as a regex. For example, `"/.+/"` matches any strings. Instead of a string with `"/"`, you can also specify a regex literal in JavaScript, such as `/.+/`.
+Some rules accept regular expressions (regex) in the `"/regex/"` format. If you surround a string option with `"/"`, it'll be interpreted as a regex. For example, `"/.+/"` matches any string. You can specify a regex literal in JavaScript, such as `/.+/`, rather than a string with `"/"`.
 
-If allowed, the `"/regex/"` format is also available in object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.
+The `"/regex/"` format is also available in some object keys. For example, when `{ "/^margin/": ["px"] }` is given, the key matches `margin`, `margin-top`, `margin-inline`, etc.
 
-Also, `*-pattern` rules translate the given string without `"/"` into a regex, like `"^foo"` into `new RegExp("^foo")`. In this case, you can directly specify a regex literal in JavaScript, such as `/^foo/`.
+The `*-pattern` rules translate the given string without `"/"` into a regex, like `"^foo"` into `new RegExp("^foo")`. In this case, you can directly specify a regex literal in JavaScript, such as `/^foo/`.
 
 You can enforce these common cases:
 

--- a/lib/rules/alpha-value-notation/README.md
+++ b/lib/rules/alpha-value-notation/README.md
@@ -85,7 +85,11 @@ a { color: rgb(0 0 0 / 50%) }
 
 ## Optional secondary options
 
-### `exceptProperties: ["/regex/", /regex/, "string"]`
+### `exceptProperties`
+
+```json
+{ "exceptProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Reverse the primary option for matching properties.
 
@@ -120,3 +124,5 @@ a { opacity: 0.5 }
 ```css
 a { color: rgb(0 0 0 / 50%) }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/alpha-value-notation/README.md
+++ b/lib/rules/alpha-value-notation/README.md
@@ -15,8 +15,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"number"|"percentage"`
-
 ### `"number"`
 
 Alpha-values _must always_ use the number notation.

--- a/lib/rules/alpha-value-notation/README.md
+++ b/lib/rules/alpha-value-notation/README.md
@@ -124,5 +124,3 @@ a { opacity: 0.5 }
 ```css
 a { color: rgb(0 0 0 / 50%) }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/annotation-no-unknown/README.md
+++ b/lib/rules/annotation-no-unknown/README.md
@@ -75,5 +75,3 @@ a {
   color: green !--bar;
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/annotation-no-unknown/README.md
+++ b/lib/rules/annotation-no-unknown/README.md
@@ -43,7 +43,11 @@ a {
 
 ## Optional secondary options
 
-### `ignoreAnnotations: ["/regex/", /regex/, "string"]`
+### `ignoreAnnotations`
+
+```json
+{ "ignoreAnnotations": ["array", "of", "annotations", "/regex/"] }
+```
 
 Given:
 
@@ -71,3 +75,5 @@ a {
   color: green !--bar;
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/annotation-no-unknown/README.md
+++ b/lib/rules/annotation-no-unknown/README.md
@@ -17,6 +17,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "annotation-no-unknown": true
+}
+```
+
 The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
@@ -42,7 +48,12 @@ a {
 Given:
 
 ```json
-["/^--foo-/", "--bar"]
+{
+  "annotation-no-unknown": [
+    true,
+    { "ignoreAnnotations": ["/^--foo-/", "--bar"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -73,3 +73,5 @@ a { @extend placeholder; }
   to { top: 20px; }
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -15,12 +15,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`
+```json
+["array", "of", "unprefixed", "at-rules"]
+```
+
+You can also specify a single at-rule instead of an array of them.
 
 Given:
 
 ```json
-["extend", "keyframes"]
+{
+  "at-rule-allowed-list": ["extend", "keyframes"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -71,5 +71,3 @@ a { @extend placeholder; }
   to { top: 20px; }
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -19,8 +19,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "at-rules"]
 ```
 
-You can also specify a single at-rule instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "at-rules"]
 ```

--- a/lib/rules/at-rule-descriptor-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-no-unknown/README.md
@@ -68,3 +68,5 @@ The following patterns are _not_ considered problems:
   syntax: "<color>";
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-descriptor-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-no-unknown/README.md
@@ -31,6 +31,12 @@ Prior art:
 
 ### `true`
 
+```json
+{
+  "at-rule-descriptor-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/at-rule-descriptor-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-no-unknown/README.md
@@ -68,5 +68,3 @@ The following patterns are _not_ considered problems:
   syntax: "<color>";
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-descriptor-value-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-value-no-unknown/README.md
@@ -78,3 +78,5 @@ The following patterns are _not_ considered problems:
   syntax: "<color>";
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-descriptor-value-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-value-no-unknown/README.md
@@ -78,5 +78,3 @@ The following patterns are _not_ considered problems:
   syntax: "<color>";
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-descriptor-value-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-value-no-unknown/README.md
@@ -41,6 +41,12 @@ Prior art:
 
 ### `true`
 
+```json
+{
+  "at-rule-descriptor-value-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -19,8 +19,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "at-rules"]
 ```
 
-You can also specify a single at-rule instead of an array of them.
-
 Given:
 
 ```json
@@ -58,3 +56,5 @@ The following patterns are _not_ considered problems:
 ```css
 @import "path/to/file.css";
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -56,5 +56,3 @@ The following patterns are _not_ considered problems:
 ```css
 @import "path/to/file.css";
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -15,12 +15,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "unprefixed", "at-rules"]|"at-rule"`
+```json
+["array", "of", "unprefixed", "at-rules"]
+```
+
+You can also specify a single at-rule instead of an array of them.
 
 Given:
 
 ```json
-["extend", "keyframes"]
+{
+  "at-rule-disallowed-list": ["extend", "keyframes"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "at-rules"]
 ```

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -21,11 +21,15 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
 
 There _must always_ be an empty line before at-rules.
+
+```json
+{
+  "at-rule-empty-line-before": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -52,6 +56,12 @@ a {}
 ### `"never"`
 
 There _must never_ be an empty line before at-rules.
+
+```json
+{
+  "at-rule-empty-line-before": "never"
+}
+```
 
 The following patterns are considered problems:
 
@@ -85,7 +95,13 @@ Reverse the primary option for at-rules that follow another at-rule with the sam
 
 This means that you can group your at-rules by name.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": ["always", { "except": ["after-same-name"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -114,7 +130,13 @@ a {
 
 Reverse the primary option for at-rules that are inside a block.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": ["always", { "except": ["inside-block"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -156,7 +178,16 @@ This means that you can group your blockless at-rules by name.
 
 Shared-line comments do not affect this option.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": [
+    "always",
+    { "except": ["blockless-after-same-name-blockless"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -194,7 +225,16 @@ Reverse the primary option for blockless at-rules that follow another blockless 
 
 Shared-line comments do not affect this option.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": [
+    "always",
+    { "except": ["blockless-after-blockless"] }
+  ]
+}
+```
 
 The following patterns are considered problems:
 
@@ -229,7 +269,13 @@ The following patterns are _not_ considered problems:
 
 Reverse the primary option for at-rules that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": ["always", { "except": ["first-nested"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -271,6 +317,14 @@ Ignore at-rules that follow a comment.
 
 Shared-line comments do not trigger this option.
 
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": ["always", { "ignore": ["after-comment"] }]
+}
+```
+
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
@@ -297,7 +351,13 @@ The following patterns are _not_ considered problems:
 
 Ignore at-rules that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": ["always", { "ignore": ["first-nested"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -314,7 +374,13 @@ The following patterns are _not_ considered problems:
 
 Ignore at-rules that are inside a block.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": ["always", { "ignore": ["inside-block"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -349,7 +415,16 @@ Ignore blockless at-rules that follow another blockless at-rule with the same na
 
 This means that you can group your blockless at-rules by name.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": [
+    "always",
+    { "ignore": ["blockless-after-same-name-blockless"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -378,7 +453,16 @@ a {
 
 Ignore blockless at-rules that follow another blockless at-rule.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "at-rule-empty-line-before": [
+    "always",
+    { "ignore": ["blockless-after-blockless"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -403,12 +487,15 @@ The following patterns are _not_ considered problems:
 
 Ignore specified at-rules.
 
-For example, with `"always"`.
-
 Given:
 
 ```json
-["namespace", "/^my-/"]
+{
+  "at-rule-empty-line-before": [
+    "always",
+    { "ignoreAtRules": ["namespace", "/^my-/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -90,7 +90,7 @@ a {}
 ### `except`
 
 ```json
-{ "except": ["array", "of", "keywords"] }
+{ "except": ["array", "of", "options"] }
 ```
 
 #### `"after-same-name"`
@@ -316,7 +316,7 @@ b {
 ### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"after-comment"`
@@ -523,5 +523,3 @@ The following patterns are _not_ considered problems:
 a {}
 @my-at-rule {}
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -87,7 +87,11 @@ a {}
 
 ## Optional secondary options
 
-### `except: ["after-same-name", "inside-block", "blockless-after-same-name-blockless", "blockless-after-blockless", "first-nested"]`
+### `except`
+
+```json
+{ "except": ["array", "of", "keywords"] }
+```
 
 #### `"after-same-name"`
 
@@ -309,7 +313,11 @@ b {
 }
 ```
 
-### `ignore: ["after-comment", "first-nested", "inside-block", "blockless-after-same-name-blockless", "blockless-after-blockless"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
 
 #### `"after-comment"`
 
@@ -483,7 +491,11 @@ The following patterns are _not_ considered problems:
 @media print {}
 ```
 
-### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
 
 Ignore specified at-rules.
 
@@ -511,3 +523,5 @@ The following patterns are _not_ considered problems:
 a {}
 @my-at-rule {}
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-no-deprecated/README.md
+++ b/lib/rules/at-rule-no-deprecated/README.md
@@ -62,7 +62,11 @@ a { @layer {} }
 
 ## Optional secondary options
 
-### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
 
 Given:
 
@@ -83,3 +87,5 @@ The following patterns are _not_ considered problems:
 ```css
 a { @apply foo; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-no-deprecated/README.md
+++ b/lib/rules/at-rule-no-deprecated/README.md
@@ -30,6 +30,12 @@ Prior art:
 
 ### `true`
 
+```json
+{
+  "at-rule-no-deprecated": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -61,7 +67,9 @@ a { @layer {} }
 Given:
 
 ```json
-["/^view/", "apply"]
+{
+  "at-rule-no-deprecated": [true, { "ignoreAtRules": ["/^view/", "apply"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/at-rule-no-deprecated/README.md
+++ b/lib/rules/at-rule-no-deprecated/README.md
@@ -87,5 +87,3 @@ The following patterns are _not_ considered problems:
 ```css
 a { @apply foo; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -78,5 +78,3 @@ The following patterns are _not_ considered problems:
 ```css
 @--custom {}
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -19,6 +19,12 @@ For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/con
 
 ### `true`
 
+```json
+{
+  "at-rule-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -47,7 +53,9 @@ The following patterns are _not_ considered problems:
 Given:
 
 ```json
-["/^--my-/", "--custom"]
+{
+  "at-rule-no-unknown": [true, { "ignoreAtRules": ["/^--my-/", "--custom"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -48,7 +48,11 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
 
 Given:
 
@@ -74,3 +78,5 @@ The following patterns are _not_ considered problems:
 ```css
 @--custom {}
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "at-rule-no-vendor-prefix": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -48,5 +48,3 @@ The following patterns are _not_ considered problems:
 ```css
 @viewport { orientation: landscape; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -48,3 +48,5 @@ The following patterns are _not_ considered problems:
 ```css
 @viewport { orientation: landscape; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-prelude-no-invalid/README.md
+++ b/lib/rules/at-rule-prelude-no-invalid/README.md
@@ -35,6 +35,12 @@ Prior art:
 
 ### `true`
 
+```json
+{
+  "at-rule-prelude-no-invalid": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -66,7 +72,12 @@ The following patterns are _not_ considered problems:
 Given:
 
 ```json
-["property", "/^font-/"]
+{
+  "at-rule-prelude-no-invalid": [
+    true,
+    { "ignoreAtRules": ["property", "/^font-/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/at-rule-prelude-no-invalid/README.md
+++ b/lib/rules/at-rule-prelude-no-invalid/README.md
@@ -67,7 +67,11 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
 
 Given:
 
@@ -91,3 +95,5 @@ The following patterns are _not_ considered problems:
 ```css
 @font-palette-values foo {}
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-prelude-no-invalid/README.md
+++ b/lib/rules/at-rule-prelude-no-invalid/README.md
@@ -95,5 +95,3 @@ The following patterns are _not_ considered problems:
 ```css
 @font-palette-values foo {}
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -13,13 +13,19 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "at-rule-name": ["array", "of", "properties or descriptors"]|"property or descriptor" }`
+```json
+{ "at-rule-name": ["array", "of", "properties or descriptors"] }
+```
+
+You can also specify a single property or descriptor instead of an array of them.
 
 Given:
 
 ```json
 {
-  "font-face": ["font-display", "font-family", "font-style"]
+  "at-rule-property-required-list": {
+    "font-face": ["font-display", "font-family", "font-style"]
+  }
 }
 ```
 

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -59,3 +59,5 @@ The following patterns are _not_ considered problems:
     src: url('./fonts/foo.woff2') format('woff2');
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -13,11 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 { "at-rule-name": ["array", "of", "properties", "or", "descriptors"] }
 ```
-
-You can also specify a single property or descriptor instead of an array of them.
 
 Given:
 

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -14,7 +14,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ## Options
 
 ```json
-{ "at-rule-name": ["array", "of", "properties or descriptors"] }
+{ "at-rule-name": ["array", "of", "properties", "or", "descriptors"] }
 ```
 
 You can also specify a single property or descriptor instead of an array of them.

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -59,5 +59,3 @@ The following patterns are _not_ considered problems:
     src: url('./fonts/foo.woff2') format('woff2');
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/block-no-empty/README.md
+++ b/lib/rules/block-no-empty/README.md
@@ -13,6 +13,12 @@ Disallow empty blocks.
 
 ### `true`
 
+```json
+{
+  "block-no-empty": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -55,6 +61,12 @@ a {
 ### `ignore: ["comments"]`
 
 Exclude comments from being treated as content inside of a block.
+
+```json
+{
+  "block-no-empty": [true, { "ignore": ["comments"] }]
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/block-no-empty/README.md
+++ b/lib/rules/block-no-empty/README.md
@@ -58,7 +58,13 @@ a {
 
 ## Optional secondary options
 
-### `ignore: ["comments"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
+
+#### `"comments"`
 
 Exclude comments from being treated as content inside of a block.
 
@@ -85,3 +91,5 @@ a {
   }
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/block-no-empty/README.md
+++ b/lib/rules/block-no-empty/README.md
@@ -61,7 +61,7 @@ a {
 ### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"comments"`
@@ -91,5 +91,3 @@ a {
   }
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-function-alias-notation/README.md
+++ b/lib/rules/color-function-alias-notation/README.md
@@ -84,5 +84,3 @@ a { color: rgba(0 0 0) }
 ```css
 a { color: hsla(270 60% 50% / 15%) }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-function-alias-notation/README.md
+++ b/lib/rules/color-function-alias-notation/README.md
@@ -17,11 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"without-alpha"|"with-alpha"`
-
 ### `"without-alpha"`
 
 Applicable color-functions _must always_ use the without alpha notation.
+
+```json
+{
+  "color-function-alias-notation": "without-alpha"
+}
+```
 
 The following patterns are considered problems:
 
@@ -50,6 +54,12 @@ a { color: hsl(270 60% 50% / 15%) }
 ### `"with-alpha"`
 
 Applicable color-functions _must always_ use with alpha notation.
+
+```json
+{
+  "color-function-alias-notation": "with-alpha"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/color-function-alias-notation/README.md
+++ b/lib/rules/color-function-alias-notation/README.md
@@ -84,3 +84,5 @@ a { color: rgba(0 0 0) }
 ```css
 a { color: hsla(270 60% 50% / 15%) }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-function-notation/README.md
+++ b/lib/rules/color-function-notation/README.md
@@ -132,7 +132,7 @@ a { color: hsl(.75turn, 60%, 70%) }
 ### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"with-var-inside"`
@@ -170,5 +170,3 @@ a {
   color: rgba(var(--foo) / 0.5);
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-function-notation/README.md
+++ b/lib/rules/color-function-notation/README.md
@@ -19,11 +19,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"modern"|"legacy"`
-
 ### `"modern"`
 
 Applicable color-functions _must always_ use modern notation.
+
+```json
+{
+  "color-function-notation": "modern"
+}
+```
 
 The following patterns are considered problems:
 
@@ -72,6 +76,12 @@ a { color: hsl(.75turn 60% 70%) }
 ### `"legacy"`
 
 Applicable color-functions _must always_ use the legacy notation.
+
+```json
+{
+  "color-function-notation": "legacy"
+}
+```
 
 The following patterns are considered problems:
 
@@ -126,7 +136,9 @@ Ignore color functions containing variables.
 Given:
 
 ```json
-["modern", { "ignore": ["with-var-inside"] }]
+{
+  "color-function-notation": ["modern", { "ignore": ["with-var-inside"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -140,7 +152,9 @@ a {
 Given:
 
 ```json
-["legacy", { "ignore": ["with-var-inside"] }]
+{
+  "color-function-notation": ["legacy", { "ignore": ["with-var-inside"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/color-function-notation/README.md
+++ b/lib/rules/color-function-notation/README.md
@@ -129,7 +129,13 @@ a { color: hsl(.75turn, 60%, 70%) }
 
 ## Optional secondary options
 
-### `ignore: ["with-var-inside"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
+
+#### `"with-var-inside"`
 
 Ignore color functions containing variables.
 
@@ -164,3 +170,5 @@ a {
   color: rgba(var(--foo) / 0.5);
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-hex-alpha/README.md
+++ b/lib/rules/color-hex-alpha/README.md
@@ -76,3 +76,5 @@ a { color: #fff; }
 ```css
 a { color: #ffffff; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-hex-alpha/README.md
+++ b/lib/rules/color-hex-alpha/README.md
@@ -76,5 +76,3 @@ a { color: #fff; }
 ```css
 a { color: #ffffff; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-hex-alpha/README.md
+++ b/lib/rules/color-hex-alpha/README.md
@@ -13,9 +13,13 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
+
+```json
+{
+  "color-hex-alpha": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -42,6 +46,12 @@ a { color: #ffffffaa; }
 ```
 
 ### `"never"`
+
+```json
+{
+  "color-hex-alpha": "never"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/color-hex-length/README.md
+++ b/lib/rules/color-hex-length/README.md
@@ -83,5 +83,3 @@ a { color: #ffffff; }
 ```css
 a { color: #ffffffaa; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-hex-length/README.md
+++ b/lib/rules/color-hex-length/README.md
@@ -83,3 +83,5 @@ a { color: #ffffff; }
 ```css
 a { color: #ffffffaa; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-hex-length/README.md
+++ b/lib/rules/color-hex-length/README.md
@@ -15,9 +15,13 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"short"|"long"`
-
 ### `"short"`
+
+```json
+{
+  "color-hex-length": "short"
+}
+```
 
 The following patterns are considered problems:
 
@@ -49,6 +53,12 @@ a { color: #a4a4a4; }
 ```
 
 ### `"long"`
+
+```json
+{
+  "color-hex-length": "long"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -130,7 +130,13 @@ a { color: var(--white); }
 
 ## Optional secondary options
 
-### `ignore: ["inside-function"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
+
+#### `"inside-function"`
 
 Ignore colors that are inside a function.
 
@@ -158,7 +164,11 @@ a {
 }
 ```
 
-### `ignoreProperties: ["/regex/", /regex/, "string"]`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Given:
 
@@ -190,3 +200,5 @@ a {
   composes: red from './index.css';
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -133,7 +133,7 @@ a { color: var(--white); }
 ### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"inside-function"`
@@ -200,5 +200,3 @@ a {
   composes: red from './index.css';
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -13,11 +13,15 @@ This rule ignores `$sass` and `@less` variable syntaxes.
 
 ## Options
 
-`string`: `"always-where-possible"|"never"`
-
 ### `"always-where-possible"`
 
 Colors _must always_, where possible, be named.
+
+```json
+{
+  "color-named": "always-where-possible"
+}
+```
 
 This will complain if a hex (3, 4, 6 and 8 digit), `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()` or `gray()` color can be represented as a named color.
 
@@ -89,6 +93,12 @@ a { color: rgb(0, 0, 0, 0.5); }
 
 Colors _must never_ be named.
 
+```json
+{
+  "color-named": "never"
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -124,7 +134,13 @@ a { color: var(--white); }
 
 Ignore colors that are inside a function.
 
-For example, with `"never"`.
+Given:
+
+```json
+{
+  "color-named": ["never", { "ignore": ["inside-function"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -144,12 +160,12 @@ a {
 
 ### `ignoreProperties: ["/regex/", /regex/, "string"]`
 
-For example with `"never"`.
-
 Given:
 
 ```json
-["/^my-/", "composes"]
+{
+  "color-named": ["never", { "ignoreProperties": ["/^my-/", "composes"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -66,3 +66,5 @@ a { color: rgb(0, 0, 0); }
 ```css
 a { color: rgba(0, 0, 0, 1); }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -66,5 +66,3 @@ a { color: rgb(0, 0, 0); }
 ```css
 a { color: rgba(0, 0, 0, 1); }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -15,6 +15,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "color-no-hex": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/color-no-invalid-hex/README.md
+++ b/lib/rules/color-no-invalid-hex/README.md
@@ -24,6 +24,12 @@ We recommend using these rules for CSS and this rule for CSS-like languages, suc
 
 ### `true`
 
+```json
+{
+  "color-no-invalid-hex": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/color-no-invalid-hex/README.md
+++ b/lib/rules/color-no-invalid-hex/README.md
@@ -68,3 +68,5 @@ a { color: #fff1a0; }
 ```css
 a { color: #123450aa; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/color-no-invalid-hex/README.md
+++ b/lib/rules/color-no-invalid-hex/README.md
@@ -68,5 +68,3 @@ a { color: #fff1a0; }
 ```css
 a { color: #123450aa; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -22,11 +22,15 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
 
 There _must always_ be an empty line before comments.
+
+```json
+{
+  "comment-empty-line-before": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -53,6 +57,12 @@ a {} /* comment */
 ### `"never"`
 
 There _must never_ be an empty line before comments.
+
+```json
+{
+  "comment-empty-line-before": "never"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -91,7 +91,7 @@ a {} /* comment */
 ### `except`
 
 ```json
-{ "except": ["array", "of", "keywords"] }
+{ "except": ["array", "of", "options"] }
 ```
 
 #### `"first-nested"`
@@ -130,7 +130,7 @@ a {
 ### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"after-comment"`
@@ -240,5 +240,3 @@ The following patterns are _not_ considered problems:
   color: pink;
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -88,11 +88,23 @@ a {} /* comment */
 
 ## Optional secondary options
 
-### `except: ["first-nested"]`
+### `except`
+
+```json
+{ "except": ["array", "of", "keywords"] }
+```
+
+#### `"first-nested"`
 
 Reverse the primary option for comments that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "comment-empty-line-before": ["always", { "except": ["first-nested"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -115,13 +127,23 @@ a {
 }
 ```
 
-### `ignore: ["after-comment", "stylelint-commands"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
 
 #### `"after-comment"`
 
 Ignore comments that follow another comment.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "comment-empty-line-before": ["always", { "ignore": ["after-comment"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -152,7 +174,13 @@ a {
 
 Ignore configuration comments, e.g. `/* stylelint-disable color-no-hex */`.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "comment-empty-line-before": ["always", { "ignore": ["stylelint-commands"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -176,14 +204,23 @@ a {
 }
 ```
 
-### `ignoreComments: ["/regex/", /regex/, "string"]`
+### `ignoreComments`
+
+```json
+{ "ignoreComments": ["array", "of", "comments", "/regex/"] }
+```
 
 Ignore comments matching the given regular expressions or strings.
 
-For example, with `"always"` and given:
+Given:
 
 ```json
-["/^ignore/", "string-ignore"]
+{
+  "comment-empty-line-before": [
+    "always",
+    { "ignoreComments": ["/^ignore/", "string-ignore"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -203,3 +240,5 @@ The following patterns are _not_ considered problems:
   color: pink;
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-no-empty/README.md
+++ b/lib/rules/comment-no-empty/README.md
@@ -56,3 +56,5 @@ The following patterns are _not_ considered problems:
  * Multi-line Comment
 **/
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-no-empty/README.md
+++ b/lib/rules/comment-no-empty/README.md
@@ -56,5 +56,3 @@ The following patterns are _not_ considered problems:
  * Multi-line Comment
 **/
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-no-empty/README.md
+++ b/lib/rules/comment-no-empty/README.md
@@ -18,6 +18,12 @@ This rule ignores SCSS-like comments.
 
 ### `true`
 
+```json
+{
+  "comment-no-empty": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -13,9 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -15,7 +15,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 Given:

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -13,7 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-Specify a regex string.
+Specify a regex string not surrounded with `"/"`.
 
 Given:
 

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -13,9 +13,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string.
 
-Given the string:
+Given:
 
 ```json
 {
@@ -38,3 +38,5 @@ The following patterns are _not_ considered problems:
 /*foo at the beginning*/
 a { color: red; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -13,14 +13,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
+
+If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
 
 Given the string:
 
 ```json
-"foo .+"
+{
+  "comment-pattern": "foo .+"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -38,5 +38,3 @@ The following patterns are _not_ considered problems:
 /*foo at the beginning*/
 a { color: red; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-whitespace-inside/README.md
+++ b/lib/rules/comment-whitespace-inside/README.md
@@ -108,3 +108,5 @@ The following patterns are _not_ considered problems:
 ```css
 /****comment****/
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-whitespace-inside/README.md
+++ b/lib/rules/comment-whitespace-inside/README.md
@@ -108,5 +108,3 @@ The following patterns are _not_ considered problems:
 ```css
 /****comment****/
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-whitespace-inside/README.md
+++ b/lib/rules/comment-whitespace-inside/README.md
@@ -18,11 +18,15 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
 
 There _must always_ be whitespace inside the markers.
+
+```json
+{
+  "comment-whitespace-inside": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -69,6 +73,12 @@ The following patterns are _not_ considered problems:
 ### `"never"`
 
 There _must never_ be whitespace on the inside the markers.
+
+```json
+{
+  "comment-whitespace-inside": "never"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -51,5 +51,3 @@ The following patterns are _not_ considered problems:
 ```css
 /* comment */
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -16,14 +16,20 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regexp`: `["array", "of", "words", /or/, "/regex/"]|"word"|"/regex/"|/regex/`
+```json
+["array", "of", "words", "or", "/regex/"]
+```
 
 If a string is surrounded with `"/"` (e.g. `"/^TODO:/"`), it is interpreted as a regular expression.
+
+You can also specify a single word or a regular expression instead of an array of them.
 
 Given:
 
 ```json
-["/^TODO:/", "badword"]
+{
+  "comment-word-disallowed-list": ["/^TODO:/", "badword"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -20,9 +20,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "words", "/regex/"]
 ```
 
-If a string is surrounded with `"/"` (e.g. `"/^TODO:/"`), it is interpreted as a regular expression.
+You can also specify a single word instead of an array of them.
 
-You can also specify a single word or a regular expression instead of an array of them.
+If a string is surrounded with `"/"` (e.g. `"/^TODO:/"`), it is interpreted as a regular expression.
 
 Given:
 

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -16,6 +16,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "words", "/regex/"]
 ```

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ## Options
 
 ```json
-["array", "of", "words", "or", "/regex/"]
+["array", "of", "words", "/regex/"]
 ```
 
 If a string is surrounded with `"/"` (e.g. `"/^TODO:/"`), it is interpreted as a regular expression.

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -20,10 +20,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "words", "/regex/"]
 ```
 
-You can also specify a single word instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/^TODO:/"`), it is interpreted as a regular expression.
-
 Given:
 
 ```json
@@ -55,3 +51,5 @@ The following patterns are _not_ considered problems:
 ```css
 /* comment */
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -13,9 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -13,9 +13,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string.
 
-Given the string:
+Given:
 
 ```json
 {
@@ -56,3 +56,5 @@ a { container-name: foo-bar; }
 ```css
 a { container: foo-baz / inline-size; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -56,5 +56,3 @@ a { container-name: foo-bar; }
 ```css
 a { container: foo-baz / inline-size; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -15,7 +15,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 Given:

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -13,7 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-Specify a regex string.
+Specify a regex string not surrounded with `"/"`.
 
 Given:
 

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -13,14 +13,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
+
+If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
 
 Given the string:
 
 ```json
-"foo-.+"
+{
+  "container-name-pattern": "foo-.+"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -13,9 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -13,9 +13,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string.
 
-Given the string:
+Given:
 
 ```json
 {
@@ -36,3 +36,5 @@ The following patterns are _not_ considered problems:
 ```css
 @custom-media --foo-bar (min-width: 30em);
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -15,7 +15,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 Given:

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -36,5 +36,3 @@ The following patterns are _not_ considered problems:
 ```css
 @custom-media --foo-bar (min-width: 30em);
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -13,7 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-Specify a regex string.
+Specify a regex string not surrounded with `"/"`.
 
 Given:
 

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -13,14 +13,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
+
+If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
 
 Given the string:
 
 ```json
-"foo-.+"
+{
+  "custom-media-pattern": "foo-.+"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -103,7 +103,7 @@ a {
 ### `except`
 
 ```json
-{ "except": ["array", "of", "keywords"] }
+{ "except": ["array", "of", "options"] }
 ```
 
 #### `"after-comment"`
@@ -264,10 +264,10 @@ a {
 }
 ```
 
-### `ignore: ["after-comment", "first-nested", "inside-single-line-block"]`
+### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"after-comment"`
@@ -342,5 +342,3 @@ The following patterns are _not_ considered problems:
 ```css
 a { --foo: pink; --bar: red; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -100,7 +100,11 @@ a {
 
 ## Optional secondary options
 
-### `except: ["after-comment", "after-custom-property", "first-nested"]`
+### `except`
+
+```json
+{ "except": ["array", "of", "keywords"] }
+```
 
 #### `"after-comment"`
 
@@ -262,6 +266,10 @@ a {
 
 ### `ignore: ["after-comment", "first-nested", "inside-single-line-block"]`
 
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
+
 #### `"after-comment"`
 
 Ignore custom properties that follow a comment.
@@ -334,3 +342,5 @@ The following patterns are _not_ considered problems:
 ```css
 a { --foo: pink; --bar: red; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -17,9 +17,13 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
+
+```json
+{
+  "custom-property-empty-line-before": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -46,6 +50,12 @@ a {
 ```
 
 ### `"never"`
+
+```json
+{
+  "custom-property-empty-line-before": "never"
+}
+```
 
 The following patterns are considered problems:
 
@@ -98,7 +108,16 @@ Reverse the primary option for custom properties that follow a comment.
 
 Shared-line comments do not trigger this option.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "custom-property-empty-line-before": [
+    "always",
+    { "except": ["after-comment"] }
+  ]
+}
+```
 
 The following patterns are considered problems:
 
@@ -150,7 +169,16 @@ Reverse the primary option for custom properties that follow another custom prop
 
 Shared-line comments do not affect this option.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "custom-property-empty-line-before": [
+    "always",
+    { "except": ["after-custom-property"] }
+  ]
+}
+```
 
 The following patterns are considered problems:
 
@@ -198,7 +226,16 @@ a {
 
 Reverse the primary option for custom properties that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "custom-property-empty-line-before": [
+    "always",
+    { "except": ["first-nested"] }
+  ]
+}
+```
 
 The following patterns are considered problems:
 
@@ -229,7 +266,16 @@ a {
 
 Ignore custom properties that follow a comment.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "custom-property-empty-line-before": [
+    "always",
+    { "except": ["after-comment"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -245,7 +291,16 @@ a {
 
 Ignore custom properties that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "custom-property-empty-line-before": [
+    "always",
+    { "except": ["first-nested"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -262,7 +317,16 @@ a {
 
 Ignore custom properties that are inside single-line blocks.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "custom-property-empty-line-before": [
+    "always",
+    { "except": ["inside-single-line-block"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/custom-property-no-missing-var-function/README.md
+++ b/lib/rules/custom-property-no-missing-var-function/README.md
@@ -21,6 +21,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "custom-property-no-missing-var-function": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/custom-property-no-missing-var-function/README.md
+++ b/lib/rules/custom-property-no-missing-var-function/README.md
@@ -60,3 +60,5 @@ a { color: var(--foo); }
 @property --foo {}
 a { transition-property: --foo; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-property-no-missing-var-function/README.md
+++ b/lib/rules/custom-property-no-missing-var-function/README.md
@@ -60,5 +60,3 @@ a { color: var(--foo); }
 @property --foo {}
 a { transition-property: --foo; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -13,11 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -17,10 +17,14 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
+If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+
 Given the string:
 
 ```json
-"foo-.+"
+{
+  "custom-property-pattern": "foo-.+"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 Given:

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -13,7 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-Specify a regex string.
+Specify a regex string not surrounded with `"/"`.
 
 Given:
 

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -36,5 +36,3 @@ The following patterns are _not_ considered problems:
 ```css
 :root { --foo-bar: 0; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -13,9 +13,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string.
 
-Given the string:
+Given:
 
 ```json
 {
@@ -36,3 +36,5 @@ The following patterns are _not_ considered problems:
 ```css
 :root { --foo-bar: 0; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
@@ -49,7 +49,11 @@ a { --custom-property: pink; --cUstOm-prOpErtY: orange; }
 
 ## Optional secondary options
 
-### `ignoreProperties: ["/regex/", /regex/, "non-regex"]`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Ignore duplicates of specific properties.
 
@@ -82,3 +86,5 @@ a { --custom-property: 1; --custom-property: 1; }
 ```css
 a { --custom-ignored-property: 1; --custom-ignored-property: 1; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
@@ -86,5 +86,3 @@ a { --custom-property: 1; --custom-property: 1; }
 ```css
 a { --custom-ignored-property: 1; --custom-ignored-property: 1; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
@@ -17,6 +17,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "declaration-block-no-duplicate-custom-properties": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -50,7 +56,12 @@ Ignore duplicates of specific properties.
 Given:
 
 ```json
-["--custom-property", "/ignored/"]
+{
+  "declaration-block-no-duplicate-custom-properties": [
+    true,
+    { "ignoreProperties": ["--custom-property", "/ignored/"] }
+  ]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/declaration-block-no-duplicate-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-properties/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "declaration-block-no-duplicate-properties": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -49,6 +55,15 @@ a { color: pink; background: orange; }
 
 Ignore consecutive duplicated properties.
 
+```json
+{
+  "declaration-block-no-duplicate-properties": [
+    true,
+    { "ignore": ["consecutive-duplicates"] }
+  ]
+}
+```
+
 They can prove to be useful fallbacks for older browsers.
 
 The following patterns are considered problems:
@@ -76,6 +91,15 @@ p {
 ### `ignore: ["consecutive-duplicates-with-different-values"]`
 
 Ignore consecutive duplicated properties with different values.
+
+```json
+{
+  "declaration-block-no-duplicate-properties": [
+    true,
+    { "ignore": ["consecutive-duplicates-with-different-values"] }
+  ]
+}
+```
 
 Including duplicate properties (fallbacks) is useful to deal with older browsers support for CSS properties. E.g. using `px` units when `rem` isn't available.
 
@@ -116,6 +140,15 @@ p {
 
 Ignore consecutive duplicated properties with different value syntaxes (type and unit of value).
 
+```json
+{
+  "declaration-block-no-duplicate-properties": [
+    true,
+    { "ignore": ["consecutive-duplicates-with-different-syntaxes"] }
+  ]
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -142,6 +175,15 @@ p {
 ### `ignore: ["consecutive-duplicates-with-same-prefixless-values"]`
 
 Ignore consecutive duplicated properties with identical values, when ignoring their prefix.
+
+```json
+{
+  "declaration-block-no-duplicate-properties": [
+    true,
+    { "ignore": ["consecutive-duplicates-with-same-prefixless-values"] }
+  ]
+}
+```
 
 This option is useful to deal with draft CSS values while still being future proof. E.g. using `fit-content` and `-moz-fit-content`.
 
@@ -183,7 +225,12 @@ Ignore duplicates of specific properties.
 Given:
 
 ```json
-["color", "/background-/"]
+{
+  "declaration-block-no-duplicate-properties": [
+    true,
+    { "ignoreProperties": ["color", "/background-/"] }
+  ]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/declaration-block-no-duplicate-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-properties/README.md
@@ -51,7 +51,13 @@ a { color: pink; background: orange; }
 
 ## Optional secondary options
 
-### `ignore: ["consecutive-duplicates"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
+
+#### `"consecutive-duplicates"`
 
 Ignore consecutive duplicated properties.
 
@@ -88,7 +94,7 @@ p {
 }
 ```
 
-### `ignore: ["consecutive-duplicates-with-different-values"]`
+#### `"consecutive-duplicates-with-different-values"`
 
 Ignore consecutive duplicated properties with different values.
 
@@ -136,7 +142,7 @@ p {
 }
 ```
 
-### `ignore: ["consecutive-duplicates-with-different-syntaxes"]`
+#### `"consecutive-duplicates-with-different-syntaxes"`
 
 Ignore consecutive duplicated properties with different value syntaxes (type and unit of value).
 
@@ -172,7 +178,7 @@ p {
 }
 ```
 
-### `ignore: ["consecutive-duplicates-with-same-prefixless-values"]`
+#### `"consecutive-duplicates-with-same-prefixless-values"`
 
 Ignore consecutive duplicated properties with identical values, when ignoring their prefix.
 
@@ -218,7 +224,11 @@ p {
 }
 ```
 
-### `ignoreProperties: ["/regex/", /regex/, "non-regex"]`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Ignore duplicates of specific properties.
 
@@ -256,3 +266,5 @@ a { color: pink; color: orange; background-color: orange; background-color: whit
 ```css
 a { color: pink; background-color: orange; color: orange; background-color: white; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-no-duplicate-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-properties/README.md
@@ -54,7 +54,7 @@ a { color: pink; background: orange; }
 ### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"consecutive-duplicates"`
@@ -266,5 +266,3 @@ a { color: pink; color: orange; background-color: orange; background-color: whit
 ```css
 a { color: pink; background-color: orange; color: orange; background-color: white; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -98,6 +98,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "declaration-block-no-redundant-longhand-properties": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -181,9 +187,20 @@ Ignore the specified longhand properties.
 
 Given:
 
-<!-- prettier-ignore -->
 ```json
-["text-decoration-thickness", "background-size", "background-origin", "background-clip"]
+{
+  "declaration-block-no-redundant-longhand-properties": [
+    true,
+    {
+      "ignoreLonghands": [
+        "text-decoration-thickness",
+        "background-size",
+        "background-origin",
+        "background-clip"
+      ]
+    }
+  ]
+}
 ```
 
 The following patterns are considered problems:
@@ -238,7 +255,12 @@ Ignore the specified shorthand properties.
 Given:
 
 ```json
-["padding", "/border/"]
+{
+  "declaration-block-no-redundant-longhand-properties": [
+    true,
+    { "ignoreShorthands": ["padding", "/border/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -181,7 +181,11 @@ a {
 
 ## Optional secondary options
 
-### `ignoreLonghands: ["array", "of", "properties"]`
+### `ignoreLonghands`
+
+```json
+{ "ignoreLonghands": ["array", "of", "properties"] }
+```
 
 Ignore the specified longhand properties.
 
@@ -248,7 +252,11 @@ a {
 }
 ```
 
-### `ignoreShorthands: ["/regex/", /regex/, "string"]`
+### `ignoreShorthands`
+
+```json
+{ "ignoreShorthands": ["array", "of", "shorthands", "/regex/"] }
+```
 
 Ignore the specified shorthand properties.
 
@@ -293,3 +301,5 @@ a {
   border-top-width: 7px;
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -301,5 +301,3 @@ a {
   border-top-width: 7px;
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
@@ -17,6 +17,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "declaration-block-no-shorthand-property-overrides": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
@@ -75,5 +75,3 @@ a { transition-property: opacity; } a { transition: opacity 1s linear; }
 ```css
 a { transition-property: opacity; -webkit-transition: opacity 1s linear; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
@@ -75,3 +75,5 @@ a { transition-property: opacity; } a { transition: opacity 1s linear; }
 ```css
 a { transition-property: opacity; -webkit-transition: opacity 1s linear; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-single-line-max-declarations/README.md
+++ b/lib/rules/declaration-block-single-line-max-declarations/README.md
@@ -56,3 +56,5 @@ a {
   top: 3px;
 }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-single-line-max-declarations/README.md
+++ b/lib/rules/declaration-block-single-line-max-declarations/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum number of declarations allowed.
 
 Given:

--- a/lib/rules/declaration-block-single-line-max-declarations/README.md
+++ b/lib/rules/declaration-block-single-line-max-declarations/README.md
@@ -56,5 +56,3 @@ a {
   top: 3px;
 }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-block-single-line-max-declarations/README.md
+++ b/lib/rules/declaration-block-single-line-max-declarations/README.md
@@ -13,9 +13,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum number of declarations allowed.
+Specify a maximum number of declarations allowed.
 
-For example, with `1`:
+Given:
+
+```json
+{
+  "declaration-block-single-line-max-declarations": 1
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/declaration-empty-line-before/README.md
+++ b/lib/rules/declaration-empty-line-before/README.md
@@ -19,9 +19,13 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
+
+```json
+{
+  "declaration-empty-line-before": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -63,6 +67,12 @@ a {
 ```
 
 ### `"never"`
+
+```json
+{
+  "declaration-empty-line-before": "never"
+}
+```
 
 The following patterns are considered problems:
 
@@ -113,7 +123,13 @@ Reverse the primary option for declarations that follow a comment.
 
 Shared-line comments do not trigger this option.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "declaration-empty-line-before": ["always", { "except": ["after-comment"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -161,7 +177,16 @@ Reverse the primary option for declarations that follow another declaration.
 
 Shared-line comments do not affect this option.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "declaration-empty-line-before": [
+    "always",
+    { "except": ["after-declaration"] }
+  ]
+}
+```
 
 The following patterns are considered problems:
 
@@ -209,7 +234,13 @@ a {
 
 Reverse the primary option for declarations that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "declaration-empty-line-before": ["always", { "except": ["first-nested"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -240,7 +271,13 @@ a {
 
 Ignore declarations that follow a comment.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "declaration-empty-line-before": ["always", { "ignore": ["after-comment"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -256,7 +293,16 @@ a {
 
 Ignore declarations that follow another declaration.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "declaration-empty-line-before": [
+    "always",
+    { "ignore": ["after-declaration"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -295,7 +341,13 @@ a {
 
 Ignore declarations that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "declaration-empty-line-before": ["always", { "ignore": ["first-nested"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -312,7 +364,16 @@ a {
 
 Ignore declarations that are inside single-line blocks.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "declaration-empty-line-before": [
+    "always",
+    { "ignore": ["inside-single-line-block"] }
+  ]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/declaration-empty-line-before/README.md
+++ b/lib/rules/declaration-empty-line-before/README.md
@@ -115,7 +115,11 @@ a {
 
 ## Optional secondary options
 
-### `except: ["after-comment", "after-declaration", "first-nested"]`
+### `except`
+
+```json
+{ "except": ["array", "of", "keywords"] }
+```
 
 #### `"after-comment"`
 
@@ -265,7 +269,11 @@ a {
 }
 ```
 
-### `ignore: ["after-comment", "after-declaration", "first-nested", "inside-single-line-block"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "keywords"] }
+```
 
 #### `"after-comment"`
 
@@ -381,3 +389,5 @@ The following patterns are _not_ considered problems:
 ```css
 a { bottom: 15px; top: 5px; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-empty-line-before/README.md
+++ b/lib/rules/declaration-empty-line-before/README.md
@@ -118,7 +118,7 @@ a {
 ### `except`
 
 ```json
-{ "except": ["array", "of", "keywords"] }
+{ "except": ["array", "of", "options"] }
 ```
 
 #### `"after-comment"`
@@ -272,7 +272,7 @@ a {
 ### `ignore`
 
 ```json
-{ "ignore": ["array", "of", "keywords"] }
+{ "ignore": ["array", "of", "options"] }
 ```
 
 #### `"after-comment"`
@@ -389,5 +389,3 @@ The following patterns are _not_ considered problems:
 ```css
 a { bottom: 15px; top: 5px; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-no-important/README.md
+++ b/lib/rules/declaration-no-important/README.md
@@ -44,3 +44,5 @@ The following patterns are _not_ considered problems:
 ```css
 a { color: pink; }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-no-important/README.md
+++ b/lib/rules/declaration-no-important/README.md
@@ -15,6 +15,12 @@ If you always want `!important` in your declarations, e.g. if you're writing [us
 
 ### `true`
 
+```json
+{
+  "declaration-no-important": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/declaration-no-important/README.md
+++ b/lib/rules/declaration-no-important/README.md
@@ -44,5 +44,3 @@ The following patterns are _not_ considered problems:
 ```css
 a { color: pink; }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-property-max-values/README.md
+++ b/lib/rules/declaration-property-max-values/README.md
@@ -12,7 +12,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 In practice, you should specify any positive integers as values.
 
-If a property name is surrounded with `"/"` (e.g. `"/^margin/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^margin/` will match `margin`, `margin-top`, `margin-inline`, etc.
+You can specify a regex for a property name, such as `"/^margin/"`.
 
 Given:
 

--- a/lib/rules/declaration-property-max-values/README.md
+++ b/lib/rules/declaration-property-max-values/README.md
@@ -6,6 +6,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Object<string, number>`
+
 ```json
 { "unprefixed-property-name": 0 }
 ```

--- a/lib/rules/declaration-property-max-values/README.md
+++ b/lib/rules/declaration-property-max-values/README.md
@@ -10,9 +10,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": 0 }
 ```
 
-In practice, you should specify any positive integers as values.
+Specify pairs of a property and a max value. In practice, you should specify any positive integers as max values.
 
-You can specify a regex for a property name, such as `"/^margin/"`.
+You can specify a regex for a property name, such as `{ "/^margin/": 0 }`.
 
 Given:
 

--- a/lib/rules/declaration-property-max-values/README.md
+++ b/lib/rules/declaration-property-max-values/README.md
@@ -6,7 +6,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": int }`
+```json
+{ "unprefixed-property-name": 0 }
+```
+
+In practice, you should specify any positive integers as values.
 
 If a property name is surrounded with `"/"` (e.g. `"/^margin/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^margin/` will match `margin`, `margin-top`, `margin-inline`, etc.
 
@@ -14,8 +18,10 @@ Given:
 
 ```json
 {
-  "border": 2,
-  "/^margin/": 1
+  "declaration-property-max-values": {
+    "border": 2,
+    "/^margin/": 1
+  }
 }
 ```
 

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "units"] }
 ```
 
-You can specify a regex for a property name, such as `"/^animation/"`.
+You can specify a regex for a property name, such as `{ "/^animation/": [] }`.
 
 Given:
 
@@ -25,7 +25,7 @@ Given:
 {
   "declaration-property-unit-allowed-list": {
     "font-size": ["em", "px"],
-    "/^animation/": "s",
+    "/^animation/": ["s"],
     "line-height": []
   }
 }

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -17,9 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "units"] }
 ```
 
-You can also specify a single unit instead of an array of them.
-
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
+You can specify a regex for a property name, such as `"/^animation/"`.
 
 Given:
 
@@ -94,7 +92,13 @@ a { line-height: 1; }
 
 ## Optional secondary options
 
-### `ignore: ["inside-function"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
+
+#### `"inside-function"`
 
 Ignore units that are inside a function.
 

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Object<string, Array<string>>`
+
 ```json
 { "unprefixed-property-name": ["array", "of", "units"] }
 ```

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -98,7 +98,7 @@ a { line-height: 1; }
 
 Ignore units that are inside a function.
 
-For example, given:
+Given:
 
 ```json
 {

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Object<string, Array<string>>`
+
 ```json
 { "unprefixed-property-name": ["array", "of", "units"] }
 ```

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -17,9 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "units"] }
 ```
 
-You can also specify a single unit instead of an array of them.
-
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
+You can specify a regex for a property name, such as `"/^animation/"`.
 
 Given:
 

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -13,7 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "units"]|"unit" }`
+```json
+{ "unprefixed-property-name": ["array", "of", "units"] }
+```
+
+You can also specify a single unit instead of an array of them.
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
@@ -21,8 +25,10 @@ Given:
 
 ```json
 {
-  "font-size": ["em", "px"],
-  "/^animation/": "s"
+  "declaration-property-unit-disallowed-list": {
+    "font-size": ["em", "px"],
+    "/^animation/": "s"
+  }
 }
 ```
 

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "units"] }
 ```
 
-You can specify a regex for a property name, such as `"/^animation/"`.
+You can specify a regex for a property name, such as `{ "/^animation/": [] }`.
 
 Given:
 
@@ -25,7 +25,7 @@ Given:
 {
   "declaration-property-unit-disallowed-list": {
     "font-size": ["em", "px"],
-    "/^animation/": "s"
+    "/^animation/": ["s"]
   }
 }
 ```

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -13,7 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "values", "/regex/", /regex/]|"value"|"/regex/"|/regex/ }`
+```json
+{ "unprefixed-property-name": ["array", "of", "values", "/regex/" }
+```
+
+You can also specify a single value or a regular expression instead of an array of them.
 
 If a property name is found in the object, only the listed property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 
@@ -27,9 +31,11 @@ Given:
 
 ```json
 {
-  "transform": ["/scale/"],
-  "whitespace": "nowrap",
-  "/color/": ["/^green/"]
+  "declaration-property-value-allowed-list": {
+    "transform": ["/scale/"],
+    "whitespace": "nowrap",
+    "/color/": ["/^green/"]
+  }
 }
 ```
 

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -17,11 +17,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```
 
-You can also specify a single value instead of an array of them.
+You can specify a regex for a property name, such as `"/^animation/"`.
 
 If a property name is found in the object, only the listed property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
-
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
 The same goes for values. Keep in mind that a regular expression value is matched against the entire value of the declaration, not specific parts of it. For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will _not_ match `"/^solid/"` (notice beginning of the line boundary) but _will_ match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
 

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -14,7 +14,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ## Options
 
 ```json
-{ "unprefixed-property-name": ["array", "of", "values", "/regex/" }
+{ "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```
 
 You can also specify a single value or a regular expression instead of an array of them.

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```
 
-You can also specify a single value or a regular expression instead of an array of them.
+You can also specify a single value instead of an array of them.
 
 If a property name is found in the object, only the listed property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```
 
-You can specify a regex for a property name, such as `"/^animation/"`.
+You can specify a regex for a property name, such as `{ "/^animation/": [] }`.
 
 If a property name is found in the object, only the listed property values are allowed. This rule complains about all non-matching values. (If the property name is not included in the object, anything goes.)
 
@@ -31,7 +31,7 @@ Given:
 {
   "declaration-property-value-allowed-list": {
     "transform": ["/scale/"],
-    "whitespace": "nowrap",
+    "whitespace": ["nowrap"],
     "/color/": ["/^green/"]
   }
 }

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Object<string, Array<string>>`
+
 ```json
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -13,7 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "unprefixed-property-name": ["array", "of", "values", "/regex/", /regex/]|"value"|"/regex/"|/regex/ }`
+```json
+{ "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
+```
+
+You can also specify a single value or a regular expression instead of an array of them.
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 
@@ -25,10 +29,12 @@ Given:
 
 ```json
 {
-  "transform": ["/scale3d/", "/rotate3d/", "/translate3d/"],
-  "position": "fixed",
-  "color": ["/^green/"],
-  "/^animation/": ["/ease/"]
+  "declaration-property-value-disallowed-list": {
+    "transform": ["/scale3d/", "/rotate3d/", "/translate3d/"],
+    "position": "fixed",
+    "color": ["/^green/"],
+    "/^animation/": ["/ease/"]
+  }
 }
 ```
 

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -17,9 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```
 
-You can also specify a single value instead of an array of them.
-
-If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
+You can specify a regex for a property name, such as `"/^animation/"`.
 
 The same goes for values. Keep in mind that a regular expression value is matched against the entire value of the declaration, not specific parts of it. For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will _not_ match `"/^solid/"` (notice beginning of the line boundary) but _will_ match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
 

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```
 
-You can also specify a single value or a regular expression instead of an array of them.
+You can also specify a single value instead of an array of them.
 
 If a property name is surrounded with `"/"` (e.g. `"/^animation/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^animation/` will match `animation`, `animation-duration`, `animation-timing-function`, etc.
 

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```
 
-You can specify a regex for a property name, such as `"/^animation/"`.
+You can specify a regex for a property name, such as `{ "/^animation/": [] }`.
 
 The same goes for values. Keep in mind that a regular expression value is matched against the entire value of the declaration, not specific parts of it. For example, a value like `"10px solid rgba( 255 , 0 , 0 , 0.5 )"` will _not_ match `"/^solid/"` (notice beginning of the line boundary) but _will_ match `"/\\s+solid\\s+/"` or `"/\\bsolid\\b/"`.
 
@@ -29,7 +29,7 @@ Given:
 {
   "declaration-property-value-disallowed-list": {
     "transform": ["/scale3d/", "/rotate3d/", "/translate3d/"],
-    "position": "fixed",
+    "position": ["fixed"],
     "color": ["/^green/"],
     "/^animation/": ["/ease/"]
   }

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Object<string, Array<string>>`
+
 ```json
 { "unprefixed-property-name": ["array", "of", "values", "/regex/"] }
 ```

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/README.md
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/README.md
@@ -59,7 +59,11 @@ a { text-justify: inter-character; }
 
 ## Optional secondary options
 
-### `ignoreKeywords: ["/regex/", /regex/, "string"]`
+### `ignoreKeywords`
+
+```json
+{ "ignoreKeywords": ["array", "of", "keywords", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/README.md
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/README.md
@@ -27,6 +27,12 @@ Prior art:
 
 ### `true`
 
+```json
+{
+  "declaration-property-value-keyword-no-deprecated": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -58,7 +64,12 @@ a { text-justify: inter-character; }
 Given:
 
 ```json
-["ActiveBorder", "/caption/i"]
+{
+  "declaration-property-value-keyword-no-deprecated": [
+    true,
+    { "ignoreKeywords": ["ActiveBorder", "/caption/i"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -69,9 +69,17 @@ a { top: var(--foo); }
 
 ## Optional secondary options
 
-### `ignoreProperties: { "property": ["/regex/", /regex/, "non-regex"]|"/regex/"|/regex/|"non-regex" }`
+### `ignoreProperties`
 
-Ignore the specified property and value pairs. Keys in the object indicate property names. If a string in the object is surrounded with `"/"`, it's interpreted as a regular expression. For example, `"/.+/"` matches any strings.
+```json
+{
+  "ignoreProperties": {
+    "property": ["array", "of", "property-values", "/regex/"]
+  }
+}
+```
+
+Ignore the specified property and value pairs. Keys in the object indicate property names.
 
 Given:
 
@@ -113,7 +121,11 @@ a { padding: invalid; }
 a { width: --unknown-value; }
 ```
 
-### `propertiesSyntax: { property: syntax }`
+### `propertiesSyntax`
+
+```json
+{ "propertiesSyntax": { "property": "syntax" } }
+```
 
 Extend or alter the properties syntax dictionary. [CSS Value Definition Syntax](https://github.com/csstree/csstree/blob/master/docs/definition-syntax.md) is used to define a value's syntax. If a definition starts with `|` it is added to the [existing definition value](https://csstree.github.io/docs/syntax/) if any.
 
@@ -123,7 +135,7 @@ Given:
 {
   "declaration-property-value-no-unknown": [
     true,
-    { "size": "<length-percentage>" }
+    { "propertiesSyntax": { "size": "<length-percentage>" } }
   ]
 }
 ```
@@ -140,7 +152,11 @@ a { size: 0; }
 a { size: 10px }
 ```
 
-### `typesSyntax: { type: syntax }`
+### `typesSyntax`
+
+```json
+{ "typesSyntax": { "type": "syntax" } }
+```
 
 Extend or alter the types syntax dictionary. [CSS Value Definition Syntax](https://github.com/csstree/csstree/blob/master/docs/definition-syntax.md) is used to define a value's syntax. If a definition starts with `|` it is added to the [existing definition value](https://csstree.github.io/docs/syntax/) if any.
 
@@ -171,3 +187,5 @@ a { top: --foo(0); }
 ```css
 a { top: --foo(10px); }
 ```
+
+See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -77,14 +77,17 @@ Given:
 
 ```json
 {
-  "declaration-property-value-no-unknown": [true, {
-    "ignoreProperties": {
-      "top": ["unknown"],
-      "/^margin-/": "/^--foo/",
-      "padding": "/.+/",
-      "/.+/": "--unknown-value"
+  "declaration-property-value-no-unknown": [
+    true,
+    {
+      "ignoreProperties": {
+        "top": ["unknown"],
+        "/^margin-/": "/^--foo/",
+        "padding": "/.+/",
+        "/.+/": "--unknown-value"
+      }
     }
-  }
+  ]
 }
 ```
 

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -37,6 +37,12 @@ Prior art:
 
 ### `true`
 
+```json
+{
+  "declaration-property-value-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -71,10 +77,14 @@ Given:
 
 ```json
 {
-  "top": ["unknown"],
-  "/^margin-/": "/^--foo/",
-  "padding": "/.+/",
-  "/.+/": "--unknown-value"
+  "declaration-property-value-no-unknown": [true, {
+    "ignoreProperties": {
+      "top": ["unknown"],
+      "/^margin-/": "/^--foo/",
+      "padding": "/.+/",
+      "/.+/": "--unknown-value"
+    }
+  }
 }
 ```
 
@@ -107,7 +117,12 @@ Extend or alter the properties syntax dictionary. [CSS Value Definition Syntax](
 Given:
 
 ```json
-{ "size": "<length-percentage>" }
+{
+  "declaration-property-value-no-unknown": [
+    true,
+    { "size": "<length-percentage>" }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -132,8 +147,13 @@ Given:
 
 ```json
 {
-  "propertiesSyntax": { "top": "| <--foo()>" },
-  "typesSyntax": { "--foo()": "--foo( <length-percentage> )" }
+  "declaration-property-value-no-unknown": [
+    true,
+    {
+      "propertiesSyntax": { "top": "| <--foo()>" },
+      "typesSyntax": { "--foo()": "--foo( <length-percentage> )" }
+    }
+  ]
 }
 ```
 

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -73,13 +73,13 @@ a { top: var(--foo); }
 
 ```json
 {
-  "ignoreProperties": {
-    "property": ["array", "of", "property-values", "/regex/"]
-  }
+  "ignoreProperties": { "property-name": ["array", "of", "values", "/regex/"] }
 }
 ```
 
 Ignore the specified property and value pairs. Keys in the object indicate property names.
+
+You can specify a regex for a property name, such as `{ "/^margin/": [] }`.
 
 Given:
 
@@ -90,9 +90,9 @@ Given:
     {
       "ignoreProperties": {
         "top": ["unknown"],
-        "/^margin-/": "/^--foo/",
-        "padding": "/.+/",
-        "/.+/": "--unknown-value"
+        "/^margin-/": ["/^--foo/"],
+        "padding": ["/.+/"],
+        "/.+/": ["--unknown-value"]
       }
     }
   ]

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -187,5 +187,3 @@ a { top: --foo(0); }
 ```css
 a { top: --foo(10px); }
 ```
-
-See also [how to configure rules](../../../docs/user-guide/configure.md#rules).

--- a/lib/rules/font-family-name-quotes/README.md
+++ b/lib/rules/font-family-name-quotes/README.md
@@ -19,8 +19,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"always-where-required"|"always-where-recommended"|"always-unless-keyword"`
-
 _Please read the following to understand these options_:
 
 - The `font` and `font-family` properties accept a short list of special **keywords**: `inherit`, `serif`, `sans-serif`, `cursive`, `fantasy`, `system-ui`, `monospace`, `ui-serif`, `ui-sans-serif`, `ui-monospace`, `ui-rounded`, `emoji`, `math` and `fangsong`. If you wrap these words in quotes, the browser will not interpret them as keywords, but will instead look for a font by that name (e.g. will look for a `"sans-serif"` font) -- which is almost _never_ what you want. Instead, you use these keywords to point to the built-in, generic fallbacks (right?). Therefore, _all of the options below enforce no quotes around these keywords_. (If you actually want to use a font named `"sans-serif"`, turn this rule off.)
@@ -36,6 +34,12 @@ For more on these subtleties, read ["Unquoted font family names in CSS"](https:/
 ### `"always-unless-keyword"`
 
 Expect quotes around every font family name that is not a keyword.
+
+```json
+{
+  "font-family-name-quotes": "always-unless-keyword"
+}
+```
 
 The following patterns are considered problems:
 
@@ -74,6 +78,12 @@ a { font: 1em 'Arial', sans-serif; }
 ### `"always-where-required"`
 
 Expect quotes only when quotes are _required_ according to the criteria above, and disallow quotes in all other cases.
+
+```json
+{
+  "font-family-name-quotes": "always-where-required"
+}
+```
 
 The following patterns are considered problems:
 
@@ -117,6 +127,12 @@ a { font: 1em Arial, sans-serif; }
 ### `"always-where-recommended"`
 
 Expect quotes only when quotes are _recommended_ according to the criteria above, and disallow quotes in all other cases. (This includes all cases where quotes are _required_, as well.)
+
+```json
+{
+  "font-family-name-quotes": "always-where-recommended"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/font-family-no-duplicate-names/README.md
+++ b/lib/rules/font-family-no-duplicate-names/README.md
@@ -64,7 +64,11 @@ a { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif; }
 
 ## Optional secondary options
 
-### `ignoreFontFamilyNames: ["/regex/", /regex/, "string"]`
+### `ignoreFontFamilyNames`
+
+```json
+{ "ignoreFontFamilyNames": ["array", "of", "font-family-names", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/font-family-no-duplicate-names/README.md
+++ b/lib/rules/font-family-no-duplicate-names/README.md
@@ -22,6 +22,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "font-family-no-duplicate-names": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -63,7 +69,12 @@ a { font: normal 14px/32px -apple-system, BlinkMacSystemFont, sans-serif; }
 Given:
 
 ```json
-["/^My Font /", "monospace"]
+{
+  "font-family-no-duplicate-names": [
+    true,
+    { "ignoreFontFamilyNames": ["/^My Font /", "monospace"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -72,7 +72,11 @@ a { font-family: Helvetica, var(--font-family-common); }
 
 ## Optional secondary options
 
-### `ignoreFontFamilies: ["/regex/", /regex/, "string"]`
+### `ignoreFontFamilies`
+
+```json
+{ "ignoreFontFamilies": ["array", "of", "font-families", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -20,6 +20,12 @@ This rule checks the `font` and `font-family` properties.
 
 ### `true`
 
+```json
+{
+  "font-family-no-missing-generic-family-keyword": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -71,7 +77,11 @@ a { font-family: Helvetica, var(--font-family-common); }
 Given:
 
 ```json
-["custom-font"]
+{
+  "font-family-no-missing-generic-family-keyword": [true, {
+    "ignoreFontFamilies": ["custom-font"]
+  }
+}
 ```
 
 The following pattern is _not_ considered a problem:

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -78,9 +78,12 @@ Given:
 
 ```json
 {
-  "font-family-no-missing-generic-family-keyword": [true, {
-    "ignoreFontFamilies": ["custom-font"]
-  }
+  "font-family-no-missing-generic-family-keyword": [
+    true,
+    {
+      "ignoreFontFamilies": ["custom-font"]
+    }
+  ]
 }
 ```
 

--- a/lib/rules/font-weight-notation/README.md
+++ b/lib/rules/font-weight-notation/README.md
@@ -23,11 +23,15 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"numeric"|"named-where-possible"`
-
 ### `"numeric"`
 
 `font-weight` values _must always_ be numbers.
+
+```json
+{
+  "font-weight-notation": "numeric"
+}
+```
 
 The following patterns are considered problems:
 
@@ -67,6 +71,12 @@ a { font: italic 400 20px; }
 
 `font-weight` values _must always_ be keywords when an appropriate keyword is available.
 
+```json
+{
+  "font-weight-notation": "named-where-possible"
+}
+```
+
 This means that only `400` and `700` will be rejected, because those are the only numbers with keyword equivalents (`normal` and `bold`).
 
 The following patterns are considered problems:
@@ -98,6 +108,12 @@ a { font: italic normal 20px sans-serif; }
 ### `ignore: ["relative"]`
 
 Ignore the [_relative_](https://drafts.csswg.org/css-fonts/#font-weight-prop) keyword names of `bolder` and `lighter`.
+
+```json
+{
+  "font-weight-notation": ["numeric", { "ignore": ["relative"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/font-weight-notation/README.md
+++ b/lib/rules/font-weight-notation/README.md
@@ -105,9 +105,17 @@ a { font: italic normal 20px sans-serif; }
 
 ## Optional secondary options
 
-### `ignore: ["relative"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
+
+#### `"relative"`
 
 Ignore the [_relative_](https://drafts.csswg.org/css-fonts/#font-weight-prop) keyword names of `bolder` and `lighter`.
+
+Given:
 
 ```json
 {

--- a/lib/rules/function-allowed-list/README.md
+++ b/lib/rules/function-allowed-list/README.md
@@ -17,9 +17,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "functions", "/regex/"]
 ```
 
-If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
+You can also specify a single function instead of an array of them.
 
-You can also specify a single function or a regular expression instead of an array of them.
+If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
 
 Given:
 

--- a/lib/rules/function-allowed-list/README.md
+++ b/lib/rules/function-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "functions", "/regex/"]
 ```

--- a/lib/rules/function-allowed-list/README.md
+++ b/lib/rules/function-allowed-list/README.md
@@ -17,10 +17,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "functions", "/regex/"]
 ```
 
-You can also specify a single function instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
-
 Given:
 
 ```json
@@ -82,7 +78,19 @@ a {
 
 ## Optional secondary options
 
-### `exceptWithoutPropertyFallback`: `["array", "of", "unprefixed", /functions/, "/regex/"]|"function"|"/regex/"|/regex/`
+### `exceptWithoutPropertyFallback`
+
+```json
+{
+  "exceptWithoutPropertyFallback": [
+    "array",
+    "of",
+    "unprefixed",
+    "functions",
+    "/regex/"
+  ]
+}
+```
 
 Disallow the matching functions when they are without a property fallback in the same declaration block.
 

--- a/lib/rules/function-allowed-list/README.md
+++ b/lib/rules/function-allowed-list/README.md
@@ -13,14 +13,20 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /functions/, "/regex/"]|"function"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "functions", "/regex/"]
+```
 
 If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
+
+You can also specify a single function or a regular expression instead of an array of them.
 
 Given:
 
 ```json
-["scale", "rgba", "/linear-gradient/"]
+{
+  "function-allowed-list": ["scale", "rgba", "/linear-gradient/"]
+}
 ```
 
 The following patterns are considered problems:
@@ -83,10 +89,13 @@ Disallow the matching functions when they are without a property fallback in the
 Given:
 
 ```json
-["min", "/max/"]
+{
+  "function-allowed-list": [
+    ["scale", "min", "/max/"],
+    { "exceptWithoutPropertyFallback": ["min", "/max/"] }
+  ]
+}
 ```
-
-For example, with `["scale", "min", "/max/"]` as the primary option.
 
 The following patterns are considered problems:
 

--- a/lib/rules/function-calc-no-unspaced-operator/README.md
+++ b/lib/rules/function-calc-no-unspaced-operator/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "function-calc-no-unspaced-operator": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/function-disallowed-list/README.md
+++ b/lib/rules/function-disallowed-list/README.md
@@ -17,9 +17,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "functions", "/regex/"]
 ```
 
-If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
+You can also specify a single function instead of an array of them.
 
-You can also specify a single function or a regular expression instead of an array of them.
+If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
 
 Given:
 

--- a/lib/rules/function-disallowed-list/README.md
+++ b/lib/rules/function-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "functions", "/regex/"]
 ```

--- a/lib/rules/function-disallowed-list/README.md
+++ b/lib/rules/function-disallowed-list/README.md
@@ -13,14 +13,20 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /functions/, "regex"]|"function"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "functions", "/regex/"]
+```
 
 If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
+
+You can also specify a single function or a regular expression instead of an array of them.
 
 Given:
 
 ```json
-["scale", "rgba", "linear-gradient"]
+{
+  "function-disallowed-list": ["scale", "rgba", "/linear-gradient/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/function-disallowed-list/README.md
+++ b/lib/rules/function-disallowed-list/README.md
@@ -17,10 +17,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "functions", "/regex/"]
 ```
 
-You can also specify a single function instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/^rgb/"`), it is interpreted as a regular expression.
-
 Given:
 
 ```json

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
@@ -27,6 +27,12 @@ We recommend using these rules for CSS and this rule for CSS-like languages, suc
 
 ### `true`
 
+```json
+{
+  "function-linear-gradient-no-nonstandard-direction": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/function-name-case/README.md
+++ b/lib/rules/function-name-case/README.md
@@ -17,9 +17,13 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"lower"|"upper"`
-
 ### `"lower"`
+
+```json
+{
+  "function-name-case": "lower"
+}
+```
 
 The following patterns are considered problems:
 
@@ -68,6 +72,12 @@ a {
 ```
 
 ### `"upper"`
+
+```json
+{
+  "function-name-case": "upper"
+}
+```
 
 The following patterns are considered problems:
 
@@ -121,12 +131,15 @@ a {
 
 Ignore case of function names.
 
-For example, with `"lower"`.
-
 Given:
 
 ```json
-["--some-function", "/^--get.*$/"]
+{
+  "function-name-case": [
+    "lower",
+    { "ignoreFunctions": ["--some-function", "/^--get.*$/"] }
+  ]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/function-name-case/README.md
+++ b/lib/rules/function-name-case/README.md
@@ -127,7 +127,11 @@ a {
 
 ## Optional secondary options
 
-### `ignoreFunctions: ["/regex/", /regex/, "non-regex"]`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
 
 Ignore case of function names.
 

--- a/lib/rules/function-no-unknown/README.md
+++ b/lib/rules/function-no-unknown/README.md
@@ -26,6 +26,12 @@ We recommend using these rules for CSS and this rule for CSS-like languages, suc
 
 ### `true`
 
+```json
+{
+  "function-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -51,12 +57,12 @@ a { transform: --custom-function(1); }
 
 Ignore the specified functions.
 
-For example, with `true`.
-
 Given:
 
 ```json
-["theme", "/^foo-/"]
+{
+  "function-no-unknown": [true, { "ignoreFunctions": ["theme", "/^foo-/"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/function-no-unknown/README.md
+++ b/lib/rules/function-no-unknown/README.md
@@ -53,7 +53,11 @@ a { transform: --custom-function(1); }
 
 ## Optional secondary options
 
-### `ignoreFunctions: ["/regex/", /regex/, "non-regex"]`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
 
 Ignore the specified functions.
 

--- a/lib/rules/function-url-no-scheme-relative/README.md
+++ b/lib/rules/function-url-no-scheme-relative/README.md
@@ -17,6 +17,12 @@ This rule ignores url arguments that are variables (`$sass`, `@less`, `--custom-
 
 ### `true`
 
+```json
+{
+  "function-url-no-scheme-relative": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/function-url-quotes/README.md
+++ b/lib/rules/function-url-quotes/README.md
@@ -98,7 +98,13 @@ a { background: url(x.jpg); }
 
 ## Optional secondary options
 
-### `except: ["empty"]`
+### `except`
+
+```json
+{ "except": ["array", "of", "options"] }
+```
+
+#### `"empty"`
 
 Reverse the primary option for functions that have no arguments.
 

--- a/lib/rules/function-url-quotes/README.md
+++ b/lib/rules/function-url-quotes/README.md
@@ -13,11 +13,15 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
 
 Urls _must always_ be quoted.
+
+```json
+{
+  "function-url-quotes": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -51,6 +55,12 @@ a { background: url('x.jpg'); }
 ### `"never"`
 
 Urls _must never_ be quoted.
+
+```json
+{
+  "function-url-quotes": "never"
+}
+```
 
 The following patterns are considered problems:
 
@@ -92,7 +102,13 @@ a { background: url(x.jpg); }
 
 Reverse the primary option for functions that have no arguments.
 
-For example, with `"always"`.
+Given:
+
+```json
+{
+  "function-url-quotes": ["always", { "except": ["empty"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/function-url-scheme-allowed-list/README.md
+++ b/lib/rules/function-url-scheme-allowed-list/README.md
@@ -24,8 +24,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "schemes", "/regex/"]
 ```
 
-You can also specify a single scheme or a regular expression instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/function-url-scheme-allowed-list/README.md
+++ b/lib/rules/function-url-scheme-allowed-list/README.md
@@ -20,12 +20,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", /schemes/, "/regex/"]|"scheme"|"/regex/"|/regex/`
+```json
+["array", "of", "schemes", "/regex/"]
+```
+
+You can also specify a single scheme or a regular expression instead of an array of them.
 
 Given:
 
 ```json
-["data", "/^http/"]
+{
+  "function-url-scheme-allowed-list": ["data", "/^http/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/function-url-scheme-allowed-list/README.md
+++ b/lib/rules/function-url-scheme-allowed-list/README.md
@@ -20,6 +20,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "schemes", "/regex/"]
 ```

--- a/lib/rules/function-url-scheme-disallowed-list/README.md
+++ b/lib/rules/function-url-scheme-disallowed-list/README.md
@@ -20,6 +20,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "schemes", "/regex/"]
 ```

--- a/lib/rules/function-url-scheme-disallowed-list/README.md
+++ b/lib/rules/function-url-scheme-disallowed-list/README.md
@@ -24,8 +24,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "schemes", "/regex/"]
 ```
 
-You can also specify a single scheme instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/function-url-scheme-disallowed-list/README.md
+++ b/lib/rules/function-url-scheme-disallowed-list/README.md
@@ -24,7 +24,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "schemes", "/regex/"]
 ```
 
-You can also specify a single scheme or a regular expression instead of an array of them.
+You can also specify a single scheme instead of an array of them.
 
 Given:
 

--- a/lib/rules/function-url-scheme-disallowed-list/README.md
+++ b/lib/rules/function-url-scheme-disallowed-list/README.md
@@ -20,12 +20,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", /schemes/, "/regex/"]|"scheme"|"/regex/"|/regex/`
+```json
+["array", "of", "schemes", "/regex/"]
+```
+
+You can also specify a single scheme or a regular expression instead of an array of them.
 
 Given:
 
 ```json
-["ftp", "/^http/"]
+{
+  "function-url-scheme-disallowed-list": ["ftp", "/^http/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/hue-degree-notation/README.md
+++ b/lib/rules/hue-degree-notation/README.md
@@ -17,11 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"angle"|"number"`
-
 ### `"angle"`
 
 Degree hues _must always_ use angle notation.
+
+```json
+{
+  "hue-degree-notation": "angle"
+}
+```
 
 The following patterns are considered problems:
 
@@ -50,6 +54,12 @@ a { color: lch(56.29% 19.86 10deg / 15%) }
 ### `"number"`
 
 Degree hues _must always_ use the number notation.
+
+```json
+{
+  "hue-degree-notation": "number"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/import-notation/README.md
+++ b/lib/rules/import-notation/README.md
@@ -15,11 +15,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"string"|"url"`
-
 ### `"string"`
 
 `@import` rules _must always_ use string notation.
+
+```json
+{
+  "import-notation": "string"
+}
+```
 
 The following patterns are considered problems:
 
@@ -53,6 +57,12 @@ The following patterns are _not_ considered problems:
 ### `"url"`
 
 `@import` rules _must always_ use URL notation.
+
+```json
+{
+  "import-notatin": "url"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/keyframe-block-no-duplicate-selectors/README.md
+++ b/lib/rules/keyframe-block-no-duplicate-selectors/README.md
@@ -17,6 +17,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "keyframe-block-no-duplicate-selectors": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/keyframe-declaration-no-important/README.md
+++ b/lib/rules/keyframe-declaration-no-important/README.md
@@ -18,6 +18,12 @@ Using `!important` within keyframes declarations is [completely ignored in some 
 
 ### `true`
 
+```json
+{
+  "keyframe-declaration-no-important": true
+}
+```
+
 The following pattern is considered a problem:
 
 <!-- prettier-ignore -->

--- a/lib/rules/keyframe-selector-notation/README.md
+++ b/lib/rules/keyframe-selector-notation/README.md
@@ -17,11 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"keyword"|"percentage"|"percentage-unless-within-keyword-only-block"`
-
 ### `"keyword"`
 
 Keyframe selectors _must always_ use the keyword notation.
+
+```json
+{
+  "keyframe-selector-notation": "keyword"
+}
+```
 
 The following pattern is considered a problem:
 
@@ -41,6 +45,12 @@ The following pattern is _not_ considered a problem:
 
 Keyframe selectors _must always_ use the percentage notation.
 
+```json
+{
+  "keyframe-selector-notation": "percentage"
+}
+```
+
 The following pattern is considered a problem:
 
 <!-- prettier-ignore -->
@@ -58,6 +68,12 @@ The following pattern is _not_ considered a problem:
 ### `"percentage-unless-within-keyword-only-block"`
 
 Keyframe selectors _must_ use the percentage notation unless within a keyword-only block.
+
+```json
+{
+  "keyframe-selector-notation": "percentage-unless-within-keyword-only-block"
+}
+```
 
 The following pattern is considered a problem:
 

--- a/lib/rules/keyframes-name-pattern/README.md
+++ b/lib/rules/keyframes-name-pattern/README.md
@@ -13,9 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/keyframes-name-pattern/README.md
+++ b/lib/rules/keyframes-name-pattern/README.md
@@ -15,7 +15,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/keyframes-name-pattern/README.md
+++ b/lib/rules/keyframes-name-pattern/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 Given:

--- a/lib/rules/keyframes-name-pattern/README.md
+++ b/lib/rules/keyframes-name-pattern/README.md
@@ -13,9 +13,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string not surrounded with `"/"`.
 
-Given the string:
+Given:
 
 ```json
 {

--- a/lib/rules/keyframes-name-pattern/README.md
+++ b/lib/rules/keyframes-name-pattern/README.md
@@ -13,14 +13,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
+
+If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
 
 Given the string:
 
 ```json
-"foo-.+"
+{
+  "keyframes-name-pattern": "foo-.+"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/layer-name-pattern/README.md
+++ b/lib/rules/layer-name-pattern/README.md
@@ -13,11 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/layer-name-pattern/README.md
+++ b/lib/rules/layer-name-pattern/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 Given:

--- a/lib/rules/layer-name-pattern/README.md
+++ b/lib/rules/layer-name-pattern/README.md
@@ -13,9 +13,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string not surrounded with `"/"`.
 
-Given the string:
+Given:
 
 ```json
 {

--- a/lib/rules/layer-name-pattern/README.md
+++ b/lib/rules/layer-name-pattern/README.md
@@ -17,7 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
-If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
 
 Given the string:
 

--- a/lib/rules/layer-name-pattern/README.md
+++ b/lib/rules/layer-name-pattern/README.md
@@ -17,10 +17,14 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
+If configuring this rule in JavaScript, you can use a regular expression directly, such as `/yourPattern/`.
+
 Given the string:
 
 ```json
-"^[a-z][a-z0-9.-]*$"
+{
+  "layer-name-pattern": "^[a-z][a-z0-9.-]*$"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/length-zero-no-unit/README.md
+++ b/lib/rules/length-zero-no-unit/README.md
@@ -61,7 +61,11 @@ a { top: 1.001vh }
 
 ## Optional secondary options
 
-### `ignore: ["custom-properties"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
 
 #### `"custom-properties"`
 
@@ -80,7 +84,11 @@ The following pattern is _not_ considered a problem:
 a { --x: 0px; }
 ```
 
-### `ignoreFunctions: ["/regex/", /regex/, "string"]`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
 
 Ignore units for zero lengths within the specified functions.
 
@@ -104,7 +112,13 @@ a { top: var(--foo, 0px); }
 a { top: --bar(0px); }
 ```
 
-### `ignorePreludeOfAtRules: ["/regex/", /regex/, "string"]`
+### `ignorePreludeOfAtRules`
+
+```json
+{
+  "ignorePreludeOfAtRules": ["array", "of", "at-rules", "/regex/"]
+}
+```
 
 Ignore units for zero lengths within the preludes of the specified at-rules.
 

--- a/lib/rules/length-zero-no-unit/README.md
+++ b/lib/rules/length-zero-no-unit/README.md
@@ -19,6 +19,12 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ### `true`
 
+```json
+{
+  "length-zero-no-unit": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -59,7 +65,13 @@ a { top: 1.001vh }
 
 #### `"custom-properties"`
 
-Ignore units for zero length in custom properties.
+Ignore units for zero lengths in custom properties.
+
+```json
+{
+  "length-zero-no-unit": [true, { "ignore": ["custom-properties"] }]
+}
+```
 
 The following pattern is _not_ considered a problem:
 
@@ -70,10 +82,14 @@ a { --x: 0px; }
 
 ### `ignoreFunctions: ["/regex/", /regex/, "string"]`
 
+Ignore units for zero lengths within the specified functions.
+
 Given:
 
 ```json
-["var", "/^--/"]
+{
+  "length-zero-no-unit": [true, { "ignoreFunctions": ["var", "/^--/"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -95,7 +111,12 @@ Ignore units for zero lengths within the preludes of the specified at-rules.
 Given:
 
 ```json
-["media", "/^--bar/"]
+{
+  "length-zero-no-unit": [
+    true,
+    { "ignorePreludeOfAtRules": ["media", "/^--bar/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/lightness-notation/README.md
+++ b/lib/rules/lightness-notation/README.md
@@ -17,11 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"percentage"|"number"`
-
 ### `"percentage"`
 
 Lightness _must always_ use the percentage notation.
+
+```json
+{
+  "lightness-notation": "percentage"
+}
+```
 
 The following patterns are considered problems:
 
@@ -70,6 +74,12 @@ a { color: lab(86% 0.2 154) }
 ### `"number"`
 
 Lightness _must always_ use the number notation.
+
+```json
+{
+  "lightness-notation": "number"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -395,6 +395,8 @@ a {
 
 Ignore the specified pseudo-classes.
 
+Given:
+
 ```json
 {
   "max-nesting-depth": [1, { "ignorePseudoClasses": ["hover", "^focus-"] }]

--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -52,6 +52,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum nesting depth allowed.
 
 Given:

--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -112,7 +112,13 @@ a .foo__foo .bar .baz {}
 
 ## Optional secondary options
 
-### `ignore: ["blockless-at-rules"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
+
+#### `"blockless-at-rules"`
 
 Ignore at-rules that only wrap other rules, and do not themselves have declaration blocks.
 
@@ -175,7 +181,7 @@ a {
 }
 ```
 
-### `ignore: ["pseudo-classes"]`
+#### `"pseudo-classes"`
 
 Ignore rules where the first selector in each selector list item is a pseudo-class
 
@@ -299,7 +305,11 @@ a {
 }
 ```
 
-### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
 
 Ignore the specified at-rules.
 
@@ -377,7 +387,11 @@ a {
 }
 ```
 
-### `ignorePseudoClasses: ["/regex/", /regex/, "string"]`
+### `ignorePseudoClasses`
+
+```json
+{ "ignorePseudoClasses": ["array", "of", "pseudo-classes", "/regex/"] }
+```
 
 Ignore the specified pseudo-classes.
 
@@ -435,7 +449,11 @@ a {
 }
 ```
 
-### `ignoreRules: ["/regex/", /regex/, "string"]`
+### `ignoreRules`
+
+```json
+{ "ignoreRules": ["array", "of", "selectors", "/regex/"] }
+```
 
 Ignore rules matching with the specified selectors.
 

--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -52,9 +52,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum nesting depth allowed.
+Specify a maximum nesting depth allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "max-nesting-depth": 2
+}
+```
 
 The following patterns are considered problems:
 
@@ -110,7 +116,13 @@ a .foo__foo .bar .baz {}
 
 Ignore at-rules that only wrap other rules, and do not themselves have declaration blocks.
 
-For example, with `1`:
+Given:
+
+```json
+{
+  "max-nesting-depth": [1, { "ignore": ["blockless-at-rules"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -167,7 +179,13 @@ a {
 
 Ignore rules where the first selector in each selector list item is a pseudo-class
 
-For example, with `1`:
+Given:
+
+```json
+{
+  "max-nesting-depth": [1, { "ignore": ["pseudo-classes"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -285,10 +303,12 @@ a {
 
 Ignore the specified at-rules.
 
-For example, with `1` and given:
+Given:
 
 ```json
-["/^--my-/", "media"]
+{
+  "max-nesting-depth": [1, { "ignoreAtRules": ["/^--my-/", "media"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -361,10 +381,10 @@ a {
 
 Ignore the specified pseudo-classes.
 
-For example, with `1` and given:
-
 ```json
-["hover", "^focus-"]
+{
+  "max-nesting-depth": [1, { "ignorePseudoClasses": ["hover", "^focus-"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -419,10 +439,15 @@ a {
 
 Ignore rules matching with the specified selectors.
 
-For example, with `1` and given:
+Given:
 
 ```json
-[".my-selector", "/^.ignored-sel/"]
+{
+  "max-nesting-depth": [
+    1,
+    { "ignoreRules": [".my-selector", "/^.ignored-sel/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/media-feature-name-allowed-list/README.md
+++ b/lib/rules/media-feature-name-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "media-features", "/regex/"]
 ```

--- a/lib/rules/media-feature-name-allowed-list/README.md
+++ b/lib/rules/media-feature-name-allowed-list/README.md
@@ -13,12 +13,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /media-features/, "regex"]|"media-feature"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "media-features", "/regex/"]
+```
 
 Given:
 
 ```json
-["max-width", "/^my-/"]
+{
+  "media-feature-name-allowed-list": ["max-width", "/^my-/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/media-feature-name-disallowed-list/README.md
+++ b/lib/rules/media-feature-name-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "media-features", "/regex/"]
 ```

--- a/lib/rules/media-feature-name-disallowed-list/README.md
+++ b/lib/rules/media-feature-name-disallowed-list/README.md
@@ -13,12 +13,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /media-features/, "regex"]|"media-feature"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "media-features", "/regex/"]
+```
 
 Given:
 
 ```json
-["max-width", "/^my-/"]
+{
+  "media-feature-name-disallowed-list": ["max-width", "/^my-/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/media-feature-name-no-unknown/README.md
+++ b/lib/rules/media-feature-name-no-unknown/README.md
@@ -71,7 +71,11 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `ignoreMediaFeatureNames: ["/regex/", /regex/, "string"]`
+### `ignoreMediaFeatureNames`
+
+```json
+{ "ignoreMediaFeatureNames": ["array", "of", "media-features", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/media-feature-name-no-unknown/README.md
+++ b/lib/rules/media-feature-name-no-unknown/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "media-feature-name-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -70,7 +76,12 @@ The following patterns are _not_ considered problems:
 Given:
 
 ```json
-["/^my-/", "custom"]
+{
+  "media-feature-name-no-unknown": [
+    true,
+    { "ignoreMediaFeatureNames": ["/^my-/", "custom"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/lib/rules/media-feature-name-no-vendor-prefix/README.md
@@ -17,6 +17,12 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ### `true`
 
+```json
+{
+  "media-feature-name-no-vendor-prefix": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/media-feature-name-unit-allowed-list/README.md
+++ b/lib/rules/media-feature-name-unit-allowed-list/README.md
@@ -13,7 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "name": ["array", "of", "units"]|"unit" }`
+```json
+{ "media-feature-name": ["array", "of", "units"] }
+```
+
+You can also specify a single unit instead of an array of them.
 
 If a feature name is surrounded with `"/"` (e.g. `"/height/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/height/` will match `height`, `min-height`, `max-height`, etc.
 
@@ -21,8 +25,10 @@ Given:
 
 ```json
 {
-  "width": "em",
-  "/height/": ["em", "rem"]
+  "media-feature-name-unit-allowed-list": {
+    "width": "em",
+    "/height/": ["em", "rem"]
+  }
 }
 ```
 

--- a/lib/rules/media-feature-name-unit-allowed-list/README.md
+++ b/lib/rules/media-feature-name-unit-allowed-list/README.md
@@ -17,9 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "media-feature-name": ["array", "of", "units"] }
 ```
 
-You can also specify a single unit instead of an array of them.
-
-If a feature name is surrounded with `"/"` (e.g. `"/height/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/height/` will match `height`, `min-height`, `max-height`, etc.
+You can specify a regex for a media feature name, such as `{ "/height$/": [] }`.
 
 Given:
 

--- a/lib/rules/media-feature-name-unit-allowed-list/README.md
+++ b/lib/rules/media-feature-name-unit-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 { "media-feature-name": ["array", "of", "units"] }
 ```

--- a/lib/rules/media-feature-name-value-allowed-list/README.md
+++ b/lib/rules/media-feature-name-value-allowed-list/README.md
@@ -17,13 +17,10 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "unprefixed-media-feature-name": ["array", "of", "values", "/regex/"] }
 ```
 
-You can also specify a single value instead of an array of them.
+You can specify a regex for a media feature name, such as `{ "/width$/": [] }`.
 
 If a media feature name is found in the object, only its allowed-listed values are
 allowed. If the media feature name is not included in the object, anything goes.
-
-If a name or value is surrounded with `/` (e.g. `"/width$/"`), it is interpreted
-as a regular expression. For example, `/width$/` will match `max-width` and `min-width`.
 
 Given:
 
@@ -31,7 +28,7 @@ Given:
 {
   "media-feature-name-value-allowed-list": {
     "min-width": ["768px", "1024px"],
-    "/resolution/": "/dpcm$/"
+    "/resolution/": ["/dpcm$/"]
   }
 }
 ```

--- a/lib/rules/media-feature-name-value-allowed-list/README.md
+++ b/lib/rules/media-feature-name-value-allowed-list/README.md
@@ -13,7 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "unprefixed-media-feature-name": ["array", "of", "values", "/regex/", /regex/]|"value"|"/regex/"|/regex/ }`
+```json
+{ "unprefixed-media-feature-name": ["array", "of", "values", "/regex/"] }
+```
+
+You can also specify a single value instead of an array of them.
 
 If a media feature name is found in the object, only its allowed-listed values are
 allowed. If the media feature name is not included in the object, anything goes.
@@ -25,8 +29,10 @@ Given:
 
 ```json
 {
-  "min-width": ["768px", "1024px"],
-  "/resolution/": "/dpcm$/"
+  "media-feature-name-value-allowed-list": {
+    "min-width": ["768px", "1024px"],
+    "/resolution/": "/dpcm$/"
+  }
 }
 ```
 

--- a/lib/rules/media-feature-name-value-allowed-list/README.md
+++ b/lib/rules/media-feature-name-value-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Object<string, Array<string>>`
+
 ```json
 { "unprefixed-media-feature-name": ["array", "of", "values", "/regex/"] }
 ```

--- a/lib/rules/media-feature-name-value-no-unknown/README.md
+++ b/lib/rules/media-feature-name-value-no-unknown/README.md
@@ -25,6 +25,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "media-feature-name-value-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/media-feature-range-notation/README.md
+++ b/lib/rules/media-feature-range-notation/README.md
@@ -19,11 +19,15 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"context"|"prefix"`
-
 ### `"context"`
 
 Media feature ranges _must always_ use context notation.
+
+```json
+{
+  "media-feature-range-notation": "context"
+}
+```
 
 The following patterns are considered problems:
 
@@ -52,6 +56,12 @@ The following patterns are _not_ considered problems:
 ### `"prefix"`
 
 Media feature ranges _must always_ use prefix notation.
+
+```json
+{
+  "media-feature-range-notation": "prefix"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/media-query-no-invalid/README.md
+++ b/lib/rules/media-query-no-invalid/README.md
@@ -24,6 +24,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "media-query-no-invalid": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -72,7 +78,12 @@ Ignore the specified functions.
 Given:
 
 ```json
-["theme", "/^get.*$/"]
+{
+  "media-query-no-invalid": [
+    true,
+    { "ignoreFunctions": ["theme", "/^get.*$/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/media-query-no-invalid/README.md
+++ b/lib/rules/media-query-no-invalid/README.md
@@ -71,7 +71,11 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `ignoreFunctions: ["/regex/", /regex/, "string"]`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
 
 Ignore the specified functions.
 

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -22,6 +22,12 @@ And all named grid areas that spans multiple grid cells must form a single fille
 
 ### `true`
 
+```json
+{
+  "named-grid-areas-no-invalid": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -96,6 +96,12 @@ This may lead to confusion because both rules contain different declarations and
 
 ### `true`
 
+```json
+{
+  "no-descending-specificity": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -189,6 +195,12 @@ a { top: 10px; }
 ### `ignore: ["selectors-within-list"]`
 
 Ignores selectors within list of selectors.
+
+```json
+{
+  "no-descending-specificity": [true, { "ignore": ["selectors-within-list"] }]
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -192,7 +192,13 @@ a { top: 10px; }
 
 ## Optional secondary options
 
-### `ignore: ["selectors-within-list"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
+
+#### `"selectors-within-list"`
 
 Ignores selectors within list of selectors.
 

--- a/lib/rules/no-duplicate-at-import-rules/README.md
+++ b/lib/rules/no-duplicate-at-import-rules/README.md
@@ -16,6 +16,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "no-duplicate-at-import-rules": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/no-duplicate-selectors/README.md
+++ b/lib/rules/no-duplicate-selectors/README.md
@@ -28,6 +28,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "no-duplicate-selectors": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -121,7 +127,13 @@ a {
 
 This option will also disallow duplicate selectors within selector lists.
 
-For example, with `true`.
+Given:
+
+```json
+{
+  "no-duplicate-selectors": [true, { "disallowInList": true }]
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/no-duplicate-selectors/README.md
+++ b/lib/rules/no-duplicate-selectors/README.md
@@ -123,9 +123,9 @@ a {
 
 ## Optional secondary options
 
-### `disallowInList: true | false` (default: `false`)
+### `disallowInList`
 
-This option will also disallow duplicate selectors within selector lists.
+This option will also disallow duplicate selectors within selector lists. Defaults to `false`.
 
 Given:
 

--- a/lib/rules/no-empty-source/README.md
+++ b/lib/rules/no-empty-source/README.md
@@ -13,6 +13,12 @@ A source containing only whitespace, e.g., spaces, tabs, or newlines, is conside
 
 ### `true`
 
+```json
+{
+  "no-empty-source": true
+}
+```
+
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/no-invalid-double-slash-comments/README.md
+++ b/lib/rules/no-invalid-double-slash-comments/README.md
@@ -19,6 +19,12 @@ If you are using a preprocessor that allows `//` single-line comments (e.g. Sass
 
 ### `true`
 
+```json
+{
+  "no-invalid-double-slash-comments": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/no-invalid-position-at-import-rule/README.md
+++ b/lib/rules/no-invalid-position-at-import-rule/README.md
@@ -16,6 +16,12 @@ Any `@import` rules must precede all other valid at-rules and style rules in a s
 
 ### `true`
 
+```json
+{
+  "no-invalid-position-at-import-rule": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -63,7 +69,12 @@ a {}
 Given:
 
 ```json
-["/^--my-/", "--custom"]
+{
+  "no-invalid-position-at-import-rule": [
+    true,
+    { "ignoreAtRules": ["/^--my-/", "--custom"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/no-invalid-position-at-import-rule/README.md
+++ b/lib/rules/no-invalid-position-at-import-rule/README.md
@@ -64,7 +64,11 @@ a {}
 
 ## Optional secondary options
 
-### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/no-irregular-whitespace/README.md
+++ b/lib/rules/no-irregular-whitespace/README.md
@@ -13,6 +13,12 @@ Disallow irregular whitespaces.
 
 ### `true`
 
+```json
+{
+  "no-irregular-whitespace": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/no-unknown-animations/README.md
+++ b/lib/rules/no-unknown-animations/README.md
@@ -21,6 +21,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "no-unknown-animations": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/no-unknown-custom-media/README.md
+++ b/lib/rules/no-unknown-custom-media/README.md
@@ -21,6 +21,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "no-unknown-custom-media": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/no-unknown-custom-properties/README.md
+++ b/lib/rules/no-unknown-custom-properties/README.md
@@ -21,6 +21,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "no-unknown-custom-properties": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/number-max-precision/README.md
+++ b/lib/rules/number-max-precision/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum number of decimal places allowed.
 
 Given:

--- a/lib/rules/number-max-precision/README.md
+++ b/lib/rules/number-max-precision/README.md
@@ -54,7 +54,11 @@ a { top: 3.24px; }
 
 ## Optional secondary options
 
-### `ignoreProperties: ["/regex/", /regex/, "string"]`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Ignore the precision of numbers for the specified properties.
 
@@ -80,7 +84,11 @@ The following patterns are _not_ considered problems:
 a { transition: all 4.5s ease; }
 ```
 
-### `ignoreUnits: ["/regex/", /regex/, "string"]`
+### `ignoreUnits`
+
+```json
+{ "ignoreUnits": ["array", "of", "units", "/regex/"] }
+```
 
 Ignore the precision of numbers for values with the specified units.
 
@@ -140,7 +148,13 @@ a {
 }
 ```
 
-### `insideFunctions: {"/regex/": int, /regex/: int, "string": int}`
+### `insideFunctions`
+
+```json
+{ "insideFunctions": { "function-name": 0 } }
+```
+
+You can specify a regex for a function name, such as `{ "/^(oklch|oklab)$/": 0 }`.
 
 The `insideFunctions` option can change a primary option value for specified functions.
 

--- a/lib/rules/number-max-precision/README.md
+++ b/lib/rules/number-max-precision/README.md
@@ -13,9 +13,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum number of decimal places allowed.
+Specify a maximum number of decimal places allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "number-max-precision": 2
+}
+```
 
 The following patterns are considered problems:
 
@@ -52,12 +58,12 @@ a { top: 3.24px; }
 
 Ignore the precision of numbers for the specified properties.
 
-For example, with `0`.
-
 Given:
 
 ```json
-["transition"]
+{
+  "number-max-precision": [0, { "ignoreProperties": ["transition"] }]
+}
 ```
 
 The following patterns are considered problems:
@@ -78,12 +84,12 @@ a { transition: all 4.5s ease; }
 
 Ignore the precision of numbers for values with the specified units.
 
-For example, with `2`.
-
 Given:
 
 ```json
-["/^my-/", "%"]
+{
+  "number-max-precision": [2, { "ignoreUnits": ["/^my-/", "%"] }]
+}
 ```
 
 The following patterns are considered problems:
@@ -138,12 +144,15 @@ a {
 
 The `insideFunctions` option can change a primary option value for specified functions.
 
-For example, with `2`.
-
 Given:
 
 ```json
-{ "/^(oklch|oklab|lch|lab)$/": 4 }
+{
+  "number-max-precision": [
+    2,
+    { "insideFunctions": { "/^(oklch|oklab|lch|lab)$/": 4 } }
+  ]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/property-allowed-list/README.md
+++ b/lib/rules/property-allowed-list/README.md
@@ -15,14 +15,20 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", /properties/, "regex"]|"property"|"/regex/"|/regex/`
+```json
+["array", "of", "properties", "/regex/"]
+```
+
+You can also specify a single property instead of an array of them.
 
 If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 
 Given:
 
 ```json
-["display", "animation", "/^background/", "--foo"]
+{
+  "property-allowed-list": ["display", "animation", "/^background/", "--foo"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/property-allowed-list/README.md
+++ b/lib/rules/property-allowed-list/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "properties", "/regex/"]
 ```

--- a/lib/rules/property-allowed-list/README.md
+++ b/lib/rules/property-allowed-list/README.md
@@ -19,10 +19,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "properties", "/regex/"]
 ```
 
-You can also specify a single property instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
-
 Given:
 
 ```json

--- a/lib/rules/property-disallowed-list/README.md
+++ b/lib/rules/property-disallowed-list/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "properties", "/regex/"]
 ```

--- a/lib/rules/property-disallowed-list/README.md
+++ b/lib/rules/property-disallowed-list/README.md
@@ -15,14 +15,25 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", /properties/, "regex"]|"property"|"/regex/"|/regex/`
+```json
+["array", "of", "properties", "/regex/"]
+```
+
+You can also specify a single property instead of an array of them.
 
 If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
 
 Given:
 
 ```json
-["text-rendering", "animation", "/^background/", "--foo"]
+{
+  "property-disallowed-list": [
+    "text-rendering",
+    "animation",
+    "/^background/",
+    "--foo"
+  ]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/property-disallowed-list/README.md
+++ b/lib/rules/property-disallowed-list/README.md
@@ -19,10 +19,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "properties", "/regex/"]
 ```
 
-You can also specify a single property instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/^background/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^background/` will match `background`, `background-size`, `background-color`, etc.
-
 Given:
 
 ```json

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -26,6 +26,12 @@ For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/con
 
 ### `true`
 
+```json
+{
+  "property-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -86,7 +92,9 @@ a {
 Given:
 
 ```json
-["/^my-/", "custom"]
+{
+  "property-no-unknown": [true, { "ignoreProperties": ["/^my-/", "custom"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -119,7 +127,9 @@ Skips checking properties of the given selectors against this rule.
 Given:
 
 ```json
-[":root"]
+{
+  "property-no-unknown": [true, { "ignoreSelectors": [":root"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -138,7 +148,9 @@ Ignores properties nested within specified at-rules.
 Given:
 
 ```json
-["supports"]
+{
+  "property-no-unknown": [true, { "ignoreAtRules": ["supports"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -156,7 +168,13 @@ The following patterns are _not_ considered problems:
 
 If `true`, this rule will check vendor-prefixed properties.
 
-For example with `true`:
+Given:
+
+```json
+{
+  "property-no-unknown": [true, { "checkPrefixed": true }]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -87,7 +87,11 @@ a {
 
 ## Optional secondary options
 
-### `ignoreProperties: ["/regex/", /regex/, "string"]`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Given:
 
@@ -120,7 +124,11 @@ a {
 }
 ```
 
-### `ignoreSelectors: ["/regex/", /regex/, "string"]`
+### `ignoreSelectors`
+
+```json
+{ "ignoreSelectors": ["array", "of", "selectors", "/regex/"] }
+```
 
 Skips checking properties of the given selectors against this rule.
 
@@ -141,7 +149,11 @@ The following patterns are _not_ considered problems:
 }
 ```
 
-### `ignoreAtRules: ["/regex/", /regex/, "string"]`
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
 
 Ignores properties nested within specified at-rules.
 
@@ -164,9 +176,9 @@ The following patterns are _not_ considered problems:
 }
 ```
 
-### `checkPrefixed: true | false` (default: `false`)
+### `checkPrefixed`
 
-If `true`, this rule will check vendor-prefixed properties.
+If `true`, this rule will check vendor-prefixed properties. Defaults to `false`.
 
 Given:
 

--- a/lib/rules/property-no-vendor-prefix/README.md
+++ b/lib/rules/property-no-vendor-prefix/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "property-no-vendor-prefix": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -55,7 +61,12 @@ a { -webkit-touch-callout: none; }
 Given:
 
 ```json
-["transform", "columns"]
+{
+  "property-no-vendor-prefix": [
+    true,
+    { "ignoreProperties": ["transform", "columns"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/property-no-vendor-prefix/README.md
+++ b/lib/rules/property-no-vendor-prefix/README.md
@@ -56,7 +56,11 @@ a { -webkit-touch-callout: none; }
 
 ## Optional secondary options
 
-### `ignoreProperties: ["/regex/", /regex/, "string"]`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/rule-empty-line-before/README.md
+++ b/lib/rules/rule-empty-line-before/README.md
@@ -153,7 +153,11 @@ b {
 
 ## Optional secondary options
 
-### `except: ["after-rule", "after-single-line-comment", "inside-block-and-after-rule", "inside-block", "first-nested"]`
+### `except`
+
+```json
+{ "except": ["array", "of", "options"] }
+```
 
 #### `"after-rule"`
 
@@ -327,7 +331,11 @@ The following patterns are _not_ considered problems:
 }
 ```
 
-### `ignore: ["after-comment", "first-nested", "inside-block"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
 
 #### `"after-comment"`
 

--- a/lib/rules/rule-empty-line-before/README.md
+++ b/lib/rules/rule-empty-line-before/README.md
@@ -17,11 +17,15 @@ The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fi
 
 ## Options
 
-`string`: `"always"|"never"|"always-multi-line"|"never-multi-line"`
-
 ### `"always"`
 
 There _must always_ be an empty line before rules.
+
+```json
+{
+  "rule-empty-line-before": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -49,6 +53,12 @@ b {}
 
 There _must never_ be an empty line before rules.
 
+```json
+{
+  "rule-empty-line-before": "never"
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -74,6 +84,12 @@ b {}
 ### `"always-multi-line"`
 
 There _must always_ be an empty line before multi-line rules.
+
+```json
+{
+  "rule-empty-line-before": "always-multi-line"
+}
+```
 
 The following patterns are considered problems:
 
@@ -103,6 +119,12 @@ b {
 ### `"never-multi-line"`
 
 There _must never_ be an empty line before multi-line rules.
+
+```json
+{
+  "rule-empty-line-before": "never-multi-line"
+}
+```
 
 The following patterns are considered problems:
 
@@ -137,7 +159,13 @@ b {
 
 Reverse the primary option for rules that follow another rule.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": ["always", { "except": ["after-rule"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -160,7 +188,16 @@ b {}
 
 Reverse the primary option for rules that follow a single-line comment.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": [
+    "always",
+    { "except": ["after-single-line-comment"] }
+  ]
+}
+```
 
 The following patterns are considered problems:
 
@@ -183,7 +220,16 @@ a {}
 
 Reverse the primary option for rules that are inside a block and follow another rule.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": [
+    "always",
+    { "except": ["inside-block-and-after-rule"] }
+  ]
+}
+```
 
 The following patterns are considered problems:
 
@@ -212,7 +258,13 @@ The following patterns are _not_ considered problems:
 
 Reverse the primary option for rules that are inside a block.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": ["always", { "except": ["inside-block"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -244,7 +296,13 @@ a {
 
 Reverse the primary option for rules that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": ["always", { "except": ["first-nested"] }]
+}
+```
 
 The following patterns are considered problems:
 
@@ -275,7 +333,13 @@ The following patterns are _not_ considered problems:
 
 Ignore rules that follow a comment.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": ["always", { "ignore": ["after-comment"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -289,7 +353,13 @@ a {}
 
 Ignore rules that are nested and the first child of their parent node.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": ["always", { "ignore": ["first-nested"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -306,7 +376,13 @@ The following patterns are _not_ considered problems:
 
 Ignore rules that are inside a block.
 
-For example, with `"always"`:
+Given:
+
+```json
+{
+  "rule-empty-line-before": ["always", { "ignore": ["inside-block"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -13,7 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`object`: `{ "selector": ["array", "of", "properties", "/regex/", /regex/]|"property"|"/regex/"|/regex/`
+```json
+{ "selector": ["array", "of", "properties", "/regex/"] }
+```
+
+You can also specify a single property instead of an array of them.
 
 If a selector name is surrounded with `"/"` (e.g. `"/anchor/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of all the potential anchors: `/anchor/` will match `.anchor`, `[data-anchor]`, etc.
 
@@ -23,8 +27,10 @@ Given:
 
 ```json
 {
-  "a": ["color", "/margin/"],
-  "/foo/": "/size/"
+  "rule-selector-property-disallowed-list": {
+    "a": ["color", "/margin/"],
+    "/foo/": "/size/"
+  }
 }
 ```
 
@@ -71,7 +77,12 @@ Ignore keyframe selectors.
 Given:
 
 ```json
-[{ "/^[a-z]+$/": ["opacity"] }, { "ignore": ["keyframe-selectors"] }]
+{
+  "rule-selector-property-disallowed-list": [
+    { "/^[a-z]+$/": ["opacity"] },
+    { "ignore": ["keyframe-selectors"] }
+  ]
+}
 ```
 
 The following pattern is _not_ considered a problem:

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -17,11 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 { "selector": ["array", "of", "properties", "/regex/"] }
 ```
 
-You can also specify a single property instead of an array of them.
-
-If a selector name is surrounded with `"/"` (e.g. `"/anchor/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of all the potential anchors: `/anchor/` will match `.anchor`, `[data-anchor]`, etc.
-
-The same goes for properties. Keep in mind that a regular expression value is matched against the entire property name, not specific parts of it. For example, a value like `"animation-duration"` will _not_ match `"/^duration/"` (notice beginning of the line boundary) but _will_ match `"/duration/"`.
+You can specify a regex for a selector, such as `{ "/foo-/": [] }`.
 
 Given:
 
@@ -29,7 +25,7 @@ Given:
 {
   "rule-selector-property-disallowed-list": {
     "a": ["color", "/margin/"],
-    "/foo/": "/size/"
+    "/foo/": ["/size/"]
   }
 }
 ```
@@ -70,7 +66,13 @@ html[data-foo] { color: red; }
 
 ## Optional secondary options
 
-### `ignore: ["keyframe-selectors"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
+
+#### `"keyframe-selectors"`
 
 Ignore keyframe selectors.
 

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Object<string, Array<string>>`
+
 ```json
 { "selector": ["array", "of", "properties", "/regex/"] }
 ```

--- a/lib/rules/selector-anb-no-unmatchable/README.md
+++ b/lib/rules/selector-anb-no-unmatchable/README.md
@@ -17,6 +17,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "selector-anb-no-unmatchable": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/selector-attribute-name-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-name-disallowed-list/README.md
@@ -17,8 +17,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "attribute-names", "/regex/"]
 ```
 
-You can also specify a single attribute name instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/selector-attribute-name-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-name-disallowed-list/README.md
@@ -13,12 +13,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", /names/, "regex"]|"name"|"/regex/"|/regex/`
+```json
+["array", "of", "attribute-names", "/regex/"]
+```
+
+You can also specify a single attribute name instead of an array of them.
 
 Given:
 
 ```json
-["class", "id", "/^data-/"]
+{
+  "selector-attribute-name-disallowed-list": ["class", "id", "/^data-/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-attribute-name-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-name-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "attribute-names", "/regex/"]
 ```

--- a/lib/rules/selector-attribute-operator-allowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-allowed-list/README.md
@@ -17,8 +17,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "attribute-operators"]
 ```
 
-You can also specify a single attribute operator instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/selector-attribute-operator-allowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "attribute-operators"]
 ```

--- a/lib/rules/selector-attribute-operator-allowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-allowed-list/README.md
@@ -13,12 +13,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "operators"]|"operator"`
+```json
+["array", "of", "attribute-operators"]
+```
+
+You can also specify a single attribute operator instead of an array of them.
 
 Given:
 
 ```json
-["=", "|="]
+{
+  "selector-attribute-operator-allowed-list": ["=", "|="]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-attribute-operator-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-disallowed-list/README.md
@@ -17,8 +17,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "attribute-operators"]
 ```
 
-You can also specify a single attribute operator instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/selector-attribute-operator-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "attribute-operators"]
 ```

--- a/lib/rules/selector-attribute-operator-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-disallowed-list/README.md
@@ -13,12 +13,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "operators"]|"operator"`
+```json
+["array", "of", "attribute-operators"]
+```
+
+You can also specify a single attribute operator instead of an array of them.
 
 Given:
 
 ```json
-["*="]
+{
+  "selector-attribute-operator-disallowed-list": ["*="]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-attribute-quotes/README.md
+++ b/lib/rules/selector-attribute-quotes/README.md
@@ -15,11 +15,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"always"|"never"`
-
 ### `"always"`
 
 Attribute values _must always_ be quoted.
+
+```json
+{
+  "selector-attribute-quotes": "always"
+}
+```
 
 The following patterns are considered problems:
 
@@ -63,6 +67,12 @@ The following patterns are _not_ considered problems:
 ### `"never"`
 
 Attribute values _must never_ be quoted.
+
+```json
+{
+  "selector-attribute-quotes": "never"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -21,12 +21,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
 
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+
 The selector value _after `.`_ will be checked. No need to include `.` in your pattern.
 
 Given the string:
 
 ```json
-"foo-[a-z]+"
+{
+  "selector-class-pattern": "foo-[a-z]+"
+}
 ```
 
 The following patterns are considered problems:
@@ -74,12 +78,12 @@ div > #zing + .foo-bar {}
 
 This option will resolve nested selectors with `&` interpolation.
 
-For example, with `true`.
-
 Given the string:
 
 ```json
-"^[A-Z]+$"
+{
+  "selector-class-pattern": ["^[A-Z]+$", { "resolveNestedSelectors": true }]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -17,11 +17,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string not surrounded with `"/"`.
 
 The selector value _after `.`_ will be checked. No need to include `.` in your pattern.
 
-Given the string:
+Given:
 
 ```json
 {
@@ -70,9 +70,9 @@ div > #zing + .foo-bar {}
 
 ## Optional secondary options
 
-### `resolveNestedSelectors: true | false` (default: `false`)
+### `resolveNestedSelectors`
 
-This option will resolve nested selectors with `&` interpolation.
+This option will resolve nested selectors with `&` interpolation. Defaults to `false`.
 
 Given the string:
 

--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -17,11 +17,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 The selector value _after `.`_ will be checked. No need to include `.` in your pattern.
 

--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 The selector value _after `.`_ will be checked. No need to include `.` in your pattern.

--- a/lib/rules/selector-combinator-allowed-list/README.md
+++ b/lib/rules/selector-combinator-allowed-list/README.md
@@ -21,8 +21,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "combinators"]
 ```
 
-You can also specify a single combinator instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/selector-combinator-allowed-list/README.md
+++ b/lib/rules/selector-combinator-allowed-list/README.md
@@ -17,12 +17,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "combinators"]|"combinator"`
+```json
+["array", "of", "combinators"]
+```
+
+You can also specify a single combinator instead of an array of them.
 
 Given:
 
 ```json
-[">", " "]
+{
+  "selector-combinator-allowed-list": [">", " "]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-combinator-allowed-list/README.md
+++ b/lib/rules/selector-combinator-allowed-list/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "combinators"]
 ```

--- a/lib/rules/selector-combinator-disallowed-list/README.md
+++ b/lib/rules/selector-combinator-disallowed-list/README.md
@@ -21,8 +21,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "combinators"]
 ```
 
-You can also specify a single combinator instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/selector-combinator-disallowed-list/README.md
+++ b/lib/rules/selector-combinator-disallowed-list/README.md
@@ -17,12 +17,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "combinators"]|"combinator"`
+```json
+["array", "of", "combinators"]
+```
+
+You can also specify a single combinator instead of an array of them.
 
 Given:
 
 ```json
-[">", " "]
+{
+  "selector-combinator-disallowed-list": [">", " "]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-combinator-disallowed-list/README.md
+++ b/lib/rules/selector-combinator-disallowed-list/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "combinators"]
 ```

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -99,7 +99,7 @@ The following pattern is _not_ considered a problem:
 .bar .foo {}
 ```
 
-### `ignore: ["inside-block", "keyframe-selectors"]`
+### `ignore`
 
 ```json
 { "ignore": ["array", "of", "options"] }

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "selectors", "/regex/"]
 ```

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -13,14 +13,20 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regexp`: `["array", "of", "selectors", /or/, "/regex/"]|"selector"|"/regex/"|/regex/`
+```json
+["array", "of", "selectors", "/regex/"]
+```
+
+You can also specify a single selector instead of an array of them.
 
 If a string is surrounded with `"/"` (e.g. `"/\.foo/"`), it is interpreted as a regular expression.
 
 Given:
 
 ```json
-["a > .foo", "/\\[data-.+]/"]
+{
+  "selector-disallowed-list": ["a > .foo", "/\\[data-.+]/"]
+}
 ```
 
 The following patterns are considered problems:
@@ -75,12 +81,12 @@ a[href] {}
 
 Split selector lists into individual selectors.
 
-For example, with `true`.
-
 Given:
 
 ```json
-[".foo", { "splitList": true }]
+{
+  "selector-disallowed-list": [".foo", { "splitList": true }]
+}
 ```
 
 The following pattern is considered a problem:
@@ -97,14 +103,18 @@ The following pattern is _not_ considered a problem:
 .bar .foo {}
 ```
 
-### `ignore: ["inside-block"]`
+### `ignore: ["inside-block", "keyframe-selectors"]`
+
+#### `"inside-block"`
 
 Ignore selectors that are inside a block.
 
 Given:
 
 ```json
-[".foo", { "ignore": ["inside-block"] }]
+{
+  "selector-disallowed-list": [".foo", { "ignore": ["inside-block"] }]
+}
 ```
 
 The following pattern is _not_ considered a problem:
@@ -116,14 +126,16 @@ The following pattern is _not_ considered a problem:
 }
 ```
 
-### `ignore: ["keyframe-selectors"]`
+#### `"keyframe-selectors"`
 
 Ignore keyframe selectors.
 
 Given:
 
 ```json
-["/from/", { "ignore": ["keyframe-selectors"] }]
+{
+  "selector-disallowed-list": ["/from/", { "ignore": ["keyframe-selectors"] }]
+}
 ```
 
 The following pattern is _not_ considered a problem:

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -17,10 +17,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "selectors", "/regex/"]
 ```
 
-You can also specify a single selector instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/\.foo/"`), it is interpreted as a regular expression.
-
 Given:
 
 ```json
@@ -77,9 +73,9 @@ a[href] {}
 
 ## Optional secondary options
 
-### `splitList: true | false` (default: `false`)
+### `splitList`
 
-Split selector lists into individual selectors.
+Split selector lists into individual selectors. Defaults to `false`.
 
 Given:
 
@@ -104,6 +100,10 @@ The following pattern is _not_ considered a problem:
 ```
 
 ### `ignore: ["inside-block", "keyframe-selectors"]`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
 
 #### `"inside-block"`
 

--- a/lib/rules/selector-id-pattern/README.md
+++ b/lib/rules/selector-id-pattern/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 The selector value _after `#`_ will be checked. No need to include `#` in your pattern.

--- a/lib/rules/selector-id-pattern/README.md
+++ b/lib/rules/selector-id-pattern/README.md
@@ -13,16 +13,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
 A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
+
+You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
 
 The selector value _after `#`_ will be checked. No need to include `#` in your pattern.
 
 Given the string:
 
 ```json
-"foo-[a-z]+"
+{
+  "selector-id-pattern": "foo-[a-z]+"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-id-pattern/README.md
+++ b/lib/rules/selector-id-pattern/README.md
@@ -13,9 +13,7 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
-
-You can also use a regular expression directly in a JavaScript config, such as `/yourPattern/`.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 The selector value _after `#`_ will be checked. No need to include `#` in your pattern.
 

--- a/lib/rules/selector-id-pattern/README.md
+++ b/lib/rules/selector-id-pattern/README.md
@@ -13,11 +13,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string not surrounded with `"/"`.
 
 The selector value _after `#`_ will be checked. No need to include `#` in your pattern.
 
-Given the string:
+Given:
 
 ```json
 {

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -98,7 +98,11 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `ignoreAttributes: ["/regex/", /regex/, "non-regex"]`
+### `ignoreAttributes`
+
+```json
+{ "ignoreAttributes": ["array", "of", "attributes", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum attribute selectors allowed.
 
 Given:

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -17,9 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum attribute selectors allowed.
+Specify a maximum attribute selectors allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-attribute": 2
+}
+```
 
 The following patterns are considered problems:
 
@@ -97,10 +103,10 @@ The following patterns are _not_ considered problems:
 Given:
 
 ```json
-["/^data-my-/", "dir"]
+{
+  "selector-max-attribute": [0, { "ignoreAttributes": ["/^data-my-/", "dir"] }]
+}
 ```
-
-For example, with `0`.
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/selector-max-class/README.md
+++ b/lib/rules/selector-max-class/README.md
@@ -18,6 +18,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum classes allowed.
 
 Given:

--- a/lib/rules/selector-max-class/README.md
+++ b/lib/rules/selector-max-class/README.md
@@ -18,9 +18,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum classes allowed.
+Specify a maximum classes allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-class": 2
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/selector-max-combinators/README.md
+++ b/lib/rules/selector-max-combinators/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum combinators selectors allowed.
 
 Given:

--- a/lib/rules/selector-max-combinators/README.md
+++ b/lib/rules/selector-max-combinators/README.md
@@ -15,9 +15,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum combinators selectors allowed.
+Specify a maximum combinators selectors allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-combinators": 2
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/selector-max-compound-selectors/README.md
+++ b/lib/rules/selector-max-compound-selectors/README.md
@@ -21,6 +21,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum compound selectors allowed.
 
 Given:

--- a/lib/rules/selector-max-compound-selectors/README.md
+++ b/lib/rules/selector-max-compound-selectors/README.md
@@ -21,16 +21,22 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum compound selectors allowed.
+Specify a maximum compound selectors allowed.
 
-For example, with `3`:
+Given:
+
+```json
+{
+  "selector-max-compound-selectors": 3
+}
+```
 
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
 ```css
 .foo .bar .baz .lorem {}
-```
+````
 
 <!-- prettier-ignore -->
 ```css
@@ -67,12 +73,15 @@ div {}
 
 Ignore some compound selectors. This may be useful for deep selectors like Vue's `::v-deep` or Angular's `::ng-deep` that behave more like combinators than compound selectors.
 
-For example, with `2`.
-
 Given:
 
 ```json
-["::v-deep", "/ignored/", ":not"]
+{
+  "selector-max-compound-selectors": [
+    2,
+    { "ignoreSelectors": ["::v-deep", "/ignored/", ":not"] }
+  ]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-max-compound-selectors/README.md
+++ b/lib/rules/selector-max-compound-selectors/README.md
@@ -69,7 +69,11 @@ div {}
 
 ## Optional secondary options
 
-### `ignoreSelectors: ["/regex/", /regex/, "non-regex"]`
+### `ignoreSelectors`
+
+```json
+{ "ignoreSelectors": ["array", "of", "selectors", "/regex/"] }
+```
 
 Ignore some compound selectors. This may be useful for deep selectors like Vue's `::v-deep` or Angular's `::ng-deep` that behave more like combinators than compound selectors.
 

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum universal selectors allowed.
 
 Given:

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -85,7 +85,18 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `checkContextFunctionalPseudoClasses: ["/regex/", /regex/, "non-regex"]`
+### `checkContextFunctionalPseudoClasses`
+
+```json
+{
+  "checkContextFunctionalPseudoClasses": [
+    "array",
+    "of",
+    "pseudo-classes",
+    "/regex/"
+  ]
+}
+```
 
 Check selectors inside of the specified custom [functional pseudo-classes](https://drafts.csswg.org/selectors-4/#pseudo-classes) that provide [evaluation contexts](https://drafts.csswg.org/selectors-4/#specificity-rules).
 
@@ -113,7 +124,18 @@ The following pattern is _not_ considered a problem:
 :--foo() {}
 ```
 
-### `ignoreContextFunctionalPseudoClasses: ["/regex/", /regex/, "non-regex"]`
+### `ignoreContextFunctionalPseudoClasses`
+
+```json
+{
+  "ignoreContextFunctionalPseudoClasses": [
+    "array",
+    "of",
+    "pseudo-classes",
+    "/regex/"
+  ]
+}
+```
 
 Ignore selectors inside of the specified [functional pseudo-classes](https://drafts.csswg.org/selectors-4/#pseudo-classes) that provide [evaluation contexts](https://drafts.csswg.org/selectors-4/#specificity-rules).
 

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -17,9 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum universal selectors allowed.
+Specify a maximum universal selectors allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-id": 2
+}
+```
 
 The following patterns are considered problems:
 
@@ -88,7 +94,9 @@ This option has a higher precedence than `ignoreContextFunctionalPseudoClasses`.
 Given:
 
 ```json
-[":--foo"]
+{
+  "selector-max-id": [2, { "checkContextFunctionalPseudoClasses": [":--foo"] }]
+}
 ```
 
 The following pattern is considered a problem:
@@ -112,7 +120,12 @@ Ignore selectors inside of the specified [functional pseudo-classes](https://dra
 Given:
 
 ```json
-[":not", "/^:(h|H)as$/"]
+{
+  "selector-max-id": [
+    0,
+    { "ignoreContextFunctionalPseudoClasses": [":not", "/^:(h|H)as$/"] }
+  ]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-max-pseudo-class/README.md
+++ b/lib/rules/selector-max-pseudo-class/README.md
@@ -18,9 +18,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum pseudo-classes allowed.
+Specify a maximum pseudo-classes allowed.
 
-For example, with `1`:
+Given:
+
+```json
+{
+  "selector-max-pseudo-class": 1
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/selector-max-pseudo-class/README.md
+++ b/lib/rules/selector-max-pseudo-class/README.md
@@ -18,6 +18,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum pseudo-classes allowed.
 
 Given:

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -19,11 +19,17 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: Maximum specificity allowed.
+Specify a maximum specificity allowed.
 
-Format is `"id,class,type"`, as laid out in the [W3C selector spec](https://drafts.csswg.org/selectors/#specificity-rules).
+The format is `"id,class,type"`, as laid out in the [W3C selector spec](https://drafts.csswg.org/selectors/#specificity-rules).
 
-For example, with `"0,2,0"`:
+Given:
+
+```json
+{
+  "selector-max-specificity": "0,2,0"
+}
+```
 
 The following patterns are considered problems:
 
@@ -97,12 +103,14 @@ div {}
 Given:
 
 ```json
-[
-  "0,2,0",
-  {
-    "ignoreSelectors": [":host", ":host-context", "/^my-/"]
-  }
-]
+{
+  "selector-max-specificity": [
+    "0,2,0",
+    {
+      "ignoreSelectors": [":host", ":host-context", "/^my-/"]
+    }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -98,7 +98,11 @@ div {}
 
 ## Optional secondary options
 
-### `ignoreSelectors: ["/regex/", /regex/, "non-regex"]`
+### `ignoreSelectors`
+
+```json
+{ "ignoreSelectors": ["array", "of", "selectors", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -19,6 +19,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a maximum specificity allowed.
 
 The format is `"id,class,type"`, as laid out in the [W3C selector spec](https://drafts.csswg.org/selectors/#specificity-rules).

--- a/lib/rules/selector-max-type/README.md
+++ b/lib/rules/selector-max-type/README.md
@@ -85,7 +85,11 @@ div a .foo:not(span) {}
 
 ## Optional secondary options
 
-### `ignore: ["child", "compounded", "custom-elements", "descendant", "next-sibling"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
 
 #### `"child"`
 
@@ -202,7 +206,11 @@ div a + span {}
 #bar + div + span + a + span {}
 ```
 
-### `ignoreTypes: ["/regex/", /regex/, "non-regex"]`
+### `ignoreTypes`
+
+```json
+{ "ignoreTypes": ["array", "of", "types", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/selector-max-type/README.md
+++ b/lib/rules/selector-max-type/README.md
@@ -17,9 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum type selectors allowed.
+Specify a maximum type selectors allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-type": 2
+}
+```
 
 The following patterns are considered problems:
 
@@ -85,7 +91,13 @@ div a .foo:not(span) {}
 
 Discount child type selectors.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-type": [2, { "ignore": ["child"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -103,7 +115,13 @@ div span > a {}
 
 Discount compounded type selectors -- i.e. type selectors chained with other selectors.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-type": [2, { "ignore": ["compounded"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -121,7 +139,13 @@ div span a#bar {}
 
 Discount custom elements.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-type": [2, { "ignore": ["custom-elements"] }]
+}
+```
 
 The following pattern is _not_ considered a problem:
 
@@ -134,7 +158,13 @@ div a foo-bar {}
 
 Discount descendant type selectors.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-type": [2, { "ignore": ["descendant"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -152,7 +182,13 @@ The following patterns are _not_ considered problems:
 
 Discount next-sibling type selectors.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-type": [2, { "ignore": ["next-sibling"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 
@@ -171,10 +207,10 @@ div a + span {}
 Given:
 
 ```json
-["/^my-/", "custom"]
+{
+  "selector-max-type": [2, { "ignoreTypes": ["/^my-/", "custom"] }]
+}
 ```
-
-For example, with `2`.
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/selector-max-type/README.md
+++ b/lib/rules/selector-max-type/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum type selectors allowed.
 
 Given:

--- a/lib/rules/selector-max-universal/README.md
+++ b/lib/rules/selector-max-universal/README.md
@@ -85,7 +85,11 @@ The following patterns are _not_ considered problems:
 
 ## Optional secondary options
 
-### `ignoreAfterCombinators: ["array", "of", "combinators"]`
+### `ignoreAfterCombinators`
+
+```json
+{ "ignoreAfterCombinators": ["array", "of", "combinators"] }
+```
 
 Ignore universal selectors that come after one of the specified combinators.
 

--- a/lib/rules/selector-max-universal/README.md
+++ b/lib/rules/selector-max-universal/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a maximum universal selectors allowed.
 
 Given:

--- a/lib/rules/selector-max-universal/README.md
+++ b/lib/rules/selector-max-universal/README.md
@@ -17,9 +17,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Maximum universal selectors allowed.
+Specify a maximum universal selectors allowed.
 
-For example, with `2`:
+Given:
+
+```json
+{
+  "selector-max-universal": 2
+}
+```
 
 The following patterns are considered problems:
 
@@ -86,10 +92,10 @@ Ignore universal selectors that come after one of the specified combinators.
 Given:
 
 ```json
-[">", "+"]
+{
+  "selector-max-universal": [2, { "ignoreAfterCombinators": [">", "+"] }]
+}
 ```
-
-For example, with `2`.
 
 The following pattern is _not_ considered a problem:
 

--- a/lib/rules/selector-nested-pattern/README.md
+++ b/lib/rules/selector-nested-pattern/README.md
@@ -17,6 +17,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `string`
+
 Specify a regex string not surrounded with `"/"`.
 
 The selector value will be checked in its entirety. If you'd like to allow for combinators and commas, you must incorporate them into your pattern.

--- a/lib/rules/selector-nested-pattern/README.md
+++ b/lib/rules/selector-nested-pattern/README.md
@@ -17,16 +17,16 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`regex|string`
-
-A string will be translated into a RegExp like so `new RegExp(yourString)` — so be sure to escape properly.
+A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
 
 The selector value will be checked in its entirety. If you'd like to allow for combinators and commas, you must incorporate them into your pattern.
 
 Given the string:
 
 ```json
-"^&:(?:hover|focus)$"
+{
+  "selector-nested-pattern": "^&:(?:hover|focus)$"
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-nested-pattern/README.md
+++ b/lib/rules/selector-nested-pattern/README.md
@@ -17,11 +17,11 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-A string will be translated into a regular expression like `new RegExp(yourString)`, so make sure to escape it properly. Alternatively, a regular expression literal in JavaScript is available, such as `/yourPattern/`.
+Specify a regex string not surrounded with `"/"`.
 
 The selector value will be checked in its entirety. If you'd like to allow for combinators and commas, you must incorporate them into your pattern.
 
-Given the string:
+Given:
 
 ```json
 {
@@ -79,16 +79,16 @@ a {
 
 ## Optional secondary options
 
-### `splitList: true | false` (default: `false`)
+### `splitList`
 
-Split selector lists into individual selectors.
+Split selector lists into individual selectors. Defaults to `false`.
 
-For example, with `true`.
-
-Given the string:
+Given:
 
 ```json
-"^&:(?:hover|focus)$"
+{
+  "selector-nested-pattern": ["^&:(?:hover|focus)$", { "splitList": true }]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-no-qualifying-type/README.md
+++ b/lib/rules/selector-no-qualifying-type/README.md
@@ -71,7 +71,11 @@ input {
 
 ## Optional secondary options
 
-### `ignore: ["attribute", "class", "id"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
 
 #### `"attribute"`
 

--- a/lib/rules/selector-no-qualifying-type/README.md
+++ b/lib/rules/selector-no-qualifying-type/README.md
@@ -17,6 +17,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "selector-no-qualifying-type": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -71,6 +77,12 @@ input {
 
 Allow attribute selectors qualified by type.
 
+```json
+{
+  "selector-no-qualifying-type": [true, { "ignore": ["attribute"] }]
+}
+```
+
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
@@ -84,6 +96,12 @@ input[type='button'] {
 
 Allow class selectors qualified by type.
 
+```json
+{
+  "selector-no-qualifying-type": [true, { "ignore": ["class"] }]
+}
+```
+
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
@@ -96,6 +114,12 @@ a.foo {
 #### `"id"`
 
 Allow ID selectors qualified by type.
+
+```json
+{
+  "selector-no-qualifying-type": [true, { "ignore": ["id"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/selector-no-vendor-prefix/README.md
+++ b/lib/rules/selector-no-vendor-prefix/README.md
@@ -51,7 +51,11 @@ input::placeholder {}
 
 ## Optional secondary options
 
-### `ignoreSelectors: ["/regex/", /regex/, "non-regex"]`
+### `ignoreSelectors`
+
+```json
+{ "ignoreSelectors": ["array", "of", "selectors", "/regex/"] }
+```
 
 Ignore vendor prefixes for selectors.
 

--- a/lib/rules/selector-no-vendor-prefix/README.md
+++ b/lib/rules/selector-no-vendor-prefix/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "selector-no-vendor-prefix": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -52,7 +58,12 @@ Ignore vendor prefixes for selectors.
 Given:
 
 ```json
-["::-webkit-input-placeholder", "/-moz-.*/"]
+{
+  "selector-no-vendor-prefix": [
+    true,
+    { "ignoreSelectors": ["::-webkit-input-placeholder", "/-moz-.*/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/selector-not-notation/README.md
+++ b/lib/rules/selector-not-notation/README.md
@@ -34,9 +34,13 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"simple"|"complex"`
-
 ### `"simple"`
+
+```json
+{
+  "selector-not-notation": "simple"
+}
+```
 
 The following patterns are considered problems:
 
@@ -63,6 +67,12 @@ The following patterns are _not_ considered problems:
 ```
 
 ### `"complex"`
+
+```json
+{
+  "selector-not-notation": "complex"
+}
+```
 
 The following pattern is considered a problem:
 

--- a/lib/rules/selector-pseudo-class-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-allowed-list/README.md
@@ -15,14 +15,20 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /pseudo-classes/, "/regex/"]|"pseudo-class"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "pseudo-classes", "/regex/"]
+```
+
+You can also specify a single pseudo-class instead of an array of them.
 
 If a string is surrounded with `"/"` (e.g. `"/^nth-/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^nth-/` will match `nth-child`, `nth-last-child`, `nth-of-type`, etc.
 
 Given:
 
 ```json
-["hover", "/^nth-/"]
+{
+  "selector-pseudo-class-allowed-list": ["hover", "/^nth-/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-pseudo-class-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-allowed-list/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "pseudo-classes", "/regex/"]
 ```

--- a/lib/rules/selector-pseudo-class-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-allowed-list/README.md
@@ -19,10 +19,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "pseudo-classes", "/regex/"]
 ```
 
-You can also specify a single pseudo-class instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/^nth-/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^nth-/` will match `nth-child`, `nth-last-child`, `nth-of-type`, etc.
-
 Given:
 
 ```json

--- a/lib/rules/selector-pseudo-class-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-disallowed-list/README.md
@@ -15,14 +15,20 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /pseudo-classes/, "/regex/"]|"pseudo-class"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "pseudo-classes", "/regex/"]
+```
+
+You can also specify a single pseudo-class instead of an array of them.
 
 If a string is surrounded with `"/"` (e.g. `"/^nth-/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^nth-/` will match `nth-child`, `nth-last-child`, `nth-of-type`, etc.
 
 Given:
 
 ```json
-["hover", "/^nth-/"]
+{
+  "selector-pseudo-class-disallowed-list": ["hover", "/^nth-/"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-pseudo-class-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-disallowed-list/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "pseudo-classes", "/regex/"]
 ```

--- a/lib/rules/selector-pseudo-class-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-disallowed-list/README.md
@@ -19,10 +19,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "pseudo-classes", "/regex/"]
 ```
 
-You can also specify a single pseudo-class instead of an array of them.
-
-If a string is surrounded with `"/"` (e.g. `"/^nth-/"`), it is interpreted as a regular expression. This allows, for example, easy targeting of shorthands: `/^nth-/` will match `nth-child`, `nth-last-child`, `nth-of-type`, etc.
-
 Given:
 
 ```json

--- a/lib/rules/selector-pseudo-class-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-class-no-unknown/README.md
@@ -66,7 +66,11 @@ input:-moz-placeholder {}
 
 ## Optional secondary options
 
-### `ignorePseudoClasses: ["/regex/", /regex/, "non-regex"]`
+### `ignorePseudoClasses`
+
+```json
+{ "ignorePseudoClasses": ["array", "of", "pseudo-classes", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/selector-pseudo-class-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-class-no-unknown/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "selector-pseudo-class-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -65,7 +71,12 @@ input:-moz-placeholder {}
 Given:
 
 ```json
-["/^--my-/", "--pseudo-class"]
+{
+  "selector-pseudo-class-no-unknown": [
+    true,
+    { "ignorePseudoClasses": ["/^--my-/", "--pseudo-class"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/selector-pseudo-element-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-allowed-list/README.md
@@ -18,6 +18,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "pseudo-elements", "/regex/"]
 ```

--- a/lib/rules/selector-pseudo-element-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-allowed-list/README.md
@@ -22,8 +22,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "pseudo-elements", "/regex/"]
 ```
 
-You can also specify a single pseudo-element instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/selector-pseudo-element-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-allowed-list/README.md
@@ -18,12 +18,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /pseudo-elements/, "/regex/"]|"pseudo-element"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "pseudo-elements", "/regex/"]
+```
+
+You can also specify a single pseudo-element instead of an array of them.
 
 Given:
 
 ```json
-["before", "/^--my-/i"]
+{
+  "selector-pseudo-element-allowed-list": ["before", "/^--my-/i"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-pseudo-element-colon-notation/README.md
+++ b/lib/rules/selector-pseudo-element-colon-notation/README.md
@@ -19,11 +19,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"single"|"double"`
-
 ### `"single"`
 
 Applicable pseudo-elements _must always_ use the single colon notation.
+
+```json
+{
+  "selector-pseudo-element-colon-notation": "single"
+}
+```
 
 The following patterns are considered problems:
 
@@ -82,6 +86,12 @@ li::marker { font-variant-numeric: tabular-nums; }
 ### `"double"`
 
 Applicable pseudo-elements _must always_ use the double colon notation.
+
+```json
+{
+  "selector-pseudo-element-colon-notation": "double"
+}
+```
 
 The following patterns are considered problems:
 

--- a/lib/rules/selector-pseudo-element-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-disallowed-list/README.md
@@ -18,6 +18,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "unprefixed", "pseudo-elements", "/regex/"]
 ```

--- a/lib/rules/selector-pseudo-element-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-disallowed-list/README.md
@@ -22,8 +22,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "unprefixed", "pseudo-elements", "/regex/"]
 ```
 
-You can also specify a single pseudo-element instead of an array of them.
-
 Given:
 
 ```json

--- a/lib/rules/selector-pseudo-element-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-disallowed-list/README.md
@@ -18,12 +18,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string|regex`: `["array", "of", "unprefixed", /pseudo-elements/, "/regex/"]|"pseudo-element"|"/regex/"|/regex/`
+```json
+["array", "of", "unprefixed", "pseudo-elements", "/regex/"]
+```
+
+You can also specify a single pseudo-element instead of an array of them.
 
 Given:
 
 ```json
-["before", "/^--my-/i"]
+{
+  "selector-pseudo-element-disallowed-list": ["before", "/^--my-/i"]
+}
 ```
 
 The following patterns are considered problems:

--- a/lib/rules/selector-pseudo-element-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-element-no-unknown/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "selector-pseudo-element-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -65,7 +71,12 @@ input::-moz-placeholder {}
 Given:
 
 ```json
-["/^--my-/", "--pseudo-element"]
+{
+  "selector-pseudo-element-no-unknown": [
+    true,
+    { "ignorePseudoElements": ["/^--my-/", "--pseudo-element"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/selector-pseudo-element-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-element-no-unknown/README.md
@@ -66,7 +66,11 @@ input::-moz-placeholder {}
 
 ## Optional secondary options
 
-### `ignorePseudoElements: ["/regex/", /regex/, "non-regex"]`
+### `ignorePseudoElements`
+
+```json
+{ "ignorePseudoElements": ["array", "of", "pseudo-elements", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/selector-type-case/README.md
+++ b/lib/rules/selector-type-case/README.md
@@ -81,7 +81,11 @@ LI {}
 
 ## Optional secondary options
 
-### `ignoreTypes: ["/regex/", /regex/, "non-regex"]`
+### `ignoreTypes`
+
+```json
+{ "ignoreTypes": ["array", "of", "types", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/selector-type-case/README.md
+++ b/lib/rules/selector-type-case/README.md
@@ -15,9 +15,13 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"lower"|"upper"`
-
 ### `"lower"`
+
+```json
+{
+  "selector-type-case": "lower"
+}
+```
 
 The following patterns are considered problems:
 
@@ -44,6 +48,12 @@ li {}
 ```
 
 ### `"upper"`
+
+```json
+{
+  "selector-type-case": "upper"
+}
+```
 
 The following patterns are considered problems:
 
@@ -76,7 +86,12 @@ LI {}
 Given:
 
 ```json
-["$childClass", "/(p|P)arent.*/"]
+{
+  "selector-type-case": [
+    "lower",
+    { "ignoreTypes": ["$childClass", "/(p|P)arent.*/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/selector-type-no-unknown/README.md
+++ b/lib/rules/selector-type-no-unknown/README.md
@@ -17,6 +17,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "selector-type-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -54,6 +60,12 @@ li > a {}
 
 Allow custom elements.
 
+```json
+{
+  "selector-type-no-unknown": [true, { "ignore": ["custom-elements"] }]
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -77,6 +89,12 @@ x-foo {}
 
 Allow unknown type selectors if they belong to the default namespace.
 
+```json
+{
+  "selector-type-no-unknown": [true, { "ignore": ["default-namespace"] }]
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -96,7 +114,12 @@ unknown {}
 Given:
 
 ```json
-["/^my-/", "custom-namespace"]
+{
+  "selector-type-no-unknown": [
+    true,
+    { "ignoreNamespaces": ["/^my-/", "custom-namespace"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -121,7 +144,12 @@ my-other-namespace|unknown {}
 Given:
 
 ```json
-["/^my-/", "custom-type"]
+{
+  "selector-type-no-unknown": [
+    true,
+    { "ignoreTypes": ["/^my-/", "custom-type"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/selector-type-no-unknown/README.md
+++ b/lib/rules/selector-type-no-unknown/README.md
@@ -54,7 +54,11 @@ li > a {}
 
 ## Optional secondary options
 
-### `ignore: ["custom-elements", "default-namespace"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
 
 #### `"custom-elements"`
 
@@ -109,7 +113,11 @@ The following patterns are _not_ considered problems:
 unknown {}
 ```
 
-### `ignoreNamespaces: ["/regex/", /regex/, "string"]`
+### `ignoreNamespaces`
+
+```json
+{ "ignoreNamespaces": ["array", "of", "namespaces", "/regex/"] }
+```
 
 Given:
 
@@ -139,7 +147,11 @@ my-namespace|unknown {}
 my-other-namespace|unknown {}
 ```
 
-### `ignoreTypes: ["/regex/", /regex/, "string"]`
+### `ignoreTypes`
+
+```json
+{ "ignoreTypes": ["array", "of", "types", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/shorthand-property-no-redundant-values/README.md
+++ b/lib/rules/shorthand-property-no-redundant-values/README.md
@@ -36,6 +36,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "shorthand-property-no-redundant-values": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/shorthand-property-no-redundant-values/README.md
+++ b/lib/rules/shorthand-property-no-redundant-values/README.md
@@ -93,7 +93,13 @@ a { border-radius: 10px / 5px; }
 
 ## Optional secondary options
 
-### `ignore: ["four-into-three-edge-values"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
+
+#### `"four-into-three-edge-values"`
 
 Ignore four-value shorthand declarations that could be shortened to three values when applied to edges.
 

--- a/lib/rules/string-no-newline/README.md
+++ b/lib/rules/string-no-newline/README.md
@@ -88,7 +88,11 @@ a {
 
 ## Optional secondary options
 
-### `ignore: ["at-rule-preludes", "declaration-values"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
 
 #### `"at-rule-preludes"`
 

--- a/lib/rules/string-no-newline/README.md
+++ b/lib/rules/string-no-newline/README.md
@@ -26,6 +26,12 @@ We recommend configuring this rule so that it doesn't overlap.
 
 ### `true`
 
+```json
+{
+  "string-no-newline": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -87,6 +93,12 @@ a {
 #### `"at-rule-preludes"`
 
 Ignore strings in at-rule preludes.
+
+```json
+{
+  "string-no-newline": [true, { "ignore": ["at-rule-preludes"] }]
+}
+```
 
 The following patterns are _not_ considered problems:
 

--- a/lib/rules/syntax-string-no-invalid/README.md
+++ b/lib/rules/syntax-string-no-invalid/README.md
@@ -21,6 +21,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "syntax-string-no-invalid": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->

--- a/lib/rules/time-min-milliseconds/README.md
+++ b/lib/rules/time-min-milliseconds/README.md
@@ -71,7 +71,13 @@ a { animation-delay: 1s; }
 
 ## Optional secondary options
 
-### `ignore: ["delay"]`
+### `ignore`
+
+```json
+{ "ignore": ["array", "of", "options"] }
+```
+
+#### `"delay"`
 
 Ignore time values for an animation or transition delay.
 

--- a/lib/rules/time-min-milliseconds/README.md
+++ b/lib/rules/time-min-milliseconds/README.md
@@ -15,9 +15,15 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`int`: Minimum number of milliseconds for time values.
+Specify a minimum number of milliseconds for time values.
 
-For example, with `100`:
+Given:
+
+```json
+{
+  "time-min-milliseconds": 100
+}
+```
 
 The following patterns are considered problems:
 
@@ -69,7 +75,13 @@ a { animation-delay: 1s; }
 
 Ignore time values for an animation or transition delay.
 
-For example, with a minimum of `200` milliseconds.
+Given:
+
+```json
+{
+  "time-min-milliseconds": [200, { "ignore": ["delay"] }]
+}
+```
 
 The following pattern is _not_ considered a problem:
 

--- a/lib/rules/time-min-milliseconds/README.md
+++ b/lib/rules/time-min-milliseconds/README.md
@@ -15,6 +15,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `number`
+
 Specify a minimum number of milliseconds for time values.
 
 Given:

--- a/lib/rules/unit-allowed-list/README.md
+++ b/lib/rules/unit-allowed-list/README.md
@@ -13,13 +13,9 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "units"]|"unit"`
-
 ```json
 ["array", "of", "units"]
 ```
-
-You can also specify a single unit instead of an array of them.
 
 Given:
 
@@ -75,7 +71,11 @@ a { transform: rotate(30deg); }
 
 ## Optional secondary options
 
-### `ignoreProperties: { "unit": ["property", "/regex/", /regex/]|"property"|"/regex/"|/regex/ }`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": { "unit": ["array", "of", "properties", "/regex/"] } }
+```
 
 Ignore units in the values of declarations with the specified properties.
 
@@ -129,7 +129,11 @@ a { -moz-border-radius-topright: 20rem; }
 a { height: 100%; }
 ```
 
-### `ignoreFunctions: ["function", "/regex/", /regex/]|"function"|"/regex/"|/regex/`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
 
 Ignore units that are inside of the specified functions.
 

--- a/lib/rules/unit-allowed-list/README.md
+++ b/lib/rules/unit-allowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "units"]
 ```

--- a/lib/rules/unit-allowed-list/README.md
+++ b/lib/rules/unit-allowed-list/README.md
@@ -15,10 +15,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 `array|string`: `["array", "of", "units"]|"unit"`
 
+```json
+["array", "of", "units"]
+```
+
+You can also specify a single unit instead of an array of them.
+
 Given:
 
 ```json
-["px", "em", "deg"]
+{
+  "unit-allowed-list": ["px", "em", "deg"]
+}
 ```
 
 The following patterns are considered problems:
@@ -71,14 +79,19 @@ a { transform: rotate(30deg); }
 
 Ignore units in the values of declarations with the specified properties.
 
-For example, with `["px", "em"]`.
-
 Given:
 
 ```json
 {
-  "rem": ["line-height", "/^border/"],
-  "%": ["width"]
+  "unit-allowed-list": [
+    ["px", "em"],
+    {
+      "ignoreProperties": {
+        "rem": ["line-height", "/^border/"],
+        "%": ["width"]
+      }
+    }
+  ]
 }
 ```
 
@@ -120,12 +133,12 @@ a { height: 100%; }
 
 Ignore units that are inside of the specified functions.
 
-For example, with `["px", "em"]`.
-
 Given:
 
 ```json
-["/^hsl/", "calc"]
+{
+  "unit-allowed-list": [["px", "em"], { "ignoreFunctions": ["/^hsl/", "calc"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/unit-disallowed-list/README.md
+++ b/lib/rules/unit-disallowed-list/README.md
@@ -13,6 +13,8 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
+### `Array<string>`
+
 ```json
 ["array", "of", "units"]
 ```

--- a/lib/rules/unit-disallowed-list/README.md
+++ b/lib/rules/unit-disallowed-list/README.md
@@ -13,12 +13,18 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`array|string`: `["array", "of", "units"]|"unit"`
+```json
+["array", "of", "units"]
+```
+
+You can also specify a single unit instead of an array of them.
 
 Given:
 
 ```json
-["px", "em", "deg"]
+{
+  "unit-disallowed-list": ["px", "em", "deg"]
+}
 ```
 
 The following patterns are considered problems:
@@ -66,14 +72,19 @@ a { animation: animation-name 5s ease; }
 
 Ignore units in the values of declarations with the specified properties.
 
-For example, with `["px", "vmin"]`.
-
 Given:
 
 ```json
 {
-  "px": ["font-size", "/^border/"],
-  "vmin": "width"
+  "unit-disallowed-list": [
+    ["px", "vmin"],
+    {
+      "ignoreProperties": {
+        "px": ["font-size", "/^border/"],
+        "vmin": "width"
+      }
+    }
+  ]
 }
 ```
 
@@ -115,14 +126,19 @@ a { height: 100vmin; }
 
 Ignore units for specific feature names.
 
-For example, with `["px", "dpi"]`.
-
 Given:
 
 ```json
 {
-  "px": ["min-width", "/height$/"],
-  "dpi": "resolution"
+  "unit-disallowed-list": [
+    ["px", "dpi"],
+    {
+      "ignoreMediaFeatureNames": {
+        "px": ["min-width", "/height$/"],
+        "dpi": "resolution"
+      }
+    }
+  ]
 }
 ```
 
@@ -164,12 +180,15 @@ The following patterns are considered problems:
 
 Ignore units that are inside of the specified functions.
 
-For example, with `["px"]`.
-
 Given:
 
 ```json
-["calc", "/^translate/"]
+{
+  "unit-disallowed-list": [
+    ["px"],
+    { "ignoreFunctions": ["calc", "/^translate/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/unit-disallowed-list/README.md
+++ b/lib/rules/unit-disallowed-list/README.md
@@ -17,8 +17,6 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 ["array", "of", "units"]
 ```
 
-You can also specify a single unit instead of an array of them.
-
 Given:
 
 ```json
@@ -68,7 +66,11 @@ a { animation: animation-name 5s ease; }
 
 ## Optional secondary options
 
-### `ignoreProperties: { "unit": ["property", "/regex/", /regex/]|"property"|"/regex/"|/regex/ }`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": { "unit": ["array", "of", "properties", "/regex/"] } }
+```
 
 Ignore units in the values of declarations with the specified properties.
 
@@ -122,7 +124,15 @@ a { -moz-border-radius-topright: 40px; }
 a { height: 100vmin; }
 ```
 
-### `ignoreMediaFeatureNames: { "unit": ["property", "/regex/", /regex/]|"property"|"/regex/"|/regex/ }`
+### `ignoreMediaFeatureNames`
+
+```json
+{
+  "ignoreMediaFeatureNames": {
+    "unit": ["array", "of", "feature-names", "/regex/"]
+  }
+}
+```
 
 Ignore units for specific feature names.
 
@@ -176,7 +186,11 @@ The following patterns are considered problems:
 @media print and (max-resolution: 100dpi) {}
 ```
 
-### `ignoreFunctions: ["function", "/regex/", /regex/]|"function"|"/regex/"|/regex/`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": { "unit": ["array", "of", "functions", "/regex/"] } }
+```
 
 Ignore units that are inside of the specified functions.
 

--- a/lib/rules/unit-no-unknown/README.md
+++ b/lib/rules/unit-no-unknown/README.md
@@ -81,7 +81,11 @@ a {
 
 ## Optional secondary options
 
-### `ignoreUnits: ["/regex/", /regex/, "string"]`
+### `ignoreUnits`
+
+```json
+{ "ignoreUnits": ["array", "of", "units", "/regex/"] }
+```
 
 Given:
 
@@ -107,7 +111,11 @@ a {
 }
 ```
 
-### `ignoreFunctions: ["/regex/", /regex/, "string"]`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/unit-no-unknown/README.md
+++ b/lib/rules/unit-no-unknown/README.md
@@ -27,6 +27,12 @@ We recommend using these rules for CSS and this rule for CSS-like languages, suc
 
 ### `true`
 
+```json
+{
+  "unit-no-unknown": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -80,7 +86,9 @@ a {
 Given:
 
 ```json
-["/^--foo-/", "--bar"]
+{
+  "unit-no-unknown": [true, { "ignoreUnits": ["/^--foo-/", "--bar"] }]
+}
 ```
 
 The following patterns are _not_ considered problems:
@@ -104,7 +112,12 @@ a {
 Given:
 
 ```json
-["foo", "/^my-/", "/^YOUR-/i"]
+{
+  "unit-no-unknown": [
+    true,
+    { "ignoreFunctions": ["foo", "/^my-/", "/^YOUR-/i"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:

--- a/lib/rules/value-keyword-case/README.md
+++ b/lib/rules/value-keyword-case/README.md
@@ -17,9 +17,13 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ## Options
 
-`string`: `"lower"|"upper"`
-
 ### `"lower"`
+
+```json
+{
+  "value-keyword-case": "lower"
+}
+```
 
 The following patterns are considered problems:
 
@@ -68,6 +72,12 @@ a {
 ```
 
 ### `"upper"`
+
+```json
+{
+  "value-keyword-case": "upper"
+}
+```
 
 The following patterns are considered problems:
 
@@ -121,12 +131,15 @@ a {
 
 Ignore case of keywords values.
 
-For example, with `"lower"`.
-
 Given:
 
 ```json
-["Block", "/^(f|F)lex$/"]
+{
+  "value-keyword-case": [
+    "lower",
+    { "ignoreKeywords": ["Block", "/^(f|F)lex$/"] }
+  ]
+}
 ```
 
 The following patterns are considered problems:
@@ -193,10 +206,15 @@ a {
 
 Ignore case of the values of the listed properties.
 
-For example, with `"lower"`.
+Given:
 
-```js
-["/^(b|B)ackground$/", "display"];
+```json
+{
+  "value-keyword-case": [
+    "lower",
+    { "ignoreProperties": ["/^(b|B)ackground$/", "display"] }
+  ]
+}
 ```
 
 The following patterns are considered problems:
@@ -263,10 +281,12 @@ a {
 
 Ignore case of the values inside the listed functions.
 
-For example, with `"upper"`.
+Given:
 
-```js
-["/^(f|F)oo$/", "t"];
+```json
+{
+  "value-keyword-case": ["upper", { "ignoreFunctions": ["/^(f|F)oo$/", "t"] }]
+}
 ```
 
 The following patterns are considered problems:
@@ -325,7 +345,13 @@ a {
 
 If `true`, this rule expects SVG keywords to be camel case when the primary option is `"lower"`.
 
-For example with `true`:
+Given:
+
+```json
+{
+  "value-keyword-case": ["lower", { "camelCaseSvgKeywords": true }]
+}
+```
 
 The following pattern is _not_ considered a problem:
 

--- a/lib/rules/value-keyword-case/README.md
+++ b/lib/rules/value-keyword-case/README.md
@@ -127,7 +127,11 @@ a {
 
 ## Optional secondary options
 
-### `ignoreKeywords: ["/regex/", /regex/, "non-regex"]`
+### `ignoreKeywords`
+
+```json
+{ "ignoreKeywords": ["array", "of", "keywords", "/regex/"] }
+```
 
 Ignore case of keywords values.
 
@@ -202,7 +206,11 @@ a {
 }
 ```
 
-### `ignoreProperties: ["/regex/", /regex/, "non-regex"]`
+### `ignoreProperties`
+
+```json
+{ "ignoreProperties": ["array", "of", "properties", "/regex/"] }
+```
 
 Ignore case of the values of the listed properties.
 
@@ -277,7 +285,11 @@ a {
 }
 ```
 
-### `ignoreFunctions: ["/regex/", /regex/, "non-regex"]`
+### `ignoreFunctions`
+
+```json
+{ "ignoreFunctions": ["array", "of", "functions", "/regex/"] }
+```
 
 Ignore case of the values inside the listed functions.
 
@@ -341,9 +353,9 @@ a {
 }
 ```
 
-### `camelCaseSvgKeywords: true | false` (default: `false`)
+### `camelCaseSvgKeywords`
 
-If `true`, this rule expects SVG keywords to be camel case when the primary option is `"lower"`.
+If `true`, this rule expects SVG keywords to be camel case when the primary option is `"lower"`. Defaults to `false`.
 
 Given:
 

--- a/lib/rules/value-no-vendor-prefix/README.md
+++ b/lib/rules/value-no-vendor-prefix/README.md
@@ -61,7 +61,11 @@ a { background: linear-gradient(bottom, #000, #fff); }
 
 ## Optional secondary options
 
-### `ignoreValues: ["/regex/", /regex/, "string"]`
+### `ignoreValues`
+
+```json
+{ "ignoreValues": ["array", "of", "values", "/regex/"] }
+```
 
 Given:
 

--- a/lib/rules/value-no-vendor-prefix/README.md
+++ b/lib/rules/value-no-vendor-prefix/README.md
@@ -19,6 +19,12 @@ The [`message` secondary option](../../../docs/user-guide/configure.md#message) 
 
 ### `true`
 
+```json
+{
+  "value-no-vendor-prefix": true
+}
+```
+
 The following patterns are considered problems:
 
 <!-- prettier-ignore -->
@@ -60,7 +66,12 @@ a { background: linear-gradient(bottom, #000, #fff); }
 Given:
 
 ```json
-["grab", "max-content", "/^-moz-all$/"]
+{
+  "value-no-vendor-prefix": [
+    true,
+    { "ignoreValues": ["grab", "max-content", "/^-moz-all$/"] }
+  ]
+}
 ```
 
 The following patterns are _not_ considered problems:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #3372
Closes #4808

Follow-up to #8552 #8553

> Is there anything in the PR that needs further explanation?

This change documents full configs of all the rules.

The points are:

- Describe a rule's options as a valid JSON code block
- Unify descriptions and examples to use arrays instead of a single value
  - No behavior change, but users will be encouraged to use arrays instead
- Simplify headings, not including details of types
  - This breaks permalinks with a hash (`#`), but it's acceptable

If you want to preview the website, visit:
- https://github.com/stylelint/stylelint.io/pull/512
- https://deploy-preview-512--stylelint.netlify.app/