### PR TITLE
Fix `property-no-deprecated` example

### DIFF
--- a/lib/rules/property-no-deprecated/README.md
+++ b/lib/rules/property-no-deprecated/README.md
@@ -49,7 +49,7 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-a { clip-path: rect(0, 0, 0, 0); }
+a { clip-path: rect(0 0 0 0); }
 ```
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
The comma syntax was only supported as part of the `clip` property which is replaced in this example. Per [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/clip#values):

> Note: The rect() [<shape>](https://developer.mozilla.org/en-US/docs/Web/CSS/shape) function used in the deprecated clip property is different from the CSS [rect()](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape/rect) function used to define a CSS [<basic-shape>](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape).

---

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
