### PR TITLE
Add experimental `referenceFiles` resolver support

### DIFF
--- a/.changeset/reference-files-resolver.md
+++ b/.changeset/reference-files-resolver.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: experimental `entrypoints` and `resolver` properties to `referenceFiles` configuration

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -589,6 +589,28 @@ Each entry can be:
 - an object that
   - must contain a `files` property (a string or an array of glob patterns)
   - may contain a [`customSyntax`](#customsyntax) property
+- an object that
+  - must contain an `entrypoints` property (a string or an array of file paths)
+  - must contain a `resolver` property (a function that returns a PostCSS plugin)
+  - may contain a [`customSyntax`](#customsyntax) property
+
+CSS depends on order, with many features being "last one wins". Globs match files in filesystem order, which may differ from the actual order of imports. For order-sensitive cases, use the `entrypoints` and `resolver` form to load reference files in dependency order via a PostCSS plugin like [`postcss-import`](https://github.com/postcss/postcss-import):
+
+```js
+import postcssImport from "postcss-import";
+
+export default {
+  referenceFiles: {
+    entrypoints: ["src/main.css"],
+    resolver: (entrypoint) => postcssImport()
+  },
+  rules: {
+    "no-unknown-custom-properties": true
+  }
+};
+```
+
+The `resolver` is a function that receives an `entrypoint` path and returns a PostCSS plugin (or array of plugins). The plugin is responsible for inlining dependencies into a single root. This lets the resolver be configured per entrypoint, which is useful when the same files are used in multiple bundles.
 
 You can also use `referenceFiles` inside [`overrides`](#overrides) to scope reference files to specific file patterns.
 

--- a/lib/__tests__/fixtures/config-reference-files/entrypoint-multi.css
+++ b/lib/__tests__/fixtures/config-reference-files/entrypoint-multi.css
@@ -1,0 +1,2 @@
+@import "tokens/animations.css";
+@import "tokens.css";

--- a/lib/__tests__/fixtures/config-reference-files/entrypoint.css
+++ b/lib/__tests__/fixtures/config-reference-files/entrypoint.css
@@ -1,0 +1,1 @@
+@import "tokens.css";

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -1,10 +1,39 @@
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import postcss from 'postcss';
 
 import standalone from '../standalone.mjs';
 import stylelint from '../index.mjs';
 
 const fixturesPath = fileURLToPath(new URL('./fixtures/config-reference-files', import.meta.url));
+
+function makeImportResolver() {
+	return () => ({
+		postcssPlugin: 'test-import',
+		async Once(root) {
+			const imports = [];
+
+			root.walkAtRules('import', (rule) => {
+				imports.push(rule);
+			});
+
+			for (const rule of imports) {
+				const match = rule.params.match(/['"]([^'"]+)['"]/);
+
+				if (!match) continue;
+
+				const from = rule.source?.input.from;
+				const importPath = path.resolve(path.dirname(from), match[1]);
+				const content = await readFile(importPath, 'utf8');
+				const importedRoot = postcss.parse(content, { from: importPath });
+
+				rule.replaceWith(importedRoot);
+			}
+		},
+	});
+}
 
 describe('standalone with referenceFiles', () => {
 	describe('basic pipeline', () => {
@@ -424,6 +453,173 @@ describe('standalone with referenceFiles', () => {
 			expect(regularResult.results).toHaveLength(1);
 			expect(regularResult.results[0].warnings).toHaveLength(1);
 			expect(regularResult.results[0].warnings[0].rule).toBe('no-unknown-animations');
+		});
+	});
+
+	describe('with resolver', () => {
+		it('resolves references via a resolver plugin from a single entrypoint', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: foo; color: var(--bar); }',
+				config: {
+					referenceFiles: {
+						entrypoints: ['entrypoint.css'],
+						resolver: makeImportResolver(),
+					},
+					rules: {
+						'no-unknown-animations': true,
+						'no-unknown-custom-properties': true,
+					},
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
+
+		it('passes the entrypoint path to the resolver function', async () => {
+			const seenEntrypoints = [];
+
+			const resolver = (entrypoint) => {
+				seenEntrypoints.push(entrypoint);
+
+				return makeImportResolver()();
+			};
+
+			await standalone({
+				code: 'a {}',
+				config: {
+					referenceFiles: {
+						entrypoints: ['entrypoint.css', 'entrypoint-multi.css'],
+						resolver,
+					},
+					rules: {},
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(seenEntrypoints).toHaveLength(2);
+			expect(seenEntrypoints[0]).toMatch(/entrypoint\.css$/);
+			expect(seenEntrypoints[1]).toMatch(/entrypoint-multi\.css$/);
+		});
+
+		it('resolves references from multiple entrypoints in declared order', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: bar; animation-name: foo; }',
+				config: {
+					referenceFiles: {
+						entrypoints: ['entrypoint-multi.css'],
+						resolver: makeImportResolver(),
+					},
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
+
+		it('still warns for identifiers not present in resolved entrypoints', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: nope; }',
+				config: {
+					referenceFiles: {
+						entrypoints: ['entrypoint.css'],
+						resolver: makeImportResolver(),
+					},
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0].rule).toBe('no-unknown-animations');
+		});
+
+		it('accepts entrypoints as a bare string', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: foo; }',
+				config: {
+					referenceFiles: {
+						entrypoints: 'entrypoint.css',
+						resolver: makeImportResolver(),
+					},
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
+
+		it('can be mixed with files-based entries in an array', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: foo; animation-name: bar; }',
+				config: {
+					referenceFiles: [
+						{ files: ['tokens/animations.css'] },
+						{
+							entrypoints: ['entrypoint.css'],
+							resolver: makeImportResolver(),
+						},
+					],
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
+
+		it('throws when entrypoint file does not exist', async () => {
+			await expect(
+				standalone({
+					code: 'a {}',
+					config: {
+						referenceFiles: {
+							entrypoints: ['nonexistent.css'],
+							resolver: makeImportResolver(),
+						},
+						rules: {},
+					},
+					configBasedir: fixturesPath,
+				}),
+			).rejects.toThrow(/nonexistent\.css/);
+		});
+
+		it('throws when "entrypoints" is provided without a resolver function', async () => {
+			await expect(
+				standalone({
+					code: 'a {}',
+					config: {
+						referenceFiles: {
+							entrypoints: ['entrypoint.css'],
+						},
+						rules: {},
+					},
+					configBasedir: fixturesPath,
+				}),
+			).rejects.toThrow(/resolver/);
+		});
+
+		it('throws when "entrypoints" is empty', async () => {
+			await expect(
+				standalone({
+					code: 'a {}',
+					config: {
+						referenceFiles: {
+							entrypoints: [],
+							resolver: makeImportResolver(),
+						},
+						rules: {},
+					},
+					configBasedir: fixturesPath,
+				}),
+			).rejects.toThrow(/entrypoint/);
 		});
 	});
 });

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -206,12 +206,22 @@ function absolutizePaths(config, configDir, cwd) {
 			}
 
 			if (isObject(entry)) {
+				const customSyntax =
+					isString(entry.customSyntax) && isPathLike(entry.customSyntax)
+						? getModulePath(configDir, entry.customSyntax, cwd)
+						: entry.customSyntax;
+
+				if ('entrypoints' in entry) {
+					return {
+						entrypoints: [entry.entrypoints].flat().map((file) => absolutizeGlob(file, configDir)),
+						resolver: entry.resolver,
+						customSyntax,
+					};
+				}
+
 				return {
 					files: [entry.files].flat().map((glob) => absolutizeGlob(glob, configDir)),
-					customSyntax:
-						isString(entry.customSyntax) && isPathLike(entry.customSyntax)
-							? getModulePath(configDir, entry.customSyntax, cwd)
-							: entry.customSyntax,
+					customSyntax,
 				};
 			}
 
@@ -491,9 +501,35 @@ async function resolveReferenceFiles(config) {
 	assert(Array.isArray(config.referenceFiles));
 
 	const resolved = config.referenceFiles.map(async (entry) => {
-		if (!entry || !isObject(entry) || !entry.files) {
+		if (!entry || !isObject(entry)) {
 			throw new ConfigurationError(
-				'Every entry in the "referenceFiles" configuration property must be a string or an object with a "files" property, e.g. { "referenceFiles": ["tokens.css"] }.',
+				'Every entry in the "referenceFiles" configuration property must be a string, an object with a "files" property, or an object with "entrypoints" and "resolver" properties, e.g. { "referenceFiles": ["tokens.css"] }.',
+			);
+		}
+
+		const customSyntax = entry.customSyntax ? await getCustomSyntax(entry.customSyntax) : undefined;
+
+		if ('entrypoints' in entry) {
+			if (!isFunction(entry.resolver)) {
+				throw new ConfigurationError(
+					'Every entry with "entrypoints" in the "referenceFiles" configuration property must include a "resolver" function.',
+				);
+			}
+
+			assert(Array.isArray(entry.entrypoints));
+
+			if (entry.entrypoints.length === 0) {
+				throw new ConfigurationError(
+					'Every entry with "entrypoints" in the "referenceFiles" configuration property must include at least one entrypoint.',
+				);
+			}
+
+			return { entrypoints: entry.entrypoints, resolver: entry.resolver, customSyntax };
+		}
+
+		if (!entry.files) {
+			throw new ConfigurationError(
+				'Every entry in the "referenceFiles" configuration property must be a string, an object with a "files" property, or an object with "entrypoints" and "resolver" properties, e.g. { "referenceFiles": ["tokens.css"] }.',
 			);
 		}
 
@@ -506,8 +542,6 @@ async function resolveReferenceFiles(config) {
 				`No files matching the pattern "${patterns.join(', ')}" were found.`,
 			);
 		}
-
-		const customSyntax = entry.customSyntax ? await getCustomSyntax(entry.customSyntax) : undefined;
 
 		return { files, customSyntax };
 	});

--- a/lib/utils/getReferenceRoots.mjs
+++ b/lib/utils/getReferenceRoots.mjs
@@ -21,6 +21,31 @@ export default async function getReferenceRoots(config) {
 	}
 
 	const promisedRoots = entries.flatMap((entry) => {
+		if ('entrypoints' in entry) {
+			return entry.entrypoints.map(async (entrypoint) => {
+				try {
+					const content = await readFile(entrypoint, 'utf8');
+					const plugins = [entry.resolver(entrypoint)].flat();
+					const result = await postcss(plugins).process(content, {
+						from: entrypoint,
+						syntax: entry.customSyntax,
+					});
+
+					if (!isRoot(result.root)) {
+						throw new ConfigurationError(
+							`Failed to resolve reference entrypoint "${entrypoint}": expected a Root node but got "${result.root.type}"`,
+						);
+					}
+
+					return result.root;
+				} catch (error) {
+					throw new ConfigurationError(
+						`Failed to resolve reference entrypoint "${entrypoint}": ${error instanceof Error ? error.message : error}`,
+					);
+				}
+			});
+		}
+
 		const parse = entry.customSyntax?.parse ?? postcss.parse;
 
 		return entry.files.map(async (file) => {

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -91,10 +91,21 @@ declare namespace stylelint {
 		customSyntax?: CustomSyntax;
 	};
 
+	type ConfigReferenceFilesResolver = (
+		entrypoint: string,
+	) => PostCSS.AcceptedPlugin | PostCSS.AcceptedPlugin[];
+
+	type ConfigReferenceFilesResolverEntry = {
+		entrypoints: string | string[];
+		resolver: ConfigReferenceFilesResolver;
+		customSyntax?: CustomSyntax;
+	};
+
 	type ConfigReferenceFiles =
 		| string
 		| ConfigReferenceFilesEntry
-		| (string | ConfigReferenceFilesEntry)[];
+		| ConfigReferenceFilesResolverEntry
+		| (string | ConfigReferenceFilesEntry | ConfigReferenceFilesResolverEntry)[];
 
 	type LanguageOptions = {
 		syntax?: {
@@ -248,7 +259,14 @@ declare namespace stylelint {
 		 */
 		referenceFiles?: ConfigReferenceFiles;
 		/** @internal */
-		_resolvedReferenceFiles?: Array<{ files: string[]; customSyntax?: PostCSS.Syntax }>;
+		_resolvedReferenceFiles?: Array<
+			| { files: string[]; customSyntax?: PostCSS.Syntax }
+			| {
+					entrypoints: string[];
+					resolver: ConfigReferenceFilesResolver;
+					customSyntax?: PostCSS.Syntax;
+			  }
+		>;
 		/**
 		 * Language options to extend the syntax.
 		 *


### PR DESCRIPTION
Closes #9204.

Adds an `entrypoints` + `resolver` form to `referenceFiles` so reference roots can be loaded in dependency order via a PostCSS plugin (e.g. `postcss-import`) instead of filesystem-ordered globbing. This matters for order-sensitive CSS features where "last one wins".

```js
import postcssImport from "postcss-import";

export default {
  referenceFiles: {
    entrypoints: ["src/main.css"],
    resolver: (entrypoint) => postcssImport()
  }
};
```

The resolver is a function returning a PostCSS plugin (or array of plugins). Making it a function lets the resolver be configured per entrypoint. The new shape can be mixed with the existing `files` form in arrays and inside `overrides`.