### PR TITLE
Document extending syntax in applicable `*-no-unknown` rules

### DIFF
--- a/lib/rules/at-rule-descriptor-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-no-unknown/README.md
@@ -13,13 +13,11 @@ Disallow unknown descriptors for at-rules.
 
 This rule considers descriptors defined in the CSS Specifications, up to and including Editor's Drafts, to be known.
 
-You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what descriptors are known for an at-rule.
+You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what descriptors are known for an at-rule, and use the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) configuration property to extend it.
 
 This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
 This rule checks descriptors within at-rules. To check properties, you can use the [`property-no-unknown`](../property-no-unknown/README.md) rule.
-
-For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) section.
 
 Prior art:
 

--- a/lib/rules/at-rule-descriptor-value-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-value-no-unknown/README.md
@@ -13,7 +13,7 @@ Disallow unknown values for descriptors within at-rules.
 
 This rule considers descriptors and values defined in the CSS Specifications, up to and including Editor's Drafts, to be known.
 
-You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what values are valid for a descriptor of an at-rule.
+You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what values are known for a descriptor of an at-rule, and use the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) configuration property to extend it.
 
 This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
@@ -28,8 +28,6 @@ This rule overlaps with:
 - [`unit-no-unknown`](../unit-no-unknown/README.md)
 
 You can either turn off the rules or configure them to ignore the overlaps.
-
-For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) section.
 
 Prior art:
 

--- a/lib/rules/at-rule-prelude-no-invalid/README.md
+++ b/lib/rules/at-rule-prelude-no-invalid/README.md
@@ -11,7 +11,7 @@ Disallow invalid preludes for at-rules.
 
 This rule considers preludes for at-rules defined within the CSS specifications, up to and including Editor's Drafts, to be valid.
 
-You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what preludes are valid for an at-rule.
+You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what preludes are valid for an at-rule, and use the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) configuration property to extend it.
 
 This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
@@ -22,8 +22,6 @@ This rule overlaps with:
 - [`unit-no-unknown`](../unit-no-unknown/README.md)
 
 You can either turn off the rules or configure them to ignore the overlaps.
-
-For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) section.
 
 Prior art:
 

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -11,7 +11,7 @@ a { top: unknown; }
 
 This rule considers values for properties defined within the CSS specifications to be known. You can use the `propertiesSyntax` and `typesSyntax` secondary options to extend the syntax.
 
-You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what value syntax is known for a property.
+You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what value syntax is known for a property, and use the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) configuration property to extend it.
 
 This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/9037

> Is there anything in the PR that needs further explanation?

Moves the how-to-extend-syntax bit further up the extended description and co-locates it with the sentence about how to check what's known/valid.
