### PR TITLE
Exclude `stylelint/.github/*` GitHub Actions from Dependabot `cooldown` config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
 
   test:
-    uses: stylelint/.github/.github/workflows/call-test.yml@56c5d6e7e35009b7748db7558eac5377ec88f446 # 0.6.1
+    uses: stylelint/.github/.github/workflows/call-test.yml@60889da59f384526b8185d2aa85b35620aa6bcc0 # 0.6.0
     with:
       node-version: '["20", "22", "24"]'
       os: '["ubuntu-latest", "windows-latest", "macos-latest"]'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

For example, PR #9182 is blocked due to CI failures. [`stylelint/.github@0.6.1`](https://github.com/stylelint/.github/releases/tag/0.6.1) (a new version) should resolve the issue.

> Is there anything in the PR that needs further explanation?

This PR excludes GitHub Actions implemented in the `stylelint/.github` repository from the `cooldown` configuration for Dependabot.

I believe it's safe because they're owned by the Stylelint team, and we often would like to quickly apply some fixes from the bump.

Ref https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
