### PR TITLE
Refactor to remove deprecated parameter from `parseSelector()` utility

### DIFF
--- a/lib/utils/__tests__/parseSelector.test.mjs
+++ b/lib/utils/__tests__/parseSelector.test.mjs
@@ -45,17 +45,4 @@ describe('parseSelector', () => {
 			},
 		]);
 	});
-
-	it('keeps the callback support for backward compatibility', async () => {
-		expect.assertions(3);
-
-		const result = await postcss().process('a {}', { from: undefined });
-		const rule = result.root.first;
-		const processed = parseSelector(rule.selector, result, rule, (selectorRoot) => {
-			expect(selectorRoot).toHaveProperty('type', 'root');
-			expect(selectorRoot).toHaveProperty('nodes[0].nodes[0].value', 'a');
-		});
-
-		expect(typeof processed).toBe('string');
-	});
 });

--- a/lib/utils/parseSelector.mjs
+++ b/lib/utils/parseSelector.mjs
@@ -4,19 +4,12 @@ import selectorParser from 'postcss-selector-parser';
  * @param {string} selector
  * @param {import('stylelint').PostcssResult} result
  * @param {import('postcss').Node} node
- * @param {(root: import('postcss-selector-parser').Root) => void} [callback] - Deprecated. It will be removed in the future.
  * @returns {import('postcss-selector-parser').Root | undefined}
  */
-export default function parseSelector(selector, result, node, callback) {
+export default function parseSelector(selector, result, node) {
 	if (!selector) return undefined;
 
 	try {
-		// TODO: Remove `callback` in the future. See #7647.
-		if (callback) {
-			// @ts-expect-error -- TS2322: Type 'string' is not assignable to type 'Root'.
-			return selectorParser(callback).processSync(selector);
-		}
-
 		return selectorParser().astSync(selector);
 	} catch (err) {
 		result.warn(`Cannot parse selector (${err})`, { node, stylelintType: 'parseError' });


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates #7647

> Is there anything in the PR that needs further explanation?

This removes the deprecated fourth `callback` parameter from the `parseSelector()` utility function. It's only for internal use, so this change does not affect external users.
