### PR TITLE
Document naming convention for comments in docs and tests

### DIFF
--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -38,7 +38,7 @@ You should use:
 - the minimum amount of valid CSS possible, e.g. use an empty rule if targeting selectors and avoid optional names
 - `{}` for empty rules, rather than `{ }`
 - trailing semicolons within declaration blocks
-- _foo_, _bar_ and _baz_ for names, e.g. `.foo`, `#bar`, `--baz`
+- _foo_, _bar_, _baz_ and _qux_ for names, e.g. `.foo`, `#bar`, `--baz` and `/* qux */`
 
 By default, you should use the:
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Ref: https://github.com/stylelint/stylelint/pull/8883#discussion_r2588206503

We sometimes test with multiple comments, so using metasyntactic names can help keep these consistent, e.g.:

```css
/* foo */ a /* bar /* {}
```
