### PR TITLE
Update `tsconfig.json` for newly supported Node.js versions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"compilerOptions": {
-		"module": "Node16",
-		"moduleResolution": "Node16",
-		"target": "ES2022",
+		"module": "nodenext",
+		"target": "es2023",
 		"lib": ["ES2023"],
 		"checkJs": true,
 		"noEmit": true,
@@ -15,7 +14,7 @@
 		"noUncheckedIndexedAccess": true,
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
-		"skipLibCheck": false
+		"skipLibCheck": true
 	},
 	"include": ["lib/**/*.mjs", "types/**/*.ts", "rollup.config.*", ".changeset/*.mjs"],
 	"exclude": ["**/__tests__/**"]


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow up on PR #8867

> Is there anything in the PR that needs further explanation?

We can now update `tsconfig.json` to fit the newly supported Node.js versions, i.e., 20.19.0 or later.

- `module` is now `nodenext`, which is officially recommended for modern Node.js projects.
  Ref https://www.typescriptlang.org/tsconfig/#module
- `moduleResolution` is no longer needed, as it defaults to `nodenext` when `module` is set to `nodenext`.
  Ref https://www.typescriptlang.org/tsconfig/#moduleResolution
- `target` is now `es2023`, which is supported by Node.js 20.19.0 and later.
  Ref https://www.typescriptlang.org/tsconfig/#target
- `lib` is now `ES2023` to match the `target`.
  Ref https://www.typescriptlang.org/tsconfig/#lib
- `skipLibCheck` is now enabled to improve build performance.
  Ref https://www.typescriptlang.org/tsconfig/#skipLibCheck


