### PR TITLE
Document extension in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
+++ b/.github/ISSUE_TEMPLATE/REPORT_A_BUG.yml
@@ -7,6 +7,8 @@ body:
       value: |
         Thank you for taking the time to report a bug!
 
+        If you encountered it using the [Visual Studio Code extension](https://github.com/stylelint/vscode-stylelint) and can't reproduce it using the Stylelint CLI, e.g. npx stylelint "**/*.css", please create the issue in the [extension issue tracker](https://github.com/stylelint/vscode-stylelint/issues/new?template=bug.yml) instead.
+
         Please [search our issues](https://github.com/search?q=repo%3Astylelint%2Fstylelint+&type=issues) to check that the bug hasn't already been reported.
 
         You can help us fix the bug more quickly by:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/8964#issuecomment-3743075010

> Is there anything in the PR that needs further explanation?

There may be an uptick in extension bugs after the major release. This is a (perhaps temporarily) signpost pointing people in the right direction.

Base = `main`, so it activates. Won't conflict with `v17` merge.
