### PR TITLE
Revert "Change `target-branch` to `v17` in Dependabot config"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
         update-types: ['version-update:semver-major']
     cooldown:
       default-days: 7
-    target-branch: v17 # TODO: Remove after 17.0.0 is released.
 
   - package-ecosystem: github-actions
     directory: '/'
@@ -40,4 +39,3 @@ updates:
       - 'pr: dependencies'
     cooldown:
       default-days: 7
-    target-branch: v17 # TODO: Remove after 17.0.0 is released.


### PR DESCRIPTION
Reverts stylelint/stylelint#8894

> [!CAUTION]
> We MUST merge this PR after the [`v17`](https://github.com/stylelint/stylelint/tree/v17) branch is deleted.