### PR TITLE
[codex] feat: add with-alpha-component exception

### DIFF
--- a/lib/rules/color-function-alias-notation/README.md
+++ b/lib/rules/color-function-alias-notation/README.md
@@ -82,3 +82,34 @@ a { color: rgba(0 0 0) }
 ```css
 a { color: hsla(270 60% 50% / 15%) }
 ```
+
+## Optional secondary options
+
+### `except: ["with-alpha-component"]`
+
+Reverse the primary option for color functions that include an alpha component.
+
+For example, with the following configuration:
+
+```json
+{
+  "color-function-alias-notation": [
+    "without-alpha",
+    { "except": ["with-alpha-component"] }
+  ]
+}
+```
+
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
+```css
+a { color: rgb(0 0 0 / 50%) }
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a { color: rgba(0 0 0 / 50%) }
+```

--- a/lib/rules/color-function-alias-notation/__tests__/index.mjs
+++ b/lib/rules/color-function-alias-notation/__tests__/index.mjs
@@ -184,3 +184,80 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: ['without-alpha', { except: ['with-alpha-component'] }],
+	fix: true,
+	computeEditInfo: true,
+
+	accept: [
+		{
+			code: 'a { color: rgb(0 0 0) }',
+		},
+		{
+			code: 'a { color: rgba(0 0 0 / 50%) }',
+		},
+		{
+			code: 'a { color: hsla(270 60% 70% / 15%) }',
+		},
+		{
+			code: 'a { color: rgba(0, 0, 0, 0.5) }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a { color: rgb(0 0 0 / 50%) }',
+			fixed: 'a { color: rgba(0 0 0 / 50%) }',
+			message: messages.expected('rgb', 'rgba'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 15,
+			fix: {
+				range: [13, 14],
+				text: 'ba',
+			},
+		},
+		{
+			code: 'a { color: hsl(270 60% 70% / 15%) }',
+			fixed: 'a { color: hsla(270 60% 70% / 15%) }',
+			message: messages.expected('hsl', 'hsla'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 15,
+			fix: {
+				range: [13, 14],
+				text: 'la',
+			},
+		},
+		{
+			code: 'a { color: rgb(0, 0, 0, 0.5) }',
+			fixed: 'a { color: rgba(0, 0, 0, 0.5) }',
+			message: messages.expected('rgb', 'rgba'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 15,
+			fix: {
+				range: [13, 14],
+				text: 'ba',
+			},
+		},
+		{
+			code: 'a { color: rgba(0 0 0) }',
+			fixed: 'a { color: rgb(0 0 0) }',
+			message: messages.expected('rgba', 'rgb'),
+			line: 1,
+			column: 12,
+			endLine: 1,
+			endColumn: 16,
+			fix: {
+				range: [14, 15],
+				text: '',
+			},
+		},
+	],
+});

--- a/lib/rules/color-function-alias-notation/index.mjs
+++ b/lib/rules/color-function-alias-notation/index.mjs
@@ -9,6 +9,7 @@ import getDeclarationValue from '../../utils/getDeclarationValue.mjs';
 import isStandardSyntaxColorFunction from '../../utils/isStandardSyntaxColorFunction.mjs';
 import { isValueFunction } from '../../utils/typeGuards.mjs';
 import { mayIncludeRegexes } from '../../utils/regexes.mjs';
+import optionsMatches from '../../utils/optionsMatches.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import setDeclarationValue from '../../utils/setDeclarationValue.mjs';
@@ -26,21 +27,37 @@ const meta = {
 };
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
-const rule = (primary) => {
+const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
-		const validOptions = validateOptions(result, ruleName, {
-			actual: primary,
-			possible: ['with-alpha', 'without-alpha'],
-		});
+		const validOptions = validateOptions(
+			result,
+			ruleName,
+			{
+				actual: primary,
+				possible: ['with-alpha', 'without-alpha'],
+			},
+			{
+				actual: secondaryOptions,
+				possible: {
+					except: ['with-alpha-component'],
+				},
+				optional: true,
+			},
+		);
 
 		if (!validOptions) return;
 
-		const targetFunctionCall =
-			primary === 'with-alpha'
+		const exceptWithAlphaComponent = optionsMatches(
+			secondaryOptions,
+			'except',
+			'with-alpha-component',
+		);
+
+		const targetFunctionCall = exceptWithAlphaComponent
+			? mayIncludeRegexes.colorFunction
+			: primary === 'with-alpha'
 				? mayIncludeRegexes.withoutAlphaAliasColorFunction
 				: mayIncludeRegexes.withAlphaAliasColorFunction;
-		const targetFunctionName =
-			primary === 'with-alpha' ? withoutAlphaAliasColorFunctions : withAlphaAliasColorFunctions;
 
 		root.walkDecls((decl) => {
 			if (!targetFunctionCall.test(decl.value)) return;
@@ -51,10 +68,29 @@ const rule = (primary) => {
 				if (!isValueFunction(node) || !isStandardSyntaxColorFunction(node)) return;
 
 				const { value, sourceIndex } = node;
+				const lowerCaseValue = value.toLowerCase();
 
-				if (!targetFunctionName.has(value.toLowerCase())) return;
+				if (
+					!withAlphaAliasColorFunctions.has(lowerCaseValue) &&
+					!withoutAlphaAliasColorFunctions.has(lowerCaseValue)
+				) {
+					return;
+				}
 
-				const fixed = primary === 'with-alpha' ? `${value}a` : value.slice(0, -1);
+				let expected = primary;
+
+				if (exceptWithAlphaComponent && hasAlphaComponent(node)) {
+					expected = primary === 'with-alpha' ? 'without-alpha' : 'with-alpha';
+				}
+
+				const targetFunctionName =
+					expected === 'with-alpha'
+						? withoutAlphaAliasColorFunctions
+						: withAlphaAliasColorFunctions;
+
+				if (!targetFunctionName.has(lowerCaseValue)) return;
+
+				const fixed = expected === 'with-alpha' ? `${value}a` : value.slice(0, -1);
 				const fix = () => {
 					node.value = fixed;
 					setDeclarationValue(decl, parsedValue.toString());
@@ -80,6 +116,19 @@ const rule = (primary) => {
 		});
 	};
 };
+
+function hasAlphaComponent(node) {
+	let commaCount = 0;
+
+	for (const childNode of node.nodes) {
+		if (childNode.type !== 'div') continue;
+
+		if (childNode.value === '/') return true;
+		if (childNode.value === ',') commaCount += 1;
+	}
+
+	return commaCount === 3;
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;


### PR DESCRIPTION
## Summary
- add `except: ["with-alpha-component"]` support to `color-function-alias-notation`
- reverse the primary alias expectation only for color functions that actually include an alpha component
- cover both slash syntax and legacy comma syntax in the rule tests
- document the new secondary option in the rule README

Closes #8746.

## Validation
- `npm run test-only -- --runTestsByPath lib/rules/color-function-alias-notation/__tests__/index.mjs`
- `npx prettier --check lib/rules/color-function-alias-notation/index.mjs lib/rules/color-function-alias-notation/__tests__/index.mjs lib/rules/color-function-alias-notation/README.md`
