### PR TITLE
Bump eslint-config-stylelint from 25.0.1 to 26.0.0 and enable `import/enforce-node-protocol-usage`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,13 +13,13 @@ export default [
 			import: importPlugin,
 		},
 		languageOptions: {
-			ecmaVersion: 2025,
 			globals: {
 				testRule: 'readonly',
 				testRuleConfigs: 'readonly',
 			},
 		},
 		rules: {
+			'import/enforce-node-protocol-usage': ['error', 'always'],
 			'import/extensions': ['error', 'ignorePackages'],
 			'jest/no-standalone-expect': ['error', { additionalTestBlockFunctions: ['testFn'] }],
 		},

--- a/lib/__tests__/standalone-fix.test.mjs
+++ b/lib/__tests__/standalone-fix.test.mjs
@@ -1,8 +1,8 @@
+import { copyFile, readFile, rm } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import process from 'node:process';
 
-import { copyFile, readFile, rm } from 'fs/promises';
 import { jest, describe as suite } from '@jest/globals';
 import { stripIndent } from 'common-tags';
 

--- a/lib/isPathIgnored.mjs
+++ b/lib/isPathIgnored.mjs
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, resolve } from 'path';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 import micromatch from 'micromatch';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "common-tags": "^1.8.2",
         "deepmerge": "^4.3.1",
         "eslint": "^9.39.1",
-        "eslint-config-stylelint": "^25.0.1",
+        "eslint-config-stylelint": "^26.0.0",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jest": "^29.2.1",
         "husky": "^9.1.7",
@@ -2780,14 +2780,14 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz",
-      "integrity": "sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.6.1.tgz",
+      "integrity": "sha512-JCs+MqoXfXrRPGbGmho/zGS/jMcn3ieKl/A8YImqib76C8kjgZwq5uUFzc30lJkMvcchuRn6/v8IApLxli3Jyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.44.0",
+        "@typescript-eslint/types": "^8.47.0",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -2801,9 +2801,9 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "8.46.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.0.tgz",
-      "integrity": "sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==",
+      "version": "8.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.48.1.tgz",
+      "integrity": "sha512-+fZ3LZNeiELGmimrujsDCT4CRIbq5oXdHe7chLiW8qzqyPMnn1puNstCrMNVAqwcl2FdIxkuJ4tOs/RFDBVc/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5261,9 +5261,9 @@
       }
     },
     "node_modules/eslint-config-stylelint": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-25.0.1.tgz",
-      "integrity": "sha512-dvfNH6Lz8j1GmaocJJX9C1fq6Sm58dK2LGyvqQRBw4njeOin5BQaeuU9KIZvZmiMddzhanqPjA1qbZYDGuIkQA==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-stylelint/-/eslint-config-stylelint-26.0.0.tgz",
+      "integrity": "sha512-G9Cwgmfh0vle6G81Zu4avT10uqXY+IbIZGwA3YmtZYCROujnyhQS3GmHehgNYNLy3liRfyLUmdzk/JCotD8EPg==",
       "dev": true,
       "funding": [
         {
@@ -5277,13 +5277,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@stylistic/eslint-plugin": "^5.4.0",
+        "@stylistic/eslint-plugin": "^5.5.0",
         "eslint-plugin-n": "^17.23.1",
         "eslint-plugin-regexp": "^2.10.0",
         "globals": "^16.4.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "eslint": ">=9.13.0",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "common-tags": "^1.8.2",
     "deepmerge": "^4.3.1",
     "eslint": "^9.39.1",
-    "eslint-config-stylelint": "^25.0.1",
+    "eslint-config-stylelint": "^26.0.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.2.1",
     "husky": "^9.1.7",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Today, I released `eslint-config-stylelint@26.0.0`, which should benefit this repo.

Also, I believe `import/enforce-node-protocol-usage` can help us keep consistency in the code base, since we've already used the `node:` protocol in most places.

Ref:
- https://github.com/stylelint/eslint-config-stylelint/releases/tag/26.0.0
- https://github.com/import-js/eslint-plugin-import/blob/v2.32.0/docs/rules/enforce-node-protocol-usage.md

