### PR TITLE
Fix normalizing of windows drive letter

### DIFF
--- a/.changeset/beige-spoons-sit.md
+++ b/.changeset/beige-spoons-sit.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: Windows drive letter casing inconsistencies when matching patterns against file paths

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,14 @@ export default [
 		rules: {
 			'import/enforce-node-protocol-usage': ['error', 'always'],
 			'import/extensions': ['error', 'ignorePackages'],
-			'jest/no-standalone-expect': ['error', { additionalTestBlockFunctions: ['testFn'] }],
+			'jest/no-standalone-expect': [
+				'error',
+				{ additionalTestBlockFunctions: ['testFn', 'win32OnlyTest'] },
+			],
+			'jest/expect-expect': [
+				'error',
+				{ additionalTestBlockFunctions: ['testFn', 'win32OnlyTest'] },
+			],
 		},
 	},
 ];

--- a/lib/__tests__/getConfigForFile.test.mjs
+++ b/lib/__tests__/getConfigForFile.test.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 import createStylelint from '../createStylelint.mjs';
 import getConfigForFile from '../getConfigForFile.mjs';
 import pluginWarnAboutFoo from './fixtures/plugin-warn-about-foo.mjs';
+import withMockedPlatform from '../testUtils/withMockedPlatform.mjs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -23,5 +24,43 @@ test('augmented config loads', async () => {
 			},
 		},
 		filepath: path.join(__dirname, 'fixtures/getConfigForFile/a/.stylelintrc'),
+	});
+});
+
+describe('path normalization for caches', () => {
+	test('specified config cache reuses entry across drive-letter casing on Windows', async () => {
+		const stylelint = createStylelint({ config: { rules: {} } });
+		const driveUpper = 'C:\\foo.css';
+		const driveLower = 'c:\\foo.css';
+
+		const first = await withMockedPlatform('win32', () =>
+			getConfigForFile({ stylelint, searchPath: driveUpper, filePath: driveUpper }),
+		);
+
+		const second = await withMockedPlatform('win32', () =>
+			getConfigForFile({ stylelint, searchPath: driveLower, filePath: driveLower }),
+		);
+
+		expect(second).toBe(first);
+		expect(stylelint._specifiedConfigCache.get(stylelint._options.config)?.size).toBe(1);
+	});
+
+	test('specified config cache remains case-sensitive on non-Windows platforms', async () => {
+		// Drive letters do not exist on non-Windows platforms, but nonetheless
+		// we want to ensure that the drive-letter casing logic is not applied.
+		const stylelint = createStylelint({ config: { rules: {} } });
+		const driveUpper = 'C:\\foo.css';
+		const driveLower = 'c:\\foo.css';
+
+		const first = await withMockedPlatform('linux', () =>
+			getConfigForFile({ stylelint, searchPath: driveUpper, filePath: driveUpper }),
+		);
+
+		const second = await withMockedPlatform('linux', () =>
+			getConfigForFile({ stylelint, searchPath: driveLower, filePath: driveLower }),
+		);
+
+		expect(second).not.toBe(first);
+		expect(stylelint._specifiedConfigCache.get(stylelint._options.config)?.size).toBe(2);
 	});
 });

