### PR TITLE
Remove `display-notation` secondary options while the specification is in flux

### DIFF
--- a/lib/rules/display-notation/README.md
+++ b/lib/rules/display-notation/README.md
@@ -11,7 +11,7 @@ a { display: block; }
 
 Modern `display` property values allow you to define both the [outer and inner display type](https://drafts.csswg.org/css-display-3/#the-display-properties) separately (e.g. `inline flex`). While CSS 2 used a single-keyword, precomposed syntax for the `display` property (e.g. `inline-flex`).
 
-In the [Display Module Level 3 specification](https://drafts.csswg.org/css-display-3/) the following precomposed values are defined as legacy:
+In the [Display Module Level 3 specification](https://drafts.csswg.org/css-display-3/) the following precomposed values are defined:
 
 - `inline-block`
 - `inline-flex`
@@ -22,7 +22,7 @@ More recent and future inner display types (e.g. `grid-lanes`) can only be combi
 
 The full notation explicitly describes the inner and outer display types of elements. This notation makes it easier to understand how an element will behave and to learn about the various display types.
 
-The short notation omits defaults or switches to legacy values, and doesn't follow the modern principle of value composition.
+The short notation omits defaults or switches to precomposed values, and doesn't follow the modern principle of value composition.
 
 This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntaxes.
 
@@ -116,110 +116,4 @@ a { display: grid; }
 <!-- prettier-ignore -->
 ```css
 a { display: list-item; }
-```
-
-## Optional secondary options
-
-### `ignore`
-
-```json
-{ "ignore": ["array", "of", "options"] }
-```
-
-#### `"non-legacy-values"`
-
-Ignore display values that are not legacy values.
-
-Given:
-
-```json
-{
-  "display-notation": ["full", { "ignore": ["non-legacy-values"] }]
-}
-```
-
-The following patterns are considered problems:
-
-```css
-a {
-  display: inline-block;
-}
-```
-
-```css
-a {
-  display: inline-flex;
-}
-```
-
-The following patterns are _not_ considered problems:
-
-```css
-a {
-  display: inline;
-}
-```
-
-```css
-a {
-  display: grid;
-}
-```
-
-```css
-a {
-  display: inline flow-root;
-}
-```
-
-### `except`
-
-```json
-{ "except": ["array", "of", "options"] }
-```
-
-#### `"legacy-values"`
-
-Reverse the primary option for legacy values.
-
-Given:
-
-```json
-{
-  "display-notation": ["short", { "except": ["legacy-values"] }]
-}
-```
-
-The following patterns are considered problems:
-
-```css
-a {
-  display: inline-block;
-}
-```
-
-```css
-a {
-  display: inline-flex;
-}
-```
-
-The following patterns are _not_ considered problems:
-
-```css
-a {
-  display: block;
-}
-```
-
-```css
-a {
-  display: inline flow-root;
-}
-```
-
-```css
-a {
-  display: inline list-root;
-}
 ```

--- a/lib/rules/display-notation/__tests__/index.mjs
+++ b/lib/rules/display-notation/__tests__/index.mjs
@@ -97,71 +97,6 @@ testRule({
 
 testRule({
 	ruleName,
-	config: ['short', { except: 'legacy-values' }],
-	fix: true,
-	computeEditInfo: true,
-
-	accept: [
-		{
-			code: 'a { display: block; }',
-		},
-		{
-			code: 'a { display: run-in flow-root; }',
-		},
-		{
-			code: 'a { display: flow-root list-item; }',
-		},
-		{
-			code: 'a { display: inline flow-root; }',
-		},
-	],
-
-	reject: [
-		{
-			code: 'a { display: block flow; }',
-			fixed: 'a { display: block; }',
-			message: messages.expected('block flow', 'block'),
-			line: 1,
-			column: 14,
-			endLine: 1,
-			endColumn: 24,
-			fix: { range: [18, 23], text: '' },
-		},
-		{
-			code: 'a { display: inline-block; }',
-			fixed: 'a { display: inline flow-root; }',
-			message: messages.expected('inline-block', 'inline flow-root'),
-			line: 1,
-			column: 14,
-			endLine: 1,
-			endColumn: 26,
-			fix: { range: [19, 25], text: ' flow-root' },
-		},
-		{
-			code: 'a { display: block list-item; }',
-			fixed: 'a { display: list-item; }',
-			message: messages.expected('block list-item', 'list-item'),
-			line: 1,
-			column: 14,
-			endLine: 1,
-			endColumn: 29,
-			fix: { range: [13, 19], text: '' },
-		},
-		{
-			code: 'a { display: flow list-item; }',
-			fixed: 'a { display: list-item; }',
-			message: messages.expected('flow list-item', 'list-item'),
-			line: 1,
-			column: 14,
-			endLine: 1,
-			endColumn: 28,
-			fix: { range: [13, 18], text: '' },
-		},
-	],
-});
-
-testRule({
-	ruleName,
 	config: ['full'],
 	fix: true,
 	computeEditInfo: true,
@@ -238,38 +173,6 @@ testRule({
 			endLine: 1,
 			endColumn: 28,
 			fix: { range: [26, 27], text: 'k flow' },
-		},
-	],
-});
-
-testRule({
-	ruleName,
-	config: ['full', { ignore: ['non-legacy-values'] }],
-	fix: true,
-	computeEditInfo: true,
-
-	accept: [
-		{
-			code: 'a { display: inline; }',
-		},
-		{
-			code: 'a { display: grid; }',
-		},
-		{
-			code: 'a { display: inline flow-root; }',
-		},
-	],
-
-	reject: [
-		{
-			code: 'a { display: inline-block; }',
-			fixed: 'a { display: inline flow-root; }',
-			message: messages.expected('inline-block', 'inline flow-root'),
-			line: 1,
-			column: 14,
-			endLine: 1,
-			endColumn: 26,
-			fix: { range: [19, 25], text: ' flow-root' },
 		},
 	],
 });

--- a/lib/rules/display-notation/index.mjs
+++ b/lib/rules/display-notation/index.mjs
@@ -11,7 +11,6 @@ import {
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
-import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import setDeclarationValue from '../../utils/setDeclarationValue.mjs';
@@ -87,67 +86,15 @@ const LONG_TO_SHORT = {
 	'run-in flow': ['run-in'],
 };
 
-const NON_LEGACY_VALUES = [
-	'block flex',
-	'block flow list-item',
-	'block flow',
-	'block flow-root',
-	'block grid',
-	'block list-item',
-	'block ruby',
-	'block table',
-	'block',
-	'flex',
-	'flow list-item',
-	'flow-root',
-	'grid',
-	'inline flex',
-	'inline flow list-item',
-	'inline flow',
-	'inline flow-root',
-	'inline grid',
-	'inline list-item',
-	'inline ruby',
-	'inline table',
-	'inline',
-	'list-item',
-	'ruby',
-	'run-in flow',
-	'run-in',
-	'table',
-];
-
 /** @type {import('stylelint').CoreRules[ruleName]} */
-const rule = (primary, secondaryOptions) => {
+const rule = (primary) => {
 	return (root, result) => {
-		const validOptions = validateOptions(
-			result,
-			ruleName,
-			{
-				actual: primary,
-				possible: ['short', 'full'],
-			},
-			{
-				actual: secondaryOptions,
-				possible: {
-					except: ['legacy-values'],
-					ignore: ['non-legacy-values'],
-				},
-				optional: true,
-			},
-		);
+		const validOptions = validateOptions(result, ruleName, {
+			actual: primary,
+			possible: ['short', 'full'],
+		});
 
 		if (!validOptions) return;
-
-		const except = optionsMatches(secondaryOptions, 'except', 'legacy-values')
-			? [
-					...DISPLAY_LEGACY_KEYWORDS,
-					...DISPLAY_LEGACY_KEYWORDS.map((keyword) => SHORT_TO_LONG[keyword]?.join(' ')),
-				]
-			: [];
-		const ignore = optionsMatches(secondaryOptions, 'ignore', 'non-legacy-values')
-			? NON_LEGACY_VALUES
-			: [];
 
 		root.walkDecls(DISPLAY_PROPERTY, (decl) => {
 			const value = getDeclarationValue(decl);
@@ -171,16 +118,8 @@ const rule = (primary, secondaryOptions) => {
 
 			const normalizedValue = normalizeValue(keywords);
 
-			if (ignore.includes(normalizedValue)) return;
-
-			let expected = primary;
-
-			if (except.includes(normalizedValue)) {
-				expected = primary === 'short' ? 'full' : 'short';
-			}
-
 			const replacementValue =
-				expected === 'short' ? LONG_TO_SHORT[normalizedValue] : SHORT_TO_LONG[normalizedValue];
+				primary === 'short' ? LONG_TO_SHORT[normalizedValue] : SHORT_TO_LONG[normalizedValue];
 
 			if (!replacementValue) return;
 

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -562,10 +562,7 @@ declare namespace stylelint {
 		'custom-property-pattern': PatternRule;
 		'display-notation': CoreRule<
 			'short' | 'full',
-			{
-				except: OneOrMany<'legacy-values'>;
-				ignore: OneOrMany<'non-legacy-values'>;
-			},
+			{},
 			ExpectedMessage<[unexpected: string, expected: string]>
 		>;
 		'declaration-block-no-duplicate-custom-properties': CoreRule<


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/9005

> Is there anything in the PR that needs further explanation?

Shall we omit a changelog entry?
From a user perspective the `display-notation` is newly added in this release.
