### PR TITLE
Change `target-branch` to `v17` in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,7 @@ updates:
         update-types: ['version-update:semver-major']
     cooldown:
       default-days: 7
+    target-branch: v17 # TODO: Remove after 17.0.0 is released.
 
   - package-ecosystem: github-actions
     directory: '/'
@@ -39,3 +40,4 @@ updates:
       - 'pr: dependencies'
     cooldown:
       default-days: 7
+    target-branch: v17 # TODO: Remove after 17.0.0 is released.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

We've already updated dependencies in the `v17` branch many times. So, we should change the target branch of Dependabot to `v17`.

Ref https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#target-branch-

