### PR TITLE
Fix autofix introducing new violations

### DIFF
--- a/lib/constants.mjs
+++ b/lib/constants.mjs
@@ -23,3 +23,5 @@ export const SEVERITY_WARNING = 'warning';
 export const DEFAULT_SEVERITY = SEVERITY_ERROR;
 
 export const DEFAULT_FIX_MODE = 'strict';
+
+export const MAX_AUTOFIX_PASSES = 10;

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -2,6 +2,7 @@ import { isAbsolute } from 'node:path';
 
 import postcss from 'postcss';
 
+import { MAX_AUTOFIX_PASSES } from './constants.mjs';
 import descriptionlessDisables from './descriptionlessDisables.mjs';
 import getConfigForFile from './getConfigForFile.mjs';
 import getLexer from './utils/getLexer.mjs';
@@ -98,6 +99,26 @@ export default async function lintSource(stylelint, options = {}) {
 	});
 
 	await lintPostcssResult(stylelint._options, stylelintPostcssResult, config);
+
+	// When fix mode is enabled, re-run linting up to MAX_AUTOFIX_PASSES times.
+	// A rule's fix can introduce violations for rules that already ran,
+	// so we iterate until no more fixes are applied or we hit the limit.
+	if (config.fix) {
+		for (let pass = 1; pass < MAX_AUTOFIX_PASSES; pass++) {
+			const previousFixersData = stylelintPostcssResult.stylelint.fixersData;
+			const fixesApplied = Object.values(previousFixersData).some((count) => count > 0);
+
+			if (!fixesApplied) break;
+
+			// Reset transient state for the next pass
+			stylelintPostcssResult.stylelint.fixersData = {};
+			stylelintPostcssResult.stylelint.disabledRanges = {};
+			stylelintPostcssResult.stylelint.rangesOfComputedEditInfos = [];
+			stylelintPostcssResult.messages.length = 0;
+
+			await lintPostcssResult(stylelint._options, stylelintPostcssResult, config);
+		}
+	}
 
 	reportDisables(stylelintPostcssResult);
 	needlessDisables(stylelintPostcssResult);


### PR DESCRIPTION
## Problem

When running stylelint with `--fix`, a rule's autofix can introduce violations for rules that have already been checked. Since rules run in a single pass, these new violations are never caught or fixed. Users have to run stylelint multiple times to converge on clean output.

Fixes #3853

## Solution

Adopt the same approach as ESLint: run the fix pass iteratively (up to 10 times) until no more fixes are applied.

After the initial `lintPostcssResult()` call, the loop checks `fixersData` to see if any fixes were applied. If so, it resets the transient state and re-runs linting. It stops when either:
- No fixes were applied in the last pass (code is stable)
- The maximum of 10 passes is reached

## Changes

- `lib/constants.mjs` - add `MAX_AUTOFIX_PASSES = 10`
- `lib/lintSource.mjs` - wrap `lintPostcssResult()` in an iterative fix loop

## Notes

- Zero performance impact when fix mode is off or when no fixes are needed (the first pass always runs exactly as before)
- The disable reports (`reportDisables`, `needlessDisables`, etc.) run once after the loop, using the final-pass state
- Between passes, transient state is reset: `fixersData`, `disabledRanges`, `rangesOfComputedEditInfos`, and accumulated warnings
- All existing tests pass (670 lib tests, 10 system tests, 42 fix-specific tests)