### PR TITLE
Fix `lightness-notation` crash with `"number"` option and single-digit percentage

### DIFF
--- a/.changeset/major-seals-bathe.md
+++ b/.changeset/major-seals-bathe.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `lightness-notation` crash with `"number"` option and single-digit percentage

--- a/lib/rules/lightness-notation/__tests__/index.mjs
+++ b/lib/rules/lightness-notation/__tests__/index.mjs
@@ -214,6 +214,19 @@ testRule({
 				},
 			],
 		},
+		{
+			code: 'a { color: oklab(0 0.1 241) }',
+			fixed: 'a { color: oklab(0% 0.1 241) }',
+			fix: {
+				range: [17, 18],
+				text: '0%',
+			},
+			message: messages.expected('0', '0%'),
+			line: 1,
+			column: 18,
+			endLine: 1,
+			endColumn: 19,
+		},
 	],
 });
 
@@ -422,6 +435,32 @@ testRule({
 					endColumn: 13,
 				},
 			],
+		},
+		{
+			code: 'a { color: oklab(5% -100% 0.4) }',
+			fixed: 'a { color: oklab(0.05 -100% 0.4) }',
+			fix: {
+				range: [17, 19],
+				text: '0.05',
+			},
+			message: messages.expected('5%', '0.05'),
+			line: 1,
+			column: 18,
+			endLine: 1,
+			endColumn: 20,
+		},
+		{
+			code: 'a { color: oklab(0% -100% 0.4) }',
+			fixed: 'a { color: oklab(0 -100% 0.4) }',
+			fix: {
+				range: [18, 19],
+				text: '',
+			},
+			message: messages.expected('0%', '0'),
+			line: 1,
+			column: 18,
+			endLine: 1,
+			endColumn: 20,
 		},
 	],
 });

--- a/lib/rules/lightness-notation/index.cjs
+++ b/lib/rules/lightness-notation/index.cjs
@@ -142,9 +142,16 @@ function asNumber(value, func) {
 /**
  * @param {number} num
  * @param {string} value
+ * @returns {string}
  */
 function roundToNumberOfDigits(num, value) {
-	return num.toPrecision(value.length - 2);
+	if (num === 0) return '0';
+
+	const precision = value.replace('%', '').replace('.', '').length;
+
+	if (precision === 0) return `${num}`;
+
+	return num.toPrecision(precision).replace(/0+$/, ''); // trim trailing zeros
 }
 
 /**

--- a/lib/rules/lightness-notation/index.cjs
+++ b/lib/rules/lightness-notation/index.cjs
@@ -147,7 +147,7 @@ function asNumber(value, func) {
 function roundToNumberOfDigits(num, value) {
 	if (num === 0) return '0';
 
-	const precision = value.replace('%', '').replace('.', '').length;
+	const precision = value.replaceAll('%', '').replaceAll('.', '').length;
 
 	if (precision === 0) return `${num}`;
 

--- a/lib/rules/lightness-notation/index.mjs
+++ b/lib/rules/lightness-notation/index.mjs
@@ -139,9 +139,16 @@ function asNumber(value, func) {
 /**
  * @param {number} num
  * @param {string} value
+ * @returns {string}
  */
 function roundToNumberOfDigits(num, value) {
-	return num.toPrecision(value.length - 2);
+	if (num === 0) return '0';
+
+	const precision = value.replace('%', '').replace('.', '').length;
+
+	if (precision === 0) return `${num}`;
+
+	return num.toPrecision(precision).replace(/0+$/, ''); // trim trailing zeros
 }
 
 /**

--- a/lib/rules/lightness-notation/index.mjs
+++ b/lib/rules/lightness-notation/index.mjs
@@ -144,7 +144,7 @@ function asNumber(value, func) {
 function roundToNumberOfDigits(num, value) {
 	if (num === 0) return '0';
 
-	const precision = value.replace('%', '').replace('.', '').length;
+	const precision = value.replaceAll('%', '').replaceAll('.', '').length;
 
 	if (precision === 0) return `${num}`;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8659

> Is there anything in the PR that needs further explanation?

The implementation of the current `roundToNumberOfDigits()` private function seems a bit too simple. This PR fixes the function only.