--- a/lib/__tests__/getPostcssResult.test.mjs
+++ b/lib/__tests__/getPostcssResult.test.mjs
@@ -1,0 +1,41 @@
+import createStylelint from '../createStylelint.mjs';
+import getPostcssResult from '../getPostcssResult.mjs';
+import withMockedPlatform from '../testUtils/withMockedPlatform.mjs';
+
+describe('getPostcssResult cache normalization', () => {
+	test('postcss result cache reuses entry across drive-letter casing on Windows', async () => {
+		const stylelint = createStylelint();
+		const driveUpper = 'D:\\path\\to\\file.css';
+		const driveLower = 'd:\\path\\to\\file.css';
+
+		const first = await withMockedPlatform('win32', () =>
+			getPostcssResult(stylelint, { code: 'a {}', filePath: driveUpper }),
+		);
+
+		const second = await withMockedPlatform('win32', () =>
+			getPostcssResult(stylelint, { code: 'a {}', filePath: driveLower }),
+		);
+
+		expect(second).toBe(first);
+		expect(stylelint._postcssResultCache.size).toBe(1);
+	});
+
+	test('postcss result cache remains case-sensitive on non-Windows platforms', async () => {
+		// Drive letters do not exist on non-Windows platforms, but nonetheless
+		// we want to ensure that the drive-letter casing logic is not applied.
+		const stylelint = createStylelint();
+		const driveUpper = 'E:\\path\\to\\file.css';
+		const driveLower = 'e:\\path\\to\\file.css';
+
+		const first = await withMockedPlatform('linux', () =>
+			getPostcssResult(stylelint, { code: 'a {}', filePath: driveUpper }),
+		);
+
+		const second = await withMockedPlatform('linux', () =>
+			getPostcssResult(stylelint, { code: 'a {}', filePath: driveLower }),
+		);
+
+		expect(second).not.toBe(first);
+		expect(stylelint._postcssResultCache.size).toBe(2);
+	});
+});

--- a/lib/__tests__/ignore.test.mjs
+++ b/lib/__tests__/ignore.test.mjs
@@ -1,16 +1,21 @@
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import process from 'node:process';
 
 import { AllFilesIgnoredError, NoFilesFoundError } from '../utils/errors.mjs';
 import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import safeChdir from '../testUtils/safeChdir.mjs';
 import standalone from '../standalone.mjs';
+import withMockedPlatform from '../testUtils/withMockedPlatform.mjs';
 
 const fixtures = (...elem) => {
 	const dir = fileURLToPath(new URL('./fixtures', import.meta.url));
 
 	return replaceBackslashes(path.join(dir, ...elem));
 };
+
+const isWindowsHost = process.platform === 'win32';
+const win32OnlyTest = isWindowsHost ? test : test.skip;
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -361,6 +366,52 @@ test('using codeFilename and ignoreFiles together', async () => {
 
 	// ignored
 	expect(results[0].ignored).toBeTruthy();
+});
+
+// Only run this test on Windows platforms, since current architecture would
+// require significant mocking throughout to simulate Windows path behavior on
+// non-Windows platforms.
+win32OnlyTest(
+	'using codeFilename and ignoreFiles together on Windows regardless of drive letter case',
+	async () => {
+		const driveUpper = 'C:\\path\\to\\foo.css';
+		const driveLower = 'c:\\path\\to\\foo.css';
+
+		const { results } = await standalone({
+			code: 'a {}',
+			codeFilename: driveLower,
+			config: {
+				ignoreFiles: [driveUpper],
+				rules: { 'block-no-empty': true },
+			},
+		});
+
+		// Ignored when drive letter casing differs.
+		expect(results[0].warnings).toHaveLength(0);
+		expect(results[0].ignored).toBeTruthy();
+	},
+);
+
+test('codeFilename and ignoreFiles remain case-sensitive on non-Windows platforms', async () => {
+	// Drive letters do not exist on non-Windows platforms, but nonetheless
+	// we want to ensure that the drive-letter casing logic is not applied.
+	const driveUpper = 'C:\\path\\to\\foo.css';
+	const driveLower = 'c:\\path\\to\\foo.css';
+
+	const { results } = await withMockedPlatform('linux', () =>
+		standalone({
+			code: 'a {}',
+			codeFilename: driveLower,
+			config: {
+				ignoreFiles: [driveUpper],
+				rules: { 'block-no-empty': true },
+			},
+		}),
+	);
+
+	// Not ignored when drive letter casing differs.
+	expect(results[0].warnings).toHaveLength(1);
+	expect(results[0].ignored).toBeFalsy();
 });
 
 test('using codeFilename and ignoreFiles with configBasedir', async () => {

--- a/lib/__tests__/isPathIgnored.test.mjs
+++ b/lib/__tests__/isPathIgnored.test.mjs
@@ -1,3 +1,6 @@
+import path from 'node:path';
+import process from 'node:process';
+
 import createStylelint from '../createStylelint.mjs';
 import isPathIgnored from '../isPathIgnored.mjs';
 
@@ -16,4 +19,26 @@ test('isPathIgnored()', async () => {
 			isPathIgnored(stylelint, 'foo/invalid-hex.css'),
 		]),
 	).resolves.toEqual([true, true, false, false]);
+});
+
+const isWindowsHost = process.platform === 'win32';
+const win32OnlyTest = isWindowsHost ? test : test.skip;
+
+win32OnlyTest('normalizes string ignoreFiles on Windows', async () => {
+	const cwd = process.cwd();
+	const uppercasePath = path.win32
+		.join(cwd, 'foo.css')
+		.replace(/^([a-z]):/i, (drive) => drive.toUpperCase());
+	const lowercasePath = uppercasePath.replace(/^([A-Z]):/, (drive) => drive.toLowerCase());
+
+	const stylelint = createStylelint({
+		config: {
+			ignoreFiles: uppercasePath,
+			rules: { 'block-no-empty': true },
+		},
+	});
+
+	const ignored = await isPathIgnored(stylelint, lowercasePath);
+
+	expect(ignored).toBe(true);
 });

