### PR TITLE
Fix config resolution performance

### DIFF
--- a/lib/isPathIgnored.cjs
+++ b/lib/isPathIgnored.cjs
@@ -8,21 +8,24 @@ const filterFilePaths = require('./utils/filterFilePaths.cjs');
 const getConfigForFile = require('./getConfigForFile.cjs');
 const getFileIgnorer = require('./utils/getFileIgnorer.cjs');
 
+/** @import {CosmiconfigResult} from 'stylelint' */
+
 /**
  * To find out if a path is ignored, we need to load the config,
  * which may have an ignoreFiles property. We then check the path
  * against these.
  * @param {import('stylelint').InternalApi} stylelint
  * @param {string} [filePath]
+ * @param {CosmiconfigResult} [config] - Optional pre-fetched config to use.
  * @returns {Promise<boolean>}
  */
-async function isPathIgnored(stylelint, filePath) {
+async function isPathIgnored(stylelint, filePath, config) {
 	if (!filePath) {
 		return false;
 	}
 
 	const cwd = stylelint._options.cwd;
-	const result = await getConfigForFile({ stylelint, searchPath: filePath, filePath });
+	const result = config ?? (await getConfigForFile({ stylelint, searchPath: filePath, filePath }));
 
 	if (!result) {
 		return true;

--- a/lib/isPathIgnored.mjs
+++ b/lib/isPathIgnored.mjs
@@ -6,21 +6,24 @@ import filterFilePaths from './utils/filterFilePaths.mjs';
 import getConfigForFile from './getConfigForFile.mjs';
 import getFileIgnorer from './utils/getFileIgnorer.mjs';
 
+/** @import {CosmiconfigResult} from 'stylelint' */
+
 /**
  * To find out if a path is ignored, we need to load the config,
  * which may have an ignoreFiles property. We then check the path
  * against these.
  * @param {import('stylelint').InternalApi} stylelint
  * @param {string} [filePath]
+ * @param {CosmiconfigResult} [config] - Optional pre-fetched config to use.
  * @returns {Promise<boolean>}
  */
-export default async function isPathIgnored(stylelint, filePath) {
+export default async function isPathIgnored(stylelint, filePath, config) {
 	if (!filePath) {
 		return false;
 	}
 
 	const cwd = stylelint._options.cwd;
-	const result = await getConfigForFile({ stylelint, searchPath: filePath, filePath });
+	const result = config ?? (await getConfigForFile({ stylelint, searchPath: filePath, filePath }));
 
 	if (!result) {
 		return true;

--- a/lib/lintSource.cjs
+++ b/lib/lintSource.cjs
@@ -16,16 +16,17 @@ const reportDisables = require('./reportDisables.cjs');
 const unscopedDisables = require('./unscopedDisables.cjs');
 
 /** @import {Result} from 'postcss' */
-/** @import {GetLintSourceOptions as Options, InternalApi as StylelintInternalApi, PostcssResult, StylelintPostcssResult} from 'stylelint' */
+/** @import {GetLintSourceOptions as Options, InternalApi as StylelintInternalApi, PostcssResult, StylelintPostcssResult, CosmiconfigResult} from 'stylelint' */
 
 /**
  * Run stylelint on a PostCSS Result, either one that is provided
  * or one that we create
  * @param {StylelintInternalApi} stylelint
  * @param {Options} options
+ * @param {CosmiconfigResult} [configForFile] - Optional pre-fetched config to use.
  * @returns {Promise<PostcssResult>}
  */
-async function lintSource(stylelint, options = {}) {
+async function lintSource(stylelint, options = {}, configForFile) {
 	if (!options.filePath && options.code === undefined && !options.existingPostcssResult) {
 		return Promise.reject(new Error('You must provide filePath, code, or existingPostcssResult'));
 	}
@@ -42,7 +43,13 @@ async function lintSource(stylelint, options = {}) {
 		return Promise.reject(new Error('filePath must be an absolute path'));
 	}
 
-	const isIgnored = await isPathIgnored(stylelint, inputFilePath).catch((err) => {
+	configForFile ??= await getConfigForFile({
+		stylelint,
+		searchPath: inputFilePath,
+		filePath: inputFilePath,
+	});
+
+	const isIgnored = await isPathIgnored(stylelint, inputFilePath, configForFile).catch((err) => {
 		if (isCodeNotFile && isPathNotFoundError(err)) return false;
 
 		throw err;
@@ -51,12 +58,6 @@ async function lintSource(stylelint, options = {}) {
 	if (isIgnored) {
 		return createEmptyPostcssResult(inputFilePath, options.existingPostcssResult);
 	}
-
-	const configForFile = await getConfigForFile({
-		stylelint,
-		searchPath: inputFilePath,
-		filePath: inputFilePath,
-	});
 
 	if (!configForFile) {
 		return Promise.reject(new Error('Config file not found'));

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -14,16 +14,17 @@ import reportDisables from './reportDisables.mjs';
 import reportUnscopedDisables from './unscopedDisables.mjs';
 
 /** @import {Result} from 'postcss' */
-/** @import {GetLintSourceOptions as Options, InternalApi as StylelintInternalApi, PostcssResult, StylelintPostcssResult} from 'stylelint' */
+/** @import {GetLintSourceOptions as Options, InternalApi as StylelintInternalApi, PostcssResult, StylelintPostcssResult, CosmiconfigResult} from 'stylelint' */
 
 /**
  * Run stylelint on a PostCSS Result, either one that is provided
  * or one that we create
  * @param {StylelintInternalApi} stylelint
  * @param {Options} options
+ * @param {CosmiconfigResult} [configForFile] - Optional pre-fetched config to use.
  * @returns {Promise<PostcssResult>}
  */
-export default async function lintSource(stylelint, options = {}) {
+export default async function lintSource(stylelint, options = {}, configForFile) {
 	if (!options.filePath && options.code === undefined && !options.existingPostcssResult) {
 		return Promise.reject(new Error('You must provide filePath, code, or existingPostcssResult'));
 	}
@@ -40,7 +41,13 @@ export default async function lintSource(stylelint, options = {}) {
 		return Promise.reject(new Error('filePath must be an absolute path'));
 	}
 
-	const isIgnored = await isPathIgnored(stylelint, inputFilePath).catch((err) => {
+	configForFile ??= await getConfigForFile({
+		stylelint,
+		searchPath: inputFilePath,
+		filePath: inputFilePath,
+	});
+
+	const isIgnored = await isPathIgnored(stylelint, inputFilePath, configForFile).catch((err) => {
 		if (isCodeNotFile && isPathNotFoundError(err)) return false;
 
 		throw err;
@@ -49,12 +56,6 @@ export default async function lintSource(stylelint, options = {}) {
 	if (isIgnored) {
 		return createEmptyPostcssResult(inputFilePath, options.existingPostcssResult);
 	}
-
-	const configForFile = await getConfigForFile({
-		stylelint,
-		searchPath: inputFilePath,
-		filePath: inputFilePath,
-	});
 
 	if (!configForFile) {
 		return Promise.reject(new Error('Config file not found'));

--- a/lib/standalone.cjs
+++ b/lib/standalone.cjs
@@ -28,7 +28,7 @@ const debug = createDebug('stylelint:standalone');
 
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 
-/** @import {InternalApi, LintResult} from 'stylelint' */
+/** @import {InternalApi, LintResult, CosmiconfigResult} from 'stylelint' */
 
 /**
  * @type {import('stylelint').PublicApi['lint']}
@@ -199,7 +199,18 @@ async function standalone({
 		fileList = fileList.concat(ALWAYS_IGNORED_GLOBS.map((glob) => `!${glob}`));
 	}
 
-	const useCache = await resolveOptionValue({ stylelint, name: 'cache', default: false });
+	/**  @type {Partial<Record<string, any>>} */
+	const configs = {};
+	const currentConfig = await getConfigForFile({ stylelint, failIfNoConfig: false });
+
+	if (currentConfig?.filepath) {
+		configs[currentConfig?.filepath] = currentConfig;
+	}
+
+	const useCache = await resolveOptionValue(
+		{ stylelint, name: 'cache', default: false },
+		currentConfig,
+	);
 
 	if (!useCache) {
 		stylelint._fileCache.destroy();
@@ -239,10 +250,23 @@ async function standalone({
 			debug(`Processing ${absoluteFilepath}`);
 
 			try {
-				const postcssResult = await lintSource(stylelint, {
-					filePath: absoluteFilepath,
-					cache: useCache,
-				});
+				const configForFile =
+					configs[absoluteFilepath] ??
+					(await getConfigForFile({
+						stylelint,
+						searchPath: absoluteFilepath,
+						filePath: absoluteFilepath,
+					}));
+				const postcssResult = await lintSource(
+					stylelint,
+					{
+						filePath: absoluteFilepath,
+						cache: useCache,
+					},
+					configForFile,
+				);
+
+				configs[absoluteFilepath] = configForFile;
 
 				if (
 					(postcssResult.stylelint.stylelintError || postcssResult.stylelint.stylelintWarning) &&
@@ -269,7 +293,12 @@ async function standalone({
 
 				const stylelintResult = createPartialStylelintResult(postcssResult);
 
-				await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
+				await postProcessStylelintResult(
+					stylelint,
+					stylelintResult,
+					absoluteFilepath,
+					configs[absoluteFilepath],
+				);
 
 				return stylelintResult;
 			} catch (error) {
@@ -278,7 +307,12 @@ async function standalone({
 
 				const stylelintResult = handleError(error);
 
-				await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
+				await postProcessStylelintResult(
+					stylelint,
+					stylelintResult,
+					absoluteFilepath,
+					configs[absoluteFilepath],
+				);
 
 				return stylelintResult;
 			}
@@ -329,10 +363,11 @@ function handleError(error) {
  * @param {InternalApi} stylelint
  * @param {LintResult} stylelintResult
  * @param {string} [filePath]
+ * @param {CosmiconfigResult} [configForFile] - Optional pre-fetched config to use.
  * @returns {Promise<void>}
  */
-async function postProcessStylelintResult(stylelint, stylelintResult, filePath) {
-	const configForFile = await getConfigForFile({ stylelint, searchPath: filePath, filePath });
+async function postProcessStylelintResult(stylelint, stylelintResult, filePath, configForFile) {
+	configForFile ??= await getConfigForFile({ stylelint, searchPath: filePath, filePath });
 
 	const config = configForFile === null ? {} : configForFile.config;
 

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -26,7 +26,7 @@ import resolveOptionValue from './utils/resolveOptionValue.mjs';
 
 const ALWAYS_IGNORED_GLOBS = ['**/node_modules/**'];
 
-/** @import {InternalApi, LintResult} from 'stylelint' */
+/** @import {InternalApi, LintResult, CosmiconfigResult} from 'stylelint' */
 
 /**
  * @type {import('stylelint').PublicApi['lint']}
@@ -197,7 +197,18 @@ export default async function standalone({
 		fileList = fileList.concat(ALWAYS_IGNORED_GLOBS.map((glob) => `!${glob}`));
 	}
 
-	const useCache = await resolveOptionValue({ stylelint, name: 'cache', default: false });
+	/**  @type {Partial<Record<string, any>>} */
+	const configs = {};
+	const currentConfig = await getConfigForFile({ stylelint, failIfNoConfig: false });
+
+	if (currentConfig?.filepath) {
+		configs[currentConfig?.filepath] = currentConfig;
+	}
+
+	const useCache = await resolveOptionValue(
+		{ stylelint, name: 'cache', default: false },
+		currentConfig,
+	);
 
 	if (!useCache) {
 		stylelint._fileCache.destroy();
@@ -237,10 +248,23 @@ export default async function standalone({
 			debug(`Processing ${absoluteFilepath}`);
 
 			try {
-				const postcssResult = await lintSource(stylelint, {
-					filePath: absoluteFilepath,
-					cache: useCache,
-				});
+				const configForFile =
+					configs[absoluteFilepath] ??
+					(await getConfigForFile({
+						stylelint,
+						searchPath: absoluteFilepath,
+						filePath: absoluteFilepath,
+					}));
+				const postcssResult = await lintSource(
+					stylelint,
+					{
+						filePath: absoluteFilepath,
+						cache: useCache,
+					},
+					configForFile,
+				);
+
+				configs[absoluteFilepath] = configForFile;
 
 				if (
 					(postcssResult.stylelint.stylelintError || postcssResult.stylelint.stylelintWarning) &&
@@ -267,7 +291,12 @@ export default async function standalone({
 
 				const stylelintResult = createPartialStylelintResult(postcssResult);
 
-				await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
+				await postProcessStylelintResult(
+					stylelint,
+					stylelintResult,
+					absoluteFilepath,
+					configs[absoluteFilepath],
+				);
 
 				return stylelintResult;
 			} catch (error) {
@@ -276,7 +305,12 @@ export default async function standalone({
 
 				const stylelintResult = handleError(error);
 
-				await postProcessStylelintResult(stylelint, stylelintResult, absoluteFilepath);
+				await postProcessStylelintResult(
+					stylelint,
+					stylelintResult,
+					absoluteFilepath,
+					configs[absoluteFilepath],
+				);
 
 				return stylelintResult;
 			}
@@ -327,10 +361,11 @@ function handleError(error) {
  * @param {InternalApi} stylelint
  * @param {LintResult} stylelintResult
  * @param {string} [filePath]
+ * @param {CosmiconfigResult} [configForFile] - Optional pre-fetched config to use.
  * @returns {Promise<void>}
  */
-async function postProcessStylelintResult(stylelint, stylelintResult, filePath) {
-	const configForFile = await getConfigForFile({ stylelint, searchPath: filePath, filePath });
+async function postProcessStylelintResult(stylelint, stylelintResult, filePath, configForFile) {
+	configForFile ??= await getConfigForFile({ stylelint, searchPath: filePath, filePath });
 
 	const config = configForFile === null ? {} : configForFile.config;
 

--- a/lib/utils/resolveOptionValue.cjs
+++ b/lib/utils/resolveOptionValue.cjs
@@ -4,23 +4,28 @@
 
 const getConfigForFile = require('../getConfigForFile.cjs');
 
-/** @import {InternalApi, LinterOptions, Config} from 'stylelint' */
+/** @import {InternalApi, LinterOptions, Config, CosmiconfigResult} from 'stylelint' */
 
 /**
  * Get a value of the specified lint option or configuration.
  *
  * @template T
- * @param {Object} options
- * @param {InternalApi} options.stylelint
- * @param {keyof LinterOptions & keyof Config} options.name
- * @param {T} [options.default]
+ * @typedef {object} ResolveOptionValueOptions
+ * @property {InternalApi} stylelint
+ * @property {keyof LinterOptions & keyof Config} name
+ * @property {T} [default]
+ */
+
+/**
+ * @template T
+ * @param {ResolveOptionValueOptions<T>} options
+ * @param {CosmiconfigResult} [config]
  * @returns {Promise<T>}
  */
-async function resolveOptionValue({
-	stylelint,
-	name,
-	default: defaultValue = undefined,
-}) {
+async function resolveOptionValue(
+	{ stylelint, name, default: defaultValue = undefined },
+	config,
+) {
 	const options = stylelint._options;
 	const value = options[name] ?? options.config?.[name];
 
@@ -28,7 +33,9 @@ async function resolveOptionValue({
 		return /** @type {T} */ (value);
 	}
 
-	const configForFile = await getConfigForFile({ stylelint, failIfNoConfig: false });
+	const configForFile = config
+		? config
+		: await getConfigForFile({ stylelint, failIfNoConfig: false });
 
 	return configForFile?.config?.[name] ?? defaultValue;
 }

--- a/lib/utils/resolveOptionValue.mjs
+++ b/lib/utils/resolveOptionValue.mjs
@@ -1,22 +1,27 @@
 import getConfigForFile from '../getConfigForFile.mjs';
 
-/** @import {InternalApi, LinterOptions, Config} from 'stylelint' */
+/** @import {InternalApi, LinterOptions, Config, CosmiconfigResult} from 'stylelint' */
 
 /**
  * Get a value of the specified lint option or configuration.
  *
  * @template T
- * @param {Object} options
- * @param {InternalApi} options.stylelint
- * @param {keyof LinterOptions & keyof Config} options.name
- * @param {T} [options.default]
+ * @typedef {object} ResolveOptionValueOptions
+ * @property {InternalApi} stylelint
+ * @property {keyof LinterOptions & keyof Config} name
+ * @property {T} [default]
+ */
+
+/**
+ * @template T
+ * @param {ResolveOptionValueOptions<T>} options
+ * @param {CosmiconfigResult} [config]
  * @returns {Promise<T>}
  */
-export default async function resolveOptionValue({
-	stylelint,
-	name,
-	default: defaultValue = undefined,
-}) {
+export default async function resolveOptionValue(
+	{ stylelint, name, default: defaultValue = undefined },
+	config,
+) {
 	const options = stylelint._options;
 	const value = options[name] ?? options.config?.[name];
 
@@ -24,7 +29,9 @@ export default async function resolveOptionValue({
 		return /** @type {T} */ (value);
 	}
 
-	const configForFile = await getConfigForFile({ stylelint, failIfNoConfig: false });
+	const configForFile = config
+		? config
+		: await getConfigForFile({ stylelint, failIfNoConfig: false });
 
 	return configForFile?.config?.[name] ?? defaultValue;
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as this is a performance enhancement.

> Is there anything in the PR that needs further explanation?

This PR significantly improves performance by reusing a file's configuration (CosmiconfigResult) instead of repeatedly looking it up.

>> The Problem:

Previously, functions like postProcessStylelintResult would call getConfigForFile for every single file being processed. This created a major performance bottleneck due to redundant file system lookups, especially in large codebases where many files share the same configuration.

>> The Solution:

This change introduces a mechanism to pass the already-resolved config down the call chain.

The `lintSource` and `postProcessStylelintResult` functions are updated to accept an optional, pre-fetched `configForFile`.

`postProcessStylelintResult` now only calls `getConfigForFile` if a config hasn't already been provided, using `configForFile ??= await getConfigForFile(...)`.

In `standalone.mjs`, we now pass the resolved config into the linting process for each file.

Local testing shows this change reduces execution time by approximately 75% on projects with many files.
