### PR TITLE
Fix inconsistent error messages when module is not found

### DIFF
--- a/.changeset/clever-numbers-sell.md
+++ b/.changeset/clever-numbers-sell.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: inconsistent error messages when module is not found

--- a/lib/__tests__/standalone-syntax.test.mjs
+++ b/lib/__tests__/standalone-syntax.test.mjs
@@ -138,9 +138,7 @@ it('rejects on unknown custom syntax option', async () => {
 			code: '',
 			config: config(),
 		}),
-	).rejects.toThrow(
-		'Cannot resolve custom syntax module "unknown-module". Check that module "unknown-module" is available and spelled correctly.',
-	);
+	).rejects.toThrow(/unknown-module/);
 });
 
 describe('customSyntax set in the config', () => {
@@ -255,9 +253,7 @@ describe('customSyntax set in the config', () => {
 				code: '',
 				config: config({ customSyntax: 'unknown-module' }),
 			}),
-		).rejects.toThrow(
-			'Cannot resolve custom syntax module "unknown-module". Check that module "unknown-module" is available and spelled correctly.',
-		);
+		).rejects.toThrow(/unknown-module/);
 	});
 
 	it('rejects on invalid custom syntax object', async () => {

--- a/lib/utils/__tests__/dynamicImport.test.mjs
+++ b/lib/utils/__tests__/dynamicImport.test.mjs
@@ -1,0 +1,42 @@
+import child_process from 'node:child_process';
+import { promisify } from 'node:util';
+
+import dynamicImport from '../dynamicImport.mjs';
+
+const execFile = promisify(child_process.execFile);
+
+test('imports module successfully', async () => {
+	const module = await dynamicImport('postcss');
+
+	expect(module).toBeDefined();
+	expect(typeof module).toBe('object');
+	expect(typeof module.default).toBe('function');
+});
+
+// Use `node -e` to bypass Jest's module resolution
+test('throws error when module is not found', async () => {
+	const { stderr } = await execFile(
+		'node',
+		['-e', 'import("../dynamicImport.mjs").then(m => m.default("nonexistent-module"))'],
+		{ cwd: import.meta.dirname },
+	).catch((e) => e);
+
+	expect(stderr).toContain(
+		'Cannot resolve module "nonexistent-module". Check that module "nonexistent-module" is available and spelled correctly',
+	);
+});
+
+test('throws customized error when module is not found', async () => {
+	const { stderr } = await execFile(
+		'node',
+		[
+			'-e',
+			'import("../dynamicImport.mjs").then(m => m.default("nonexistent-module", { moduleLabel: "test" }))',
+		],
+		{ cwd: import.meta.dirname },
+	).catch((e) => e);
+
+	expect(stderr).toContain(
+		'Cannot resolve test module "nonexistent-module". Check that module "nonexistent-module" is available and spelled correctly',
+	);
+});

--- a/lib/utils/dynamicImport.mjs
+++ b/lib/utils/dynamicImport.mjs
@@ -7,7 +7,22 @@ import { pathToFileURL } from 'node:url';
  * @see https://github.com/stylelint/stylelint/issues/7382
  *
  * @param {string} path
+ * @param {object} [options]
+ * @param {string} [options.moduleLabel]
+ * @returns {Promise<any>}
  */
-export default function dynamicImport(path) {
-	return import(isAbsolute(path) ? pathToFileURL(path).toString() : path);
+export default async function dynamicImport(path, { moduleLabel } = {}) {
+	const resolvedPath = isAbsolute(path) ? pathToFileURL(path).toString() : path;
+
+	return import(resolvedPath).catch((e) => {
+		if (e && typeof e === 'object' && 'code' in e && e.code === 'ERR_MODULE_NOT_FOUND') {
+			const label = moduleLabel ? `${moduleLabel} ` : '';
+
+			throw new Error(
+				`Cannot resolve ${label}module "${path}". Check that module "${path}" is available and spelled correctly`,
+			);
+		}
+
+		throw e;
+	});
 }

--- a/lib/utils/getCustomSyntax.mjs
+++ b/lib/utils/getCustomSyntax.mjs
@@ -13,29 +13,8 @@ export default async function getCustomSyntax(customSyntax) {
 	if (typeof customSyntax === 'string') {
 		let resolved;
 
-		try {
-			resolved = await dynamicImport(customSyntax);
-			resolved = resolved.default ?? resolved;
-		} catch (error) {
-			if (
-				error &&
-				typeof error === 'object' &&
-				'code' in error &&
-				// TODO: Remove 'MODULE_NOT_FOUND' when we drop the CommonJS support.
-				// See https://nodejs.org/api/errors.html#module_not_found
-				(error.code === 'MODULE_NOT_FOUND' || error.code === 'ERR_MODULE_NOT_FOUND') &&
-				'message' in error &&
-				typeof error.message === 'string' &&
-				error.message.includes(customSyntax)
-			) {
-				throw new Error(
-					`Cannot resolve custom syntax module "${customSyntax}". Check that module "${customSyntax}" is available and spelled correctly.\n\nCaused by: ${error}`,
-					{ cause: error },
-				);
-			}
-
-			throw error;
-		}
+		resolved = await dynamicImport(customSyntax, { moduleLabel: 'custom syntax' });
+		resolved = resolved.default ?? resolved;
 
 		/*
 		 * PostCSS allows for syntaxes that only contain a parser, however,


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref #9251 (this PR should help implement `getLoader()` utility)

> Is there anything in the PR that needs further explanation?

This PR fixes inconsistent error messages when a module is not found with `dynamicImport()`.

`dynamicImport()` now accepts an optional parameter to customize the error message.

New messages align with the error message thrown by `getCustomSyntax()` and remove verbose "Caused by" output.

We can verify the message change by the shell command.

```shell
node -e 'import("./lib/utils/getCustomSyntax.mjs").then(m => m.default("foo"))'
```

Before:

```
Error: Cannot resolve custom syntax module "foo". Check that module "foo" is available and spelled correctly.

Caused by: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'foo' imported from /Users/masafumi.koba/git/stylelint/stylelint/lib/utils/dynamicImport.mjs
    at Module.getCustomSyntax (file:///Users/masafumi.koba/git/stylelint/stylelint/lib/utils/getCustomSyntax.mjs:31:11) {
  [cause]: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'foo' imported from /Users/masafumi.koba/git/stylelint/stylelint/lib/utils/dynamicImport.mjs
      at Object.getPackageJSONURL (node:internal/modules/package_json_reader:314:9)
      ...
```

After:

```
Error: Cannot resolve custom syntax module "foo". Check that module "foo" is available and spelled correctly
    at file:///Users/masafumi.koba/git/stylelint/stylelint/lib/utils/dynamicImport.mjs:21:10
    at async Module.getCustomSyntax (file:///Users/masafumi.koba/git/stylelint/stylelint/lib/utils/getCustomSyntax.mjs:16:14)
```

