### PR TITLE
Document `custom-property-empty-line-before` ignore examples correctly

### DIFF
--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -280,7 +280,7 @@ Given:
 {
   "custom-property-empty-line-before": [
     "always",
-    { "except": ["after-comment"] }
+    { "ignore": ["after-comment"] }
   ]
 }
 ```
@@ -305,7 +305,7 @@ Given:
 {
   "custom-property-empty-line-before": [
     "always",
-    { "except": ["first-nested"] }
+    { "ignore": ["first-nested"] }
   ]
 }
 ```
@@ -331,7 +331,7 @@ Given:
 {
   "custom-property-empty-line-before": [
     "always",
-    { "except": ["inside-single-line-block"] }
+    { "ignore": ["inside-single-line-block"] }
   ]
 }
 ```


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/8627#discussion_r2153147227

> Is there anything in the PR that needs further explanation?

I checked through the other `*-empty-line-before` rules, and it's only this one that the LLM tripped up on the `ignore` examples.
