### PR TITLE
Refactor `resolveFilePath()` internal utility

### DIFF
--- a/lib/utils/resolveFilePath.cjs
+++ b/lib/utils/resolveFilePath.cjs
@@ -22,26 +22,19 @@ function resolveFilePath(location, cwd, defaultFileName) {
 	 * Make sure path separators are normalized for environment/os.
 	 * Also, keep trailing path separator if present.
 	 */
-	location = node_path.normalize(location);
+	const normalizedLocation = node_path.normalize(location);
 
-	const resolvedLocation = node_path.resolve(cwd, location);
-	// If the last character passed is a path separator, we assume is a directory.
-	const looksLikeADirectory = location[location.length - 1] === node_path.sep;
+	const resolvedLocation = node_path.resolve(cwd, normalizedLocation);
 
-	/**
-	 * Return the file path when the location is a directory.
-	 * @returns {string} - Resolved path to the file
-	 */
-	function getFilePathForDirectory() {
-		return node_path.join(resolvedLocation, defaultFileName);
-	}
+	// If the location path ends with a separator, we assume is a directory.
+	const looksLikeADirectory = location.endsWith(node_path.sep);
 
 	if (
 		looksLikeADirectory ||
 		node_fs.lstatSync(resolvedLocation, { throwIfNoEntry: false })?.isDirectory()
 	) {
 		// Return path to provided directory with the specified file name.
-		return getFilePathForDirectory();
+		return node_path.join(resolvedLocation, defaultFileName);
 	}
 
 	// Return normalized path to file.

--- a/lib/utils/resolveFilePath.mjs
+++ b/lib/utils/resolveFilePath.mjs
@@ -18,26 +18,19 @@ export default function resolveFilePath(location, cwd, defaultFileName) {
 	 * Make sure path separators are normalized for environment/os.
 	 * Also, keep trailing path separator if present.
 	 */
-	location = normalize(location);
+	const normalizedLocation = normalize(location);
 
-	const resolvedLocation = resolve(cwd, location);
-	// If the last character passed is a path separator, we assume is a directory.
-	const looksLikeADirectory = location[location.length - 1] === sep;
+	const resolvedLocation = resolve(cwd, normalizedLocation);
 
-	/**
-	 * Return the file path when the location is a directory.
-	 * @returns {string} - Resolved path to the file
-	 */
-	function getFilePathForDirectory() {
-		return join(resolvedLocation, defaultFileName);
-	}
+	// If the location path ends with a separator, we assume is a directory.
+	const looksLikeADirectory = location.endsWith(sep);
 
 	if (
 		looksLikeADirectory ||
 		lstatSync(resolvedLocation, { throwIfNoEntry: false })?.isDirectory()
 	) {
 		// Return path to provided directory with the specified file name.
-		return getFilePathForDirectory();
+		return join(resolvedLocation, defaultFileName);
 	}
 
 	// Return normalized path to file.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow-up to PR #8655

> Is there anything in the PR that needs further explanation?


This just refactor the internal code in the `resolveFilePath()` utility to improve the code readability:

- Avoid assigning to an argument.
- Use `endsWith` over `[]` for a string.
- Inline an private function to avoid needless function creation.
