### PR TITLE
Fix `property-no-deprecated` false positive for `-webkit-box-orient: vertical`

### DIFF
--- a/.changeset/clear-suns-trade.md
+++ b/.changeset/clear-suns-trade.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `property-no-deprecated` mapping of `clip`

--- a/.changeset/clear-suns-trade.md
+++ b/.changeset/clear-suns-trade.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `property-no-deprecated` is now only reporting `clip` instead of erroneously fixing it previously
+Fixed: `property-no-deprecated` erroneously autofixing `clip`

--- a/.changeset/clear-suns-trade.md
+++ b/.changeset/clear-suns-trade.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `property-no-deprecated` mapping of `clip`
+Fixed: `property-no-deprecated` is now only reporting `clip` instead of erroneously fixing it previously

--- a/.changeset/modern-days-try.md
+++ b/.changeset/modern-days-try.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `property-no-deprecated` false positive for `-webkit-box-orient: vertical;`

--- a/.changeset/modern-days-try.md
+++ b/.changeset/modern-days-try.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `property-no-deprecated` false positive for `-webkit-box-orient: vertical;`
+Fixed: `property-no-deprecated` false positives for `-webkit-box-orient: vertical;`

--- a/lib/rules/property-no-deprecated/README.md
+++ b/lib/rules/property-no-deprecated/README.md
@@ -49,7 +49,7 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-a { clip-path: rect(0, 0, 0, 0); }
+a { clip-path: rect(0 0 0 0); }
 ```
 
 <!-- prettier-ignore -->

--- a/lib/rules/property-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/property-no-deprecated/__tests__/index.mjs
@@ -11,7 +11,7 @@ testRule({
 
 	accept: [
 		{
-			code: 'a { clip-path: rect(0, 0, 0, 0); }',
+			code: 'a { clip-path: rect(0 0 0 0); }',
 		},
 		{
 			code: stripIndent`

