### PR TITLE
Fix `node_modules` not ignored when using `codeFilename` in Node.js API

### DIFF
--- a/.changeset/fix-node-modules-code-filename.md
+++ b/.changeset/fix-node-modules-code-filename.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `node_modules` not ignored when using `codeFilename` in Node.js API

--- a/lib/__tests__/ignore.test.mjs
+++ b/lib/__tests__/ignore.test.mjs
@@ -472,3 +472,33 @@ test('disableDefaultIgnores allows paths in node_modules', async () => {
 	expect(results).toHaveLength(1);
 	expect(results[0].warnings).toHaveLength(1);
 });
+
+test('file in node_modules is ignored when using codeFilename', async () => {
+	const { results } = await standalone({
+		code: 'a {}',
+		codeFilename: fixtures('node_modules', 'test.css'),
+		config: {
+			rules: {
+				'block-no-empty': true,
+			},
+		},
+	});
+
+	expect(results).toHaveLength(0);
+});
+
+test('disableDefaultIgnores allows codeFilename in node_modules', async () => {
+	const { results } = await standalone({
+		code: 'a {}',
+		codeFilename: fixtures('node_modules', 'test.css'),
+		disableDefaultIgnores: true,
+		config: {
+			rules: {
+				'block-no-empty': true,
+			},
+		},
+	});
+
+	expect(results).toHaveLength(1);
+	expect(results[0].warnings).toHaveLength(1);
+});

--- a/lib/standalone.mjs
+++ b/lib/standalone.mjs
@@ -6,6 +6,7 @@ const debug = createDebug('stylelint:standalone');
 
 import fastGlob from 'fast-glob';
 import { globby } from 'globby';
+import micromatch from 'micromatch';
 import normalizePath from 'normalize-path';
 import writeFileAtomic from 'write-file-atomic';
 
@@ -133,7 +134,8 @@ export default async function standalone({
 		// if file is ignored, return nothing
 		if (
 			absoluteCodeFilename &&
-			!filterFilePaths(ignorer, [relative(cwd, absoluteCodeFilename)]).length
+			(!filterFilePaths(ignorer, [relative(cwd, absoluteCodeFilename)]).length ||
+				(!disableDefaultIgnores && micromatch.isMatch(absoluteCodeFilename, ALWAYS_IGNORED_GLOBS)))
 		) {
 			return prepareReturnValue({
 				results: [],


### PR DESCRIPTION
Fixes #9129 

Aligns behaviour when using `codeFilename` with behaviour when using `files`.