### PR TITLE
Fix `selector-type-no-unknown` false positives for `install`

### DIFF
--- a/.changeset/cruel-foxes-add.md
+++ b/.changeset/cruel-foxes-add.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-type-no-unknown` false positives for `install`

--- a/lib/reference/selectors.mjs
+++ b/lib/reference/selectors.mjs
@@ -53,6 +53,7 @@ const experimentalHtmlTypeSelectors = new Set([
 	'selectlist',
 	'geolocation',
 	'usermedia',
+	'install',
 ]);
 
 /** @type {ReadonlySet<string>} */

--- a/lib/rules/selector-type-no-unknown/__tests__/index.mjs
+++ b/lib/rules/selector-type-no-unknown/__tests__/index.mjs
@@ -100,7 +100,7 @@ testRule({
 			description: 'obsolete tag',
 		},
 		{
-			code: 'fencedframe, listbox, model, portal, selectlist, selectedcontent, geolocation, usermedia {}',
+			code: 'fencedframe, listbox, model, portal, selectlist, selectedcontent, geolocation, usermedia, install {}',
 			description: 'experimental tags',
 		},
 		{


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

followup of #9004

> Is there anything in the PR that needs further explanation?

https://developer.chrome.com/blog/install-element-ot