--- a/lib/rules/property-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/property-no-deprecated/__tests__/index.mjs
@@ -26,12 +26,8 @@ testRule({
 	reject: [
 		{
 			code: 'a { clip: rect(0, 0, 0, 0); }',
-			fixed: 'a { clip-path: rect(0, 0, 0, 0); }',
-			fix: {
-				range: [7, 8],
-				text: 'p-path',
-			},
-			message: messages.expected('clip', 'clip-path'),
+			unfixable: true,
+			message: messages.rejected('clip'),
 			column: 5,
 			endColumn: 9,
 			line: 1,
@@ -39,12 +35,8 @@ testRule({
 		},
 		{
 			code: 'a { /* comment */ clip: rect(0, 0, 0, 0); }',
-			fixed: 'a { /* comment */ clip-path: rect(0, 0, 0, 0); }',
-			fix: {
-				range: [21, 22],
-				text: 'p-path',
-			},
-			message: messages.expected('clip', 'clip-path'),
+			unfixable: true,
+			message: messages.rejected('clip'),
 			column: 19,
 			endColumn: 23,
 			line: 1,

--- a/lib/rules/property-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/property-no-deprecated/__tests__/index.mjs
@@ -13,6 +13,14 @@ testRule({
 		{
 			code: 'a { clip-path: rect(0, 0, 0, 0); }',
 		},
+		{
+			code: stripIndent`
+				display: -webkit-box;
+				-webkit-box-orient: vertical;
+				-webkit-line-clamp: 2;
+			`,
+			description: 'Accept `-webkit-box-orient` if its value is `vertical`',
+		},
 	],
 
 	reject: [

--- a/lib/rules/property-no-deprecated/index.cjs
+++ b/lib/rules/property-no-deprecated/index.cjs
@@ -74,7 +74,7 @@ const DEPRECATED_PROPS_REMAP = {
 	'scroll-snap-type-x': null,
 	'scroll-snap-type-y': null,
 	'word-wrap': 'overflow-wrap',
-	clip: 'clip-path',
+	clip: null,
 };
 
 /** @type {import('stylelint').CoreRules[ruleName]} */

--- a/lib/rules/property-no-deprecated/index.cjs
+++ b/lib/rules/property-no-deprecated/index.cjs
@@ -51,7 +51,7 @@ const DEPRECATED_PROPS_REMAP = {
 	'-webkit-box-flex': 'flex-grow',
 	'-webkit-box-lines': null,
 	'-webkit-box-ordinal-group': 'order',
-	'-webkit-box-orient': null,
+	'-webkit-box-orient': null, // Allowed when the value is `vertical`
 	'-webkit-box-pack': null,
 	'-webkit-user-modify': null,
 	'grid-column-gap': 'column-gap',
@@ -98,7 +98,7 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls((decl) => {
 			if (!isStandardSyntaxDeclaration(decl)) return;
 
-			const { prop } = decl;
+			const { prop, value } = decl;
 
 			if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) return;
 
@@ -106,6 +106,8 @@ const rule = (primary, secondaryOptions) => {
 			const mappedProp = DEPRECATED_PROPS_REMAP[normalizedProp];
 
 			if (typeof mappedProp === 'undefined') return;
+
+			if (normalizedProp === '-webkit-box-orient' && value === 'vertical') return;
 
 			let fix;
 			let message;

--- a/lib/rules/property-no-deprecated/index.cjs
+++ b/lib/rules/property-no-deprecated/index.cjs
@@ -107,7 +107,7 @@ const rule = (primary, secondaryOptions) => {
 
 			if (typeof mappedProp === 'undefined') return;
 
-			if (normalizedProp === '-webkit-box-orient' && value === 'vertical') return;
+			if (normalizedProp === '-webkit-box-orient' && value.toLowerCase() === 'vertical') return;
 
 			let fix;
 			let message;

--- a/lib/rules/property-no-deprecated/index.mjs
+++ b/lib/rules/property-no-deprecated/index.mjs
@@ -70,7 +70,7 @@ const DEPRECATED_PROPS_REMAP = {
 	'scroll-snap-type-x': null,
 	'scroll-snap-type-y': null,
 	'word-wrap': 'overflow-wrap',
-	clip: 'clip-path',
+	clip: null,
 };
 
 /** @type {import('stylelint').CoreRules[ruleName]} */

--- a/lib/rules/property-no-deprecated/index.mjs
+++ b/lib/rules/property-no-deprecated/index.mjs
@@ -103,7 +103,7 @@ const rule = (primary, secondaryOptions) => {
 
 			if (typeof mappedProp === 'undefined') return;
 
-			if (normalizedProp === '-webkit-box-orient' && value === 'vertical') return;
+			if (normalizedProp === '-webkit-box-orient' && value.toLowerCase() === 'vertical') return;
 
 			let fix;
 			let message;

--- a/lib/rules/property-no-deprecated/index.mjs
+++ b/lib/rules/property-no-deprecated/index.mjs
@@ -47,7 +47,7 @@ const DEPRECATED_PROPS_REMAP = {
 	'-webkit-box-flex': 'flex-grow',
 	'-webkit-box-lines': null,
 	'-webkit-box-ordinal-group': 'order',
-	'-webkit-box-orient': null,
+	'-webkit-box-orient': null, // Allowed when the value is `vertical`
 	'-webkit-box-pack': null,
 	'-webkit-user-modify': null,
 	'grid-column-gap': 'column-gap',
@@ -94,7 +94,7 @@ const rule = (primary, secondaryOptions) => {
 		root.walkDecls((decl) => {
 			if (!isStandardSyntaxDeclaration(decl)) return;
 
-			const { prop } = decl;
+			const { prop, value } = decl;
 
 			if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) return;
 
@@ -102,6 +102,8 @@ const rule = (primary, secondaryOptions) => {
 			const mappedProp = DEPRECATED_PROPS_REMAP[normalizedProp];
 
 			if (typeof mappedProp === 'undefined') return;
+
+			if (normalizedProp === '-webkit-box-orient' && value === 'vertical') return;
 
 			let fix;
 			let message;


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Closes #8698 

> Is there anything in the PR that needs further explanation?

This PR consists of two fixes: the discussion of the first one can be found in thread #8698 , and the second one is [here](https://github.com/stylelint/stylelint/pull/8682#discussion_r2247806673).

Both are related to inaccuracies made when adding the `property-no-deprecated` rule in the previous release.
