### PR TITLE
Fix `release-pr` workflow failure

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release-pr:
-    uses: stylelint/.github/.github/workflows/call-release-pr.yml@fix-call-release-pr # TODO: Fix the ref name to a newly published tag later.
+    uses: stylelint/.github/.github/workflows/call-release-pr.yml@f34faf02df201c8c204df4ae2543523ad54ceb07 # 0.3.1
     with:
       new-version-command: npm run changeset
     permissions:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,7 +7,7 @@ jobs:
   release-pr:
     uses: stylelint/.github/.github/workflows/call-release-pr.yml@fix-call-release-pr # TODO: Fix the ref name to a newly published tag later.
     with:
-      new-version-command: npm run changeset
+      new-version-command: 'GITHUB_TOKEN=${{ github.token }} npm run changeset'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,7 +7,7 @@ jobs:
   release-pr:
     uses: stylelint/.github/.github/workflows/call-release-pr.yml@fix-call-release-pr # TODO: Fix the ref name to a newly published tag later.
     with:
-      new-version-command: 'GITHUB_TOKEN=${{ github.token }} npm run changeset'
+      new-version-command: npm run changeset
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release-pr:
-    uses: stylelint/.github/.github/workflows/call-release-pr.yml@34f1c0ac91f245ee4ee5ce725bb844328c17ccf5 # 0.3.0
+    uses: stylelint/.github/.github/workflows/call-release-pr.yml@fix-call-release-pr # TODO: Fix the ref name to a newly published tag later.
     with:
       new-version-command: npm run changeset
     permissions:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Blocked by <https://github.com/stylelint/.github/pull/66>

> Is there anything in the PR that needs further explanation?

This PR fixes the error below:

```
Error: Either `new-version` or `new-version-command` input is required.
```

Ref https://github.com/stylelint/stylelint/actions/runs/18218125564/job/51871855921#step:6:25

