### PR TITLE
Improve `postcss-naive-css-in-js` test fixture

### DIFF
--- a/lib/__tests__/fixtures/postcss-naive-css-in-js.cjs
+++ b/lib/__tests__/fixtures/postcss-naive-css-in-js.cjs
@@ -13,8 +13,12 @@ function parse(css) {
 		},
 	});
 
+	let noMatches = true;
+
 	// E.g. "css` color: red; `;"
 	for (const match of source.matchAll(/\bcss`([^`]+)`;/g)) {
+		noMatches = false;
+
 		let parsedNode;
 
 		try {
@@ -28,6 +32,10 @@ function parse(css) {
 		}
 
 		document.append(parsedNode);
+	}
+
+	if (noMatches) {
+		throw new Error('No CSS-in-JS code found in the input source. Ensure it contains valid CSS-in-JS code, such as "css` color: red; `;"');
 	}
 
 	return document;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/8701#discussion_r2250793041

> Is there anything in the PR that needs further explanation?

This makes the `postcss-naive-css-in-js` fixture stricter for a case when an input source doesn't contain a valid CSS-in-JS code.

Example:

```
● color-hex-length › accept › [ 'short' ] › 'css` color: #aaa; `' › no description

  No CSS-in-JS code found in the input source. Ensure it contains valid CSS-in-JS code, such as "css` color: red; `;"
```
