### PR TITLE
Refactor to document properties in `Config` type

### DIFF
--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -215,9 +215,14 @@ declare namespace stylelint {
 		 * @see [processors](https://stylelint.io/user-guide/configure#processors)
 		 */
 		processors?: ConfigProcessors;
-		languageOptions?: LanguageOptions;
 		/** @internal */
 		_processorFunctions?: Map<string, ReturnType<Processor>['postprocess']>;
+		/**
+		 * Language options to extend the syntax.
+		 *
+		 * @see [languageOptions](https://stylelint.io/user-guide/configure#languageoptions)
+		 */
+		languageOptions?: LanguageOptions;
 		/**
 		 * If true, Stylelint does not throw an error when the glob pattern matches no files.
 		 *
@@ -242,6 +247,7 @@ declare namespace stylelint {
 		 * @see [fix](https://stylelint.io/user-guide/configure#fix)
 		 */
 		fix?: boolean;
+		/** @internal */
 		computeEditInfo?: boolean;
 		/**
 		 * Force enable/disable the validation of the rules' options


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Related to #9193

> Is there anything in the PR that needs further explanation?

This PR aims to make it easier to understand the properties of the `Config` type. Especially, which properties are public or internal.

Note that `computeEditInfo` is internal, but doesn't start with `_` because it would require more code changes to append `_` to it.

Since the `computeEditInfo` option (`--compute-edit-info`) has been supported, we might support it as the configuration property as well in the future.


