### PR TITLE
Document config, plugin and formatter packages on npm

### DIFF
--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -481,7 +481,7 @@ The value of `"extends"` is a "locater" (or an array of "locaters") that is ulti
 - an absolute path to a file (which makes sense if you're creating a JS object in a Node.js context and passing it in) with a `.js` or `.json` extension.
 - a relative path to a file with a `.js` or `.json` extension, relative to the referencing configuration (e.g. if configA has `extends: "../configB"`, we'll look for `configB` relative to configA).
 
-You'll find more configs in [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint#readme) and [on the npm registry](https://www.npmjs.com/search?q=keywords:stylelint-config).
+You'll find more configs in [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint#configs) and [on the npm registry](https://www.npmjs.com/search?q=keywords:stylelint-config).
 
 ## `plugins`
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/awesome-stylelint/issues/95

> Is there anything in the PR that needs further explanation?

Rather than add links to the Awesome page, we can include them in our main docs. It feels like a better fit, and there wasn't an obvious place to add them on the awesome page that didn't disrupt the flow of the page.

[Plugins](https://stylelint.io/developer-guide/plugins#sharing-plugins-and-plugin-packs), [configs](https://stylelint.io/developer-guide/plugins#sharing-configurations) and [formatters](https://stylelint.io/developer-guide/formatters#sharing-formatters) are the three things we mention adding specific npm keywords for.