### PR TITLE
Document patch-package in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Then:
 
 1. [Fork and clone](https://guides.github.com/activities/forking/) the Stylelint repository.
 2. Install all the dependencies with `npm ci`.
+3. Patch packages with `npx patch-package`.
 
 ### Run tests
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Packages aren't automatically patched when using `npm ci`, so this manual step ensures they are patched to avoid type errors.