### PR TITLE
Add `ignoreAtRules: []` to `nesting-selector-no-missing-scoping-root`

### DIFF
--- a/lib/rules/nesting-selector-no-missing-scoping-root/README.md
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/README.md
@@ -64,3 +64,47 @@ a {
   @scope (&) {}
 }
 ```
+
+## Optional secondary options
+
+### `ignoreAtRules`
+
+```json
+{ "ignoreAtRules": ["array", "of", "at-rules", "/regex/"] }
+```
+
+Ignore nesting selectors within specified at-rules.
+
+Given:
+
+```json
+{
+  "nesting-selector-no-missing-scoping-root": [
+    true,
+    { "ignoreAtRules": ["mixin", "utility"] }
+  ]
+}
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```scss
+@mixin test() {
+  &:before {
+    content: "a";
+  }
+  &:hover:before {
+    content: "b";
+  }
+}
+```
+
+<!-- prettier-ignore -->
+```css
+@utility scrollbar-hidden {
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+```

--- a/lib/rules/nesting-selector-no-missing-scoping-root/README.md
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/README.md
@@ -90,13 +90,8 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```scss
-@mixin test() {
-  &:before {
-    content: "a";
-  }
-  &:hover:before {
-    content: "b";
-  }
+@--foo {
+  & {}
 }
 ```
 

--- a/lib/rules/nesting-selector-no-missing-scoping-root/README.md
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/README.md
@@ -81,7 +81,7 @@ Given:
 {
   "nesting-selector-no-missing-scoping-root": [
     true,
-    { "ignoreAtRules": ["mixin", "utility"] }
+    { "ignoreAtRules": ["--foo", "/^--bar-/"] }
   ]
 }
 ```

--- a/lib/rules/nesting-selector-no-missing-scoping-root/README.md
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/README.md
@@ -89,7 +89,7 @@ Given:
 The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
-```scss
+```css
 @--foo {
   & {}
 }

--- a/lib/rules/nesting-selector-no-missing-scoping-root/README.md
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/README.md
@@ -97,9 +97,7 @@ The following patterns are _not_ considered problems:
 
 <!-- prettier-ignore -->
 ```css
