### PR TITLE
Add `selector-no-invalid` rule

### DIFF
--- a/.changeset/nervous-boats-deliver.md
+++ b/.changeset/nervous-boats-deliver.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `selector-no-invalid` rule

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -78,6 +78,7 @@ Disallow invalid syntax with these (sometimes implicit) `no-invalid` rules.
 | [`no-invalid-double-slash-comments`](../../lib/rules/no-invalid-double-slash-comments/README.md)<br/>Disallow invalid double-slash comments. | ✅ | |
 | [`no-invalid-position-at-import-rule`](../../lib/rules/no-invalid-position-at-import-rule/README.md)<br/>Disallow invalid position `@import` rules. | ✅ | |
 | [`no-invalid-position-declaration`](../../lib/rules/no-invalid-position-declaration/README.md)<br/>Disallow invalid position declarations. | ✅ | |
+| [`selector-no-invalid`](../../lib/rules/selector-no-invalid/README.md)<br/>Disallow invalid selectors. | | |
 | [`string-no-newline`](../../lib/rules/string-no-newline/README.md)<br/>Disallow invalid newlines within strings. | ✅ | |
 | [`syntax-string-no-invalid`](../../lib/rules/syntax-string-no-invalid/README.md)<br/>Disallow invalid syntax strings. | ✅ | |
 <!-- prettier-ignore-end -->

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -306,6 +306,9 @@ export const atRulePagePseudoClasses = new Set([
 export const linguisticPseudoClasses = new Set(['dir', 'lang']);
 
 /** @type {ReadonlySet<string>} */
+export const dirIdentifiers = new Set(['ltr', 'rtl']);
+
+/** @type {ReadonlySet<string>} */
 export const logicalCombinationsPseudoClasses = new Set(['has', 'is', 'matches', 'not', 'where']);
 
 /** @type {ReadonlySet<string>} */

--- a/lib/rules/index.mjs
+++ b/lib/rules/index.mjs
@@ -145,6 +145,7 @@ const ruleNames = [
 	'selector-max-universal',
 	'selector-nested-pattern',
 	'selector-no-deprecated',
+	'selector-no-invalid',
 	'selector-no-qualifying-type',
 	'selector-no-vendor-prefix',
 	'selector-not-notation',

--- a/lib/rules/selector-no-invalid/README.md
+++ b/lib/rules/selector-no-invalid/README.md
@@ -14,6 +14,8 @@ This rule considers selectors defined within the CSS specifications, up to and i
 > [!WARNING]
 > This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
 
+This rule supports 2 [message arguments](../../../docs/user-guide/configure.md#message): the selector and the reason it is invalid.
+
 ## Options
 
 ### `true`

--- a/lib/rules/selector-no-invalid/README.md
+++ b/lib/rules/selector-no-invalid/README.md
@@ -1,0 +1,69 @@
+# selector-no-invalid
+
+Disallow invalid selectors.
+
+<!-- prettier-ignore -->
+```css
+a ) b {}
+/*↑
+ * Selectors like this */
+```
+
+This rule considers selectors defined within the CSS specifications, up to and including Editor's Drafts, to be valid.
+
+> [!WARNING]
+> This rule is only appropriate for CSS. You should not turn it on for CSS-like languages, such as SCSS or Less.
+
+## Options
+
+### `true`
+
+```json
+{
+  "selector-no-invalid": true
+}
+```
+
+The following patterns are considered problems:
+
+<!-- prettier-ignore -->
+```css
+a ) b {}
+```
+
+<!-- prettier-ignore -->
+```css
+:nth-child(2n+) {}
+```
+
+<!-- prettier-ignore -->
+```css
+[0foo] {}
+```
+
+<!-- prettier-ignore -->
+```css
+:dir(foo) {}
+```
+
+The following patterns are _not_ considered problems:
+
+<!-- prettier-ignore -->
+```css
+a b {}
+```
+
+<!-- prettier-ignore -->
+```css
+:nth-child(2n+1) {}
+```
+
+<!-- prettier-ignore -->
+```css
+[foo] {}
+```
+
+<!-- prettier-ignore -->
+```css
+:dir(ltr) {}
+```

--- a/lib/rules/selector-no-invalid/README.md
+++ b/lib/rules/selector-no-invalid/README.md
@@ -5,7 +5,7 @@ Disallow invalid selectors.
 <!-- prettier-ignore -->
 ```css
 a ) b {}
-/*↑
+/* ↑
  * Selectors like this */
 ```
 

--- a/lib/rules/selector-no-invalid/__tests__/index.mjs
+++ b/lib/rules/selector-no-invalid/__tests__/index.mjs
@@ -61,6 +61,10 @@ testRule({
 			code: ':dir(rtl) {}',
 		},
 		{
+			code: ':dir(rtl), :lang(en) {}',
+		},
+
+		{
 			code: '@keyframes foo { from {} 50% {} to {} }',
 		},
 	],

--- a/lib/rules/selector-no-invalid/__tests__/index.mjs
+++ b/lib/rules/selector-no-invalid/__tests__/index.mjs
@@ -1,0 +1,161 @@
+import rule from '../index.mjs';
+const { messages, ruleName } = rule;
+
+testRule({
+	ruleName,
+	config: true,
+
+	accept: [
+		{
+			code: 'a {}',
+		},
+		{
+			code: '.foo {}',
+		},
+		{
+			code: 'a, b {}',
+		},
+		{
+			code: 'a > b {}',
+		},
+		{
+			code: 'a + b {}',
+		},
+		{
+			code: 'a ~ b {}',
+		},
+		{
+			code: '[foo] {}',
+		},
+		{
+			code: '[foo="bar"] {}',
+		},
+		{
+			code: ':hover {}',
+		},
+		{
+			code: ':nth-child(2n+1) {}',
+		},
+		{
+			code: ':not(.foo) {}',
+		},
+		{
+			code: ':is(a, b) {}',
+		},
+		{
+			code: ':has(> a) {}',
+		},
+		{
+			code: '::before {}',
+		},
+		{
+			code: '& a {}',
+		},
+		{
+			code: '&:hover {}',
+		},
+		{
+			code: ':dir(ltr) {}',
+		},
+		{
+			code: ':dir(rtl) {}',
+		},
+		{
+			code: '@keyframes foo { from {} 50% {} to {} }',
+		},
+	],
+
+	reject: [
+		{
+			code: 'a ) b {}',
+			message: messages.rejected('a ) b', 'unexpected input'),
+			line: 1,
+			column: 3,
+			endLine: 1,
+			endColumn: 4,
+			description: 'Stray closing parenthesis',
+		},
+		{
+			code: ', a {}',
+			message: messages.rejected(', a', 'selector is expected'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 2,
+			description: 'Leading comma',
+		},
+		{
+			code: ':nth-child(2n+) {}',
+			message: messages.rejected(':nth-child(2n+)', 'integer is expected'),
+			line: 1,
+			column: 15,
+			endLine: 1,
+			endColumn: 16,
+			description: 'Trailing operator in An+B',
+		},
+		{
+			code: '[0foo] {}',
+			message: messages.rejected('[0foo]', 'identifier is expected'),
+			line: 1,
+			column: 2,
+			endLine: 1,
+			endColumn: 3,
+			description: 'Attribute name starting with a digit',
+		},
+		{
+			code: '[foo==bar] {}',
+			message: messages.rejected('[foo==bar]', 'identifier is expected'),
+			line: 1,
+			column: 6,
+			endLine: 1,
+			endColumn: 7,
+			description: 'Doubled operator in attribute selector',
+		},
+		{
+			code: '.foo..bar {}',
+			message: messages.rejected('.foo..bar', 'identifier is expected'),
+			line: 1,
+			column: 6,
+			endLine: 1,
+			endColumn: 7,
+			description: 'Doubled class dot',
+		},
+		{
+			code: ':dir() {}',
+			message: messages.rejected(':dir()', 'expected "ltr" or "rtl"'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 7,
+			description: 'Empty :dir() argument',
+		},
+		{
+			code: ':dir(foo) {}',
+			message: messages.rejected(':dir(foo)', 'expected "ltr" or "rtl"'),
+			line: 1,
+			column: 1,
+			endLine: 1,
+			endColumn: 10,
+			description: 'Invalid argument to :dir()',
+		},
+		{
+			code: ':dir(foo), :dir(bar) {}',
+			warnings: [
+				{
+					message: messages.rejected(':dir(foo)', 'expected "ltr" or "rtl"'),
+					line: 1,
+					column: 1,
+					endLine: 1,
+					endColumn: 10,
+				},
+				{
+					message: messages.rejected(':dir(bar)', 'expected "ltr" or "rtl"'),
+					line: 1,
+					column: 12,
+					endLine: 1,
+					endColumn: 21,
+				},
+			],
+		},
+	],
+});

--- a/lib/rules/selector-no-invalid/__tests__/index.mjs
+++ b/lib/rules/selector-no-invalid/__tests__/index.mjs
@@ -163,3 +163,18 @@ testRule({
 		},
 	],
 });
+
+testRule({
+	ruleName,
+	config: true,
+	customSyntax: 'postcss-scss',
+
+	accept: [
+		{
+			code: '#{$foo} {}',
+		},
+		{
+			code: '%foo {}',
+		},
+	],
+});

--- a/lib/rules/selector-no-invalid/__tests__/index.mjs
+++ b/lib/rules/selector-no-invalid/__tests__/index.mjs
@@ -139,7 +139,7 @@ testRule({
 			description: 'Invalid argument to :dir()',
 		},
 		{
-			code: ':dir(foo), :dir(bar) {}',
+			code: ':dir(foo), :DIR(bar) {}',
 			warnings: [
 				{
 					message: messages.rejected(':dir(foo)', 'expected "ltr" or "rtl"'),
@@ -149,7 +149,7 @@ testRule({
 					endColumn: 10,
 				},
 				{
-					message: messages.rejected(':dir(bar)', 'expected "ltr" or "rtl"'),
+					message: messages.rejected(':DIR(bar)', 'expected "ltr" or "rtl"'),
 					line: 1,
 					column: 12,
 					endLine: 1,

--- a/lib/rules/selector-no-invalid/index.mjs
+++ b/lib/rules/selector-no-invalid/index.mjs
@@ -1,0 +1,93 @@
+import { parse, walk } from 'css-tree';
+
+import { dirIdentifiers } from '../../reference/selectors.mjs';
+import getRuleSelector from '../../utils/getRuleSelector.mjs';
+import isKeyframeRule from '../../utils/isKeyframeRule.mjs';
+import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
+import report from '../../utils/report.mjs';
+import ruleMessages from '../../utils/ruleMessages.mjs';
+import validateOptions from '../../utils/validateOptions.mjs';
+
+const ruleName = 'selector-no-invalid';
+
+const messages = ruleMessages(ruleName, {
+	rejected: (selector, reason) => `Invalid selector "${selector}"${reason ? `, ${reason}` : ''}`,
+});
+
+const meta = {
+	url: 'https://stylelint.io/user-guide/rules/selector-no-invalid',
+};
+
+/** @type {import('stylelint').CoreRules[ruleName]} */
+const rule = (primary) => {
+	return (root, result) => {
+		const validOptions = validateOptions(result, ruleName, { actual: primary });
+
+		if (!validOptions) return;
+
+		root.walkRules((ruleNode) => {
+			if (!isStandardSyntaxRule(ruleNode)) return;
+
+			if (isKeyframeRule(ruleNode)) return;
+
+			const selector = getRuleSelector(ruleNode);
+			let ast;
+
+			try {
+				ast = parse(selector, { context: 'selectorList', positions: true });
+			} catch (error) {
+				const { offset = 0, message = '' } = /** @type {{ offset?: number; message?: string }} */ (
+					error
+				);
+				const index = offset;
+				const endIndex = index + 1;
+
+				report({
+					message: messages.rejected,
+					messageArgs: [selector, message.charAt(0).toLowerCase() + message.slice(1)],
+					node: ruleNode,
+					index,
+					endIndex,
+					ruleName,
+					result,
+				});
+
+				return;
+			}
+
+			walk(ast, (node) => {
+				if (node.type !== 'PseudoClassSelector') return;
+
+				if (node.name.toLowerCase() !== 'dir') return;
+
+				if (!node.loc) return;
+
+				const first = node.children?.first;
+				const hasValidIdentifier =
+					node.children?.size === 1 &&
+					first?.type === 'Identifier' &&
+					dirIdentifiers.has(first.name.toLowerCase());
+
+				if (hasValidIdentifier) return;
+
+				const index = node.loc.start.offset;
+				const endIndex = node.loc.end.offset;
+
+				report({
+					message: messages.rejected,
+					messageArgs: [selector.slice(index, endIndex), 'expected "ltr" or "rtl"'],
+					node: ruleNode,
+					index,
+					endIndex,
+					ruleName,
+					result,
+				});
+			});
+		});
+	};
+};
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+rule.meta = meta;
+export default rule;

--- a/lib/rules/selector-no-invalid/index.mjs
+++ b/lib/rules/selector-no-invalid/index.mjs
@@ -4,6 +4,7 @@ import { dirIdentifiers } from '../../reference/selectors.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import isKeyframeRule from '../../utils/isKeyframeRule.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
+import { mayIncludeRegexes } from '../../utils/regexes.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -31,6 +32,25 @@ const rule = (primary) => {
 			if (isKeyframeRule(ruleNode)) return;
 
 			const selector = getRuleSelector(ruleNode);
+
+			/**
+			 * @param {number} index
+			 * @param {number} endIndex
+			 * @param {string} subject
+			 * @param {string} reason
+			 */
+			const complain = (index, endIndex, subject, reason) => {
+				report({
+					message: messages.rejected,
+					messageArgs: [subject, reason],
+					node: ruleNode,
+					index,
+					endIndex,
+					ruleName,
+					result,
+				});
+			};
+
 			let ast;
 
 			try {
@@ -39,21 +59,18 @@ const rule = (primary) => {
 				const { offset = 0, message = '' } = /** @type {{ offset?: number; message?: string }} */ (
 					error
 				);
-				const index = offset;
-				const endIndex = index + 1;
 
-				report({
-					message: messages.rejected,
-					messageArgs: [selector, message.charAt(0).toLowerCase() + message.slice(1)],
-					node: ruleNode,
-					index,
-					endIndex,
-					ruleName,
-					result,
-				});
+				complain(
+					offset,
+					Math.min(offset + 1, selector.length),
+					selector,
+					message.charAt(0).toLowerCase() + message.slice(1),
+				);
 
 				return;
 			}
+
+			if (!mayIncludeRegexes.dirPseudoClass.test(selector)) return;
 
 			walk(ast, (node) => {
 				if (node.type !== 'PseudoClassSelector') return;
@@ -62,9 +79,10 @@ const rule = (primary) => {
 
 				if (!node.loc) return;
 
-				const first = node.children?.first;
+				const { children } = node;
+				const first = children?.first;
 				const hasValidIdentifier =
-					node.children?.size === 1 &&
+					children?.size === 1 &&
 					first?.type === 'Identifier' &&
 					dirIdentifiers.has(first.name.toLowerCase());
 
@@ -73,15 +91,7 @@ const rule = (primary) => {
 				const index = node.loc.start.offset;
 				const endIndex = node.loc.end.offset;
 
-				report({
-					message: messages.rejected,
-					messageArgs: [selector.slice(index, endIndex), 'expected "ltr" or "rtl"'],
-					node: ruleNode,
-					index,
-					endIndex,
-					ruleName,
-					result,
-				});
+				complain(index, endIndex, selector.slice(index, endIndex), 'expected "ltr" or "rtl"');
 			});
 		});
 	};

--- a/lib/rules/selector-no-invalid/index.mjs
+++ b/lib/rules/selector-no-invalid/index.mjs
@@ -56,9 +56,10 @@ const rule = (primary) => {
 			try {
 				ast = parse(selector, { context: 'selectorList', positions: true });
 			} catch (error) {
-				const { offset = 0, message = '' } = /** @type {{ offset?: number; message?: string }} */ (
-					error
-				);
+				if (!(error instanceof SyntaxError)) throw error;
+
+				const offset = 'offset' in error && typeof error.offset === 'number' ? error.offset : 0;
+				const message = error.message;
 
 				complain(
 					offset,

--- a/lib/rules/selector-no-invalid/index.mjs
+++ b/lib/rules/selector-no-invalid/index.mjs
@@ -92,7 +92,8 @@ const rule = (primary) => {
 				const index = node.loc.start.offset;
 				const endIndex = node.loc.end.offset;
 
-				complain(index, endIndex, selector.slice(index, endIndex), 'expected "ltr" or "rtl"');
+				const reason = `expected ${[...dirIdentifiers].map((id) => `"${id}"`).join(' or ')}`;
+				complain(index, endIndex, selector.slice(index, endIndex), reason);
 			});
 		});
 	};

--- a/lib/rules/selector-no-invalid/index.mjs
+++ b/lib/rules/selector-no-invalid/index.mjs
@@ -73,27 +73,29 @@ const rule = (primary) => {
 
 			if (!mayIncludeRegexes.dirPseudoClass.test(selector)) return;
 
-			walk(ast, (node) => {
-				if (node.type !== 'PseudoClassSelector') return;
+			walk(ast, {
+				visit: 'PseudoClassSelector',
+				enter(node) {
+					if (node.name.toLowerCase() !== 'dir') return walk.skip;
 
-				if (node.name.toLowerCase() !== 'dir') return;
+					if (!node.loc) return walk.skip;
 
-				if (!node.loc) return;
+					const { children } = node;
+					const first = children?.first;
+					const hasValidIdentifier =
+						children?.size === 1 &&
+						first?.type === 'Identifier' &&
+						dirIdentifiers.has(first.name.toLowerCase());
 
-				const { children } = node;
-				const first = children?.first;
-				const hasValidIdentifier =
-					children?.size === 1 &&
-					first?.type === 'Identifier' &&
-					dirIdentifiers.has(first.name.toLowerCase());
+					if (hasValidIdentifier) return walk.skip;
 
-				if (hasValidIdentifier) return;
+					const index = node.loc.start.offset;
+					const endIndex = node.loc.end.offset;
 
-				const index = node.loc.start.offset;
-				const endIndex = node.loc.end.offset;
+					const reason = `expected ${[...dirIdentifiers].map((id) => `"${id}"`).join(' or ')}`;
 
-				const reason = `expected ${[...dirIdentifiers].map((id) => `"${id}"`).join(' or ')}`;
-				complain(index, endIndex, selector.slice(index, endIndex), reason);
+					complain(index, endIndex, selector.slice(index, endIndex), reason);
+				},
 			});
 		});
 	};

--- a/lib/rules/selector-no-invalid/index.mjs
+++ b/lib/rules/selector-no-invalid/index.mjs
@@ -80,14 +80,7 @@ const rule = (primary) => {
 
 					if (!node.loc) return walk.skip;
 
-					const { children } = node;
-					const first = children?.first;
-					const hasValidIdentifier =
-						children?.size === 1 &&
-						first?.type === 'Identifier' &&
-						dirIdentifiers.has(first.name.toLowerCase());
-
-					if (hasValidIdentifier) return walk.skip;
+					if (isValidDirPseudoClass(node, dirIdentifiers)) return walk.skip;
 
 					const index = node.loc.start.offset;
 					const endIndex = node.loc.end.offset;
@@ -100,6 +93,23 @@ const rule = (primary) => {
 		});
 	};
 };
+
+/**
+ * @param {import('css-tree').PseudoClassSelector} node
+ * @param {ReadonlySet<string>} identifiers
+ * @returns {boolean}
+ */
+function isValidDirPseudoClass(node, identifiers) {
+	const { children } = node;
+
+	if (children?.size !== 1) return false;
+
+	const first = children.first;
+
+	if (first?.type !== 'Identifier') return false;
+
+	return identifiers.has(first.name.toLowerCase());
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/utils/regexes.mjs
+++ b/lib/utils/regexes.mjs
@@ -92,6 +92,7 @@ export const mayIncludeRegexes = {
 		'i',
 	),
 	dimension: /\d[%\w-]/,
+	dirPseudoClass: /:dir\(/i,
 	grayFunction: /\bgray\(/i,
 	hexColor: /#[\da-z]+/i,
 	hueColorFunction: new RegExp(`\\b(?:${[...hueColorFunctions.values()].join('|')})\\(`, 'i'),

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1013,6 +1013,7 @@ declare namespace stylelint {
 			{ ignoreSelectors: OneOrMany<StringOrRegex> },
 			AutofixMessage & RejectedMessage<[selector: string]>
 		>;
+		'selector-no-invalid': CoreRule<true, {}, RejectedMessage<[selector: string, reason: string]>>;
 		'selector-no-qualifying-type': CoreRule<
 			true,
 			{ ignore: OneOrMany<'attribute' | 'class' | 'id'> },


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/3480
Closes https://github.com/stylelint/stylelint/issues/9230

> Is there anything in the PR that needs further explanation?

I've based it on the patterns in `media-query-no-invalid` and `at-rule-prelude-no-invalid`.

It seems like a quick win that'll catch typos in selectors.  It can serve as a home for ad hoc validation, such as `:dir()`.  If csstree adds selector validation, it can also serve as its home.
