### PR TITLE
Document using latest version of create script

### DIFF
--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -7,7 +7,7 @@ You can quickly get started by extending an appropriate shared config.
 Use [npm](https://docs.npmjs.com/about-npm/) and [our `create` tool](https://www.npmjs.com/package/create-stylelint) to automatically setup Stylelint and extend [our standard config](https://www.npmjs.com/package/stylelint-config-standard):
 
 ```shell
-npm create stylelint
+npm create stylelint@latest
 ```
 
 > [!NOTE]


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

It seems we need `@latest` to ensure the new version of the create script is run if the older one has been previously used. I saw this locally. I assume that's why ESLint uses `@latest` in their docs. 
