### PR TITLE
Refactor to replace `__dirname` with `import.meta.dirname`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,12 @@ export default [
 				'error',
 				{ additionalTestBlockFunctions: ['testFn', 'win32OnlyTest'] },
 			],
+
+			// TODO: Remove this config after dropping the Node.js 20 support, since newer versions support them officially.
+			'n/no-unsupported-features/node-builtins': [
+				'error',
+				{ ignores: ['import.meta.dirname', 'import.meta.filename'] },
+			],
 		},
 	},
 ];

--- a/lib/__tests__/applyOverrides.test.mjs
+++ b/lib/__tests__/applyOverrides.test.mjs
@@ -1,9 +1,8 @@
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import { applyOverrides } from '../augmentConfig.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 test('no overrides', () => {
 	const config = {
@@ -12,7 +11,7 @@ test('no overrides', () => {
 		},
 	};
 
-	const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.css'));
+	const applied = applyOverrides(config, dirname, path.join(dirname, 'style.css'));
 
 	expect(applied).toEqual(config);
 });
@@ -40,7 +39,7 @@ describe('single matching override', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -67,7 +66,7 @@ describe('single matching override', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -97,7 +96,7 @@ describe('single matching override', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -116,11 +115,7 @@ describe('single matching override', () => {
 			customSyntax: 'postcss-scss',
 		};
 
-		const applied = applyOverrides(
-			config,
-			__dirname,
-			path.join(__dirname, '.dot-dir', 'style.scss'),
-		);
+		const applied = applyOverrides(config, dirname, path.join(dirname, '.dot-dir', 'style.scss'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -150,7 +145,7 @@ describe('single matching override', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -187,7 +182,7 @@ describe('two matching overrides', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -226,7 +221,7 @@ describe('two matching overrides', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -265,7 +260,7 @@ describe('two matching overrides', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -289,7 +284,7 @@ describe('two matching overrides', () => {
 			extends: ['stylelint-config2', 'stylelint-config1', 'stylelint-config3'],
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -317,7 +312,7 @@ describe('no matching overrides', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -346,7 +341,7 @@ describe('no matching overrides', () => {
 			},
 		};
 
-		const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		const applied = applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 
 		expect(applied).toEqual(expectedConfig);
 	});
@@ -366,7 +361,7 @@ test('overrides is not an array', () => {
 	};
 
 	expect(() => {
-		applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 	}).toThrowErrorMatchingInlineSnapshot(
 		`"The \`overrides\` configuration property should be an array, e.g. { "overrides": [{ "files": "*.css", "rules": {} }] }."`,
 	);
@@ -387,7 +382,7 @@ test('`files` is missing', () => {
 	};
 
 	expect(() => {
-		applyOverrides(config, __dirname, path.join(__dirname, 'style.module.css'));
+		applyOverrides(config, dirname, path.join(dirname, 'style.module.css'));
 	}).toThrowErrorMatchingInlineSnapshot(
 		`"Every object in the \`overrides\` configuration property should have a \`files\` property with globs, e.g. { "overrides": [{ "files": "*.css", "rules": {} }] }."`,
 	);
@@ -400,7 +395,7 @@ test('if glob is absolute path', () => {
 		},
 		overrides: [
 			{
-				files: [path.join(__dirname, 'style.css')],
+				files: [path.join(dirname, 'style.css')],
 				rules: {
 					'color-no-hex': true,
 				},
@@ -415,7 +410,7 @@ test('if glob is absolute path', () => {
 		},
 	};
 
-	const applied = applyOverrides(config, __dirname, path.join(__dirname, 'style.css'));
+	const applied = applyOverrides(config, dirname, path.join(dirname, 'style.css'));
 
 	expect(applied).toEqual(expectedConfig);
 });

--- a/lib/__tests__/getConfigForFile.test.mjs
+++ b/lib/__tests__/getConfigForFile.test.mjs
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import createStylelint from '../createStylelint.mjs';
@@ -6,15 +5,15 @@ import getConfigForFile from '../getConfigForFile.mjs';
 import pluginWarnAboutFoo from './fixtures/plugin-warn-about-foo.mjs';
 import withMockedPlatform from '../testUtils/withMockedPlatform.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 test('augmented config loads', async () => {
 	const stylelint = createStylelint();
-	const filepath = path.join(__dirname, 'fixtures/getConfigForFile/a/b/foo.css');
+	const filepath = path.join(dirname, 'fixtures/getConfigForFile/a/b/foo.css');
 
 	await expect(getConfigForFile({ stylelint, searchPath: filepath })).resolves.toEqual({
 		config: {
-			plugins: [path.join(__dirname, '/fixtures/plugin-warn-about-foo.mjs')],
+			plugins: [path.join(dirname, '/fixtures/plugin-warn-about-foo.mjs')],
 			rules: {
 				'block-no-empty': [true],
 				'plugin/warn-about-foo': ['always'],
@@ -23,7 +22,7 @@ test('augmented config loads', async () => {
 				'plugin/warn-about-foo': pluginWarnAboutFoo.rule,
 			},
 		},
-		filepath: path.join(__dirname, 'fixtures/getConfigForFile/a/.stylelintrc'),
+		filepath: path.join(dirname, 'fixtures/getConfigForFile/a/.stylelintrc'),
 	});
 });
 

--- a/lib/__tests__/ignore.test.mjs
+++ b/lib/__tests__/ignore.test.mjs
@@ -8,6 +8,8 @@ import safeChdir from '../testUtils/safeChdir.mjs';
 import standalone from '../standalone.mjs';
 import withMockedPlatform from '../testUtils/withMockedPlatform.mjs';
 
+const dirname = import.meta.dirname;
+
 const fixtures = (...elem) => {
 	const dir = fileURLToPath(new URL('./fixtures', import.meta.url));
 
@@ -17,9 +19,7 @@ const fixtures = (...elem) => {
 const isWindowsHost = process.platform === 'win32';
 const win32OnlyTest = isWindowsHost ? test : test.skip;
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
-
-safeChdir(__dirname);
+safeChdir(dirname);
 
 test('extending config and ignoreFiles glob ignoring single glob', async () => {
 	const { results } = await standalone({
@@ -85,7 +85,7 @@ test('same as above with no configBasedir, ignore-files path relative to options
 			ignoreFiles: 'fixtures/invalid-hex.css',
 			extends: [fixtures('config-block-no-empty.json'), fixtures('config-color-no-invalid-hex')],
 		},
-		cwd: __dirname,
+		cwd: dirname,
 	});
 
 	// two files found
@@ -211,7 +211,7 @@ test('specified `ignorePath` file ignoring one file using options.cwd', async ()
 				},
 			},
 			ignorePath: [fixtures('ignore.txt')],
-			cwd: __dirname,
+			cwd: dirname,
 		}),
 	).rejects.toThrow(new AllFilesIgnoredError());
 });
@@ -222,7 +222,7 @@ test('specified `ignorePath` directory, not a file', async () => {
 			files: [],
 			config: {},
 			ignorePath: ['__snapshots__'],
-			cwd: __dirname,
+			cwd: dirname,
 		}),
 	).rejects.toThrow(/EISDIR/);
 });
@@ -255,7 +255,7 @@ test('specified `ignorePattern` file ignoring one file using options.cwd', async
 				},
 			},
 			ignorePattern: 'fixtures/empty-block.css',
-			cwd: __dirname,
+			cwd: dirname,
 		}),
 	).rejects.toThrow(new AllFilesIgnoredError());
 });
@@ -288,7 +288,7 @@ test('specified `ignorePattern` file ignoring two files using options.cwd', asyn
 				},
 			},
 			ignorePattern: ['fixtures/empty-block.css', 'fixtures/no-syntax-error.css'],
-			cwd: __dirname,
+			cwd: dirname,
 		}),
 	).rejects.toThrow(new AllFilesIgnoredError());
 });