--- a/lib/getConfigForFile.mjs
+++ b/lib/getConfigForFile.mjs
@@ -5,6 +5,7 @@ import { cosmiconfig } from 'cosmiconfig';
 
 import { ConfigurationError } from './utils/errors.mjs';
 import { augmentConfigFull } from './augmentConfig.mjs';
+import normalizeFilePath from './utils/normalizeFilePath.mjs';
 
 const IS_TEST = process.env.NODE_ENV === 'test';
 const STOP_DIR = IS_TEST ? process.cwd() : undefined;
@@ -35,7 +36,7 @@ export default async function getConfigForFile({
 	const cwd = stylelint._options.cwd;
 
 	if (optionsConfig) {
-		const filePathAsCacheKey = filePath ?? '';
+		const filePathAsCacheKey = normalizeFilePath(filePath ?? '');
 		/** @type {Map<string, CosmiconfigResult>} */
 		const cachedForFiles = stylelint._specifiedConfigCache.get(optionsConfig) ?? new Map();
 		const cached = cachedForFiles.get(filePathAsCacheKey);

--- a/lib/getPostcssResult.mjs
+++ b/lib/getPostcssResult.mjs
@@ -4,6 +4,7 @@ import postcss from 'postcss';
 
 import dynamicImport from './utils/dynamicImport.mjs';
 import getModulePath from './utils/getModulePath.mjs';
+import normalizeFilePath from './utils/normalizeFilePath.mjs';
 import normalizeFixMode from './utils/normalizeFixMode.mjs';
 
 /** @import {Result, Syntax} from 'postcss' */
@@ -18,7 +19,8 @@ const postcssProcessor = postcss();
  * @returns {Promise<Result>}
  */
 export default async function getPostcssResult(stylelint, { customSyntax, filePath, code } = {}) {
-	const cached = filePath ? stylelint._postcssResultCache.get(filePath) : undefined;
+	const normalizedPath = filePath ? normalizeFilePath(filePath) : undefined;
+	const cached = normalizedPath ? stylelint._postcssResultCache.get(normalizedPath) : undefined;
 
 	if (cached) {
 		return cached;
@@ -49,8 +51,8 @@ export default async function getPostcssResult(stylelint, { customSyntax, filePa
 
 	const postcssResult = await postcssProcessor.process(getCode, postcssOptions).async();
 
-	if (filePath) {
-		stylelint._postcssResultCache.set(filePath, postcssResult);
+	if (normalizedPath) {
+		stylelint._postcssResultCache.set(normalizedPath, postcssResult);
 	}
 
 	return postcssResult;

--- a/lib/isPathIgnored.mjs
+++ b/lib/isPathIgnored.mjs
@@ -1,10 +1,10 @@
 import { isAbsolute, relative, resolve } from 'node:path';
-
 import micromatch from 'micromatch';
 
 import filterFilePaths from './utils/filterFilePaths.mjs';
 import getConfigForFile from './getConfigForFile.mjs';
 import getFileIgnorer from './utils/getFileIgnorer.mjs';
+import normalizeFilePath from './utils/normalizeFilePath.mjs';
 
 /**
  * To find out if a path is ignored, we need to load the config,
@@ -29,7 +29,12 @@ export default async function isPathIgnored(stylelint, filePath) {
 	const ignoreFiles = result.config.ignoreFiles || [];
 	const absoluteFilePath = isAbsolute(filePath) ? filePath : resolve(cwd, filePath);
 
-	if (micromatch([absoluteFilePath], ignoreFiles).length > 0) {
+	const normalizedAbsolutePath = normalizeFilePath(absoluteFilePath);
+	const normalizedIgnoreFiles = ignoreFiles.map((/** @type {string} */ glob) =>
+		normalizeFilePath(String(glob)),
+	);
+
+	if (micromatch([normalizedAbsolutePath], normalizedIgnoreFiles).length > 0) {
 		return true;
 	}
 

--- a/lib/testUtils/withMockedPlatform.mjs
+++ b/lib/testUtils/withMockedPlatform.mjs
@@ -1,0 +1,22 @@
+import process from 'node:process';
+
+/**
+ * Temporarily override process.platform for a single async operation.
+ *
+ * @param {NodeJS.Platform} platform
+ * @param {() => Promise<unknown>} fn
+ * @returns {Promise<unknown>}
+ */
+export default async function withMockedPlatform(platform, fn) {
+	const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+	Object.defineProperty(process, 'platform', { value: platform });
+
+	try {
+		return await fn();
+	} finally {
+		if (descriptor) {
+			Object.defineProperty(process, 'platform', descriptor);
+		}
+	}
+}

--- a/lib/utils/__tests__/normalizeFilePath.test.mjs
+++ b/lib/utils/__tests__/normalizeFilePath.test.mjs
@@ -1,0 +1,20 @@
+import normalizeFilePath from '../normalizeFilePath.mjs';
+
+describe('normalizeFilePath', () => {
+	test('lowercases drive letter and normalizes separators on Windows', () => {
+		expect(normalizeFilePath('C:\\Path\\To\\file.css', 'win32')).toBe('c:/Path/To/file.css');
+	});
+
+	test('preserves negation while lowercasing drive letter on Windows', () => {
+		expect(normalizeFilePath('!D:\\Foo\\bar.css', 'win32')).toBe('!d:/Foo/bar.css');
+	});
+
+	test('does not affect Windows paths on non-Windows platforms', () => {
+		expect(normalizeFilePath('C:\\Path\\To\\file.css', 'linux')).toBe('C:\\Path\\To\\file.css');
+	});
+
+	test('leaves non-Windows paths untouched', () => {
+		expect(normalizeFilePath('/tmp/FOO.css', 'win32')).toBe('/tmp/FOO.css');
+		expect(normalizeFilePath('/tmp/FOO.css', 'linux')).toBe('/tmp/FOO.css');
+	});
+});

--- a/lib/utils/normalizeFilePath.mjs
+++ b/lib/utils/normalizeFilePath.mjs
@@ -1,0 +1,26 @@
+import normalizePath from 'normalize-path';
+import process from 'node:process';
+
+/**
+ * Normalize a path for comparisons on Windows while keeping POSIX platforms
+ * untouched. On Windows, this lowercases the drive letter and converts
+ * backslashes to forward slashes. Only the drive letter is lowercased, since
+ * the rest of the path may be case-sensitive on certain file systems mounted
+ * on Windows.
+ *
+ * @param {string} filePath
+ * @param {NodeJS.Platform} [platform=process.platform]
+ * @returns {string}
+ */
+export default function normalizeFilePath(filePath, platform = process.platform) {
+	if (platform !== 'win32') {
+		return filePath;
+	}
+
+	const loweredDrive = filePath.replace(
+		/^(!?)([a-z]):/i,
+		(_, prefix, drive) => `${prefix}${drive.toLowerCase()}:`,
+	);
+
+	return normalizePath(loweredDrive);
+}


### PR DESCRIPTION
Fixes #5594.

- Add shared normalizeFilePath utility to align drive-letter casing.
- Apply normalization to ignoreFiles, config cache, and postcss cache.