### PR TITLE
Fix `no-irregular-whitespace` false positives for strings

### DIFF
--- a/.changeset/popular-actors-develop.md
+++ b/.changeset/popular-actors-develop.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `no-irregular-whitespace` false positives for strings

--- a/lib/rules/no-irregular-whitespace/__tests__/index.mjs
+++ b/lib/rules/no-irregular-whitespace/__tests__/index.mjs
@@ -83,6 +83,9 @@ testRule({
 				}
 			`,
 		},
+		{
+			code: `.a { content: ' '; }`,
+		},
 	],
 
 	reject: [

--- a/lib/rules/no-irregular-whitespace/index.cjs
+++ b/lib/rules/no-irregular-whitespace/index.cjs
@@ -119,7 +119,7 @@ const rule = (primary) => {
 			validate(decl, decl.raws.before, zeroIndex);
 			validate(decl, decl.prop, zeroIndex);
 			validate(decl, decl.raws.between, nodeFieldIndices.declarationBetweenIndex);
-			validate(decl, getDeclarationValue(decl), nodeFieldIndices.declarationValueIndex);
+			validate(decl, returnIfNotQuoted(getDeclarationValue(decl)), nodeFieldIndices.declarationValueIndex);
 		});
 	};
 };
@@ -130,6 +130,14 @@ function zeroIndex() {
 
 function oneIndex() {
 	return 1;
+}
+
+/**
+ * @param {string} str
+ * @returns {string | undefined}
+ */
+function returnIfNotQuoted(str) {
+	return /^(['"]).*?\1$/.test(str) ? undefined : str;
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/no-irregular-whitespace/index.mjs
+++ b/lib/rules/no-irregular-whitespace/index.mjs
@@ -125,7 +125,7 @@ const rule = (primary) => {
 			validate(decl, decl.raws.before, zeroIndex);
 			validate(decl, decl.prop, zeroIndex);
 			validate(decl, decl.raws.between, declarationBetweenIndex);
-			validate(decl, getDeclarationValue(decl), declarationValueIndex);
+			validate(decl, returnIfNotQuoted(getDeclarationValue(decl)), declarationValueIndex);
 		});
 	};
 };
@@ -136,6 +136,14 @@ function zeroIndex() {
 
 function oneIndex() {
 	return 1;
+}
+
+/**
+ * @param {string} str
+ * @returns {string | undefined}
+ */
+function returnIfNotQuoted(str) {
+	return /^(['"]).*?\1$/.test(str) ? undefined : str;
 }
 
 rule.ruleName = ruleName;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #8558 

> Is there anything in the PR that needs further explanation?

I have a question.
In the thread, @jeddy3 suggested that ignoring strings might be needed for AtRule, Rule, and Declaration. I’m not sure what cases are possible with AtRule and Rule that could cause this error and that haven’t been covered by tests yet.
In general, I would appreciate it if you could point out such cases.
