### PR TITLE
Fix `declaration-property-value-no-unknown` false negatives for custom properties defined in reference files

### DIFF
--- a/.changeset/beige-bees-rush.md
+++ b/.changeset/beige-bees-rush.md
@@ -1,0 +1,5 @@
+---
+"stylelint": minor
+---
+
+Fixed: `declaration-property-value-no-unknown` false negatives for custom properties defined in reference files

--- a/lib/__tests__/fixtures/config-reference-files/tokens.css
+++ b/lib/__tests__/fixtures/config-reference-files/tokens.css
@@ -11,9 +11,3 @@
 }
 
 @custom-media --qux (width > 10em);
-
-@property --foo {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: #c0ffee;
-}

--- a/lib/__tests__/fixtures/config-reference-files/tokens.css
+++ b/lib/__tests__/fixtures/config-reference-files/tokens.css
@@ -11,3 +11,9 @@
 }
 
 @custom-media --qux (width > 10em);
+
+@property --foo {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #c0ffee;
+}

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -258,7 +258,7 @@ describe('standalone with referenceFiles', () => {
 	describe('declaration-property-value-no-unknown', () => {
 		it('allows matching syntax for @property defined in reference file', async () => {
 			const { results } = await standalone({
-				code: 'a { --foo: red; }',
+				code: 'a { --baz: red; }',
 				config: {
 					referenceFiles: [{ files: ['tokens.css'] }],
 					rules: { 'declaration-property-value-no-unknown': true },

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -255,6 +255,37 @@ describe('standalone with referenceFiles', () => {
 		});
 	});
 
+	describe('declaration-property-value-no-unknown', () => {
+		it('allows matching syntax for @property defined in reference file', async () => {
+			const { results } = await standalone({
+				code: 'a { --foo: red; }',
+				config: {
+					referenceFiles: [{ files: ['tokens.css'] }],
+					rules: { 'declaration-property-value-no-unknown': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
+
+		it('warns on incorrect syntax for @property defined in reference file', async () => {
+			const { results } = await standalone({
+				code: 'a { --foo: 10px; }',
+				config: {
+					referenceFiles: [{ files: ['tokens.css'] }],
+					rules: { 'declaration-property-value-no-unknown': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(1);
+			expect(results[0].warnings[0].rule).toBe('declaration-property-value-no-unknown');
+		});
+	});
+
 	describe('customSyntax support', () => {
 		it('parses non-CSS file with customSyntax', async () => {
 			const { results } = await standalone({

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -272,7 +272,7 @@ describe('standalone with referenceFiles', () => {
 
 		it('warns on incorrect syntax for @property defined in reference file', async () => {
 			const { results } = await standalone({
-				code: 'a { --foo: 10px; }',
+				code: 'a { --baz: 10px; }',
 				config: {
 					referenceFiles: [{ files: ['tokens.css'] }],
 					rules: { 'declaration-property-value-no-unknown': true },

--- a/lib/rules/declaration-property-value-no-unknown/README.md
+++ b/lib/rules/declaration-property-value-no-unknown/README.md
@@ -11,6 +11,8 @@ a { top: unknown; }
 
 This rule considers values for properties defined in the CSS Specifications, up to and including Editor's Drafts, to be known.
 
+This rule checks the values of custom properties defined using `@property` within the same source or within the files specified in the [`referenceFiles`](../../../docs/user-guide/configure.md#referencefiles) configuration property.
+
 You can filter the [CSSTree Syntax Reference](https://csstree.github.io/docs/syntax/) to find out what value syntax is known for a property, and use the [`languageOptions`](../../../docs/user-guide/configure.md#languageoptions) configuration property to extend it.
 
 This rule checks property values. You can use [`at-rule-descriptor-value-no-unknown`](../at-rule-descriptor-value-no-unknown/README.md) to disallow unknown values for descriptors within at-rules.

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -103,38 +103,42 @@ const rule = (primary, secondaryOptions) => {
 		/** @type {Map<string, string>} */
 		const typedCustomPropertyNames = new Map();
 
-		root.walkAtRules(atRuleRegexes.propertyName, (atRule) => {
-			const propName = atRule.params.trim();
+		const referenceRoots = result.stylelint.referenceRoots;
 
-			if (!propName || !atRule.nodes || !isCustomProperty(propName)) return;
+		for (const rootNode of [root, ...referenceRoots]) {
+			rootNode.walkAtRules(atRuleRegexes.propertyName, (atRule) => {
+				const propName = atRule.params.trim();
 
-			for (const node of atRule.nodes) {
-				if (isDeclaration(node) && SYNTAX_DESCRIPTOR.test(node.prop)) {
-					const value = node.value.trim();
-					const unquoted = string.decode(value);
+				if (!propName || !atRule.nodes || !isCustomProperty(propName)) return;
 
-					// Only string values are valid.
-					// We can not check the syntax of this property.
-					if (unquoted === value) continue;
+				for (const node of atRule.nodes) {
+					if (isDeclaration(node) && SYNTAX_DESCRIPTOR.test(node.prop)) {
+						const value = node.value.trim();
+						const unquoted = string.decode(value);
 
-					// Any value is allowed in this custom property.
-					// We don't need to check this property.
-					if (unquoted === '*') continue;
+						// Only string values are valid.
+						// We can not check the syntax of this property.
+						if (unquoted === value) continue;
 
-					// https://github.com/csstree/csstree/pull/256
-					// We can circumvent this issue by prefixing the property name,
-					// making it a vendor-prefixed property instead of a custom property.
-					// No one should be using `-stylelint--` as a property prefix.
-					//
-					// When this is resolved `typedCustomPropertyNames` can become a `Set<string>`
-					// and the prefix can be removed.
-					const prefixedPropName = `-stylelint${propName}`;
+						// Any value is allowed in this custom property.
+						// We don't need to check this property.
+						if (unquoted === '*') continue;
 
-					typedCustomPropertyNames.set(propName, prefixedPropName);
-					propertiesSyntax[prefixedPropName] = unquoted;
+						// https://github.com/csstree/csstree/pull/256
+						// We can circumvent this issue by prefixing the property name,
+						// making it a vendor-prefixed property instead of a custom property.
+						// No one should be using `-stylelint--` as a property prefix.
+						//
+						// When this is resolved `typedCustomPropertyNames` can become a `Set<string>`
+						// and the prefix can be removed.
+						const prefixedPropName = `-stylelint${propName}`;
+
+						typedCustomPropertyNames.set(propName, prefixedPropName);
+						propertiesSyntax[prefixedPropName] = unquoted;
+					}
 				}
-			}
-		});
+			});
+		}
 
 		const hasExtraSyntax =
 			Object.keys(propertiesSyntax).length > 0 || Object.keys(typesSyntax).length > 0;

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -105,7 +105,7 @@ const rule = (primary, secondaryOptions) => {
 
 		const referenceRoots = result.stylelint.referenceRoots;
 
-		for (const rootNode of [root, ...referenceRoots]) {
+		for (const rootNode of [...referenceRoots, root]) {
 			rootNode.walkAtRules(atRuleRegexes.propertyName, (atRule) => {
 				const propName = atRule.params.trim();
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/9291

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
