### PR TITLE
Document `selector-no-deprecated` not yet in config

### DIFF
--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -22,7 +22,7 @@ Disallow deprecated things with these `no-deprecated` rules.
 | [`declaration-property-value-keyword-no-deprecated`](../../lib/rules/declaration-property-value-keyword-no-deprecated/README.md)<br/>Disallow deprecated keywords for properties within declarations. | ✅ | 🔧 |
 | [`media-type-no-deprecated`](../../lib/rules/media-type-no-deprecated/README.md)<br/>Disallow deprecated media types. | ✅ | |
 | [`property-no-deprecated`](../../lib/rules/property-no-deprecated/README.md)<br/>Disallow deprecated properties. | ✅ | 🔧 |
-| [`selector-no-deprecated`](../../lib/rules/selector-no-deprecated/README.md)<br/>Disallow deprecated selectors. | ✅ | 🔧 |
+| [`selector-no-deprecated`](../../lib/rules/selector-no-deprecated/README.md)<br/>Disallow deprecated selectors. | | 🔧 |
 <!-- prettier-ignore-end -->
 
 ### Descending


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's a documentation fix.

> Is there anything in the PR that needs further explanation?

Related issue to add it soon: https://github.com/stylelint/stylelint-config-recommended/issues/291