-@utility scrollbar-hidden {
-  &::-webkit-scrollbar {
-    display: none;
-  }
+@--bar-baz qux {
+  & {}
 }
 ```

--- a/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
@@ -233,17 +233,11 @@ testRule({
 
 	accept: [
 		{
-			code: '@mixin test() { &:before { content: "a"; } &:hover:before { content: "b"; } }',
+			code: '@--foo { & {} }',
 		},
 		{
-			code: '@mixin foo { & {} }',
-		},
-		{
-			code: '@utility scrollbar-hidden { &::-webkit-scrollbar { display: none; } }',
-		},
-		{
-			code: '@utility btn { &:hover { opacity: 0.8; } }',
-		},
+			code: '@bar-baz qux { & {} }',
+		}
 	],
 
 	reject: [

--- a/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
@@ -237,7 +237,7 @@ testRule({
 		},
 		{
 			code: '@--bar-baz qux { & {} }',
-		}
+		},
 	],
 
 	reject: [

--- a/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
@@ -229,7 +229,7 @@ testRule({
 
 testRule({
 	ruleName,
-	config: [true, { ignoreAtRules: ['mixin', 'utility'] }],
+	config: [true, { ignoreAtRules: ['--foo', '/^--bar-/'] }],
 
 	accept: [
 		{

--- a/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
@@ -236,7 +236,7 @@ testRule({
 			code: '@--foo { & {} }',
 		},
 		{
-			code: '@bar-baz qux { & {} }',
+			code: '@--bar-baz qux { & {} }',
 		}
 	],
 

--- a/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
@@ -226,3 +226,42 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: [true, { ignoreAtRules: ['mixin', 'utility'] }],
+
+	accept: [
+		{
+			code: '@mixin test() { &:before { content: "a"; } &:hover:before { content: "b"; } }',
+		},
+		{
+			code: '@mixin foo { & {} }',
+		},
+		{
+			code: '@utility scrollbar-hidden { &::-webkit-scrollbar { display: none; } }',
+		},
+		{
+			code: '@utility btn { &:hover { opacity: 0.8; } }',
+		},
+	],
+
+	reject: [
+		{
+			code: '@other { & {} }',
+			message: messages.rejected,
+			line: 1,
+			column: 10,
+			endLine: 1,
+			endColumn: 11,
+		},
+		{
+			code: '@function test() { & {} }',
+			message: messages.rejected,
+			line: 1,
+			column: 20,
+			endLine: 1,
+			endColumn: 21,
+		},
+	],
+});

--- a/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
@@ -250,12 +250,12 @@ testRule({
 			endColumn: 15,
 		},
 		{
-			code: '@function test() { & {} }',
+			code: '@--baz { & {} }',
 			message: messages.rejected,
 			line: 1,
-			column: 20,
+			column: 10,
 			endLine: 1,
-			endColumn: 21,
+			endColumn: 11,
 		},
 	],
 });

--- a/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/__tests__/index.mjs
@@ -242,12 +242,12 @@ testRule({
 
 	reject: [
 		{
-			code: '@other { & {} }',
+			code: '@media all { & {} }',
 			message: messages.rejected,
 			line: 1,
-			column: 10,
+			column: 14,
 			endLine: 1,
-			endColumn: 11,
+			endColumn: 15,
 		},
 		{
 			code: '@function test() { & {} }',

--- a/lib/rules/nesting-selector-no-missing-scoping-root/index.cjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/index.cjs
@@ -3,12 +3,14 @@
 'use strict';
 
 const cssTree = require('css-tree');
+const validateTypes = require('../../utils/validateTypes.cjs');
 const nodeFieldIndices = require('../../utils/nodeFieldIndices.cjs');
 const regexes = require('../../utils/regexes.cjs');
 const getAtRuleParams = require('../../utils/getAtRuleParams.cjs');
 const getRuleSelector = require('../../utils/getRuleSelector.cjs');
 const isStandardSyntaxAtRule = require('../../utils/isStandardSyntaxAtRule.cjs');
 const isStandardSyntaxRule = require('../../utils/isStandardSyntaxRule.cjs');
+const optionsMatches = require('../../utils/optionsMatches.cjs');
 const report = require('../../utils/report.cjs');
 const ruleMessages = require('../../utils/ruleMessages.cjs');
 const validateOptions = require('../../utils/validateOptions.cjs');
@@ -24,12 +26,20 @@ const meta = {
 };
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
-const rule = (primary) => {
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [true],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{ actual: primary, possible: [true] },
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignoreAtRules: [validateTypes.isString, validateTypes.isRegExp],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) return;
 
@@ -37,7 +47,7 @@ const rule = (primary) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
 
 			// Check if the rule is nested within a scoping root
-			if (hasValidScopingRoot(ruleNode)) return;
+			if (hasValidScopingRoot(ruleNode, secondaryOptions)) return;
 
 			let ast;
 
@@ -59,7 +69,7 @@ const rule = (primary) => {
 			if (!atRule.params.includes('&')) return;
 
 			// Only check @scope at-rules that don't have a parent scoping context
-			if (hasValidScopingRoot(atRule)) return;
+			if (hasValidScopingRoot(atRule, secondaryOptions)) return;
 
 			let ast;
 
@@ -112,9 +122,10 @@ const rule = (primary) => {
 /**
  * Check if a node has a valid scoping root
  * @param {import('postcss').Rule | import('postcss').AtRule} node
+ * @param {object} secondaryOptions
  * @returns {boolean}
  */
-function hasValidScopingRoot(node) {
+function hasValidScopingRoot(node, secondaryOptions) {
 	let current = node.parent;
 
 	while (current) {
@@ -125,6 +136,14 @@ function hasValidScopingRoot(node) {
 
 		// If we find an @scope at-rule, it provides a scoping root
 		if (current.type === 'atrule' && current.name === 'scope') {
+			return true;
+		}
+
+		// If we find an ignored at-rule, it provides a scoping root
+		if (
+			current.type === 'atrule' &&
+			optionsMatches(secondaryOptions, 'ignoreAtRules', current.name)
+		) {
 			return true;
 		}
 

--- a/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/index.mjs
@@ -1,11 +1,13 @@
 import { parse, walk } from 'css-tree';
 
+import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
 import { atRuleRegexes } from '../../utils/regexes.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
+import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -21,12 +23,20 @@ const meta = {
 };
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
-const rule = (primary) => {
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: [true],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{ actual: primary, possible: [true] },
+			{
+				actual: secondaryOptions,
+				possible: {
+					ignoreAtRules: [isString, isRegExp],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) return;
 
@@ -34,7 +44,7 @@ const rule = (primary) => {
 			if (!isStandardSyntaxRule(ruleNode)) return;
 
 			// Check if the rule is nested within a scoping root
-			if (hasValidScopingRoot(ruleNode)) return;
+			if (hasValidScopingRoot(ruleNode, secondaryOptions)) return;
 
 			let ast;
 
@@ -56,7 +66,7 @@ const rule = (primary) => {
 			if (!atRule.params.includes('&')) return;
 
 			// Only check @scope at-rules that don't have a parent scoping context
-			if (hasValidScopingRoot(atRule)) return;
+			if (hasValidScopingRoot(atRule, secondaryOptions)) return;
 
 			let ast;
 
@@ -109,9 +119,10 @@ const rule = (primary) => {
 /**
  * Check if a node has a valid scoping root
  * @param {import('postcss').Rule | import('postcss').AtRule} node
+ * @param {object} secondaryOptions
  * @returns {boolean}
  */
-function hasValidScopingRoot(node) {
+function hasValidScopingRoot(node, secondaryOptions) {
 	let current = node.parent;
 
 	while (current) {
@@ -122,6 +133,14 @@ function hasValidScopingRoot(node) {
 
 		// If we find an @scope at-rule, it provides a scoping root
 		if (current.type === 'atrule' && current.name === 'scope') {
+			return true;
+		}
+
+		// If we find an ignored at-rule, it provides a scoping root
+		if (
+			current.type === 'atrule' &&
+			optionsMatches(secondaryOptions, 'ignoreAtRules', current.name)
+		) {
 			return true;
 		}
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -783,7 +783,10 @@ declare namespace stylelint {
 			RejectedMessage<[name: string]>
 		>;
 		'named-grid-areas-no-invalid': CoreRule<true>;
-		'nesting-selector-no-missing-scoping-root': CoreRule<true>;
+		'nesting-selector-no-missing-scoping-root': CoreRule<
+			true,
+			{ ignoreAtRules: OneOrMany<StringOrRegex> }
+		>;
 		'no-descending-specificity': CoreRule<
 			true,
 			{ ignore: OneOrMany<'selectors-within-list'> },


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8728

> Is there anything in the PR that needs further explanation?

Useful for at-rules like `@mixin` from SCSS and `@utility` from Tailwind CSS.
