### PR TITLE
Revert "Add v17 branch to CI workflow"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v17 # TODO: Remove this setting after v17.0.0 is released.
   pull_request:
   merge_group:
 


### PR DESCRIPTION
Reverts stylelint/stylelint#8869

> [!CAUTION]
> We MUST merge this PR after the [`v17`](https://github.com/stylelint/stylelint/tree/v17) branch is deleted. 