### PR TITLE
Fix Yarn PnP system test with Node.js v24.15.0

### DIFF
--- a/system-tests/006/templates/combined/package.json
+++ b/system-tests/006/templates/combined/package.json
@@ -6,5 +6,5 @@
     "stylelint": "file:../stylelint.tgz",
     "stylelint-config-standard": "40.0.0"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.14.1"
 }

--- a/system-tests/006/templates/config-only/package.json
+++ b/system-tests/006/templates/config-only/package.json
@@ -5,5 +5,5 @@
   "devDependencies": {
     "stylelint-config-standard": "40.0.0"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.14.1"
 }

--- a/system-tests/006/templates/stylelint-only/package.json
+++ b/system-tests/006/templates/stylelint-only/package.json
@@ -5,5 +5,5 @@
   "devDependencies": {
     "stylelint": "file:../stylelint.tgz"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See also <https://github.com/stylelint/stylelint/pull/9294#issuecomment-4462085071>

> Is there anything in the PR that needs further explanation?

This fixes the test failure by bumping Yarn from 4.12.0 to 4.14.1 in the fixtures.

Reproduction (with Node.js v24.15.0):

```shell
npm install --global corepack
STYLELINT_TEST_YARN_PNP=true npm run test-node
```

Output:

```
test at system-tests/006/yarn-pnp.test.mjs:169:2
✖ lints with stylelint-config-standard in same repo (288.530958ms)
  AssertionError [ERR_ASSERTION]: Expected exit code 2 but got: 1
  stdout:
  stderr: node:fs:391
    const stats = binding.fstat(fd, false, undefined, true /* shouldNotThrow */);
                          ^

  Error: EBADF: bad file descriptor, fstat
      at tryStatSync (node:fs:391:25)
      at readFileSync (node:fs:447:17)
      at getSourceSync (node:internal/modules/esm/load:37:14)
      at createCJSModuleWrap (node:internal/modules/esm/translators:210:32)
      at ModuleLoader.commonjsStrategy (node:internal/modules/esm/translators:349:10)
      at #translate (node:internal/modules/esm/loader:451:20)
      at afterLoad (node:internal/modules/esm/loader:507:29)
      at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:512:12)
      at #getOrCreateModuleJobAfterResolve (node:internal/modules/esm/loader:555:36)
      at afterResolve (node:internal/modules/esm/loader:603:52) {
    errno: -9,
    code: 'EBADF',
    syscall: 'fstat'
  }

  Node.js v24.15.0

      at runStylelint (file:///Users/masafumi.koba/git/stylelint/stylelint/system-tests/006/yarn-pnp.test.mjs:134:11)
      at async TestContext.<anonymous> (file:///Users/masafumi.koba/git/stylelint/stylelint/system-tests/006/yarn-pnp.test.mjs:172:19)
      at async Test.run (node:internal/test_runner/test:1208:7)
      at async Promise.all (index 0)
      at async Suite.run (node:internal/test_runner/test:1619:7)
      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:385:3) {
    generatedMessage: false,
    code: 'ERR_ASSERTION',
    actual: undefined,
    expected: undefined,
    operator: 'fail',
    diff: 'simple'
  }
```

Maybe related to:
- nodejs/node#62012

