### PR TITLE
chore: bump version to 17.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint",
-  "version": "16.26.1",
+  "version": "17.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint",
-      "version": "16.26.1",
+      "version": "17.0.0",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint",
-  "version": "16.26.1",
+  "version": "17.0.0",
   "description": "A mighty CSS linter that helps you avoid errors and enforce conventions.",
   "keywords": [
     "css-in-js",


### PR DESCRIPTION
Downstream in vscode-stylelint, we use the version number in the package manifest to determine what behaviour to expect in tests. Updating to 17.0.0 so that tests for v17 can expect new breaking changes to behaviour.