### PR TITLE
Document `*-list` prefix behaviour

### DIFF
--- a/lib/rules/media-feature-name-allowed-list/README.md
+++ b/lib/rules/media-feature-name-allowed-list/README.md
@@ -14,7 +14,7 @@ Specify a list of allowed media feature names.
 ### `Array<string>`
 
 ```json
-["array", "of", "unprefixed", "media-features", "/regex/"]
+["array", "of", "media-features", "/regex/"]
 ```
 
 Given:

--- a/lib/rules/media-feature-name-disallowed-list/README.md
+++ b/lib/rules/media-feature-name-disallowed-list/README.md
@@ -14,7 +14,7 @@ Specify a list of disallowed media feature names.
 ### `Array<string>`
 
 ```json
-["array", "of", "unprefixed", "media-features", "/regex/"]
+["array", "of", "media-features", "/regex/"]
 ```
 
 Given:

--- a/lib/rules/media-feature-name-value-allowed-list/README.md
+++ b/lib/rules/media-feature-name-value-allowed-list/README.md
@@ -14,7 +14,7 @@ Specify a list of allowed media feature name and value pairs.
 ### `Object<string, Array<string>>`
 
 ```json
-{ "unprefixed-media-feature-name": ["array", "of", "values", "/regex/"] }
+{ "media-feature-name": ["array", "of", "values", "/regex/"] }
 ```
 
 You can specify a regex for a media feature name, such as `{ "/width$/": [] }`.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follow on from https://github.com/stylelint/stylelint/pull/8912

> Is there anything in the PR that needs further explanation?

Corrects the READMEs of these three rules to reflect that they don't silently unprefix.

The READMEs of the other `*-list` rules are already correct.
