### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for nested `webkit-scrollbar` part

### DIFF
--- a/.changeset/short-penguins-sip.md
+++ b/.changeset/short-penguins-sip.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fix `selector-pseudo-class-no-unknown` false positives for nested `webkit-scrollbar` part

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -126,6 +126,14 @@ testRule({
 			description: 'non-standalone webkit scrollbar multiple pseudo classes',
 		},
 		{
+			code: stripIndent`
+				::-webkit-scrollbar {
+					&:horizontal {}
+				}
+			`,
+			description: 'nested webkit scrollbar pseudo class',
+		},
+		{
 			code: 'a:defined { }',
 			description:
 				'represents any element that has been defined; includes any standard element built into the browser, and custom elements that have been successfully defined (i.e. with the CustomElementRegistry.define() method).',

--- a/lib/rules/selector-pseudo-class-no-unknown/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.mjs
@@ -18,6 +18,7 @@ import isStandardSyntaxSelector from '../../utils/isStandardSyntaxSelector.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
+import resolveNestedSelectorsForRule from '../../utils/resolveNestedSelectorsForRule.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
 import vendor from '../../utils/vendor.mjs';
@@ -31,6 +32,101 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-pseudo-class-no-unknown',
 };
+
+/**
+ * @param {import('postcss-selector-parser').Pseudo} pseudoNode
+ * @returns {boolean}
+ */
+function isWebkitScrollbarPseudoElement(pseudoNode) {
+	const name = pseudoNode.value.toLowerCase().slice(2);
+
+	return pseudoNode.value.startsWith('::') && webkitScrollbarPseudoElements.has(name);
+}
+
+/**
+ * @param {import('postcss-selector-parser').Selector} selectorNode
+ * @returns {boolean}
+ */
+function selectorEndsWithWebkitScrollbarPseudoElement(selectorNode) {
+	/** @type {import('postcss-selector-parser').Node | undefined} */
+	let current = selectorNode.last;
+
+	while (current) {
+		if (current.type === 'combinator') return false;
+
+		if (current.type === 'pseudo' && current.value.startsWith('::')) {
+			return isWebkitScrollbarPseudoElement(current);
+		}
+
+		current = current.prev();
+	}
+
+	return false;
+}
+
+/**
+ * @param {import('postcss-selector-parser').Pseudo} pseudoNode
+ * @returns {boolean}
+ */
+function isNestedParentWebkitScrollbarPseudoElement(pseudoNode) {
+	if (pseudoNode.value !== ':is' || !pseudoNode.nodes?.length) return false;
+
+	return pseudoNode.nodes.every(selectorEndsWithWebkitScrollbarPseudoElement);
+}
+
+/**
+ * @param {import('postcss-selector-parser').Pseudo} pseudoNode
+ * @returns {boolean}
+ */
+function hasPreviousWebkitScrollbarPseudoElement(pseudoNode) {
+	/** @type {import('postcss-selector-parser').Node | undefined} */
+	let prevNode = pseudoNode;
+
+	do {
+		prevNode = prevNode.prev();
+
+		if (prevNode?.type === 'pseudo') {
+			if (prevNode.value.startsWith('::')) return isWebkitScrollbarPseudoElement(prevNode);
+
+			if (isNestedParentWebkitScrollbarPseudoElement(prevNode)) return true;
+		}
+	} while (prevNode);
+
+	return false;
+}
+
+/**
+ * @param {import('postcss-selector-parser').Pseudo} a
+ * @param {import('postcss-selector-parser').Pseudo} b
+ * @returns {boolean}
+ */
+function isSameSourcePseudo(a, b) {
+	return (
+		a.value === b.value &&
+		a.sourceIndex === b.sourceIndex &&
+		a.source?.start?.line === b.source?.start?.line &&
+		a.source?.start?.column === b.source?.start?.column &&
+		a.source?.end?.line === b.source?.end?.line &&
+		a.source?.end?.column === b.source?.end?.column
+	);
+}
+
+/**
+ * @param {import('postcss-selector-parser').Pseudo} pseudoNode
+ * @param {import('postcss-selector-parser').Root | undefined} resolvedSelectors
+ * @returns {boolean}
+ */
+function hasResolvedWebkitScrollbarPseudoElement(pseudoNode, resolvedSelectors) {
+	let result = false;
+
+	resolvedSelectors?.walkPseudos((resolvedPseudoNode) => {
+		if (result || !isSameSourcePseudo(pseudoNode, resolvedPseudoNode)) return;
+
+		result = hasPreviousWebkitScrollbarPseudoElement(resolvedPseudoNode);
+	});
+
+	return result;
+}
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
@@ -53,11 +149,12 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		/**
-		 * @param {string} selector
+		 * @param {import('postcss-selector-parser').Root | import('postcss-selector-parser').Selector} selectorNode
 		 * @param {import('postcss').ChildNode} node
+		 * @param {import('postcss-selector-parser').Root | undefined} resolvedSelectors
 		 */
-		function check(selector, node) {
-			parseSelector(selector, result, node)?.walkPseudos((pseudoNode) => {
+		function check(selectorNode, node, resolvedSelectors) {
+			selectorNode.walkPseudos((pseudoNode) => {
 				const value = pseudoNode.value;
 
 				if (!isStandardSyntaxSelector(value)) {
@@ -98,28 +195,12 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
-					/** @type {import('postcss-selector-parser').Base} */
-					let prevPseudoElement = pseudoNode;
-
-					do {
-						prevPseudoElement = /** @type {import('postcss-selector-parser').Base} */ (
-							prevPseudoElement.prev()
-						);
-
-						if (prevPseudoElement && prevPseudoElement.value.slice(0, 2) === '::') {
-							break;
-						}
-					} while (prevPseudoElement);
-
-					if (prevPseudoElement) {
-						const prevPseudoElementValue = prevPseudoElement.value.toLowerCase().slice(2);
-
-						if (
-							webkitScrollbarPseudoElements.has(prevPseudoElementValue) &&
-							webkitScrollbarPseudoClasses.has(name)
-						) {
-							return;
-						}
+					if (
+						webkitScrollbarPseudoClasses.has(name) &&
+						(hasPreviousWebkitScrollbarPseudoElement(pseudoNode) ||
+							hasResolvedWebkitScrollbarPseudoElement(pseudoNode, resolvedSelectors))
+					) {
+						return;
 					}
 
 					index = pseudoNode.sourceIndex;
@@ -148,7 +229,21 @@ const rule = (primary, secondaryOptions) => {
 				}
 
 				selector = getRuleSelector(node);
-			} else if (isAtRule(node) && node.name === 'page' && node.params) {
+
+				if (!selector?.includes(':')) {
+					return;
+				}
+
+				resolveNestedSelectorsForRule(node, result).forEach(
+					({ selector: selectorNode, resolvedSelectors }) => {
+						check(selectorNode, node, resolvedSelectors);
+					},
+				);
+
+				return;
+			}
+
+			if (isAtRule(node) && node.name === 'page' && node.params) {
 				if (!isStandardSyntaxAtRule(node)) {
 					return;
 				}
@@ -168,7 +263,13 @@ const rule = (primary, secondaryOptions) => {
 				return;
 			}
 
-			check(selector, node);
+			const selectorRoot = parseSelector(selector, result, node);
+
+			if (!selectorRoot) {
+				return;
+			}
+
+			check(selectorRoot, node, undefined);
 		});
 	};
 };


### PR DESCRIPTION
## Summary
- resolves nested selectors before checking webkit scrollbar pseudo-class context
- allows `:horizontal` and related webkit scrollbar pseudo-classes when nested under `::-webkit-scrollbar`
- adds a regression test for nested scrollbar selectors

Fixes #9224

## Verification
- `npm run test-only -- lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs --runInBand`
- `npm run lint`
