### PR TITLE
Fix `declaration-property-value-no-unknown` false positives for `calc()` with mixed operations

### DIFF
--- a/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs
@@ -255,6 +255,11 @@ testRule({
 			description: 'calc with var() multiplication is skipped',
 		},
 		{
+			code: 'a { top: calc(0.3 * 100vh + 15px); }',
+			description:
+				'calc with fractional number multiplication and dimension addition (issue #9066)',
+		},
+		{
 			code: 'a { z-index: calc(2); }',
 			description: 'calc resulting in number for property that accepts number',
 		},

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -480,9 +480,9 @@ function hasInvalidTypeMix(value) {
 		// Get the operands and operators at the top level of this function
 		const children = funcNode.value;
 
-		/** @type {Array<'number' | 'dimension' | 'percentage' | 'other'>} */
+		/** @type {Array<{type: 'number' | 'dimension' | 'percentage' | 'other'}>} */
 		const operands = [];
-		/** @type {Array<string>} */
+		/** @type {Array<{op: string, precedingOperandIndex: number}>} */
 		const operators = [];
 
 		for (const child of children) {
@@ -490,16 +490,17 @@ function hasInvalidTypeMix(value) {
 				const token = child.value;
 
 				if (isTokenNumber(token)) {
-					operands.push('number');
+					operands.push({ type: 'number' });
 				} else if (isTokenDimension(token)) {
-					operands.push('dimension');
+					operands.push({ type: 'dimension' });
 				} else if (isTokenPercentage(token)) {
-					operands.push('percentage');
+					operands.push({ type: 'percentage' });
 				} else if (isTokenDelim(token)) {
 					const op = token[4].value;
 
-					if (op === '+' || op === '-') {
-						operators.push(op);
+					if (op === '+' || op === '-' || op === '*' || op === '/') {
+						// Record which operand precedes this operator
+						operators.push({ op, precedingOperandIndex: operands.length - 1 });
 					}
 				}
 			} else if (isFunctionNode(child)) {
@@ -509,20 +510,47 @@ function hasInvalidTypeMix(value) {
 				}
 
 				// Nested function results contribute to operands
-				operands.push('other');
+				operands.push({ type: 'other' });
 			}
 		}
 
-		// Check for invalid patterns: number +/- dimension or dimension +/- number
-		// This is a simplified check - we look for the pattern where we have both
-		// a pure number and a dimension/percentage, connected by + or -
-		if (operators.length > 0) {
-			const hasNumber = operands.includes('number');
-			const hasDimensionOrPercentage =
-				operands.includes('dimension') || operands.includes('percentage');
+		// Check each operator to see if it's an invalid + or - between number and dimension/percentage
+		for (let i = 0; i < operators.length; i++) {
+			const operator = operators[i];
 
-			if (hasNumber && hasDimensionOrPercentage) {
-				// Found a mix of numbers and dimensions/percentages with +/- operators
+			if (!operator) continue;
+
+			const { op, precedingOperandIndex } = operator;
+
+			// Only check addition and subtraction (multiplication and division with numbers are valid)
+			if (op !== '+' && op !== '-') {
+				continue;
+			}
+
+			const leftOperand = operands[precedingOperandIndex];
+			const rightOperand = operands[precedingOperandIndex + 1];
+
+			if (!leftOperand || !rightOperand) {
+				continue;
+			}
+
+			const leftType = leftOperand.type;
+			const rightType = rightOperand.type;
+
+			// Invalid patterns:
+			// - number +/- dimension
+			// - dimension +/- number
+			// - number +/- percentage
+			// - percentage +/- number
+			const isLeftNumber = leftType === 'number';
+			const isRightNumber = rightType === 'number';
+			const isLeftDimensionOrPercentage = leftType === 'dimension' || leftType === 'percentage';
+			const isRightDimensionOrPercentage = rightType === 'dimension' || rightType === 'percentage';
+
+			if (
+				(isLeftNumber && isRightDimensionOrPercentage) ||
+				(isLeftDimensionOrPercentage && isRightNumber)
+			) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## Which issue, if any, is this issue related to?

Fixes #9066

## Is there anything in the PR that needs further explanation?

This PR fixes a false positive in the `declaration-property-value-no-unknown` rule where valid calc expressions like `calc(0.3 * 100vh + 15px)` were incorrectly flagged as invalid.

### Root Cause
The `hasInvalidTypeMix()` function was using a simplified approach that:
- Only tracked `+` and `-` operators
- Checked if ANY number and ANY dimension/percentage existed in the expression
- Didn't verify which operands were actually connected by which operators

This caused `calc(0.3 * 100vh + 15px)` to be flagged because it found a number (`0.3`), dimensions (`100vh`, `15px`), and a `+` operator, assuming they were connected incorrectly.

### Solution
Updated `hasInvalidTypeMix()` to:
1. Track ALL operators (`+`, `-`, `*`, `/`) along with their positions
2. Record which operand precedes each operator
3. Only validate type compatibility for addition and subtraction operators (multiplication and division with numbers are valid)
4. Check that adjacent operands connected by `+` or `-` have compatible types

This correctly identifies:
- ✅ Valid: `0.3 * 100vh` (number × dimension = dimension)
- ✅ Valid: `dimension + dimension` 
- ❌ Invalid: `2 + 100px` (number + dimension)
- ❌ Invalid: `100px - 2` (dimension - number)

### Testing

```
import stylelint from './lib/index.mjs';

const code = `.foo-5 {
  top: calc(0.3 * 100vh + 15px)
}`;

const config = {
    rules: {
        'declaration-property-value-no-unknown': true,
    },
};

const result = await stylelint.lint({ code, config });

console.log('Warnings:', result.results[0].warnings);
console.log('Total warnings:', result.results[0].warnings.length);
```


- All existing tests pass
- Added specific test case for issue #9066