### PR TITLE
Document message arguments of rules

### DIFF
--- a/docs/contributor-guide/rules.md
+++ b/docs/contributor-guide/rules.md
@@ -449,7 +449,15 @@ You should:
 - add the fewest examples possible to communicate the intent of the rule, rather than show edge cases
 - use `<!-- prettier-ignore -->` before `css` code fences
 - use "this rule" to refer to the rule, e.g. "This rule ignores ..."
+- summarise the rule's message arguments
 - include a bulleted list of prior art in the expanded description
+
+Look at the READMEs of other rules to glean more conventional patterns.
+
+#### Prototypical code example
+
+You should:
+
 - align the arrows within the prototypical code example with the beginning of the highlighted construct
 - align the text within the prototypical code example as far to the left as possible
 
@@ -462,7 +470,22 @@ For example:
   *       These names and values */
 ```
 
-Look at the READMEs of other rules to glean more conventional patterns.
+#### Message arguments
+
+You should state how many message arguments the rule exposes and what each contains.
+
+For:
+
+- fixed shapes use `This rule supports N [message argument(s)](…#message): <slot 1> and <slot 2>.`
+- diverging shapes use `This rule supports [up to] N [message arguments](…#message): <shape 1>, or <shape 2>.`, using "up to N" when argument counts differ
+- no arguments use `This rule doesn't have any [message arguments](…#message).`
+
+Describe each slot in user-facing terms, e.g. `the disallowed property`.
+
+Use:
+
+- `the configured X` when the slot holds the raw configuration value (e.g. `primary`)
+- `its expected X`, `its condensed form` or similar when the slot holds the fix (e.g. `#ffffff` → `#fff`).
 
 ### Wire up the rule
 

--- a/lib/rules/__tests__/index.test.mjs
+++ b/lib/rules/__tests__/index.test.mjs
@@ -50,11 +50,44 @@ describe('fixability', () => {
 
 describe('message arguments', () => {
 	test.each(ruleNames)('"%s" should document message arguments', async (name) => {
+		const rule = await rules[name];
 		const ruleDoc = await readFile(new URL(`../${name}/README.md`, import.meta.url), 'utf8');
 
 		expect(ruleDoc).toMatch(
 			/\[message arguments?\]\(\.\.\/\.\.\/\.\.\/docs\/user-guide\/configure\.md#message\)/,
 		);
+
+		const noneMatch = ruleDoc.match(/This rule doesn't have any \[message arguments?\]\(/);
+		const upToMatch = ruleDoc.match(/This rule supports up to (\d+) \[message arguments?\]\(/);
+		const perMatch = ruleDoc.match(/This rule supports \d+ \[message arguments?\]\(.*\bper\b/);
+		const exactMatch =
+			!perMatch && ruleDoc.match(/This rule supports (\d+) \[message arguments?\]\(/);
+
+		expect(noneMatch ?? upToMatch ?? exactMatch ?? perMatch).not.toBeNull();
+
+		const messageFns = Object.values(rule.messages).filter((m) => typeof m === 'function');
+
+		if (noneMatch) {
+			// eslint-disable-next-line jest/no-conditional-expect
+			expect(messageFns).toHaveLength(0);
+
+			return;
+		}
+
+		const match = upToMatch ?? exactMatch;
+
+		if (!match) return;
+
+		const documentedCount = Number(match[1]);
+		const maxActual = Math.max(...messageFns.map((fn) => fn.length));
+
+		if (upToMatch) {
+			// eslint-disable-next-line jest/no-conditional-expect
+			expect(maxActual).toBeLessThanOrEqual(documentedCount);
+		} else {
+			// eslint-disable-next-line jest/no-conditional-expect
+			expect(maxActual).toBe(documentedCount);
+		}
 	});
 });
 

--- a/lib/rules/__tests__/index.test.mjs
+++ b/lib/rules/__tests__/index.test.mjs
@@ -48,6 +48,16 @@ describe('fixability', () => {
 	});
 });
 
+describe('message arguments', () => {
+	test.each(ruleNames)('"%s" should document message arguments', async (name) => {
+		const ruleDoc = await readFile(new URL(`../${name}/README.md`, import.meta.url), 'utf8');
+
+		expect(ruleDoc).toMatch(
+			/\[message arguments?\]\(\.\.\/\.\.\/\.\.\/docs\/user-guide\/configure\.md#message\)/,
+		);
+	});
+});
+
 describe('deprecated rules', () => {
 	test.each(ruleNames)('"%s" should describe deprecation in the document', async (name) => {
 		const rule = await rules[name];

--- a/lib/rules/alpha-value-notation/README.md
+++ b/lib/rules/alpha-value-notation/README.md
@@ -11,6 +11,8 @@ Specify percentage or number notation for alpha-values.
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the alpha value and its expected notation.
+
 ## Options
 
 ### `"number"`

--- a/lib/rules/annotation-no-unknown/README.md
+++ b/lib/rules/annotation-no-unknown/README.md
@@ -11,6 +11,8 @@ a { color: green !imprtant; }
 
 This rule considers annotations defined in the CSS Specifications, up to and including Editor's Drafts, to be known.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown annotation.
+
 ## Options
 
 ### `true`

--- a/lib/rules/at-rule-allowed-list/README.md
+++ b/lib/rules/at-rule-allowed-list/README.md
@@ -11,6 +11,8 @@ Specify a list of allowed at-rules.
 
 This rule ignores the `@charset` rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed at-rule.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/at-rule-descriptor-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-no-unknown/README.md
@@ -20,6 +20,8 @@ You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syn
 
 This rule checks descriptors within at-rules. To check properties, you can use the [`property-no-unknown`](../property-no-unknown/README.md) rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the at-rule and the unknown descriptor.
+
 Prior art:
 
 - [stylelint-csstree-validator](https://www.npmjs.com/package/stylelint-csstree-validator)

--- a/lib/rules/at-rule-descriptor-value-no-unknown/README.md
+++ b/lib/rules/at-rule-descriptor-value-no-unknown/README.md
@@ -29,6 +29,8 @@ This rule checks descriptor values within at-rules. You can use [`declaration-pr
 > - [`string-no-newline`](../string-no-newline/README.md)
 > - [`unit-no-unknown`](../unit-no-unknown/README.md)
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the descriptor and the unknown value.
+
 Prior art:
 
 - [stylelint-csstree-validator](https://www.npmjs.com/package/stylelint-csstree-validator)

--- a/lib/rules/at-rule-disallowed-list/README.md
+++ b/lib/rules/at-rule-disallowed-list/README.md
@@ -11,6 +11,8 @@ Specify a list of disallowed at-rules.
 
 This rule ignores the `@charset` rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed at-rule.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/at-rule-empty-line-before/README.md
+++ b/lib/rules/at-rule-empty-line-before/README.md
@@ -19,6 +19,8 @@ This rule ignores:
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/at-rule-no-deprecated/README.md
+++ b/lib/rules/at-rule-no-deprecated/README.md
@@ -19,6 +19,8 @@ This rule flags at-rules that were removed or deprecated after being in the CSS 
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix some of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the deprecated at-rule.
+
 Prior art:
 
 - [@csstools/stylelint-no-at-nest-rule](https://www.npmjs.com/package/@csstools/stylelint-no-at-nest-rule)

--- a/lib/rules/at-rule-no-unknown/README.md
+++ b/lib/rules/at-rule-no-unknown/README.md
@@ -13,6 +13,8 @@ This rule considers at-rules defined in the CSS Specifications, up to and includ
 
 For customizing syntax, see the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) section.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown at-rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/at-rule-no-vendor-prefix/README.md
+++ b/lib/rules/at-rule-no-vendor-prefix/README.md
@@ -13,6 +13,8 @@ This rule ignores non-standard vendor-prefixed at-rules that aren't handled by [
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate at-rules produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the vendor-prefixed at-rule.
+
 ## Options
 
 ### `true`

--- a/lib/rules/at-rule-prelude-no-invalid/README.md
+++ b/lib/rules/at-rule-prelude-no-invalid/README.md
@@ -23,6 +23,8 @@ You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syn
 > - [`string-no-newline`](../string-no-newline/README.md)
 > - [`unit-no-unknown`](../unit-no-unknown/README.md)
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the at-rule and the invalid prelude.
+
 Prior art:
 
 - [stylelint-csstree-validator](https://www.npmjs.com/package/stylelint-csstree-validator)

--- a/lib/rules/at-rule-property-required-list/README.md
+++ b/lib/rules/at-rule-property-required-list/README.md
@@ -9,6 +9,8 @@ Specify a list of required properties (or descriptors) for an at-rule.
  *  At-rule and required descriptor names */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the at-rule and the required property.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/block-no-empty/README.md
+++ b/lib/rules/block-no-empty/README.md
@@ -9,6 +9,8 @@ Disallow empty blocks.
  * Blocks like this */
 ```
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/block-no-redundant-nested-style-rules/README.md
+++ b/lib/rules/block-no-redundant-nested-style-rules/README.md
@@ -9,6 +9,8 @@ a { & { color: red; } }
  * This nested style rule */
 ```
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/color-function-alias-notation/README.md
+++ b/lib/rules/color-function-alias-notation/README.md
@@ -13,6 +13,8 @@ Color functions `rgb()` and `hsl()` have aliases `rgba()` and `hsla()`. Those ar
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the color value and its expected notation.
+
 ## Options
 
 ### `"without-alpha"`

--- a/lib/rules/color-function-notation/README.md
+++ b/lib/rules/color-function-notation/README.md
@@ -15,6 +15,8 @@ For legacy reasons, `rgb()` and `hsl()` also supports an alternate syntax that s
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix some of the problems reported by this rule when the primary option is `"modern"`.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured notation.
+
 ## Options
 
 ### `"modern"`

--- a/lib/rules/color-hex-alpha/README.md
+++ b/lib/rules/color-hex-alpha/README.md
@@ -9,6 +9,8 @@ a { color: #fffa }
  * This alpha channel */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the hex color.
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/color-hex-length/README.md
+++ b/lib/rules/color-hex-length/README.md
@@ -11,6 +11,8 @@ a { color: #fff }
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the hex color and its expected notation.
+
 ## Options
 
 ### `"short"`

--- a/lib/rules/color-named/README.md
+++ b/lib/rules/color-named/README.md
@@ -11,6 +11,8 @@ a { color: black }
 
 This rule ignores `$sass` and `@less` variable syntaxes.
 
+This rule supports up to 2 [message arguments](../../../docs/user-guide/configure.md#message): the disallowed named color, or a color and its named equivalent.
+
 ## Options
 
 ### `"always-where-possible"`

--- a/lib/rules/color-no-hex/README.md
+++ b/lib/rules/color-no-hex/README.md
@@ -9,6 +9,8 @@ a { color: #333 }
  * This hex color */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed hex color.
+
 ## Options
 
 ### `true`

--- a/lib/rules/color-no-invalid-hex/README.md
+++ b/lib/rules/color-no-invalid-hex/README.md
@@ -17,6 +17,8 @@ Longhand hex colors can be either 6 or 8 (with alpha channel) hexadecimal charac
 > - [`at-rule-descriptor-value-no-unknown`](../at-rule-descriptor-value-no-unknown/README.md)
 > - [`declaration-property-value-no-unknown`](../declaration-property-value-no-unknown/README.md)
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the invalid hex color.
+
 ## Options
 
 ### `true`

--- a/lib/rules/comment-empty-line-before/README.md
+++ b/lib/rules/comment-empty-line-before/README.md
@@ -20,6 +20,8 @@ This rule ignores:
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/comment-no-empty/README.md
+++ b/lib/rules/comment-no-empty/README.md
@@ -14,6 +14,8 @@ This rule ignores SCSS-like comments.
 > [!WARNING]
 > Comments within _selector and value lists_ are currently ignored.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/comment-pattern/README.md
+++ b/lib/rules/comment-pattern/README.md
@@ -9,6 +9,8 @@ Specify a pattern for comments.
  * The pattern of this */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/comment-whitespace-inside/README.md
+++ b/lib/rules/comment-whitespace-inside/README.md
@@ -16,6 +16,8 @@ Any number of asterisks are allowed at the beginning or end of the comment. So `
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/comment-word-disallowed-list/README.md
+++ b/lib/rules/comment-word-disallowed-list/README.md
@@ -12,6 +12,8 @@ Specify a list of disallowed words within comments.
 > [!WARNING]
 > Comments within _selector and value lists_ are currently ignored.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed word.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/container-name-pattern/README.md
+++ b/lib/rules/container-name-pattern/README.md
@@ -9,6 +9,8 @@ Specify a pattern for container names.
  * The pattern of this */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the container name and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/custom-media-pattern/README.md
+++ b/lib/rules/custom-media-pattern/README.md
@@ -9,6 +9,8 @@ Specify a pattern for custom media query names.
  * The pattern of this */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the custom media name and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/custom-property-empty-line-before/README.md
+++ b/lib/rules/custom-property-empty-line-before/README.md
@@ -15,6 +15,8 @@ a {
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/custom-property-no-missing-var-function/README.md
+++ b/lib/rules/custom-property-no-missing-var-function/README.md
@@ -15,6 +15,8 @@ This rule has the following limitations:
 - It only reports custom properties that are defined within the same source.
 - It does not check properties that can contain author-defined identifiers, e.g. `transition-property`.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the custom property.
+
 ## Options
 
 ### `true`

--- a/lib/rules/custom-property-pattern/README.md
+++ b/lib/rules/custom-property-pattern/README.md
@@ -9,6 +9,8 @@ a { --foo-: 1px; }
  * The pattern of this */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the custom property name and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-custom-properties/README.md
@@ -11,6 +11,8 @@ a { --custom-property: pink; --custom-property: orange; }
 
 This rule is case-sensitive.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the duplicate custom property.
+
 ## Options
 
 ### `true`

--- a/lib/rules/declaration-block-no-duplicate-properties/README.md
+++ b/lib/rules/declaration-block-no-duplicate-properties/README.md
@@ -13,6 +13,8 @@ This rule ignores variables (`$sass`, `@less`, `--custom-property`).
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the duplicate property.
+
 ## Options
 
 ### `true`

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/README.md
@@ -92,6 +92,8 @@ Flexbox-related properties can be ignored using `ignoreShorthands: ["/flex/"]` (
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix most of the problems reported by this rule.
 
+This rule supports up to 2 [message arguments](../../../docs/user-guide/configure.md#message): the shorthand property, or the redundant longhand property and its shorthand.
+
 ## Options
 
 ### `true`

--- a/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
+++ b/lib/rules/declaration-block-no-shorthand-property-overrides/README.md
@@ -11,6 +11,8 @@ a { background-repeat: repeat; background: green; }
 
 In almost every case, this is just an authorial oversight. For more about this behavior, see [MDN's documentation of shorthand properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties).
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the shorthand property and the overridden longhand declaration.
+
 ## Options
 
 ### `true`

--- a/lib/rules/declaration-block-single-line-max-declarations/README.md
+++ b/lib/rules/declaration-block-single-line-max-declarations/README.md
@@ -9,6 +9,8 @@ a { color: pink; top: 0; }
  * The number of these declarations */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/declaration-empty-line-before/README.md
+++ b/lib/rules/declaration-empty-line-before/README.md
@@ -17,6 +17,8 @@ This rule only applies to standard property declarations. Use the [`custom-prope
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/declaration-no-important/README.md
+++ b/lib/rules/declaration-no-important/README.md
@@ -11,6 +11,8 @@ a { color: pink !important; }
 
 If you always want `!important` in your declarations, e.g. if you're writing [user styles](https://userstyles.org/), you can _safely_ add them using [`postcss-safe-important`](https://github.com/crimx/postcss-safe-important).
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/declaration-property-max-values/README.md
+++ b/lib/rules/declaration-property-max-values/README.md
@@ -2,6 +2,8 @@
 
 Limit the number of values for a list of properties within declarations.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the property name and the configured maximum.
+
 ## Options
 
 ### `Object<string, number>`

--- a/lib/rules/declaration-property-unit-allowed-list/README.md
+++ b/lib/rules/declaration-property-unit-allowed-list/README.md
@@ -9,6 +9,8 @@ a { width: 100px; }
  * These properties and these units */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the property name and the disallowed unit.
+
 ## Options
 
 ### `Object<string, Array<string>>`

--- a/lib/rules/declaration-property-unit-disallowed-list/README.md
+++ b/lib/rules/declaration-property-unit-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { width: 100px; }
  * These properties and these units */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the property name and the disallowed unit.
+
 ## Options
 
 ### `Object<string, Array<string>>`

--- a/lib/rules/declaration-property-value-allowed-list/README.md
+++ b/lib/rules/declaration-property-value-allowed-list/README.md
@@ -9,6 +9,8 @@ a { text-transform: uppercase; }
  * These properties and these values */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the property name and the disallowed value.
+
 ## Options
 
 ### `Object<string, Array<string>>`

--- a/lib/rules/declaration-property-value-disallowed-list/README.md
+++ b/lib/rules/declaration-property-value-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { text-transform: uppercase; }
  * These properties and these values */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the property name and the disallowed value.
+
 ## Options
 
 ### `Object<string, Array<string>>`

--- a/lib/rules/declaration-property-value-keyword-no-deprecated/README.md
+++ b/lib/rules/declaration-property-value-keyword-no-deprecated/README.md
@@ -19,6 +19,8 @@ This rule flags keywords that were removed or deprecated after being in the CSS 
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix some of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the property name and the deprecated keyword.
+
 Prior art:
 
 - [@isnotdefined/no-obsolete](https://www.npmjs.com/package/@isnotdefined/stylelint-plugin)

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -27,6 +27,8 @@ This rule checks property values. You can use [`at-rule-descriptor-value-no-unkn
 > - [`string-no-newline`](../string-no-newline/README.md)
 > - [`unit-no-unknown`](../unit-no-unknown/README.md)
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the property name and the unknown value.
+
 Prior art:
 
 - [stylelint-csstree-validator](https://www.npmjs.com/package/stylelint-csstree-validator)

--- a/lib/rules/display-notation/README.md
+++ b/lib/rules/display-notation/README.md
@@ -28,6 +28,8 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the display value and its expected notation.
+
 ## Options
 
 ### `"full"`

--- a/lib/rules/font-family-name-quotes/README.md
+++ b/lib/rules/font-family-name-quotes/README.md
@@ -15,6 +15,8 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix most of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the font family name.
+
 ## Options
 
 _Please read the following to understand these options_:

--- a/lib/rules/font-family-no-duplicate-names/README.md
+++ b/lib/rules/font-family-no-duplicate-names/README.md
@@ -16,6 +16,8 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 > [!WARNING]
 > This rule will stumble on _unquoted_ multi-word font names and _unquoted_ font names containing escape sequences. Wrap these font names in quotation marks, and everything should be fine.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the duplicate font family name.
+
 ## Options
 
 ### `true`

--- a/lib/rules/font-family-no-missing-generic-family-keyword/README.md
+++ b/lib/rules/font-family-no-missing-generic-family-keyword/README.md
@@ -16,6 +16,8 @@ The generic font family can be:
 
 This rule checks the `font` and `font-family` properties.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/font-weight-notation/README.md
+++ b/lib/rules/font-weight-notation/README.md
@@ -21,6 +21,8 @@ This rule ignores `$sass`, `@less`, and `var(--custom-property)` variable syntax
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports up to 2 [message arguments](../../../docs/user-guide/configure.md#message): the notation type, or the actual and expected font-weight values.
+
 ## Options
 
 ### `"numeric"`

--- a/lib/rules/function-allowed-list/README.md
+++ b/lib/rules/function-allowed-list/README.md
@@ -9,6 +9,8 @@ a { transform: scale(1); }
  * This function */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed function.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/function-calc-no-unspaced-operator/README.md
+++ b/lib/rules/function-calc-no-unspaced-operator/README.md
@@ -13,6 +13,8 @@ This rule checks that there is a single whitespace or a newline plus indentation
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the operator.
+
 ## Options
 
 ### `true`

--- a/lib/rules/function-disallowed-list/README.md
+++ b/lib/rules/function-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { transform: scale(1); }
  * This function */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed function.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
+++ b/lib/rules/function-linear-gradient-no-nonstandard-direction/README.md
@@ -22,6 +22,8 @@ A common mistake (matching outdated non-standard syntax) is to use just a side-o
 > - [`at-rule-descriptor-value-no-unknown`](../at-rule-descriptor-value-no-unknown/README.md)
 > - [`declaration-property-value-no-unknown`](../declaration-property-value-no-unknown/README.md)
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/function-name-case/README.md
+++ b/lib/rules/function-name-case/README.md
@@ -13,6 +13,8 @@ Camel case function names, e.g. `translateX`, are accounted for when the `lower`
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the function name and its expected case.
+
 ## Options
 
 ### `"lower"`

--- a/lib/rules/function-no-unknown/README.md
+++ b/lib/rules/function-no-unknown/README.md
@@ -19,6 +19,8 @@ This rule ignores double-dashed custom functions, e.g. `--custom-function()`.
 > - [`at-rule-descriptor-value-no-unknown`](../at-rule-descriptor-value-no-unknown/README.md)
 > - [`declaration-property-value-no-unknown`](../declaration-property-value-no-unknown/README.md)
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown function.
+
 ## Options
 
 ### `true`

--- a/lib/rules/function-url-no-scheme-relative/README.md
+++ b/lib/rules/function-url-no-scheme-relative/README.md
@@ -13,6 +13,8 @@ A [scheme-relative url](https://url.spec.whatwg.org/#syntax-url-scheme-relative)
 
 This rule ignores url arguments that are variables (`$sass`, `@less`, `--custom-property`).
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/function-url-quotes/README.md
+++ b/lib/rules/function-url-quotes/README.md
@@ -11,6 +11,8 @@ a { background: url("x.jpg") }
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix most of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the URL function name.
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/function-url-scheme-allowed-list/README.md
+++ b/lib/rules/function-url-scheme-allowed-list/README.md
@@ -16,6 +16,8 @@ This rule ignores:
 - URL arguments without an existing URL scheme
 - URL arguments with variables or variable interpolation (`$sass`, `@less`, `--custom-property`, `#{$var}`, `@{var}`, `$(var)`)
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed URL scheme.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/function-url-scheme-disallowed-list/README.md
+++ b/lib/rules/function-url-scheme-disallowed-list/README.md
@@ -16,6 +16,8 @@ This rule ignores:
 - URL arguments without an existing URL scheme
 - URL arguments with variables or variable interpolation (`$sass`, `@less`, `--custom-property`, `#{$var}`, `@{var}`, `$(var)`)
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed URL scheme.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/hue-degree-notation/README.md
+++ b/lib/rules/hue-degree-notation/README.md
@@ -13,6 +13,8 @@ Because hues are so often given in degrees, a hue can also be given as a number,
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the hue and its expected notation.
+
 ## Options
 
 ### `"angle"`

--- a/lib/rules/import-notation/README.md
+++ b/lib/rules/import-notation/README.md
@@ -11,6 +11,8 @@ Specify string or URL notation for `@import` rules.
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the import value and its expected notation.
+
 ## Options
 
 ### `"string"`

--- a/lib/rules/keyframe-block-no-duplicate-selectors/README.md
+++ b/lib/rules/keyframe-block-no-duplicate-selectors/README.md
@@ -11,6 +11,8 @@ Disallow duplicate selectors within keyframe blocks.
 
 This rule is case-insensitive.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the duplicate selector.
+
 ## Options
 
 ### `true`

--- a/lib/rules/keyframe-declaration-no-important/README.md
+++ b/lib/rules/keyframe-declaration-no-important/README.md
@@ -14,6 +14,8 @@ Disallow invalid `!important` within keyframe declarations.
 
 Using `!important` within keyframes declarations is [completely ignored in some browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes#!important_in_a_keyframe).
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/keyframe-selector-notation/README.md
+++ b/lib/rules/keyframe-selector-notation/README.md
@@ -13,6 +13,8 @@ The keyword `from` is equivalent to the value `0%`. The keyword `to` is equivale
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and its expected notation.
+
 ## Options
 
 ### `"keyword"`

--- a/lib/rules/keyframes-name-pattern/README.md
+++ b/lib/rules/keyframes-name-pattern/README.md
@@ -9,6 +9,8 @@ Specify a pattern for keyframe names.
  * The pattern of this */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the keyframes name and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/layer-name-pattern/README.md
+++ b/lib/rules/layer-name-pattern/README.md
@@ -9,6 +9,8 @@ Specify a pattern for layer names.
  * This layer name */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the layer name and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/length-zero-no-unit/README.md
+++ b/lib/rules/length-zero-no-unit/README.md
@@ -15,6 +15,8 @@ This rule ignores lengths within math functions (e.g. `calc`).
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/lightness-notation/README.md
+++ b/lib/rules/lightness-notation/README.md
@@ -13,6 +13,8 @@ This rule supports `oklch`, `oklab`, `lch` and `lab` functions.
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the lightness value and its expected notation.
+
 ## Options
 
 ### `"percentage"`

--- a/lib/rules/max-nesting-depth/README.md
+++ b/lib/rules/max-nesting-depth/README.md
@@ -48,6 +48,8 @@ a {
 
 This rule integrates into Stylelint's core the functionality of the (now deprecated) plugin [`stylelint-statement-max-nesting-depth`](https://github.com/davidtheclark/stylelint-statement-max-nesting-depth).
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured maximum depth.
+
 ## Options
 
 ### `number`

--- a/lib/rules/media-feature-name-allowed-list/README.md
+++ b/lib/rules/media-feature-name-allowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of allowed media feature names.
  * This media feature name */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed media feature name.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/media-feature-name-disallowed-list/README.md
+++ b/lib/rules/media-feature-name-disallowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of disallowed media feature names.
  * This media feature name */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed media feature name.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/media-feature-name-no-unknown/README.md
+++ b/lib/rules/media-feature-name-no-unknown/README.md
@@ -13,6 +13,8 @@ This rule considers media feature names defined in the CSS Specifications, up to
 
 This rule ignores vendor-prefixed media feature names.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown media feature name.
+
 ## Options
 
 ### `true`

--- a/lib/rules/media-feature-name-no-vendor-prefix/README.md
+++ b/lib/rules/media-feature-name-no-vendor-prefix/README.md
@@ -13,6 +13,8 @@ This rule ignores non-standard vendor-prefixed media feature names that aren't h
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate media feature names produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/media-feature-name-unit-allowed-list/README.md
+++ b/lib/rules/media-feature-name-unit-allowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of allowed name and unit pairs within media features.
  * This media feature name and these units */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the disallowed unit and the media feature name.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/media-feature-name-value-allowed-list/README.md
+++ b/lib/rules/media-feature-name-value-allowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of allowed media feature name and value pairs.
  *    These features and values */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the media feature name and the disallowed value.
+
 ## Options
 
 ### `Object<string, Array<string>>`

--- a/lib/rules/media-feature-name-value-no-unknown/README.md
+++ b/lib/rules/media-feature-name-value-no-unknown/README.md
@@ -21,6 +21,8 @@ This rule considers values for media features defined within the CSS specificati
 
 If duplicate problems are flagged, you can turn off the corresponding rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the media feature name and the unknown value.
+
 ## Options
 
 ### `true`

--- a/lib/rules/media-feature-range-notation/README.md
+++ b/lib/rules/media-feature-range-notation/README.md
@@ -15,6 +15,8 @@ Because `min-` and `max-` both equate to range comparisons that include the valu
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix some of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured notation.
+
 ## Options
 
 ### `"context"`

--- a/lib/rules/media-query-no-invalid/README.md
+++ b/lib/rules/media-query-no-invalid/README.md
@@ -19,6 +19,8 @@ It works well with other rules that validate feature names and values:
 > [!WARNING]
 > This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the media query and the reason it is invalid.
+
 ## Options
 
 ### `true`

--- a/lib/rules/media-type-no-deprecated/README.md
+++ b/lib/rules/media-type-no-deprecated/README.md
@@ -28,6 +28,8 @@ Currently, the recommended media types are:
 
 The deprecated media types were removed because they were either never widely implemented or their use cases are now better handled by media features rather than broad device categories.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the deprecated media type.
+
 ## Options
 
 ### `true`

--- a/lib/rules/named-grid-areas-no-invalid/README.md
+++ b/lib/rules/named-grid-areas-no-invalid/README.md
@@ -18,6 +18,8 @@ For a named grid area to be valid, all strings must define:
 
 And all named grid areas that spans multiple grid cells must form a single filled-in rectangle.
 
+This rule supports up to 1 [message argument](../../../docs/user-guide/configure.md#message): the grid-area name.
+
 ## Options
 
 ### `true`

--- a/lib/rules/nesting-selector-no-missing-scoping-root/README.md
+++ b/lib/rules/nesting-selector-no-missing-scoping-root/README.md
@@ -11,6 +11,8 @@ Disallow missing scoping root for nesting selectors.
 
 CSS nesting selectors (`&`) represent the parent selector in nested CSS. When used at the top level or within certain at-rules without a scoping root, they can cause unexpected behavior or indicate a mistake in the CSS structure.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-descending-specificity/README.md
+++ b/lib/rules/no-descending-specificity/README.md
@@ -93,6 +93,8 @@ This is a correct error because the `a:hover` on line 1 has a higher specificity
 
 This may lead to confusion because both rules contain different declarations and there isn't any conflict between either. However, the linter only evaluates selectors, and therefore correctly reports the error about descending specificity.
 
+This rule supports 5 [message arguments](../../../docs/user-guide/configure.md#message): the selector, the prior selector, its line number, and the resolved form of each.
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-duplicate-at-import-rules/README.md
+++ b/lib/rules/no-duplicate-at-import-rules/README.md
@@ -10,6 +10,8 @@ Disallow duplicate `@import` rules.
  * These are duplicates */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the duplicate URL.
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-duplicate-selectors/README.md
+++ b/lib/rules/no-duplicate-selectors/README.md
@@ -31,6 +31,8 @@ a, b { & c {} } /* with nesting */
 > [!WARNING]
 > This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the duplicate selector and the line where it first appeared.
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-empty-source/README.md
+++ b/lib/rules/no-empty-source/README.md
@@ -9,6 +9,8 @@ Disallow empty sources.
 
 A source containing only whitespace, e.g., spaces, tabs, or newlines, is considered empty.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-invalid-double-slash-comments/README.md
+++ b/lib/rules/no-invalid-double-slash-comments/README.md
@@ -15,6 +15,8 @@ Disallow double-slash comments (`//...`) are not supported by CSS and [could lea
 
 If you are using a preprocessor that allows `//` single-line comments (e.g. Sass, Less, Stylus), this rule will not complain about those. They are compiled into standard CSS comments by your preprocessor, so Stylelint will consider them valid. This rule only complains about the lesser-known method of using `//` to "comment out" a single-line of code in regular CSS. (If you didn't know this was possible, have a look at ["Single Line Comments (//) in CSS"](http://www.xanthir.com/b4U10)).
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-invalid-position-at-import-rule/README.md
+++ b/lib/rules/no-invalid-position-at-import-rule/README.md
@@ -12,6 +12,8 @@ a {}
 
 Any `@import` rules must precede all other valid at-rules and style rules in a stylesheet (ignoring `@charset` and `@layer`), or else the `@import` rule is invalid.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-invalid-position-declaration/README.md
+++ b/lib/rules/no-invalid-position-declaration/README.md
@@ -11,6 +11,8 @@ color: red;
 
 Declarations can only be positioned within the `<declaration-list>`, `<declaration-rule-list>` and `<block-contents>` productions.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-irregular-whitespace/README.md
+++ b/lib/rules/no-irregular-whitespace/README.md
@@ -9,6 +9,8 @@ Disallow irregular whitespaces.
  * Irregular whitespace. Selector would fail to match '.firstClass' */
 ```
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-unknown-animations/README.md
+++ b/lib/rules/no-unknown-animations/README.md
@@ -15,6 +15,8 @@ a { animation: fancy-slide 2s linear; }
 
 This rule considers the identifiers of `@keyframes` rules defined within the same source or within the files specified in the [`referenceFiles`](../../../docs/user-guide/configure.md#referencefiles) configuration property to be known.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown animation name.
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-unknown-custom-media/README.md
+++ b/lib/rules/no-unknown-custom-media/README.md
@@ -15,6 +15,8 @@ Disallow unknown custom media queries.
 
 This rule considers custom media queries defined within the same source or within the files specified in the [`referenceFiles`](../../../docs/user-guide/configure.md#referencefiles) configuration property to be known.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown custom media name.
+
 ## Options
 
 ### `true`

--- a/lib/rules/no-unknown-custom-properties/README.md
+++ b/lib/rules/no-unknown-custom-properties/README.md
@@ -15,6 +15,8 @@ a { color: var(--foo, var(--bar)); }
 
 This rule considers custom properties defined within the same source or within the files specified in the [`referenceFiles`](../../../docs/user-guide/configure.md#referencefiles) configuration property to be known.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown custom property.
+
 ## Options
 
 ### `true`

--- a/lib/rules/number-max-precision/README.md
+++ b/lib/rules/number-max-precision/README.md
@@ -9,6 +9,8 @@ a { top: 3.245634px; }
  * This decimal place */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the number and its rounded equivalent.
+
 ## Options
 
 ### `number`

--- a/lib/rules/property-allowed-list/README.md
+++ b/lib/rules/property-allowed-list/README.md
@@ -11,6 +11,8 @@ a { color: red; }
 
 This rule ignores preprocessor variables (e.g. `$sass`, `@less`).
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed property.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/property-disallowed-list/README.md
+++ b/lib/rules/property-disallowed-list/README.md
@@ -11,6 +11,8 @@ a { text-rendering: optimizeLegibility; }
 
 This rule ignores preprocessor variables (e.g. `$sass`, `@less`).
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed property.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/property-layout-mappings/README.md
+++ b/lib/rules/property-layout-mappings/README.md
@@ -13,6 +13,8 @@ Physical layout properties like `margin-left` are tied to the physical dimension
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix problems reported by this rule when both the primary option is `"flow-relative"` and the [`languageOptions.directionality`](../../../docs/user-guide/configure.md#directionality) configuration property is configured.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the disallowed mapping and the property, or the physical property and its flow-relative equivalent.
+
 Prior art:
 
 - [stylelint-plugin-logical-css](https://www.npmjs.com/package/stylelint-plugin-logical-css)

--- a/lib/rules/property-no-deprecated/README.md
+++ b/lib/rules/property-no-deprecated/README.md
@@ -19,6 +19,8 @@ This rule flags properties that were removed or deprecated after being in the CS
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix some of the problems reported by this rule.
 
+This rule supports up to 2 [message arguments](../../../docs/user-guide/configure.md#message): the deprecated property, or the property and its replacement.
+
 Prior art:
 
 - [@isnotdefined/no-obsolete](https://www.npmjs.com/package/@isnotdefined/stylelint-plugin)

--- a/lib/rules/property-no-unknown/README.md
+++ b/lib/rules/property-no-unknown/README.md
@@ -18,6 +18,8 @@ This rule ignores:
 - variables, e.g., `$sass`, `@less`, `--custom-property`
 - vendor-prefixed properties, e.g., `-moz-overflow-scrolling` (unless `checkPrefixed` is set to `true`)
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown property.
+
 ## Options
 
 ### `true`

--- a/lib/rules/property-no-vendor-prefix/README.md
+++ b/lib/rules/property-no-vendor-prefix/README.md
@@ -13,6 +13,8 @@ This rule ignores non-standard vendor-prefixed properties that aren't handled by
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate properties produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the vendor-prefixed property.
+
 ## Options
 
 ### `true`

--- a/lib/rules/relative-selector-nesting-notation/README.md
+++ b/lib/rules/relative-selector-nesting-notation/README.md
@@ -13,6 +13,8 @@ When a relative selector starts with a combinator (like ` `, `>`, `+`, `~`), you
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured notation.
+
 ## Options
 
 ### `"explicit"`

--- a/lib/rules/rule-empty-line-before/README.md
+++ b/lib/rules/rule-empty-line-before/README.md
@@ -15,6 +15,8 @@ This rule ignores rules that are the very first node in a source.
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/rule-nesting-at-rule-required-list/README.md
+++ b/lib/rules/rule-nesting-at-rule-required-list/README.md
@@ -9,6 +9,8 @@ a { color: red; }
  * This rule */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message) per configured at-rule pattern.
+
 ## Options
 
 ### `Array<string | RegExp>`

--- a/lib/rules/rule-selector-property-disallowed-list/README.md
+++ b/lib/rules/rule-selector-property-disallowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of disallowed properties for selectors within rules.
  * Selector and property name */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the disallowed property.
+
 ## Options
 
 ### `Object<string, Array<string>>`

--- a/lib/rules/selector-anb-no-unmatchable/README.md
+++ b/lib/rules/selector-anb-no-unmatchable/README.md
@@ -11,6 +11,8 @@ a:nth-child(0n+0) {}
 
 [An+B selectors](https://www.w3.org/TR/css-syntax-3/#anb-microsyntax) are one-indexed. Selectors that always evaluate to `0` will not match any elements.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unmatchable selector.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-attribute-name-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-name-disallowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of disallowed attribute names.
  * This name */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed attribute name.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-attribute-operator-allowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-allowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of allowed attribute operators.
  * This operator */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed attribute operator.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-attribute-operator-disallowed-list/README.md
+++ b/lib/rules/selector-attribute-operator-disallowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of disallowed attribute operators.
  * This operator */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed attribute operator.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-attribute-quotes/README.md
+++ b/lib/rules/selector-attribute-quotes/README.md
@@ -11,6 +11,8 @@ Require or disallow quotes for attribute values.
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix most of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the attribute value.
+
 ## Options
 
 ### `"always"`

--- a/lib/rules/selector-class-pattern/README.md
+++ b/lib/rules/selector-class-pattern/README.md
@@ -13,6 +13,8 @@ This rule ignores non-outputting Less mixin definitions and called Less mixins.
 
 Escaped selectors (e.g. `.u-size-11\/12\@sm`) are parsed as escaped twice (e.g. `.u-size-11\\/12\\@sm`). Your RegExp should account for that.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/selector-combinator-allowed-list/README.md
+++ b/lib/rules/selector-combinator-allowed-list/README.md
@@ -13,6 +13,8 @@ This rule normalizes the whitespace descendant combinator to be a single space.
 
 This rule ignores [reference combinators](https://www.w3.org/TR/selectors4/#idref-combinators) e.g. `/for/`.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed combinator.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-combinator-disallowed-list/README.md
+++ b/lib/rules/selector-combinator-disallowed-list/README.md
@@ -13,6 +13,8 @@ This rule normalizes the whitespace descendant combinator to be a single space.
 
 This rule ignores [reference combinators](https://www.w3.org/TR/selectors4/#idref-combinators) e.g. `/for/`.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed combinator.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-disallowed-list/README.md
+++ b/lib/rules/selector-disallowed-list/README.md
@@ -9,6 +9,8 @@ Specify a list of disallowed selectors.
  * This is selector */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed selector.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-id-pattern/README.md
+++ b/lib/rules/selector-id-pattern/README.md
@@ -9,6 +9,8 @@ Specify a pattern for ID selectors.
  * These ID selectors */
 ```
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/selector-max-attribute/README.md
+++ b/lib/rules/selector-max-attribute/README.md
@@ -14,6 +14,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-max-class/README.md
+++ b/lib/rules/selector-max-class/README.md
@@ -15,6 +15,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-max-combinators/README.md
+++ b/lib/rules/selector-max-combinators/README.md
@@ -14,6 +14,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-max-compound-selectors/README.md
+++ b/lib/rules/selector-max-compound-selectors/README.md
@@ -17,6 +17,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-max-id/README.md
+++ b/lib/rules/selector-max-id/README.md
@@ -14,6 +14,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-max-pseudo-class/README.md
+++ b/lib/rules/selector-max-pseudo-class/README.md
@@ -15,6 +15,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-max-specificity/README.md
+++ b/lib/rules/selector-max-specificity/README.md
@@ -20,6 +20,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!WARNING]
 > This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
+This rule supports 3 [message arguments](../../../docs/user-guide/configure.md#message): the selector, the configured maximum specificity, and the selector's resolved form.
+
 ## Options
 
 ### `string`

--- a/lib/rules/selector-max-type/README.md
+++ b/lib/rules/selector-max-type/README.md
@@ -14,6 +14,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-max-universal/README.md
+++ b/lib/rules/selector-max-universal/README.md
@@ -14,6 +14,8 @@ Each selector in a [selector list](https://drafts.csswg.org/selectors-4/#groupin
 > [!NOTE]
 > In versions prior to `17.0.0`, this rule would evaluate functional pseudo-classes separately, such as `:not()` and `:is()`, and resolve nested selectors (in a nonstandard way) before counting.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured maximum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/selector-nested-pattern/README.md
+++ b/lib/rules/selector-nested-pattern/README.md
@@ -13,6 +13,8 @@ Specify a pattern for the selectors of rules nested within rules.
 
 Non-standard selectors (e.g. selectors with Sass or Less interpolation) and selectors of rules nested within at-rules are ignored.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the configured pattern.
+
 ## Options
 
 ### `string`

--- a/lib/rules/selector-no-deprecated/README.md
+++ b/lib/rules/selector-no-deprecated/README.md
@@ -19,6 +19,8 @@ This rule flags selectors that were removed or deprecated after being in the CSS
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix some of the problems reported by this rule.
 
+This rule supports up to 2 [message arguments](../../../docs/user-guide/configure.md#message): the deprecated selector, or the selector and its replacement.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-no-qualifying-type/README.md
+++ b/lib/rules/selector-no-qualifying-type/README.md
@@ -16,6 +16,8 @@ This rule resolves nested selectors according the [CSS Nesting specification](ht
 > [!WARNING]
 > This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the qualifying type.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-no-vendor-prefix/README.md
+++ b/lib/rules/selector-no-vendor-prefix/README.md
@@ -13,6 +13,8 @@ This rule ignores non-standard vendor-prefixed selectors that aren't handled by 
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate selectors produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the vendor-prefixed selector.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-not-notation/README.md
+++ b/lib/rules/selector-not-notation/README.md
@@ -30,6 +30,8 @@ a:not(.foo):not(.bar) {}
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) option can automatically fix most of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured notation.
+
 ## Options
 
 ### `"simple"`

--- a/lib/rules/selector-pseudo-class-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-allowed-list/README.md
@@ -11,6 +11,8 @@ Specify a list of allowed pseudo-class selectors.
 
 This rule ignores selectors that use variable interpolation e.g. `:#{$variable} {}`.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed pseudo-class.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-pseudo-class-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-class-disallowed-list/README.md
@@ -11,6 +11,8 @@ Specify a list of disallowed pseudo-class selectors.
 
 This rule ignores selectors that use variable interpolation e.g. `:#{$variable} {}`.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed pseudo-class.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-pseudo-class-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-class-no-unknown/README.md
@@ -13,6 +13,8 @@ This rule considers pseudo-class selectors defined in the CSS Specifications, up
 
 This rule ignores vendor-prefixed pseudo-class selectors.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown pseudo-class.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-pseudo-element-allowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-allowed-list/README.md
@@ -14,6 +14,8 @@ This rule ignores:
 - CSS2 pseudo-elements i.e. those prefixed with a single colon
 - selectors that use variable interpolation e.g. `::#{$variable} {}`
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed pseudo-element.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-pseudo-element-colon-notation/README.md
+++ b/lib/rules/selector-pseudo-element-colon-notation/README.md
@@ -15,6 +15,8 @@ However, for compatibility with existing style sheets, user agents also accept t
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured notation.
+
 ## Options
 
 ### `"single"`

--- a/lib/rules/selector-pseudo-element-disallowed-list/README.md
+++ b/lib/rules/selector-pseudo-element-disallowed-list/README.md
@@ -14,6 +14,8 @@ This rule ignores:
 - CSS2 pseudo-elements i.e. those prefixed with a single colon
 - selectors that use variable interpolation e.g. `::#{$variable} {}`
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed pseudo-element.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/selector-pseudo-element-no-unknown/README.md
+++ b/lib/rules/selector-pseudo-element-no-unknown/README.md
@@ -13,6 +13,8 @@ This rule considers pseudo-element selectors defined in the CSS Specifications, 
 
 This rule ignores vendor-prefixed pseudo-element selectors.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown pseudo-element.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-type-case/README.md
+++ b/lib/rules/selector-type-case/README.md
@@ -11,6 +11,8 @@ Specify lowercase or uppercase for type selectors.
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the type selector and its expected case.
+
 ## Options
 
 ### `"lower"`

--- a/lib/rules/selector-type-no-unknown/README.md
+++ b/lib/rules/selector-type-no-unknown/README.md
@@ -11,6 +11,8 @@ Disallow unknown type selectors.
 
 This rule considers tags defined in the HTML, SVG, and MathML specifications to be known.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown type selector.
+
 ## Options
 
 ### `true`

--- a/lib/rules/shorthand-property-no-redundant-values/README.md
+++ b/lib/rules/shorthand-property-no-redundant-values/README.md
@@ -30,6 +30,8 @@ This rule checks the following shorthand properties:
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the redundant value and its condensed form.
+
 ## Options
 
 ### `true`

--- a/lib/rules/string-no-newline/README.md
+++ b/lib/rules/string-no-newline/README.md
@@ -21,6 +21,8 @@ a {
 > - [`declaration-property-value-no-unknown`](../declaration-property-value-no-unknown/README.md)
 > - [`media-query-no-invalid`](../media-query-no-invalid/README.md)
 
+This rule doesn't have any [message arguments](../../../docs/user-guide/configure.md#message).
+
 ## Options
 
 ### `true`

--- a/lib/rules/syntax-string-no-invalid/README.md
+++ b/lib/rules/syntax-string-no-invalid/README.md
@@ -15,6 +15,8 @@ Syntax strings are used for the `syntax` descriptor value of the `@property` at-
 
 You can check [§5.1 “Supported Names” of the CSS Properties & Values API](https://drafts.css-houdini.org/css-properties-values-api/#supported-names) for a list of valid syntax component names.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the invalid syntax string.
+
 ## Options
 
 ### `true`

--- a/lib/rules/time-min-milliseconds/README.md
+++ b/lib/rules/time-min-milliseconds/README.md
@@ -11,6 +11,8 @@ a { animation: slip-n-slide 150ms linear; }
 
 This rule checks positive numbers in `transition-duration`, `transition-delay`, `animation-duration`, `animation-delay`, and those times as they manifest in the `transition` and `animation` shorthands.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the configured minimum.
+
 ## Options
 
 ### `number`

--- a/lib/rules/unit-allowed-list/README.md
+++ b/lib/rules/unit-allowed-list/README.md
@@ -9,6 +9,8 @@ a { width: 100px; }
  *  These units */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed unit.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/unit-disallowed-list/README.md
+++ b/lib/rules/unit-disallowed-list/README.md
@@ -9,6 +9,8 @@ a { width: 100px; }
  *  These units */
 ```
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the disallowed unit.
+
 ## Options
 
 ### `Array<string>`

--- a/lib/rules/unit-no-unknown/README.md
+++ b/lib/rules/unit-no-unknown/README.md
@@ -22,6 +22,8 @@ You can use the [`languageOptions`](../../../docs/user-guide/configure.md#langua
 > - [`media-feature-name-value-no-unknown`](../media-feature-name-value-no-unknown/README.md)
 > - [`media-query-no-invalid`](../media-query-no-invalid/README.md)
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the unknown unit.
+
 ## Options
 
 ### `true`

--- a/lib/rules/value-keyword-case/README.md
+++ b/lib/rules/value-keyword-case/README.md
@@ -13,6 +13,8 @@ This rule ignores [`<custom-idents>`](https://developer.mozilla.org/en/docs/Web/
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the keyword and its expected case.
+
 ## Options
 
 ### `"lower"`

--- a/lib/rules/value-no-vendor-prefix/README.md
+++ b/lib/rules/value-no-vendor-prefix/README.md
@@ -13,6 +13,8 @@ This rule does not fix vendor-prefixed values that weren't handled by [Autoprefi
 
 The [`fix` option](../../../docs/user-guide/options.md#fix) can automatically fix all of the problems reported by this rule. However, it will not remove duplicate values produced when the prefixes are removed. You can use [Autoprefixer](https://github.com/postcss/autoprefixer) itself, with the [`add` option off and the `remove` option on](https://github.com/postcss/autoprefixer#options), in these situations.
 
+This rule supports 1 [message argument](../../../docs/user-guide/configure.md#message): the vendor-prefixed value.
+
 ## Options
 
 ### `true`

--- a/lib/utils/ruleMessages.mjs
+++ b/lib/utils/ruleMessages.mjs
@@ -10,6 +10,7 @@ export default function ruleMessages(ruleName, messages) {
 			newMessages[messageId] = `${messageText} (${ruleName})`;
 		} else {
 			newMessages[messageId] = (...args) => `${messageText(...args)} (${ruleName})`;
+			Object.defineProperty(newMessages[messageId], 'length', { value: messageText.length });
 		}
 	}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/8802
Closes https://github.com/stylelint/stylelint/pull/9185 (seemingly abandoned)

> Is there anything in the PR that needs further explanation?

I've opened a new PR as coming up with a convention requires an understanding of our rules because we have some that have diverging shapes, e.g.:

https://github.com/stylelint/stylelint/blob/84f2c6b75186dc4370b5a7419e26c661fad3acbe/lib/rules/color-named/index.mjs#L18-L21

(The previous PR seems like a flyby, too, and I'm trying to clear our stale PRs.)

I've tried to find a convention that is simple and concise yet flexible enough; settling on using "up to" and "or" to handle divergence. 

Like the problem messages PR, this one touches many files, but the change is consistent across them. I hope the review isn't too burdensome.