### PR TITLE
Remove ignoring ESLint major updates in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,9 +24,6 @@ updates:
         patterns: ['@stylelint/*']
       typescript:
         patterns: ['typescript', '@types/*']
-    ignore:
-      - dependency-name: 'eslint'
-        update-types: ['version-update:semver-major']
     cooldown:
       default-days: 7
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Follows up to #7716

> Is there anything in the PR that needs further explanation?

Since we've already upgraded to the latest ESLint version, we no longer need to ignore major updates.
