### PR TITLE
Fix performance of config augmentation and module imports

### DIFF
--- a/.changeset/fast-config-resolution.md
+++ b/.changeset/fast-config-resolution.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: performance of config augmentation and module imports

--- a/lib/__tests__/getConfigForFile.test.mjs
+++ b/lib/__tests__/getConfigForFile.test.mjs
@@ -63,3 +63,87 @@ describe('path normalization for caches', () => {
 		expect(stylelint._specifiedConfigCache.get(stylelint._options.config)?.size).toBe(2);
 	});
 });
+
+describe('augmented config cache', () => {
+	test('caches augmented config for same config file and target file', async () => {
+		const stylelint = createStylelint();
+		const filepath = path.join(dirname, 'fixtures/getConfigForFile/a/b/foo.css');
+
+		const first = await getConfigForFile({ stylelint, searchPath: filepath, filePath: filepath });
+		const second = await getConfigForFile({ stylelint, searchPath: filepath, filePath: filepath });
+
+		// Should return the exact same cached object.
+		expect(second).toBe(first);
+		expect(stylelint._augmentedConfigCache.size).toBe(1);
+	});
+
+	test('creates separate cache entries for different target files', async () => {
+		const stylelint = createStylelint();
+		const filepath1 = path.join(dirname, 'fixtures/getConfigForFile/a/b/foo.css');
+		const filepath2 = path.join(dirname, 'fixtures/getConfigForFile/a/b/bar.css');
+
+		const first = await getConfigForFile({
+			stylelint,
+			searchPath: filepath1,
+			filePath: filepath1,
+		});
+		const second = await getConfigForFile({
+			stylelint,
+			searchPath: filepath2,
+			filePath: filepath2,
+		});
+
+		// Different target files should have separate cache entries.
+		expect(second).not.toBe(first);
+		expect(stylelint._augmentedConfigCache.size).toBe(2);
+	});
+
+	test('augmented config cache normalizes paths on Windows', async () => {
+		const stylelint = createStylelint();
+		const driveUpper = 'C:\\project\\foo.css';
+		const driveLower = 'c:\\project\\foo.css';
+
+		await withMockedPlatform('win32', async () => {
+			const filepath = path.join(dirname, 'fixtures/getConfigForFile/a/b/foo.css');
+
+			const first = await getConfigForFile({
+				stylelint,
+				searchPath: filepath,
+				filePath: driveUpper,
+			});
+
+			const second = await getConfigForFile({
+				stylelint,
+				searchPath: filepath,
+				filePath: driveLower,
+			});
+
+			expect(second).toBe(first);
+			expect(stylelint._augmentedConfigCache.size).toBe(1);
+		});
+	});
+
+	test('does not cache null results', async () => {
+		const stylelint = createStylelint();
+
+		const result = await getConfigForFile({
+			stylelint,
+			searchPath: '/nonexistent/path',
+			failIfNoConfig: false,
+		});
+
+		expect(result).toBeNull();
+		expect(stylelint._augmentedConfigCache.size).toBe(0);
+	});
+
+	test('cache key handles empty filePath', async () => {
+		const stylelint = createStylelint();
+		const searchPath = path.join(dirname, 'fixtures/getConfigForFile/a/b/foo.css');
+
+		const first = await getConfigForFile({ stylelint, searchPath });
+		const second = await getConfigForFile({ stylelint, searchPath });
+
+		expect(second).toBe(first);
+		expect(stylelint._augmentedConfigCache.size).toBe(1);
+	});
+});

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -6,7 +6,7 @@ import normalizePath from 'normalize-path';
 
 import { isFunction, isString } from './utils/validateTypes.mjs';
 import { ConfigurationError } from './utils/errors.mjs';
-import dynamicImport from './utils/dynamicImport.mjs';
+import cachedImport from './utils/cachedImport.mjs';
 import getModulePath from './utils/getModulePath.mjs';
 import normalizeAllRuleSettings from './normalizeAllRuleSettings.mjs';
 
