### PR TITLE
Mention PR authors in `close-low-quality-prs` GHA workflow

### DIFF
--- a/.github/workflows/close-low-quality-prs.yml
+++ b/.github/workflows/close-low-quality-prs.yml
@@ -18,13 +18,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment on low-quality PR
-        run: gh pr comment "${PR_URL}" --body "${pr_comment}"
+        run: gh pr comment "${PR_URL}" --body "${PR_COMMENT}"
         env:
           GH_REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-          pr_comment: |-
-            Thank you for your contribution. However, this pull request does not appear to follow our [contributing guide](https://stylelint.io/CONTRIBUTING). Please review it and update your pull request.
+          PR_COMMENT: |-
+            @${{ github.event.pull_request.user.login }} Thank you for your contribution. However, this pull request does not appear to follow our [contributing guide](https://stylelint.io/CONTRIBUTING). Please review it and update your pull request.
 
             This pull request will automatically close if there is no activity within 2 days.
 


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

To reduce the possibility that PR authors can miss such comments.
