### PR TITLE
Fix `selector-pseudo-element-no-unknown` false positives for `::scroll-button()`

### DIFF
--- a/.changeset/brown-buses-refuse.md
+++ b/.changeset/brown-buses-refuse.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-element-no-unknown` false positives for `::scroll-button()`

--- a/lib/reference/selectors.cjs
+++ b/lib/reference/selectors.cjs
@@ -254,6 +254,7 @@ const pseudoElements = uniteSets(
 		'picker-icon',
 		'picker',
 		'placeholder',
+		'scroll-button',
 		'scroll-marker-group',
 		'scroll-marker',
 		'search-text',

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -251,6 +251,7 @@ export const pseudoElements = uniteSets(
 		'picker-icon',
 		'picker',
 		'placeholder',
+		'scroll-button',
 		'scroll-marker-group',
 		'scroll-marker',
 		'search-text',

--- a/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-element-no-unknown/__tests__/index.mjs
@@ -112,7 +112,7 @@ testRule({
 			code: 'a::part(shadow-part) { }',
 		},
 		{
-			code: '::scroll-marker, ::scroll-marker-group { }',
+			code: '::scroll-marker, ::scroll-marker-group, ::scroll-button(inline-end) { }',
 		},
 		{
 			code: '::picker(select) {}',


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

followup of #8110

> reference

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::scroll-button#browser_compatibility
