### PR TITLE
Configure Dependabot to group Stylelint actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - 'pr: dependencies'
+    groups:
+      stylelint-actions:
+        patterns: ['stylelint/.github/*']
     cooldown:
       default-days: 7
       exclude: ['stylelint/.github/*']


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

As other repos in the org do, this change groups the Stylelint GitHub Actions (defined in `stylelint/.github`) for Dependabot.

E.g.,
https://github.com/stylelint/stylelint-config-recommended/blob/c305e9900e7c2824c7a1744e23edae1fe664e26f/.github/dependabot.yml#L27-L29


