### PR TITLE
Fix `patch-package` warning about mismatched `@types/css-tree` version

### DIFF
--- a/patches/@types+css-tree+2.3.11.patch
+++ b/patches/@types+css-tree+2.3.11.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@types/css-tree/index.d.ts b/node_modules/@types/css-tree/index.d.ts
-index b9c1d73..f3d9ba9 100644
+index c005ef3..eb6e819 100644
 --- a/node_modules/@types/css-tree/index.d.ts
 +++ b/node_modules/@types/css-tree/index.d.ts
-@@ -910,7 +910,12 @@ export class Lexer {
+@@ -911,7 +911,12 @@ export class Lexer {
  export const lexer: Lexer;
  
  export function fork(extension: {


### PR DESCRIPTION
<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This just fixes a warning emitted by `patch-package` when applying `@types/css-tree` patch:

```sh-session
$ npx patch-package
...
Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    @types/css-tree@2.3.10

  applied to

    @types/css-tree@2.3.11

  At path

    node_modules/@types/css-tree

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package @types/css-tree

  to update the version in the patch file name and make this warning go away.
```

We can see the version diff via `npm diff --diff=@types/css-tree@2.3.10 --diff=@types/css-tree@2.3.11`:

```diff
diff --git a/README.md b/README.md
index v2.3.10..v2.3.11 100644
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/css-tree.

 ### Additional Details
- * Last updated: Sun, 29 Dec 2024 00:47:13 GMT
+ * Last updated: Mon, 29 Sep 2025 21:02:22 GMT
  * Dependencies: none

 # Credits
diff --git a/index.d.ts b/index.d.ts
index v2.3.10..v2.3.11 100644
--- a/index.d.ts
+++ b/index.d.ts
@@ -565,6 +565,7 @@
 ) => void;

 export interface WalkOptionsNoVisit {
+    visit?: never;
     enter?: EnterOrLeaveFn | undefined;
     leave?: EnterOrLeaveFn | undefined;
     reverse?: boolean | undefined;
diff --git a/package.json b/package.json
index v2.3.10..v2.3.11 100644
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@types/css-tree",
-    "version": "2.3.10",
+    "version": "2.3.11",
     "description": "TypeScript definitions for css-tree",
     "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/css-tree",
     "license": "MIT",
@@ -26,6 +26,6 @@
     "scripts": {},
     "dependencies": {},
     "peerDependencies": {},
-    "typesPublisherContentHash": "e05b2a8814822786a494f85847feb174e2af238259e7e221c141bebbf2e51a67",
-    "typeScriptVersion": "5.0"
+    "typesPublisherContentHash": "47e292f7a43d61b26ab50e29bf2103358c13952e3f5569fdcc9d4107234d992d",
+    "typeScriptVersion": "5.2"
 }
```

Note: this change will not impact the Stylelint behavior. Only for development.
