### PR TITLE
Refactor `declaration-block-no-redundant-longhand-properties` rule

### DIFF
--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -364,32 +364,29 @@ const rule = (primary, secondaryOptions) => {
  * @returns {string[]}
  */
 function commaSeparated(input) {
-	const trimmedInput = input?.trim();
+	const trimmed = input?.trim();
 
-	if (!trimmedInput) return [];
+	if (!trimmed) return [];
 
-	if (!trimmedInput.includes(',')) return [trimmedInput];
+	if (!trimmed.includes(',')) return [trimmed];
 
-	const parsedValue = valueParser(trimmedInput);
 	/** @type {ValueNode[][]} */
-	const valueParts = [];
+	const parts = [];
 	/** @type {ValueNode[]} */
-	let currentListItem = [];
+	let current = [];
 
-	parsedValue.nodes.forEach((node) => {
+	parts.push(current);
+
+	for (const node of valueParser(trimmed).nodes) {
 		if (node.type === 'div' && node.value === ',') {
-			valueParts.push(currentListItem);
-			currentListItem = [];
-
-			return;
+			current = [];
+			parts.push(current);
+		} else {
+			current.push(node);
 		}
+	}
 
-		currentListItem.push(node);
-	});
-
-	valueParts.push(currentListItem);
-
-	return valueParts.map((s) => valueParser.stringify(s).trim()).filter((s) => s.length > 0);
+	return parts.map((nodes) => valueParser.stringify(nodes).trim()).filter(Boolean);
 }
 
 /**
@@ -397,8 +394,6 @@ function commaSeparated(input) {
  * @returns {boolean}
  */
 function hasMixedImportant(decls) {
-	if (decls.length === 0) return false;
-
 	/** @type {(decl: Declaration) => boolean} */
 	const isImportant = (decl) => decl.important;
 

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -161,32 +161,6 @@ const OVERLAPPING_SHORTHANDS = new Set([
 	'grid-row',
 ]);
 
-/**
- * @param {string} prefixedShorthandProperty
- * @param {string[]} prefixedShorthandData
- * @param {Map<string, Declaration>} transformedDeclarationNodes
- * @returns {string | undefined}
- */
-const resolveShorthandValue = (
-	prefixedShorthandProperty,
-	prefixedShorthandData,
-	transformedDeclarationNodes,
-) => {
-	const resolver = customResolvers.get(prefixedShorthandProperty);
-
-	if (resolver === undefined) {
-		// the "default" resolver: sort the longhand values in the order
-		// of their properties
-		const values = prefixedShorthandData
-			.map((p) => transformedDeclarationNodes.get(p)?.value.trim())
-			.filter(Boolean);
-
-		return values.length > 0 ? values.join(' ') : undefined;
-	}
-
-	return resolver(transformedDeclarationNodes);
-};
-
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
 	return (root, result) => {
@@ -398,6 +372,31 @@ function hasMixedImportant(decls) {
 	const isImportant = (decl) => decl.important;
 
 	return decls.some(isImportant) && !decls.every(isImportant);
+}
+
+/**
+ * @param {string} prefixedShorthandProperty
+ * @param {string[]} prefixedShorthandData
+ * @param {Map<string, Declaration>} transformedDeclarationNodes
+ * @returns {string | undefined}
+ */
+function resolveShorthandValue(
+	prefixedShorthandProperty,
+	prefixedShorthandData,
+	transformedDeclarationNodes,
+) {
+	const resolver = customResolvers.get(prefixedShorthandProperty);
+
+	if (resolver === undefined) {
+		// the "default" resolver: sort the longhand values in the order
+		// of their properties
+		return prefixedShorthandData
+			.map((p) => transformedDeclarationNodes.get(p)?.value.trim() ?? '')
+			.filter(Boolean)
+			.join(' ');
+	}
+
+	return resolver(transformedDeclarationNodes);
 }
 
 rule.ruleName = ruleName;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -24,7 +24,9 @@ const meta = {
 	fixable: true,
 };
 
-/** @typedef {import('postcss').Declaration} Declaration */
+/** @import { Declaration } from 'postcss' */
+/** @import { Node as ValueNode } from 'postcss-value-parser' */
+/** @import { ShorthandProperties } from 'stylelint' */
 
 /** @type {Map<string, (decls: Map<string, Declaration>) => (string | undefined)>} */
 const customResolvers = new Map([
@@ -117,40 +119,6 @@ const customResolvers = new Map([
 	[
 		'transition',
 		(decls) => {
-			/** @type {(input: string | undefined) => string[]} */
-			const commaSeparated = (input = '') => {
-				const trimmedInput = input.trim();
-
-				if (!trimmedInput) return [];
-
-				if (trimmedInput.indexOf(',') === -1) return [trimmedInput];
-
-				/** @type {import('postcss-value-parser').ParsedValue} */
-				const parsedValue = valueParser(trimmedInput);
-				/** @type {Array<Array<import('postcss-value-parser').Node>>} */
-				const valueParts = [];
-
-				{
-					/** @type {Array<import('postcss-value-parser').Node>} */
-					let currentListItem = [];
-
-					parsedValue.nodes.forEach((node) => {
-						if (node.type === 'div' && node.value === ',') {
-							valueParts.push(currentListItem);
-							currentListItem = [];
-
-							return;
-						}
-
-						currentListItem.push(node);
-					});
-
-					valueParts.push(currentListItem);
-				}
-
-				return valueParts.map((s) => valueParser.stringify(s).trim()).filter((s) => s.length > 0);
-			};
-
 			const delays = commaSeparated(decls.get('transition-delay')?.value);
 			const durations = commaSeparated(decls.get('transition-duration')?.value);
 			const timingFunctions = commaSeparated(decls.get('transition-timing-function')?.value);
@@ -181,7 +149,7 @@ const customResolvers = new Map([
 	],
 ]);
 
-const haveConflicts = [
+const OVERLAPPING_SHORTHANDS = new Set([
 	'border-width',
 	'border-style',
 	'border-color',
@@ -191,7 +159,7 @@ const haveConflicts = [
 	'border-left',
 	'grid-column',
 	'grid-row',
-];
+]);
 
 /**
  * @param {string} prefixedShorthandProperty
@@ -240,14 +208,12 @@ const rule = (primary, secondaryOptions) => {
 			return;
 		}
 
-		/** @type {Map<string, import('stylelint').ShorthandProperties[]>} */
+		/** @type {Map<string, ShorthandProperties[]>} */
 		const longhandToShorthands = new Map();
 		const ignoreLonghands = [secondaryOptions?.ignoreLonghands ?? []].flat();
 
 		for (const [shorthand, longhandProps] of longhandSubPropertiesOfShorthandProperties.entries()) {
-			if (optionsMatches(secondaryOptions, 'ignoreShorthands', shorthand)) {
-				continue;
-			}
+			if (optionsMatches(secondaryOptions, 'ignoreShorthands', shorthand)) continue;
 
 			for (const longhand of longhandProps) {
 				if (ignoreLonghands.includes(longhand)) continue;
@@ -260,8 +226,6 @@ const rule = (primary, secondaryOptions) => {
 		}
 
 		eachDeclarationBlock(root, (eachDecl) => {
-			/** @type {Map<string, string[]>} */
-			const longhandDeclarations = new Map();
 			/** @type {Map<string, Declaration[]>} */
 			const longhandDeclarationNodes = new Map();
 			/** @type {Map<string, string>} */
@@ -271,9 +235,7 @@ const rule = (primary, secondaryOptions) => {
 				const declValue = decl.value.trim();
 
 				// basic keywords are not allowed in shorthand properties
-				if (basicKeywords.has(decl.value)) {
-					return;
-				}
+				if (basicKeywords.has(declValue)) return;
 
 				const prop = decl.prop.toLowerCase();
 				const unprefixedProp = vendor.unprefixed(prop);
@@ -281,7 +243,7 @@ const rule = (primary, secondaryOptions) => {
 
 				if (
 					longhandSubPropertiesOfShorthandProperties.has(
-						/** @type {import('stylelint').ShorthandProperties} */ (unprefixedProp),
+						/** @type {ShorthandProperties} */ (unprefixedProp),
 					)
 				) {
 					declaredShorthands.set(prop, declValue);
@@ -289,9 +251,7 @@ const rule = (primary, secondaryOptions) => {
 
 				const shorthandProperties = longhandToShorthands.get(unprefixedProp);
 
-				if (!shorthandProperties) {
-					return;
-				}
+				if (!shorthandProperties) return;
 
 				const { parent } = decl;
 
@@ -302,10 +262,6 @@ const rule = (primary, secondaryOptions) => {
 					const shorthandValue = declaredShorthands.get(prefixedShorthandProperty);
 
 					if (shorthandValue === declValue) {
-						const fix = () => {
-							decl.remove();
-						};
-
 						report({
 							ruleName,
 							result,
@@ -314,7 +270,9 @@ const rule = (primary, secondaryOptions) => {
 							message: messages.unexpectedLonghand,
 							messageArgs: [decl.prop, prefixedShorthandProperty],
 							fix: {
-								apply: fix,
+								apply: () => {
+									decl.remove();
+								},
 								node: parent,
 							},
 						});
@@ -322,59 +280,40 @@ const rule = (primary, secondaryOptions) => {
 						return;
 					}
 
-					const longhandDeclaration = longhandDeclarations.get(prefixedShorthandProperty) || [];
-					const longhandDeclarationNode =
-						longhandDeclarationNodes.get(prefixedShorthandProperty) || [];
-
-					longhandDeclaration.push(prop);
-					longhandDeclarations.set(prefixedShorthandProperty, longhandDeclaration);
-
-					longhandDeclarationNode.push(decl);
-					longhandDeclarationNodes.set(prefixedShorthandProperty, longhandDeclarationNode);
-
-					const shorthandProps = new Set(
-						longhandSubPropertiesOfShorthandProperties.get(shorthandProperty),
-					);
-
-					ignoreLonghands.forEach((value) => shorthandProps.delete(value));
-					const prefixedShorthandData = Array.from(shorthandProps, (item) => prefix + item);
-
-					if (!arrayEqual(prefixedShorthandData.toSorted(), longhandDeclaration.toSorted())) {
-						continue;
-					}
-
 					const declNodes = longhandDeclarationNodes.get(prefixedShorthandProperty) || [];
 
-					const importantDeclNodesCount = declNodes.reduce(
-						(count, declNode) => (declNode.important ? count + 1 : count),
-						0,
-					);
+					declNodes.push(decl);
+					longhandDeclarationNodes.set(prefixedShorthandProperty, declNodes);
 
-					if (importantDeclNodesCount && importantDeclNodesCount !== declNodes.length) {
+					const prefixedShorthandData = [
+						...(longhandSubPropertiesOfShorthandProperties.get(shorthandProperty) ?? []),
+					]
+						.filter((item) => !ignoreLonghands.includes(item))
+						.map((item) => prefix + item);
+					const collectedProps = declNodes.map((n) => n.prop.toLowerCase());
+
+					if (!arrayEqual(prefixedShorthandData.toSorted(), collectedProps.toSorted())) {
 						continue;
 					}
+
+					if (hasMixedImportant(declNodes)) continue;
 
 					const firstDeclNode = declNodes.at(0);
 					const lastDeclNode = declNodes.at(-1);
 
 					assert(firstDeclNode && lastDeclNode);
 
-					let resolvedShorthandValue = undefined;
+					const transformedDeclarationNodes = new Map(
+						declNodes.map((d) => [d.prop.toLowerCase(), d]),
+					);
 
-					if (firstDeclNode) {
-						const transformedDeclarationNodes = new Map(
-							declNodes.map((d) => [d.prop.toLowerCase(), d]),
-						);
+					const resolvedShorthandValue = resolveShorthandValue(
+						prefixedShorthandProperty,
+						prefixedShorthandData,
+						transformedDeclarationNodes,
+					);
 
-						resolvedShorthandValue = resolveShorthandValue(
-							prefixedShorthandProperty,
-							prefixedShorthandData,
-							transformedDeclarationNodes,
-						);
-					}
-
-					const hasFix = firstDeclNode && resolvedShorthandValue;
-					const fix = hasFix
+					const fix = resolvedShorthandValue
 						? () => {
 								const newShorthandDeclarationNode = firstDeclNode.clone({
 									prop: prefixedShorthandProperty,
@@ -384,11 +323,13 @@ const rule = (primary, secondaryOptions) => {
 								firstDeclNode.replaceWith(newShorthandDeclarationNode);
 								declNodes.forEach((node) => node.remove());
 
-								if (haveConflicts.includes(shorthandProperty)) {
-									longhandDeclarations.forEach((longhands, shorthand) => {
-										longhandDeclarations.set(
+								if (OVERLAPPING_SHORTHANDS.has(shorthandProperty)) {
+									const consumedProps = new Set(collectedProps);
+
+									longhandDeclarationNodes.forEach((nodes, shorthand) => {
+										longhandDeclarationNodes.set(
 											shorthand,
-											longhands.filter((longhand) => !longhandDeclaration.includes(longhand)),
+											nodes.filter((node) => !consumedProps.has(node.prop.toLowerCase())),
 										);
 									});
 								}
@@ -417,6 +358,52 @@ const rule = (primary, secondaryOptions) => {
 		});
 	};
 };
+
+/**
+ * @param {string | undefined} input
+ * @returns {string[]}
+ */
+function commaSeparated(input) {
+	const trimmedInput = input?.trim();
+
+	if (!trimmedInput) return [];
+
+	if (!trimmedInput.includes(',')) return [trimmedInput];
+
+	const parsedValue = valueParser(trimmedInput);
+	/** @type {ValueNode[][]} */
+	const valueParts = [];
+	/** @type {ValueNode[]} */
+	let currentListItem = [];
+
+	parsedValue.nodes.forEach((node) => {
+		if (node.type === 'div' && node.value === ',') {
+			valueParts.push(currentListItem);
+			currentListItem = [];
+
+			return;
+		}
+
+		currentListItem.push(node);
+	});
+
+	valueParts.push(currentListItem);
+
+	return valueParts.map((s) => valueParser.stringify(s).trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * @param {Declaration[]} decls
+ * @returns {boolean}
+ */
+function hasMixedImportant(decls) {
+	if (decls.length === 0) return false;
+
+	/** @type {(decl: Declaration) => boolean} */
+	const isImportant = (decl) => decl.important;
+
+	return decls.some(isImportant) && !decls.every(isImportant);
+}
 
 rule.ruleName = ruleName;
 rule.messages = messages;

--- a/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
+++ b/lib/rules/declaration-block-no-redundant-longhand-properties/index.mjs
@@ -387,16 +387,14 @@ function resolveShorthandValue(
 ) {
 	const resolver = customResolvers.get(prefixedShorthandProperty);
 
-	if (resolver === undefined) {
-		// the "default" resolver: sort the longhand values in the order
-		// of their properties
-		return prefixedShorthandData
-			.map((p) => transformedDeclarationNodes.get(p)?.value.trim() ?? '')
-			.filter(Boolean)
-			.join(' ');
-	}
+	if (resolver) return resolver(transformedDeclarationNodes);
 
-	return resolver(transformedDeclarationNodes);
+	// the "default" resolver: sort the longhand values in the order
+	// of their properties
+	return prefixedShorthandData
+		.map((p) => transformedDeclarationNodes.get(p)?.value.trim() ?? '')
+		.filter(Boolean)
+		.join(' ');
 }
 
 rule.ruleName = ruleName;


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates #9273

> Is there anything in the PR that needs further explanation?

- Hoist `commaSeparated` to a module-level function
- Switch type imports to JSDoc `@import` syntax
- Rename `haveConflicts` array to `OVERLAPPING_SHORTHANDS` set
- Collapse parallel longhand maps into a single declaration-node map
- Drop dead branch after `assert` and tighten `let` to `const`
- Extract `hasMixedImportant` helper
- Replace intermediate set with a filter/map chain on the longhand list
- Inline single-statement early returns and fix closures
