### PR TITLE
Fix `selector-pseudo-class-no-unknown` false positives for nested `webkit-scrollbar` part

### DIFF
--- a/.changeset/honest-boats-brake.md
+++ b/.changeset/honest-boats-brake.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-pseudo-class-no-unknown` false positives for nested `webkit-scrollbar` part

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -142,6 +142,10 @@ testRule({
 			description: 'multiple webkit scrollbar pseudo classes in nested rule',
 		},
 		{
+			code: '::-webkit-scrollbar { @media (prefers-color-scheme: dark) { &:horizontal {} } }',
+			description: 'webkit scrollbar pseudo class nested through an at-rule',
+		},
+		{
 			code: 'a:defined { }',
 			description:
 				'represents any element that has been defined; includes any standard element built into the browser, and custom elements that have been successfully defined (i.e. with the CustomElementRegistry.define() method).',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -142,7 +142,7 @@ testRule({
 			description: 'nested webkit scrollbar pseudo classes',
 		},
 		{
-			code: '::-webkit-scrollbar { @media (prefers-color-scheme: dark) { &:horizontal {} } }',
+			code: '::-webkit-scrollbar { @media all { &:horizontal {} } }',
 			description: 'webkit scrollbar pseudo class nested through an at-rule',
 		},
 		{

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -126,6 +126,22 @@ testRule({
 			description: 'non-standalone webkit scrollbar multiple pseudo classes',
 		},
 		{
+			code: '::-webkit-scrollbar { &:horizontal {} }',
+			description: 'webkit scrollbar pseudo class in nested rule with explicit &',
+		},
+		{
+			code: '::-webkit-scrollbar { :horizontal {} }',
+			description: 'webkit scrollbar pseudo class in nested rule with implicit nesting',
+		},
+		{
+			code: '::-webkit-scrollbar { & { &:horizontal {} } }',
+			description: 'webkit scrollbar pseudo class in deeply nested rule',
+		},
+		{
+			code: '::-webkit-scrollbar-button { &:horizontal:decrement {} }',
+			description: 'multiple webkit scrollbar pseudo classes in nested rule',
+		},
+		{
 			code: 'a:defined { }',
 			description:
 				'represents any element that has been defined; includes any standard element built into the browser, and custom elements that have been successfully defined (i.e. with the CustomElementRegistry.define() method).',
@@ -253,6 +269,15 @@ testRule({
 			column: 38,
 			endLine: 1,
 			endColumn: 46,
+		},
+		{
+			code: '.foo { &:horizontal {} }',
+			description: 'webkit scrollbar pseudo class nested without webkit scrollbar ancestor',
+			message: messages.rejected(':horizontal'),
+			line: 1,
+			column: 9,
+			endLine: 1,
+			endColumn: 20,
 		},
 		{
 			code: ':first { }',

--- a/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/__tests__/index.mjs
@@ -130,16 +130,16 @@ testRule({
 			description: 'webkit scrollbar pseudo class in nested rule with explicit &',
 		},
 		{
-			code: '::-webkit-scrollbar { :horizontal {} }',
-			description: 'webkit scrollbar pseudo class in nested rule with implicit nesting',
-		},
-		{
 			code: '::-webkit-scrollbar { & { &:horizontal {} } }',
 			description: 'webkit scrollbar pseudo class in deeply nested rule',
 		},
 		{
 			code: '::-webkit-scrollbar-button { &:horizontal:decrement {} }',
 			description: 'multiple webkit scrollbar pseudo classes in nested rule',
+		},
+		{
+			code: '::-webkit-scrollbar-button { &:horizontal { &:decrement {} } }',
+			description: 'nested webkit scrollbar pseudo classes',
 		},
 		{
 			code: '::-webkit-scrollbar { @media (prefers-color-scheme: dark) { &:horizontal {} } }',
@@ -282,6 +282,24 @@ testRule({
 			column: 9,
 			endLine: 1,
 			endColumn: 20,
+		},
+		{
+			code: '::-webkit-scrollbar { :horizontal {} }',
+			description: 'webkit scrollbar pseudo class via implicit nesting (descendant)',
+			message: messages.rejected(':horizontal'),
+			line: 1,
+			column: 23,
+			endLine: 1,
+			endColumn: 34,
+		},
+		{
+			code: '::-webkit-scrollbar { & :horizontal {} }',
+			description: 'webkit scrollbar pseudo class with descendant combinator after &',
+			message: messages.rejected(':horizontal'),
+			line: 1,
+			column: 25,
+			endLine: 1,
+			endColumn: 36,
 		},
 		{
 			code: ':first { }',

--- a/lib/rules/selector-pseudo-class-no-unknown/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.mjs
@@ -33,19 +33,18 @@ const meta = {
 };
 
 /**
- * @param {import('postcss').ChildNode} node
+ * @param {import('postcss').Node} node
  * @param {import('stylelint').PostcssResult} result
  * @returns {boolean}
  */
 function hasNestedWebkitScrollbarAncestor(node, result) {
-	/** @type {import('postcss').Container | import('postcss').Document | undefined} */
 	let current = node.parent;
 
 	while (current) {
 		if (isRule(current)) {
 			const selector = getRuleSelector(current);
 
-			if (selector && selector.includes('::')) {
+			if (selector.includes('::')) {
 				let found = false;
 
 				parseSelector(selector, result, current)?.walkPseudos((pseudo) => {
@@ -54,6 +53,7 @@ function hasNestedWebkitScrollbarAncestor(node, result) {
 						webkitScrollbarPseudoElements.has(pseudo.value.toLowerCase().slice(2))
 					) {
 						found = true;
+						return false;
 					}
 				});
 
@@ -150,7 +150,7 @@ const rule = (primary, secondaryOptions) => {
 								nestingInCompound = true;
 							}
 
-							if (prevPseudoElement.value.slice(0, 2) === '::') break;
+							if (prevPseudoElement.value.startsWith('::')) break;
 						}
 					} while (prevPseudoElement);
 

--- a/lib/rules/selector-pseudo-class-no-unknown/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.mjs
@@ -53,6 +53,7 @@ function hasNestedWebkitScrollbarAncestor(node, result) {
 						webkitScrollbarPseudoElements.has(pseudo.value.toLowerCase().slice(2))
 					) {
 						found = true;
+
 						return false;
 					}
 				});

--- a/lib/rules/selector-pseudo-class-no-unknown/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.mjs
@@ -41,22 +41,24 @@ function hasNestedWebkitScrollbarAncestor(node, result) {
 	/** @type {import('postcss').Container | import('postcss').Document | undefined} */
 	let current = node.parent;
 
-	while (current && isRule(current)) {
-		const selector = getRuleSelector(current);
+	while (current) {
+		if (isRule(current)) {
+			const selector = getRuleSelector(current);
 
-		if (selector && selector.includes('::')) {
-			let found = false;
+			if (selector && selector.includes('::')) {
+				let found = false;
 
-			parseSelector(selector, result, current)?.walkPseudos((pseudo) => {
-				if (
-					pseudo.value.startsWith('::') &&
-					webkitScrollbarPseudoElements.has(pseudo.value.toLowerCase().slice(2))
-				) {
-					found = true;
-				}
-			});
+				parseSelector(selector, result, current)?.walkPseudos((pseudo) => {
+					if (
+						pseudo.value.startsWith('::') &&
+						webkitScrollbarPseudoElements.has(pseudo.value.toLowerCase().slice(2))
+					) {
+						found = true;
+					}
+				});
 
-			if (found) return true;
+				if (found) return true;
+			}
 		}
 
 		current = current.parent;

--- a/lib/rules/selector-pseudo-class-no-unknown/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.mjs
@@ -135,14 +135,22 @@ const rule = (primary, secondaryOptions) => {
 
 					/** @type {import('postcss-selector-parser').Base} */
 					let prevPseudoElement = pseudoNode;
+					let crossedCombinator = false;
+					let nestingInCompound = false;
 
 					do {
 						prevPseudoElement = /** @type {import('postcss-selector-parser').Base} */ (
 							prevPseudoElement.prev()
 						);
 
-						if (prevPseudoElement && prevPseudoElement.value.slice(0, 2) === '::') {
-							break;
+						if (prevPseudoElement) {
+							if (prevPseudoElement.type === 'combinator') crossedCombinator = true;
+
+							if (prevPseudoElement.type === 'nesting' && !crossedCombinator) {
+								nestingInCompound = true;
+							}
+
+							if (prevPseudoElement.value.slice(0, 2) === '::') break;
 						}
 					} while (prevPseudoElement);
 
@@ -157,6 +165,7 @@ const rule = (primary, secondaryOptions) => {
 						}
 					} else if (
 						webkitScrollbarPseudoClasses.has(name) &&
+						nestingInCompound &&
 						hasNestedWebkitScrollbarAncestor(node, result)
 					) {
 						return;

--- a/lib/rules/selector-pseudo-class-no-unknown/index.mjs
+++ b/lib/rules/selector-pseudo-class-no-unknown/index.mjs
@@ -6,11 +6,11 @@ import {
 	webkitScrollbarPseudoClasses,
 	webkitScrollbarPseudoElements,
 } from '../../reference/selectors.mjs';
+import { isAtRule, isRule } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
 import getAtRuleParams from '../../utils/getAtRuleParams.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
-import { isAtRule } from '../../utils/typeGuards.mjs';
 import isCustomSelector from '../../utils/isCustomSelector.mjs';
 import isStandardSyntaxAtRule from '../../utils/isStandardSyntaxAtRule.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
@@ -31,6 +31,39 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-pseudo-class-no-unknown',
 };
+
+/**
+ * @param {import('postcss').ChildNode} node
+ * @param {import('stylelint').PostcssResult} result
+ * @returns {boolean}
+ */
+function hasNestedWebkitScrollbarAncestor(node, result) {
+	/** @type {import('postcss').Container | import('postcss').Document | undefined} */
+	let current = node.parent;
+
+	while (current && isRule(current)) {
+		const selector = getRuleSelector(current);
+
+		if (selector && selector.includes('::')) {
+			let found = false;
+
+			parseSelector(selector, result, current)?.walkPseudos((pseudo) => {
+				if (
+					pseudo.value.startsWith('::') &&
+					webkitScrollbarPseudoElements.has(pseudo.value.toLowerCase().slice(2))
+				) {
+					found = true;
+				}
+			});
+
+			if (found) return true;
+		}
+
+		current = current.parent;
+	}
+
+	return false;
+}
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
@@ -120,6 +153,11 @@ const rule = (primary, secondaryOptions) => {
 						) {
 							return;
 						}
+					} else if (
+						webkitScrollbarPseudoClasses.has(name) &&
+						hasNestedWebkitScrollbarAncestor(node, result)
+					) {
+						return;
 					}
 
 					index = pseudoNode.sourceIndex;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Fixes #9224 

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
