### PR TITLE
Fix `function-no-unknown` false positives for `contrast-color()` and `sibling-*()`

### DIFF
--- a/.changeset/little-rats-lay.md
+++ b/.changeset/little-rats-lay.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `function-no-unknown` false positives for `contrast-color()` and `sibling-*()`

--- a/lib/rules/function-no-unknown/__tests__/index.mjs
+++ b/lib/rules/function-no-unknown/__tests__/index.mjs
@@ -61,6 +61,12 @@ testRule({
 		{
 			code: 'a { --color: if(media(width >= 1px): red; else: green); }',
 		},
+		{
+			code: '.foo { --bar: sibling-index(); column-count: sibling-count(); }',
+		},
+		{
+			code: 'a { color: contrast-color(var(--qux)); }',
+		},
 	],
 
 	reject: [

--- a/lib/rules/function-no-unknown/index.cjs
+++ b/lib/rules/function-no-unknown/index.cjs
@@ -30,6 +30,11 @@ const FUNCTIONS = [
 	'content',
 	'running',
 	'string',
+	// https://drafts.csswg.org/css-values-5/#tree-counting
+	'sibling-count',
+	'sibling-index',
+	// https://drafts.csswg.org/css-color-5/#contrast-color
+	'contrast-color',
 ];
 
 const ruleName = 'function-no-unknown';

--- a/lib/rules/function-no-unknown/index.mjs
+++ b/lib/rules/function-no-unknown/index.mjs
@@ -27,6 +27,11 @@ const FUNCTIONS = [
 	'content',
 	'running',
 	'string',
+	// https://drafts.csswg.org/css-values-5/#tree-counting
+	'sibling-count',
+	'sibling-index',
+	// https://drafts.csswg.org/css-color-5/#contrast-color
+	'contrast-color',
 ];
 
 const ruleName = 'function-no-unknown';


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

followup of #8677

> Is there anything in the PR that needs further explanation?

https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/contrast-color#browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/CSS/sibling-count#browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/CSS/sibling-index#browser_compatibility
