### PR TITLE
Add Node.js v26 to test matrix on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     uses: stylelint/.github/.github/workflows/call-test.yml@61e84671c2d4d7af47353e7f5289a2df81bd681d # 0.7.0
     with:
-      node-version: '["20", "22", "24"]'
+      node-version: '["20", "22", "24", "26"]'
       os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
       exclude: '[{"node-version": "24", "os": "ubuntu-latest"}]' # for coverage
     permissions:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

v26 is now available and will become LTS.
Ref: https://nodejs.org/en/about/previous-releases
