### PR TITLE
Fix `selector-max-type` false positives for nested selectors

### DIFF
--- a/.changeset/curvy-bees-end.md
+++ b/.changeset/curvy-bees-end.md
@@ -2,4 +2,4 @@
 "stylelint": patch
 ---
 
-Fixed: `selector-max-type` false positives with nested selectors
+Fixed: `selector-max-type` false positives for nested selectors

--- a/.changeset/curvy-bees-end.md
+++ b/.changeset/curvy-bees-end.md
@@ -1,0 +1,5 @@
+---
+"stylelint": patch
+---
+
+Fixed: `selector-max-type` false positives with nested selectors

--- a/lib/rules/selector-max-type/__tests__/index.mjs
+++ b/lib/rules/selector-max-type/__tests__/index.mjs
@@ -287,6 +287,18 @@ testRule({
 			code: '#bar div.foo {}',
 			description: 'compounded and descendant',
 		},
+		{
+			code: '.foo { div {} }',
+		},
+		{
+			code: '@scope (.foo) { div {} }',
+		},
+		{
+			code: '.foo { div, a {} }',
+		},
+		{
+			code: '.foo { div, .bar& {} }',
+		},
 	],
 
 	reject: [
@@ -299,29 +311,45 @@ testRule({
 			endColumn: 4,
 		},
 		{
-			code: '.foo { div {} }',
-			message: messages.expected('div', 0),
+			code: '.foo { div& {} }',
+			message: messages.expected('div&', 0),
 			line: 1,
 			column: 8,
 			endLine: 1,
-			endColumn: 11,
+			endColumn: 12,
 		},
 		{
-			code: '.foo { div, a {} }',
+			code: '.foo { div:is(&) {} }',
+			message: messages.expected('div:is(&)', 0),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 17,
+		},
+		{
+			code: '.foo { & :is(div) {} }',
+			message: messages.expected('& :is(div)', 0),
+			line: 1,
+			column: 8,
+			endLine: 1,
+			endColumn: 18,
+		},
+		{
+			code: '.foo { div&, a& {} }',
 			warnings: [
 				{
-					message: messages.expected('div', 0),
+					message: messages.expected('div&', 0),
 					line: 1,
 					column: 8,
 					endLine: 1,
-					endColumn: 11,
+					endColumn: 12,
 				},
 				{
-					message: messages.expected('a', 0),
+					message: messages.expected('a&', 0),
 					line: 1,
-					column: 13,
+					column: 14,
 					endLine: 1,
-					endColumn: 14,
+					endColumn: 16,
 				},
 			],
 		},

--- a/lib/rules/selector-max-type/index.mjs
+++ b/lib/rules/selector-max-type/index.mjs
@@ -72,7 +72,13 @@ const rule = (primary, secondaryOptions) => {
 					return;
 				}
 
-				if (ignoreDescendant && hasDescendantCombinatorBefore(childNode, ruleNode)) {
+				if (
+					ignoreDescendant &&
+					(hasDescendantCombinatorBefore(childNode) ||
+						hasImplicitDescendantCombinator(childNode, ruleNode))
+				) {
+					return;
+				}
 					return;
 				}
 

--- a/lib/rules/selector-max-type/index.mjs
+++ b/lib/rules/selector-max-type/index.mjs
@@ -1,3 +1,7 @@
+import parser from 'postcss-selector-parser';
+
+import { atRuleRegexes, mayIncludeRegexes } from '../../utils/regexes.mjs';
+import { isAtRule, isRule } from '../../utils/typeGuards.mjs';
 import { isRegExp, isString } from '../../utils/validateTypes.mjs';
 import getRuleSelector from '../../utils/getRuleSelector.mjs';
 import getStrippedSelectorSource from '../../utils/getStrippedSelectorSource.mjs';
@@ -7,7 +11,6 @@ import isNonNegativeInteger from '../../utils/isNonNegativeInteger.mjs';
 import isOnlyWhitespace from '../../utils/isOnlyWhitespace.mjs';
 import isStandardSyntaxRule from '../../utils/isStandardSyntaxRule.mjs';
 import isStandardSyntaxTypeSelector from '../../utils/isStandardSyntaxTypeSelector.mjs';
-import { mayIncludeRegexes } from '../../utils/regexes.mjs';
 import optionsMatches from '../../utils/optionsMatches.mjs';
 import parseSelector from '../../utils/parseSelector.mjs';
 import report from '../../utils/report.mjs';
@@ -23,6 +26,9 @@ const messages = ruleMessages(ruleName, {
 const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-max-type',
 };
+
+/** @typedef {import('postcss-selector-parser').Node} SelectorNode */
+/** @typedef {import('postcss').Rule} Rule */
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
@@ -56,7 +62,7 @@ const rule = (primary, secondaryOptions) => {
 
 		/**
 		 * @param {import('postcss-selector-parser').Selector} selectorNode
-		 * @param {import('postcss').Rule} ruleNode
+		 * @param {Rule} ruleNode
 		 */
 		function checkSelector(selectorNode, ruleNode) {
 			let count = 0;
@@ -66,7 +72,7 @@ const rule = (primary, secondaryOptions) => {
 					return;
 				}
 
-				if (ignoreDescendant && hasDescendantCombinatorBefore(childNode)) {
+				if (ignoreDescendant && hasDescendantCombinatorBefore(childNode, ruleNode)) {
 					return;
 				}
 
@@ -122,18 +128,53 @@ const rule = (primary, secondaryOptions) => {
 	};
 };
 
-/** @typedef {import('postcss-selector-parser').Node} SelectorNode */
-
 /**
  * @param {SelectorNode} node
+ * @param {Rule} ruleNode
  * @returns {boolean}
  */
-function hasDescendantCombinatorBefore(node) {
-	if (!node.parent) return false;
+function hasDescendantCombinatorBefore(node, ruleNode) {
+	const parent = node.parent;
 
-	const nodeIndex = node.parent.nodes.indexOf(node);
+	if (!parent) return false;
 
-	return node.parent.nodes.slice(0, nodeIndex).some((n) => isDescendantCombinator(n));
+	const nodeIndex = parent.nodes.indexOf(node);
+
+	if (parent.nodes.slice(0, nodeIndex).some((n) => isDescendantCombinator(n))) return true;
+
+	// check for implicit `&` in nested rules
+	// 1. parent must be a selector and the parent of that selector must be the root.
+	if (!parser.isSelector(parent) || !parser.isRoot(parent.parent)) return false;
+
+	// 2. the current `ruleNode` must be a nested rule
+	/** @type {import('postcss').Container['parent']} */
+	let parentNode = ruleNode.parent;
+	let isNestedRule = false;
+
+	while (parentNode) {
+		if (
+			isRule(parentNode) ||
+			(isAtRule(parentNode) && atRuleRegexes.scopeName.test(parentNode.name))
+		) {
+			isNestedRule = true;
+			break;
+		}
+
+		parentNode = parentNode.parent;
+	}
+
+	if (!isNestedRule) return false;
+
+	// 3. the current selector must not contain `&`
+	let isNestContaining = false;
+
+	parent.walkNesting(() => {
+		isNestContaining = true;
+
+		return false;
+	});
+
+	return !isNestContaining;
 }
 
 /**

--- a/lib/rules/selector-max-type/index.mjs
+++ b/lib/rules/selector-max-type/index.mjs
@@ -28,7 +28,7 @@ const meta = {
 };
 
 /** @import { Rule } from 'postcss' */
-/** @import { Container, Node as SelectorNode } from 'postcss-selector-parser' */
+/** @import { Container as SelectorContainer, Node as SelectorNode } from 'postcss-selector-parser' */
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {
@@ -77,8 +77,6 @@ const rule = (primary, secondaryOptions) => {
 					(hasDescendantCombinatorBefore(childNode) ||
 						hasImplicitDescendantCombinator(childNode, ruleNode))
 				) {
-					return;
-				}
 					return;
 				}
 
@@ -136,51 +134,66 @@ const rule = (primary, secondaryOptions) => {
 
 /**
  * @param {SelectorNode} node
- * @param {Rule} ruleNode
  * @returns {boolean}
  */
-function hasDescendantCombinatorBefore(node, ruleNode) {
+function hasDescendantCombinatorBefore(node) {
 	const parent = node.parent;
 
 	if (!parent) return false;
 
 	const nodeIndex = parent.nodes.indexOf(node);
 
-	if (parent.nodes.slice(0, nodeIndex).some((n) => isDescendantCombinator(n))) return true;
+	return parent.nodes.slice(0, nodeIndex).some((n) => isDescendantCombinator(n));
+}
 
-	// check for implicit `&` in nested rules
-	// 1. parent must be a selector and the parent of that selector must be the root.
-	if (!parser.isSelector(parent) || !parser.isRoot(parent.parent)) return false;
+/**
+ * @param {SelectorNode} node
+ * @param {Rule} ruleNode
+ * @returns {boolean}
+ */
+function hasImplicitDescendantCombinator(node, ruleNode) {
+	const selector = node.parent;
 
-	// 2. the current `ruleNode` must be a nested rule
+	if (!parser.isSelector(selector) || !parser.isRoot(selector.parent)) return false;
+
+	if (!isNestedRule(ruleNode)) return false;
+
+	return !isNestContaining(selector);
+}
+
+/**
+ * @param {Rule} ruleNode
+ * @returns {boolean}
+ */
+function isNestedRule(ruleNode) {
 	/** @type {import('postcss').Container['parent']} */
 	let parentNode = ruleNode.parent;
-	let isNestedRule = false;
 
 	while (parentNode) {
-		if (
-			isRule(parentNode) ||
-			(isAtRule(parentNode) && atRuleRegexes.scopeName.test(parentNode.name))
-		) {
-			isNestedRule = true;
-			break;
-		}
+		if (isRule(parentNode)) return true;
+
+		if (isAtRule(parentNode) && atRuleRegexes.scopeName.test(parentNode.name)) return true;
 
 		parentNode = parentNode.parent;
 	}
 
-	if (!isNestedRule) return false;
+	return false;
+}
 
-	// 3. the current selector must not contain `&`
-	let isNestContaining = false;
+/**
+ * @param {SelectorContainer} selector
+ * @returns {boolean}
+ */
+function isNestContaining(selector) {
+	let hasNesting = false;
 
-	parent.walkNesting(() => {
-		isNestContaining = true;
+	selector.walkNesting(() => {
+		hasNesting = true;
 
 		return false;
 	});
 
-	return !isNestContaining;
+	return hasNesting;
 }
 
 /**

--- a/lib/rules/selector-max-type/index.mjs
+++ b/lib/rules/selector-max-type/index.mjs
@@ -27,8 +27,8 @@ const meta = {
 	url: 'https://stylelint.io/user-guide/rules/selector-max-type',
 };
 
-/** @typedef {import('postcss-selector-parser').Node} SelectorNode */
-/** @typedef {import('postcss').Rule} Rule */
+/** @import { Rule } from 'postcss' */
+/** @import { Container, Node as SelectorNode } from 'postcss-selector-parser' */
 
 /** @type {import('stylelint').CoreRules[ruleName]} */
 const rule = (primary, secondaryOptions) => {

--- a/lib/utils/resolveNestedSelectorsForRule.mjs
+++ b/lib/utils/resolveNestedSelectorsForRule.mjs
@@ -1,6 +1,7 @@
 import { resolveNestedSelector } from '@csstools/selector-resolve-nested';
 
 import { isAtRule, isRule } from './typeGuards.mjs';
+import { atRuleRegexes } from './regexes.mjs';
 import getRuleSelector from './getRuleSelector.mjs';
 import isStandardSyntaxRule from './isStandardSyntaxRule.mjs';
 import parseSelector from './parseSelector.mjs';
@@ -57,7 +58,7 @@ export default function resolveNestedSelectorsForRule(rule, result) {
 	ancestors.reverse();
 
 	for (const child of ancestors) {
-		if (isAtRule(child) && child.name === 'scope') {
+		if (isAtRule(child) && atRuleRegexes.scopeName.test(child.name)) {
 			ast = parseSelector(':where(:scope)', result, child);
 			continue;
 		}


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint/issues/9318

> Is there anything in the PR that needs further explanation?

No, it's self-explanatory.