@@ -354,7 +354,7 @@ test('extending a config that ignores files', async () => {
 test('using codeFilename and ignoreFiles together', async () => {
 	const { results } = await standalone({
 		code: 'a {}',
-		codeFilename: replaceBackslashes(path.join(__dirname, 'foo.css')),
+		codeFilename: replaceBackslashes(path.join(dirname, 'foo.css')),
 		config: {
 			ignoreFiles: ['**/foo.css'],
 			rules: { 'block-no-empty': true },
@@ -417,12 +417,12 @@ test('codeFilename and ignoreFiles remain case-sensitive on non-Windows platform
 test('using codeFilename and ignoreFiles with configBasedir', async () => {
 	const { results } = await standalone({
 		code: 'a {}',
-		codeFilename: replaceBackslashes(path.join(__dirname, 'foo.css')),
+		codeFilename: replaceBackslashes(path.join(dirname, 'foo.css')),
 		config: {
 			ignoreFiles: ['foo.css'],
 			rules: { 'block-no-empty': true },
 		},
-		configBasedir: __dirname,
+		configBasedir: dirname,
 	});
 
 	// no warnings

--- a/lib/__tests__/languageOptions.test.mjs
+++ b/lib/__tests__/languageOptions.test.mjs
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import standalone from '../standalone.mjs';
 import { stripIndent } from 'common-tags';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 describe('standalone with languageOptions', () => {
 	describe('custom at-rules', () => {
@@ -16,7 +15,7 @@ describe('standalone with languageOptions', () => {
 						bar: red;
 					}
 				`,
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -33,7 +32,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for unknown at-rule', async () => {
 			const data = await standalone({
 				code: '@foo { foo: bar; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -53,7 +52,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for unknown descriptor in custom at-rule', async () => {
 			const data = await standalone({
 				code: '@example custom-ident { baz: red; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -73,7 +72,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for invalid type of descriptor in custom at-rule', async () => {
 			const data = await standalone({
 				code: '@example custom-ident { foo: red; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -93,7 +92,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for invalid prelude in custom at-rule', async () => {
 			const data = await standalone({
 				code: '@example 123 {}',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -115,7 +114,7 @@ describe('standalone with languageOptions', () => {
 		it('does not trigger warning for valid css-wide keyword', async () => {
 			const data = await standalone({
 				code: 'a { color: my-global-value; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -129,7 +128,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for unknown css-wide keyword', async () => {
 			const data = await standalone({
 				code: 'a { color: foo; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -151,7 +150,7 @@ describe('standalone with languageOptions', () => {
 		it('does not trigger warning for valid custom property and value', async () => {
 			const data = await standalone({
 				code: 'a { bar: red; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -165,7 +164,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for invalid value of custom property', async () => {
 			const data = await standalone({
 				code: 'a { bar: 10px; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -190,7 +189,7 @@ describe('standalone with languageOptions', () => {
 						bar: red;
 					}
 				`,
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -205,7 +204,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for invalid extended property type', async () => {
 			const data = await standalone({
 				code: 'a { top: --foo(red); }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -225,7 +224,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for unknown property', async () => {
 			const data = await standalone({
 				code: 'a { foo: 10px; }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -247,7 +246,7 @@ describe('standalone with languageOptions', () => {
 		it('triggers warning for invalid type usage in property', async () => {
 			const data = await standalone({
 				code: 'a { top: --foo(red); }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;
@@ -267,7 +266,7 @@ describe('standalone with languageOptions', () => {
 		it('does not trigger warning for valid type usage in property', async () => {
 			const data = await standalone({
 				code: 'a { top: --foo(5px); }',
-				configFile: path.join(__dirname, 'fixtures/config-language-options.json'),
+				configFile: path.join(dirname, 'fixtures/config-language-options.json'),
 			});
 
 			const { report, results } = data;

--- a/lib/__tests__/plugins.test.mjs
+++ b/lib/__tests__/plugins.test.mjs
@@ -6,7 +6,7 @@ import postcss from 'postcss';
 import safeChdir from '../testUtils/safeChdir.mjs';
 import stylelint from '../index.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 const absolutePath = (relativePath) => fileURLToPath(new URL(relativePath, import.meta.url));
 
@@ -45,16 +45,16 @@ const configRelativeAndExtendRelative = {
 };
 
 const processorRelative = postcss().use(
-	stylelint({ config: configRelative, configBasedir: __dirname }),
+	stylelint({ config: configRelative, configBasedir: dirname }),
 );
 const processorAbsolute = postcss().use(stylelint({ config: configAbsolute }));
 const processorExtendRelative = postcss().use(
-	stylelint({ config: configExtendRelative, configBasedir: __dirname }),
+	stylelint({ config: configExtendRelative, configBasedir: dirname }),
 );
 const processorRelativeAndExtendRelative = postcss().use(
 	stylelint({
 		config: configRelativeAndExtendRelative,
-		configBasedir: __dirname,
+		configBasedir: dirname,
 	}),
 );
 
@@ -300,7 +300,7 @@ it('plugin with async rule', async () => {
 });
 
 describe('loading a plugin from process.cwd', () => {
-	safeChdir(__dirname);
+	safeChdir(dirname);
 
 	let result;
 
@@ -336,7 +336,7 @@ describe('loading a plugin from options.cwd', () => {
 
 	beforeEach(async () => {
 		result = await postcss()
-			.use(stylelint({ cwd: __dirname, config }))
+			.use(stylelint({ cwd: dirname, config }))
 			.process('.foo {}', { from: undefined });
 	});
 

--- a/lib/__tests__/postcssPlugin.test.mjs
+++ b/lib/__tests__/postcssPlugin.test.mjs
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import postcss from 'postcss';
 
@@ -6,7 +5,7 @@ import { ConfigurationError } from '../utils/errors.mjs';
 import postcssPlugin from '../postcssPlugin.mjs';
 import safeChdir from '../testUtils/safeChdir.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 it('`config` option is `null`', () => {
 	return expect(
@@ -18,7 +17,7 @@ it('`config` option is `null`', () => {
 
 it('`configFile` option with absolute path', async () => {
 	const config = {
-		configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
+		configFile: path.join(dirname, 'fixtures/config-block-no-empty.json'),
 	};
 
 	const postcssResult = await postcss([postcssPlugin(config)]).process('a {}', {
@@ -38,7 +37,7 @@ it('`configFile` with bad path', () => {
 
 it('`configFile` option without rules', () => {
 	const config = {
-		configFile: path.join(__dirname, 'fixtures/config-without-rules.json'),
+		configFile: path.join(dirname, 'fixtures/config-without-rules.json'),
 	};
 
 	return expect(
@@ -52,7 +51,7 @@ it('`configFile` option without rules', () => {
 
 it('`configFile` option with undefined rule', () => {
 	const config = {
-		configFile: path.join(__dirname, 'fixtures/config-with-undefined-rule.json'),
+		configFile: path.join(dirname, 'fixtures/config-with-undefined-rule.json'),
 	};
 	const ruleName = 'unknown-rule';
 
@@ -98,7 +97,7 @@ it('`ignoreFiles` options is not empty and file not ignored', () => {
 });
 
 describe('stylelintignore', () => {
-	safeChdir(__dirname);
+	safeChdir(dirname);
 
 	it('postcssPlugin with .stylelintignore and file is ignored', () => {
 		const options = {
@@ -121,7 +120,7 @@ describe('stylelintignore', () => {
 					'block-no-empty': true,
 				},
 			},
-			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
+			ignorePath: path.join(dirname, './stylelintignore-test/.postcssPluginignore'),
 		};
 
 		return expect(
@@ -136,7 +135,7 @@ describe('stylelintignore', () => {
 					'block-no-empty': true,
 				},
 			},
-			ignorePath: [path.join(__dirname, './stylelintignore-test/.postcssPluginignore')],
+			ignorePath: [path.join(dirname, './stylelintignore-test/.postcssPluginignore')],
 		};
 
 		return expect(
@@ -153,12 +152,12 @@ describe('stylelintignore with options.cwd', () => {
 					'block-no-empty': true,
 				},
 			},
-			cwd: __dirname,
+			cwd: dirname,
 		};
 
 		return expect(
 			postcss([postcssPlugin(options)]).process('a {}', {
-				from: path.join(__dirname, 'postcssstylelintignore.css'),
+				from: path.join(dirname, 'postcssstylelintignore.css'),
 			}),
 		).resolves.toHaveProperty('stylelint.ignored', true);
 	});
@@ -170,12 +169,14 @@ describe('stylelintignore with options.cwd', () => {
 					'block-no-empty': true,
 				},
 			},
-			cwd: __dirname,
-			ignorePath: path.join(__dirname, './stylelintignore-test/.postcssPluginignore'),
+			cwd: dirname,
+			ignorePath: path.join(dirname, './stylelintignore-test/.postcssPluginignore'),
 		};
 
 		return expect(
-			postcss([postcssPlugin(options)]).process('a {}', { from: path.join(__dirname, 'foo.css') }),
+			postcss([postcssPlugin(options)]).process('a {}', {
+				from: path.join(dirname, 'foo.css'),
+			}),
 		).resolves.toHaveProperty('stylelint.ignored', true);
 	});
 
@@ -186,12 +187,14 @@ describe('stylelintignore with options.cwd', () => {
 					'block-no-empty': true,
 				},
 			},
-			cwd: __dirname,
-			ignorePath: [path.join(__dirname, './stylelintignore-test/.postcssPluginignore')],
+			cwd: dirname,
+			ignorePath: [path.join(dirname, './stylelintignore-test/.postcssPluginignore')],
 		};
 
 		return expect(
-			postcss([postcssPlugin(options)]).process('a {}', { from: path.join(__dirname, 'foo.css') }),
+			postcss([postcssPlugin(options)]).process('a {}', {
+				from: path.join(dirname, 'foo.css'),
+			}),
 		).resolves.toHaveProperty('stylelint.ignored', true);
 	});
 });

--- a/lib/__tests__/resolveConfig.test.mjs
+++ b/lib/__tests__/resolveConfig.test.mjs
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import pluginWarnAboutFoo from './fixtures/plugin-warn-about-foo.mjs';
 import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import stylelint from '../index.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 describe('resolveConfig', () => {
 	it('should resolve to undefined without a path', () => {
@@ -13,13 +12,13 @@ describe('resolveConfig', () => {
 
 	it('should use getConfigForFile to retrieve the config', async () => {
 		const filepath = replaceBackslashes(
-			path.join(__dirname, 'fixtures/getConfigForFile/a/b/foo.css'),
+			path.join(dirname, 'fixtures/getConfigForFile/a/b/foo.css'),
 		);
 
 		const config = await stylelint.resolveConfig(filepath);
 
 		expect(config).toStrictEqual({
-			plugins: [path.join(__dirname, '/fixtures/plugin-warn-about-foo.mjs')],
+			plugins: [path.join(dirname, '/fixtures/plugin-warn-about-foo.mjs')],
 			rules: {
 				'block-no-empty': [true],
 				'plugin/warn-about-foo': ['always'],
@@ -32,7 +31,7 @@ describe('resolveConfig', () => {
 
 	it('should apply config overrides', async () => {
 		const filepath = replaceBackslashes(
-			path.join(__dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
+			path.join(dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
 		);
 
 		const config = await stylelint.resolveConfig(filepath);
@@ -47,7 +46,7 @@ describe('resolveConfig', () => {
 
 	it('should respect the passed config', async () => {
 		const filepath = replaceBackslashes(
-			path.join(__dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
+			path.join(dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
 		);
 
 		const config = await stylelint.resolveConfig(filepath, {
@@ -69,11 +68,11 @@ describe('resolveConfig', () => {
 
 	it('should use the passed config file path', async () => {
 		const filepath = replaceBackslashes(
-			path.join(__dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
+			path.join(dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
 		);
 
 		const config = await stylelint.resolveConfig(filepath, {
-			configFile: path.join(__dirname, 'fixtures/getConfigForFile/a/.stylelintrc'),
+			configFile: path.join(dirname, 'fixtures/getConfigForFile/a/.stylelintrc'),
 		});
 
 		expect(config).toStrictEqual({
@@ -90,11 +89,11 @@ describe('resolveConfig', () => {
 
 	it('should use the passed config base directory', async () => {
 		const filepath = replaceBackslashes(
-			path.join(__dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
+			path.join(dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
 		);
 
 		const config = await stylelint.resolveConfig(filepath, {
-			configBasedir: path.join(__dirname, 'fixtures'),
+			configBasedir: path.join(dirname, 'fixtures'),
 			config: {
 				extends: './config-extending-two',
 			},
@@ -110,11 +109,11 @@ describe('resolveConfig', () => {
 
 	it('should use the passed cwd', async () => {
 		const filepath = replaceBackslashes(
-			path.join(__dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
+			path.join(dirname, 'fixtures/config-overrides/testPrintConfig/style.css'),
 		);
 
 		const config = await stylelint.resolveConfig(filepath, {
-			cwd: path.join(__dirname, 'fixtures'),
+			cwd: path.join(dirname, 'fixtures'),
 			config: {
 				extends: './config-extending-two',
 			},

--- a/lib/__tests__/standalone-cache.test.mjs
+++ b/lib/__tests__/standalone-cache.test.mjs
@@ -1,6 +1,5 @@
 import { copyFile, rm, utimes, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import fCache from 'file-entry-cache';
@@ -10,13 +9,13 @@ import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import safeChdir from '../testUtils/safeChdir.mjs';
 import standalone from '../standalone.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 const isChanged = (file, targetFilePath) => {
 	return file.source === targetFilePath && !file.ignored;
 };
 
-const fixturesPath = path.join(__dirname, 'fixtures');
+const fixturesPath = path.join(dirname, 'fixtures');
 const invalidFile = path.join(fixturesPath, 'empty-block.css');
 const syntaxErrorFile = path.join(fixturesPath, 'syntax_error.css');
 const validFile = path.join(fixturesPath, 'cache', 'valid.css');
@@ -37,7 +36,7 @@ function getConfig(additional = {}) {
 }
 
 describe('standalone cache', () => {
-	const cwd = path.join(__dirname, 'tmp', 'standalone-cache');
+	const cwd = path.join(dirname, 'tmp', 'standalone-cache');
 
 	safeChdir(cwd);
 
@@ -216,7 +215,7 @@ describe('standalone cache', () => {
 });
 
 describe('standalone cache uses cacheLocation', () => {
-	const cwd = path.join(__dirname, 'tmp', 'standalone-cache-uses-cacheLocation');
+	const cwd = path.join(dirname, 'tmp', 'standalone-cache-uses-cacheLocation');
 
 	safeChdir(cwd);
 
@@ -256,7 +255,7 @@ describe('standalone cache uses cacheLocation', () => {
 });
 
 describe('standalone cache (enabled in config)', () => {
-	const cwd = path.join(__dirname, 'tmp', 'standalone-cache');
+	const cwd = path.join(dirname, 'tmp', 'standalone-cache');
 
 	safeChdir(cwd);
 
@@ -341,7 +340,7 @@ describe('standalone cache (enabled in config)', () => {
 });
 
 describe('standalone cache uses a config file', () => {
-	const cwd = path.join(__dirname, 'tmp', 'standalone-cache-use-config-file');
+	const cwd = path.join(dirname, 'tmp', 'standalone-cache-use-config-file');
 
 	safeChdir(cwd);
 
@@ -412,7 +411,7 @@ describe('standalone cache uses a config file', () => {
 });
 
 describe('standalone cache uses cacheStrategy', () => {
-	const cwd = path.join(__dirname, 'tmp', 'standalone-cache-uses-cacheStrategy');
+	const cwd = path.join(dirname, 'tmp', 'standalone-cache-uses-cacheStrategy');
 
 	safeChdir(cwd);
 

--- a/lib/__tests__/standalone.test.mjs
+++ b/lib/__tests__/standalone.test.mjs
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import { NoFilesFoundError } from '../utils/errors.mjs';
@@ -7,13 +6,13 @@ import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import safeChdir from '../testUtils/safeChdir.mjs';
 import standalone from '../standalone.mjs';
 
+const dirname = import.meta.dirname;
+
 const configBlockNoEmpty = readJSONFile(
 	new URL('./fixtures/config-block-no-empty.json', import.meta.url),
 );
 
 const fixturesPath = replaceBackslashes(new URL('./fixtures', import.meta.url));
-
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 describe('standalone with one input file', () => {
 	let report;
@@ -23,7 +22,7 @@ describe('standalone with one input file', () => {
 		const data = await standalone({
 			files: `${fixturesPath}/empty-block.css`,
 			// Path to config file
-			configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
+			configFile: path.join(dirname, 'fixtures/config-block-no-empty.json'),
 		});
 
 		report = data.report;
@@ -89,7 +88,7 @@ describe('standalone with files and globbyOptions', () => {
 			files: 'empty-block.css',
 			globbyOptions: { cwd: fixturesPath },
 			// Path to config file
-			configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
+			configFile: path.join(dirname, 'fixtures/config-block-no-empty.json'),
 		});
 
 		report = data.report;
@@ -113,7 +112,7 @@ describe('standalone with files and cwd', () => {
 			files: 'empty-block.css',
 			cwd: fixturesPath,
 			// Path to config file
-			configFile: path.join(__dirname, 'fixtures/config-block-no-empty.json'),
+			configFile: path.join(dirname, 'fixtures/config-block-no-empty.json'),
 		});
 
 		report = data.report;
@@ -283,7 +282,7 @@ describe('standalone passing code with syntax error', () => {
 it('standalone passing file with syntax error', async () => {
 	const { results } = await standalone({
 		code: "a { color: 'red; }",
-		codeFilename: path.join(__dirname, 'syntax-error.css'),
+		codeFilename: path.join(dirname, 'syntax-error.css'),
 		config: { rules: { 'block-no-empty': true } },
 	});
 
@@ -370,13 +369,13 @@ describe('standalone with different configs per file', () => {
 });
 
 describe('standalone with config locatable from process.cwd not file', () => {
-	safeChdir(path.join(__dirname, './fixtures/getConfigForFile/a/b'));
+	safeChdir(path.join(dirname, './fixtures/getConfigForFile/a/b'));
 
 	let results;
 
 	beforeEach(async () => {
 		const data = await standalone({
-			files: [replaceBackslashes(path.join(__dirname, './fixtures/empty-block.css'))],
+			files: [replaceBackslashes(path.join(dirname, './fixtures/empty-block.css'))],
 		});
 
 		results = data.results;
@@ -400,8 +399,8 @@ describe('standalone with config locatable from options.cwd not file', () => {
 
 	beforeEach(async () => {
 		const data = await standalone({
-			cwd: path.join(__dirname, './fixtures/getConfigForFile/a/b'),
-			files: [replaceBackslashes(path.join(__dirname, './fixtures/empty-block.css'))],
+			cwd: path.join(dirname, './fixtures/getConfigForFile/a/b'),
+			files: [replaceBackslashes(path.join(dirname, './fixtures/empty-block.css'))],
 		});
 
 		results = data.results;
@@ -421,7 +420,7 @@ describe('standalone with config locatable from options.cwd not file', () => {
 });
 
 describe('nonexistent codeFilename with loaded config', () => {
-	safeChdir(path.join(__dirname, './fixtures/getConfigForFile/a/b'));
+	safeChdir(path.join(dirname, './fixtures/getConfigForFile/a/b'));
 
 	it('does not cause error', async () => {
 		await expect(() =>
@@ -448,7 +447,7 @@ describe('nonexistent codeFilename with loaded config and options.cwd', () => {
 			standalone({
 				code: 'a {}',
 				codeFilename: 'does-not-exist.css',
-				cwd: path.join(__dirname, './fixtures/getConfigForFile/a/b'),
+				cwd: path.join(dirname, './fixtures/getConfigForFile/a/b'),
 			}),
 		).not.toThrow();
 	});
@@ -457,7 +456,7 @@ describe('nonexistent codeFilename with loaded config and options.cwd', () => {
 		const { results } = await standalone({
 			code: 'a {}',
 			codeFilename: 'does-not-exist.css',
-			cwd: path.join(__dirname, './fixtures/getConfigForFile/a/b'),
+			cwd: path.join(dirname, './fixtures/getConfigForFile/a/b'),
 		});
 
 		expect(results[0].warnings).toHaveLength(1);
@@ -465,7 +464,7 @@ describe('nonexistent codeFilename with loaded config and options.cwd', () => {
 });
 
 describe('existing codeFilename for nested config detection', () => {
-	safeChdir(path.join(__dirname, './fixtures/getConfigForFile'));
+	safeChdir(path.join(dirname, './fixtures/getConfigForFile'));
 
 	it('loads config from a nested directory', async () => {
 		const { results } = await standalone({

--- a/lib/__tests__/stylelintignore-test/stylelintignore.test.mjs
+++ b/lib/__tests__/stylelintignore-test/stylelintignore.test.mjs
@@ -1,17 +1,16 @@
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import replaceBackslashes from '../../testUtils/replaceBackslashes.mjs';
 import safeChdir from '../../testUtils/safeChdir.mjs';
 import standalone from '../../standalone.mjs';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const dirname = import.meta.dirname;
 
 describe('stylelintignore', () => {
-	safeChdir(__dirname);
+	safeChdir(dirname);
 
 	let results;
-	const fixturesPath = path.join(__dirname, './fixtures');
+	const fixturesPath = path.join(dirname, './fixtures');
 
 	describe('standalone with .stylelintignore file ignoring one file', () => {
 		beforeEach(async () => {
@@ -53,7 +52,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: [path.join(__dirname, '.stylelintignore')],
+				ignorePath: [path.join(dirname, '.stylelintignore')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -73,7 +72,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: [path.join(__dirname, '.stylelintignore-empty')],
+				ignorePath: [path.join(dirname, '.stylelintignore-empty')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -90,7 +89,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: [path.join(__dirname, '.stylelintignore2')],
+				ignorePath: [path.join(dirname, '.stylelintignore2')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
@@ -110,7 +109,7 @@ describe('stylelintignore', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: [path.join(__dirname, '.stylelintignore2')],
+				ignorePath: [path.join(dirname, '.stylelintignore2')],
 			});
 
 			expect(data).toEqual({
@@ -127,7 +126,7 @@ describe('stylelintignore', () => {
 
 describe('stylelintignore with options.cwd', () => {
 	let results;
-	const fixturesPath = path.join(__dirname, './fixtures');
+	const fixturesPath = path.join(dirname, './fixtures');
 
 	describe('standalone with .stylelintignore file ignoring one file', () => {
 		beforeEach(async () => {
@@ -142,7 +141,7 @@ describe('stylelintignore with options.cwd', () => {
 						`${fixturesPath}/config-color-no-invalid-hex`,
 					],
 				},
-				cwd: __dirname,
+				cwd: dirname,
 			});
 
 			results = data.results;
@@ -170,11 +169,11 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: [path.join(__dirname, '.stylelintignore')],
+				ignorePath: [path.join(dirname, '.stylelintignore')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
-				cwd: __dirname,
+				cwd: dirname,
 			});
 
 			expect(data).toEqual({
@@ -191,11 +190,11 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: '.bar {}',
 				codeFilename: `${fixturesPath}/empty-block.css`,
-				ignorePath: [path.join(__dirname, '.stylelintignore-empty')],
+				ignorePath: [path.join(dirname, '.stylelintignore-empty')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
-				cwd: __dirname,
+				cwd: dirname,
 			});
 
 			expect(data).toMatchObject({
@@ -209,11 +208,11 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: [path.join(__dirname, '.stylelintignore2')],
+				ignorePath: [path.join(dirname, '.stylelintignore2')],
 				config: {
 					extends: `${fixturesPath}/config-block-no-empty`,
 				},
-				cwd: __dirname,
+				cwd: dirname,
 			});
 
 			expect(data).toEqual({
@@ -230,8 +229,8 @@ describe('stylelintignore with options.cwd', () => {
 			const data = await standalone({
 				code: 'var a = {',
 				codeFilename: `test.js`,
-				ignorePath: [path.join(__dirname, '.stylelintignore2')],
-				cwd: __dirname,
+				ignorePath: [path.join(dirname, '.stylelintignore2')],
+				cwd: dirname,
 			});
 
 			expect(data).toEqual({


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`import.meta.dirname` has been available since Node.js v20.11.0 without any warnings.
Ref https://nodejs.org/api/esm.html#importmetadirname

Our codebase is now ESM, not CJS, so this change can reduce confusion.
