### PR TITLE
Add `messageArgs` to `color-named`

### DIFF
--- a/.changeset/sour-melons-rest.md
+++ b/.changeset/sour-melons-rest.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `messageArgs` to `color-named`

--- a/lib/rules/color-named/__tests__/index.mjs
+++ b/lib/rules/color-named/__tests__/index.mjs
@@ -206,7 +206,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { color: #000 }',
-			message: messages.expected('black', '#000'),
+			message: messages.expected('#000', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -214,7 +214,7 @@ testRule({
 		},
 		{
 			code: 'a { color: #fFfFfF }',
-			message: messages.expected('white', '#fFfFfF'),
+			message: messages.expected('#fFfFfF', 'white'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -222,7 +222,7 @@ testRule({
 		},
 		{
 			code: 'a { color: #FFFFFF }',
-			message: messages.expected('white', '#FFFFFF'),
+			message: messages.expected('#FFFFFF', 'white'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -230,7 +230,7 @@ testRule({
 		},
 		{
 			code: 'a { background: #000f }',
-			message: messages.expected('black', '#000f'),
+			message: messages.expected('#000f', 'black'),
 			line: 1,
 			column: 17,
 			endLine: 1,
@@ -238,7 +238,7 @@ testRule({
 		},
 		{
 			code: 'a { color: #000000ff }',
-			message: messages.expected('black', '#000000ff'),
+			message: messages.expected('#000000ff', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -246,7 +246,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgb(0, 0, 0) }',
-			message: messages.expected('black', 'rgb(0,0,0)'),
+			message: messages.expected('rgb(0,0,0)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -254,7 +254,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rGb(0, 0, 0) }',
-			message: messages.expected('black', 'rGb(0,0,0)'),
+			message: messages.expected('rGb(0,0,0)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -262,7 +262,7 @@ testRule({
 		},
 		{
 			code: 'a { color: RGB(0, 0, 0) }',
-			message: messages.expected('black', 'RGB(0,0,0)'),
+			message: messages.expected('RGB(0,0,0)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -270,7 +270,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgba(0, 0, 0, 1) }',
-			message: messages.expected('black', 'rgba(0,0,0,1)'),
+			message: messages.expected('rgba(0,0,0,1)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -278,7 +278,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgba(0 0 0 / 1) }',
-			message: messages.expected('black', 'rgba(0 0 0/1)'),
+			message: messages.expected('rgba(0 0 0/1)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -286,7 +286,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgba(0, 0, 0, 100%) }',
-			message: messages.expected('black', 'rgba(0,0,0,100%)'),
+			message: messages.expected('rgba(0,0,0,100%)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -294,7 +294,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgb(0%,0%, 0%) }',
-			message: messages.expected('black', 'rgb(0%,0%,0%)'),
+			message: messages.expected('rgb(0%,0%,0%)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -302,7 +302,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgba(0%,0%, 0%  ,1) }',
-			message: messages.expected('black', 'rgba(0%,0%,0%,1)'),
+			message: messages.expected('rgba(0%,0%,0%,1)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -310,7 +310,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgba(0%,0%, 0%\n,100%) }',
-			message: messages.expected('black', 'rgba(0%,0%,0%,100%)'),
+			message: messages.expected('rgba(0%,0%,0%,100%)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 2,
@@ -318,7 +318,7 @@ testRule({
 		},
 		{
 			code: 'a { color: hsl(0,0%, 0%) }',
-			message: messages.expected('black', 'hsl(0,0%,0%)'),
+			message: messages.expected('hsl(0,0%,0%)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -326,7 +326,7 @@ testRule({
 		},
 		{
 			code: 'a { color: hsla(0,0%, 0%  ,1) }',
-			message: messages.expected('black', 'hsla(0,0%,0%,1)'),
+			message: messages.expected('hsla(0,0%,0%,1)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -334,7 +334,7 @@ testRule({
 		},
 		{
 			code: 'a { color: hsla(0,0%, 0%\n,100%) }',
-			message: messages.expected('black', 'hsla(0,0%,0%,100%)'),
+			message: messages.expected('hsla(0,0%,0%,100%)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 2,
@@ -342,7 +342,7 @@ testRule({
 		},
 		{
 			code: 'a { color: hwb(0,0%, 0%) }',
-			message: messages.expected('red', 'hwb(0,0%,0%)'),
+			message: messages.expected('hwb(0,0%,0%)', 'red'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -350,7 +350,7 @@ testRule({
 		},
 		{
 			code: 'a { color: hwb(0,0%, 0%  ,1) }',
-			message: messages.expected('red', 'hwb(0,0%,0%,1)'),
+			message: messages.expected('hwb(0,0%,0%,1)', 'red'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -358,7 +358,7 @@ testRule({
 		},
 		{
 			code: 'a { color: hwb(0,0%, 0%\n,100%) }',
-			message: messages.expected('red', 'hwb(0,0%,0%,100%)'),
+			message: messages.expected('hwb(0,0%,0%,100%)', 'red'),
 			line: 1,
 			column: 12,
 			endLine: 2,
@@ -366,7 +366,7 @@ testRule({
 		},
 		{
 			code: 'a { color: gray(0) }',
-			message: messages.expected('black', 'gray(0)'),
+			message: messages.expected('gray(0)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -374,7 +374,7 @@ testRule({
 		},
 		{
 			code: 'a { color: gray(0%) }',
-			message: messages.expected('black', 'gray(0%)'),
+			message: messages.expected('gray(0%)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -382,7 +382,7 @@ testRule({
 		},
 		{
 			code: 'a { color: gray(0, 1) }',
-			message: messages.expected('black', 'gray(0,1)'),
+			message: messages.expected('gray(0,1)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -390,7 +390,7 @@ testRule({
 		},
 		{
 			code: 'a { color: gray(0, 100%) }',
-			message: messages.expected('black', 'gray(0,100%)'),
+			message: messages.expected('gray(0,100%)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 1,
@@ -398,7 +398,7 @@ testRule({
 		},
 		{
 			code: 'a { color: rgb(\n0 ,\n 0 ,\r\n 0) }',
-			message: messages.expected('black', 'rgb(0,0,0)'),
+			message: messages.expected('rgb(0,0,0)', 'black'),
 			line: 1,
 			column: 12,
 			endLine: 4,
@@ -406,7 +406,7 @@ testRule({
 		},
 		{
 			code: 'a { background: #302, rgb(\n0 ,\n 0 ,\r\n 0) }',
-			message: messages.expected('black', 'rgb(0,0,0)'),
+			message: messages.expected('rgb(0,0,0)', 'black'),
 			line: 1,
 			column: 23,
 			endLine: 4,
@@ -414,7 +414,7 @@ testRule({
 		},
 		{
 			code: 'a { color: color(#000 a(50%)) }',
-			message: messages.expected('black', '#000'),
+			message: messages.expected('#000', 'black'),
 			line: 1,
 			column: 18,
 			endLine: 1,

--- a/lib/rules/color-named/index.cjs
+++ b/lib/rules/color-named/index.cjs
@@ -21,7 +21,7 @@ const validateOptions = require('../../utils/validateOptions.cjs');
 const ruleName = 'color-named';
 
 const messages = ruleMessages(ruleName, {
-	expected: (expected, actual) => `Expected "${actual}" to be "${expected}"`,
+	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 	rejected: (keyword) => `Unexpected named color "${keyword}"`,
 });
 
@@ -112,7 +112,8 @@ const rule = (primary, secondaryOptions) => {
 					keywords.namedColorsKeywords.has(value.toLowerCase())
 				) {
 					complain(
-						messages.rejected(value),
+						messages.rejected,
+						[value],
 						decl,
 						nodeFieldIndices.declarationValueIndex(decl) + sourceIndex,
 						value.length,
@@ -152,7 +153,8 @@ const rule = (primary, secondaryOptions) => {
 
 				if (namedColor && namedColor.toLowerCase() !== 'transparent') {
 					complain(
-						messages.expected(namedColor, colorString),
+						messages.expected,
+						[colorString, namedColor],
 						decl,
 						nodeFieldIndices.declarationValueIndex(decl) + sourceIndex,
 						rawColorString.length,
@@ -162,17 +164,18 @@ const rule = (primary, secondaryOptions) => {
 		});
 
 		/**
-		 * @param {string} message
+		 * @param {typeof messages[keyof messages]} message
+		 * @param {string[]} messageArgs
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {number} length
 		 */
-		function complain(message, node, index, length) {
+		function complain(message, messageArgs, node, index, length) {
 			report({
 				result,
 				ruleName,
 				message,
-				messageArgs: [],
+				messageArgs,
 				node,
 				index,
 				endIndex: index + length,

--- a/lib/rules/color-named/index.mjs
+++ b/lib/rules/color-named/index.mjs
@@ -18,7 +18,7 @@ import validateOptions from '../../utils/validateOptions.mjs';
 const ruleName = 'color-named';
 
 const messages = ruleMessages(ruleName, {
-	expected: (expected, actual) => `Expected "${actual}" to be "${expected}"`,
+	expected: (actual, expected) => `Expected "${actual}" to be "${expected}"`,
 	rejected: (keyword) => `Unexpected named color "${keyword}"`,
 });
 
@@ -109,7 +109,8 @@ const rule = (primary, secondaryOptions) => {
 					namedColorsKeywords.has(value.toLowerCase())
 				) {
 					complain(
-						messages.rejected(value),
+						messages.rejected,
+						[value],
 						decl,
 						declarationValueIndex(decl) + sourceIndex,
 						value.length,
@@ -149,7 +150,8 @@ const rule = (primary, secondaryOptions) => {
 
 				if (namedColor && namedColor.toLowerCase() !== 'transparent') {
 					complain(
-						messages.expected(namedColor, colorString),
+						messages.expected,
+						[colorString, namedColor],
 						decl,
 						declarationValueIndex(decl) + sourceIndex,
 						rawColorString.length,
@@ -159,17 +161,18 @@ const rule = (primary, secondaryOptions) => {
 		});
 
 		/**
-		 * @param {string} message
+		 * @param {typeof messages[keyof messages]} message
+		 * @param {string[]} messageArgs
 		 * @param {import('postcss').Node} node
 		 * @param {number} index
 		 * @param {number} length
 		 */
-		function complain(message, node, index, length) {
+		function complain(message, messageArgs, node, index, length) {
 			report({
 				result,
 				ruleName,
 				message,
-				messageArgs: [],
+				messageArgs,
 				node,
 				index,
 				endIndex: index + length,

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -511,7 +511,8 @@ declare namespace stylelint {
 		'color-hex-length': CoreRule<'short' | 'long', {}, AutofixMessage>;
 		'color-named': CoreRule<
 			'never' | 'always-where-possible',
-			{ ignoreProperties: OneOrMany<StringOrRegex>; ignore: OneOrMany<'inside-function'> }
+			{ ignoreProperties: OneOrMany<StringOrRegex>; ignore: OneOrMany<'inside-function'> },
+			AutofixMessage & RejectedMessage<[keyword: string]>
 		>;
 		'color-no-hex': CoreRule<true, {}, RejectedMessage<[hex: string]>>;
 		'color-no-invalid-hex': CoreRule<true, {}, RejectedMessage<[hex: string]>>;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#4117

> Is there anything in the PR that needs further explanation?

This would only be disruptive if someone did `import { messages } from 'foo/bar/lib/rules/color-named/index.mjs';` before.
i.e. reusing our internal `messages` for their own tests
I didn't find such cases in the wild.
i.e. the reversal of the arguments can be considered a refactor since we didn't pass `messageArgs` (or it was empty)