### PR TITLE
Add a helper to determine if `root` should be excluded when considering `referenceRoots`

### DIFF
--- a/.changeset/easy-boxes-leave.md
+++ b/.changeset/easy-boxes-leave.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Add a helper to determine if `root` should be excluded when considering `referenceRoots`

--- a/lib/__tests__/fixtures/config-reference-files/embedded-current-root.css
+++ b/lib/__tests__/fixtures/config-reference-files/embedded-current-root.css
@@ -1,0 +1,7 @@
+@property --embedded-color {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: red;
+}
+
+a { --embedded-color: 1px; }

--- a/lib/__tests__/fixtures/config-reference-files/entrypoint-with-current-root.css
+++ b/lib/__tests__/fixtures/config-reference-files/entrypoint-with-current-root.css
@@ -1,0 +1,2 @@
+@import url("./embedded-current-root.css");
+@import url("./override-current-root.css");

--- a/lib/__tests__/fixtures/config-reference-files/override-current-root.css
+++ b/lib/__tests__/fixtures/config-reference-files/override-current-root.css
@@ -1,0 +1,5 @@
+@property --embedded-color {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 1px;
+}

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -359,6 +359,29 @@ describe('standalone with referenceFiles', () => {
 			expect(results[0].warnings).toHaveLength(0);
 		});
 
