### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for `:heading`

### DIFF
--- a/.changeset/yummy-actors-serve.md
+++ b/.changeset/yummy-actors-serve.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for `:heading`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -424,6 +424,7 @@ const pseudoClasses = uniteSets(
 		'fullscreen',
 		'future',
 		'has-slotted',
+		'heading',
 		'high-value',
 		'host-context',
 		'host',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -421,6 +421,7 @@ export const pseudoClasses = uniteSets(
 		'fullscreen',
 		'future',
 		'has-slotted',
+		'heading',
 		'high-value',
 		'host-context',
 		'host',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -72,6 +72,9 @@ testRule({
 			code: ':--heading { }',
 		},
 		{
+			code: ':heading, :heading(1, 4), :heading(odd) { }',
+		},
+		{
 			code: '::-webkit-scrollbar-thumb:window-inactive { }',
 		},
 		{


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

N/A

> Is there anything in the PR that needs further explanation?

LadybirdBrowser/ladybird#5830
https://developer.mozilla.org/en-US/docs/Web/CSS/:heading_function#browser_compatibility
https://developer.mozilla.org/en-US/docs/Web/CSS/:heading#browser_compatibility
