### PR TITLE
Fix `selector-type-no-unknown` false positives for `geolocation` and `usermedia`

### DIFF
--- a/.changeset/strange-avocados-shop.md
+++ b/.changeset/strange-avocados-shop.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-type-no-unknown` false negatives for `geolocation` and `usermedia`

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -51,6 +51,8 @@ const experimentalHtmlTypeSelectors = new Set([
 	'portal',
 	'selectedcontent',
 	'selectlist',
+	'geolocation',
+	'usermedia',
 ]);
 
 /** @type {ReadonlySet<string>} */

--- a/lib/rules/selector-type-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.mjs
@@ -100,7 +100,7 @@ testRule({
 			description: 'obsolete tag',
 		},
 		{
-			code: 'fencedframe, listbox, model, portal, selectlist, selectedcontent {}',
+			code: 'fencedframe, listbox, model, portal, selectlist, selectedcontent, geolocation, usermedia {}',
 			description: 'experimental tags',
 		},
 		{


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

followup of #8716

> Is there anything in the PR that needs further explanation?

https://developer.chrome.com/blog/geolocation-html-element
https://chromestatus.com/feature/5125006551416832
https://chromestatus.com/feature/4926233538330624
https://developer.microsoft.com/en-us/microsoft-edge/origin-trials/trials/ff216fe5-9eb9-4acb-aace-2f6a8789b95c
Fyrd/caniuse#7456

I didn't add `<permission>` on purpose; it's subjective.
see #7510
