### PR TITLE
Add `::picker(select)` and `::picker-icon` to pseudo-elements

### DIFF
--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -415,6 +415,8 @@ const pseudoClasses = uniteSets(
 		'optional',
 		'out-of-range',
 		'past',
+		'picker-icon',
+		'picker',
 		'picture-in-picture',
 		'placeholder-shown',
 		'popover-open',

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
@@ -112,6 +112,12 @@ testRule({
 			code: '::scroll-marker, ::scroll-marker-group { }',
 		},
 		{
+			code: '::picker(select) { }',
+		},
+		{
+			code: 'select::picker-icon { }',
+		},
+		{
 			code: stripIndent`
 				/* stylelint-disable-next-line selector-pseudo-element-no-unknown */
 				a::pseudo, /* stylelint-disable-next-line selector-pseudo-element-no-unknown */


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #8622

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
