### PR TITLE
Fix wording of `context.fix` deprecation

### DIFF
--- a/lib/__tests__/standalone-fix.test.mjs
+++ b/lib/__tests__/standalone-fix.test.mjs
@@ -446,10 +446,9 @@ describe('stylelint commands', () => {
 				.foo {}
 		`);
 		expect(mock).toHaveBeenCalledTimes(1);
-		expect(mock).toHaveBeenCalledWith('`context.fix` is being deprecated.', {
+		expect(mock).toHaveBeenCalledWith('`context.fix` is deprecated.', {
 			code: 'stylelint:005',
-			detail:
-				'Please pass a `fix` callback to the `report` utility of "plugin/selector-no-foo" instead.',
+			detail: 'Pass a `fix` callback to the `report` utility of "plugin/selector-no-foo" instead.',
 			type: 'DeprecationWarning',
 		});
 

--- a/lib/lintPostcssResult.mjs
+++ b/lib/lintPostcssResult.mjs
@@ -104,9 +104,9 @@ export default async function lintPostcssResult(stylelintOptions, postcssResult,
 			get fix() {
 				if (shouldWarn) {
 					emitDeprecationWarning(
-						'`context.fix` is being deprecated.',
+						'`context.fix` is deprecated.',
 						'CONTEXT_FIX',
-						`Please pass a \`fix\` callback to the \`report\` utility of "${ruleName}" instead.`,
+						`Pass a \`fix\` callback to the \`report\` utility of "${ruleName}" instead.`,
 					);
 				}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/8901

> Is there anything in the PR that needs further explanation?

Makes the wording of the two deprecation warnings we have consistent.