### PR TITLE
Document that `undefined` also disables a rule

### DIFF
--- a/.changeset/undefined-disable.md
+++ b/.changeset/undefined-disable.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+docs: undefined also disables the rule

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -46,7 +46,7 @@ The `rules` property is _an object whose keys are rule names and values are rule
 
 Each rule configuration fits one of the following formats:
 
-- `null` (to turn the rule off)
+- `null` or `undefined` (to turn the rule off)
 - a single value (the primary option)
 - an array with two values (`[primary option, secondary options]`)
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

The documentation only indicates `null` to disable a rule. But you can also disable a rule with `undefined` ([_index.d.ts_](https://github.com/stylelint/stylelint/blob/16.21.1/types/stylelint/index.d.ts#L76), [_normalizeRuleSettings.mjs_](https://github.com/stylelint/stylelint/blob/16.21.1/lib/normalizeRuleSettings.mjs#L23)). This is useful when the configuration is in JavaScript and the ESLint [`unicorn/no-null`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v59.0.1/docs/rules/no-null.md) rule is used.