### PR TITLE
docs: add human-friendly quick start and config examples to user guide

### DIFF
--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -874,3 +874,18 @@ Options are:
 You'll find more formatters in [Awesome Stylelint](https://github.com/stylelint/awesome-stylelint#formatters) and [on the npm registry](https://www.npmjs.com/search?q=keywords:stylelint-formatter).
 
 [More info](options.md#formatter).
+
+## Easy Configuration Example
+
+Here’s a super-simple `stylelint.config.js` you can start with:
+
+module.exports = {
+"rules": {
+"color-no-invalid-hex": true,
+"block-no-empty": true
+}
+};
+
+
+Don’t worry—add more rules as you need them! Start simple, then grow your config as your project grows.
+

--- a/docs/user-guide/get-started.md
+++ b/docs/user-guide/get-started.md
@@ -121,3 +121,12 @@ And then run Stylelint on both your CSS and JavaScript files:
 ```shell
 stylelint "**/*.{css,js}"
 ```
+## Quick Start: Stylelint in Under 2 Minutes
+
+Want to lint your styles right now? Copy these commands:
+
+npm install stylelint --save-dev
+npx stylelint "**/*.css"
+
+That’s it! You’ll see instant feedback on your CSS, helping you catch mistakes and keep your code tidy.
+


### PR DESCRIPTION
None, it's a documentation fix.

This PR improves the documentation for new users:
- Added a clear and friendly quick start guide in get-started.md
- Added a simple example configuration in configure.md
- Brief explanations to help beginners understand Stylelint setup

No further explanation needed—changes are self-explanatory!

