### PR TITLE
Fix changeset verification on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
           npm run changeset
           npm run lint:md
           git checkout -- CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }} # required by Changeset
 
   spellcheck:
     runs-on: ubuntu-slim


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Follows up to #9305

> Is there anything in the PR that needs further explanation?

This PR fixes the error below by specifying the `GITHUB_TOKEN` environment variable on CI:

```
> changeset version && node .changeset/rewrite-changelog.mjs CHANGELOG.md

The following error was encountered while generating changelog entries
We have escaped applying the changesets, and no files should have been affected
🦋  error Error: Please create a GitHub personal access token at https://github.com/settings/tokens/new?scopes=read:user,repo:status&description=changesets-2026-05-31 with `read:user` and `repo:status` permissions and add it as the GITHUB_TOKEN environment variable
🦋  error     at /home/runner/work/stylelint/stylelint/node_modules/@changesets/get-github-info/dist/changesets-get-github-info.cjs.js:154:11
🦋  error     at dispatchQueueBatch (/home/runner/work/stylelint/stylelint/node_modules/dataloader/index.js:246:22)
🦋  error     at dispatchQueue (/home/runner/work/stylelint/stylelint/node_modules/dataloader/index.js:233:5)
🦋  error     at /home/runner/work/stylelint/stylelint/node_modules/dataloader/index.js:70:20
🦋  error     at process.processTicksAndRejections (node:internal/process/task_queues:85:11)
```

Ref: https://github.com/stylelint/stylelint/actions/runs/26727762767/job/78765896029#step:9:17



