### PR TITLE
Change `ubuntu-latest` to `ubuntu-slim` runner for cost efficiency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           YARN_ENABLE_HARDENED_MODE: 0 # https://yarnpkg.com/features/security#hardened-mode
 
   spellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/comment-on-old-issues.yml
+++ b/.github/workflows/comment-on-old-issues.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.repository == 'stylelint/stylelint'
     permissions:
       issues: write

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -14,7 +14,7 @@ jobs:
   pkg-pr-new:
     if: github.repository == 'stylelint/stylelint'
     name: Publish to pkg.pr.new
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-pkg.pr.new-comment.yml
+++ b/.github/workflows/update-pkg.pr.new-comment.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     if: github.repository == 'stylelint/stylelint'
     name: Update comment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR switches to `ubuntu-slim` GitHub Actions runner for short-running jobs, except for testing.

Ref https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners

For details, see also https://github.com/stylelint/.github/pull/89
