### PR TITLE
Fix `no-invalid-position-declaration` false positives for embedded styles

### DIFF
--- a/.changeset/shaggy-dancers-cheer.md
+++ b/.changeset/shaggy-dancers-cheer.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `no-invalid-position-declaration` skipped in HTML style attributes

--- a/lib/rules/no-invalid-position-declaration/__tests__/index.mjs
+++ b/lib/rules/no-invalid-position-declaration/__tests__/index.mjs
@@ -316,3 +316,29 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: true,
+	customSyntax: 'postcss-html',
+
+	accept: [
+		{
+			code: '<style>a { --foo: red; }</style>',
+		},
+		{
+			code: '<a style="--foo: red;"></a>',
+		},
+	],
+
+	reject: [
+		{
+			code: '<style>--foo: red;</style>',
+			message: messages.rejected,
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 19,
+		},
+	],
+});

--- a/lib/rules/no-invalid-position-declaration/index.cjs
+++ b/lib/rules/no-invalid-position-declaration/index.cjs
@@ -27,6 +27,18 @@ const rule = (primary) => {
 
 		if (!validOptions) return;
 
+		if (
+			root.source &&
+			'inline' in root.source &&
+			root.source.inline === true &&
+			'lang' in root.source &&
+			root.source.lang === 'css'
+		) {
+			// Everything in a HTML style attribute is at
+			// the root, so don't report anything for them.
+			return;
+		}
+
 		root.walkDecls((decl) => {
 			if (!isStandardSyntaxDeclaration(decl)) return;
 

--- a/lib/rules/no-invalid-position-declaration/index.mjs
+++ b/lib/rules/no-invalid-position-declaration/index.mjs
@@ -23,6 +23,18 @@ const rule = (primary) => {
 
 		if (!validOptions) return;
 
+		if (
+			root.source &&
+			'inline' in root.source &&
+			root.source.inline === true &&
+			'lang' in root.source &&
+			root.source.lang === 'css'
+		) {
+			// Everything in a HTML style attribute is at
+			// the root, so don't report anything for them.
+			return;
+		}
+
 		root.walkDecls((decl) => {
 			if (!isStandardSyntaxDeclaration(decl)) return;
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8695

> Is there anything in the PR that needs further explanation?

I couldn't find any other rules that specifically check for the source coming from a `style` attribute, so I don't know if this is the preferred solution.

For reference, `postcss-html` sets `inline: true` and `lang: "css"` when the CSS comes from a `style` attribute:
- https://github.com/ota-meshi/postcss-html/blob/7b8d53529ddc3988c1654c0bf02fe0eee971f6c2/lib/html/extract-styles.js#L91
- https://github.com/ota-meshi/postcss-html/blob/7b8d53529ddc3988c1654c0bf02fe0eee971f6c2/lib/html/extract-styles.js#L157
