### PR TITLE
Fix `value-keyword-layout-mappings` false positives for `caption-side`

### DIFF
--- a/.changeset/clean-badgers-agree.md
+++ b/.changeset/clean-badgers-agree.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `value-keyword-layout-mappings` false positives for `caption-side`

--- a/lib/rules/value-keyword-layout-mappings/__tests__/index.mjs
+++ b/lib/rules/value-keyword-layout-mappings/__tests__/index.mjs
@@ -16,9 +16,6 @@ testRule({
 		{
 			code: 'a { resize: horizontal; }',
 		},
-		{
-			code: 'a { caption-side: top; }',
-		},
 	],
 
 	reject: [
@@ -37,14 +34,6 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 22,
-		},
-		{
-			code: 'a { caption-side: block-start; }',
-			message: messages.rejected('flow-relative', 'block-start'),
-			line: 1,
-			column: 19,
-			endLine: 1,
-			endColumn: 30,
 		},
 		{
 			code: 'a { resize: inline; }',
@@ -101,9 +90,6 @@ testRule({
 			code: 'a { float: inline-start; }',
 		},
 		{
-			code: 'a { caption-side: block-end; }',
-		},
-		{
 			code: 'a { resize: inline; }',
 		},
 		{
@@ -128,14 +114,6 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 16,
-		},
-		{
-			code: 'a { caption-side: top; }',
-			message: messages.rejected('physical', 'top'),
-			line: 1,
-			column: 19,
-			endLine: 1,
-			endColumn: 22,
 		},
 		{
 			code: 'a { resize: horizontal; }',
@@ -191,9 +169,6 @@ testRule({
 		{
 			code: 'a { float: inline-start; }',
 		},
-		{
-			code: 'a { caption-side: block-end; }',
-		},
 	],
 
 	reject: [
@@ -222,19 +197,6 @@ testRule({
 			column: 12,
 			endLine: 1,
 			endColumn: 17,
-		},
-		{
-			code: 'a { caption-side: top; }',
-			fixed: 'a { caption-side: block-start; }',
-			fix: {
-				range: [18, 21],
-				text: 'block-start',
-			},
-			message: messages.expected('top', 'block-start'),
-			line: 1,
-			column: 19,
-			endLine: 1,
-			endColumn: 22,
 		},
 		{
 			code: 'a { resize: horizontal; }',
@@ -358,19 +320,6 @@ testRule({
 			endColumn: 21,
 		},
 		{
-			code: 'a { caption-side: top; }',
-			fixed: 'a { caption-side: inline-start; }',
-			fix: {
-				range: [18, 21],
-				text: 'inline-start',
-			},
-			message: messages.expected('top', 'inline-start'),
-			line: 1,
-			column: 19,
-			endLine: 1,
-			endColumn: 22,
-		},
-		{
 			code: 'a { clear: left; }',
 			unfixable: true,
 			message: messages.rejected('physical', 'left'),
@@ -407,9 +356,6 @@ testRule({
 	accept: [
 		{
 			code: 'a { text-align: left; }',
-		},
-		{
-			code: 'a { caption-side: top; }',
 		},
 	],
 

--- a/lib/rules/value-keyword-layout-mappings/index.mjs
+++ b/lib/rules/value-keyword-layout-mappings/index.mjs
@@ -33,7 +33,6 @@ const meta = {
 /** @import {Directionality} from 'stylelint' */
 
 const directionalMappingKinds = new Map([
-	['caption-side', 'side'],
 	['offset-anchor', 'side'],
 	['offset-position', 'side'],
 	['clear', 'inlineSide'],


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/9289

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
