### PR TITLE
[codex] fix: remap page-break always autofix

### DIFF
--- a/lib/rules/property-no-deprecated/__tests__/index.mjs
+++ b/lib/rules/property-no-deprecated/__tests__/index.mjs
@@ -83,6 +83,38 @@ testRule({
 				},
 			],
 		},
+		{
+			code: stripIndent`
+				div {
+					page-break-before: always;
+					page-break-after: always;
+				}
+			`,
+			fixed: stripIndent`
+				div {
+					break-before: page;
+					break-after: page;
+				}
+			`,
+			warnings: [
+				{
+					message: messages.expected('page-break-before', 'break-before'),
+					fix: { range: [7, 32] },
+					column: 2,
+					endColumn: 19,
+					line: 2,
+					endLine: 2,
+				},
+				{
+					message: messages.expected('page-break-after', 'break-after'),
+					fix: { range: [35, 59] },
+					column: 2,
+					endColumn: 18,
+					line: 3,
+					endLine: 3,
+				},
+			],
+		},
 	],
 });
 

--- a/lib/rules/property-no-deprecated/index.mjs
+++ b/lib/rules/property-no-deprecated/index.mjs
@@ -73,6 +73,10 @@ const DEPRECATED_PROPS_REMAP = {
 	clip: null,
 };
 
+const DEPRECATED_PAGE_BREAK_VALUES_REMAP = {
+	always: 'page',
+};
+
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -114,6 +118,14 @@ const rule = (primary, secondaryOptions) => {
 				messageArgs = [prop, mappedProp];
 				fix = () => {
 					decl.prop = mappedProp;
+
+					if (normalizedProp.startsWith('page-break-')) {
+						const mappedValue = DEPRECATED_PAGE_BREAK_VALUES_REMAP[value.toLowerCase()];
+
+						if (mappedValue) {
+							decl.value = mappedValue;
+						}
+					}
 				};
 			} else {
 				message = messages.rejected;


### PR DESCRIPTION
## Summary
- remap `page-break-*: always` to `break-*: page` during `property-no-deprecated` autofix
- keep the existing deprecated property rewrite behavior for other cases
- add a regression test covering `page-break-before` and `page-break-after`

Closes #9172.

## Validation
- `npm run test-only -- --runTestsByPath lib/rules/property-no-deprecated/__tests__/index.mjs`
