### PR TITLE
Remove unused `npm run build` step from `publish-to-pkg.pr.new` workflow

### DIFF
--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -24,9 +24,8 @@ jobs:
           cache: npm
       - name: Install Packages
         run: npm ci
-      - name: Build
-        run: npm run build
-      - run: npx pkg-pr-new publish --compact --json output.json --comment=off
+      - name: Publish
+        run: npx pkg-pr-new publish --compact --json output.json --comment=off
       - name: Add metadata to output
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow up on #8859

> Is there anything in the PR that needs further explanation?

`npm run build` has been removed in #8859.
