### PR TITLE
Fix `selector-pseudo-element-no-unknown` false positives for `::search-text`

### DIFF
--- a/.changeset/tangy-wombats-kiss.md
+++ b/.changeset/tangy-wombats-kiss.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-element-no-unknown` false positives for `::search-text`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -247,6 +247,7 @@ const pseudoElements = uniteSets(
 		'placeholder',
 		'scroll-marker-group',
 		'scroll-marker',
+		'search-text',
 		'selection',
 		'slider-fill',
 		'slider-thumb',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -244,6 +244,7 @@ export const pseudoElements = uniteSets(
 		'placeholder',
 		'scroll-marker-group',
 		'scroll-marker',
+		'search-text',
 		'selection',
 		'slider-fill',
 		'slider-thumb',

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
@@ -60,6 +60,9 @@ testRule({
 			code: 'a::grammar-error { }',
 		},
 		{
+			code: '::search-text { }',
+		},
+		{
 			code: 'li::marker { }',
 		},
 		{


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

followup of #6367

> Is there anything in the PR that needs further explanation?

https://chromestatus.com/feature/5195073796177920
https://drafts.csswg.org/css-pseudo-4/#selectordef-search-text