@@ -340,7 +340,7 @@ async function addPluginFunctions(config) {
 		let pluginImport;
 
 		if (typeof pluginLookup === 'string') {
-			pluginImport = await dynamicImport(pluginLookup);
+			pluginImport = await cachedImport(pluginLookup);
 		} else {
 			pluginImport = pluginLookup;
 		}
@@ -384,7 +384,7 @@ async function addProcessorFunctions(config) {
 	}
 
 	const processorPromises = config.processors.map(async (processorLookup) => {
-		let processor = await dynamicImport(processorLookup);
+		let processor = await cachedImport(processorLookup);
 
 		processor = processor.default ?? processor;
 

--- a/lib/createStylelint.mjs
+++ b/lib/createStylelint.mjs
@@ -24,6 +24,7 @@ export default function createStylelint(options = {}) {
 		}),
 
 		_specifiedConfigCache: new Map(),
+		_augmentedConfigCache: new Map(),
 		_postcssResultCache: new Map(),
 		_fileCache: new FileCache(options.cacheLocation, options.cacheStrategy, cwd),
 	};

--- a/lib/getConfigForFile.mjs
+++ b/lib/getConfigForFile.mjs
@@ -13,6 +13,17 @@ const STOP_DIR = IS_TEST ? process.cwd() : undefined;
 /** @import {CosmiconfigResult, InternalApi} from 'stylelint' */
 
 /**
+ * Creates a cache key for the augmented config cache.
+ *
+ * @param {string} configPath Path to the config file
+ * @param {string} filePath Path to the target file
+ * @returns {string}
+ */
+function getAugmentedConfigCacheKey(configPath, filePath) {
+	return `${configPath || 'no-config'}::${filePath || 'no-file'}`;
+}
+
+/**
  * Get a configuration by the following way:
  *
  * 1. If the `config` option is given, it's returned.
@@ -59,25 +70,50 @@ export default async function getConfigForFile({
 	}
 
 	const configExplorer = cosmiconfig('stylelint', {
-		transform: (cosmiconfigResult) => augmentConfigFull(stylelint, filePath, cosmiconfigResult),
 		stopDir: STOP_DIR,
 		searchStrategy: 'global', // for backward compatibility
 	});
 
 	const configFile = stylelint._options.configFile;
-	let config = configFile
+
+	// First, discover the raw config, cached by cosmiconfig.
+	let rawConfig = configFile
 		? await configExplorer.load(configFile)
 		: await configExplorer.search(searchPath);
 
-	if (!config) {
-		config = await configExplorer.search(cwd);
+	if (!rawConfig) {
+		rawConfig = await configExplorer.search(cwd);
 	}
 
-	if (!config && failIfNoConfig) {
+	if (!rawConfig && failIfNoConfig) {
 		throw new ConfigurationError(
 			`No configuration provided${searchPath ? ` for ${searchPath}` : ''}`,
 		);
 	}
 
-	return config;
+	if (!rawConfig) {
+		return rawConfig;
+	}
+
+	// Check the augmented config cache.
+	const cacheKey = getAugmentedConfigCacheKey(
+		rawConfig.filepath,
+		filePath ? normalizeFilePath(filePath) : '',
+	);
+
+	const cachedAugmented = stylelint._augmentedConfigCache.get(cacheKey);
+
+	if (cachedAugmented) {
+		return cachedAugmented;
+	}
+
+	// Perform full augmentation.
+	const augmentedResult = await augmentConfigFull(stylelint, filePath, rawConfig);
+
+	// Cache the augmented result.
+	if (augmentedResult) {
+		stylelint._augmentedConfigCache.set(cacheKey, augmentedResult);
+	}
+
+	return augmentedResult;
 }

--- a/lib/utils/__tests__/cachedImport.test.mjs
+++ b/lib/utils/__tests__/cachedImport.test.mjs
@@ -1,0 +1,75 @@
+import path from 'node:path';
+
+import { jest } from '@jest/globals';
+
+import cachedImport, { TTL_MS, clearModuleCache } from '../cachedImport.mjs';
+
+const dirname = import.meta.dirname;
+const fixtureModuleA = path.join(dirname, 'fixtures/module-a.mjs');
+const fixtureModuleB = path.join(dirname, 'fixtures/module-b.mjs');
+
+beforeEach(() => {
+	clearModuleCache();
+});
+
+describe('cachedImport', () => {
+	it('returns the imported module', async () => {
+		const result = await cachedImport(fixtureModuleA);
+
+		expect(result.default).toEqual({ name: 'fixture-module-a' });
+	});
+
+	it('returns cached promise on subsequent calls', async () => {
+		const first = cachedImport(fixtureModuleA);
+		const second = cachedImport(fixtureModuleA);
+
+		// Should be the exact same promise object.
+		expect(first).toBe(second);
+
+		const [result1, result2] = await Promise.all([first, second]);
+
+		expect(result1).toBe(result2);
+	});
+
+	it('caches different modules separately', async () => {
+		const resultA = await cachedImport(fixtureModuleA);
+		const resultB = await cachedImport(fixtureModuleB);
+
+		expect(resultA.default).toEqual({ name: 'fixture-module-a' });
+		expect(resultB.default).toEqual({ name: 'fixture-module-b' });
+	});
+
+	it('returns same promise for concurrent calls', async () => {
+		const promise1 = cachedImport(fixtureModuleA);
+		const promise2 = cachedImport(fixtureModuleA);
+
+		// Should be the exact same promise object.
+		expect(promise1).toBe(promise2);
+
+		const [result1, result2] = await Promise.all([promise1, promise2]);
+
+		expect(result1).toBe(result2);
+	});
+});
+
+describe('cachedImport TTL expiration', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('returns cached value before TTL expires', async () => {
+		const first = await cachedImport(fixtureModuleA);
+
+		// Advance time to just under the TTL.
+		jest.advanceTimersByTime(TTL_MS - 60 * 1000);
+
+		const second = await cachedImport(fixtureModuleA);
+
+		// Should return the same cached value.
+		expect(second).toBe(first);
+	});
+});

--- a/lib/utils/__tests__/fixtures/module-a.mjs
+++ b/lib/utils/__tests__/fixtures/module-a.mjs
@@ -1,0 +1,1 @@
+export default { name: 'fixture-module-a' };

--- a/lib/utils/__tests__/fixtures/module-b.mjs
+++ b/lib/utils/__tests__/fixtures/module-b.mjs
@@ -1,0 +1,1 @@
+export default { name: 'fixture-module-b' };

--- a/lib/utils/cachedImport.mjs
+++ b/lib/utils/cachedImport.mjs
@@ -1,0 +1,68 @@
+import dynamicImport from './dynamicImport.mjs';
+
+/** Maximum number of modules to cache to prevent unbounded memory growth. */
+const MAX_CACHE_SIZE = 1000;
+
+/** Time-to-live in milliseconds. Exported for tests. */
+export const TTL_MS = 30 * 60 * 1000;
+
+/**
+ * @typedef {Object} CacheEntry
+ * @property {Promise<any>} promise
+ * @property {number} timestamp
+ */
+
+/** @type {Map<string, CacheEntry>} */
+const moduleCache = new Map();
+
+/**
+ * Cached dynamic import - stores the Promise to avoid repeated resolution.
+ *
+ * While Node.js caches ES modules, we can avoid repeated async overhead by
+ * caching the Promise itself.
+ *
+ * @param {string} modulePath
+ * @returns {Promise<any>}
+ */
+export default function cachedImport(modulePath) {
+	const cached = moduleCache.get(modulePath);
+
+	if (cached) {
+		// Check if entry has expired.
+		if (Date.now() - cached.timestamp > TTL_MS) {
+			moduleCache.delete(modulePath);
+		} else {
+			return cached.promise;
+		}
+	}
+
+	const importPromise = dynamicImport(modulePath).catch((error) => {
+		// Remove failed imports from cache so they can be retried.
+		moduleCache.delete(modulePath);
+		throw error;
+	});
+
+	// Evict oldest entry if cache is full.
+	if (moduleCache.size >= MAX_CACHE_SIZE) {
+		const oldestKey = moduleCache.keys().next().value;
+
+		if (oldestKey) {
+			moduleCache.delete(oldestKey);
+		}
+	}
+
+	moduleCache.set(modulePath, {
+		promise: importPromise,
+		timestamp: Date.now(),
+	});
+
+	return importPromise;
+}
+
+/**
+ * Clear the module cache. Useful for testing or when modules need to be
+ * reloaded.
+ */
+export function clearModuleCache() {
+	moduleCache.clear();
+}

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1486,6 +1486,7 @@ declare namespace stylelint {
 		_options: LinterOptions & { cwd: string };
 		_extendExplorer: ReturnType<typeof cosmiconfig>;
 		_specifiedConfigCache: Map<Config, Map<string, CosmiconfigResult>>;
+		_augmentedConfigCache: Map<string, CosmiconfigResult>;
 		_postcssResultCache: Map<string, PostCSS.Result>;
 		_fileCache: FileCache;
 	};


### PR DESCRIPTION
This PR improves Stylelint's performance when linting many files by adding caching layers for config augmentation and module imports.

A new module cache wraps dynamic imports with a cache that stores the Promise itself, avoiding repeated async overhead. The cache includes a TTL, by default 30 minutes, and size limit, by default 1000 entries, to prevent unbounded memory growth in long-running processes like in the language server in vscode-stylelint.

Additionally, previously, config augmentation, resolving plugins, processors, extends, etc., was performed for every file even when using the same config. Now, augmented configs are cached by config path and target file path, so files sharing the same config only pay the augmentation cost once.

Using the benchmark tool from #9020:

| Mode | Workspace size | Before | After | Change | Status |
|-|-|-|-|-|-|
| **API** | Small | 61.82ms | 40.57ms | -34.4% | ✓ Faster |
|| Medium | 411.22ms | 302.43ms | -26.5% | ✓ Faster |
|| Large | 3.70s | 2.13s | -42.5% | ✓ Faster |
|| X-Large | 16.30s | 7.71s | -52.7% | ✓ Faster |
| **CLI** | Small | 456.81ms | 471.80ms | +3.3% | ≈ Same |
|| Medium | 1.03s | 829.15ms | -19.4% | ✓ Faster |
|| Large | 4.52s | 2.92s | -35.4% | ✓ Faster |
|| X-Large | 20.64s | 9.36s | -54.6% | ✓ Faster |

The improvement scales with the number of files since the caching benefits compound. The small CLI benchmark shows no improvement because startup overhead is the dominant factor at that scale.