### PR TITLE
Group `csstree` and `@csstools/css-syntax-patches-for-csstree` in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,14 @@ updates:
       - 'pr: dependencies'
     versioning-strategy: increase
     groups:
-      csstools-parser:
-        patterns: ['@csstools/*']
-        exclude-patterns: ['@csstools/selector-specificity'] # unrelated to other parser packages
       changesets:
         patterns: ['@changesets/*']
+      csstools-parser:
+        patterns: ['@csstools/*']
+        exclude-patterns:
+          ['@csstools/selector-specificity', '@csstools/css-syntax-patches-for-csstree']
+      csstree:
+        patterns: ['css-tree', '@csstools/css-syntax-patches-for-csstree']
       eslint:
         patterns: ['eslint', 'eslint-*']
       jest:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/pull/9168

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
