### PR TITLE
Fix `media-feature-range-notation` autofix for exact values

### DIFF
--- a/.changeset/brown-hotels-notice.md
+++ b/.changeset/brown-hotels-notice.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `media-feature-range-notation` autofix for exact values

--- a/lib/rules/media-feature-range-notation/__tests__/index.mjs
+++ b/lib/rules/media-feature-range-notation/__tests__/index.mjs
@@ -112,13 +112,15 @@ testRule({
 		{
 			code: stripIndent`
 				@media (min-width: 1px)
-				  and (max-width: 2px) {}
+				  and (max-width: 2px)
+				  and (width: 3px) {}
 			`,
 			fixed: stripIndent`
 				@media (width >= 1px)
-				  and (width <= 2px) {}
+				  and (width <= 2px)
+				  and (width = 3px) {}
 			`,
-			description: 'two range type media features in prefix notation',
+			description: 'three range type media features in prefix notation',
 			warnings: [
 				{
 					message: messages.expected('context'),
@@ -134,6 +136,14 @@ testRule({
 					column: 7,
 					endLine: 2,
 					endColumn: 23,
+					fix: undefined,
+				},
+				{
+					message: messages.expected('context'),
+					line: 3,
+					column: 7,
+					endLine: 3,
+					endColumn: 19,
 					fix: undefined,
 				},
 			],

--- a/lib/rules/media-feature-range-notation/index.cjs
+++ b/lib/rules/media-feature-range-notation/index.cjs
@@ -24,6 +24,8 @@ const meta = {
 	fixable: true,
 };
 
+/** @import {TokenDelim} from '@csstools/css-tokenizer' */
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -63,10 +65,22 @@ const rule = (primary) => {
 					 * @param {import('@csstools/media-query-list-parser').MediaFeature} entry.parent
 					 */
 					const contextFixer = (entry) => () => {
-						/** @type {import('@csstools/css-tokenizer').TokenDelim} */
-						const operator = /^min-/i.test(featureName)
-							? [cssTokenizer.TokenType.Delim, '>', -1, -1, { value: '>' }]
-							: [cssTokenizer.TokenType.Delim, '<', -1, -1, { value: '<' }];
+						/** @type {[TokenDelim]|[TokenDelim, TokenDelim]} */
+						let operator;
+
+						if (/^min-/i.test(featureName)) {
+							operator = [
+								[cssTokenizer.TokenType.Delim, '>', -1, -1, { value: '>' }],
+								[cssTokenizer.TokenType.Delim, '=', -1, -1, { value: '=' }],
+							];
+						} else if (/^max-/i.test(featureName)) {
+							operator = [
+								[cssTokenizer.TokenType.Delim, '<', -1, -1, { value: '<' }],
+								[cssTokenizer.TokenType.Delim, '=', -1, -1, { value: '=' }],
+							];
+						} else {
+							operator = [[cssTokenizer.TokenType.Delim, '=', -1, -1, { value: '=' }]];
+						}
 
 						entry.parent.feature = new mediaQueryListParser.MediaFeatureRangeNameValue(
 							new mediaQueryListParser.MediaFeatureName(
@@ -82,7 +96,7 @@ const rule = (primary) => {
 									? entry.node.name.after
 									: [[cssTokenizer.TokenType.Whitespace, ' ', -1, -1, undefined]],
 							),
-							[operator, [cssTokenizer.TokenType.Delim, '=', -1, -1, { value: '=' }]],
+							operator,
 							entry.node.value,
 						);
 

--- a/lib/rules/media-feature-range-notation/index.mjs
+++ b/lib/rules/media-feature-range-notation/index.mjs
@@ -28,6 +28,8 @@ const meta = {
 	fixable: true,
 };
 
+/** @import {TokenDelim} from '@csstools/css-tokenizer' */
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary) => {
 	return (root, result) => {
@@ -67,10 +69,22 @@ const rule = (primary) => {
 					 * @param {import('@csstools/media-query-list-parser').MediaFeature} entry.parent
 					 */
 					const contextFixer = (entry) => () => {
-						/** @type {import('@csstools/css-tokenizer').TokenDelim} */
-						const operator = /^min-/i.test(featureName)
-							? [TokenType.Delim, '>', -1, -1, { value: '>' }]
-							: [TokenType.Delim, '<', -1, -1, { value: '<' }];
+						/** @type {[TokenDelim]|[TokenDelim, TokenDelim]} */
+						let operator;
+
+						if (/^min-/i.test(featureName)) {
+							operator = [
+								[TokenType.Delim, '>', -1, -1, { value: '>' }],
+								[TokenType.Delim, '=', -1, -1, { value: '=' }],
+							];
+						} else if (/^max-/i.test(featureName)) {
+							operator = [
+								[TokenType.Delim, '<', -1, -1, { value: '<' }],
+								[TokenType.Delim, '=', -1, -1, { value: '=' }],
+							];
+						} else {
+							operator = [[TokenType.Delim, '=', -1, -1, { value: '=' }]];
+						}
 
 						entry.parent.feature = new MediaFeatureRangeNameValue(
 							new MediaFeatureName(
@@ -86,7 +100,7 @@ const rule = (primary) => {
 									? entry.node.name.after
 									: [[TokenType.Whitespace, ' ', -1, -1, undefined]],
 							),
-							[operator, [TokenType.Delim, '=', -1, -1, { value: '=' }]],
+							operator,
 							entry.node.value,
 						);
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8647

> Is there anything in the PR that needs further explanation?

[Demo](https://stylelint.io/demo/#N4Igxg9gJgpiBcIACBbGUCWBDABACgHcMoAXAC3hwDYAGGgBwA8BKHYAXxABoQAzDADYwAcljQIQMRmPpCAdGADOi7uAgA7fgHMJwADrqcOPSABOAVyGKTlfYaPGQaTFgC0vGFhLnTMV6ax1LT91CBIvDA0bR0h1EikSEwMjdgNOHljtADEIUxQvCQArRQ1VWHoVRDsjE0USAE8hAQw46JMyEhIK+AB6HvoAay05elM5dRgCHrrGmGa4pAAOXgBGRYAWACYAZhMuZMcZppaSV0yMLVc6wKgsUyg2kAEvGDqk9U52IA)
