### PR TITLE
Fix semver type for added feature

### DIFF
--- a/.changeset/chubby-donkeys-remain.md
+++ b/.changeset/chubby-donkeys-remain.md
@@ -1,5 +1,5 @@
 ---
-"stylelint": patch
+"stylelint": minor
 ---
 
 Added: support for `customSyntax` with function export


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, it correctly aligns semver type for "added".

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
