### PR TITLE
Fix `declaration-empty-line-before` types for `after-block` option

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -602,7 +602,7 @@ declare namespace stylelint {
 		'declaration-empty-line-before': CoreRule<
 			'always' | 'never',
 			{
-				except: OneOrMany<'first-nested' | 'after-comment' | 'after-declaration'>;
+				except: OneOrMany<'first-nested' | 'after-block' | 'after-comment' | 'after-declaration'>;
 				ignore: OneOrMany<
 					'after-comment' | 'after-declaration' | 'first-nested' | 'inside-single-line-block'
 				>;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow on from https://github.com/stylelint/stylelint/pull/8910/changes

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
