### PR TITLE
Document `npm ci` when installing dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ To start coding, you'll need the:
 Then:
 
 1. [Fork and clone](https://guides.github.com/activities/forking/) the Stylelint repository.
-2. Install all the dependencies with `npm install`.
+2. Install all the dependencies with `npm ci`.
 
 ### Run tests
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Nope.

Since this repo commits a `package-lock.json` file contributors should run `npm ci`. Running `npm install` could result in unexpected changes to the lockfile.
