### PR TITLE
Fix `fastest-levenshtein` import when bundling

### DIFF
--- a/.changeset/pink-chicken-clean.md
+++ b/.changeset/pink-chicken-clean.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `fastest-levenshtein` import when bundling

--- a/lib/utils/checkInvalidCLIOptions.cjs
+++ b/lib/utils/checkInvalidCLIOptions.cjs
@@ -3,7 +3,7 @@
 'use strict';
 
 const node_os = require('node:os');
-const levenshtein = require('fastest-levenshtein');
+const fastestLevenshtein = require('fastest-levenshtein');
 const picocolors = require('picocolors');
 
 const { cyan, red } = picocolors;
@@ -35,7 +35,7 @@ const suggest = (all, invalid) => {
 	const maxThreshold = 10;
 
 	for (let threshold = 1; threshold <= maxThreshold; threshold++) {
-		const suggestion = all.find((option) => levenshtein.distance(option, invalid) <= threshold);
+		const suggestion = all.find((option) => fastestLevenshtein.distance(option, invalid) <= threshold);
 
 		if (suggestion) {
 			return suggestion;

--- a/lib/utils/checkInvalidCLIOptions.mjs
+++ b/lib/utils/checkInvalidCLIOptions.mjs
@@ -1,6 +1,6 @@
 import { EOL } from 'node:os';
 
-import levenshtein from 'fastest-levenshtein';
+import { distance } from 'fastest-levenshtein';
 import picocolors from 'picocolors';
 
 const { cyan, red } = picocolors;
@@ -32,7 +32,7 @@ const suggest = (all, invalid) => {
 	const maxThreshold = 10;
 
 	for (let threshold = 1; threshold <= maxThreshold; threshold++) {
-		const suggestion = all.find((option) => levenshtein.distance(option, invalid) <= threshold);
+		const suggestion = all.find((option) => distance(option, invalid) <= threshold);
 
 		if (suggestion) {
 			return suggestion;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

Sorry I didn't create an issue first, I think this is a small change and didn't think it would require a big discussion.

I am using stylelint in a project and in this project I bundle stylelint.
It just so happens that `fastest-levenshtein` is an hybrid ESM module that doesn't have a default export. it can however be imported with `require("fatstest-levenshtein")`.

In stylelint it's already done this way in one place; https://github.com/stylelint/stylelint/blob/93d1af12d62bda32d5b29561691d7a3667616799/lib/reportUnknownRuleNames.mjs#L1 this PR adjusts the second place to use the same style of import

> Which issue, if any, is this issue related to?

None yet.

> Is there anything in the PR that needs further explanation?

I don't think so
