### PR TITLE
Always append rule name to error messages

### DIFF
--- a/lib/__tests__/integration.test.mjs
+++ b/lib/__tests__/integration.test.mjs
@@ -94,7 +94,7 @@ describe('integration test expecting warnings', () => {
 		expect(errors).toHaveLength(2);
 
 		for (const error of errors) {
-			expect(error.text).toBe('You made a mistake');
+			expect(error.text).toBe('You made a mistake (color-no-invalid-hex)');
 			expect(error.severity).toBe('warning');
 		}
 	});

--- a/lib/__tests__/message.test.mjs
+++ b/lib/__tests__/message.test.mjs
@@ -12,5 +12,5 @@ it('standalone loading YAML with custom message', async () => {
 	});
 
 	expect(results[0].warnings).toHaveLength(1);
-	expect(results[0].warnings[0].text).toBe('Unacceptable');
+	expect(results[0].warnings[0].text).toBe('Unacceptable (color-named)');
 });

--- a/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
+++ b/lib/rules/rule-selector-property-disallowed-list/__tests__/index.mjs
@@ -130,7 +130,7 @@ testRule({
 	reject: [
 		{
 			code: 'a { color: red; }',
-			message: 'foo',
+			message: `foo (${ruleName})`,
 			description: 'custom message',
 		},
 	],

--- a/lib/utils/__tests__/report.test.mjs
+++ b/lib/utils/__tests__/report.test.mjs
@@ -44,7 +44,7 @@ test('without disabledRanges', () => {
 	report(v);
 	const spyArgs = v.result.warn.mock.calls[0];
 
-	expect(spyArgs[0]).toBe('bar');
+	expect(spyArgs[0]).toBe('bar (foo)');
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
@@ -68,7 +68,7 @@ test('with irrelevant general disabledRange', () => {
 	report(v);
 	const spyArgs = v.result.warn.mock.calls[0];
 
-	expect(spyArgs[0]).toBe('bar');
+	expect(spyArgs[0]).toBe('bar (foo)');
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
@@ -114,7 +114,7 @@ test('with irrelevant rule-specific disabledRange', () => {
 	report(v);
 	const spyArgs = v.result.warn.mock.calls[0];
 
-	expect(spyArgs[0]).toBe('bar');
+	expect(spyArgs[0]).toBe('bar (foo)');
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
@@ -276,7 +276,7 @@ test('with custom rule severity', () => {
 	report(v);
 	const spyArgs = v.result.warn.mock.calls[0];
 
-	expect(spyArgs[0]).toBe('bar');
+	expect(spyArgs[0]).toBe('bar (foo)');
 	expect(spyArgs[1].severity).toBe('warning');
 	expect(spyArgs[1].node).toBe(v.node);
 });
@@ -396,7 +396,7 @@ test('with message function', () => {
 	report(v);
 	const spyArgs = v.result.warn.mock.calls[0];
 
-	expect(spyArgs[0]).toBe('a=str, b=true, c=10, d=/regex/');
+	expect(spyArgs[0]).toBe('a=str, b=true, c=10, d=/regex/ (foo)');
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
@@ -529,7 +529,7 @@ describe('with fix object', () => {
 
 		const spyArgs1 = v.result.warn.mock.calls[0];
 
-		expect(spyArgs1[0]).toBe('bar');
+		expect(spyArgs1[0]).toBe('bar (foo)');
 		expect(spyArgs1[1].fix.range).toMatchObject([0, 3]);
 		expect(spyArgs1[1].fix.text).toBe('bar');
 
@@ -543,7 +543,7 @@ describe('with fix object', () => {
 
 		const spyArgs2 = v.result.warn.mock.calls[1];
 
-		expect(spyArgs2[0]).toBe('qux');
+		expect(spyArgs2[0]).toBe('qux (foo)');
 		expect(spyArgs2[1].fix).toBeUndefined();
 	});
 
@@ -579,7 +579,7 @@ describe('with fix object', () => {
 
 		const spyArgs = v.result.warn.mock.calls[0];
 
-		expect(spyArgs[0]).toBe('bar');
+		expect(spyArgs[0]).toBe('bar (foo)');
 		expect(spyArgs[1].fix).toBeUndefined();
 	});
 
@@ -618,7 +618,7 @@ describe('with fix object', () => {
 
 		const spyArgs = v.result.warn.mock.calls[0];
 
-		expect(spyArgs[0]).toBe('bar');
+		expect(spyArgs[0]).toBe('bar (foo)');
 		expect(spyArgs[1].fix).toBeUndefined();
 	});
 
@@ -652,7 +652,7 @@ describe('with fix object', () => {
 
 		const spyArgs = v.result.warn.mock.calls[0];
 
-		expect(spyArgs[0]).toBe('bar');
+		expect(spyArgs[0]).toBe('bar (foo)');
 		expect(spyArgs[1].fix).toBeUndefined();
 	});
 
@@ -686,7 +686,7 @@ describe('with fix object', () => {
 
 		const spyArgs = v.result.warn.mock.calls[0];
 
-		expect(spyArgs[0]).toBe('bar');
+		expect(spyArgs[0]).toBe('bar (foo)');
 		expect(spyArgs[1].fix).toBeUndefined();
 	});
 });
@@ -710,7 +710,51 @@ test('with custom message', () => {
 	report(v);
 	const spyArgs = v.result.warn.mock.calls[0];
 
-	expect(spyArgs[0]).toBe('A custom message: str, true, 10, /regex/');
+	expect(spyArgs[0]).toBe('A custom message: str, true, 10, /regex/ (foo)');
+	expect(spyArgs[1].node).toBe(v.node);
+});
+
+test('with custom message (missing rule name)', () => {
+	const v = {
+		ruleName: 'foo',
+		result: {
+			warn: jest.fn(),
+			stylelint: resultStylelint({
+				customMessages: { foo: 'A custom message with appended rule name' },
+			}),
+		},
+		message: 'bar',
+		node: {
+			rangeBy: defaultRangeBy,
+		},
+	};
+
+	report(v);
+	const spyArgs = v.result.warn.mock.calls[0];
+
+	expect(spyArgs[0]).toBe('A custom message with appended rule name (foo)');
+	expect(spyArgs[1].node).toBe(v.node);
+});
+
+test('with custom message (appended rule name)', () => {
+	const v = {
+		ruleName: 'foo',
+		result: {
+			warn: jest.fn(),
+			stylelint: resultStylelint({
+				customMessages: { foo: 'A custom message with appended rule name (foo)' },
+			}),
+		},
+		message: 'bar',
+		node: {
+			rangeBy: defaultRangeBy,
+		},
+	};
+
+	report(v);
+	const spyArgs = v.result.warn.mock.calls[0];
+
+	expect(spyArgs[0]).toBe('A custom message with appended rule name (foo)');
 	expect(spyArgs[1].node).toBe(v.node);
 });
 
@@ -733,7 +777,7 @@ test('with custom message function', () => {
 	report(v);
 	const spyArgs = v.result.warn.mock.calls[0];
 
-	expect(spyArgs[0]).toBe('a=str, b=123');
+	expect(spyArgs[0]).toBe('a=str, b=123 (foo)');
 	expect(spyArgs[1].node).toBe(v.node);
 });
 

--- a/lib/utils/report.cjs
+++ b/lib/utils/report.cjs
@@ -118,7 +118,7 @@ function report(problem) {
 
 	warningProperties.fix = computeEditInfo({ ...problem, line: startLine });
 
-	const warningMessage = buildWarningMessage(message, messageArgs);
+	const warningMessage = buildWarningMessage(message, messageArgs, ruleName);
 
 	result.warn(warningMessage, warningProperties);
 }
@@ -165,14 +165,16 @@ function checkProblemRangeDeprecations(problem) {
 /**
  * @param {RuleMessage} message
  * @param {NonNullable<Problem['messageArgs']>} messageArgs
+ * @param {string} ruleName
  * @returns {string}
  */
-function buildWarningMessage(message, messageArgs) {
-	if (validateTypes.isString(message)) {
-		return printfLike(message, ...messageArgs);
-	}
+function buildWarningMessage(message, messageArgs, ruleName) {
+	const baseMessage = validateTypes.isString(message)
+		? printfLike(message, ...messageArgs)
+		: message(...messageArgs);
 
-	return message(...messageArgs);
+	// Append rule name in parentheses if not already present
+	return !baseMessage.endsWith(`(${ruleName})`) ? `${baseMessage} (${ruleName})` : baseMessage;
 }
 
 /**

--- a/lib/utils/report.mjs
+++ b/lib/utils/report.mjs
@@ -126,7 +126,7 @@ export default function report(problem) {
 
 	warningProperties.fix = computeEditInfo({ ...problem, line: startLine });
 
-	const warningMessage = buildWarningMessage(message, messageArgs);
+	const warningMessage = buildWarningMessage(message, messageArgs, ruleName);
 
 	result.warn(warningMessage, warningProperties);
 }
@@ -173,14 +173,16 @@ function checkProblemRangeDeprecations(problem) {
 /**
  * @param {RuleMessage} message
  * @param {NonNullable<Problem['messageArgs']>} messageArgs
+ * @param {string} ruleName
  * @returns {string}
  */
-function buildWarningMessage(message, messageArgs) {
-	if (isString(message)) {
-		return printfLike(message, ...messageArgs);
-	}
+function buildWarningMessage(message, messageArgs, ruleName) {
+	const baseMessage = isString(message)
+		? printfLike(message, ...messageArgs)
+		: message(...messageArgs);
 
-	return message(...messageArgs);
+	// Append rule name in parentheses if not already present
+	return !baseMessage.endsWith(`(${ruleName})`) ? `${baseMessage} (${ruleName})` : baseMessage;
 }
 
 /**


### PR DESCRIPTION
This pull request improves the handling of custom error messages in a Stylelint configuration. It ensures that when a custom error message is specified in a Stylelint configuration, the rule name is automatically appended in parentheses at the end of the message if not already present.

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8773

> Is there anything in the PR that needs further explanation?

When a custom message is defined for a rule, such as for the `custom-property-pattern` rule:

```javascript
{
  'custom-property-pattern': [
    '^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',
    {
      message: (name) => `Expected custom property name "${name}" to be kebab-case`,
    },
  ],
}
```

the rule name is now automatically appended in parentheses at the end of the message if it is not already present. This makes it easier to identify the source rule for each reported problem and improves traceability. Existing messages that already include the rule name remain unchanged.

Before:

```scss
:root {
  --MyCustomProperty: '';
  // Stylelint error: Expected custom property name "--MyCustomProperty" to be kebab-case
  //                                                                                     ^
  //                                                                            Missing rule name
}
```

After:

```scss
:root {
  --MyCustomProperty: '';
  // Stylelint error: Expected custom property name "--MyCustomProperty" to be kebab-case (custom-property-pattern)
  //                                                                                      ^
  //                                                                            Automatically appended rule name
}
```