### PR TITLE
Revert "chore: bump version to 17.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint",
-  "version": "17.0.0",
+  "version": "16.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint",
-      "version": "17.0.0",
+      "version": "16.26.1",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint",
-  "version": "17.0.0",
+  "version": "16.26.1",
   "description": "A mighty CSS linter that helps you avoid errors and enforce conventions.",
   "keywords": [
     "css-in-js",


### PR DESCRIPTION
Reverts stylelint/stylelint#8916

Blocked by:
- https://github.com/stylelint/vscode-stylelint/pull/762

> [!CAUTION]
> Merge this PR before creating a release PR for 17.0.0. 