### PR TITLE
Add `loader` to experimental `referenceFiles: {}`

### DIFF
--- a/.changeset/green-zebras-think.md
+++ b/.changeset/green-zebras-think.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Added: `loader` to experimental `referenceFiles: {}`

--- a/docs/user-guide/configure.md
+++ b/docs/user-guide/configure.md
@@ -558,6 +558,17 @@ For example:
 }
 ```
 
+For CSS bundles, you can specify a PostCSS plugin with the `loader` property:
+
+```json
+{
+  "referenceFiles": {
+    "files": "entrypoint.css",
+    "loader": "postcss-import"
+  }
+}
+```
+
 For non-CSS files, you should use an object form with a [`customSyntax`](#customsyntax) property:
 
 ```json
@@ -589,6 +600,7 @@ Each entry can be:
 - an object that
   - must contain a `files` property (a string or an array of glob patterns)
   - may contain a [`customSyntax`](#customsyntax) property
+  - may contain a `loader` property (a PostCSS plugin to bundle CSS)
 
 You can also use `referenceFiles` inside [`overrides`](#overrides) to scope reference files to specific file patterns.
 

--- a/lib/__tests__/fixtures/config-reference-files/document.html
+++ b/lib/__tests__/fixtures/config-reference-files/document.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Document</title>
+
+	<style>
+		@keyframes bar {}
+	</style>
+</head>
+<body>
+	<style>
+		@keyframes baz {}
+	</style>
+</body>
+</html>

--- a/lib/__tests__/fixtures/config-reference-files/entrypoint.css
+++ b/lib/__tests__/fixtures/config-reference-files/entrypoint.css
@@ -1,0 +1,1 @@
+@import url("./tokens/animations.css");

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -269,6 +269,20 @@ describe('standalone with referenceFiles', () => {
 			expect(results).toHaveLength(1);
 			expect(results[0].warnings).toHaveLength(0);
 		});
+
+		it('supports html documents', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: bar; } b { animation-name: baz; }',
+				config: {
+					referenceFiles: [{ files: ['document.html'], customSyntax: 'postcss-html' }],
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
 	});
 
 	describe('loader support', () => {

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -1,3 +1,5 @@
+import postcssImport from 'postcss-import';
+
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -259,6 +261,36 @@ describe('standalone with referenceFiles', () => {
 				code: 'a { animation-name: baz; }',
 				config: {
 					referenceFiles: [{ files: ['tokens.scss'], customSyntax: 'postcss-scss' }],
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
+	});
+
+	describe('loader support', () => {
+		it('adds CSS bundles as reference files', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: bar; }',
+				config: {
+					referenceFiles: [{ files: ['entrypoint.css'], loader: 'postcss-import' }],
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
+
+		it('supports PostCSS plugin objects', async () => {
+			const { results } = await standalone({
+				code: 'a { animation-name: bar; }',
+				config: {
+					referenceFiles: [{ files: ['entrypoint.css'], loader: postcssImport() }],
 					rules: { 'no-unknown-animations': true },
 				},
 				configBasedir: fixturesPath,

--- a/lib/augmentConfig.mjs
+++ b/lib/augmentConfig.mjs
@@ -9,6 +9,7 @@ import { assert, isFunction, isObject, isString } from './utils/validateTypes.mj
 import { ConfigurationError } from './utils/errors.mjs';
 import cachedImport from './utils/cachedImport.mjs';
 import getCustomSyntax from './utils/getCustomSyntax.mjs';
+import getLoader from './utils/getLoader.mjs';
 import getModulePath from './utils/getModulePath.mjs';
 import normalizeAllRuleSettings from './normalizeAllRuleSettings.mjs';
 import validateLanguageOptions from './validateLanguageOptions.mjs';
@@ -203,6 +204,9 @@ function absolutizePaths(config, configDir, cwd) {
 					customSyntax: isString(entry.customSyntax)
 						? getModulePath(configDir, entry.customSyntax, cwd)
 						: entry.customSyntax,
+					loader: isString(entry.loader)
+						? getModulePath(configDir, entry.loader, cwd)
+						: entry.loader,
 				};
 			}
 
@@ -499,8 +503,9 @@ async function resolveReferenceFiles(config) {
 		}
 
 		const customSyntax = entry.customSyntax ? await getCustomSyntax(entry.customSyntax) : undefined;
+		const loader = entry.loader ? await getLoader(entry.loader) : undefined;
 
-		return { files, customSyntax };
+		return { files, customSyntax, loader };
 	});
 
 	config._resolvedReferenceFiles = await Promise.all(resolved);

--- a/lib/utils/__tests__/fixtures/node_modules/@stylelint/loader-a/index.mjs
+++ b/lib/utils/__tests__/fixtures/node_modules/@stylelint/loader-a/index.mjs
@@ -1,0 +1,12 @@
+const loaderA = () => {
+	return {
+		postcssPlugin: 'loader-a',
+		Once() {
+			// do nothing
+		},
+	};
+};
+
+loaderA.postcss = true;
+
+export default loaderA;

--- a/lib/utils/__tests__/fixtures/node_modules/@stylelint/loader-b/index.cjs
+++ b/lib/utils/__tests__/fixtures/node_modules/@stylelint/loader-b/index.cjs
@@ -1,0 +1,12 @@
+const loaderB = () => {
+	return {
+		postcssPlugin: 'loader-b',
+		Once() {
+			// do nothing
+		},
+	};
+};
+
+loaderB.postcss = true;
+
+module.exports = loaderB

--- a/lib/utils/__tests__/getLoader.test.mjs
+++ b/lib/utils/__tests__/getLoader.test.mjs
@@ -1,0 +1,59 @@
+import getLoader from '../getLoader.mjs';
+
+describe('getLoader', () => {
+	it('returns a loader for `postcss-import`', async () => {
+		const loader = await getLoader('postcss-import');
+
+		expect(loader).toBeTruthy();
+	});
+
+	it('returns a loader for a esm loader', async () => {
+		const loader = await getLoader('./__tests__/fixtures/node_modules/@stylelint/loader-a');
+
+		expect(loader).toBeTruthy();
+	});
+
+	it('returns a loader for a cjs loader', async () => {
+		const loader = await getLoader('./__tests__/fixtures/node_modules/@stylelint/loader-b');
+
+		expect(loader).toBeTruthy();
+	});
+
+	it('returns the same loader function as provided directly', async () => {
+		const loader = () => {
+			return {
+				postcssPlugin: 'loader',
+				Once() {
+					// do nothing
+				},
+			};
+		};
+
+		loader.postcss = true;
+
+		const loaderB = await getLoader(loader);
+
+		expect(loaderB).toBeTruthy();
+		expect(loader).toBe(loaderB);
+	});
+
+	it('returns the same loader object as provided directly', async () => {
+		const loader = {
+			postcssPlugin: 'loader',
+			Once() {
+				// do nothing
+			},
+		};
+
+		const loaderB = await getLoader(loader);
+
+		expect(loaderB).toBeTruthy();
+		expect(loader).toBe(loaderB);
+	});
+
+	it('throws when not a plugin', async () => {
+		const { message } = await getLoader(false).catch((e) => e);
+
+		expect(message).toContain('Loader must be a string or a PostCSS plugin');
+	});
+});

--- a/lib/utils/getLoader.mjs
+++ b/lib/utils/getLoader.mjs
@@ -11,29 +11,8 @@ export default async function getLoader(loader) {
 	if (typeof loader === 'string') {
 		let resolved;
 
-		try {
-			resolved = await dynamicImport(loader);
-			resolved = resolved.default ?? resolved;
-		} catch (error) {
-			if (
-				error &&
-				typeof error === 'object' &&
-				'code' in error &&
-				// TODO: Remove 'MODULE_NOT_FOUND' when we drop the CommonJS support.
-				// See https://nodejs.org/api/errors.html#module_not_found
-				(error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND') &&
-				'message' in error &&
-				typeof error.message === 'string' &&
-				error.message.includes(loader)
-			) {
-				throw new Error(
-					`Cannot resolve loader module "${loader}". Check that module "${loader}" is available and spelled correctly.\n\nCaused by: ${error}`,
-					{ cause: error },
-				);
-			}
-
-			throw error;
-		}
+		resolved = await dynamicImport(loader, { moduleLabel: 'loader' });
+		resolved = resolved.default ?? resolved;
 
 		return resolved;
 	}

--- a/lib/utils/getLoader.mjs
+++ b/lib/utils/getLoader.mjs
@@ -1,0 +1,46 @@
+import dynamicImport from './dynamicImport.mjs';
+
+/** @import {Plugin,PluginCreator} from 'postcss' */
+/** @import {Loader} from 'stylelint' */
+
+/**
+ * @param {Loader} loader
+ * @returns {Promise<Plugin|PluginCreator<unknown>>}
+ */
+export default async function getLoader(loader) {
+	if (typeof loader === 'string') {
+		let resolved;
+
+		try {
+			resolved = await dynamicImport(loader);
+			resolved = resolved.default ?? resolved;
+		} catch (error) {
+			if (
+				error &&
+				typeof error === 'object' &&
+				'code' in error &&
+				// TODO: Remove 'MODULE_NOT_FOUND' when we drop the CommonJS support.
+				// See https://nodejs.org/api/errors.html#module_not_found
+				(error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND') &&
+				'message' in error &&
+				typeof error.message === 'string' &&
+				error.message.includes(loader)
+			) {
+				throw new Error(
+					`Cannot resolve loader module "${loader}". Check that module "${loader}" is available and spelled correctly.\n\nCaused by: ${error}`,
+					{ cause: error },
+				);
+			}
+
+			throw error;
+		}
+
+		return resolved;
+	}
+
+	if (typeof loader === 'object' || typeof loader === 'function') {
+		return loader;
+	}
+
+	throw new Error('Loader must be a string or a PostCSS plugin');
+}

--- a/lib/utils/getReferenceRoots.mjs
+++ b/lib/utils/getReferenceRoots.mjs
@@ -2,7 +2,7 @@ import postcss from 'postcss';
 import { readFile } from 'node:fs/promises';
 
 import { ConfigurationError } from './errors.mjs';
-import { isRoot } from './typeGuards.mjs';
+import { isDocument } from './typeGuards.mjs';
 
 /** @import {Root} from 'postcss' */
 /** @import {Config as StylelintConfig} from 'stylelint' */
@@ -21,19 +21,24 @@ export default async function getReferenceRoots(config) {
 	}
 
 	const promisedRoots = entries.flatMap((entry) => {
-		const parse = entry.customSyntax?.parse ?? postcss.parse;
+		const processor = postcss(entry.loader ? [entry.loader] : []);
 
 		return entry.files.map(async (file) => {
 			try {
-				const root = parse(await readFile(file, 'utf8'), { from: file });
+				const rootOrDocument = await processor
+					.process(await readFile(file, 'utf8'), {
+						from: file,
+						parser: entry.customSyntax,
+					})
+					.then((result) => {
+						return result.root;
+					});
 
-				if (!isRoot(root)) {
-					throw new ConfigurationError(
-						`Failed to parse reference file "${file}": expected a Root node but got "${root.type}"`,
-					);
+				if (isDocument(rootOrDocument)) {
+					return rootOrDocument.nodes;
 				}
 
-				return root;
+				return [rootOrDocument];
 			} catch (error) {
 				throw new ConfigurationError(
 					`Failed to parse reference file "${file}": ${error instanceof Error ? error.message : error}`,
@@ -42,5 +47,5 @@ export default async function getReferenceRoots(config) {
 		});
 	});
 
-	return await Promise.all(promisedRoots);
+	return (await Promise.all(promisedRoots)).flat();
 }

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -89,6 +89,7 @@ declare namespace stylelint {
 	type ConfigReferenceFilesEntry = {
 		files: string | string[];
 		customSyntax?: CustomSyntax;
+		loader?: Loader;
 	};
 
 	type ConfigReferenceFiles =
@@ -248,7 +249,11 @@ declare namespace stylelint {
 		 */
 		referenceFiles?: ConfigReferenceFiles;
 		/** @internal */
-		_resolvedReferenceFiles?: Array<{ files: string[]; customSyntax?: PostCSS.Syntax }>;
+		_resolvedReferenceFiles?: Array<{
+			files: string[];
+			customSyntax?: PostCSS.Syntax;
+			loader?: PostCSS.Plugin | PostCSS.PluginCreator<any>;
+		}>;
 		/**
 		 * Language options to extend the syntax.
 		 *
@@ -375,6 +380,9 @@ declare namespace stylelint {
 
 	/** @internal */
 	export type CustomSyntax = string | PostCSS.Syntax;
+
+	/** @internal */
+	export type Loader = string | PostCSS.Plugin | PostCSS.PluginCreator<any>;
 
 	/**
 	 * WARNING: This is an experimental feature. The API may change in the future.


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/9204#issuecomment-4332546994

> Is there anything in the PR that needs further explanation?

### `resolver` vs. `loader`

`loader` seemed clearer than `resolver`.
A `resolver` might also be interpreted as something to modify how `files` are resolved.

I think `loader` will be easier for users to understand what it will do.

I proposed using a callback mechanic to provide the loader in the linked issue so that users can further customize the loader depending on a specific file. I don't think this is needed. This API is already very customizable and I don't think we need another level.

### `entrypoint` vs. `files`

I decided to use the existing `files` property instead of adding a new `entrypoint` property.

In practice users will mostly pass a single file when using a loader and not a list or a glob. But there also isn't a good reason to disallow this.

Adding a separate `entrypoint` property would complicate our implementation.

----

I am a bit short on time and would like to check test coverage.
But given that there is now [another PR](https://github.com/stylelint/stylelint/pull/9250) for this same feature (that does follow the template from the issue) I wanted to share my findings.

> [!NOTE]
> Including co-contributors in changelog entry