### PR TITLE
Fix `selector-type-no-unknown` false positives for `selectedcontent`

### DIFF
--- a/.changeset/fair-sloths-visit.md
+++ b/.changeset/fair-sloths-visit.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-type-no-unknown` false positives for `selectedcontent`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -49,6 +49,7 @@ const experimentalHtmlTypeSelectors = new Set([
 	'listbox',
 	'model',
 	'portal',
+	'selectedcontent',
 	'selectlist',
 ]);
 

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -46,6 +46,7 @@ const experimentalHtmlTypeSelectors = new Set([
 	'listbox',
 	'model',
 	'portal',
+	'selectedcontent',
 	'selectlist',
 ]);
 

--- a/lib/rules/selector-type-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.mjs
@@ -96,7 +96,8 @@ testRule({
 			description: 'svg tags',
 		},
 		{
-			code: 'fencedframe, listbox, model, portal, selectlist {}',
+			code: 'fencedframe, listbox, model, portal, selectlist, selectedcontent {}',
+			description: 'experimental tags',
 		},
 		{
 			code: 'foreignObject {}',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

#8713
followup of #7612

> Is there anything in the PR that needs further explanation?

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/selectedcontent