### PR TITLE
Fix ruleMetadata being empty when first linted file has no rules applied

### DIFF
--- a/lib/prepareReturnValue.mjs
+++ b/lib/prepareReturnValue.mjs
@@ -1,6 +1,6 @@
 import { SEVERITY_ERROR } from './constants.mjs';
 
-/** @import { Formatter, LinterOptions, LinterResult, LintResult } from 'stylelint' */
+/** @import { Formatter, LinterOptions, LinterResult, LintResult, RuleMeta } from 'stylelint' */
 
 /**
  * @param {object} args
@@ -53,11 +53,14 @@ export default function prepareReturnValue({ results, maxWarnings, formatter, cw
  * @param {LintResult[]} lintResults
  */
 function getRuleMetadata(lintResults) {
-	const [lintResult] = lintResults;
+	/** @type {{ [ruleName: string]: Partial<RuleMeta> }} */
+	const merged = {};
 
-	if (lintResult === undefined) return {};
+	for (const lintResult of lintResults) {
+		if (lintResult?._postcssResult === undefined) continue;
 
-	if (lintResult._postcssResult === undefined) return {};
+		Object.assign(merged, lintResult._postcssResult.stylelint.ruleMetadata);
+	}
 
-	return lintResult._postcssResult.stylelint.ruleMetadata;
+	return merged;
 }


### PR DESCRIPTION
Fixes #9138

Currently `getRuleMetadata` only reads metadata from the first lint result.

If the first file has no rules applied (e.g. due to overrides), `ruleMetadata`
becomes `{}` even if subsequent files contain rules.

This change merges metadata from all lint results so the result is consistent
regardless of file order.

