### PR TITLE
Add internal benchmark tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn.lock
 .vscode/settings.json
 .idea
 tmp/
+scripts/benchmarking/.workspaces/

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,7 @@ system-tests/**/*.css
 system-tests/**/*.scss
 **/.pnp.*
 tmp/
+scripts/benchmarking/.workspaces/
 
 # This unit test required a parent directory structure and therefore is not inside /fixtures/globs
 **/standalone-glob-parent-test/**/*.css

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ To help out, you can:
 - create, enhance and debug rules using [our guide](docs/developer-guide/rules.md)
 - improve the [documentation](docs/)
 - add [new tests](https://github.com/stylelint/stylelint/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+tests%22) to _absolutely anything_
-- improve the [performance of rules](docs/developer-guide/rules.md#improve-the-performance-of-a-rule)
+- improve the [performance of rules](docs/maintainer-guide/benchmarking.md)
 - open [new issues](https://github.com/stylelint/stylelint/issues/new/choose) about your ideas for making Stylelint better
 
 Not only will you help Stylelint thrive, but you may learn a thing or two — about CSS, PostCSS, Node.js, unit testing, open-source software, and more. We want to encourage contributions! If you want to participate but couldn't, please [give us feedback](https://github.com/stylelint/stylelint/issues/new) about what we could do better.
@@ -49,7 +49,7 @@ You can write code to:
 - [add a rule](docs/developer-guide/rules.md#add-a-rule)
 - [add an option to a rule](docs/developer-guide/rules.md#add-an-option-to-a-rule)
 - [fix a bug in a rule](docs/developer-guide/rules.md#fix-a-bug-in-a-rule)
-- [improve the performance of a rule](docs/developer-guide/rules.md#improve-the-performance-of-a-rule)
+- [improve the performance of a rule](docs/maintainer-guide/benchmarking.md#rule-benchmarking)
 
 ### Format code
 

--- a/docs/developer-guide/rules.md
+++ b/docs/developer-guide/rules.md
@@ -449,42 +449,4 @@ result.warn(
 
 ## Improve the performance of a rule
 
-You can run a benchmark on any given rule with any valid config using:
-
-```shell
-npm run benchmark-rule -- ruleName ruleOptions [config]
-```
-
-If the `ruleOptions` argument is anything other than a string or a boolean, it must be valid JSON wrapped in quotation marks.
-
-```shell
-npm run benchmark-rule -- value-keyword-case lower
-```
-
-```shell
-npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'
-```
-
-If the `config` argument is specified, the same procedure would apply:
-
-```shell
-npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'
-```
-
-The script loads Bootstrap's CSS (from its CDN) and runs it through the configured rule.
-
-It will end up printing some simple stats like this:
-
-```shell
-Warnings: 1441
-Mean: 74.17598357142856 ms
-Deviation: 16.63969674310928 ms
-```
-
-When writing new rules or refactoring existing rules, use these measurements to determine the efficiency of your code.
-
-A Stylelint rule can repeat its core logic many, many times (e.g. checking every value node of every declaration in a vast CSS codebase). So it's worth paying attention to performance and doing what we can to improve it!
-
-**Improving the performance of a rule is a great way to contribute if you want a quick little project.** Try picking a rule and seeing if there's anything you can do to speed it up.
-
-Make sure you include benchmark measurements in your pull request!
+See [benchmarking](../maintainer-guide/benchmarking.md#rule-benchmarking).

--- a/docs/maintainer-guide/benchmarking.md
+++ b/docs/maintainer-guide/benchmarking.md
@@ -1,0 +1,145 @@
+# Benchmarking
+
+[Performance](../about/vision.md#performant) is one of the key aspects of [our vision](../about/vision.md). The more people who are aware of and use our benchmarking tools when contributing to Stylelint, the better.
+
+There are two benchmarking tools:
+
+- [Rule benchmarking](#rule-benchmarking), for measuring the performance of individual rules.
+- [System benchmarking](#system-benchmarking), for measuring overall performance across realistic workspaces.
+
+## Rule benchmarking
+
+You can run a benchmark on any given rule with any valid config using:
+
+```shell
+npm run benchmark-rule -- ruleName ruleOptions [config]
+```
+
+If the `ruleOptions` argument is anything other than a string or a boolean, it must be valid JSON wrapped in quotation marks.
+
+```shell
+npm run benchmark-rule -- value-keyword-case lower
+```
+
+```shell
+npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]'
+```
+
+If the `config` argument is specified, the same procedure would apply:
+
+```shell
+npm run benchmark-rule -- value-keyword-case '["lower", {"camelCaseSvgKeywords": true}]' '{"fix": true}'
+```
+
+The script loads Bootstrap's CSS (from its CDN) and runs it through the configured rule.
+
+It will end up printing some simple stats like this:
+
+```shell
+Warnings: 1441
+Mean: 74.17598357142856 ms
+Deviation: 16.63969674310928 ms
+```
+
+When writing new rules or refactoring existing rules, use these measurements to determine the efficiency of your code.
+
+A Stylelint rule can repeat its core logic many, many times (e.g. checking every value node of every declaration in a vast CSS codebase). So it's worth paying attention to performance and doing what we can to improve it!
+
+**Improving the performance of a rule is a great way to contribute if you want a quick little project.** Try picking a rule and seeing if there's anything you can do to speed it up.
+
+Make sure you include benchmark measurements in your pull request!
+
+## System benchmarking
+
+The system benchmarking tool measures overall Stylelint performance across realistic workspaces of varying sizes. It tests both the API and CLI modes to help identify performance regressions.
+
+### Quick start
+
+```shell
+# Run benchmarks and save a baseline result.
+npm run benchmark -- --save=baseline.json
+
+# Make changes or switch branches, then compare.
+npm run benchmark -- --compare=baseline.json
+```
+
+If you already have two benchmark files, you can compare them without running any benchmarks:
+
+```shell
+npm run benchmark -- --compare=baseline.json --compare-to=after.json
+```
+
+To view a saved benchmark file:
+
+```shell
+npm run benchmark -- --show=baseline.json
+```
+
+### Options
+
+| Option                              | Description                                                                                                                                           |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--sizes=small,medium,large,xlarge` | Which workspace sizes to test.                                                                                                                        |
+| `--iterations=N`                    | Measured iterations per benchmark. Default is 10.                                                                                                     |
+| `--warmup=N`                        | Warmup iterations to discard. Default is 2.                                                                                                           |
+| `--modes=api,cli`                   | Comma-separated list of modes to test. Running both modes, which is the default, is intended to help identify performance regressions in either mode. |
+| `--save=FILE`                       | Save results to JSON.                                                                                                                                 |
+| `--show=FILE`                       | Display results from a saved JSON file.                                                                                                               |
+| `--compare=FILE`                    | Compare against baseline.                                                                                                                             |
+| `--compare-to=FILE`                 | Compare `--compare` file against this file directly without running benchmarks.                                                                       |
+| `--benchmark-only`                  | Skip workspace generation.                                                                                                                            |
+
+### Interpreting results
+
+#### Summary
+
+```text
+──────────────────────────────────────────────────────────────────────────────────────────
+Size      Files   API time    ±CV    /file     CLI time    ±CV    /file
+──────────────────────────────────────────────────────────────────────────────────────────
+Small     20      32.96ms     32.1%  1.65ms    331.55ms    15.2%  16.58ms
+Medium    100     191.33ms    10.1%  1.91ms    551.01ms    12.2%  5.51ms
+Large     500     1.33s       3.7%   2.66ms    1.77s       7.1%   3.55ms
+X-Large   1000    4.79s       9.4%   4.79ms    5.72s       3.4%   5.72ms
+──────────────────────────────────────────────────────────────────────────────────────────
+```
+
+- **Time**: mean with the top and bottom 10% of iterations removed for stability.
+- **±CV**: coefficient of variation, which measures how consistent the results are. Lower is better.
+- **/file**: time per file. If this increases significantly for larger workspaces, it may indicate a performance issue. Higher values at small sizes can be explained by fixed overheads, such as process startup time.
+
+#### Comparisons
+
+```text
+────────────────────────────────────────────────────────────────────────────
+Size      Baseline    Current     Diff        Change    Status
+────────────────────────────────────────────────────────────────────────────
+Small     265.98ms    331.55ms    +65.57ms    +24.7%    ✗ Slower
+Medium    563.36ms    551.01ms    12.35ms     -2.2%     ≈ Same
+Large     1.81s       1.77s       39.93ms     -2.2%     ≈ Same
+X-Large   5.63s       5.72s       +97.60ms    +1.7%     ≈ Same
+────────────────────────────────────────────────────────────────────────────
+```
+
+The significance threshold is dynamic based on the coefficient of variation (CV) of both baseline and current runs. If the CV is high, indicating noisy measurements, the threshold is raised to avoid false positives.
+
+- **✓ Faster**: improvement beyond the CV-based threshold.
+- **✗ Slower**: regression beyond the CV-based threshold.
+- **≈ Same**: within measurement noise.
+
+### Workspace sizes
+
+| Size   | Files | Rules | Overrides | Plugins | Simulates                                     |
+| ------ | ----- | ----- | --------- | ------- | --------------------------------------------- |
+| small  | 20    | 10    | 0         | 0       | Personal site or small library                |
+| medium | 100   | 25    | 10        | 2       | Moderately-sized product or component library |
+| large  | 500   | 50    | 50        | 5       | Enterprise app or design system               |
+| xlarge | 1000  | 80    | 200       | 8       | Huge, sprawling monorepo                      |
+
+### Tips
+
+- The `xlarge` size is useful for stress testing, but takes longer to run. For faster feedback, use `--sizes=small,medium,large`.
+- Warmup iterations are discarded to account for JIT compilation and cache warming.
+- The trimmed mean removes the top and bottom 10% of iterations to reduce impact of outliers.
+- A high CV of over 15% indicates noisy measurements. Consider increasing `--iterations` or reducing system load.
+- For the most reliable results, close other applications and avoid running on battery power.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,13 @@ import stylelintJestConfig from 'eslint-config-stylelint/jest';
 
 export default [
 	{
-		ignores: ['.coverage/**', 'tmp/**', '**/.pnp.*', '**/.yarn/**'],
+		ignores: [
+			'.coverage/**',
+			'tmp/**',
+			'**/.pnp.*',
+			'**/.yarn/**',
+			'scripts/benchmarking/.workspaces/**',
+		],
 	},
 	...stylelintConfig,
 	...stylelintJestConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "lz-string": "^1.5.0",
         "npm-run-all": "^4.1.5",
         "patch-package": "^8.0.1",
+        "pidusage": "^4.0.1",
         "postcss-html": "^1.8.1",
         "postcss-import": "^16.1.1",
         "postcss-less": "^6.0.0",
@@ -11717,6 +11718,19 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/pidusage": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-4.0.1.tgz",
+      "integrity": "sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pify": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "types/stylelint/index.d.ts"
   ],
   "scripts": {
+    "benchmark": "node --expose-gc scripts/benchmarking/run.mjs",
     "benchmark-rule": "node scripts/benchmark-rule.mjs",
     "changeset": "changeset version && node .changeset/rewrite-changelog.mjs CHANGELOG.md",
     "postchangeset": "npm install --ignore-scripts",
@@ -196,6 +197,7 @@
     "lz-string": "^1.5.0",
     "npm-run-all": "^4.1.5",
     "patch-package": "^8.0.1",
+    "pidusage": "^4.0.1",
     "postcss-html": "^1.8.1",
     "postcss-import": "^16.1.1",
     "postcss-less": "^6.0.0",

--- a/scripts/benchmarking/benchmark.mjs
+++ b/scripts/benchmarking/benchmark.mjs
@@ -1,0 +1,260 @@
+/** @typedef {import('./config.mjs').WorkspaceInfo} WorkspaceInfo */
+/** @typedef {import('./config.mjs').WorkspaceSize} WorkspaceSize */
+/** @typedef {import('./config.mjs').BenchmarkMode} BenchmarkMode */
+/** @typedef {import('./config.mjs').BenchmarkOptions} BenchmarkOptions */
+/** @typedef {import('./config.mjs').BenchmarkResult} BenchmarkResult */
+/** @typedef {import('./config.mjs').RawResult} RawResult */
+
+import { join } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { spawn } from 'node:child_process';
+
+import process from 'node:process';
+
+import pidusage from 'pidusage';
+
+import stylelint from '../../lib/index.mjs';
+
+import { BENCHMARK_ITERATIONS, BENCHMARK_WARMUP } from './config.mjs';
+
+const CLI_PATH = join(import.meta.dirname, '../..', 'bin', 'stylelint.mjs');
+
+/**
+ * Run a single benchmark iteration using the API.
+ *
+ * @param {WorkspaceInfo} workspace Workspace info.
+ * @returns {Promise<RawResult>} Benchmark results.
+ */
+async function runApiBenchmark(workspace) {
+	const startTime = performance.now();
+	const startMemory = process.memoryUsage();
+
+	const result = await stylelint.lint({
+		files: `${workspace.path}/src/**/*.{css,scss,less}`,
+		configFile: workspace.configPath,
+		cache: false, // Disable cache for accurate benchmarking.
+	});
+
+	const endTime = performance.now();
+	const endMemory = process.memoryUsage();
+
+	return {
+		duration: endTime - startTime,
+		filesLinted: result.results.length,
+		errorsFound: result.results.reduce((sum, r) => sum + r.warnings.length, 0),
+		memoryUsed: endMemory.heapUsed - startMemory.heapUsed,
+		peakMemory: endMemory.heapUsed,
+	};
+}
+
+/**
+ * Run a single benchmark iteration using the CLI.
+ *
+ * @param {WorkspaceInfo} workspace Workspace info.
+ * @returns {Promise<RawResult>} Benchmark results.
+ */
+async function runCliBenchmark(workspace) {
+	const startTime = performance.now();
+
+	return new Promise((resolve, reject) => {
+		const args = [
+			CLI_PATH,
+			`${workspace.path}/src/**/*.{css,scss,less}`,
+			'--config',
+			workspace.configPath,
+			'--no-cache',
+			'--formatter',
+			'json',
+		];
+
+		const child = spawn(process.execPath, args, {
+			stdio: ['ignore', 'pipe', 'pipe'],
+			env: { ...process.env, NODE_ENV: 'production' },
+		});
+
+		let stdout = '';
+		let stderr = '';
+		let peakMemory = 0;
+
+		// Poll memory usage every 50ms.
+		const memoryInterval = setInterval(async () => {
+			try {
+				const stats = await pidusage(child.pid);
+
+				if (stats && stats.memory > peakMemory) {
+					peakMemory = stats.memory;
+				}
+			} catch {
+				// Process may have exited, ignore errors.
+			}
+		}, 50);
+
+		child.stdout.on('data', (data) => {
+			stdout += data.toString();
+		});
+
+		child.stderr.on('data', (data) => {
+			stderr += data.toString();
+		});
+
+		child.on('error', (err) => {
+			clearInterval(memoryInterval);
+			reject(err);
+		});
+
+		child.on('close', (code) => {
+			clearInterval(memoryInterval);
+
+			const endTime = performance.now();
+
+			// Parse JSON output to get file and error counts.
+			let filesLinted = 0;
+			let errorsFound = 0;
+
+			const output = stderr || stdout;
+
+			try {
+				const results = JSON.parse(output);
+
+				filesLinted = results.length;
+				errorsFound = results.reduce((sum, r) => sum + r.warnings.length, 0);
+			} catch {
+				// If JSON parsing fails, check exit code. Exit code 2 means
+				// lint errors were found.
+				if (code !== 0 && code !== 2) {
+					reject(new Error(`CLI exited with code ${code}: ${stderr}`));
+
+					return;
+				}
+			}
+
+			resolve({
+				duration: endTime - startTime,
+				filesLinted,
+				errorsFound,
+				memoryUsed: peakMemory,
+				peakMemory,
+			});
+		});
+	});
+}
+
+/**
+ * Run benchmark with multiple iterations.
+ *
+ * @param {WorkspaceInfo} workspace Workspace info.
+ * @param {BenchmarkOptions} [options] Benchmark options.
+ * @returns {Promise<BenchmarkResult>} Aggregated benchmark results.
+ */
+export async function runBenchmark(workspace, options = {}) {
+	const {
+		iterations = BENCHMARK_ITERATIONS,
+		warmup = BENCHMARK_WARMUP,
+		mode = 'api',
+		logger = () => {},
+	} = options;
+
+	const runSingleBenchmark = mode === 'cli' ? runCliBenchmark : runApiBenchmark;
+	const results = [];
+
+	// Warmup iterations, which are discarded.
+	if (warmup > 0) {
+		logger(`  Warmup: ${warmup} iterations...`);
+
+		for (let i = 0; i < warmup; i++) {
+			if (global.gc) {
+				global.gc();
+			}
+
+			await runSingleBenchmark(workspace);
+		}
+	}
+
+	logger(`  Running ${iterations} iterations (${mode.toUpperCase()} mode)...`);
+
+	for (let i = 0; i < iterations; i++) {
+		// Force garbage collection if run with --expose-gc.
+		if (global.gc) {
+			global.gc();
+		}
+
+		const result = await runSingleBenchmark(workspace);
+
+		results.push(result);
+		logger(`    Iteration ${i + 1}: ${result.duration.toFixed(2)}ms`);
+	}
+
+	// Calculate statistics.
+	const durations = results.map((r) => r.duration);
+	const sortedDurations = [...durations].sort((a, b) => a - b);
+	const mean = durations.reduce((a, b) => a + b, 0) / durations.length;
+
+	// Standard deviation.
+	const squaredDiffs = durations.map((d) => (d - mean) ** 2);
+	const variance = squaredDiffs.reduce((a, b) => a + b, 0) / durations.length;
+	const stdDev = Math.sqrt(variance);
+
+	// Trim mean by removing top and bottom 10%.
+	const trimCount = Math.max(1, Math.floor(durations.length * 0.1));
+	const trimmedDurations = sortedDurations.slice(trimCount, -trimCount);
+	const trimmedMean =
+		trimmedDurations.length > 0
+			? trimmedDurations.reduce((a, b) => a + b, 0) / trimmedDurations.length
+			: mean;
+
+	const stats = {
+		workspace: workspace.size,
+		workspaceConfig: workspace.sizeConfig,
+		iterations,
+		filesLinted: results[0].filesLinted,
+		errorsFound: results[0].errorsFound,
+		timing: {
+			min: Math.min(...durations),
+			max: Math.max(...durations),
+			mean,
+			median: sortedDurations[Math.floor(sortedDurations.length / 2)],
+			trimmedMean,
+			stdDev,
+			cv: (stdDev / mean) * 100, // Coefficient of variation as percentage.
+			p95:
+				sortedDurations.length >= 20
+					? sortedDurations[Math.floor(sortedDurations.length * 0.95)]
+					: sortedDurations[sortedDurations.length - 1],
+		},
+		memory: {
+			avgUsed: results.reduce((sum, r) => sum + r.memoryUsed, 0) / results.length,
+			peakHeap: Math.max(...results.map((r) => r.peakMemory)),
+		},
+		perFile: {
+			mean: durations.reduce((a, b) => a + b, 0) / durations.length / results[0].filesLinted,
+		},
+		raw: results,
+	};
+
+	return stats;
+}
+
+/**
+ * Run benchmarks for all workspaces.
+ *
+ * @param {Record<WorkspaceSize, WorkspaceInfo>} workspaces Map of size to workspace info.
+ * @param {BenchmarkOptions} [options] Benchmark options.
+ * @returns {Promise<Record<WorkspaceSize, BenchmarkResult>>} Map of size to benchmark results.
+ */
+export async function runAllBenchmarks(workspaces, options = {}) {
+	const {
+		iterations = BENCHMARK_ITERATIONS,
+		warmup = 2,
+		mode = 'api',
+		logger = () => {},
+	} = options;
+
+	const results = {};
+
+	for (const [size, workspace] of Object.entries(workspaces)) {
+		logger(`\nBenchmarking ${workspace.sizeConfig.name} workspace...`);
+		results[size] = await runBenchmark(workspace, { iterations, warmup, mode, logger });
+	}
+
+	return results;
+}

--- a/scripts/benchmarking/config.mjs
+++ b/scripts/benchmarking/config.mjs
@@ -1,0 +1,411 @@
+/**
+ * @typedef {'small' | 'medium' | 'large' | 'xlarge'} WorkspaceSize
+ */
+
+/**
+ * @typedef {'api' | 'cli'} BenchmarkMode
+ */
+
+/**
+ * @typedef {Object} WorkspaceSizeConfig
+ * @property {string} name Display name.
+ * @property {string} description Description of the workspace size.
+ * @property {number} files Number of CSS files to generate.
+ * @property {number} maxDepth Maximum directory depth.
+ * @property {number} dirsPerLevel Directories per level.
+ * @property {number} rules Number of rules in config.
+ * @property {number} overrides Number of config overrides.
+ * @property {number} plugins Number of plugins to generate.
+ * @property {number} extends Number of extended configs.
+ */
+
+/**
+ * @typedef {Object} WorkspaceInfo
+ * @property {string} path Path to the workspace.
+ * @property {WorkspaceSize} size Size identifier.
+ * @property {WorkspaceSizeConfig} sizeConfig Size configuration.
+ * @property {string[]} files List of generated file paths.
+ * @property {string[]} directories List of generated directories.
+ * @property {PluginInfo[]} plugins Generated plugin info.
+ * @property {string[]} extendConfigs Extended config paths.
+ * @property {string} configPath Path to main stylelint config.
+ */
+
+/**
+ * @typedef {Object} PluginInfo
+ * @property {string} path Path to the plugin file.
+ * @property {string} ruleName Plugin rule name.
+ */
+
+/**
+ * @typedef {Object} BenchmarkOptions
+ * @property {number} [iterations] Number of measured iterations.
+ * @property {number} [warmup] Number of warmup iterations (discarded).
+ * @property {BenchmarkMode} [mode] Benchmark mode.
+ * @property {(message: string) => void} [logger] Logger function.
+ */
+
+/**
+ * @typedef {Object} BenchmarkResult
+ * @property {WorkspaceSize} workspace Workspace size.
+ * @property {WorkspaceSizeConfig} workspaceConfig Workspace config.
+ * @property {number} iterations Number of iterations run.
+ * @property {number} filesLinted Number of files linted.
+ * @property {number} errorsFound Number of errors found.
+ * @property {TimingStats} timing Timing statistics.
+ * @property {MemoryStats} memory Memory statistics.
+ * @property {PerFileStats} perFile Per-file statistics.
+ * @property {RawResult[]} raw Raw results from each iteration.
+ */
+
+/**
+ * @typedef {Object} TimingStats
+ * @property {number} min Minimum duration.
+ * @property {number} max Maximum duration.
+ * @property {number} mean Mean duration.
+ * @property {number} median Median duration.
+ * @property {number} trimmedMean Mean with top and bottom 10% removed.
+ * @property {number} stdDev Standard deviation.
+ * @property {number} cv Coefficient of variation.
+ * @property {number} p95 95th percentile duration.
+ */
+
+/**
+ * @typedef {Object} MemoryStats
+ * @property {number} avgUsed Average memory used.
+ * @property {number} peakHeap Peak heap usage.
+ */
+
+/**
+ * @typedef {Object} PerFileStats
+ * @property {number} mean Mean time per file.
+ */
+
+/**
+ * @typedef {Object} RawResult
+ * @property {number} duration Duration in milliseconds.
+ * @property {number} filesLinted Files linted.
+ * @property {number} errorsFound Errors found.
+ * @property {number} memoryUsed Memory used delta.
+ * @property {number} peakMemory Peak memory.
+ */
+
+/** @type {Record<WorkspaceSize, WorkspaceSizeConfig>} */
+export const WORKSPACE_SIZES = {
+	small: {
+		name: 'Small',
+		description: '20 files, simple config, no overrides',
+		files: 20,
+		maxDepth: 2,
+		dirsPerLevel: 2,
+		rules: 10,
+		overrides: 0,
+		plugins: 0,
+		extends: 0,
+	},
+	medium: {
+		name: 'Medium',
+		description: '100 files, moderate config, 10 overrides',
+		files: 100,
+		maxDepth: 4,
+		dirsPerLevel: 3,
+		rules: 25,
+		overrides: 10,
+		plugins: 2,
+		extends: 1,
+	},
+	large: {
+		name: 'Large',
+		description: '500 files, complex config, 50 overrides',
+		files: 500,
+		maxDepth: 6,
+		dirsPerLevel: 4,
+		rules: 50,
+		overrides: 50,
+		plugins: 5,
+		extends: 2,
+	},
+	xlarge: {
+		name: 'X-Large',
+		description: '1000 files, stress test config, 200 overrides',
+		files: 1000,
+		maxDepth: 7,
+		dirsPerLevel: 5,
+		rules: 80,
+		overrides: 200,
+		plugins: 8,
+		extends: 3,
+	},
+};
+
+// CSS content templates for generating realistic files.
+export const CSS_TEMPLATES = [
+	// Simple component styles.
+	`/* Component: {{name}} */
+.{{name}} {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  margin: 0 auto;
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.{{name}}__header {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #333333;
+  margin-bottom: 0.5rem;
+}
+
+.{{name}}__content {
+  flex: 1;
+  padding: 1rem 0;
+}
+
+.{{name}}__footer {
+  border-top: 1px solid #e0e0e0;
+  padding-top: 0.5rem;
+  text-align: right;
+}
+`,
+	// Button styles.
+	`/* Button: {{name}} */
+.btn-{{name}} {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: all 0.15s ease-in-out;
+}
+
+.btn-{{name}}:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.btn-{{name}}:active {
+  transform: translateY(0);
+}
+
+.btn-{{name}}:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-{{name}}--primary {
+  background-color: #007bff;
+  color: #ffffff;
+  border: none;
+}
+
+.btn-{{name}}--secondary {
+  background-color: transparent;
+  color: #007bff;
+  border: 1px solid #007bff;
+}
+`,
+	// Form styles.
+	`/* Form: {{name}} */
+.form-{{name}} {
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.form-{{name}} .form-group {
+  margin-bottom: 1rem;
+}
+
+.form-{{name}} label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+  color: #495057;
+}
+
+.form-{{name}} input,
+.form-{{name}} textarea,
+.form-{{name}} select {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #495057;
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
+}
+
+.form-{{name}} input:focus,
+.form-{{name}} textarea:focus,
+.form-{{name}} select:focus {
+  border-color: #80bdff;
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+`,
+	// Grid layout.
+	`/* Grid: {{name}} */
+.grid-{{name}} {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  padding: 1rem;
+}
+
+.grid-{{name}}__item {
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.grid-{{name}}__item:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+@media (max-width: 768px) {
+  .grid-{{name}} {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+`,
+	// Navigation styles.
+	`/* Nav: {{name}} */
+.nav-{{name}} {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background-color: #343a40;
+}
+
+.nav-{{name}}__brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #ffffff;
+  text-decoration: none;
+  margin-right: 2rem;
+}
+
+.nav-{{name}}__links {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 1rem;
+}
+
+.nav-{{name}}__link {
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  padding: 0.5rem;
+  transition: color 0.15s;
+}
+
+.nav-{{name}}__link:hover,
+.nav-{{name}}__link--active {
+  color: #ffffff;
+}
+`,
+];
+
+// Available rules for config generation.
+export const AVAILABLE_RULES = [
+	'block-no-empty',
+	'color-no-invalid-hex',
+	'comment-no-empty',
+	'declaration-block-no-duplicate-properties',
+	'declaration-block-no-shorthand-property-overrides',
+	'font-family-no-duplicate-names',
+	'function-calc-no-unspaced-operator',
+	'keyframe-declaration-no-important',
+	'media-feature-name-no-unknown',
+	'no-descending-specificity',
+	'no-duplicate-at-import-rules',
+	'no-duplicate-selectors',
+	'no-empty-source',
+	'no-invalid-double-slash-comments',
+	'property-no-unknown',
+	'selector-pseudo-class-no-unknown',
+	'selector-pseudo-element-no-unknown',
+	'selector-type-no-unknown',
+	'string-no-newline',
+	'unit-no-unknown',
+	'alpha-value-notation',
+	'color-function-notation',
+	'color-hex-length',
+	'font-family-name-quotes',
+	'function-name-case',
+	'function-url-quotes',
+	'import-notation',
+	'keyframe-selector-notation',
+	'length-zero-no-unit',
+	'media-feature-range-notation',
+	'number-max-precision',
+	'selector-not-notation',
+	'selector-pseudo-element-colon-notation',
+	'shorthand-property-no-redundant-values',
+	'value-keyword-case',
+	'declaration-block-single-line-max-declarations',
+	'declaration-property-max-values',
+	'max-nesting-depth',
+	'selector-max-attribute',
+	'selector-max-class',
+	'selector-max-combinators',
+	'selector-max-compound-selectors',
+	'selector-max-id',
+	'selector-max-pseudo-class',
+	'selector-max-specificity',
+	'selector-max-type',
+	'selector-max-universal',
+	'time-min-milliseconds',
+	'at-rule-disallowed-list',
+	'at-rule-allowed-list',
+	'color-hex-alpha',
+	'color-named',
+	'color-no-hex',
+	'comment-word-disallowed-list',
+	'declaration-no-important',
+	'declaration-property-unit-allowed-list',
+	'declaration-property-value-disallowed-list',
+	'function-disallowed-list',
+	'function-url-no-scheme-relative',
+	'function-url-scheme-disallowed-list',
+	'media-feature-name-disallowed-list',
+	'media-feature-name-unit-allowed-list',
+	'media-feature-name-value-allowed-list',
+	'property-disallowed-list',
+	'rule-selector-property-disallowed-list',
+	'selector-attribute-name-disallowed-list',
+	'selector-attribute-operator-disallowed-list',
+	'selector-combinator-disallowed-list',
+	'selector-disallowed-list',
+	'selector-no-qualifying-type',
+	'selector-no-vendor-prefix',
+	'selector-pseudo-class-disallowed-list',
+	'selector-pseudo-element-disallowed-list',
+	'unit-disallowed-list',
+	'value-no-vendor-prefix',
+	'at-rule-empty-line-before',
+	'comment-empty-line-before',
+	'custom-property-empty-line-before',
+	'declaration-empty-line-before',
+	'rule-empty-line-before',
+];
+
+// File extensions to generate.
+export const FILE_EXTENSIONS = ['.css', '.scss', '.less'];
+
+// Benchmark defaults.
+export const BENCHMARK_ITERATIONS = 10;
+export const BENCHMARK_WARMUP = 2;
+
+/** @type {BenchmarkMode[]} */
+export const DEFAULT_MODES = ['api', 'cli'];

--- a/scripts/benchmarking/generatePlugins.mjs
+++ b/scripts/benchmarking/generatePlugins.mjs
@@ -1,0 +1,124 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/**
+ * Generate a fake plugin file.
+ *
+ * @param {string} pluginDir Directory to write plugin to.
+ * @param {number} index Plugin index for unique naming.
+ * @returns {Promise<string>} Path to the generated plugin.
+ */
+export async function generatePlugin(pluginDir, index) {
+	const pluginName = `perf-plugin-${index}`;
+	const ruleName = `${pluginName}/test-rule`;
+
+	const pluginContent = `/**
+ * Auto-generated fake plugin for performance testing
+ * Plugin: ${pluginName}
+ */
+
+const rule = (primary) => {
+	return (root, result) => {
+		// Minimal rule implementation for perf testing
+		root.walkDecls((decl) => {
+			// Just iterate, don't report anything
+			// This simulates plugin overhead without noise
+		});
+	};
+};
+
+rule.ruleName = '${ruleName}';
+rule.meta = {
+	url: 'https://example.com/perf-test',
+};
+
+export default {
+	ruleName: '${ruleName}',
+	rule,
+};
+`;
+
+	await mkdir(pluginDir, { recursive: true });
+	const pluginPath = join(pluginDir, `${pluginName}.mjs`);
+
+	await writeFile(pluginPath, pluginContent);
+
+	return { path: pluginPath, ruleName };
+}
+
+/**
+ * Generate multiple fake plugins.
+ *
+ * @param {string} pluginDir Directory to write plugins to.
+ * @param {number} count Number of plugins to generate.
+ * @returns {Promise<Array<{path: string, ruleName: string}>>}
+ */
+export async function generatePlugins(pluginDir, count) {
+	const plugins = [];
+
+	for (let i = 0; i < count; i++) {
+		const plugin = await generatePlugin(pluginDir, i);
+
+		plugins.push(plugin);
+	}
+
+	return plugins;
+}
+
+/**
+ * Generate a fake extended config.
+ *
+ * @param {string} configDir Directory to write config to.
+ * @param {number} index Config index.
+ * @param {number} ruleCount Number of rules to include.
+ * @returns {Promise<string>} Path to the generated config.
+ */
+export async function generateExtendedConfig(configDir, index, ruleCount) {
+	const configName = `perf-config-${index}`;
+	const rules = {};
+
+	// Add some rules from the available rules list.
+	const availableRules = [
+		'color-hex-length',
+		'length-zero-no-unit',
+		'shorthand-property-no-redundant-values',
+		'declaration-block-single-line-max-declarations',
+		'number-max-precision',
+		'value-keyword-case',
+		'function-name-case',
+		'selector-pseudo-element-colon-notation',
+	];
+
+	for (let i = 0; i < Math.min(ruleCount, availableRules.length); i++) {
+		const rule = availableRules[i];
+
+		if (rule === 'color-hex-length') {
+			rules[rule] = 'short';
+		} else if (rule === 'declaration-block-single-line-max-declarations') {
+			rules[rule] = 1;
+		} else if (rule === 'number-max-precision') {
+			rules[rule] = 4;
+		} else if (rule === 'value-keyword-case') {
+			rules[rule] = 'lower';
+		} else if (rule === 'function-name-case') {
+			rules[rule] = 'lower';
+		} else if (rule === 'selector-pseudo-element-colon-notation') {
+			rules[rule] = 'double';
+		} else {
+			rules[rule] = true;
+		}
+	}
+
+	const configContent = `/** @type {import('stylelint').Config} */
+export default {
+	rules: ${JSON.stringify(rules, null, '\t\t').replace(/^/gm, '\t').trim()},
+};
+`;
+
+	await mkdir(configDir, { recursive: true });
+	const configPath = join(configDir, `${configName}.mjs`);
+
+	await writeFile(configPath, configContent);
+
+	return configPath;
+}

--- a/scripts/benchmarking/generateWorkspace.mjs
+++ b/scripts/benchmarking/generateWorkspace.mjs
@@ -1,0 +1,334 @@
+/* eslint-disable no-console */
+
+/** @typedef {import('./config.mjs').WorkspaceSize} WorkspaceSize */
+/** @typedef {import('./config.mjs').WorkspaceSizeConfig} WorkspaceSizeConfig */
+/** @typedef {import('./config.mjs').WorkspaceInfo} WorkspaceInfo */
+/** @typedef {import('./config.mjs').PluginInfo} PluginInfo */
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import pc from 'picocolors';
+
+import { AVAILABLE_RULES, CSS_TEMPLATES, FILE_EXTENSIONS, WORKSPACE_SIZES } from './config.mjs';
+import { generateExtendedConfig, generatePlugins } from './generatePlugins.mjs';
+
+/**
+ * Seeded pseudo-random number generator, using the mulberry32 algorithm.
+ * Ensures reproducible, deterministic workspace generation across runs.
+ *
+ * @param {number} seed Initial seed value.
+ * @returns {() => number} Function returning pseudorandom numbers in [0, 1).
+ */
+function createSeededRandom(seed) {
+	let state = seed;
+
+	return () => {
+		state |= 0;
+		state = (state + 0x6d2b79f5) | 0;
+		let t = Math.imul(state ^ (state >>> 15), 1 | state);
+
+		t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/** Default seed for benchmarks. */
+const DEFAULT_SEED = 0x6c696e74; // "lint" in hex.
+
+/** Seeded random number generator. */
+const random = createSeededRandom(DEFAULT_SEED);
+
+/**
+ * Generate a random component name.
+ *
+ * @returns {string}
+ */
+function randomComponentName() {
+	const prefixes = ['app', 'ui', 'core', 'common', 'shared', 'feature', 'page', 'layout', 'widget'];
+	const suffixes = [
+		'button',
+		'card',
+		'modal',
+		'form',
+		'list',
+		'table',
+		'nav',
+		'header',
+		'footer',
+		'sidebar',
+		'menu',
+		'panel',
+		'container',
+		'wrapper',
+		'section',
+		'hero',
+		'banner',
+		'alert',
+		'badge',
+		'tag',
+	];
+	const prefix = prefixes[Math.floor(random() * prefixes.length)];
+	const suffix = suffixes[Math.floor(random() * suffixes.length)];
+
+	return `${prefix}-${suffix}-${Math.floor(random() * 1000)}`;
+}
+
+/**
+ * Generate CSS content from templates.
+ *
+ * @param {string} name Component name
+ * @returns {string}
+ */
+function generateCSSContent(name) {
+	const template = CSS_TEMPLATES[Math.floor(random() * CSS_TEMPLATES.length)];
+
+	return template.replace(/\{\{name\}\}/g, name);
+}
+
+/**
+ * Generate directory structure.
+ *
+ * @param {string} baseDir Base directory.
+ * @param {number} depth Current depth.
+ * @param {number} maxDepth Maximum depth.
+ * @param {number} dirsPerLevel Directories per level.
+ * @returns {Promise<string[]>} List of created directories.
+ */
+async function generateDirectoryTree(baseDir, depth, maxDepth, dirsPerLevel) {
+	const dirs = [baseDir];
+
+	if (depth >= maxDepth) {
+		return dirs;
+	}
+
+	const dirNames = ['components', 'layouts', 'pages', 'features', 'shared', 'utils', 'styles'];
+
+	for (let i = 0; i < dirsPerLevel && i < dirNames.length; i++) {
+		const dirName = dirNames[i];
+		const dirPath = join(baseDir, dirName);
+
+		await mkdir(dirPath, { recursive: true });
+
+		const subDirs = await generateDirectoryTree(dirPath, depth + 1, maxDepth, dirsPerLevel - 1);
+
+		dirs.push(...subDirs);
+	}
+
+	return dirs;
+}
+
+/**
+ * Generate stylelint config.
+ *
+ * @param {Object} options Configuration options.
+ * @param {number} options.rules Number of rules.
+ * @param {number} options.overrides Number of overrides.
+ * @param {Array} options.plugins Plugin info.
+ * @param {Array} options.extends Extended config paths.
+ * @param {string[]} options.files List of files for override targeting.
+ * @returns {Object} Stylelint config.
+ */
+function generateConfig({ rules, overrides, plugins, extends: extendConfigs, files }) {
+	const config = {
+		rules: {},
+	};
+
+	// Add rules.
+	const selectedRules = AVAILABLE_RULES.slice(0, rules);
+
+	for (const rule of selectedRules) {
+		// Simple rule configuration. Most rules just need true.
+		if (rule.includes('max-') || rule.includes('min-')) {
+			config.rules[rule] = 3;
+		} else if (rule.includes('-notation')) {
+			config.rules[rule] = null; // Disable notation rules to avoid conflicts.
+		} else if (rule.includes('-list')) {
+			config.rules[rule] = null; // Disable list rules.
+		} else if (rule.includes('-quotes')) {
+			config.rules[rule] = 'always';
+		} else if (rule === 'color-hex-length') {
+			config.rules[rule] = 'short';
+		} else if (rule === 'value-keyword-case' || rule === 'function-name-case') {
+			config.rules[rule] = 'lower';
+		} else {
+			config.rules[rule] = true;
+		}
+	}
+
+	// Add plugins.
+	if (plugins && plugins.length > 0) {
+		config.plugins = plugins.map((p) => p.path);
+
+		// Add plugin rules.
+		for (const plugin of plugins) {
+			config.rules[plugin.ruleName] = true;
+		}
+	}
+
+	// Add extends.
+	if (extendConfigs && extendConfigs.length > 0) {
+		config.extends = extendConfigs;
+	}
+
+	// Add overrides.
+	if (overrides > 0 && files.length > 0) {
+		config.overrides = [];
+
+		// Create overrides targeting different file patterns.
+		const patterns = [
+			'**/*.css',
+			'**/*.scss',
+			'**/components/**/*.css',
+			'**/layouts/**/*.css',
+			'**/pages/**/*.css',
+			'**/features/**/*.css',
+			'**/shared/**/*.css',
+		];
+
+		for (let i = 0; i < overrides; i++) {
+			const pattern = patterns[i % patterns.length];
+			const overrideRules = {};
+
+			// Add a few rules to each override.
+			const overrideRuleCount = Math.min(3, selectedRules.length);
+
+			for (let j = 0; j < overrideRuleCount; j++) {
+				const ruleIndex = (i + j) % selectedRules.length;
+				const rule = selectedRules[ruleIndex];
+
+				// Toggle the rule or change its value.
+				if (config.rules[rule] === true) {
+					overrideRules[rule] = null; // Disable in override.
+				} else if (config.rules[rule] === null) {
+					overrideRules[rule] = true; // Enable in override.
+				}
+			}
+
+			config.overrides.push({
+				files: [pattern],
+				rules: overrideRules,
+			});
+		}
+	}
+
+	return config;
+}
+
+/**
+ * Generate a complete workspace.
+ *
+ * @param {string} workspacePath Path to create workspace.
+ * @param {WorkspaceSize} size Workspace size.
+ * @param {{ logger?: (msg: string) => void }} [options] Options.
+ * @returns {Promise<WorkspaceInfo>} Workspace info.
+ */
+export async function generateWorkspace(workspacePath, size, options = {}) {
+	const log = options.logger ?? console.log;
+	const sizeConfig = WORKSPACE_SIZES[size];
+
+	if (!sizeConfig) {
+		throw new Error(`Unknown workspace size: ${size}`);
+	}
+
+	log(`  Generating ${pc.cyan(sizeConfig.name)} workspace...`);
+
+	// Clean and create workspace directory.
+	await rm(workspacePath, { recursive: true, force: true });
+	await mkdir(workspacePath, { recursive: true });
+
+	// Create directory structure.
+	const srcDir = join(workspacePath, 'src');
+
+	await mkdir(srcDir, { recursive: true });
+
+	const directories = await generateDirectoryTree(
+		srcDir,
+		0,
+		sizeConfig.maxDepth,
+		sizeConfig.dirsPerLevel,
+	);
+
+	// Generate CSS files.
+	const files = [];
+	const filesPerDir = Math.ceil(sizeConfig.files / directories.length);
+
+	for (const dir of directories) {
+		const fileCount = Math.min(filesPerDir, sizeConfig.files - files.length);
+
+		for (let i = 0; i < fileCount && files.length < sizeConfig.files; i++) {
+			const componentName = randomComponentName();
+			const ext = FILE_EXTENSIONS[Math.floor(random() * FILE_EXTENSIONS.length)];
+			const fileName = `${componentName}${ext}`;
+			const filePath = join(dir, fileName);
+			const content = generateCSSContent(componentName);
+
+			await writeFile(filePath, content);
+			files.push(filePath);
+		}
+	}
+
+	// Generate plugins.
+	const pluginDir = join(workspacePath, '.stylelint-plugins');
+	const plugins = await generatePlugins(pluginDir, sizeConfig.plugins);
+
+	// Generate extended configs.
+	const configDir = join(workspacePath, '.stylelint-configs');
+	const extendConfigs = [];
+
+	for (let i = 0; i < sizeConfig.extends; i++) {
+		const configPath = await generateExtendedConfig(configDir, i, 5);
+
+		extendConfigs.push(configPath);
+	}
+
+	// Generate main config.
+	const config = generateConfig({
+		rules: sizeConfig.rules,
+		overrides: sizeConfig.overrides,
+		plugins,
+		extends: extendConfigs,
+		files,
+	});
+
+	const configPath = join(workspacePath, 'stylelint.config.mjs');
+	const configContent = `/** @type {import('stylelint').Config} */
+export default ${JSON.stringify(config, null, 2)};
+`;
+
+	await writeFile(configPath, configContent);
+
+	log(`    ${pc.green('✓')} Created ${files.length} files in ${directories.length} directories`);
+	log(`    ${pc.green('✓')} Config: ${sizeConfig.rules} rules, ${sizeConfig.overrides} overrides`);
+	log(`    ${pc.green('✓')} Plugins: ${plugins.length}, Extends: ${extendConfigs.length}`);
+
+	return {
+		path: workspacePath,
+		size,
+		sizeConfig,
+		files,
+		directories,
+		plugins,
+		extendConfigs,
+		configPath,
+	};
+}
+
+/**
+ * Generate all workspace sizes.
+ *
+ * @param {string} baseDir Base directory for workspaces.
+ * @returns {Promise<Record<WorkspaceSize, WorkspaceInfo>>} Map of size to workspace info.
+ */
+export async function generateAllWorkspaces(baseDir) {
+	const workspaces = {};
+
+	for (const size of Object.keys(WORKSPACE_SIZES)) {
+		const workspacePath = join(baseDir, size);
+
+		workspaces[size] = await generateWorkspace(workspacePath, size);
+	}
+
+	return workspaces;
+}

--- a/scripts/benchmarking/reporter.mjs
+++ b/scripts/benchmarking/reporter.mjs
@@ -1,0 +1,366 @@
+/* eslint-disable prefer-template */
+
+import pc from 'picocolors';
+
+/**
+ * Format bytes to human readable string.
+ *
+ * @param {number} bytes
+ * @returns {string}
+ */
+function formatBytes(bytes) {
+	if (bytes < 1024) return `${bytes} B`;
+
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+/**
+ * Format milliseconds to human readable string.
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+function formatTime(ms) {
+	if (ms < 1000) return `${ms.toFixed(2)}ms`;
+
+	if (ms < 60000) return `${(ms / 1000).toFixed(2)}s`;
+
+	return `${(ms / 60000).toFixed(2)}m`;
+}
+
+/** Standard widths for consistent formatting. */
+export const WIDTH = {
+	/** Narrow width for progress output. */
+	narrow: 60,
+	/** Medium width for detail sections. */
+	medium: 76,
+	/** Default width for most output. */
+	default: 80,
+	/** Wide width for summary tables. */
+	wide: 90,
+};
+
+/**
+ * Create a horizontal line.
+ *
+ * @param {number} [length]
+ * @returns {string}
+ */
+function line(length = WIDTH.default) {
+	return pc.dim('─'.repeat(length));
+}
+
+/**
+ * Create a double horizontal line.
+ *
+ * @param {number} [length]
+ * @returns {string}
+ */
+function doubleLine(length = WIDTH.default) {
+	return pc.dim('═'.repeat(length));
+}
+
+/**
+ * Create a major header with double lines above and below.
+ *
+ * @param {string} title
+ * @param {number} [width]
+ * @returns {string}
+ */
+export function header(title, width = WIDTH.default) {
+	return [doubleLine(width), pc.bold(`  ${title.toUpperCase()}`), doubleLine(width)].join('\n');
+}
+
+/**
+ * Create a section header with a line below.
+ *
+ * @param {string} title
+ * @param {number} [width]
+ * @param {{ indent?: boolean }} [options]
+ * @returns {string}
+ */
+export function sectionHeader(title, width = WIDTH.narrow, options = {}) {
+	const indent = options.indent ? '  ' : '';
+
+	return [pc.bold(`${indent}${title.toUpperCase()}`), indent + line(width)].join('\n');
+}
+
+/**
+ * Pad string to fixed width.
+ *
+ * @param {string} str
+ * @param {number} width
+ * @param {string} [align]
+ * @returns {string}
+ */
+function pad(str, width, align = 'left') {
+	const s = String(str);
+
+	if (s.length >= width) return s;
+
+	const padding = ' '.repeat(width - s.length);
+
+	return align === 'right' ? padding + s : s + padding;
+}
+
+/**
+ * Generate a report from benchmark results.
+ *
+ * @param {Object} allResults Results keyed by mode.
+ * @returns {string}
+ */
+export function generateReport(allResults) {
+	const modes = Object.keys(allResults);
+	const lines = [];
+
+	lines.push('');
+	lines.push(header('Stylelint performance benchmark results'));
+	lines.push('');
+
+	// Get sizes from first mode's results.
+	const firstModeResults = allResults[modes[0]];
+	const sizes = Object.keys(firstModeResults);
+
+	// Summary table with all modes side by side.
+	lines.push(sectionHeader('Summary', WIDTH.wide, { indent: true }));
+
+	if (modes.length === 1) {
+		lines.push(
+			'  ' +
+				pc.dim(
+					pad('Size', 10) +
+						pad('Files', 8) +
+						pad('Rules', 8) +
+						pad('Overrides', 12) +
+						pad('Time', 12) +
+						pad('±CV', 8) +
+						pad('Per file', 10) +
+						pad('Memory', 12),
+				),
+		);
+		lines.push('  ' + line(WIDTH.wide));
+
+		for (const result of Object.values(firstModeResults)) {
+			const config = result.workspaceConfig;
+			const time = result.timing.trimmedMean;
+			const cv = result.timing.cv;
+
+			lines.push(
+				'  ' +
+					pad(config.name, 10) +
+					pad(String(result.filesLinted), 8) +
+					pad(String(config.rules), 8) +
+					pad(String(config.overrides), 12) +
+					pad(formatTime(time), 12) +
+					pad(cv.toFixed(1) + '%', 8) +
+					pad(formatTime(result.perFile.mean), 10) +
+					pad(formatBytes(result.memory.peakHeap), 12),
+			);
+		}
+	} else {
+		lines.push(
+			'  ' +
+				pc.dim(
+					pad('Size', 10) +
+						pad('Files', 8) +
+						pad('API time', 12) +
+						pad('±CV', 7) +
+						pad('/file', 10) +
+						pad('CLI time', 12) +
+						pad('±CV', 7) +
+						pad('/file', 10),
+				),
+		);
+		lines.push('  ' + line(WIDTH.wide));
+
+		for (const size of sizes) {
+			const apiResult = allResults.api?.[size];
+			const cliResult = allResults.cli?.[size];
+			const config = (apiResult || cliResult).workspaceConfig;
+			const files = (apiResult || cliResult).filesLinted;
+
+			const apiTime = apiResult ? apiResult.timing.trimmedMean : 0;
+			const cliTime = cliResult ? cliResult.timing.trimmedMean : 0;
+			const apiCv = apiResult?.timing.cv ?? 0;
+			const cliCv = cliResult?.timing.cv ?? 0;
+			const apiPerFile = apiTime / files;
+			const cliPerFile = cliTime / files;
+
+			lines.push(
+				'  ' +
+					pad(config.name, 10) +
+					pad(String(files), 8) +
+					pad(apiResult ? formatTime(apiTime) : 'N/A', 12) +
+					pad(apiResult ? apiCv.toFixed(1) + '%' : '', 7) +
+					pad(apiResult ? formatTime(apiPerFile) : '', 10) +
+					pad(cliResult ? formatTime(cliTime) : 'N/A', 12) +
+					pad(cliResult ? cliCv.toFixed(1) + '%' : '', 7) +
+					pad(cliResult ? formatTime(cliPerFile) : '', 10),
+			);
+		}
+	}
+
+	lines.push('  ' + line(WIDTH.wide));
+	lines.push('');
+
+	// Display results per mode.
+	for (const mode of modes) {
+		const results = allResults[mode];
+
+		lines.push(sectionHeader(`${mode} mode details`, WIDTH.medium, { indent: true }));
+		lines.push('');
+
+		for (const result of Object.values(results)) {
+			const config = result.workspaceConfig;
+			const timing = result.timing;
+			const trimmed = timing.trimmedMean;
+			const cv = timing.cv;
+
+			lines.push(`  ${pc.bold(config.name)} ${pc.dim(`(${config.description})`)}:`);
+			lines.push(`    Timing (${result.iterations} iterations, 2 warmup):`);
+			lines.push(
+				`      Trimmed mean: ${pc.cyan(formatTime(trimmed))}  ${pc.dim(`(±${cv.toFixed(1)}% CV)`)}`,
+			);
+			lines.push(
+				`      Range: ${formatTime(timing.min)} - ${formatTime(timing.max)}  Median: ${formatTime(timing.median)}`,
+			);
+			lines.push(
+				`    Memory: Peak ${formatBytes(result.memory.peakHeap)}, Avg Delta ${formatBytes(result.memory.avgUsed)}`,
+			);
+
+			lines.push('');
+		}
+	}
+
+	lines.push(doubleLine());
+	lines.push('');
+
+	return lines.join('\n');
+}
+
+/**
+ * Generate JSON report for programmatic use.
+ *
+ * @param {Object} allResults Results keyed by mode.
+ * @returns {Object}
+ */
+export function generateJsonReport(allResults) {
+	const report = {
+		timestamp: new Date().toISOString(),
+		modes: Object.keys(allResults),
+		summary: {},
+		detailed: {},
+	};
+
+	for (const [mode, results] of Object.entries(allResults)) {
+		report.summary[mode] = {};
+		report.detailed[mode] = results;
+
+		for (const [size, result] of Object.entries(results)) {
+			report.summary[mode][size] = {
+				files: result.filesLinted,
+				trimmedMean: result.timing.trimmedMean,
+				mean: result.timing.mean,
+				cv: result.timing.cv,
+				perFileTime: result.perFile.mean,
+				peakMemory: result.memory.peakHeap,
+			};
+		}
+	}
+
+	return report;
+}
+
+/**
+ * Generate comparison report between two benchmark runs.
+ *
+ * @param {Object} baseline Baseline results from generateJsonReport.
+ * @param {Object} current Current results keyed by mode.
+ * @returns {string}
+ */
+export function generateComparisonReport(baseline, current) {
+	const lines = [];
+
+	lines.push('');
+	lines.push(header('Performance comparison'));
+	lines.push('');
+
+	const modes = Object.keys(current);
+
+	for (const mode of modes) {
+		const baselineResults = baseline.detailed[mode];
+		const currentResults = current[mode];
+
+		if (!baselineResults || !currentResults) continue;
+
+		if (modes.length > 1) {
+			lines.push(sectionHeader(`${mode} Mode`, WIDTH.medium, { indent: true }));
+		}
+
+		lines.push(
+			'  ' +
+				pc.dim(
+					pad('Size', 10) +
+						pad('Baseline', 12) +
+						pad('Current', 12) +
+						pad('Diff', 12) +
+						pad('Change', 10) +
+						pad('Status', 10),
+				),
+		);
+		lines.push('  ' + line(WIDTH.medium));
+
+		for (const size of Object.keys(currentResults)) {
+			if (!baselineResults[size]) continue;
+
+			const baseTime = baselineResults[size].timing.trimmedMean;
+			const currTime = currentResults[size].timing.trimmedMean;
+			const baseCv = baselineResults[size].timing.cv;
+			const currCv = currentResults[size].timing.cv;
+
+			// Use combined CV to determine significance threshold.
+			const combinedCv = Math.max(baseCv, currCv, 5); // At least 5%.
+			const threshold = combinedCv / 100;
+
+			const diff = currTime - baseTime;
+			const changePercent = ((diff / baseTime) * 100).toFixed(1);
+
+			let status;
+			let statusColor;
+
+			if (diff < -baseTime * threshold) {
+				status = '✓ Faster';
+				statusColor = pc.green;
+			} else if (diff > baseTime * threshold) {
+				status = '✗ Slower';
+				statusColor = pc.red;
+			} else {
+				status = '≈ Same';
+				statusColor = pc.dim;
+			}
+
+			const diffPrefix = diff >= 0 ? '+' : '';
+			const changeColor = diff < 0 ? pc.green : diff > 0 ? pc.red : pc.dim;
+
+			lines.push(
+				'  ' +
+					pad(currentResults[size].workspaceConfig.name, 10) +
+					pad(formatTime(baseTime), 12) +
+					pad(formatTime(currTime), 12) +
+					changeColor(pad(diffPrefix + formatTime(Math.abs(diff)), 12)) +
+					changeColor(pad(diffPrefix + changePercent + '%', 10)) +
+					statusColor(pad(status, 10)),
+			);
+		}
+
+		lines.push('  ' + line(WIDTH.medium));
+		lines.push('');
+	}
+
+	lines.push(doubleLine());
+	lines.push('');
+
+	return lines.join('\n');
+}

--- a/scripts/benchmarking/run.mjs
+++ b/scripts/benchmarking/run.mjs
@@ -1,0 +1,293 @@
+/* eslint-disable no-console, n/no-process-exit */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+import process from 'node:process';
+
+import pc from 'picocolors';
+
+import {
+	BENCHMARK_ITERATIONS,
+	BENCHMARK_WARMUP,
+	DEFAULT_MODES,
+	WORKSPACE_SIZES,
+} from './config.mjs';
+import {
+	WIDTH,
+	generateComparisonReport,
+	generateJsonReport,
+	generateReport,
+	header,
+	sectionHeader,
+} from './reporter.mjs';
+import { generateWorkspace } from './generateWorkspace.mjs';
+import { runAllBenchmarks } from './benchmark.mjs';
+
+const WORKSPACES_DIR = join(import.meta.dirname, '.workspaces');
+
+/**
+ * Parse command line arguments.
+ *
+ * @returns {Object}
+ */
+function parseCLIArgs() {
+	const { values } = parseArgs({
+		options: {
+			sizes: { type: 'string' },
+			iterations: { type: 'string' },
+			warmup: { type: 'string' },
+			modes: { type: 'string' },
+			'generate-only': { type: 'boolean', default: false },
+			'benchmark-only': { type: 'boolean', default: false },
+			output: { type: 'string', default: 'text' },
+			compare: { type: 'string' },
+			'compare-to': { type: 'string' },
+			save: { type: 'string' },
+			show: { type: 'string' },
+			help: { type: 'boolean', short: 'h', default: false },
+		},
+		strict: false,
+	});
+
+	const args = {
+		sizes: values.sizes ? values.sizes.split(',') : Object.keys(WORKSPACE_SIZES),
+		iterations: values.iterations ? parseInt(values.iterations, 10) : BENCHMARK_ITERATIONS,
+		warmup: values.warmup ? parseInt(values.warmup, 10) : BENCHMARK_WARMUP,
+		modes: values.modes
+			? values.modes.split(',').filter((m) => m === 'api' || m === 'cli')
+			: [...DEFAULT_MODES],
+		generateOnly: values['generate-only'],
+		benchmarkOnly: values['benchmark-only'],
+		output: values.output,
+		compare: values.compare ?? null,
+		compareTo: values['compare-to'] ?? null,
+		save: values.save ?? null,
+		show: values.show ?? null,
+		help: values.help,
+	};
+
+	return args;
+}
+
+/**
+ * Print help message.
+ */
+function printHelp() {
+	console.log(`
+Stylelint Performance Benchmark Runner
+
+Usage:
+  npm run benchmark -- [options]
+
+Options:
+  --sizes=small,medium,large    Comma-separated list of sizes to benchmark
+                                Available: ${Object.keys(WORKSPACE_SIZES).join(', ')}
+  --modes=api,cli               Comma-separated list of modes (default: ${DEFAULT_MODES.join(',')})
+  --iterations=N                Number of measured iterations (default: ${BENCHMARK_ITERATIONS})
+  --warmup=N                    Number of warmup iterations to discard (default: ${BENCHMARK_WARMUP})
+  --generate-only               Only generate workspaces, don't run benchmarks
+  --benchmark-only              Only run benchmarks, don't generate workspaces
+  --output=FORMAT               Output format: text or json (default: text)
+  --compare=FILE                Compare current run against baseline JSON file
+  --compare-to=FILE             Compare --compare file against this file without running benchmarks
+  --save=FILE                   Save results to JSON file
+  --show=FILE                   Display results from a saved JSON file
+  --help                        Show this help message
+
+Examples:
+  npm run benchmark                              # Run full benchmark suite.
+  npm run benchmark -- --modes=api               # Run API mode only.
+  npm run benchmark -- --sizes=small,medium      # Only test small and medium.
+  npm run benchmark -- --iterations=20           # More iterations for accuracy.
+  npm run benchmark -- --save=baseline.json      # Save for later comparison.
+  npm run benchmark -- --compare=baseline.json   # Compare against baseline.
+  npm run benchmark -- --compare=old.json --compare-to=new.json  # Compare two files directly.
+  npm run benchmark -- --show=results.json       # Display saved benchmark results.
+
+Workspace Sizes:
+`);
+
+	for (const [size, config] of Object.entries(WORKSPACE_SIZES)) {
+		console.log(`  ${size.padEnd(10)} ${config.description}`);
+	}
+
+	console.log('');
+}
+
+/**
+ * Main entry point.
+ */
+async function main() {
+	const args = parseCLIArgs();
+
+	if (args.help) {
+		printHelp();
+		process.exit(0);
+	}
+
+	const log = args.output === 'json' ? console.error : console.log;
+
+	// Display saved benchmark results.
+	if (args.show) {
+		log('');
+		log(header('Stylelint Benchmark Results', WIDTH.narrow));
+		log('');
+
+		try {
+			const savedData = await readFile(args.show, 'utf-8');
+			const saved = JSON.parse(savedData);
+
+			log(`  File: ${pc.cyan(args.show)}`);
+
+			if (saved.timestamp) {
+				log(`  Recorded: ${pc.dim(saved.timestamp)}`);
+			}
+
+			log(generateReport(saved.detailed));
+		} catch (error) {
+			console.error(`Error loading file: ${error.message}`);
+			process.exit(1);
+		}
+
+		log(pc.green('Done!'));
+		log('');
+		process.exit(0);
+	}
+
+	// Direct file comparison mode (no benchmark run needed).
+	if (args.compare && args.compareTo) {
+		log('');
+		log(header('Stylelint Performance Comparison', WIDTH.narrow));
+		log('');
+
+		try {
+			const baselineData = await readFile(args.compare, 'utf-8');
+			const baseline = JSON.parse(baselineData);
+
+			const currentData = await readFile(args.compareTo, 'utf-8');
+			const current = JSON.parse(currentData);
+
+			log(`  Baseline: ${pc.cyan(args.compare)}`);
+			log(`  Current:  ${pc.cyan(args.compareTo)}`);
+
+			log(generateComparisonReport(baseline, current.detailed));
+		} catch (error) {
+			console.error(`Error loading files for comparison: ${error.message}`);
+			process.exit(1);
+		}
+
+		log(pc.green('Done!'));
+		log('');
+		process.exit(0);
+	}
+
+	log('');
+	log(header('Stylelint Performance Benchmark', WIDTH.narrow));
+	log('');
+
+	// Validate sizes.
+	for (const size of args.sizes) {
+		if (!WORKSPACE_SIZES[size]) {
+			console.error(`Unknown workspace size: ${size}`);
+			console.error(`Available sizes: ${Object.keys(WORKSPACE_SIZES).join(', ')}`);
+			process.exit(1);
+		}
+	}
+
+	// Create workspaces directory.
+	await mkdir(WORKSPACES_DIR, { recursive: true });
+
+	const workspaces = {};
+
+	// Generate workspaces.
+	if (!args.benchmarkOnly) {
+		log(sectionHeader('Generating Workspaces'));
+
+		for (const size of args.sizes) {
+			const workspacePath = join(WORKSPACES_DIR, size);
+
+			workspaces[size] = await generateWorkspace(workspacePath, size, { logger: log });
+		}
+
+		log('');
+	} else {
+		// Load existing workspace info.
+		log(sectionHeader('Using Existing Workspaces'));
+
+		for (const size of args.sizes) {
+			const workspacePath = join(WORKSPACES_DIR, size);
+			const configPath = join(workspacePath, 'stylelint.config.mjs');
+
+			workspaces[size] = {
+				path: workspacePath,
+				size,
+				sizeConfig: WORKSPACE_SIZES[size],
+				configPath,
+			};
+			log(`  ${pc.green('✓')} ${WORKSPACE_SIZES[size].name} workspace ready`);
+		}
+
+		log('');
+	}
+
+	// Run benchmarks.
+	if (!args.generateOnly) {
+		log(sectionHeader('Running Benchmarks'));
+		log(`  Modes: ${pc.cyan(args.modes.map((m) => m.toUpperCase()).join(', '))}`);
+		log(`  Warmup: ${args.warmup}, Iterations: ${args.iterations}`);
+		log('');
+
+		const allResults = {};
+
+		for (const mode of args.modes) {
+			log(`  ${pc.cyan(mode.toUpperCase())} mode...`);
+
+			const results = await runAllBenchmarks(workspaces, {
+				iterations: args.iterations,
+				warmup: args.warmup,
+				mode,
+				logger: (msg) => log(`    ${msg}`),
+			});
+
+			allResults[mode] = results;
+		}
+
+		// Output results.
+		if (args.output === 'json') {
+			const jsonReport = generateJsonReport(allResults);
+
+			console.log(JSON.stringify(jsonReport, null, 2));
+		} else {
+			console.log(generateReport(allResults));
+		}
+
+		// Save results if requested.
+		if (args.save) {
+			const jsonReport = generateJsonReport(allResults);
+
+			await writeFile(args.save, `${JSON.stringify(jsonReport, null, 2)}\n`);
+			log(`${pc.green('✓')} Results saved to: ${pc.cyan(args.save)}`);
+		}
+
+		// Compare against baseline if requested.
+		if (args.compare) {
+			try {
+				const baselineData = await readFile(args.compare, 'utf-8');
+				const baseline = JSON.parse(baselineData);
+
+				log(generateComparisonReport(baseline, allResults));
+			} catch (error) {
+				console.error(`Error loading baseline file: ${error.message}`);
+			}
+		}
+	}
+
+	log(pc.green('Done!'));
+	log('');
+}
+
+main().catch((error) => {
+	console.error('Benchmark failed:', error);
+	process.exit(1);
+});


### PR DESCRIPTION
I was working on seeing if there were some ways to optimize Stylelint's performance, but needed a way to reliably get the performance of the tool on some kind of mock workspaces, and in a way that was easy for me to interpret and compare without much hassle. To that end, I've written a benchmarking tool, which I'm introducing in this PR.

This tool generates, deterministically, several different mock workspaces of different sizes and config complexities. It runs Stylelint, both with the API and the CLI, against these workspaces, and gathers performance data. It can record this data for later comparison, so that you  get some baseline data on your machine, then compare the baseline performance against performance after your changes.

Since this tool is really likely only going to be used by contributors really getting into the weeds of optimization problems, I've relegated [some simple docs](https://github.com/stylelint/stylelint/blob/f504aeae8bb7fc0bf0c5a4490a7ea1b94d68f8fa/perf/README.md) for it to the perf/ directory, rather than cluttering our focused and concise contributor docs in CONTRIBUTING.md.

A small screenshot of the comparison output that I was using to validate the changes in #9021:

<img width="843" height="771" alt="bilde" src="https://github.com/user-attachments/assets/39395ca6-b66e-49ad-8003-db06fd0763c9" />
