### PR TITLE
Document dashed-idents convention in writing rules guide

### DIFF
--- a/docs/contributor-guide/rules.md
+++ b/docs/contributor-guide/rules.md
@@ -39,6 +39,7 @@ You should use:
 - `{}` for empty rules, rather than `{ }`
 - trailing semicolons within declaration blocks
 - _foo_, _bar_, _baz_ and _qux_ for names, e.g. `.foo`, `#bar`, `--baz` and `/* qux */`
+- dashed-idents for custom things especially in `ignore*` options, e.g. `ignoreUnits: ["--foo"]`
 
 By default, you should use the:
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Ref https://github.com/stylelint/stylelint/pull/8976#discussion_r2854242597

We've been rolling out dashed-idents in our rule tests and READMEs but haven't documented the convention.

From [specs](https://drafts.csswg.org/css-values/#example-32974307):

> CSS authoring tools, such as preprocessors that turn custom syntax into standard CSS, should use `<dashed-ident>` as well, to avoid clashing with future CSS design.
>
> For example, if a CSS preprocessor added a new "custom" at-rule, it shouldn’t spell it `@custom`, as this would clash with a future official `@custom` rule added by CSS. Instead, it should use `@--custom`, which is guaranteed to never clash with anything defined by CSS.
> 
> Even better, it should use `@--library1-custom`, so that if Library2 adds their own "custom" at-rule (spelled `@--library2-custom`), there’s no possibility of clash. Ideally this prefix should be customizable, if allowed by the tooling, so authors can manually avoid clashes on their own.
