### PR TITLE
Fix JS syntax errors in `docs/developer-guide/rules.md`

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -170,7 +170,7 @@ root.walkDecls((declNode) => {
     message: messages.rejected(),
     node: declNode,
     index,
-    endIndex:
+    endIndex,
   });
 });
 ```
@@ -192,7 +192,7 @@ root.walkDecls((declNode) => {
       message: messages.rejected(),
       node: declNode,
       index,
-      endIndex:
+      endIndex,
     });
   });
 });

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -170,7 +170,7 @@ root.walkDecls((declNode) => {
     message: messages.rejected(),
     node: declNode,
     index,
-    endIndex,
+    endIndex
   });
 });
 ```
@@ -182,7 +182,6 @@ root.walkDecls((declNode) => {
   const { prop, value: declValue } = declNode;
 
   valueParser(declValue).walk(({ value, sourceIndex }) => {
-
     const index = declarationValueIndex(decl) + sourceIndex;
     const endIndex = index + value.length;
 
@@ -192,7 +191,7 @@ root.walkDecls((declNode) => {
       message: messages.rejected(),
       node: declNode,
       index,
-      endIndex,
+      endIndex
     });
   });
 });


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

This fixes JavaScript syntax errors in code examples in the document. The errors are like so:

```
  });
  ^

SyntaxError: Unexpected token '}'
```