### PR TITLE
Refactor to remove unused `Config.ignorePatterns` property type

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -132,7 +132,6 @@ declare namespace stylelint {
 		 * @see [ignoreFiles](https://stylelint.io/user-guide/configure/#ignorefiles)
 		 */
 		ignoreFiles?: ConfigIgnoreFiles;
-		ignorePatterns?: string;
 		/**
 		 * An object containing the configured rules
 		 *


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`ignorePatterns` is now unused, but it's remaining for some reason.

```sh-session
$ git grep -w 'ignorePatterns' || echo '(not found)'
(not found)
```

We already have [`ignoreFiles`](https://github.com/stylelint/stylelint/blob/cb297bc60fda1e6193752ee3522daafff258cbc8/docs/user-guide/configure.md#ignorefiles), so `ignorePatterns` is redundant and can be removed from the `Config` type definition.
