### PR TITLE
Document sponsors, backers and donors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,23 +84,21 @@ Stylelint is maintained by volunteers. Without the code contributions from [all 
 
 We'd like to thank all past members for their invaluable contributions, including two of Stylelint's co-creators [@davidtheclark](https://github.com/davidtheclark) and [@MoOx](https://github.com/MoOx).
 
-### Sponsors
+### Sponsors, backers and donors
+
+Financial contributions help us dedicate time to Stylelint and cover our infrastructure costs.
+
+A big thank you to everyone who sponsors us on [Open Collective](https://opencollective.com/stylelint/):
 
 <object data="https://opencollective.com/stylelint/sponsors.svg?width=420&button=false" type="image/svg+xml">
   <img src="https://opencollective.com/stylelint/sponsors.svg?width=840&button=false" />
 </object>
 
-Thank you to all our sponsors! [Become a sponsor](https://opencollective.com/stylelint).
+And thank you to all our Open Collective backers, GitHub sponsors and one-off donors.
 
-### Backers
+[Contribute via Open Collective](hhttps://opencollective.com/stylelint/contribute) or [sponsor us on GitHub](https://github.com/sponsors/stylelint).
 
-<object data="https://opencollective.com/stylelint/backers.svg?width=420&avatarHeight=48&button=false" type="image/svg+xml">
-  <img src="https://opencollective.com/stylelint/backers.svg?width=840&avatarHeight=48&button=false" />
-</object>
-
-Thank you to all our backers! [Become a backer](https://opencollective.com/stylelint).
-
-### Website hosting
+#### Website hosting
 
 [![Deploys by Netlify](https://www.netlify.com/img/global/badges/netlify-color-accent.svg)](https://www.netlify.com)
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A big thank you to everyone who sponsors us on [Open Collective](https://opencol
 
 And thank you to all our Open Collective backers, GitHub sponsors and one-off donors.
 
-[Contribute via Open Collective](hhttps://opencollective.com/stylelint/contribute) or [sponsor us on GitHub](https://github.com/sponsors/stylelint).
+[Contribute via Open Collective](https://opencollective.com/stylelint/contribute) or [sponsor us on GitHub](https://github.com/sponsors/stylelint).
 
 #### Website hosting
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #8765

> Is there anything in the PR that needs further explanation?

Our messaging around sponsorship got a bit mixed up since we enabled GitHub sponsors alongside our existing Open Collective. For example, we have a $100 GitHub sponsor tier that states your logo will appear in our README, but that only happens for our Open Collective sponsors because we use Open Collective's embed, or the fact that we also display Open Collective _backer_ logos in our README, undermining a perk of being a _sponsor_.

The wording used across GitHub sponsors and Open Collective differs, adding to the confusion. For example, Open Collective uses "financial contributions" as an umbrella term for sponsors, backers and donations (which can be one-off or recurring), whereas GitHub only uses the word "sponsor" (which can be monthly or one-off).

In addition to adding a line about how financial contributions help us, I've also:

- changed the wording to reflect the language used on Open Collective, as that's our primary platform
- removed the Open Collective _backer_ logos from our README
- included a link to GitHub sponsor at the end, as it's our supplementary mechanism for receiving sponsorship 
- dropped the website hosting heading down a level to fall within the "Sponsors, backers and _donors_" section
- changed our [GitHub sponsorship](https://github.com/sponsors/stylelint?frequency=recurring) to a single tier with the description "Get a Sponsor badge on our [organisation profile](https://github.com/stylelint)" (this happens automatically)

Ultimately, all donations end up in Open Collective, so I've aligned our README with their model.

(I've also updated the descriptions on our Open Collective and GitHub Sponsorship profiles to align with the changes here.)

