### PR TITLE
Add `after-custom-property` to 'ignore' for rule `custom-property-empy-line-before` #8615

### DIFF
--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -280,7 +280,7 @@ Given:
 {
   "custom-property-empty-line-before": [
     "always",
-    { "except": ["after-comment"] }
+    { "ignore": ["after-comment"] }
   ]
 }
 ```
@@ -292,6 +292,32 @@ The following patterns are _not_ considered problems:
 a {
   /* comment */
   --foo: pink;
+}
+```
+
+#### `"after-custom-property"`
+
+Ignore custom properties that follow another custom property.
+
+Given:
+
+```json
+{
+  "custom-property-empty-line-before": [
+    "always",
+    { "ignore": ["after-custom-property"] }
+  ]
+}
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a {
+
+  --foo: pink;
+  --bar: red;
 }
 ```
 

--- a/lib/rules/custom-property-empty-line-before/__tests__/index.mjs
+++ b/lib/rules/custom-property-empty-line-before/__tests__/index.mjs
@@ -143,6 +143,119 @@ testRule({
 
 testRule({
 	ruleName,
+	config: ['always', { ignore: ['after-custom-property'] }],
+	fix: true,
+	computeEditInfo: true,
+
+	accept: [
+		{
+			code: 'a {\n\n --custom-prop: value; --custom-prop2: value;\n}',
+		},
+		{
+			code: 'a {\r\n\r\n --custom-prop: value; --custom-prop2: value;\r\n}',
+		},
+		{
+			code: 'a {\n\n --custom-prop: value;\n --custom-prop2: value;\n}',
+		},
+		{
+			code: 'a {\n\n --custom-prop: value; /* comment */\n --custom-prop2: value;\n}',
+			description: 'shared-line comment accepted',
+		},
+		{
+			code: 'a {\r\n\r\n --custom-prop: value;\r\n --custom-prop2: value;\r\n}',
+		},
+		{
+			code: 'a {\n\n --custom-prop: value;\n\n --custom-prop2: value;\n}',
+		},
+		{
+			code: 'a {\r\n\r\n --custom-prop: value;\r\n\r\n --custom-prop2: value;\r\n}',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a{\n @extends .class;\n --custom-prop: value;\n}',
+			fixed: 'a{\n @extends .class;\n\n --custom-prop: value;\n}',
+			fix: {
+				range: [20, 21],
+				text: '\n\n',
+			},
+			message: messages.expected,
+			line: 3,
+			column: 2,
+		},
+		{
+			code: 'a{\r\n @extends .class;\r\n --custom-prop: value;\r\n}',
+			fixed: 'a{\r\n @extends .class;\r\n\r\n --custom-prop: value;\r\n}',
+			fix: {
+				range: [22, 23],
+				text: '\n\r\n',
+			},
+			message: messages.expected,
+			line: 3,
+			column: 2,
+		},
+		{
+			code: 'a{\n @include mixin;\n --custom-prop: value;\n}',
+			fixed: 'a{\n @include mixin;\n\n --custom-prop: value;\n}',
+			fix: {
+				range: [19, 20],
+				text: '\n\n',
+			},
+			message: messages.expected,
+			line: 3,
+			column: 2,
+		},
+		{
+			code: 'a{\r\n @include mixin;\r\n --custom-prop: value;\r\n}',
+			fixed: 'a{\r\n @include mixin;\r\n\r\n --custom-prop: value;\r\n}',
+			fix: {
+				range: [21, 22],
+				text: '\n\r\n',
+			},
+			message: messages.expected,
+			line: 3,
+			column: 2,
+		},
+		{
+			code: 'a {\n --custom-prop: value;\n}',
+			fixed: 'a {\n\n --custom-prop: value;\n}',
+			fix: {
+				range: [3, 4],
+				text: '\n\n',
+			},
+			message: messages.expected,
+			line: 2,
+			column: 2,
+		},
+		{
+			code: 'a {\r\n --custom-prop: value;\r\n}',
+			fixed: 'a {\r\n\r\n --custom-prop: value;\r\n}',
+			fix: {
+				range: [4, 5],
+				text: '\n\r\n',
+			},
+			message: messages.expected,
+			line: 2,
+			column: 2,
+		},
+		{
+			code: 'a {\n  top: 15px;\n  --custom-prop: value;\n}',
+			fixed: 'a {\n  top: 15px;\n\n  --custom-prop: value;\n}',
+			fix: {
+				range: [16, 17],
+				text: '\n\n',
+			},
+			message: messages.expected,
+			line: 3,
+			column: 3,
+			description: "standard properties don't count",
+		},
+	],
+});
+
+testRule({
+	ruleName,
 	config: ['always', { ignore: ['first-nested'] }],
 	fix: true,
 	computeEditInfo: true,

--- a/lib/rules/custom-property-empty-line-before/index.cjs
+++ b/lib/rules/custom-property-empty-line-before/index.cjs
@@ -42,8 +42,13 @@ const rule = (primary, secondaryOptions, context) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					except: ['first-nested', 'after-comment', 'after-custom-property'],
-					ignore: ['after-comment', 'first-nested', 'inside-single-line-block'],
+					except: ['after-comment', 'after-custom-property', 'first-nested'],
+					ignore: [
+						'after-comment',
+						'after-custom-property',
+						'first-nested',
+						'inside-single-line-block',
+					],
 				},
 				optional: true,
 			},
@@ -67,6 +72,14 @@ const rule = (primary, secondaryOptions, context) => {
 
 			// Optionally ignore the node if a comment precedes it
 			if (optionsMatches(secondaryOptions, 'ignore', 'after-comment') && isAfterComment(decl)) {
+				return;
+			}
+
+			// Optionally ignore the node if a custom property precedes it
+			if (
+				optionsMatches(secondaryOptions, 'ignore', 'after-custom-property') &&
+				isAfterCustomProperty(decl)
+			) {
 				return;
 			}
 

--- a/lib/rules/custom-property-empty-line-before/index.mjs
+++ b/lib/rules/custom-property-empty-line-before/index.mjs
@@ -38,8 +38,13 @@ const rule = (primary, secondaryOptions, context) => {
 			{
 				actual: secondaryOptions,
 				possible: {
-					except: ['first-nested', 'after-comment', 'after-custom-property'],
-					ignore: ['after-comment', 'first-nested', 'inside-single-line-block'],
+					except: ['after-comment', 'after-custom-property', 'first-nested'],
+					ignore: [
+						'after-comment',
+						'after-custom-property',
+						'first-nested',
+						'inside-single-line-block',
+					],
 				},
 				optional: true,
 			},
@@ -63,6 +68,14 @@ const rule = (primary, secondaryOptions, context) => {
 
 			// Optionally ignore the node if a comment precedes it
 			if (optionsMatches(secondaryOptions, 'ignore', 'after-comment') && isAfterComment(decl)) {
+				return;
+			}
+
+			// Optionally ignore the node if a custom property precedes it
+			if (
+				optionsMatches(secondaryOptions, 'ignore', 'after-custom-property') &&
+				isAfterCustomProperty(decl)
+			) {
 				return;
 			}
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -493,8 +493,10 @@ declare namespace stylelint {
 		'custom-property-empty-line-before': CoreRule<
 			'always' | 'never',
 			{
-				except: OneOrMany<'first-nested' | 'after-comment' | 'after-custom-property'>;
-				ignore: OneOrMany<'after-comment' | 'first-nested' | 'inside-single-line-block'>;
+				except: OneOrMany<'after-comment' | 'after-custom-property' | 'first-nested'>;
+				ignore: OneOrMany<
+					'after-comment' | 'after-custom-property' | 'first-nested' | 'inside-single-line-block'
+				>;
 			}
 		>;
 		'custom-property-no-missing-var-function': CoreRule<true>;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

> Is there anything in the PR that needs further explanation?

The tests are intended to mimic (read: copied from) those for  `declaration-empty-line-before`.
