### PR TITLE
Add v17 branch to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v17 # TODO: Remove this setting after v17.0.0 is released.
   pull_request:
   merge_group:
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #7396 

> Is there anything in the PR that needs further explanation?

The CI workflow should run once a PR on the v17 branch is merged (until v17.0.0 is released).
