### PR TITLE
Introduce cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
     ignore:
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: '/'
@@ -35,3 +37,5 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - 'pr: dependencies'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This aims to mitigate Supply Chain Attacks by bumping to malicious dependency versions too quickly.

Ref https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

