### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for `:unchecked`

### DIFF
--- a/.changeset/easy-oranges-punch.md
+++ b/.changeset/easy-oranges-punch.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for `:unchecked`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -442,6 +442,7 @@ const pseudoClasses = uniteSets(
 		'scope',
 		'state',
 		'target',
+		'unchecked',
 		'unresolved',
 		'user-invalid',
 		'user-valid',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -439,6 +439,7 @@ export const pseudoClasses = uniteSets(
 		'scope',
 		'state',
 		'target',
+		'unchecked',
 		'unresolved',
 		'user-invalid',
 		'user-valid',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -151,6 +151,9 @@ testRule({
 			code: ':seeking, :stalled, :buffering, :volume-locked, :muted {}',
 		},
 		{
+			code: ':checked, :unchecked, :indeterminate {}',
+		},
+		{
 			code: 'meter:low-value {}',
 		},
 		{


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

followup of #8623

> Is there anything in the PR that needs further explanation?

https://ladybird.org/newsletter/2025-07-31/#statefoo-and-unchecked-pseudo-classes
https://drafts.csswg.org/selectors/#checked