### PR TITLE
Ignore `tmp` directories from ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import stylelintJestConfig from 'eslint-config-stylelint/jest';
 
 export default [
 	{
-		ignores: ['.coverage/*'],
+		ignores: ['.coverage/**', 'tmp/**'],
 	},
 	...stylelintConfig,
 	...stylelintJestConfig,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Git and Prettier also ignore such directories, ref:
- https://github.com/stylelint/stylelint/blob/a8c356eaad7d40770e167ff3aef753da775d7f3d/.gitignore#L10
- https://github.com/stylelint/stylelint/blob/a8c356eaad7d40770e167ff3aef753da775d7f3d/.prettierignore#L16

