### PR TITLE
Fix `npm run changeset` to update `version` in `package-lock.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "test-coverage": "npm test --ignore-scripts -- --coverage",
     "test-only": "npm test --ignore-scripts",
     "watch": "npm test --ignore-scripts -- --watch",
-    "changeset": "changeset version && node .changeset/rewrite-changelog.mjs CHANGELOG.md"
+    "changeset": "changeset version && node .changeset/rewrite-changelog.mjs CHANGELOG.md",
+    "postchangeset": "npm install --ignore-scripts"
   },
   "lint-staged": {
     "*.{js,mjs}": "eslint --cache --fix",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates to https://github.com/stylelint/stylelint/pull/8796#issuecomment-3365210812

> Is there anything in the PR that needs further explanation?

The current `npm run changeset` script updates the `version` field in `package.json`, but does not update the corresponding `version` field in `package-lock.json`. This can lead to inconsistencies between the two files.

