### PR TITLE
Document getting started with alternative package managers

### DIFF
--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -17,26 +17,21 @@ npm create stylelint
 
 Alternatively, you can manually setup Stylelint to lint CSS.
 
-1\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
-
-```js
-/** @type {import('stylelint').Config} */
-export default {
-  extends: ["stylelint-config-standard"]
-};
-```
-
-2\. Use [npm](https://docs.npmjs.com/about-npm/) (or your preferred package manager) to add the related dependencies:
-
-```shell
-npm add -D stylelint stylelint-config-standard
-```
-
-3\. Run Stylelint on all the CSS files in your project:
-
-```shell
-npx stylelint "**/*.css"
-```
+1. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
+   ```js
+   /** @type {import('stylelint').Config} */
+   export default {
+     extends: ["stylelint-config-standard"]
+   };
+   ```
+2. Use [npm](https://docs.npmjs.com/about-npm/) (or your preferred package manager) to add the related dependencies:
+   ```shell
+   npm add -D stylelint stylelint-config-standard
+   ```
+3. Run Stylelint on all the CSS files in your project:
+   ```shell
+   npx stylelint "**/*.css"
+   ```
 
 > [!NOTE]
 > The [`npx`](https://docs.npmjs.com/cli/commands/npx) command allows you to run locally installed tools.
@@ -52,31 +47,28 @@ You can extend a community config to lint:
 - CSS-like languages, e.g. SCSS, Sass and Less
 - CSS within containers, e.g. in HTML, CSS-in-JS and Vue SFCs
 
-For example, to lint SCSS you can extend the [SCSS community config](https://www.npmjs.com/package/stylelint-config-standard-scss). It includes the:
+For example, to lint SCSS you can extend the [SCSS community config](https://www.npmjs.com/package/stylelint-config-standard-scss):
+
+1. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
+   ```js
+   /** @type {import('stylelint').Config} */
+   export default {
+     extends: ["stylelint-config-standard-scss"]
+   };
+   ```
+2. Use [npm](https://docs.npmjs.com/about-npm/) (or your preferred package manager) to add the related dependencies:
+   ```shell
+   npm add -D stylelint stylelint-config-standard-scss
+   ```
+3. Run Stylelint on all the SCSS files in your project:
+   ```shell
+   stylelint "**/*.scss"
+   ```
+
+The config includes the:
 
 - [SCSS syntax](https://www.npmjs.com/package/postcss-scss) - a custom syntax to parse SCSS
 - [SCSS plugin](https://www.npmjs.com/package/stylelint-scss) - a set of custom rules for SCSS
-
-1\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
-
-```js
-/** @type {import('stylelint').Config} */
-export default {
-  extends: ["stylelint-config-standard-scss"]
-};
-```
-
-2\. Use [npm](https://docs.npmjs.com/about-npm/) (or your preferred package manager) to add the related dependencies:
-
-```shell
-npm add -D stylelint stylelint-config-standard-scss
-```
-
-3\. Run Stylelint on all the SCSS files in your project:
-
-```shell
-stylelint "**/*.scss"
-```
 
 You'll find more community configs in [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint#readme).
 
@@ -84,29 +76,24 @@ You'll find more community configs in [Awesome Stylelint](https://github.com/sty
 
 If a shared config isn't available for your preferred language or container, you can install the appropriate custom syntax and use the [`customSyntax` option](../user-guide/options.md#customsyntax) yourself.
 
-For example, to lint CSS inside of [Lit elements](https://lit.dev/) using the [Lit custom syntax](https://www.npmjs.com/package/postcss-lit).
+For example, to lint CSS inside of [Lit elements](https://lit.dev/) using the [Lit custom syntax](https://www.npmjs.com/package/postcss-lit):
 
-1\. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
-
-```js
-/** @type {import('stylelint').Config} */
-export default {
-  extends: "stylelint-config-standard",
-  customSyntax: "postcss-lit"
-};
-```
-
-2\. Use [npm](https://docs.npmjs.com/about-npm/) (our your preferred package manager) to add the related dependencies:
-
-```shell
-npm add -D stylelint stylelint-config-standard postcss-lit
-```
-
-3\. Run Stylelint on all the JavaScript files in your project:
-
-```shell
-stylelint "**/*.js"
-```
+1. Create a `stylelint.config.mjs` configuration file in the root of your project with the following content:
+   ```js
+   /** @type {import('stylelint').Config} */
+   export default {
+     extends: "stylelint-config-standard",
+     customSyntax: "postcss-lit"
+   };
+   ```
+2. Use [npm](https://docs.npmjs.com/about-npm/) (or your preferred package manager) to add the related dependencies:
+   ```shell
+   npm add -D stylelint stylelint-config-standard postcss-lit
+   ```
+3. Run Stylelint on all the JavaScript files in your project:
+   ```shell
+   stylelint "**/*.js"
+   ```
 
 You'll find more custom syntaxes in [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint#custom-syntaxes).
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8721
Closes https://github.com/stylelint/stylelint/issues/8210
Closes https://github.com/stylelint/stylelint/issues/7444

> Is there anything in the PR that needs further explanation?

Once https://github.com/stylelint/create-stylelint/pull/105 lands (needs a review), the Stylelint setup should be broadly compatible with the `pnpm`, `bun` and `yarn` package managers.

This pull request simplifies the getting-started instructions for linting CSS, as the `create` tool now provides context.

I suspect most users will use `npm create stylelint`, some will use other package managers (e.g. `bun create stylelint`), and a small majority want to see the manual instructions. The changes in this PR cover all the bases in that order.

(In an ideal world, we'd have tabbed instructions for each of the package managers, but investigating if we can achieve that for Docusaurus and on GitHub is for another day.)
