### PR TITLE
Remove redundant `@types/file-entry-cache` type dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
         "@stylelint/remark-preset": "^5.1.1",
         "@types/css-tree": "^2.3.11",
         "@types/debug": "^4.1.12",
-        "@types/file-entry-cache": "^5.0.4",
         "@types/global-modules": "^2.0.2",
         "@types/globjoin": "^0.1.2",
         "@types/imurmurhash": "^0.1.4",
@@ -2972,15 +2971,6 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
-      }
-    },
-    "node_modules/@types/file-entry-cache": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/file-entry-cache/-/file-entry-cache-5.0.4.tgz",
-      "integrity": "sha512-Fa2gRWMSgbVEJ6GeDkFfBEDK/wpFBHkfeRt7oaeOjuPMdPr8KtA3y+onRuZNxgPOwyABD1chCzmE7pz10ouNog==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/global-modules": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "@stylelint/remark-preset": "^5.1.1",
     "@types/css-tree": "^2.3.11",
     "@types/debug": "^4.1.12",
-    "@types/file-entry-cache": "^5.0.4",
     "@types/global-modules": "^2.0.2",
     "@types/globjoin": "^0.1.2",
     "@types/imurmurhash": "^0.1.4",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/pull/9107

> Is there anything in the PR that needs further explanation?

Has its own types: https://www.npmjs.com/package/@types/file-entry-cache