### PR TITLE
Fix `property-layout-mappings` false positives for `@page` properties

### DIFF
--- a/.changeset/thick-rules-compare.md
+++ b/.changeset/thick-rules-compare.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `property-layout-mappings` false positives for `@page` properties

--- a/lib/rules/property-layout-mappings/__tests__/index.mjs
+++ b/lib/rules/property-layout-mappings/__tests__/index.mjs
@@ -91,6 +91,14 @@ testRule({
 				},
 			],
 		},
+		{
+			code: '@media print { a { margin-left: 0; } }',
+			message: messages.rejected('physical', 'margin-left'),
+			line: 1,
+			column: 20,
+			endLine: 1,
+			endColumn: 31,
+		},
 	],
 });
 
@@ -193,6 +201,20 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 17,
+		},
+	],
+});
+
+testRule({
+	ruleName,
+	config: ['physical'],
+
+	accept: [
+		{
+			code: '@page { margin-inline-start: 0; }',
+		},
+		{
+			code: '@page { @top-left { margin-inline-start: 0; } }',
 		},
 	],
 });

--- a/lib/rules/property-layout-mappings/__tests__/index.mjs
+++ b/lib/rules/property-layout-mappings/__tests__/index.mjs
@@ -31,6 +31,12 @@ testRule({
 		{
 			code: 'a { border-start-start-radius: 0; }',
 		},
+		{
+			code: '@page { margin-left: 0; }',
+		},
+		{
+			code: '@page { @top-left { margin-left: 0; } }',
+		},
 	],
 
 	reject: [

--- a/lib/rules/property-layout-mappings/__tests__/index.mjs
+++ b/lib/rules/property-layout-mappings/__tests__/index.mjs
@@ -122,6 +122,12 @@ testRule({
 		{
 			code: 'a { width: 0; }',
 		},
+		{
+			code: '@page { margin-inline-start: 0; }',
+		},
+		{
+			code: '@page { @top-left { margin-inline-start: 0; } }',
+		},
 	],
 
 	reject: [
@@ -201,20 +207,6 @@ testRule({
 			column: 5,
 			endLine: 1,
 			endColumn: 17,
-		},
-	],
-});
-
-testRule({
-	ruleName,
-	config: ['physical'],
-
-	accept: [
-		{
-			code: '@page { margin-inline-start: 0; }',
-		},
-		{
-			code: '@page { @top-left { margin-inline-start: 0; } }',
 		},
 	],
 });

--- a/lib/rules/property-layout-mappings/index.mjs
+++ b/lib/rules/property-layout-mappings/index.mjs
@@ -24,6 +24,11 @@ const meta = {
 	fixable: true,
 };
 
+/** @param {import('postcss').Node} node */
+function isPageAtRule(node) {
+	return isAtRule(node) && node.name.toLowerCase() === 'page';
+}
+
 /** @typedef  {'top-to-bottom'|'bottom-to-top'|'left-to-right'|'right-to-left'} Direction */
 
 /**
@@ -208,17 +213,16 @@ const rule = (primary, secondaryOptions) => {
 
 			if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) return;
 
-			/** @type {(node: import('postcss').Node) => boolean} */
-			const isPageAtRule = (node) => isAtRule(node) && node.name.toLowerCase() === 'page';
-
-			if (findNodeUpToRoot(decl, isPageAtRule)) return;
-
 			if (primary === 'physical') {
 				if (!flowRelativeProperties.has(prop)) return;
+
+				if (findNodeUpToRoot(decl, isPageAtRule)) return;
 
 				complain('flow-relative', decl);
 			} else {
 				if (!physicalToFlowRelativeProperties.has(prop)) return;
+
+				if (findNodeUpToRoot(decl, isPageAtRule)) return;
 
 				if (!directionalMap) {
 					complain('physical', decl);

--- a/lib/rules/property-layout-mappings/index.mjs
+++ b/lib/rules/property-layout-mappings/index.mjs
@@ -3,6 +3,8 @@ import {
 	physicalToFlowRelativeProperties,
 } from '../../reference/properties.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import findNodeUpToRoot from '../../utils/findNodeUpToRoot.mjs';
+import { isAtRule } from '../../utils/typeGuards.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
 import isStandardSyntaxProperty from '../../utils/isStandardSyntaxProperty.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
@@ -205,6 +207,11 @@ const rule = (primary, secondaryOptions) => {
 			if (isCustomProperty(prop)) return;
 
 			if (optionsMatches(secondaryOptions, 'ignoreProperties', prop)) return;
+
+			/** @type {(node: import('postcss').Node) => boolean} */
+			const isPageAtRule = (node) => isAtRule(node) && node.name.toLowerCase() === 'page';
+
+			if (findNodeUpToRoot(decl, isPageAtRule)) return;
 
 			if (primary === 'physical') {
 				if (!flowRelativeProperties.has(prop)) return;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/issues/5430#issuecomment-2599725677

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
