### PR TITLE
Document using `languageOptions` over secondary in `declaration-property-value-no-unknown`

### DIFF
--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -9,7 +9,7 @@ a { top: unknown; }
  * property and value pairs like these */
 ```
 
-This rule considers values for properties defined within the CSS specifications to be known. You can use the `propertiesSyntax` and `typesSyntax` secondary options to extend the syntax.
+This rule considers values for properties defined in the CSS Specifications, up to and including Editor's Drafts, to be known.
 
 You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what value syntax is known for a property.
 
@@ -121,6 +121,9 @@ a { width: --unknown-value; }
 
 ### `propertiesSyntax`
 
+> [!WARNING]
+> We will remove this option in the next major release. Use the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) configuration property instead.
+
 ```json
 { "propertiesSyntax": { "property": "syntax" } }
 ```
@@ -151,6 +154,9 @@ a { size: 10px }
 ```
 
 ### `typesSyntax`
+
+> [!WARNING]
+> We will remove this option in the next major release. Use the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) configuration property instead.
 
 ```json
 { "typesSyntax": { "type": "syntax" } }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/9063
Ref https://github.com/stylelint/stylelint/issues/9037

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
