### PR TITLE
Fix `declaration-block-no-redundant-longhand-properties` range for contiguous redundant longhand properties

### DIFF
--- a/.changeset/tasty-shirts-crash.md
+++ b/.changeset/tasty-shirts-crash.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `declaration-block-no-redundant-longhand-properties` range for contiguous redundant longhand properties

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/__tests__/index.mjs
@@ -92,16 +92,53 @@ testRule({
 
 	reject: [
 		{
-			code: 'a { margin-left: 40px; margin-right: 10px; margin-top: 20px; margin-bottom: 30px; }',
-			fixed: 'a { margin: 20px 10px 30px 40px; }',
+			code: stripIndent`
+				a {
+					margin-left: 40px;
+					margin-right: 10px;
+					margin-top: 20px;
+					margin-bottom: 30px;
+				}
+			`,
+			fixed: stripIndent`
+				a {
+					margin: 20px 10px 30px 40px;
+				}
+			`,
 			message: messages.expected('margin'),
-			line: 1,
-			column: 62,
-			endLine: 1,
-			endColumn: 75,
+			line: 2,
+			column: 2,
+			endLine: 5,
+			endColumn: 22,
 			fix: {
-				range: [10, 77],
+				range: [11, 81],
 				text: ': 20px 10px 30px 4',
+			},
+		},
+		{
+			code: stripIndent`
+				a {
+					margin-left: 40px;
+					margin-right: 10px;
+					margin-top: 20px;
+					color: blue;
+					margin-bottom: 30px;
+				}
+			`,
+			fixed: stripIndent`
+				a {
+					margin: 20px 10px 30px 40px;
+					color: blue;
+				}
+			`,
+			message: messages.expected('margin'),
+			line: 6,
+			column: 2,
+			endLine: 6,
+			endColumn: 22,
+			fix: {
+				range: [11, 98],
+				text: `: 20px 10px 30px 40px;\n\tcolor: blue`,
 			},
 		},
 		{
@@ -109,9 +146,9 @@ testRule({
 			fixed: 'a { margin: 20px 10px 30px 10px; }',
 			message: messages.expected('margin'),
 			line: 1,
-			column: 62,
+			column: 5,
 			endLine: 1,
-			endColumn: 75,
+			endColumn: 82,
 			fix: {
 				range: [4, 77],
 				text: 'margin: 20px 10px 30px 1',
@@ -122,9 +159,9 @@ testRule({
 			fixed: 'a { margin: 20px 10px 30px 10px; }',
 			message: messages.expected('margin'),
 			line: 1,
-			column: 62,
+			column: 5,
 			endLine: 1,
-			endColumn: 75,
+			endColumn: 82,
 			fix: {
 				range: [4, 77],
 				text: 'margin: 20px 10px 30px 1',
@@ -135,9 +172,9 @@ testRule({
 			fixed: 'a { padding: 20px 10px 30px 10px; }',
 			message: messages.expected('padding'),
 			line: 1,
-			column: 65,
+			column: 5,
 			endLine: 1,
-			endColumn: 79,
+			endColumn: 86,
 			fix: {
 				range: [11, 81],
 				text: ': 20px 10px 30px 1',
@@ -148,9 +185,9 @@ testRule({
 			fixed: 'a { font: italic normal bold normal .8em 1.2 Arial; }',
 			message: messages.expected('font'),
 			line: 1,
-			column: 121,
+			column: 5,
 			endLine: 1,
-			endColumn: 133,
+			endColumn: 142,
 			fix: {
 				range: [8, 138],
 				text: ': italic normal bold normal .8em 1.2 Ari',
@@ -161,9 +198,9 @@ testRule({
 			fixed: 'a { border-top: 7px double green; }',
 			message: messages.expected('border-top'),
 			line: 1,
-			column: 54,
+			column: 5,
 			endLine: 1,
-			endColumn: 70,
+			endColumn: 78,
 			fix: {
 				range: [14, 70],
 				text: ': 7px double',
@@ -174,9 +211,9 @@ testRule({
 			fixed: 'a { -webkit-transition: top 2s ease 0.5s; }',
 			message: messages.expected('-webkit-transition'),
 			line: 1,
-			column: 104,
+			column: 5,
 			endLine: 1,
-			endColumn: 138,
+			endColumn: 145,
 			fix: {
 				range: [22, 143],
 				text: ': top 2s ease 0.5s',
@@ -187,9 +224,9 @@ testRule({
 			fixed: 'a { -webkit-transition: top 2s ease 0.5s; }',
 			message: messages.expected('-webkit-transition'),
 			line: 1,
-			column: 104,
+			column: 5,
 			endLine: 1,
-			endColumn: 138,
+			endColumn: 145,
 			fix: {
 				range: [5, 143],
 				text: 'webkit-transition: top 2s ease 0.5s',
@@ -221,10 +258,10 @@ testRule({
 			`,
 			warnings: [
 				{
-					line: 5,
+					line: 2,
 					column: 2,
 					endLine: 5,
-					endColumn: 19,
+					endColumn: 25,
 					message: messages.expected('border-width'),
 					fix: {
 						range: [12, 100],
@@ -232,17 +269,17 @@ testRule({
 					},
 				},
 				{
-					line: 9,
+					line: 6,
 					column: 2,
 					endLine: 9,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-color'),
 				},
 				{
-					line: 13,
+					line: 10,
 					column: 2,
 					endLine: 13,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-style'),
 				},
 			],
@@ -273,10 +310,10 @@ testRule({
 			`,
 			warnings: [
 				{
-					line: 5,
+					line: 2,
 					column: 2,
 					endLine: 5,
-					endColumn: 19,
+					endColumn: 25,
 					message: messages.expected('border-width'),
 					fix: {
 						range: [12, 100],
@@ -284,17 +321,17 @@ testRule({
 					},
 				},
 				{
-					line: 9,
+					line: 6,
 					column: 2,
 					endLine: 9,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-style'),
 				},
 				{
-					line: 13,
+					line: 10,
 					column: 2,
 					endLine: 13,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-color'),
 				},
 			],
@@ -326,10 +363,10 @@ testRule({
 			`,
 			warnings: [
 				{
-					line: 4,
+					line: 2,
 					column: 2,
 					endLine: 4,
-					endColumn: 18,
+					endColumn: 24,
 					message: messages.expected('border-top'),
 					fix: {
 						range: [15, 73],
@@ -337,24 +374,24 @@ testRule({
 					},
 				},
 				{
-					line: 7,
+					line: 5,
 					column: 2,
 					endLine: 7,
-					endColumn: 20,
+					endColumn: 28,
 					message: messages.expected('border-right'),
 				},
 				{
-					line: 10,
+					line: 8,
 					column: 2,
 					endLine: 10,
-					endColumn: 21,
+					endColumn: 28,
 					message: messages.expected('border-bottom'),
 				},
 				{
-					line: 13,
+					line: 11,
 					column: 2,
 					endLine: 13,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-left'),
 				},
 			],
@@ -386,10 +423,10 @@ testRule({
 			`,
 			warnings: [
 				{
-					line: 4,
+					line: 2,
 					column: 2,
 					endLine: 4,
-					endColumn: 18,
+					endColumn: 24,
 					message: messages.expected('border-top'),
 					fix: {
 						range: [15, 73],
@@ -397,24 +434,24 @@ testRule({
 					},
 				},
 				{
-					line: 7,
+					line: 5,
 					column: 2,
 					endLine: 7,
-					endColumn: 21,
+					endColumn: 28,
 					message: messages.expected('border-bottom'),
 				},
 				{
-					line: 10,
+					line: 8,
 					column: 2,
 					endLine: 10,
-					endColumn: 20,
+					endColumn: 28,
 					message: messages.expected('border-right'),
 				},
 				{
-					line: 13,
+					line: 11,
 					column: 2,
 					endLine: 13,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-left'),
 				},
 			],
@@ -445,10 +482,10 @@ testRule({
 			`,
 			warnings: [
 				{
-					line: 5,
+					line: 2,
 					column: 2,
 					endLine: 5,
-					endColumn: 19,
+					endColumn: 25,
 					message: messages.expected('border-width'),
 					fix: {
 						range: [12, 100],
@@ -459,14 +496,14 @@ testRule({
 					line: 12,
 					column: 2,
 					endLine: 12,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-style'),
 				},
 				{
 					line: 13,
 					column: 2,
 					endLine: 13,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-color'),
 				},
 			],
@@ -498,10 +535,10 @@ testRule({
 			`,
 			warnings: [
 				{
-					line: 4,
+					line: 2,
 					column: 2,
 					endLine: 4,
-					endColumn: 18,
+					endColumn: 24,
 					message: messages.expected('border-top'),
 					fix: {
 						range: [15, 73],
@@ -512,21 +549,21 @@ testRule({
 					line: 11,
 					column: 2,
 					endLine: 11,
-					endColumn: 20,
+					endColumn: 28,
 					message: messages.expected('border-right'),
 				},
 				{
 					line: 12,
 					column: 2,
 					endLine: 12,
-					endColumn: 21,
+					endColumn: 28,
 					message: messages.expected('border-bottom'),
 				},
 				{
 					line: 13,
 					column: 2,
 					endLine: 13,
-					endColumn: 19,
+					endColumn: 28,
 					message: messages.expected('border-left'),
 				},
 			],
@@ -689,10 +726,10 @@ testRule({
 			description: 'combination of grid-row and grid-column test',
 			warnings: [
 				{
+					line: 2,
 					column: 2,
-					endColumn: 14,
 					endLine: 3,
-					line: 3,
+					endColumn: 18,
 					message: messages.expected('grid-row'),
 					fix: {
 						range: [13, 38],
@@ -700,10 +737,10 @@ testRule({
 					},
 				},
 				{
+					line: 4,
 					column: 2,
-					endColumn: 17,
 					endLine: 5,
-					line: 5,
+					endColumn: 21,
 					message: messages.expected('grid-column'),
 				},
 			],

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -1,6 +1,6 @@
 import valueParser from 'postcss-value-parser';
 
-import { isRegExp, isString } from '../../utils/validateTypes.mjs';
+import { assert, isRegExp, isString } from '../../utils/validateTypes.mjs';
 import arrayEqual from '../../utils/arrayEqual.mjs';
 import { basicKeywords } from '../../reference/keywords.mjs';
 import eachDeclarationBlock from '../../utils/eachDeclarationBlock.mjs';
@@ -293,6 +293,10 @@ const rule = (primary, secondaryOptions) => {
 					return;
 				}
 
+				const { parent } = decl;
+
+				assert(parent);
+
 				for (const shorthandProperty of shorthandProperties) {
 					const prefixedShorthandProperty = prefix + shorthandProperty;
 					const shorthandValue = declaredShorthands.get(prefixedShorthandProperty);
@@ -311,7 +315,7 @@ const rule = (primary, secondaryOptions) => {
 							messageArgs: [decl.prop, prefixedShorthandProperty],
 							fix: {
 								apply: fix,
-								node: decl.parent,
+								node: parent,
 							},
 						});
 
@@ -350,7 +354,11 @@ const rule = (primary, secondaryOptions) => {
 						continue;
 					}
 
-					const [firstDeclNode] = declNodes;
+					const firstDeclNode = declNodes.at(0);
+					const lastDeclNode = declNodes.at(-1);
+
+					assert(firstDeclNode && lastDeclNode);
+
 					let resolvedShorthandValue = undefined;
 
 					if (firstDeclNode) {
@@ -387,16 +395,21 @@ const rule = (primary, secondaryOptions) => {
 							}
 						: undefined;
 
+					const span = parent.index(lastDeclNode) - parent.index(firstDeclNode) + 1;
+					const isContiguous = span === declNodes.length;
+					const startDeclNode = isContiguous ? firstDeclNode : lastDeclNode;
+
 					report({
 						ruleName,
 						result,
-						node: decl,
-						word: decl.prop,
 						message: messages.expected,
 						messageArgs: [prefixedShorthandProperty],
+						node: parent,
+						start: startDeclNode.rangeBy({}).start,
+						end: lastDeclNode.rangeBy({}).end,
 						fix: {
 							apply: fix,
-							node: decl.parent,
+							node: parent,
 						},
 					});
 				}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #9272.

Previously, the `declaration-block-no-redundant-longhand-properties` rule only reported the position of the last redundant declaration. When viewed in an editor via LSP, developers would only see a warning highlight on the final property, rather than the whole block of redundant longhands.

> Is there anything in the PR that needs further explanation?

- Added Contiguity Checking: The rule now calculates the index differences between the collected longhand nodes. If they are contiguous (uninterrupted by other declarations or comments), the reported warning now spans from the start offset of the first declaration to the end offset of the last declaration.

- Safe Fallback: If the redundant longhand properties are separated by unrelated properties (e.g., color: blue; in the middle of margin declarations), the rule falls back to the previous behavior of highlighting only the final trigger node. This prevents editors from falsely highlighting unrelated properties.

Before:
Editors would only highlight the last line:

```CSS
a {
    margin-left: 40px; 
    margin-right: 10px; 
    margin-top: 20px; 
    ^^^^^^^^^^^^^^^^^^^^ /* Only this was flagged */
    margin-bottom: 30px; 
}
```

After:
Editors will now highlight the entire contiguous block:

```CSS
a {
    ^^^^^^^^^^^^^^^^^^^^
    margin-left: 40px; 
    margin-right: 10px; 
    margin-top: 20px; 
    margin-bottom: 30px;
    ^^^^^^^^^^^^^^^^^^^^
}
```