### PR TITLE
Improves plugin module resolution

### DIFF
--- a/lib/augmentConfig.cjs
+++ b/lib/augmentConfig.cjs
@@ -13,7 +13,7 @@ const emitWarning = require('./utils/emitWarning.cjs');
 const getModulePath = require('./utils/getModulePath.cjs');
 const normalizeAllRuleSettings = require('./normalizeAllRuleSettings.cjs');
 
-/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi} from 'stylelint' */
+/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi, Plugin as StylelintPlugin} from 'stylelint' */
 
 /**
  * @param {string} glob
@@ -333,15 +333,14 @@ function mergeConfigs(a, b) {
  * @returns {StylelintPlugin}
  */
 function resolvePluginModule(mod) {
-  let candidate = mod;
+	let candidate = mod;
 
-  // Drill down through nested `.default` wrappers
-  while (candidate?.default && typeof candidate.default === 'object') {
-    if (candidate.ruleName) break; // bail early if valid
-    candidate = candidate.default;
-  }
+	while (candidate?.default && typeof candidate.default === 'object') {
+		if (candidate.ruleName) break;
+		candidate = candidate.default;
+	}
 
-  return candidate;
+	return candidate;
 }
 
 /**

--- a/lib/augmentConfig.cjs
+++ b/lib/augmentConfig.cjs
@@ -326,6 +326,25 @@ function mergeConfigs(a, b) {
 }
 
 /**
+ * Drill down through potentially nested `.default` wrappers.
+ * This is necessary due to packages potentially using cjs/esm interop transformers
+ *
+ * @param {unknown} mod
+ * @returns {StylelintPlugin}
+ */
+function resolvePluginModule(mod) {
+  let candidate = mod;
+
+  // Drill down through nested `.default` wrappers
+  while (candidate?.default && typeof candidate.default === 'object') {
+    if (candidate.ruleName) break; // bail early if valid
+    candidate = candidate.default;
+  }
+
+  return candidate;
+}
+
+/**
  * @param {StylelintConfig} config
  * @param {import('stylelint').LinterOptions} options
  * @returns {Promise<StylelintConfig>}
@@ -359,7 +378,7 @@ async function addPluginFunctions(config, { quietDeprecationWarnings }) {
 		}
 
 		// Handle either ES6 or CommonJS modules
-		pluginImport = pluginImport.default || pluginImport;
+		pluginImport = resolvePluginModule(pluginImport);
 
 		// A plugin can export either a single rule definition
 		// or an array of them

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -333,12 +333,12 @@ function mergeConfigs(a, b) {
 function resolvePluginModule(mod) {
 	let candidate = mod;
 
-  while (candidate?.default && typeof candidate.default === 'object') {
-    if (candidate.ruleName) break; // bail early if valid
-    candidate = candidate.default;
-  }
+	while (candidate?.default && typeof candidate.default === 'object') {
+		if (candidate.ruleName) break;
+		candidate = candidate.default;
+	}
 
-  return candidate;
+	return candidate;
 }
 
 /**

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -11,7 +11,7 @@ import { emitDeprecationWarning } from './utils/emitWarning.mjs';
 import getModulePath from './utils/getModulePath.mjs';
 import normalizeAllRuleSettings from './normalizeAllRuleSettings.mjs';
 
-/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi} from 'stylelint' */
+/** @import {Config as StylelintConfig, CosmiconfigResult as StylelintCosmiconfigResult, InternalApi as StylelintInternalApi, Plugin as StylelintPlugin} from 'stylelint' */
 
 /**
  * @param {string} glob
@@ -324,6 +324,24 @@ function mergeConfigs(a, b) {
 }
 
 /**
+ * Drill down through potentially nested `.default` wrappers.
+ * This is necessary due to packages potentially using cjs/esm interop transformers
+ *
+ * @param {unknown} mod
+ * @returns {StylelintPlugin}
+ */
+function resolvePluginModule(mod) {
+	let candidate = mod;
+
+  while (candidate?.default && typeof candidate.default === 'object') {
+    if (candidate.ruleName) break; // bail early if valid
+    candidate = candidate.default;
+  }
+
+  return candidate;
+}
+
+/**
  * @param {StylelintConfig} config
  * @param {import('stylelint').LinterOptions} options
  * @returns {Promise<StylelintConfig>}
@@ -357,7 +375,7 @@ async function addPluginFunctions(config, { quietDeprecationWarnings }) {
 		}
 
 		// Handle either ES6 or CommonJS modules
-		pluginImport = pluginImport.default || pluginImport;
+		pluginImport = resolvePluginModule(pluginImport);
 
 		// A plugin can export either a single rule definition
 		// or an array of them


### PR DESCRIPTION
Closes #8573 

Improves the way plugins with various types of cjs/esm interop layers are resolved. 

Previously the resolver would only check for top-level `.default` imports, however, there are cases where the transpilation step may add an additional `.default` as a way to support different module types "synthetic modules". 

For more context, please refer to this comment: https://github.com/stylelint/stylelint/issues/8573#issuecomment-2982939797