+		it('reuses parsed reference roots for multiple files', async () => {
+			let loaderCalls = 0;
+			const countingLoader = {
+				postcssPlugin: 'count-reference-loader',
+				Once() {
+					loaderCalls += 1;
+				},
+			};
+
+			const { results } = await standalone({
+				files: ['test.css', 'test.module.css'],
+				config: {
+					referenceFiles: [{ files: ['tokens.css'], loader: countingLoader }],
+					rules: { 'no-unknown-animations': true },
+				},
+				configBasedir: fixturesPath,
+				cwd: fixturesPath,
+			});
+
+			expect(results).toHaveLength(2);
+			expect(loaderCalls).toBe(1);
+		});
+
 		it('supports PostCSS plugin objects', async () => {
 			const { results } = await standalone({
 				code: 'a { animation-name: bar; }',

--- a/lib/__tests__/referenceFiles.test.mjs
+++ b/lib/__tests__/referenceFiles.test.mjs
@@ -284,6 +284,34 @@ describe('standalone with referenceFiles', () => {
 			expect(results[0].warnings).toHaveLength(1);
 			expect(results[0].warnings[0].rule).toBe('declaration-property-value-no-unknown');
 		});
+
+		it('uses the embedded source order when a reference bundle includes the current root', async () => {
+			const codeFilename = path.join(fixturesPath, 'embedded-current-root.css');
+			const code = `
+				@property --embedded-color {
+					syntax: "<color>";
+					inherits: false;
+					initial-value: red;
+				}
+
+				a { --embedded-color: 1px; }
+			`;
+
+			const { results } = await standalone({
+				code,
+				codeFilename,
+				config: {
+					referenceFiles: [
+						{ files: ['entrypoint-with-current-root.css'], loader: postcssImport() },
+					],
+					rules: { 'declaration-property-value-no-unknown': true },
+				},
+				configBasedir: fixturesPath,
+			});
+
+			expect(results).toHaveLength(1);
+			expect(results[0].warnings).toHaveLength(0);
+		});
 	});
 
 	describe('customSyntax support', () => {

--- a/lib/createStylelint.mjs
+++ b/lib/createStylelint.mjs
@@ -32,6 +32,7 @@ export default function createStylelint(options = {}) {
 		_augmentedConfigCache: new Map(),
 		_postcssResultCache: new Map(),
 		_compiledOverridesCache: new Map(),
+		_referenceRootsCache: new Map(),
 		_fileCache: new FileCache(options.cacheLocation, options.cacheStrategy, cwd),
 	};
 }

--- a/lib/lintSource.mjs
+++ b/lib/lintSource.mjs
@@ -99,7 +99,7 @@ export default async function lintSource(stylelint, options = {}) {
 		throw abortSignal.reason;
 	}
 
-	const referenceRoots = await getReferenceRoots(config);
+	const referenceRoots = await getReferenceRoots(config, stylelint._referenceRootsCache);
 
 	if (abortSignal?.aborted) {
 		throw abortSignal.reason;

--- a/lib/rules/declaration-property-value-no-unknown/index.mjs
+++ b/lib/rules/declaration-property-value-no-unknown/index.mjs
@@ -17,6 +17,7 @@ import getLexer from '../../utils/getLexer.mjs';
 import isCustomProperty from '../../utils/isCustomProperty.mjs';
 import { isDeclaration } from '../../utils/typeGuards.mjs';
 import isDescriptorDeclaration from '../../utils/isDescriptorDeclaration.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import isStandardSyntaxDeclaration from '../../utils/isStandardSyntaxDeclaration.mjs';
 import isStandardSyntaxProperty from '../../utils/isStandardSyntaxProperty.mjs';
 import isStandardSyntaxValue from '../../utils/isStandardSyntaxValue.mjs';
@@ -104,8 +105,11 @@ const rule = (primary, secondaryOptions) => {
 		const typedCustomPropertyNames = new Map();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const roots = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [...referenceRoots, root];
 
-		for (const rootNode of [...referenceRoots, root]) {
+		for (const rootNode of roots) {
 			rootNode.walkAtRules(atRuleRegexes.propertyName, (atRule) => {
 				const propName = atRule.params.trim();
 

--- a/lib/rules/no-unknown-animations/index.mjs
+++ b/lib/rules/no-unknown-animations/index.mjs
@@ -2,6 +2,7 @@ import { animationNameKeywords } from '../../reference/keywords.mjs';
 import { atRuleRegexes } from '../../utils/regexes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
 import findAnimationName from '../../utils/findAnimationName.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
 import validateOptions from '../../utils/validateOptions.mjs';
@@ -28,8 +29,11 @@ const rule = (primary) => {
 		const declaredAnimations = new Set();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const roots = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [root, ...referenceRoots];
 
-		for (const rootNode of [root, ...referenceRoots]) {
+		for (const rootNode of roots) {
 			rootNode.walkAtRules(atRuleRegexes.keyframesName, (atRule) => {
 				declaredAnimations.add(atRule.params);
 			});

--- a/lib/rules/no-unknown-custom-media/index.mjs
+++ b/lib/rules/no-unknown-custom-media/index.mjs
@@ -2,6 +2,7 @@ import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
 import { isMediaFeature, isMediaQueryInvalid } from '@csstools/media-query-list-parser';
 import { atRuleParamIndex } from '../../utils/nodeFieldIndices.mjs';
 import isCustomMediaQuery from '../../utils/isCustomMediaQuery.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import parseCustomMediaQuery from '../../utils/parseCustomMediaQuery.mjs';
 import parseMediaQuery from '../../utils/parseMediaQuery.mjs';
 import report from '../../utils/report.mjs';
@@ -28,8 +29,11 @@ const rule = (primary) => {
 		const declaredCustomMediaQueries = new Set();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const roots = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [root, ...referenceRoots];
 
-		for (const rootNode of [root, ...referenceRoots]) {
+		for (const rootNode of roots) {
 			rootNode.walkAtRules(atRuleRegexes.customMediaName, (atRule) => {
 				const customMediaQuery = parseCustomMediaQuery(atRule);
 

--- a/lib/rules/no-unknown-custom-properties/index.mjs
+++ b/lib/rules/no-unknown-custom-properties/index.mjs
@@ -2,6 +2,7 @@ import valueParser from 'postcss-value-parser';
 
 import { atRuleRegexes, propertyRegexes } from '../../utils/regexes.mjs';
 import { declarationValueIndex } from '../../utils/nodeFieldIndices.mjs';
+import isRootIncludedInReferenceRoots from '../../utils/isRootIncludedInReferenceRoots.mjs';
 import isVarFunction from '../../utils/isVarFunction.mjs';
 import report from '../../utils/report.mjs';
 import ruleMessages from '../../utils/ruleMessages.mjs';
@@ -28,8 +29,11 @@ const rule = (primary) => {
 		const declaredCustomProps = new Set();
 
 		const referenceRoots = result.stylelint.referenceRoots;
+		const roots = isRootIncludedInReferenceRoots(root, referenceRoots)
+			? referenceRoots
+			: [root, ...referenceRoots];
 
-		for (const rootNode of [root, ...referenceRoots]) {
+		for (const rootNode of roots) {
 			rootNode.walkAtRules(atRuleRegexes.propertyName, ({ params }) => {
 				declaredCustomProps.add(params);
 			});

--- a/lib/utils/getReferenceRoots.mjs
+++ b/lib/utils/getReferenceRoots.mjs
@@ -7,19 +7,47 @@ import { isDocument } from './typeGuards.mjs';
 /** @import {Root} from 'postcss' */
 /** @import {Config as StylelintConfig} from 'stylelint' */
 
+const cacheObjectIds = new WeakMap();
+let nextCacheObjectId = 0;
+
 /**
  * Read and parse reference files from resolved config entries.
  *
  * @param {StylelintConfig} config
+ * @param {Map<string, Promise<Root[]>>} [cache]
  * @returns {Promise<Root[]>}
  */
-export default async function getReferenceRoots(config) {
+export default async function getReferenceRoots(config, cache) {
 	const entries = config._resolvedReferenceFiles;
 
 	if (!entries || entries.length === 0) {
 		return [];
 	}
 
+	if (!cache) {
+		return parseReferenceRoots(entries);
+	}
+
+	const cacheKey = getReferenceRootsCacheKey(entries);
+	let roots = cache.get(cacheKey);
+
+	if (!roots) {
+		roots = parseReferenceRoots(entries).catch((error) => {
+			cache.delete(cacheKey);
+
+			throw error;
+		});
+		cache.set(cacheKey, roots);
+	}
+
+	return roots;
+}
+
+/**
+ * @param {NonNullable<StylelintConfig['_resolvedReferenceFiles']>} entries
+ * @returns {Promise<Root[]>}
+ */
+async function parseReferenceRoots(entries) {
 	const promisedRoots = entries.flatMap((entry) => {
 		const processor = postcss(entry.loader ? [entry.loader] : []);
 
@@ -48,4 +76,45 @@ export default async function getReferenceRoots(config) {
 	});
 
 	return (await Promise.all(promisedRoots)).flat();
+}
+
+/**
+ * @param {NonNullable<StylelintConfig['_resolvedReferenceFiles']>} entries
+ * @returns {string}
+ */
+function getReferenceRootsCacheKey(entries) {
+	return entries
+		.map((entry) =>
+			[
+				entry.files.join('\u0000'),
+				getCacheIdentity(entry.customSyntax),
+				getCacheIdentity(entry.loader),
+			].join('\u0000'),
+		)
+		.join('\u0001');
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function getCacheIdentity(value) {
+	if (!value) return '';
+
+	const valueType = typeof value;
+
+	if (valueType !== 'object' && valueType !== 'function') {
+		return `${valueType}:${String(value)}`;
+	}
+
+	const object = /** @type {object} */ (value);
+	let objectId = cacheObjectIds.get(object);
+
+	if (objectId === undefined) {
+		objectId = nextCacheObjectId;
+		nextCacheObjectId += 1;
+		cacheObjectIds.set(object, objectId);
+	}
+
+	return `${valueType}:${objectId}`;
 }

--- a/lib/utils/isRootIncludedInReferenceRoots.mjs
+++ b/lib/utils/isRootIncludedInReferenceRoots.mjs
@@ -2,6 +2,8 @@ import { resolve } from 'node:path';
 
 /** @import {Node, Root} from 'postcss' */
 
+const referenceRootSourcePathsCache = new WeakMap();
+
 /**
  * Check whether a root's source file is already embedded in reference roots.
  *
@@ -14,19 +16,40 @@ export default function isRootIncludedInReferenceRoots(root, referenceRoots) {
 
 	if (!rootSourcePath) return false;
 
-	return referenceRoots.some((referenceRoot) => {
-		if (getSourcePath(referenceRoot) === rootSourcePath) return true;
+	return getReferenceRootSourcePaths(referenceRoots).has(rootSourcePath);
+}
 
-		let found = false;
+/**
+ * @param {Root[]} referenceRoots
+ * @returns {Set<string>}
+ */
+function getReferenceRootSourcePaths(referenceRoots) {
+	const cachedSourcePaths = referenceRootSourcePathsCache.get(referenceRoots);
 
-		referenceRoot.walk((node) => {
-			if (getSourcePath(node) === rootSourcePath) {
-				found = true;
-			}
-		});
+	if (cachedSourcePaths) return cachedSourcePaths;
 
-		return found;
-	});
+	const sourcePaths = new Set();
+
+	for (const referenceRoot of referenceRoots) {
+		addSourcePath(sourcePaths, referenceRoot);
+		referenceRoot.walk((node) => addSourcePath(sourcePaths, node));
+	}
+
+	referenceRootSourcePathsCache.set(referenceRoots, sourcePaths);
+
+	return sourcePaths;
+}
+
+/**
+ * @param {Set<string>} sourcePaths
+ * @param {Node | Root} node
+ */
+function addSourcePath(sourcePaths, node) {
+	const sourcePath = getSourcePath(node);
+
+	if (sourcePath) {
+		sourcePaths.add(sourcePath);
+	}
 }
 
 /**

--- a/lib/utils/isRootIncludedInReferenceRoots.mjs
+++ b/lib/utils/isRootIncludedInReferenceRoots.mjs
@@ -1,0 +1,42 @@
+import { resolve } from 'node:path';
+
+/** @import {Node, Root} from 'postcss' */
+
+/**
+ * Check whether a root's source file is already embedded in reference roots.
+ *
+ * @param {Root} root
+ * @param {Root[]} referenceRoots
+ * @returns {boolean}
+ */
+export default function isRootIncludedInReferenceRoots(root, referenceRoots) {
+	const rootSourcePath = getSourcePath(root);
+
+	if (!rootSourcePath) return false;
+
+	return referenceRoots.some((referenceRoot) => {
+		if (getSourcePath(referenceRoot) === rootSourcePath) return true;
+
+		let found = false;
+
+		referenceRoot.walk((node) => {
+			if (getSourcePath(node) === rootSourcePath) {
+				found = true;
+			}
+		});
+
+		return found;
+	});
+}
+
+/**
+ * @param {Node | Root} node
+ * @returns {string | undefined}
+ */
+function getSourcePath(node) {
+	const sourcePath = node.source?.input.from;
+
+	if (!sourcePath) return undefined;
+
+	return resolve(sourcePath);
+}

--- a/types/stylelint/index.d.ts
+++ b/types/stylelint/index.d.ts
@@ -1601,6 +1601,7 @@ declare namespace stylelint {
 		_augmentedConfigCache: Map<string, CosmiconfigResult>;
 		_postcssResultCache: Map<string, PostCSS.Result>;
 		_compiledOverridesCache: Map<string, CompiledOverride[]>;
+		_referenceRootsCache: Map<string, Promise<PostCSS.Root[]>>;
 		_fileCache: FileCache;
 	};
 


### PR DESCRIPTION
Closes #9297.\n\nThis adds a helper that detects when the linted root source is already embedded in one of the configured reference roots, using the absolute `source.input.from` paths. The reference-aware rules now skip the standalone root in that case so the loader bundle keeps the more accurate source order.\n\nTests:\n- npm run test-only -- --runTestsByPath lib/__tests__/referenceFiles.test.mjs -t "uses the embedded source order"\n- npm run test-only -- lib/__tests__/referenceFiles.test.mjs lib/rules/no-unknown-animations/__tests__/index.mjs lib/rules/no-unknown-custom-media/__tests__/index.mjs lib/rules/no-unknown-custom-properties/__tests__/index.mjs lib/rules/declaration-property-value-no-unknown/__tests__/index.mjs\n- npm run lint\n- npm test\n- git diff --check