### PR TITLE
Prevent scheduled workflow from running in forks

### DIFF
--- a/.github/workflows/comment-on-old-issues.yml
+++ b/.github/workflows/comment-on-old-issues.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.repository == 'stylelint/stylelint'
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

Currently, the scheduled workflow runs in all forked repositories daily,  which is unnecessary and wastes CI resources.

<img  height="374" alt="CleanShot 2025-12-15 at 09 47 57@2x" src="https://github.com/user-attachments/assets/ba153e67-3147-428d-9c30-ef5b03f326e0" />



> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

No
