### PR TITLE
Replace `globby` and `fast-glob` with `tinyglobby`

### DIFF
--- a/lib/printConfig.mjs
+++ b/lib/printConfig.mjs
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-import { isDynamicPattern } from 'globby';
+import { isDynamicPattern } from 'tinyglobby';
 
 import resolveConfig from './resolveConfig.mjs';
 import toPath from './utils/toPath.mjs';

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -4,8 +4,7 @@ import process from 'node:process';
 import createDebug from 'debug';
 const debug = createDebug('stylelint:standalone');
 
-import fastGlob from 'fast-glob';
-import { globby } from 'globby';
+import { escapePath, glob } from 'tinyglobby';
 import normalizePath from 'normalize-path';
 import writeFileAtomic from 'write-file-atomic';
 
@@ -188,7 +187,7 @@ export default async function standalone({
 
 			if (await pathExists(absolutePath)) {
 				// This path points to a file. Return an escaped path to avoid globbing
-				return fastGlob.escapePath(normalizePath(entry));
+				return escapePath(normalizePath(entry));
 			}
 
 			return entry;
@@ -196,7 +195,7 @@ export default async function standalone({
 	);
 
 	if (!disableDefaultIgnores) {
-		fileList = fileList.concat(ALWAYS_IGNORED_GLOBS.map((glob) => `!${glob}`));
+		fileList = fileList.concat(ALWAYS_IGNORED_GLOBS.map((pattern) => `!${pattern}`));
 	}
 
 	const useCache = await resolveOptionValue({ stylelint, name: 'cache', default: false });
@@ -213,7 +212,7 @@ export default async function standalone({
 
 	const globCWD = toPath(effectiveGlobbyOptions.cwd);
 
-	let filePaths = await globby(fileList, effectiveGlobbyOptions);
+	let filePaths = await glob(fileList, effectiveGlobbyOptions);
 
 	// Record the length of filePaths before ignore operation
 	// Prevent prompting "No files matching the pattern 'xx' were found." when .stylelintignore ignore all input files

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,11 +31,9 @@
         "css-functions-list": "^3.3.3",
         "css-tree": "^3.1.0",
         "debug": "^4.4.3",
-        "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
         "file-entry-cache": "^11.1.2",
         "global-modules": "^2.0.0",
-        "globby": "^16.1.0",
         "globjoin": "^0.1.4",
         "html-tags": "^5.1.0",
         "ignore": "^7.0.5",
@@ -55,6 +53,7 @@
         "supports-hyperlinks": "^4.4.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",
+        "tinyglobby": "^0.2.15",
         "write-file-atomic": "^7.0.0"
       },
       "bin": {
@@ -73,6 +72,7 @@
         "@types/imurmurhash": "^0.1.4",
         "@types/micromatch": "^4.0.10",
         "@types/normalize-path": "^3.0.2",
+        "@types/picomatch": "^4.0.2",
         "@types/postcss-less": "^4.0.7",
         "@types/postcss-safe-parser": "^5.0.4",
         "@types/svg-tags": "^1.0.2",
@@ -156,6 +156,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -651,6 +652,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1018,6 +1020,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1056,6 +1059,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2551,6 +2555,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -2563,6 +2568,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -2571,6 +2577,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -2716,18 +2723,6 @@
       "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -3071,6 +3066,7 @@
       "integrity": "sha512-9pLGGwdzOUBDYi0GNjM97FIA+f92fqSke6joWeBjWXllfNxZBs7qeMF7tvtOIsbY45xkWkxrdwUfUf3MnQa9gA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3080,6 +3076,13 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-path/-/normalize-path-3.0.2.tgz",
       "integrity": "sha512-DO++toKYPaFn0Z8hQ7Tx+3iT9t77IJo/nDiqTXilgEP+kPNIYdpS9kh3fXuc53ugqwp9pxC1PVjCpV1tQDyqMA==",
       "dev": true
+    },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/postcss-less": {
       "version": "4.0.7",
@@ -3524,6 +3527,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4076,6 +4080,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5199,6 +5204,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5457,6 +5463,7 @@
       "integrity": "sha512-IIRg0IZ5yuERfzOZrKuNScxk9yeuKo0M4Urx7RZcthK5HE/8gJUY518bdi7picLRBJVctjOW3yVx0zyBp4Cq+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.0.0"
       },
@@ -6063,6 +6070,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -6078,6 +6086,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -6125,6 +6134,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -6586,38 +6596,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/globby": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.0.tgz",
-      "integrity": "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.5",
-        "is-path-inside": "^4.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globjoin": {
@@ -7172,6 +7150,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7241,6 +7220,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -7306,18 +7286,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -7674,6 +7642,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -10388,6 +10357,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -11825,6 +11795,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11971,6 +11942,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11999,6 +11971,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12116,6 +12089,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12882,6 +12856,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -12898,6 +12873,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13941,7 +13917,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -13958,7 +13933,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -13976,8 +13950,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14240,6 +14214,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14273,18 +14248,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/unified": {
       "version": "11.0.4",

--- a/package.json
+++ b/package.json
@@ -137,11 +137,9 @@
     "css-functions-list": "^3.3.3",
     "css-tree": "^3.1.0",
     "debug": "^4.4.3",
-    "fast-glob": "^3.3.3",
     "fastest-levenshtein": "^1.0.16",
     "file-entry-cache": "^11.1.2",
     "global-modules": "^2.0.0",
-    "globby": "^16.1.0",
     "globjoin": "^0.1.4",
     "html-tags": "^5.1.0",
     "ignore": "^7.0.5",
@@ -161,6 +159,7 @@
     "supports-hyperlinks": "^4.4.0",
     "svg-tags": "^1.0.0",
     "table": "^6.9.0",
+    "tinyglobby": "^0.2.15",
     "write-file-atomic": "^7.0.0"
   },
   "devDependencies": {
@@ -176,6 +175,7 @@
     "@types/imurmurhash": "^0.1.4",
     "@types/micromatch": "^4.0.10",
     "@types/normalize-path": "^3.0.2",
+    "@types/picomatch": "^4.0.2",
     "@types/postcss-less": "^4.0.7",
     "@types/postcss-safe-parser": "^5.0.4",
     "@types/svg-tags": "^1.0.2",

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1,5 +1,5 @@
 import type * as PostCSS from 'postcss';
-import type { Options as GlobbyOptions } from 'globby';
+import type { GlobOptions as GlobbyOptions } from 'tinyglobby';
 import type { cosmiconfig, TransformSync as CosmiconfigTransformSync } from 'cosmiconfig';
 import type { Lexer as CSSTreeLexer } from 'css-tree';
 


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Addresses #8051

> Is there anything in the PR that needs further explanation?

This replaces both `globby` (23 transitive deps) and `fast-glob` with `tinyglobby` (2 deps), reducing the dependency tree while maintaining identical runtime behavior.

## Changes

- `lib/standalone.mjs`: `globby()` → `glob()`, `fastGlob.escapePath()` → `escapePath()` from tinyglobby
- `lib/printConfig.mjs`: `isDynamicPattern` import switched to tinyglobby (same API)
- `types/stylelint/index.d.ts`: Type import updated from `globby.Options` to `tinyglobby.GlobOptions` (aliased as `GlobbyOptions` to keep the public type name stable)
- `package.json`: Removed `globby` and `fast-glob`, added `tinyglobby`. Added `@types/picomatch` dev dep required by tinyglobby's `fdir` types with `skipLibCheck: false`.
- Renamed `glob` → `pattern` in a local arrow function parameter to avoid `no-shadow` with the imported `glob`.

## Notes

- The `globbyOptions` option name and public API surface are preserved (no breaking change).
- `tinyglobby` supports a subset of `globby`'s options, but the options actually used by Stylelint internally (`cwd`, `absolute`) and commonly passed by users (`dot`, `ignore`, `onlyFiles`, `expandDirectories`) are all supported.
- `tinyglobby` now handles `cwd` as both `string` and `URL`, which the existing tests confirm.

## Testing

- Full test suite passes: 311 suites, 10,418 tests, 0 failures
- Linter passes (ESLint, Prettier, TypeScript, remark)
- Node native tests pass