### PR TITLE
Fix `ConfigurationError` regression for custom syntaxes

### DIFF
--- a/.changeset/silent-carpets-repeat.md
+++ b/.changeset/silent-carpets-repeat.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `ConfigurationError` regression for custom syntaxes

--- a/lib/__tests__/standalone-syntax.test.mjs
+++ b/lib/__tests__/standalone-syntax.test.mjs
@@ -1,4 +1,6 @@
-import { writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 import replaceBackslashes from '../testUtils/replaceBackslashes.mjs';
 import standalone from '../standalone.mjs';
@@ -137,7 +139,7 @@ it('rejects on unknown custom syntax option', async () => {
 			config: config(),
 		}),
 	).rejects.toThrow(
-		'Could not find "unknown-module". Do you need to install the package or use the "configBasedir" option?',
+		'Cannot resolve custom syntax module "unknown-module". Check that module "unknown-module" is available and spelled correctly.',
 	);
 });
 
@@ -176,6 +178,26 @@ describe('customSyntax set in the config', () => {
 		expect(results).toHaveLength(1);
 		expect(results[0].warnings).toHaveLength(1);
 		expect(results[0].warnings[0]).toMatchObject({ line: 2, column: 3, rule: 'block-no-empty' });
+	});
+
+	it('standalone with bare-package custom syntax not reachable from configBasedir or cwd', async () => {
+		const isolatedDir = await mkdtemp(join(tmpdir(), 'stylelint-isolated-'));
+
+		try {
+			const { results } = await standalone({
+				config: config({ customSyntax: 'postcss-scss' }),
+				configBasedir: isolatedDir,
+				cwd: isolatedDir,
+				code: '$foo: bar; // foo;\nb {}',
+				formatter: stringFormatter,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0]).toMatchObject({ line: 2, column: 3, rule: 'block-no-empty' });
+		} finally {
+			await rm(isolatedDir, { recursive: true, force: true });
+		}
 	});
 
 	it('standalone with custom syntax as npm package', async () => {
@@ -234,7 +256,7 @@ describe('customSyntax set in the config', () => {
 				config: config({ customSyntax: 'unknown-module' }),
 			}),
 		).rejects.toThrow(
-			'Could not find "unknown-module". Do you need to install the package or use the "configBasedir" option?',
+			'Cannot resolve custom syntax module "unknown-module". Check that module "unknown-module" is available and spelled correctly.',
 		);
 	});
 

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -36,6 +36,14 @@ function absolutizeGlob(glob, basedir) {
 }
 
 /**
+ * @param {string} lookup
+ * @returns {boolean}
+ */
+function isPathLike(lookup) {
+	return lookup.startsWith('./') || lookup.startsWith('../') || isAbsolute(lookup);
+}
+
+/**
  * - Merges config and stylelint options
  * - Makes all paths absolute
  * - Merges extends
@@ -187,7 +195,7 @@ function absolutizePaths(config, configDir, cwd) {
 		config.processors = config.processors.map(toAbsolutePath);
 	}
 
-	if (isString(config.customSyntax)) {
+	if (isString(config.customSyntax) && isPathLike(config.customSyntax)) {
 		config.customSyntax = getModulePath(configDir, config.customSyntax, cwd);
 	}
 
@@ -200,9 +208,10 @@ function absolutizePaths(config, configDir, cwd) {
 			if (isObject(entry)) {
 				return {
 					files: [entry.files].flat().map((glob) => absolutizeGlob(glob, configDir)),
-					customSyntax: isString(entry.customSyntax)
-						? getModulePath(configDir, entry.customSyntax, cwd)
-						: entry.customSyntax,
+					customSyntax:
+						isString(entry.customSyntax) && isPathLike(entry.customSyntax)
+							? getModulePath(configDir, entry.customSyntax, cwd)
+							: entry.customSyntax,
 				};
 			}
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #9244

> Is there anything in the PR that needs further explanation?

Reverts a change in https://github.com/stylelint/stylelint/pull/9179 (and these [two tests](https://github.com/stylelint/stylelint/pull/9179/changes#diff-4bc12df8513c8dcf94b1de2dd098265eefc75cef9cd4114a81fe1b5e73f5b566)) so that npm packages are only looked up via `dynamicImport` (called from `getCustomSyntax`).