### PR TITLE
Document larger `message` arguments example

### DIFF
--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -132,26 +132,7 @@ For example, the following rule configuration would substitute in custom message
 }
 ```
 
-#### Example: using `message` with declaration-property-value-disallowed-list
-
-You can also use a message for disallowed property values in `declaration-property-value-disallowed-list`. For example:
-
-```json
-{
-  "rules": {
-    "declaration-property-value-disallowed-list": {
-      "color": ["red", { "message": "Unexpected color 'red'" }],
-      "font-weight": ["bold", { "message": "Unexpected font-weight 'bold'" }]
-    }
-  }
-}
-```
-
-Alternately, you can write a [custom formatter](../developer-guide/formatters.md) for maximum control if you need serious customization.
-
-Some rules support message arguments. For example, when configuring the `color-no-hex` rule, the hex color can be used in the message string:
-
-Via JavaScript:
+Some rules support message arguments. For example, the `color-no-hex` rule has one argument:
 
 ```js
 export default {
@@ -166,7 +147,34 @@ export default {
 };
 ```
 
-Via JSON:
+And the `declaration-property-value-disallowed-list` rule has two:
+
+```js
+export default {
+  rules: {
+    "declaration-property-value-disallowed-list": [
+      {
+        "font-weight": ["normal", "bold"],
+        "font-style": ["italic", "oblique"]
+      },
+      {
+        message: (property, value) => {
+          switch (property) {
+            case "font-weight":
+              return `Use "var(--font-weight-${value})" instead`;
+            case "font-style":
+              return `Use "class: 'italic'" instead`;
+            default:
+              return `Unexpected value "${value}" for property "${property}"`;
+          }
+        }
+      }
+    ]
+  }
+};
+```
+
+With config formats that don't support a function, like JSON, you can use a simplifed `printf`-like format (e.g., `%s`).
 
 ```json
 {
@@ -181,7 +189,9 @@ Via JSON:
 }
 ```
 
-With formats that don't support a function like JSON, you can use a `printf`-like format (e.g., `%s`). On the other hand, with JS format, you can use both a `printf`-like format and a function.
+With the JavaScript format, you can use both a `printf`-like format and a function.
+
+Alternately, you can write a [custom formatter](../developer-guide/formatters.md) for maximum control if you need serious customization.
 
 ### `url`
 


### PR DESCRIPTION
I hope this works. I tried only one object instead of an array and it seemed to take it. I appreciate kindness and patience not dismissiveness. I'm doing this for Hacktoberfest and to learn. 

Ref: https://github.com/stylelint/stylelint/issues/8802